### PR TITLE
Issue/7639 photo picker loses selection

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -785,11 +785,10 @@ public class EditPostActivity extends AppCompatActivity implements
         // size the picker before creating the fragment to avoid having it load media now
         resizePhotoPicker();
 
-        MediaBrowserType mediaBrowserType =
-                mShowAztecEditor ? MediaBrowserType.AZTEC_EDITOR_PICKER : MediaBrowserType.EDITOR_PICKER;
-
         mPhotoPickerFragment = (PhotoPickerFragment) getFragmentManager().findFragmentByTag(PHOTO_PICKER_TAG);
         if (mPhotoPickerFragment == null) {
+            MediaBrowserType mediaBrowserType =
+                    mShowAztecEditor ? MediaBrowserType.AZTEC_EDITOR_PICKER : MediaBrowserType.EDITOR_PICKER;
             mPhotoPickerFragment = PhotoPickerFragment.newInstance(this, mediaBrowserType, getSite());
             getFragmentManager()
                     .beginTransaction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -788,12 +788,14 @@ public class EditPostActivity extends AppCompatActivity implements
         MediaBrowserType mediaBrowserType =
                 mShowAztecEditor ? MediaBrowserType.AZTEC_EDITOR_PICKER : MediaBrowserType.EDITOR_PICKER;
 
-        mPhotoPickerFragment = PhotoPickerFragment.newInstance(this, mediaBrowserType, getSite());
-
-        getFragmentManager()
-                .beginTransaction()
-                .add(R.id.photo_fragment_container, mPhotoPickerFragment, PHOTO_PICKER_TAG)
-                .commit();
+        mPhotoPickerFragment = (PhotoPickerFragment) getFragmentManager().findFragmentByTag(PHOTO_PICKER_TAG);
+        if (mPhotoPickerFragment == null) {
+            mPhotoPickerFragment = PhotoPickerFragment.newInstance(this, mediaBrowserType, getSite());
+            getFragmentManager()
+                    .beginTransaction()
+                    .add(R.id.photo_fragment_container, mPhotoPickerFragment, PHOTO_PICKER_TAG)
+                    .commit();
+        }
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1035,6 +1035,8 @@ public class EditPostActivity extends AppCompatActivity implements
             }
             mViewPager.setCurrentItem(PAGE_CONTENT);
             invalidateOptionsMenu();
+        } else if (isPhotoPickerShowing()) {
+            hidePhotoPicker();
         } else {
             savePostAndOptionallyFinish(true);
         }
@@ -1044,13 +1046,13 @@ public class EditPostActivity extends AppCompatActivity implements
     // Menu actions
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
-        hidePhotoPicker();
-
         int itemId = item.getItemId();
 
         if (itemId == android.R.id.home) {
             return handleBackPressed();
         }
+
+        hidePhotoPicker();
 
         if (itemId == R.id.menu_save_post) {
             if (!AppPrefs.isAsyncPromoRequired()) {
@@ -1420,11 +1422,6 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onBackPressed() {
-        if (isPhotoPickerShowing()) {
-            hidePhotoPicker();
-            return;
-        }
-
         handleBackPressed();
     }
 


### PR DESCRIPTION
Fixes #7639 - as @hypest noticed [here](https://github.com/wordpress-mobile/WordPress-Android/pull/7589#issuecomment-381061526), if you select photos to add to a post then rotate the device, the selection is lost.

This PR fixes that problem, and addresses a related problem where tapping the back button when the photo picker is showing causes the activity to finish (whereas it should just close the picker).