### PR TITLE
Improve Aztec external editor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1334,17 +1334,18 @@ public class EditPostActivity extends AppCompatActivity implements
                     // entries and 64kb max, and they only travel with the next crash happening, so logging an
                     // Exception assures us to have this information sent in the next batch).
                     // For more info: http://bit.ly/2oJHMG7 and http://bit.ly/2oPOtFX
-                    CrashlyticsUtils.logException(new AztecEditorFragment.AztecLoggingException(s));
+                    CrashlyticsUtils.logException(new AztecEditorFragment.AztecLoggingException(s), T.EDITOR);
                 }
 
                 @Override
                 public void logException(Throwable throwable) {
-                    CrashlyticsUtils.logException(throwable);
+                    CrashlyticsUtils.logException(new AztecEditorFragment.AztecLoggingException(throwable), T.EDITOR);
                 }
 
                 @Override
                 public void logException(Throwable throwable, String s) {
-                    CrashlyticsUtils.logException(throwable, T.EDITOR, s);
+                    CrashlyticsUtils.logException(
+                            new AztecEditorFragment.AztecLoggingException(throwable), T.EDITOR, s);
                 }
             });
         }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -119,6 +119,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         public AztecLoggingException(String message) {
             super(message);
         }
+        public AztecLoggingException(Throwable originalException) {
+            super(originalException);
+        }
     }
 
     private static final String ATTR_TAPPED_MEDIA_PREDICATE = "tapped_media_predicate";


### PR DESCRIPTION
In this PR I'm proposing to wrap logged Aztec Exception in a `AztecLoggingException`. This  should help when searching issues in Fabric.io.

Note that we're already wrapping simple "text message" in a AztecLoggingException.


cc @mzorz 