### PR TITLE
gradle change pointing to fix in <hr/> tags in AztecEditor lib

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -53,9 +53,9 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'org.wordpress:utils:1.18.1'
 
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.2')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.3.2')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.3.2')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:649fc4dbc9eaa0886de48d8065dae86f10131dd1')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:649fc4dbc9eaa0886de48d8065dae86f10131dd1')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:649fc4dbc9eaa0886de48d8065dae86f10131dd1')
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.1.4"


### PR DESCRIPTION
**IMPORTANT:**  needs https://github.com/wordpress-mobile/AztecEditor-Android/pull/661 to be merged first.

Fixes an annoying bug that would break Gutenberg posts containing `<hr>`  tags.

See https://github.com/wordpress-mobile/AztecEditor-Android/pull/661 for more information

To test:
1. on the web, open Gutenberg and write some text, and also insert a line (ruler). Content in html editor should look like this:
```
<!-- wp:separator -->
<hr class="wp-block-separator" />
 <!-- /wp:separator -->
```
2. save the draft and open it on the mobile app
3. exit the editor
4. observe the same draft on Gutenberg and make sure nothing is broken.


