### PR TITLE
Add support for savedForLater/Bookmarked posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -20,7 +20,7 @@ import java.util.Locale;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 134;
+    private static final int DB_VERSION = 135;
 
     /*
      * version history
@@ -87,6 +87,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      * 132 - no schema changes, simply clearing to accommodate gallery card_type
      * 133 - no schema changes, simply clearing to accommodate video card_type
      * 134 - added tbl_posts.use_excerpt
+     * 135 - added tbl_posts.is_bookmarked
      */
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -928,7 +928,7 @@ public class ReaderPostTable {
             return new ReaderBlogIdPostIdList();
         }
 
-        String sql = "SELECT blog_id, post_id FROM tbl_posts WHERE tag_name=? AND tag_type=?";
+        String sql = "SELECT blog_id, post_id FROM tbl_posts WHERE tag_type=?";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + Integer.toString(maxPosts);

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -77,7 +77,8 @@ public class ReaderPostTable {
             + "tag_type," // 42
             + "has_gap_marker," // 43
             + "card_type," // 44
-            + "use_excerpt"; // 45
+            + "use_excerpt," // 45
+            + "is_bookmarked"; // 46
 
     // used when querying multiple rows and skipping text column
     private static final String COLUMN_NAMES_NO_TEXT =
@@ -124,7 +125,8 @@ public class ReaderPostTable {
             + "tag_type," // 41
             + "has_gap_marker," // 42
             + "card_type," // 43
-            + "use_excerpt"; // 44
+            + "use_excerpt," // 44
+            + "is_bookmarked"; // 45
 
     protected static void createTables(SQLiteDatabase db) {
         db.execSQL("CREATE TABLE tbl_posts ("
@@ -173,6 +175,7 @@ public class ReaderPostTable {
                    + " has_gap_marker INTEGER DEFAULT 0,"
                    + " card_type TEXT,"
                    + " use_excerpt INTEGER DEFAULT 0,"
+                   + " is_bookmarked INTEGER DEFAULT 0,"
                    + " PRIMARY KEY (pseudo_id, tag_name, tag_type)"
                    + ")");
 
@@ -405,16 +408,10 @@ public class ReaderPostTable {
     }
 
     public static void setNumCommentsForPost(long blogId, long postId, int numComments) {
-        String[] args = {Long.toString(blogId), Long.toString(postId)};
-
         ContentValues values = new ContentValues();
         values.put("num_replies", numComments);
 
-        ReaderDatabase.getWritableDb().update(
-                "tbl_posts",
-                values,
-                "blog_id=? AND post_id=?",
-                args);
+        update(blogId, postId, values);
     }
 
     public static void incNumCommentsForPost(long blogId, long postId) {
@@ -452,13 +449,23 @@ public class ReaderPostTable {
         if (post == null) {
             return;
         }
-
-        String[] args = {Long.toString(post.blogId), Long.toString(post.postId)};
-
         ContentValues values = new ContentValues();
         values.put("num_likes", numLikes);
         values.put("is_liked", SqlUtils.boolToSql(isLikedByCurrentUser));
 
+        update(post.blogId, post.postId, values);
+    }
+
+
+    public static void setBookmarkFlag(long blogId, long postId, boolean bookmark) {
+        ContentValues values = new ContentValues();
+        values.put("is_bookmarked", SqlUtils.boolToSql(bookmark));
+
+        update(blogId, postId, values);
+    }
+
+    private static void update(long blogId, long postId, ContentValues values) {
+        String[] args = {Long.toString(blogId), Long.toString(postId)};
         ReaderDatabase.getWritableDb().update(
                 "tbl_posts",
                 values,
@@ -486,6 +493,18 @@ public class ReaderPostTable {
         return ReaderDatabase.getWritableDb().delete(
                 "tbl_posts",
                 "tag_name=? AND tag_type=?",
+                args);
+    }
+
+    public static int removeTagsFromPost(long blogId, long postId, final ReaderTagType tagType) {
+        if (tagType == null) {
+            return 0;
+        }
+
+        String[] args = {Integer.toString(tagType.toInt()), Long.toString(blogId), Long.toString(postId)};
+        return ReaderDatabase.getWritableDb().delete(
+                "tbl_posts",
+                "tag_type=? AND blog_id=? AND post_id=?",
                 args);
     }
 
@@ -630,7 +649,7 @@ public class ReaderPostTable {
             return "date_published";
         } else if (tag.tagType == ReaderTagType.SEARCH) {
             return "score";
-        } else if (tag.isTagTopic()) {
+        } else if (tag.isTagTopic() || tag.isBookmarked()) {
             return "date_tagged";
         } else {
             return "date_published";
@@ -734,12 +753,14 @@ public class ReaderPostTable {
             return;
         }
 
+        updateIsBookmarkedField(posts);
+
         SQLiteDatabase db = ReaderDatabase.getWritableDb();
         SQLiteStatement stmtPosts = db.compileStatement(
                 "INSERT OR REPLACE INTO tbl_posts ("
                 + COLUMN_NAMES
                 + ") VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,"
-                + "?25,?26,?27,?28,?29,?30,?31,?32,?33,?34,?35,?36,?37,?38,?39,?40,?41,?42,?43,?44, ?45)");
+                + "?25,?26,?27,?28,?29,?30,?31,?32,?33,?34,?35,?36,?37,?38,?39,?40,?41,?42,?43,?44, ?45, ?46)");
 
         db.beginTransaction();
         try {
@@ -796,6 +817,7 @@ public class ReaderPostTable {
                 stmtPosts.bindLong(43, SqlUtils.boolToSql(hasGapMarker));
                 stmtPosts.bindString(44, ReaderCardType.toString(post.getCardType()));
                 stmtPosts.bindLong(45, SqlUtils.boolToSql(post.useExcerpt));
+                stmtPosts.bindLong(46, SqlUtils.boolToSql(post.isBookmarked));
                 stmtPosts.execute();
             }
 
@@ -877,9 +899,8 @@ public class ReaderPostTable {
      * same as getPostsWithTag() but only returns the blogId/postId pairs
      */
     public static ReaderBlogIdPostIdList getBlogIdPostIdsWithTag(ReaderTag tag, int maxPosts) {
-        ReaderBlogIdPostIdList idList = new ReaderBlogIdPostIdList();
         if (tag == null) {
-            return idList;
+            return new ReaderBlogIdPostIdList();
         }
 
         String sql = "SELECT blog_id, post_id FROM tbl_posts WHERE tag_name=? AND tag_type=?";
@@ -899,6 +920,26 @@ public class ReaderPostTable {
         }
 
         String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
+        return getBlogIdPostIds(sql, args);
+    }
+
+    private static ReaderBlogIdPostIdList getBlogIdPostIdsWithTagType(ReaderTagType tagType, int maxPosts) {
+        if (tagType == null) {
+            return new ReaderBlogIdPostIdList();
+        }
+
+        String sql = "SELECT blog_id, post_id FROM tbl_posts WHERE tag_name=? AND tag_type=?";
+
+        if (maxPosts > 0) {
+            sql += " LIMIT " + Integer.toString(maxPosts);
+        }
+
+        String[] args = {Integer.toString(tagType.toInt())};
+        return getBlogIdPostIds(sql, args);
+    }
+
+    private static ReaderBlogIdPostIdList getBlogIdPostIds(@NonNull String sql, @NonNull String[] args) {
+        ReaderBlogIdPostIdList idList = new ReaderBlogIdPostIdList();
         Cursor cursor = ReaderDatabase.getReadableDb().rawQuery(sql, args);
         try {
             if (cursor != null && cursor.moveToFirst()) {
@@ -987,6 +1028,7 @@ public class ReaderPostTable {
         post.isPrivate = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_private")));
         post.isVideoPress = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_videopress")));
         post.isJetpack = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_jetpack")));
+        post.isBookmarked = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_bookmarked")));
 
         post.setPrimaryTag(c.getString(c.getColumnIndex("primary_tag")));
         post.setSecondaryTag(c.getString(c.getColumnIndex("secondary_tag")));
@@ -1018,5 +1060,25 @@ public class ReaderPostTable {
             AppLog.e(AppLog.T.READER, e);
         }
         return posts;
+    }
+
+    /**
+     * Currently "is_bookmarked" field is not supported by the server, therefore posts from the server have always
+     * is_bookmarked set to false. This method is a workaround which makes sure, that the field is always up to date
+     * and synced across all instances(rows) of each post.
+     */
+    private static void updateIsBookmarkedField(final ReaderPostList posts) {
+        ReaderBlogIdPostIdList bookmarkedPosts = getBookmarkedPostIds();
+        for (ReaderPost post : posts) {
+            for (ReaderBlogIdPostId bookmarkedPostId : bookmarkedPosts) {
+                if (post.blogId == bookmarkedPostId.getBlogId() && post.postId == bookmarkedPostId.getPostId()) {
+                    post.isBookmarked = true;
+                }
+            }
+        }
+    }
+
+    private static ReaderBlogIdPostIdList getBookmarkedPostIds() {
+        return getBlogIdPostIdsWithTagType(ReaderTagType.BOOKMARKED, 99999);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderTagTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderTagTable.java
@@ -221,6 +221,10 @@ public class ReaderTagTable {
         return getTagsOfType(ReaderTagType.CUSTOM_LIST);
     }
 
+    public static ReaderTagList getBookmarkTags() {
+        return getTagsOfType(ReaderTagType.BOOKMARKED);
+    }
+
     private static ReaderTagList getTagsOfType(ReaderTagType tagType) {
         String[] args = {Integer.toString(tagType.toInt())};
         Cursor c = ReaderDatabase.getReadableDb()

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -56,6 +56,7 @@ public class ReaderPost {
 
     public boolean isLikedByCurrentUser;
     public boolean isFollowedByCurrentUser;
+    public boolean isBookmarked;
     public boolean isCommentsOpen;
     public boolean isExternal;
     public boolean isPrivate;

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -153,6 +153,10 @@ public class ReaderTag implements Serializable, FilterCriteria {
         return tagType == ReaderTagType.DEFAULT && getEndpoint().endsWith("/read/following");
     }
 
+    public boolean isBookmarked() {
+        return tagType == ReaderTagType.BOOKMARKED;
+    }
+
     public boolean isDiscover() {
         return tagType == ReaderTagType.DEFAULT && getTagSlug().equals(TAG_TITLE_DISCOVER);
     }

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTagType.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTagType.java
@@ -3,6 +3,7 @@ package org.wordpress.android.models;
 public enum ReaderTagType {
     FOLLOWED,
     DEFAULT,
+    BOOKMARKED,
     RECOMMENDED,
     CUSTOM_LIST,
     SEARCH;
@@ -12,6 +13,8 @@ public enum ReaderTagType {
     private static final int INT_RECOMMENDED = 2;
     private static final int INT_CUSTOM_LIST = 3;
     private static final int INT_SEARCH = 4;
+    private static final int INT_BOOKMARKED = 5;
+
 
     public static ReaderTagType fromInt(int value) {
         switch (value) {
@@ -23,6 +26,8 @@ public enum ReaderTagType {
                 return CUSTOM_LIST;
             case INT_SEARCH:
                 return SEARCH;
+            case INT_BOOKMARKED:
+                return BOOKMARKED;
             default:
                 return DEFAULT;
         }
@@ -38,6 +43,9 @@ public enum ReaderTagType {
                 return INT_CUSTOM_LIST;
             case SEARCH:
                 return INT_SEARCH;
+            case BOOKMARKED:
+                return INT_BOOKMARKED;
+            case DEFAULT:
             default:
                 return INT_DEFAULT;
         }


### PR DESCRIPTION
Fixes #7685 

Adds new column with savedForLater/bookmarked flag. 

Adds new tag and tagType. At first I wanted to create a tag with the default tagType, but I believe we need the new tagType because we want to persist bookmarked posts permanently. Currently tags with same tagType are identified by slug and title, which are both dependant on current locale.

To test
1. Make sure the Reader works as before this PR.

Note
The naming is not final - we might need to renamed all the related things from "bookmark" -> "saveForLater". But I believe we can do that in another PR.