### PR TITLE
Awesome accessibility lint

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -178,7 +178,7 @@ dependencies {
         exclude group: 'com.github.bumptech.glide'
     }
 
-    lintChecks 'org.wordpress:lint:1.0.0'
+    lintChecks 'org.wordpress:lint:1.0.1'
 
     // Debug
     debugImplementation 'com.facebook.stetho:stetho:1.4.2'

--- a/WordPress/lint.xml
+++ b/WordPress/lint.xml
@@ -61,11 +61,16 @@
     <issue id="RelativeOverlap" severity="error" />
     <issue id="PrivateResource" severity="error" />
     <issue id="StaticFieldLeak" severity="error" />
+    <issue id="ContentDescription" severity="error" />
+    <issue id="ClickableViewAccessibility" severity="error" />
+    <issue id="KeyboardInaccessibleWidget" severity="error" />
 
     <!-- IGNORE -->
     <issue id="MissingTranslation" severity="ignore" />
     <issue id="ExtraTranslation" severity="ignore" />
     <issue id="PluralsCandidate" severity="ignore" /> <!-- GlotPress doesn't support plurals -->
+    <issue id="LabelFor" severity="ignore" /> <!-- Severity should be increased to error when minSdk >= 17 -->
+    <issue id="OldTargetApi" severity="ignore" /> <!-- We are aware of down sides of having an old targetApi -->
 
     <issue id="InvalidPackage">
         <ignore regexp="okio-1.9.0.jar" />

--- a/WordPress/src/main/res/layout/stock_media_picker_activity.xml
+++ b/WordPress/src/main/res/layout/stock_media_picker_activity.xml
@@ -52,6 +52,7 @@
                 android:layout_height="100dp"
                 android:layout_gravity="center_horizontal"
                 android:layout_marginBottom="@dimen/margin_large"
+                android:importantForAccessibility="no"
                 app:srcCompat="@drawable/ic_stock_media"/>
 
             <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/stock_media_picker_thumbnail.xml
+++ b/WordPress/src/main/res/layout/stock_media_picker_thumbnail.xml
@@ -27,6 +27,7 @@
         android:includeFontPadding="false"
         android:textColor="@color/white"
         android:textSize="@dimen/text_sz_small"
-        tools:text="5" />
+        tools:text="5"
+        tools:ignore="UnusedAttribute"/>
 
 </FrameLayout>

--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'com.automattic:tracks:1.1.4'
     implementation 'org.wordpress:utils:1.19.0'
 
-    lintChecks 'org.wordpress:lint:1.0.0'
+    lintChecks 'org.wordpress:lint:1.0.1'
 }
 
 android {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 
     implementation 'com.google.code.gson:gson:2.6.+'
 
-    lintChecks 'org.wordpress:lint:1.0.0'
+    lintChecks 'org.wordpress:lint:1.0.1'
 }
 
 signing {

--- a/libs/editor/WordPressEditor/src/main/res/layout/alert_image_options.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/alert_image_options.xml
@@ -46,7 +46,8 @@
             android:layout_height="wrap_content"
             android:text="@string/width"
             android:textStyle="bold"
-            android:textColor="@color/image_options_label"/>
+            android:textColor="@color/image_options_label"
+            android:labelFor="@+id/imageWidthText"/>
 
         <SeekBar
             android:layout_height="wrap_content"

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     implementation 'com.google.dagger:dagger-android-support:2.11'
     annotationProcessor 'com.google.dagger:dagger-android-processor:2.11'
 
-    lintChecks 'org.wordpress:lint:1.0.0'
+    lintChecks 'org.wordpress:lint:1.0.1'
 }
 
 // Add properties named "wp.xxx" to our BuildConfig

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'org.wordpress:utils:1.18.1'
     implementation 'com.automattic:rest:1.0.7'
 
-    lintChecks 'org.wordpress:lint:1.0.0'
+    lintChecks 'org.wordpress:lint:1.0.1'
 }
 
 uploadArchives {

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation 'com.android.support:recyclerview-v7:27.1.0'
     implementation 'org.greenrobot:eventbus:3.0.0'
 
-    lintChecks 'org.wordpress:lint:1.0.0'
+    lintChecks 'org.wordpress:lint:1.0.1'
 }
 
 android {


### PR DESCRIPTION
- Updates version of WordPress-Android-lint library
- Increases severity of some accessibility related lint issues
- Fixes few minor accessibility related issues

Note:
- I've disabled lint check for "LabelFor" as it wants us to fix minor issue on API 16 which might not be supported for much longer. We should increase the severity to an error as soon as the minSdkVersion is increased.

- WordPress-Android-Lint v1.0.1 is not released yet - it'll be released as soon as a PR with version update is merged.
