### PR TITLE
Accept more than 4 segments to cater for `/amp/`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -321,7 +321,7 @@ public class ReaderPostPagerActivity extends AppCompatActivity
 
                 showPost(interceptType, blogIdentifier, postIdentifier);
                 return;
-            } else if (segments.size() == 4) {
+            } else if (segments.size() >= 4) {
                 blogIdentifier = uri.getHost();
                 try {
                     postIdentifier = URLEncoder.encode(segments.get(3), "UTF-8");


### PR DESCRIPTION
Fixes #6604 

To test:
1. With the device connected or the emulator running, issue the following `adb` command:
> adb shell am start -W -a android.intent.action.VIEW -d "https://dailypost.wordpress.com/2018/04/13/first-friday-96/amp/"
2. Notice the app opening on the device/emulator and the Daily Post post opening normally in the Reader