### PR TITLE
issue/7636-reader-youtube

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -78,19 +78,23 @@ class ReaderPostRenderer {
             @Override
             public void run() {
                 final boolean hasTiledGallery = hasTiledGallery(mRenderBuilder.toString());
-                String content = mRenderBuilder.toString();
 
                 if (!(hasTiledGallery && mResourceVars.mIsWideDisplay)) {
-                    resizeImages(content);
+                    resizeImages();
                 }
 
-                resizeIframes(content);
+                resizeIframes();
 
                 // Get the set of JS scripts to inject in our Webview to support some specific Embeds.
-                Set<String> jsToInject = injectJSForSpecificEmbedSupport(content);
+                Set<String> jsToInject = injectJSForSpecificEmbedSupport();
 
                 final String htmlContent =
-                        formatPostContentForWebView(content, jsToInject, hasTiledGallery, mResourceVars.mIsWideDisplay);
+                        formatPostContentForWebView(
+                                mRenderBuilder.toString(),
+                                jsToInject,
+                                hasTiledGallery,
+                                mResourceVars.mIsWideDisplay);
+
                 mRenderBuilder = null;
                 handler.post(new Runnable() {
                     @Override
@@ -110,7 +114,7 @@ class ReaderPostRenderer {
     /*
      * scan the content for images and make sure they're correctly sized for the device
      */
-    private void resizeImages(String content) {
+    private void resizeImages() {
         ReaderHtmlUtils.HtmlScannerListener imageListener = new ReaderHtmlUtils.HtmlScannerListener() {
             @Override
             public void onTagFound(String imageTag, String imageUrl) {
@@ -119,6 +123,7 @@ class ReaderPostRenderer {
                 }
             }
         };
+        String content = mRenderBuilder.toString();
         ReaderImageScanner scanner = new ReaderImageScanner(content, mPost.isPrivate);
         scanner.beginScan(imageListener);
     }
@@ -126,18 +131,19 @@ class ReaderPostRenderer {
     /*
      * scan the content for iframes and make sure they're correctly sized for the device
      */
-    private void resizeIframes(String content) {
+    private void resizeIframes() {
         ReaderHtmlUtils.HtmlScannerListener iframeListener = new ReaderHtmlUtils.HtmlScannerListener() {
             @Override
             public void onTagFound(String tag, String src) {
                 replaceIframeTag(tag, src);
             }
         };
+        String content = mRenderBuilder.toString();
         ReaderIframeScanner scanner = new ReaderIframeScanner(content);
         scanner.beginScan(iframeListener);
     }
 
-    private Set<String> injectJSForSpecificEmbedSupport(String content) {
+    private Set<String> injectJSForSpecificEmbedSupport() {
         final Set<String> jsToInject = new HashSet<>();
         ReaderHtmlUtils.HtmlScannerListener embedListener = new ReaderHtmlUtils.HtmlScannerListener() {
             @Override
@@ -145,6 +151,7 @@ class ReaderPostRenderer {
                 jsToInject.add(src);
             }
         };
+        String content = mRenderBuilder.toString();
         ReaderEmbedScanner scanner = new ReaderEmbedScanner(content);
         scanner.beginScan(embedListener);
         return jsToInject;


### PR DESCRIPTION
Fixes #7636 - previously YouTube videos would appear cut off in the reader (they were actually displaying wider than the screen, so they were horizontally scrollable).

The problem was caused by operating on a copy of the post's content rather than the internal rendered copy of it (hard to explain, but it should be clear from looking at the code).

To test:
* Add "YouTube" as a tag in the reader
* Browse around until you see an obvious YouTube video and ensure it fits the space in the detail view
Screenshots below, one on a phone the other a tablet, showing the fix.

![screenshot_1523907412](https://user-images.githubusercontent.com/3903757/38831390-33ca3636-418d-11e8-912d-4b077e978d18.png)

![screenshot_1523907321](https://user-images.githubusercontent.com/3903757/38831395-36e6a606-418d-11e8-9427-eae06b956ea1.png)

Aside: note that the video may not play well, or at all, in an emulator.

