### PR TITLE
Fix issue with Reader Photo Viewer after rotation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerActivity.java
@@ -1,13 +1,14 @@
 package org.wordpress.android.ui.reader;
 
-import android.app.Fragment;
-import android.app.FragmentManager;
+
 import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
-import android.support.v13.app.FragmentStatePagerAdapter;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentStatePagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -108,10 +109,7 @@ public class ReaderPhotoViewerActivity extends AppCompatActivity
             imageList = new ReaderImageScanner(mContent, mIsPrivate).getImageList(0, minImageWidth);
         }
 
-        // make sure initial image is in the list
-        if (!TextUtils.isEmpty(mInitialImageUrl) && !imageList.hasImageUrl(mInitialImageUrl)) {
-            imageList.addImageUrl(0, mInitialImageUrl);
-        }
+        imageList.addImageUrl(0, mInitialImageUrl);
 
         getAdapter().setImageList(imageList, mInitialImageUrl);
     }
@@ -177,7 +175,7 @@ public class ReaderPhotoViewerActivity extends AppCompatActivity
 
     private PhotoPagerAdapter getAdapter() {
         if (mAdapter == null) {
-            mAdapter = new PhotoPagerAdapter(getFragmentManager());
+            mAdapter = new PhotoPagerAdapter(getSupportFragmentManager());
         }
         return mAdapter;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerActivity.java
@@ -109,7 +109,9 @@ public class ReaderPhotoViewerActivity extends AppCompatActivity
             imageList = new ReaderImageScanner(mContent, mIsPrivate).getImageList(0, minImageWidth);
         }
 
-        imageList.addImageUrl(0, mInitialImageUrl);
+        if (!TextUtils.isEmpty(mInitialImageUrl)) {
+            imageList.addImageUrl(0, mInitialImageUrl);
+        }
 
         getAdapter().setImageList(imageList, mInitialImageUrl);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerFragment.java
@@ -1,9 +1,9 @@
 package org.wordpress.android.ui.reader;
 
 import android.app.Activity;
-import android.app.Fragment;
 import android.graphics.Point;
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;


### PR DESCRIPTION
Fixes #7624 - Reader image viewer starts from the beginning on rotation

To test:

1. In the Reader, open a post with more than one photos
2. Tap on the first photo. The embedded image viewer is launched and the photo is displayed full-screen
3. Swipe to move to the second photo
4. Rotate the device
5. The image viewer show the second photo

I also updated the code to use support library fragments because there were some deprecated methods such as **restoreState()** and **getItem()** in **PhotoPagerAdapter**