### PR TITLE
Add Stetho network interceptor

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -181,7 +181,8 @@ dependencies {
     lintChecks 'org.wordpress:lint:1.0.0'
 
     // Debug
-    debugImplementation 'com.facebook.stetho:stetho:1.4.2'
+    debugImplementation 'com.facebook.stetho:stetho:1.5.0'
+    debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.5.0'
 }
 
 configurations.all {

--- a/WordPress/src/debug/java/org/wordpress/android/WordPressDebug.java
+++ b/WordPress/src/debug/java/org/wordpress/android/WordPressDebug.java
@@ -4,6 +4,7 @@ import android.os.StrictMode;
 
 import com.facebook.stetho.Stetho;
 
+import org.wordpress.android.modules.DaggerAppComponentDebug;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -13,6 +14,13 @@ public class WordPressDebug extends WordPress {
         super.onCreate();
         // enableStrictMode()
         Stetho.initializeWithDefaults(this);
+    }
+
+    @Override
+    protected void initDaggerComponent() {
+        mAppComponent = DaggerAppComponentDebug.builder()
+                                               .application(this)
+                                               .build();
     }
 
     /**

--- a/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
+++ b/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
@@ -1,0 +1,41 @@
+package org.wordpress.android.modules;
+
+import android.app.Application;
+
+import org.wordpress.android.fluxc.module.ReleaseBaseModule;
+import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
+import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule;
+import org.wordpress.android.fluxc.module.ReleaseToolsModule;
+import org.wordpress.android.login.di.LoginFragmentModule;
+import org.wordpress.android.login.di.LoginServiceModule;
+
+import javax.inject.Singleton;
+
+import dagger.BindsInstance;
+import dagger.Component;
+import dagger.android.support.AndroidSupportInjectionModule;
+
+@Singleton
+@Component(modules = {
+        ApplicationModule.class,
+        AppSecretsModule.class,
+        ReleaseBaseModule.class,
+        ReleaseOkHttpClientModule.class,
+        ReleaseNetworkModule.class,
+        LegacyModule.class,
+        ReleaseToolsModule.class,
+        AndroidSupportInjectionModule.class,
+        ViewModelModule.class,
+        // Login flow library
+        LoginAnalyticsModule.class,
+        LoginFragmentModule.class,
+        LoginServiceModule.class
+})
+public interface AppComponentDebug extends AppComponent {
+    @Component.Builder
+    interface Builder extends AppComponent.Builder {
+        @Override
+        @BindsInstance
+        AppComponentDebug.Builder application(Application application);
+    }
+}

--- a/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
+++ b/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
@@ -2,9 +2,9 @@ package org.wordpress.android.modules;
 
 import android.app.Application;
 
+import org.wordpress.android.fluxc.module.DebugOkHttpClientModule;
 import org.wordpress.android.fluxc.module.ReleaseBaseModule;
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
-import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule;
 import org.wordpress.android.fluxc.module.ReleaseToolsModule;
 import org.wordpress.android.login.di.LoginFragmentModule;
 import org.wordpress.android.login.di.LoginServiceModule;
@@ -20,7 +20,8 @@ import dagger.android.support.AndroidSupportInjectionModule;
         ApplicationModule.class,
         AppSecretsModule.class,
         ReleaseBaseModule.class,
-        ReleaseOkHttpClientModule.class,
+        DebugOkHttpClientModule.class,
+        InterceptorModule.class,
         ReleaseNetworkModule.class,
         LegacyModule.class,
         ReleaseToolsModule.class,

--- a/WordPress/src/debug/java/org/wordpress/android/modules/InterceptorModule.java
+++ b/WordPress/src/debug/java/org/wordpress/android/modules/InterceptorModule.java
@@ -1,0 +1,15 @@
+package org.wordpress.android.modules;
+
+import com.facebook.stetho.okhttp3.StethoInterceptor;
+
+import dagger.Module;
+import dagger.Provides;
+import okhttp3.Interceptor;
+
+@Module
+public class InterceptorModule {
+    @Provides
+    public Interceptor provideNetworkInterceptor() {
+        return new StethoInterceptor();
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -144,7 +144,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
     @Inject OAuthAuthenticator mOAuthAuthenticator;
     public static OAuthAuthenticator sOAuthAuthenticator;
 
-    private AppComponent mAppComponent;
+    protected AppComponent mAppComponent;
 
     public AppComponent component() {
         return mAppComponent;
@@ -220,9 +220,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         WellSql.init(new WellSqlConfig(getApplicationContext()));
 
         // Init Dagger
-        mAppComponent = DaggerAppComponent.builder()
-                                          .application(this)
-                                          .build();
+        initDaggerComponent();
         component().inject(this);
         mDispatcher.register(this);
 
@@ -309,6 +307,12 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
                 .addApi(Auth.CREDENTIALS_API)
                 .build();
         mCredentialsClient.connect();
+    }
+
+    protected void initDaggerComponent() {
+        mAppComponent = DaggerAppComponent.builder()
+                                          .application(this)
+                                          .build();
     }
 
     private void disableRtlLayoutDirectionOnSdk17() {


### PR DESCRIPTION
We've already been using [Stetho](http://facebook.github.io/stetho/) in this project for UI and storage/DB inspection - this PR also hooks up Stetho's network interceptor to debug builds.

To use Stetho's network view, run the debug WordPress app and visit `chrome://inspect` in desktop Chrome. You should see the app in the list (e.g. `WordPress Beta (powered by Stetho)`). Open that, visit the 'Network' tab, and any network calls in the app will show up there.

cc @malinajirka @planarvoid 