### PR TITLE
Issue/7629 reader use excerpt

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -20,7 +20,7 @@ import java.util.Locale;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 133;
+    private static final int DB_VERSION = 134;
 
     /*
      * version history
@@ -86,6 +86,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      * 131 - added tbl_posts.card_type
      * 132 - no schema changes, simply clearing to accommodate gallery card_type
      * 133 - no schema changes, simply clearing to accommodate video card_type
+     * 134 - added tbl_posts.use_excerpt
      */
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -76,7 +76,8 @@ public class ReaderPostTable {
             + "tag_name," // 41
             + "tag_type," // 42
             + "has_gap_marker," // 43
-            + "card_type"; // 44
+            + "card_type," // 44
+            + "use_excerpt"; // 45
 
     // used when querying multiple rows and skipping text column
     private static final String COLUMN_NAMES_NO_TEXT =
@@ -122,7 +123,8 @@ public class ReaderPostTable {
             + "tag_name," // 40
             + "tag_type," // 41
             + "has_gap_marker," // 42
-            + "card_type"; // 43
+            + "card_type," // 43
+            + "use_excerpt"; // 44
 
     protected static void createTables(SQLiteDatabase db) {
         db.execSQL("CREATE TABLE tbl_posts ("
@@ -170,6 +172,7 @@ public class ReaderPostTable {
                    + " tag_type INTEGER DEFAULT 0,"
                    + " has_gap_marker INTEGER DEFAULT 0,"
                    + " card_type TEXT,"
+                   + " use_excerpt INTEGER DEFAULT 0,"
                    + " PRIMARY KEY (pseudo_id, tag_name, tag_type)"
                    + ")");
 
@@ -734,7 +737,7 @@ public class ReaderPostTable {
                 "INSERT OR REPLACE INTO tbl_posts ("
                 + COLUMN_NAMES
                 + ") VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,"
-                + "?25,?26,?27,?28,?29,?30,?31,?32,?33,?34,?35,?36,?37,?38,?39,?40,?41,?42,?43,?44)");
+                + "?25,?26,?27,?28,?29,?30,?31,?32,?33,?34,?35,?36,?37,?38,?39,?40,?41,?42,?43,?44, ?45)");
 
         db.beginTransaction();
         try {
@@ -790,6 +793,7 @@ public class ReaderPostTable {
                 stmtPosts.bindLong(42, tagType);
                 stmtPosts.bindLong(43, SqlUtils.boolToSql(hasGapMarker));
                 stmtPosts.bindString(44, ReaderCardType.toString(post.getCardType()));
+                stmtPosts.bindLong(45, SqlUtils.boolToSql(post.useExcerpt));
                 stmtPosts.execute();
             }
 
@@ -993,6 +997,8 @@ public class ReaderPostTable {
 
         post.setRailcarJson(c.getString(c.getColumnIndex("railcar_json")));
         post.setCardType(ReaderCardType.fromString(c.getString(c.getColumnIndex("card_type"))));
+
+        post.useExcerpt = SqlUtils.sqlToBool(c.getColumnIndex("use_excerpt"));
 
         return post;
     }

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -61,6 +61,7 @@ public class ReaderPost {
     public boolean isPrivate;
     public boolean isVideoPress;
     public boolean isJetpack;
+    public boolean useExcerpt;
 
     private String mAttachmentsJson;
     private String mDiscoverJson;
@@ -106,6 +107,7 @@ public class ReaderPost {
         post.isExternal = JSONUtils.getBool(json, "is_external");
         post.isPrivate = JSONUtils.getBool(json, "site_is_private");
         post.isJetpack = JSONUtils.getBool(json, "is_jetpack");
+        post.useExcerpt = JSONUtils.getBool(json, "use_excerpt");
 
         JSONObject jsonDiscussion = json.optJSONObject("discussion");
         if (jsonDiscussion != null) {
@@ -626,10 +628,10 @@ public class ReaderPost {
     }
 
     /*
-     * we should show the excerpt rather than full content for Jetpack posts that have one
+     * we should show the excerpt rather than full content for Jetpack posts that specify to show only the excerpt
      */
     public boolean shouldShowExcerpt() {
-        return isJetpack && hasExcerpt();
+        return isJetpack && useExcerpt;
     }
 
     /*
@@ -661,6 +663,7 @@ public class ReaderPost {
                && post.isFollowedByCurrentUser == this.isFollowedByCurrentUser
                && post.isLikedByCurrentUser == this.isLikedByCurrentUser
                && post.isCommentsOpen == this.isCommentsOpen
+               && post.useExcerpt == this.useExcerpt
                && post.getTitle().equals(this.getTitle())
                && post.getExcerpt().equals(this.getExcerpt())
                && post.getText().equals(this.getText());


### PR DESCRIPTION
Fixes #7629 - the reader now shows the excerpt for Jetpack posts **only** if the `use_excerpt` field of post is true.

To test:

1. On a Jetpack site, go to the reading settings and for the "For each article in a feed, show" setting choose Summary
2. Create a new post that has both full text and an excerpt
3. View that post in the reader and verify the excerpt is showing



