### PR TITLE
Analytics: Log tracks to the console. Highlight with dot.

### DIFF
--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -8,6 +8,7 @@ import com.automattic.android.tracks.TracksClient;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -279,10 +280,11 @@ public class AnalyticsTrackerNosara extends Tracker {
 
         if (propertiesToJSON.length() > 0) {
             mNosaraClient.track(EVENTS_PREFIX + eventName, propertiesToJSON, user, userType);
-            AppLog.i(AppLog.T.STATS, "\uD83D\uDD35 Tracked : " + eventName + ", Properties: " + propertiesToJSON.toString());
+            String jsonString = propertiesToJSON.toString();
+            AppLog.i(T.STATS, "\uD83D\uDD35 Tracked: " + eventName + ", Properties: " + jsonString);
         } else {
             mNosaraClient.track(EVENTS_PREFIX + eventName, user, userType);
-            AppLog.i(AppLog.T.STATS, "\uD83D\uDD35 Tracked : " + eventName);
+            AppLog.i(T.STATS, "\uD83D\uDD35 Tracked: " + eventName);
         }
     }
 

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -279,8 +279,10 @@ public class AnalyticsTrackerNosara extends Tracker {
 
         if (propertiesToJSON.length() > 0) {
             mNosaraClient.track(EVENTS_PREFIX + eventName, propertiesToJSON, user, userType);
+            AppLog.i(AppLog.T.STATS, "\uD83D\uDD35 Tracked : " + eventName + ", Properties: " + propertiesToJSON.toString());
         } else {
             mNosaraClient.track(EVENTS_PREFIX + eventName, user, userType);
+            AppLog.i(AppLog.T.STATS, "\uD83D\uDD35 Tracked : " + eventName);
         }
     }
 


### PR DESCRIPTION
This is the Android companion to https://github.com/wordpress-mobile/WordPress-iOS/pull/9107.
This PR logs tracks events to the console, outputting an eye catching dot, the event name, and any properties associated to the event.

To test:
Run the branch and observe the console output.  Confirm that you see tracks events logging as expected. 

Example:
<img width="1302" alt="screen shot 2018-05-01 at 2 24 21 pm" src="https://user-images.githubusercontent.com/1435271/39489929-ba594e42-4d4c-11e8-8a6e-d936c8e539be.png">
