### PR TITLE
Sync analytics opt-out settings with dotcom

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -524,7 +524,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
             AnalyticsTracker.setHasUserOptedOut(hasUserOptedOut);
             // When local and remote prefs are different, force opt out to TRUE
             if (hasUserOptedOut != mAccountStore.getAccount().getTracksOptOut()) {
-                AnalyticsUtils.syncAnalyticsOptionWithWpCom(getContext(), mDispatcher, mAccountStore, true);
+                AnalyticsUtils.updateAnalyticsPreference(getContext(), mDispatcher, mAccountStore, true);
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -10,12 +10,14 @@ import android.content.ComponentCallbacks2;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.net.ConnectivityManager;
 import android.net.http.HttpResponseCache;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
+import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.support.multidex.MultiDexApplication;
 import android.support.v7.app.AppCompatDelegate;
@@ -43,6 +45,7 @@ import org.wordpress.android.analytics.AnalyticsTrackerNosara;
 import org.wordpress.android.datasets.NotificationsTable;
 import org.wordpress.android.datasets.ReaderDatabase;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.generated.ThemeActionBuilder;
@@ -513,6 +516,15 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
             AbstractAppLock appLock = AppLockManager.getInstance().getAppLock();
             if (appLock != null) {
                 appLock.setPassword(null);
+            }
+        }
+        if (!event.isError() && event.causeOfChange == AccountAction.FETCH_SETTINGS && mAccountStore.hasAccessToken()) {
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
+            boolean hasUserOptedOut = !prefs.getBoolean(getString(R.string.pref_key_send_usage), true);
+            AnalyticsTracker.setHasUserOptedOut(hasUserOptedOut);
+            // When local and remote prefs are different, force opt out to TRUE
+            if (hasUserOptedOut != mAccountStore.getAccount().getTracksOptOut()) {
+                AnalyticsUtils.syncAnalyticsOptionWithWpCom(getContext(), mDispatcher, mAccountStore, true);
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -10,19 +10,26 @@ import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceScreen;
+import android.preference.SwitchPreference;
 import android.text.TextUtils;
 import android.util.Pair;
 import android.view.MenuItem;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.LocaleManager;
+import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.util.WPPrefUtils;
 
@@ -52,6 +59,7 @@ public class AppSettingsFragment extends PreferenceFragment
 
     @Inject SiteStore mSiteStore;
     @Inject AccountStore mAccountStore;
+    @Inject Dispatcher mDispatcher;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -68,13 +76,12 @@ public class AppSettingsFragment extends PreferenceFragment
                         if (newValue == null) {
                             return false;
                         }
-                        // flush gathered events (if any)
-                        AnalyticsTracker.flush();
-                        AnalyticsTracker.setHasUserOptedOut(!(boolean) newValue);
+                        synchAnalyticsOption(!(boolean) newValue);
                         return true;
                     }
                 }
                                                                                              );
+        updateAnalyticsSyncOptionUI();
 
         mLanguagePreference = (DetailListPreference) findPreference(getString(R.string.pref_key_language));
         mLanguagePreference.setOnPreferenceChangeListener(this);
@@ -133,12 +140,77 @@ public class AppSettingsFragment extends PreferenceFragment
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        if (NetworkUtils.isNetworkAvailable(getActivity())) {
+            mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        mDispatcher.register(this);
+    }
+
+    @Override
+    public void onStop() {
+        mDispatcher.unregister(this);
+        super.onStop();
+    }
+
+    @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
         updateLanguagePreference(getResources().getConfiguration().locale.toString());
         // flush gathered events (if any)
         AnalyticsTracker.flush();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onAccountChanged(AccountStore.OnAccountChanged event) {
+        if (!isAdded()) {
+            return;
+        }
+
+        if (event.isError()) {
+            switch (event.error.type) {
+                case SETTINGS_FETCH_ERROR:
+                    ToastUtils
+                            .showToast(getActivity(), R.string.error_fetch_account_settings, ToastUtils.Duration.LONG);
+                    break;
+                case SETTINGS_POST_ERROR:
+                    ToastUtils.showToast(getActivity(), R.string.error_post_account_settings, ToastUtils.Duration.LONG);
+                    break;
+            }
+        } else {
+            updateAnalyticsSyncOptionUI();
+        }
+    }
+
+
+    private void updateAnalyticsSyncOptionUI() {
+        SwitchPreference tracksOptOutPreference =
+                (SwitchPreference) findPreference(getString(R.string.pref_key_send_usage));
+        if (mAccountStore.hasAccessToken()) {
+            tracksOptOutPreference.setChecked(!mAccountStore.getAccount().getTracksOptOut());
+        }
+    }
+
+    private void synchAnalyticsOption(boolean optOut) {
+        AnalyticsTracker.setHasUserOptedOut(optOut);
+        if (optOut) {
+            AnalyticsTracker.clearAllData();
+        }
+        if (mAccountStore.hasAccessToken()) {
+            mAccountStore.getAccount().setTracksOptOut(optOut);
+            AccountStore.PushAccountSettingsPayload payload = new AccountStore.PushAccountSettingsPayload();
+            payload.params = new HashMap<>();
+            payload.params.put("tracks_opt_out", optOut);
+            mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -76,12 +76,16 @@ public class AppSettingsFragment extends PreferenceFragment
                         if (newValue == null) {
                             return false;
                         }
-                        synchAnalyticsOption(!(boolean) newValue);
+                        AnalyticsUtils.syncAnalyticsOptionWithWpCom(
+                                getActivity(),
+                                mDispatcher,
+                                mAccountStore,
+                                !(boolean) newValue);
                         return true;
                     }
                 }
                                                                                              );
-        updateAnalyticsSyncOptionUI();
+        updateAnalyticsSyncUI();
 
         mLanguagePreference = (DetailListPreference) findPreference(getString(R.string.pref_key_language));
         mLanguagePreference.setOnPreferenceChangeListener(this);
@@ -185,31 +189,17 @@ public class AppSettingsFragment extends PreferenceFragment
                     ToastUtils.showToast(getActivity(), R.string.error_post_account_settings, ToastUtils.Duration.LONG);
                     break;
             }
-        } else {
-            updateAnalyticsSyncOptionUI();
         }
+        // no need to sync with remote here, or do anything else here, since the logic is already in WordPress.java
+        updateAnalyticsSyncUI();
     }
 
-
-    private void updateAnalyticsSyncOptionUI() {
+    /* Make sure the UI is synced with the backend value */
+    private void updateAnalyticsSyncUI() {
+        if (mAccountStore.hasAccessToken()) {
         SwitchPreference tracksOptOutPreference =
                 (SwitchPreference) findPreference(getString(R.string.pref_key_send_usage));
-        if (mAccountStore.hasAccessToken()) {
             tracksOptOutPreference.setChecked(!mAccountStore.getAccount().getTracksOptOut());
-        }
-    }
-
-    private void synchAnalyticsOption(boolean optOut) {
-        AnalyticsTracker.setHasUserOptedOut(optOut);
-        if (optOut) {
-            AnalyticsTracker.clearAllData();
-        }
-        if (mAccountStore.hasAccessToken()) {
-            mAccountStore.getAccount().setTracksOptOut(optOut);
-            AccountStore.PushAccountSettingsPayload payload = new AccountStore.PushAccountSettingsPayload();
-            payload.params = new HashMap<>();
-            payload.params.put("tracks_opt_out", optOut);
-            mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -22,6 +22,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
@@ -189,13 +190,17 @@ public class AppSettingsFragment extends PreferenceFragment
                     ToastUtils.showToast(getActivity(), R.string.error_post_account_settings, ToastUtils.Duration.LONG);
                     break;
             }
+        } else if (event.causeOfChange == AccountAction.FETCH_SETTINGS) {
+            // no need to sync with remote here, or do anything else here, since the logic is already in WordPress.java
+            updateAnalyticsSyncUI();
         }
-        // no need to sync with remote here, or do anything else here, since the logic is already in WordPress.java
-        updateAnalyticsSyncUI();
     }
 
     /* Make sure the UI is synced with the backend value */
     private void updateAnalyticsSyncUI() {
+        if (!isAdded()) {
+            return;
+        }
         if (mAccountStore.hasAccessToken()) {
         SwitchPreference tracksOptOutPreference =
                 (SwitchPreference) findPreference(getString(R.string.pref_key_send_usage));

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -76,7 +76,7 @@ public class AppSettingsFragment extends PreferenceFragment
                         if (newValue == null) {
                             return false;
                         }
-                        AnalyticsUtils.syncAnalyticsOptionWithWpCom(
+                        AnalyticsUtils.updateAnalyticsPreference(
                                 getActivity(),
                                 mDispatcher,
                                 mAccountStore,

--- a/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
@@ -1,7 +1,9 @@
 package org.wordpress.android.util;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.net.Uri;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.text.Html;
 import android.text.TextUtils;
@@ -9,10 +11,13 @@ import android.webkit.MimeTypeMap;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsMetadata;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTrackerNosara;
 import org.wordpress.android.datasets.ReaderPostTable;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.model.CommentModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
@@ -45,6 +50,28 @@ public class AnalyticsUtils {
     private static final String INTENT_DATA = "intent_data";
     private static final String INTERCEPTED_URI = "intercepted_uri";
     private static final String INTERCEPTOR_CLASSNAME = "interceptor_classname";
+
+    public static void syncAnalyticsOptionWithWpCom(Context ctx,
+                                                    Dispatcher mDispatcher,
+                                                    AccountStore mAccountStore,
+                                                    boolean optOut) {
+        AnalyticsTracker.setHasUserOptedOut(optOut);
+        if (optOut) {
+            AnalyticsTracker.clearAllData();
+        }
+        if (mAccountStore.hasAccessToken()) {
+            mAccountStore.getAccount().setTracksOptOut(optOut);
+            AccountStore.PushAccountSettingsPayload payload = new AccountStore.PushAccountSettingsPayload();
+            payload.params = new HashMap<>();
+            payload.params.put("tracks_opt_out", optOut);
+            mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
+        }
+        // Store the preference locally
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
+        final SharedPreferences.Editor editor = prefs.edit();
+        editor.putBoolean(ctx.getString(R.string.pref_key_send_usage), !optOut);
+        editor.apply();
+    }
 
     /**
      * Utility methods to refresh metadata.

--- a/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
@@ -51,14 +51,15 @@ public class AnalyticsUtils {
     private static final String INTERCEPTED_URI = "intercepted_uri";
     private static final String INTERCEPTOR_CLASSNAME = "interceptor_classname";
 
-    public static void syncAnalyticsOptionWithWpCom(Context ctx,
-                                                    Dispatcher mDispatcher,
-                                                    AccountStore mAccountStore,
-                                                    boolean optOut) {
+    public static void updateAnalyticsPreference(Context ctx,
+                                                 Dispatcher mDispatcher,
+                                                 AccountStore mAccountStore,
+                                                 boolean optOut) {
         AnalyticsTracker.setHasUserOptedOut(optOut);
         if (optOut) {
             AnalyticsTracker.clearAllData();
         }
+        // Sync with wpcom if a token is available
         if (mAccountStore.hasAccessToken()) {
             mAccountStore.getAccount().setTracksOptOut(optOut);
             AccountStore.PushAccountSettingsPayload payload = new AccountStore.PushAccountSettingsPayload();

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '4399d48b000c6e31b0da33628482c4124e68cf1b'
+    fluxCVersion = '4838eea3c6ecdaea1865dcefea882a9c6660af46'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '486fad5468547399d0ebf73edec5e88f689e2196'
+    fluxCVersion = 'e111acd69bc92c65c5f8389549f9524d101e93b7'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '4838eea3c6ecdaea1865dcefea882a9c6660af46'
+    fluxCVersion = '486fad5468547399d0ebf73edec5e88f689e2196'
 }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -320,6 +320,7 @@ public class AnalyticsTrackerNosara extends Tracker {
             return;
         }
         mNosaraClient.clearUserProperties();
+        mNosaraClient.clearQueues();
     }
 
     @Override


### PR DESCRIPTION
Fixes #7523 by synching analytics `opt_out` settings with dotcom backend when needed.

*This PR needs to be reviewed after https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/778*

To test:
- Dotcom REST API Endpoint is available here https://developer.wordpress.com/docs/api/1.1/get/me/settings/ You can query it with cURL `curl GET "https://public-api.wordpress.com/rest/v1.1/me/settings/?pretty=true" -H 'Authorization: Bearer AAAA-REDACTED----AAAA'`.
- Open the app, and check that the value received from FluxC in `WordPress.java->onAccountChanged` is the correct one that's on the server.
- Go to `App settings` and switch the pref.
- Query the backend endpoint with cURL and check the changes are reflected.

**Note:** Copy still needs to be be changed, but we can do that later in a separate PR. I will open a new issue once this is merged.