### PR TITLE
Issue/jetpack connect notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -98,12 +98,12 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.notifications_fragment_notes_list, container, false);
 
-        mRecyclerView = (RecyclerView) view.findViewById(R.id.recycler_view_notes);
+        mRecyclerView = view.findViewById(R.id.recycler_view_notes);
 
-        mFilterRadioGroup = (RadioGroup) view.findViewById(R.id.notifications_radio_group);
+        mFilterRadioGroup = view.findViewById(R.id.notifications_radio_group);
         mFilterRadioGroup.setOnCheckedChangeListener(this);
         mFilterContainer = view.findViewById(R.id.notifications_filter_container);
-        mEmptyView = (ViewGroup) view.findViewById(R.id.empty_view);
+        mEmptyView = view.findViewById(R.id.empty_view);
         mConnectJetpackView = view.findViewById(R.id.connect_jetpack);
         mFilterView = view.findViewById(R.id.notifications_filter);
 
@@ -119,7 +119,7 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
                         fetchNotesFromRemote();
                     }
                 }
-                                                         );
+            );
 
         // bar that appears at bottom after new notes are received and the user is on this screen
         mNewNotificationsBar = view.findViewById(R.id.layout_new_notificatons);
@@ -314,14 +314,14 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
             setFilterViewScrollable(false);
             ((TextView) mEmptyView.findViewById(R.id.text_empty)).setText(titleResId);
 
-            TextView descriptionTextView = (TextView) mEmptyView.findViewById(R.id.text_empty_description);
+            TextView descriptionTextView = mEmptyView.findViewById(R.id.text_empty_description);
             if (descriptionResId != 0) {
                 descriptionTextView.setText(descriptionResId);
             } else {
                 descriptionTextView.setVisibility(View.GONE);
             }
 
-            TextView btnAction = (TextView) mEmptyView.findViewById(R.id.button_empty_action);
+            TextView btnAction = mEmptyView.findViewById(R.id.button_empty_action);
             if (buttonResId != 0) {
                 btnAction.setText(buttonResId);
                 btnAction.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -309,7 +309,6 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
     private void showEmptyView(@StringRes int titleResId, @StringRes int descriptionResId, @StringRes int buttonResId) {
         if (isAdded() && mEmptyView != null) {
             mEmptyView.setVisibility(View.VISIBLE);
-            mFilterContainer.setVisibility(View.GONE);
             mRecyclerView.setVisibility(View.GONE);
             mConnectJetpackView.setVisibility(View.GONE);
             setFilterViewScrollable(false);
@@ -378,7 +377,6 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
             setFilterViewScrollable(true);
             mEmptyView.setVisibility(View.GONE);
             mConnectJetpackView.setVisibility(View.GONE);
-            mFilterContainer.setVisibility(View.VISIBLE);
             mRecyclerView.setVisibility(View.VISIBLE);
         }
     }

--- a/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
@@ -215,7 +215,9 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:visibility="invisible"
+        tools:visibility="visible" >
 
         <android.support.v4.widget.NestedScrollView
             android:layout_width="match_parent"


### PR DESCRIPTION
### Fix
Remove notifications list filter view visibility toggling when hiding and showing the empty view on the ***Notifications*** tab.  The filter view is only to be hidden when the Jetpack connect view is shown.  Add the Jetpack connect view visibility to be invisible by default to avoid quickly showing the view when resuming the app.

### Test
#### WordPress.com
0. Log in with WordPress.com account.
1. Go to ***Notifications*** tab.
2. Tap ***Unread*** filter.
3. Notice empty view is shown.
4. Notice filter view is shown.
5. Exit app.
6. Resume app.
7. Notice Jetpack connect view is not shown.

#### WordPress.org
0. Log in with self-hosted site only.
1. Go to ***Notifications*** tab.
2. Notice Jetpack connect view is shown.
3. Notice filter view is not shown.