### PR TITLE
Api26/stats service loading spinner

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -52,6 +52,7 @@ import javax.inject.Inject;
 
 import de.greenrobot.event.EventBus;
 
+import static org.wordpress.android.ui.stats.service.StatsService.TASK_ID_GROUP_ALL;
 import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
 
 /**
@@ -667,8 +668,13 @@ public class StatsActivity extends AppCompatActivity
             return;
         }
 
-        if (mCallsToWaitFor > 0) {
-            mCallsToWaitFor--;
+        // in legacy StatsService we just need this signal to know one taskID grouped all concurrent requests
+        if (event.mTaskId == TASK_ID_GROUP_ALL) {
+            mCallsToWaitFor = 0;
+        } else {
+            if (mCallsToWaitFor > 0) {
+                mCallsToWaitFor--;
+            }
         }
 
         if (mCallsToWaitFor == 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsEvents.java
@@ -22,11 +22,19 @@ import org.wordpress.android.ui.stats.models.VisitsModel;
 import org.wordpress.android.ui.stats.service.StatsServiceLogic.StatsEndpointsEnum;
 
 public class StatsEvents {
-    public static class UpdateStatusChanged {
-        public final boolean mUpdating;
+    public static class UpdateStatusStarted {
+        public final int mTaskId;
 
-        public UpdateStatusChanged(boolean updating) {
-            mUpdating = updating;
+        public UpdateStatusStarted(int taskId) {
+            mTaskId = taskId;
+        }
+    }
+
+    public static class UpdateStatusFinished {
+        public final int mTaskId;
+
+        public UpdateStatusFinished(int taskId) {
+            mTaskId = taskId;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
@@ -182,13 +182,23 @@ public class StatsViewAllActivity extends AppCompatActivity {
     }
 
     @SuppressWarnings("unused")
-    public void onEventMainThread(StatsEvents.UpdateStatusChanged event) {
+    public void onEventMainThread(StatsEvents.UpdateStatusStarted event) {
         if (isFinishing() || !mIsInFront) {
             return;
         }
-        mSwipeToRefreshHelper.setRefreshing(event.mUpdating);
-        mIsUpdatingStats = event.mUpdating;
+        mSwipeToRefreshHelper.setRefreshing(true);
+        mIsUpdatingStats = true;
     }
+
+    @SuppressWarnings("unused")
+    public void onEventMainThread(StatsEvents.UpdateStatusFinished event) {
+        if (isFinishing() || !mIsInFront) {
+            return;
+        }
+        mSwipeToRefreshHelper.setRefreshing(false);
+        mIsUpdatingStats = false;
+    }
+
 
     private String getDateForDisplayInLabels(String date, StatsTimeframe timeframe) {
         String prefix = getString(R.string.stats_for);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsJobService.java
@@ -29,7 +29,7 @@ public class StatsJobService extends JobService implements StatsServiceLogic.Ser
             int startId = params.getExtras().getInt(ARG_START_ID);
             EventBus.getDefault().post(new StatsEvents.UpdateStatusStarted(startId));
             AppLog.i(T.STATS, "stats job service > task: " + startId + " started");
-            StatsServiceLogic logic = new StatsServiceLogic(this, true);
+            StatsServiceLogic logic = new StatsServiceLogic(this);
             logic.onCreate((WordPress) getApplication());
             logic.performTask(
                     new Bundle(params.getExtras()),

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsJobService.java
@@ -6,8 +6,11 @@ import android.app.job.JobService;
 import android.os.Bundle;
 
 import org.wordpress.android.WordPress;
+import org.wordpress.android.ui.stats.StatsEvents;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+
+import de.greenrobot.event.EventBus;
 
 import static org.wordpress.android.ui.stats.service.StatsServiceStarter.ARG_START_ID;
 
@@ -20,29 +23,15 @@ import static org.wordpress.android.ui.stats.service.StatsServiceStarter.ARG_STA
 
 @TargetApi(21)
 public class StatsJobService extends JobService implements StatsServiceLogic.ServiceCompletionListener {
-    private StatsServiceLogic mStatsServiceLogic;
-
-    @Override
-    public void onCreate() {
-        super.onCreate();
-        AppLog.i(T.STATS, "stats job service created");
-        mStatsServiceLogic = new StatsServiceLogic(this);
-        mStatsServiceLogic.onCreate((WordPress) getApplication());
-    }
-
-    @Override
-    public void onDestroy() {
-        AppLog.i(T.STATS, "stats job service destroyed");
-        mStatsServiceLogic.onDestroy();
-        super.onDestroy();
-    }
-
     @Override
     public boolean onStartJob(JobParameters params) {
         if (params.getExtras() != null) {
             int startId = params.getExtras().getInt(ARG_START_ID);
+            EventBus.getDefault().post(new StatsEvents.UpdateStatusStarted(startId));
             AppLog.i(T.STATS, "stats job service > task: " + startId + " started");
-            mStatsServiceLogic.performTask(
+            StatsServiceLogic logic = new StatsServiceLogic(this, true);
+            logic.onCreate((WordPress) getApplication());
+            logic.performTask(
                     new Bundle(params.getExtras()),
                     params);
             return true;
@@ -61,6 +50,7 @@ public class StatsJobService extends JobService implements StatsServiceLogic.Ser
     public void onCompleted(Object companion) {
         int startId = ((JobParameters) companion).getExtras().getInt(ARG_START_ID, 0);
         AppLog.i(T.STATS, "stats job service > task: " + startId + " completed");
+        EventBus.getDefault().post(new StatsEvents.UpdateStatusFinished(startId));
         jobFinished((JobParameters) companion, false);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -63,7 +63,7 @@ public class StatsService extends Service implements StatsServiceLogic.ServiceCo
 
     @Override
     public void onCompleted(Object companion) {
-        EventBus.getDefault().post(new StatsEvents.UpdateStatusFinished(-2));
+        EventBus.getDefault().post(new StatsEvents.UpdateStatusFinished(TASK_ID_GROUP_ALL));
         if (companion instanceof Integer) {
             AppLog.i(AppLog.T.STATS, "stats service > task: " + companion + " completed");
             stopSelf((Integer) companion);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -36,7 +36,7 @@ public class StatsService extends Service implements StatsServiceLogic.ServiceCo
     public void onCreate() {
         super.onCreate();
         AppLog.i(T.STATS, "stats service created");
-        mStatsServiceLogic = new StatsServiceLogic(this, false);
+        mStatsServiceLogic = new StatsServiceLogic(this);
         mStatsServiceLogic.onCreate((WordPress) getApplication());
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -55,6 +55,7 @@ public class StatsService extends Service implements StatsServiceLogic.ServiceCo
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
+        AppLog.i(AppLog.T.STATS, "stats service > task: " + startId + " started");
         EventBus.getDefault().post(new StatsEvents.UpdateStatusStarted(startId));
         mStatsServiceLogic.performTask(intent.getExtras(), Integer.valueOf(startId));
         return START_NOT_STICKY;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -5,8 +5,11 @@ import android.content.Intent;
 import android.os.IBinder;
 
 import org.wordpress.android.WordPress;
+import org.wordpress.android.ui.stats.StatsEvents;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+
+import de.greenrobot.event.EventBus;
 
 
 /**
@@ -33,7 +36,7 @@ public class StatsService extends Service implements StatsServiceLogic.ServiceCo
     public void onCreate() {
         super.onCreate();
         AppLog.i(T.STATS, "stats service created");
-        mStatsServiceLogic = new StatsServiceLogic(this);
+        mStatsServiceLogic = new StatsServiceLogic(this, false);
         mStatsServiceLogic.onCreate((WordPress) getApplication());
     }
 
@@ -51,7 +54,7 @@ public class StatsService extends Service implements StatsServiceLogic.ServiceCo
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        AppLog.i(AppLog.T.STATS, "stats service > task: " + startId + " started");
+        EventBus.getDefault().post(new StatsEvents.UpdateStatusStarted(startId));
         mStatsServiceLogic.performTask(intent.getExtras(), Integer.valueOf(startId));
         return START_NOT_STICKY;
     }
@@ -59,6 +62,7 @@ public class StatsService extends Service implements StatsServiceLogic.ServiceCo
     @Override
     public void onCompleted(Object companion) {
         if (companion instanceof Integer) {
+            EventBus.getDefault().post(new StatsEvents.UpdateStatusFinished((Integer) companion));
             AppLog.i(AppLog.T.STATS, "stats service > task: " + companion + " completed");
             stopSelf((Integer) companion);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -29,6 +29,7 @@ public class StatsService extends Service implements StatsServiceLogic.ServiceCo
     // The number of results to return per page for Paged REST endpoints. Numbers larger than 20 will
     // default to 20 on the server.
     public static final int MAX_RESULTS_REQUESTED_PER_PAGE = 20;
+    public static final int TASK_ID_GROUP_ALL = -2;
 
     private StatsServiceLogic mStatsServiceLogic;
 
@@ -61,8 +62,8 @@ public class StatsService extends Service implements StatsServiceLogic.ServiceCo
 
     @Override
     public void onCompleted(Object companion) {
+        EventBus.getDefault().post(new StatsEvents.UpdateStatusFinished(-2));
         if (companion instanceof Integer) {
-            EventBus.getDefault().post(new StatsEvents.UpdateStatusFinished((Integer) companion));
             AppLog.i(AppLog.T.STATS, "stats service > task: " + companion + " completed");
             stopSelf((Integer) companion);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsServiceLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsServiceLogic.java
@@ -67,7 +67,6 @@ public class StatsServiceLogic {
     private final ThreadPoolExecutor mSingleThreadNetworkHandler = (ThreadPoolExecutor) Executors.newFixedThreadPool(1);
 
     private final ServiceCompletionListener mCompletionListener;
-    private final boolean mSingleTasked;
     private Object mListenerCompanion;
 
 
@@ -224,9 +223,8 @@ public class StatsServiceLogic {
         }
     }
 
-    public StatsServiceLogic(ServiceCompletionListener completionListener, boolean singleTasked) {
+    public StatsServiceLogic(ServiceCompletionListener completionListener) {
         mCompletionListener = completionListener;
-        mSingleTasked = singleTasked;
     }
 
     public void onCreate(WordPress app) {
@@ -613,13 +611,9 @@ public class StatsServiceLogic {
                 mStatsNetworkRequests.remove(req);
             }
 
-            if (!mSingleTasked) {
-                boolean isStillWorking =
-                        mStatsNetworkRequests.size() > 0 || mSingleThreadNetworkHandler.getQueue().size() > 0;
-                if (!isStillWorking) {
-                    stopService();
-                }
-            } else {
+            boolean isStillWorking =
+                    mStatsNetworkRequests.size() > 0 || mSingleThreadNetworkHandler.getQueue().size() > 0;
+            if (!isStillWorking) {
                 stopService();
             }
         }


### PR DESCRIPTION
Coming from https://github.com/wordpress-mobile/WordPress-Android/pull/7617#issuecomment-379583077 and  https://github.com/wordpress-mobile/WordPress-Android/pull/7506#issuecomment-379915796

This is an improvement over the current intermittent PTR spinner, and makes the loading spinning wheel stay for as long as there are scheduled Jobs expected to be finished.

Note: I have seen some glitches while going back and forth from the Stats screen or changing the filter repeatedly, but it should work fine enough for people using the screen normally.

cc @nbradbury 
