### PR TITLE
Correctly displaying Gutenberg posts

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -542,6 +542,25 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         mAztecReady = true;
     }
 
+    /*
+        Note the way we detect we're in presence of Gutenberg blocks logic is taken from
+        https://github.com/WordPress/gutenberg/blob/5a6693589285363341bebad15bd56d9371cf8ecc/lib/register.php#L331-L345
+
+        * Determine whether a content string contains blocks. This test optimizes for
+        * performance rather than strict accuracy, detecting the pattern of a block
+        * but not validating its structure. For strict accuracy, you should use the
+        * block parser on post content.
+        *
+        * @since 1.6.0
+        * @see gutenberg_parse_blocks()
+        *
+        * @param string $content Content to test.
+        * @return bool Whether the content contains blocks.
+
+        function gutenberg_content_has_blocks( $content ) {
+            return false !== strpos( $content, '<!-- wp:' );
+        }
+     */
     private boolean contentContainsGutenbergBlocks(String postContent) {
         return (postContent != null && postContent.contains(GUTENBERG_BLOCK_START));
     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -83,6 +83,7 @@ import org.wordpress.aztec.plugins.shortcodes.VideoShortcodePlugin;
 import org.wordpress.aztec.plugins.shortcodes.extensions.CaptionExtensionsKt;
 import org.wordpress.aztec.plugins.shortcodes.extensions.VideoPressExtensionsKt;
 import org.wordpress.aztec.plugins.wpcomments.CommentsTextFormat;
+import org.wordpress.aztec.plugins.wpcomments.HiddenGutenbergPlugin;
 import org.wordpress.aztec.plugins.wpcomments.WordPressCommentsPlugin;
 import org.wordpress.aztec.plugins.wpcomments.toolbar.MoreToolbarButton;
 import org.wordpress.aztec.source.Format;
@@ -134,6 +135,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     private static final String ATTR_SIZE_DASH = "size-";
     private static final String TEMP_IMAGE_ID = "data-temp-aztec-id";
     private static final String TEMP_VIDEO_UPLOADING_CLASS = "data-temp-aztec-video";
+    private static final String GUTENBERG_BLOCK_START = "<!-- wp:";
 
     private static final int MIN_BITMAP_DIMENSION_DP = 48;
     public static final int DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP = 196;
@@ -331,6 +333,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 .addPlugin(new CaptionShortcodePlugin(mContent))
                 .addPlugin(new VideoShortcodePlugin())
                 .addPlugin(new AudioShortcodePlugin())
+                .addPlugin(new HiddenGutenbergPlugin())
                 .addPlugin(mediaToolbarGalleryButton)
                 .addPlugin(mediaToolbarCameraButton)
                 .addPlugin(mediaToolbarLibraryButton);
@@ -519,15 +522,28 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             text = "";
         }
 
-        if (mContent == null) {
+        if (mContent == null || mSource == null) {
             return;
         }
 
-        mContent.fromHtml(removeVisualEditorProgressTag(text.toString()));
+        String postContent = removeVisualEditorProgressTag(text.toString());
+        if (contentContainsGutenbergBlocks(postContent)) {
+            mContent.setCalypsoMode(false);
+            mSource.setCalypsoMode(false);
+        } else {
+            mContent.setCalypsoMode(true);
+            mSource.setCalypsoMode(true);
+        }
+
+        mContent.fromHtml(postContent);
 
         updateFailedAndUploadingMedia();
 
         mAztecReady = true;
+    }
+
+    private boolean contentContainsGutenbergBlocks(String postContent){
+        return (postContent != null && postContent.contains(GUTENBERG_BLOCK_START));
     }
 
     /*

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -542,7 +542,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         mAztecReady = true;
     }
 
-    private boolean contentContainsGutenbergBlocks(String postContent){
+    private boolean contentContainsGutenbergBlocks(String postContent) {
         return (postContent != null && postContent.contains(GUTENBERG_BLOCK_START));
     }
 


### PR DESCRIPTION
This PR fixes the fact that Gutenberg posts were not being displayed correctly, as the recently added `HiddenGutenberg` plugin was not enabled in WPAndroid.

Also, we're setting Calypso mode to `false` when we're detecting the presence of a Gutenberg post content.

Note the way we detect we're in presence of Gutenberg blocks logic is taken from https://github.com/WordPress/gutenberg/blob/5a6693589285363341bebad15bd56d9371cf8ecc/lib/register.php#L331-L345

To test:
1. write a post on Gutenberg (web)
2. open the post in the app
3. observe there are no Gutenberg block delimiters being shown as part of the content in the post, and the post is being formatted correctly.

cc @daniloercoli / @0nko for code review

### TECHNICAL NOTE
This PR only tackles a part of the problem (displaying the Post). Another thing that is happening, is that Gutenberg (not sure since when, but tested at least in 2.7.0) is adding `class` modifiers to some of the html tags belonging to the content between block delimiters, for example:

```
<!-- wp:separator -->
<hr class="wp-block-separator" />
<!-- /wp:separator -->
```

and

```
<!-- wp:quote -->
<blockquote class="wp-block-quote">
    <p>bla bla bla bla this is a quote.</p>
</blockquote>
<!-- /wp:quote -->
```

These `class` modifiers are somehow lost by Aztec in the process of converting the post content to Aztec spans and bringing it back to html. 
_[technical aside, for future reference: AztecText's toHtml() calls toPlainHtml() which in turns serves itself of AztecParser's toHtml() method. This one finally makes a call to withinHtml to reconstruct the HTML out of the present spans, where the information about `class` modifiers is just not present (as it has not been saved when converting from html to Aztec spans in the visual editor).]_

<img width="307" alt="screen shot 2018-04-25 at 22 44 32" src="https://user-images.githubusercontent.com/6597771/39281339-690864fe-48da-11e8-8f9b-336d00a244e2.png">


In practical terms, this means that _**as soon as you exit the editor, the original content as compared to the reconstructed content differ, and WPAndroid determines the content has been modified, thus updating the Post content and breaking these particular blocks.**_


### Consideration on how to tackle this problem

I request your feedback on this: I believe the work involved in keeping up with these modifiers as described in the previous section exceeds this particular PR, and maybe also the direction in which we're working to support Gutenberg in the mobile apps, and therefore I think the best way to handle it for now is by adding a dialog that warns the user that they're about to open a Gutenberg post, as has been discussed on Slack with @koke @diegoreymendez @elibud and @iamthomasbishop (who is working on a flow for this). If the user chooses to continue, they can perfectly edit the Post as usual, but they should know that they will get a warning on the Gutenberg editor when they upload their post back to the server.

To complete the picture, this is what they'll see on the web editor (Gutenberg) once they re-open the same Post after having opened it in Aztec:

![gutenbergblock](https://user-images.githubusercontent.com/6597771/39281237-014ff82c-48da-11e8-9193-877f774bc7e4.gif)

OTOH my judgment is, if we choose to try and support "saving" the class modifiers, we will invariably have to keep up with new modifiers every time a new change is made in Gutenberg, and thus the effort is probably not worth it given we already are working on a Gutenberg-compatible editor for the mobile apps themselves.

Open to discussing this further.

 