### PR TITLE
Setup unit tests - Add mockito, kotlin support and support of final classes

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -121,6 +121,12 @@ dependencies {
     // ViewModel and LiveData
     implementation 'android.arch.lifecycle:extensions:1.1.0'
 
+    testCompile("android.arch.core:core-testing:1.1.0", {
+        exclude group: 'com.android.support', module: 'support-compat'
+        exclude group: 'com.android.support', module: 'support-annotations'
+        exclude group: 'com.android.support', module: 'support-core-utils'
+    })
+
     implementation 'com.google.android.gms:play-services-gcm:12.0.1'
     implementation 'com.google.android.gms:play-services-auth:12.0.1'
     implementation 'com.google.android.gms:play-services-places:12.0.1'
@@ -146,6 +152,8 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.6.1'
     testImplementation 'org.robolectric:shadows-multidex:3.6.1'
+    testImplementation 'org.mockito:mockito-core:2.8.9'
+    testImplementation 'com.nhaarman:mockito-kotlin:1.5.0'
 
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.0'
     androidTestImplementation 'org.objenesis:objenesis:2.1'

--- a/WordPress/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/WordPress/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This allows us to unit test LiveData and Kotlin ViewModels with injected final classes (all Kotlin classes are by default final). 

- add mockito for unit testing 
- add kotlin mockito for unit testing of kotlin code
- add MockMaker to enable mocking of final (kotlin) classes
- add support testing libraries to test view models