### PR TITLE
Hide/show the bottom navbar on search action

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BottomNavController.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BottomNavController.java
@@ -1,6 +1,6 @@
 package org.wordpress.android.ui.main;
 
 public interface BottomNavController {
-    void showBottomNavigation();
-    void hideBottomNavigation();
+    void onRequestShowBottomNavigation();
+    void onRequestHideBottomNavigation();
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BottomNavController.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BottomNavController.java
@@ -1,0 +1,6 @@
+package org.wordpress.android.ui.main;
+
+public interface BottomNavController {
+    void showBottomNavigation();
+    void hideBottomNavigation();
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -7,7 +7,6 @@ import android.app.DialogFragment;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -55,6 +54,7 @@ import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.stats.datasets.StatsTable;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.DeviceUtils;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -476,20 +476,16 @@ public class SitePickerActivity extends AppCompatActivity
     }
 
     private void hideSoftKeyboard() {
-        if (!hasHardwareKeyboard()) {
+        if (!DeviceUtils.getInstance().hasHardwareKeyboard(this)) {
             ActivityUtils.hideKeyboardForced(mSearchView);
         }
     }
 
     private void showSoftKeyboard() {
-        if (!hasHardwareKeyboard()) {
+        if (!DeviceUtils.getInstance().hasHardwareKeyboard(this)) {
             InputMethodManager inputMethodManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
             inputMethodManager.toggleSoftInput(InputMethodManager.SHOW_IMPLICIT, InputMethodManager.HIDE_NOT_ALWAYS);
         }
-    }
-
-    private boolean hasHardwareKeyboard() {
-        return (getResources().getConfiguration().keyboard != Configuration.KEYBOARD_NOKEYS);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -92,7 +92,7 @@ import static org.wordpress.android.ui.main.WPMainNavigationView.PAGE_READER;
 /**
  * Main activity which hosts sites, reader, me and notifications pages
  */
-public class WPMainActivity extends AppCompatActivity implements OnPageListener {
+public class WPMainActivity extends AppCompatActivity implements OnPageListener, BottomNavController {
     public static final String ARG_CONTINUE_JETPACK_CONNECT = "ARG_CONTINUE_JETPACK_CONNECT";
     public static final String ARG_DO_LOGIN_UPDATE = "ARG_DO_LOGIN_UPDATE";
     public static final String ARG_IS_MAGIC_LINK_LOGIN = "ARG_IS_MAGIC_LINK_LOGIN";
@@ -105,6 +105,7 @@ public class WPMainActivity extends AppCompatActivity implements OnPageListener 
     public static final String ARG_OPEN_PAGE = "open_page";
     public static final String ARG_NOTIFICATIONS = "show_notifications";
 
+    private View mBottomNavContainer;
     private WPMainNavigationView mBottomNav;
     private Toolbar mToolbar;
 
@@ -155,6 +156,8 @@ public class WPMainActivity extends AppCompatActivity implements OnPageListener 
         mToolbar = findViewById(R.id.toolbar);
         mToolbar.setTitle(R.string.app_title);
         setSupportActionBar(mToolbar);
+
+        mBottomNavContainer = findViewById(R.id.navbar_container);
 
         mBottomNav = findViewById(R.id.bottom_navigation);
         mBottomNav.init(getFragmentManager(), this);
@@ -460,6 +463,16 @@ public class WPMainActivity extends AppCompatActivity implements OnPageListener 
             }
         }
         super.onBackPressed();
+    }
+
+    @Override
+    public void showBottomNavigation() {
+        mBottomNavContainer.setVisibility(View.VISIBLE);
+    }
+
+    @Override
+    public void hideBottomNavigation() {
+        mBottomNavContainer.setVisibility(View.GONE);
     }
 
     // user switched pages in the bottom navbar

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -477,7 +477,10 @@ public class WPMainActivity extends AppCompatActivity implements OnPageListener,
 
     @Override
     public void onRequestHideBottomNavigation() {
-        mBottomNavContainer.setVisibility(View.GONE);
+        // we only hide the bottom navigation when there's not a hardware keyboard present
+        if (!DeviceUtils.getInstance().hasHardwareKeyboard(this)) {
+            mBottomNavContainer.setVisibility(View.GONE);
+        }
     }
 
     // user switched pages in the bottom navbar

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -471,12 +471,12 @@ public class WPMainActivity extends AppCompatActivity implements OnPageListener,
     }
 
     @Override
-    public void showBottomNavigation() {
+    public void onRequestShowBottomNavigation() {
         mBottomNavContainer.setVisibility(View.VISIBLE);
     }
 
     @Override
-    public void hideBottomNavigation() {
+    public void onRequestHideBottomNavigation() {
         mBottomNavContainer.setVisibility(View.GONE);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -611,7 +611,7 @@ public class ReaderPostListFragment extends Fragment
                 mSettingsMenuItem.setVisible(false);
 
                 if (mBottonNavController != null) {
-                    mBottonNavController.hideBottomNavigation();
+                    mBottonNavController.onRequestHideBottomNavigation();
                 }
 
                 return true;
@@ -625,7 +625,7 @@ public class ReaderPostListFragment extends Fragment
                 mCurrentSearchQuery = null;
 
                 if (mBottonNavController != null) {
-                    mBottonNavController.showBottomNavigation();
+                    mBottonNavController.onRequestShowBottomNavigation();
                 }
 
                 // return to the followed tag that was showing prior to searching

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -610,6 +610,7 @@ public class ReaderPostListFragment extends Fragment
                 showSearchMessage();
                 mSettingsMenuItem.setVisible(false);
 
+                // hide the bottom navigation when search is active
                 if (mBottonNavController != null) {
                     mBottonNavController.onRequestHideBottomNavigation();
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -43,6 +43,7 @@ import org.wordpress.android.models.ReaderTagList;
 import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.EmptyViewMessageType;
 import org.wordpress.android.ui.FilteredRecyclerView;
+import org.wordpress.android.ui.main.BottomNavController;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
@@ -102,6 +103,8 @@ public class ReaderPostListFragment extends Fragment
     private SearchView mSearchView;
     private MenuItem mSettingsMenuItem;
     private MenuItem mSearchMenuItem;
+
+    private BottomNavController mBottonNavController;
 
     private ReaderTag mCurrentTag;
     private long mCurrentBlogId;
@@ -313,6 +316,21 @@ public class ReaderPostListFragment extends Fragment
             refreshPosts();
             updateCurrentTagIfTime();
         }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void onAttach(Context context) {
+        super.onAttach(context);
+
+        // this will throw if parent activity doesn't implement the bottomnav controller interface
+        mBottonNavController = (BottomNavController) context;
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        mBottonNavController = null;
     }
 
     @Override
@@ -591,6 +609,11 @@ public class ReaderPostListFragment extends Fragment
                 resetPostAdapter(ReaderPostListType.SEARCH_RESULTS);
                 showSearchMessage();
                 mSettingsMenuItem.setVisible(false);
+
+                if (mBottonNavController != null) {
+                    mBottonNavController.hideBottomNavigation();
+                }
+
                 return true;
             }
 
@@ -600,6 +623,10 @@ public class ReaderPostListFragment extends Fragment
                 resetSearchSuggestionAdapter();
                 mSettingsMenuItem.setVisible(true);
                 mCurrentSearchQuery = null;
+
+                if (mBottonNavController != null) {
+                    mBottonNavController.showBottomNavigation();
+                }
 
                 // return to the followed tag that was showing prior to searching
                 resetPostAdapter(ReaderPostListType.TAG_FOLLOWED);

--- a/WordPress/src/main/java/org/wordpress/android/widgets/SuggestionAutoCompleteText.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/SuggestionAutoCompleteText.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.widgets;
 
 import android.content.Context;
-import android.content.res.Configuration;
 import android.graphics.Rect;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -13,6 +12,7 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 
 import org.wordpress.android.ui.suggestion.util.SuggestionTokenizer;
+import org.wordpress.android.util.DeviceUtils;
 import org.wordpress.persistentedittext.PersistentEditTextHelper;
 
 public class SuggestionAutoCompleteText extends AppCompatMultiAutoCompleteTextView {
@@ -152,7 +152,7 @@ public class SuggestionAutoCompleteText extends AppCompatMultiAutoCompleteTextVi
         super.onFocusChanged(focused, direction, previouslyFocusedRect);
 
         // if no hardware keys are present, associate being focused to having the on-screen keyboard visible
-        if (getResources().getConfiguration().keyboard == Configuration.KEYBOARD_NOKEYS) {
+        if (!DeviceUtils.getInstance().hasHardwareKeyboard(getContext())) {
             InputMethodManager inputMethodManager = (InputMethodManager) getContext()
                     .getSystemService(Context.INPUT_METHOD_SERVICE);
 

--- a/WordPress/src/main/res/layout/main_activity.xml
+++ b/WordPress/src/main/res/layout/main_activity.xml
@@ -28,7 +28,8 @@
         android:id="@+id/connection_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_above="@+id/navbar_separator"
+        android:layout_above="@+id/navbar_container"
+        android:layout_alignParentBottom="true"
         android:background="@color/alert_yellow"
         android:gravity="center"
         android:paddingBottom="@dimen/margin_medium"
@@ -40,21 +41,27 @@
         android:visibility="gone"
         tools:visibility="visible"/>
 
-    <View
-        android:id="@+id/navbar_separator"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_above="@+id/bottom_navigation"
-        android:background="@color/grey_lighten_20"/>
-
-    <org.wordpress.android.ui.main.WPMainNavigationView
-        android:id="@+id/bottom_navigation"
+    <RelativeLayout
+        android:id="@+id/navbar_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:background="@color/white"
-        app:elevation="0dp"
-        app:menu="@menu/bottom_nav_main"/>
+        android:layout_alignParentBottom="true">
+
+        <View
+            android:id="@+id/navbar_separator"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/grey_lighten_20"/>
+
+        <org.wordpress.android.ui.main.WPMainNavigationView
+            android:id="@+id/bottom_navigation"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/white"
+            android:layout_below="@+id/navbar_separator"
+            app:elevation="0dp"
+            app:menu="@menu/bottom_nav_main"/>
+    </RelativeLayout>
 
     <!-- this coordinator exists only for snackbars -->
     <android.support.design.widget.CoordinatorLayout

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DeviceUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DeviceUtils.java
@@ -104,6 +104,9 @@ public class DeviceUtils {
         return context.getPackageManager().hasSystemFeature(APP_RUNTIME_ON_CHROME_FLAG);
     }
 
+    /**
+     * Checks if the device has a hardware keyboard - note this will return true for emulators
+     */
     public boolean hasHardwareKeyboard(@NonNull Context context) {
         return context.getResources().getConfiguration().keyboard != Configuration.KEYBOARD_NOKEYS;
     }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DeviceUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DeviceUtils.java
@@ -3,7 +3,9 @@ package org.wordpress.android.util;
 import android.app.KeyguardManager;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.os.Build;
+import android.support.annotation.NonNull;
 
 import org.wordpress.android.util.AppLog.T;
 
@@ -100,6 +102,10 @@ public class DeviceUtils {
      */
     public boolean isChromebook(Context context) {
         return context.getPackageManager().hasSystemFeature(APP_RUNTIME_ON_CHROME_FLAG);
+    }
+
+    public boolean hasHardwareKeyboard(@NonNull Context context) {
+        return context.getResources().getConfiguration().keyboard != Configuration.KEYBOARD_NOKEYS;
     }
 
     private String capitalize(String s) {


### PR DESCRIPTION
Note: this PR is opened against another PR ([the bottom nav phase2 PR](https://github.com/wordpress-mobile/WordPress-Android/pull/7680))

I've been in touch with @nbradbury and since he's AFK at the time of writing, I investigated the issue and came up with this PR.

### Issue
The bottom nav bar stays visible when searching in the Reader. As per the Material Design guidelines, it should be hidden when the virtual keyboard is visible.

### Solution
Unfortunately, there is no robust way to detect or follow the IME's state. There a a few _hacks_ on how to follow it but I don't think those are practical. Until we come up with a workable solution that can be implemented across the app, this PR offers a compromise: Hide/show the bottom nav when the search action is active in the Reader page.

We don't need to accept this PR. It's opened as a small proposal/solution.

### To test
1. Go to the Reader and notice the bottom nav being visible
2. Tap on the search button to initiate the search mode. Notice the virtual keyboard opening and the bottom nav disappearing.
3. Hit the _system_ Back button (not the toolbar one) and notice the virtual keyboard disappearing but the bottom nav bar still be hidden
4. Hit "Back" again to exit the search more. Notice the bottom nav re-appearing.