### PR TITLE
Stats on API26: avoid scheduling jobs with identical parameters

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
+++ b/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
@@ -59,7 +59,7 @@ public class JobServiceId {
                             Object one = extras.get(key);
                             Object two = bundleCompare.get(key);
 
-                            if ((one != null && two == null) || (one == null)) {
+                            if ((one != null && two == null) || (one == null && two != null)) {
                                 jobAlreadyScheduled = false;
                                 break;
                             }

--- a/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
+++ b/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
@@ -1,5 +1,14 @@
 package org.wordpress.android;
 
+import android.annotation.TargetApi;
+import android.app.job.JobInfo;
+import android.app.job.JobScheduler;
+import android.content.ComponentName;
+import android.content.Context;
+import android.os.PersistableBundle;
+
+import org.wordpress.android.util.AppLog;
+
 public class JobServiceId {
     public static final int JOB_STATS_SERVICE_ID = 8000;
     public static final int JOB_NOTIFICATIONS_UPDATE_SERVICE_ID = 7000;
@@ -7,4 +16,38 @@ public class JobServiceId {
     public static final int JOB_PUBLICIZE_UPDATE_SERVICE_ID = 3000;
     public static final int JOB_READER_UPDATE_SERVICE_ID = 2000;
     public static final int JOB_GCM_REG_SERVICE_ID = 1000;
+
+    @TargetApi(21)
+    public static boolean isJobServiceWithSameParamsPending(Context context, ComponentName componentName, PersistableBundle bundleCompare) {
+        JobScheduler scheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+        boolean jobAlreadyScheduled = false;
+
+        for (JobInfo jobInfo : scheduler.getAllPendingJobs()) {
+            // check this is the same Service we are looking for
+            if (jobInfo.getService().getClassName().compareTo(componentName.getClassName()) == 0) {
+                PersistableBundle extras = jobInfo.getExtras();
+                if (extras != null) {
+                    if (extras.keySet().containsAll(bundleCompare.keySet())) {
+                        // compare all parameters
+                        jobAlreadyScheduled = true;
+                        for (String key : bundleCompare.keySet()) {
+                            // this is contained, check the value is the same now
+                            Object one = extras.get(key);
+                            Object two = bundleCompare.get(key);
+                            if (!one.equals(two)) {
+                                jobAlreadyScheduled = false;
+                                break;
+                            }
+                        }
+                        // if all is good, we found it
+                        if (jobAlreadyScheduled) {
+                            AppLog.i(AppLog.T.STATS, "Job was already scheduled");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return jobAlreadyScheduled;
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
+++ b/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
@@ -18,7 +18,8 @@ public class JobServiceId {
     public static final int JOB_GCM_REG_SERVICE_ID = 1000;
 
     @TargetApi(21)
-    public static boolean isJobServiceWithSameParamsPending(Context context, ComponentName componentName, PersistableBundle bundleCompare) {
+    public static boolean isJobServiceWithSameParamsPending(Context context, ComponentName componentName,
+                                                            PersistableBundle bundleCompare) {
         JobScheduler scheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
         boolean jobAlreadyScheduled = false;
 

--- a/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
+++ b/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
@@ -52,7 +52,7 @@ public class JobServiceId {
                         // if all is good, we found it
                         if (jobAlreadyScheduled) {
                             AppLog.i(AppLog.T.STATS, "Job was already scheduled");
-                            break;
+                            return jobAlreadyScheduled;
                         }
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
+++ b/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
@@ -20,6 +20,14 @@ public class JobServiceId {
     public static final int JOB_READER_UPDATE_SERVICE_ID = 2000;
     public static final int JOB_GCM_REG_SERVICE_ID = 1000;
 
+    /*
+     * This method checks that a spefic bundle for a given JobServie matches perfectly (all extras and all of its
+     * values match) to check if it is already scheduled or not.
+     * TODO IMPORTANT: note that this particular method checks for int[] and compares within the array, as that's
+     * a case we needed to implement. In the future, if you need to compare other kind of arrays, you'll need to
+     * implement each case as you see fit.
+     */
+
     @TargetApi(21)
     public static boolean isJobServiceWithSameParamsPending(Context context, ComponentName componentName,
                                                             PersistableBundle bundleCompare, String exceptKey) {
@@ -60,6 +68,10 @@ public class JobServiceId {
                                     jobAlreadyScheduled = false;
                                     break;
                                 }
+                                // TODO here implement other cases, i.e.
+                                // if (one instanceof StringArray && two instanceof StringArray) {
+                                //   ...
+                                // }
                             } else {
                                 if (!one.equals(two)) {
                                     jobAlreadyScheduled = false;

--- a/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
+++ b/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
@@ -9,6 +9,7 @@ import android.os.PersistableBundle;
 
 import org.wordpress.android.util.AppLog;
 
+import java.util.Arrays;
 import java.util.Set;
 
 public class JobServiceId {
@@ -44,9 +45,26 @@ public class JobServiceId {
                             // this is contained, check the value is the same now
                             Object one = extras.get(key);
                             Object two = bundleCompare.get(key);
-                            if (one != null && !one.equals(two)) {
+
+                            if ((one != null && two == null) || (one == null)) {
                                 jobAlreadyScheduled = false;
                                 break;
+                            }
+                            if (one == two) {
+                                continue;
+                            }
+                            if (one instanceof int[] && two instanceof int[]) {
+                                if (Arrays.equals((int[]) one, (int[]) two)) {
+                                    continue;
+                                } else {
+                                    jobAlreadyScheduled = false;
+                                    break;
+                                }
+                            } else {
+                                if (!one.equals(two)) {
+                                    jobAlreadyScheduled = false;
+                                    break;
+                                }
                             }
                         }
                         // if all is good, we found it

--- a/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
+++ b/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
@@ -44,7 +44,7 @@ public class JobServiceId {
                             // this is contained, check the value is the same now
                             Object one = extras.get(key);
                             Object two = bundleCompare.get(key);
-                            if (!one.equals(two)) {
+                            if (one != null && !one.equals(two)) {
                                 jobAlreadyScheduled = false;
                                 break;
                             }

--- a/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
+++ b/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
@@ -9,6 +9,8 @@ import android.os.PersistableBundle;
 
 import org.wordpress.android.util.AppLog;
 
+import java.util.Set;
+
 public class JobServiceId {
     public static final int JOB_STATS_SERVICE_ID = 8000;
     public static final int JOB_NOTIFICATIONS_UPDATE_SERVICE_ID = 7000;
@@ -19,7 +21,7 @@ public class JobServiceId {
 
     @TargetApi(21)
     public static boolean isJobServiceWithSameParamsPending(Context context, ComponentName componentName,
-                                                            PersistableBundle bundleCompare) {
+                                                            PersistableBundle bundleCompare, String exceptKey) {
         JobScheduler scheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
         boolean jobAlreadyScheduled = false;
 
@@ -28,7 +30,14 @@ public class JobServiceId {
             if (jobInfo.getService().getClassName().compareTo(componentName.getClassName()) == 0) {
                 PersistableBundle extras = jobInfo.getExtras();
                 if (extras != null) {
-                    if (extras.keySet().containsAll(bundleCompare.keySet())) {
+                    // check the keySet for both bundles are the exact same
+                    Set<String> keySetOne = extras.keySet();
+                    Set<String> keySetTwo = bundleCompare.keySet();
+
+                    // don't check `exceptKey` if it's null
+                    if ((exceptKey == null && (keySetOne.size() == keySetTwo.size()))
+                        || ((exceptKey != null && (keySetOne.size() - 1 == keySetTwo.size()))
+                        && extras.keySet().containsAll(bundleCompare.keySet()))) {
                         // compare all parameters
                         jobAlreadyScheduled = true;
                         for (String key : bundleCompare.keySet()) {

--- a/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
+++ b/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
@@ -39,7 +39,6 @@ public class JobServiceId {
         if (jobs == null) {
             return jobAlreadyScheduled;
         }
-        
         for (JobInfo jobInfo : jobs) {
             // check this is the same Service we are looking for
             if (jobInfo.getService().getClassName().compareTo(componentName.getClassName()) == 0) {

--- a/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
+++ b/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
@@ -10,6 +10,7 @@ import android.os.PersistableBundle;
 import org.wordpress.android.util.AppLog;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 public class JobServiceId {
@@ -34,7 +35,12 @@ public class JobServiceId {
         JobScheduler scheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
         boolean jobAlreadyScheduled = false;
 
-        for (JobInfo jobInfo : scheduler.getAllPendingJobs()) {
+        List<JobInfo> jobs = scheduler.getAllPendingJobs();
+        if (jobs == null) {
+            return jobAlreadyScheduled;
+        }
+        
+        for (JobInfo jobInfo : jobs) {
             // check this is the same Service we are looking for
             if (jobInfo.getService().getClassName().compareTo(componentName.getClassName()) == 0) {
                 PersistableBundle extras = jobInfo.getExtras();

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsServiceStarter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsServiceStarter.java
@@ -10,6 +10,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.PersistableBundle;
 
+import org.wordpress.android.JobServiceId;
 import org.wordpress.android.util.AppLog;
 
 import static org.wordpress.android.JobServiceId.JOB_STATS_SERVICE_ID;
@@ -32,21 +33,27 @@ public class StatsServiceStarter {
             ComponentName componentName = new ComponentName(context, StatsJobService.class);
 
             PersistableBundle extras = passBundleExtrasToPersistableBundle(originalExtras);
-            extras.putInt(ARG_START_ID, getNewStartId());
 
-            JobInfo jobInfo = new JobInfo.Builder(JOB_STATS_SERVICE_ID + jobId, componentName)
-                    .setRequiresCharging(false)
-                    .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
-                    .setOverrideDeadline(0) // if possible, try to run right away
-                    .setExtras(extras)
-                    .build();
+            // don't schedule the same kind of request twice for Stats - just wait for the pending Job to be
+            // executed.
+            if (!JobServiceId.isJobServiceWithSameParamsPending(context, componentName, extras)) {
+                // if not found, let's add a new Job Id and schedule this onw
+                extras.putInt(ARG_START_ID, getNewStartId());
 
-            JobScheduler jobScheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
-            int resultCode = jobScheduler.schedule(jobInfo);
-            if (resultCode == JobScheduler.RESULT_SUCCESS) {
-                AppLog.i(AppLog.T.STATS, "stats job service > job scheduled");
-            } else {
-                AppLog.e(AppLog.T.STATS, "stats job service > job could not be scheduled");
+                JobInfo jobInfo = new JobInfo.Builder(JOB_STATS_SERVICE_ID + jobId, componentName)
+                        .setRequiresCharging(false)
+                        .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+                        .setOverrideDeadline(0) // if possible, try to run right away
+                        .setExtras(extras)
+                        .build();
+
+                JobScheduler jobScheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+                int resultCode = jobScheduler.schedule(jobInfo);
+                if (resultCode == JobScheduler.RESULT_SUCCESS) {
+                    AppLog.i(AppLog.T.STATS, "stats job service > job scheduled");
+                } else {
+                    AppLog.e(AppLog.T.STATS, "stats job service > job could not be scheduled");
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsServiceStarter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsServiceStarter.java
@@ -36,7 +36,7 @@ public class StatsServiceStarter {
 
             // don't schedule the same kind of request twice for Stats - just wait for the pending Job to be
             // executed.
-            if (!JobServiceId.isJobServiceWithSameParamsPending(context, componentName, extras)) {
+            if (!JobServiceId.isJobServiceWithSameParamsPending(context, componentName, extras, ARG_START_ID)) {
                 // if not found, let's add a new Job Id and schedule this onw
                 extras.putInt(ARG_START_ID, getNewStartId());
 


### PR DESCRIPTION
Continues on the API26 migration series.

This PR adds a utility method that checks that no duplicate job is scheduled with the same parameters. @daniloercoli found a possibility that on slow connections the same requests could be made given the jobs seemed to be enqueued and only executed one by one, thus making the internal url path check in `StatsServiceLogic` (method `checkIfRequestShouldBeEnqueued()`) returning all times true (as the internal url queue was always free), as it works differently than in the former legacy `Service` class, this allowing for the same url to be queried multiple times.

This PR was going to make use of the url path as a basis for comparison as well, but realized it's more natural and general to check the following:

1. the JobService class name is the same
2. all keys to the bundle extras are contained (with the exception of the JobId which we're preventing to duplicate)
3. all values to each key are equal compared to one another

cc @daniloercoli I'm labelling `not ready for review` but in reality I'd like to get your pair of eyes on this one in terms of testing: as per my tests I couldn't make this actual condition (to find an already scheduled job) be met, even when on a slow network connection (2G) and changing the stats period dropdown, going back and again into the activity while it's loading, etc. Thanks in advance!