### PR TITLE
Issue/7623 stock photo rotation take2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -100,6 +100,7 @@ import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaBrowserType;
 import org.wordpress.android.ui.media.MediaSettingsActivity;
 import org.wordpress.android.ui.notifications.utils.PendingDraftsNotificationsUtils;
+import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment;
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment.PhotoPickerIcon;
 import org.wordpress.android.ui.posts.InsertMediaDialog.InsertMediaCallback;
@@ -2469,6 +2470,22 @@ public class EditPostActivity extends AppCompatActivity implements
         }
     }
 
+    private void setFeaturedImageId(final long mediaId) {
+        mPost.setFeaturedImageId(mediaId);
+        savePostAsync(new AfterSavePostListener() {
+            @Override
+            public void onPostSave() {
+                EditPostActivity.this.runOnUiThread(new Runnable() {
+                    @Override public void run() {
+                        if (mEditPostSettingsFragment != null) {
+                            mEditPostSettingsFragment.updateFeaturedImage(mediaId);
+                        }
+                    }
+                });
+            }
+        });
+    }
+
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
@@ -2486,9 +2503,10 @@ public class EditPostActivity extends AppCompatActivity implements
                     break;
                 case RequestCodes.PHOTO_PICKER:
                 case RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT:
-                    // user chose a featured image - pass it to the settings fragment
-                    if (mEditPostSettingsFragment != null) {
-                        mEditPostSettingsFragment.onActivityResult(requestCode, resultCode, data);
+                    // user chose a featured image
+                    if (resultCode == RESULT_OK && data.hasExtra(PhotoPickerActivity.EXTRA_MEDIA_ID)) {
+                        long mediaId = data.getLongExtra(PhotoPickerActivity.EXTRA_MEDIA_ID, 0);
+                        setFeaturedImageId(mediaId);
                     }
                     break;
                 case RequestCodes.PICTURE_LIBRARY:

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2476,7 +2476,8 @@ public class EditPostActivity extends AppCompatActivity implements
             @Override
             public void onPostSave() {
                 EditPostActivity.this.runOnUiThread(new Runnable() {
-                    @Override public void run() {
+                    @Override
+                    public void run() {
                         if (mEditPostSettingsFragment != null) {
                             mEditPostSettingsFragment.updateFeaturedImage(mediaId);
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -55,7 +55,6 @@ import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaBrowserType;
-import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
 import org.wordpress.android.ui.posts.PostDatePickerDialogFragment.PickerDialogType;
 import org.wordpress.android.ui.posts.PostSettingsListDialogFragment.DialogType;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -408,13 +407,6 @@ public class EditPostSettingsFragment extends Fragment {
                     if (resultCode == RESULT_OK && extras != null) {
                         String selectedTags = extras.getString(PostSettingsTagsActivity.KEY_SELECTED_TAGS);
                         updateTags(selectedTags);
-                    }
-                    break;
-                case RequestCodes.PHOTO_PICKER:
-                case RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT:
-                    if (resultCode == RESULT_OK && data.hasExtra(PhotoPickerActivity.EXTRA_MEDIA_ID)) {
-                        long mediaId = data.getLongExtra(PhotoPickerActivity.EXTRA_MEDIA_ID, 0);
-                        updateFeaturedImage(mediaId);
                     }
                     break;
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -817,10 +817,6 @@ public class EditPostSettingsFragment extends Fragment {
 
     public void updateFeaturedImage(long featuredImageId) {
         PostModel postModel = getPost();
-        if (postModel.getFeaturedImageId() == featuredImageId) {
-            return;
-        }
-
         postModel.setFeaturedImageId(featuredImageId);
         updateFeaturedImageView();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
@@ -191,6 +191,7 @@ public class StockMediaPickerActivity extends AppCompatActivity implements Searc
             mSearchView.setOnQueryTextListener(null);
             mSearchView.setOnCloseListener(null);
         }
+        showUploadProgressDialog(false);
         super.onDestroy();
     }
 


### PR DESCRIPTION
Fixes #7623 - resolves two issues while choosing a featured image from stock media:

1. Progress dialog is leaked upon rotation - this was fixed simply by dismissing the dialog when the activity is destroyed
2. Featured image is never set upon rotation - this was uglier, and was caused by the activity's onActivityResult() relying on the settings fragment to exist before setting the featured image id. This was fixed by moving the logic to the activity, and giving the fragment time to be created before passing it the chosen mediaId.