### PR TITLE
Show delete confirmation message according of the type of Post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -551,11 +551,18 @@ public class PostsListFragment extends Fragment
             case PostListButton.BUTTON_TRASH:
             case PostListButton.BUTTON_DELETE:
                 if (!UploadService.isPostUploadingOrQueued(post)) {
+                    String message = post.isPage() ? getString(R.string.dialog_confirm_delete_page)
+                            : getString(R.string.dialog_confirm_delete_post);
+
+                    if (post.isLocalDraft()) {
+                        message = post.isPage() ? getString(R.string.dialog_confirm_delete_permanently_page)
+                                : getString(R.string.dialog_confirm_delete_permanently_post);
+                    }
+
                     AlertDialog.Builder builder = new AlertDialog.Builder(
                             new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
                     builder.setTitle(post.isPage() ? getString(R.string.delete_page) : getString(R.string.delete_post))
-                            .setMessage(post.isPage() ? getString(R.string.dialog_confirm_delete_page)
-                                                : getString(R.string.dialog_confirm_delete_post))
+                            .setMessage(message)
                             .setPositiveButton(R.string.delete, new DialogInterface.OnClickListener() {
                                 @Override
                                 public void onClick(DialogInterface dialogInterface, int i) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -301,6 +301,8 @@
     <string name="dialog_confirm_publish_message_post">This post will be published immediately.</string>
     <string name="dialog_confirm_publish_message_page">This page will be published immediately.</string>
     <string name="dialog_confirm_publish_yes">Publish now</string>
+    <string name="dialog_confirm_delete_permanently_post">Are you sure you\'d like to permanently delete this post?</string>
+    <string name="dialog_confirm_delete_permanently_page">Are you sure you\'d like to permanently delete this page?</string>
 
     <!-- reload drop down -->
     <string name="loading">Loading…</string>


### PR DESCRIPTION
Fixes #7493 - Posts: Use different confirmation message when deleting local drafts

**CASE A:**

1. Take your device offline (e.g. airplane mode).
2. Go to Posts list
3. try to trash/delete a Post by tapping on the Trash/delete action icon on the right-bottom corner of the post's card within the list.
4. see the confirmation dialog appear.

![screenshot_1524067446](https://user-images.githubusercontent.com/2581647/38944202-4b12bc6c-4301-11e8-9f98-a87a0f4693e9.png)


**CASE B:**

1. Take your device online
2. Go to Posts list
3. try to trash/delete a Post by tapping on the Trash/delete action icon on the right-bottom corner of the post's card within the list.
4. see the confirmation dialog appear.

![screenshot_1524067425](https://user-images.githubusercontent.com/2581647/38944225-601db4e0-4301-11e8-8524-e988a59a4c13.png)

Do the same test (A and B) going to **Pages list**

cc @theck13 @nbradbury