### PR TITLE
Issue/7600 crash social response

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '5147680838494249110f9a07b16f4217e5f0a2dc'
+    fluxCVersion = '4399d48b000c6e31b0da33628482c4124e68cf1b'
 }


### PR DESCRIPTION
### Fix
Update FluxC with null checks added in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/773 to resolve the `NullPointerException` described in https://github.com/wordpress-mobile/WordPress-Android/issues/7600.