### PR TITLE
Issue/7693 preference category color

### DIFF
--- a/WordPress/src/main/res/xml/notifications_settings.xml
+++ b/WordPress/src/main/res/xml/notifications_settings.xml
@@ -5,17 +5,18 @@
     android:key="@string/wp_pref_notifications_root" >
 
     <PreferenceCategory
-        android:layout="@layout/wp_preference_category"
         android:key="@string/pref_notification_blogs"
+        android:layout="@layout/wp_preference_category"
         android:title="@string/notification_settings_category_your_sites" />
 
     <PreferenceCategory
-        android:layout="@layout/wp_preference_category"
         android:key="@string/pref_notification_blogs_followed"
+        android:layout="@layout/wp_preference_category"
         android:title="@string/notification_settings_category_followed_sites" />
 
     <PreferenceCategory
         android:key="@string/pref_notification_other_category"
+        android:layout="@layout/wp_preference_category"
         android:title="@string/notification_settings_category_other" >
 
         <PreferenceScreen
@@ -30,8 +31,8 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:layout="@layout/wp_preference_category"
         android:key="@string/pref_notification_sights_sounds"
+        android:layout="@layout/wp_preference_category"
         android:title="@string/notification_settings_category_sights_and_sounds" >
 
         <RingtonePreference


### PR DESCRIPTION
### Fix
Add the `layout` attribute with the `wp_preference_category` value to the ***Other*** preference category in ***Notification Settings*** to ensure the text color is `grey_text_min` as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7693.

### Test
1. Go to ***Me*** tab.
2. Tap ***Notification Settings*** item.
3. Notice ***Other*** text color.