### PR TITLE
Issue/7708 custom dialog snackbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPDialogSnackbar.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPDialogSnackbar.java
@@ -93,6 +93,28 @@ public class WPDialogSnackbar {
         return this;
     }
 
+    public WPDialogSnackbar setNeutralButton(CharSequence text, final View.OnClickListener listener) {
+        TextView button = mContentView.findViewById(R.id.button_neutral);
+
+        // Hide neutral button when text is empty or listener is null.
+        if (TextUtils.isEmpty(text) || listener == null) {
+            button.setVisibility(View.GONE);
+            button.setOnClickListener(null);
+        } else {
+            button.setVisibility(View.VISIBLE);
+            button.setText(text);
+            button.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    listener.onClick(view);
+                    dismiss();
+                }
+            });
+        }
+
+        return this;
+    }
+
     public WPDialogSnackbar setPositiveButton(CharSequence text, final View.OnClickListener listener) {
         TextView button = mContentView.findViewById(R.id.button_positive);
 

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPDialogSnackbar.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPDialogSnackbar.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.widgets;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import android.support.design.widget.Snackbar.SnackbarLayout;
@@ -41,8 +40,7 @@ public class WPDialogSnackbar {
         TextView snackbarAction = snackbarLayout.findViewById(android.support.design.R.id.snackbar_action);
         snackbarAction.setVisibility(View.INVISIBLE);
 
-        mContentView = ((LayoutInflater) view.getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE))
-                .inflate(R.layout.dialog_snackbar, null);
+        mContentView = LayoutInflater.from(view.getContext()).inflate(R.layout.dialog_snackbar, null);
 
         TextView message = mContentView.findViewById(R.id.message);
 

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPDialogSnackbar.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPDialogSnackbar.java
@@ -1,0 +1,135 @@
+package org.wordpress.android.widgets;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
+import android.support.design.widget.Snackbar.SnackbarLayout;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.TextView;
+
+import org.wordpress.android.R;
+
+/**
+ * {@link Snackbar} with {@link android.app.Dialog}-like layout.  The layout views include title, message,
+ * positive button, and negative button.  Any empty or null view is hidden.  The only required view is message.
+ */
+public class WPDialogSnackbar {
+    private Snackbar mSnackbar;
+    private View mContentView;
+
+    private WPDialogSnackbar(@NonNull View view, @NonNull CharSequence text, int duration) {
+        switch (duration) {
+            case Snackbar.LENGTH_INDEFINITE:
+                mSnackbar = Snackbar.make(view, "", Snackbar.LENGTH_INDEFINITE);
+                break;
+            case Snackbar.LENGTH_LONG:
+                mSnackbar = Snackbar.make(view, "", Snackbar.LENGTH_LONG);
+                break;
+            default:
+                mSnackbar = Snackbar.make(view, "", Snackbar.LENGTH_SHORT);
+        }
+
+        // Set underlying snackbar layout.
+        SnackbarLayout snackbarLayout = (SnackbarLayout) mSnackbar.getView();
+        snackbarLayout.setPadding(0, 0, 0, 0);
+
+        // Hide underlying snackbar text and action.
+        TextView snackbarText = snackbarLayout.findViewById(android.support.design.R.id.snackbar_text);
+        snackbarText.setVisibility(View.INVISIBLE);
+        TextView snackbarAction = snackbarLayout.findViewById(android.support.design.R.id.snackbar_action);
+        snackbarAction.setVisibility(View.INVISIBLE);
+
+        mContentView = ((LayoutInflater) view.getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE))
+                .inflate(R.layout.dialog_snackbar, null);
+
+        TextView message = mContentView.findViewById(R.id.message);
+
+        // Hide message view when text is empty.
+        if (TextUtils.isEmpty(text)) {
+            message.setVisibility(View.GONE);
+        } else {
+            message.setVisibility(View.VISIBLE);
+            message.setText(text);
+        }
+
+        snackbarLayout.addView(mContentView, 0);
+    }
+
+    public void dismiss() {
+        if (mSnackbar != null) {
+            mSnackbar.dismiss();
+        }
+    }
+
+    public boolean isShowing() {
+        return mSnackbar != null && mSnackbar.isShown();
+    }
+
+    public static WPDialogSnackbar make(@NonNull View view, @NonNull CharSequence text, int duration) {
+        return new WPDialogSnackbar(view, text, duration);
+    }
+
+    public WPDialogSnackbar setNegativeButton(CharSequence text, final View.OnClickListener listener) {
+        TextView button = mContentView.findViewById(R.id.button_negative);
+
+        // Hide negative button when text is empty or listener is null.
+        if (TextUtils.isEmpty(text) || listener == null) {
+            button.setVisibility(View.GONE);
+            button.setOnClickListener(null);
+        } else {
+            button.setVisibility(View.VISIBLE);
+            button.setText(text);
+            button.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    listener.onClick(view);
+                    dismiss();
+                }
+            });
+        }
+
+        return this;
+    }
+
+    public WPDialogSnackbar setPositiveButton(CharSequence text, final View.OnClickListener listener) {
+        TextView button = mContentView.findViewById(R.id.button_positive);
+
+        // Hide positive button when text is empty or listener is null.
+        if (TextUtils.isEmpty(text) || listener == null) {
+            button.setVisibility(View.GONE);
+            button.setOnClickListener(null);
+        } else {
+            button.setVisibility(View.VISIBLE);
+            button.setText(text);
+            button.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    listener.onClick(view);
+                    dismiss();
+                }
+            });
+        }
+
+        return this;
+    }
+
+    public WPDialogSnackbar setTitle(@NonNull CharSequence text) {
+        TextView title = mContentView.findViewById(R.id.title);
+
+        // Hide title view when text is empty.
+        if (TextUtils.isEmpty(text)) {
+            title.setVisibility(View.GONE);
+        } else {
+            title.setVisibility(View.VISIBLE);
+            title.setText(text);
+        }
+
+        return this;
+    }
+
+    public void show() {
+        mSnackbar.show();
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPDialogSnackbar.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPDialogSnackbar.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.widgets;
 
 import android.support.annotation.NonNull;
+import android.support.design.widget.BaseTransientBottomBar.Duration;
 import android.support.design.widget.Snackbar;
 import android.support.design.widget.Snackbar.SnackbarLayout;
 import android.text.TextUtils;
@@ -18,17 +19,8 @@ public class WPDialogSnackbar {
     private Snackbar mSnackbar;
     private View mContentView;
 
-    private WPDialogSnackbar(@NonNull View view, @NonNull CharSequence text, int duration) {
-        switch (duration) {
-            case Snackbar.LENGTH_INDEFINITE:
-                mSnackbar = Snackbar.make(view, "", Snackbar.LENGTH_INDEFINITE);
-                break;
-            case Snackbar.LENGTH_LONG:
-                mSnackbar = Snackbar.make(view, "", Snackbar.LENGTH_LONG);
-                break;
-            default:
-                mSnackbar = Snackbar.make(view, "", Snackbar.LENGTH_SHORT);
-        }
+    private WPDialogSnackbar(@NonNull View view, @NonNull CharSequence text, @Duration int duration) {
+        mSnackbar = Snackbar.make(view, "", duration);
 
         // Set underlying snackbar layout.
         SnackbarLayout snackbarLayout = (SnackbarLayout) mSnackbar.getView();
@@ -65,7 +57,7 @@ public class WPDialogSnackbar {
         return mSnackbar != null && mSnackbar.isShown();
     }
 
-    public static WPDialogSnackbar make(@NonNull View view, @NonNull CharSequence text, int duration) {
+    public static WPDialogSnackbar make(@NonNull View view, @NonNull CharSequence text, @Duration int duration) {
         return new WPDialogSnackbar(view, text, duration);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPDialogSnackbar.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPDialogSnackbar.java
@@ -69,10 +69,8 @@ public class WPDialogSnackbar {
         return new WPDialogSnackbar(view, text, duration);
     }
 
-    public WPDialogSnackbar setNegativeButton(CharSequence text, final View.OnClickListener listener) {
-        TextView button = mContentView.findViewById(R.id.button_negative);
-
-        // Hide negative button when text is empty or listener is null.
+    private void setButtonTextAndVisibility(TextView button, CharSequence text, final View.OnClickListener listener) {
+        // Hide button when text is empty or listener is null.
         if (TextUtils.isEmpty(text) || listener == null) {
             button.setVisibility(View.GONE);
             button.setOnClickListener(null);
@@ -87,51 +85,20 @@ public class WPDialogSnackbar {
                 }
             });
         }
+    }
 
+    public WPDialogSnackbar setNegativeButton(CharSequence text, View.OnClickListener listener) {
+        setButtonTextAndVisibility((TextView) mContentView.findViewById(R.id.button_negative), text, listener);
         return this;
     }
 
-    public WPDialogSnackbar setNeutralButton(CharSequence text, final View.OnClickListener listener) {
-        TextView button = mContentView.findViewById(R.id.button_neutral);
-
-        // Hide neutral button when text is empty or listener is null.
-        if (TextUtils.isEmpty(text) || listener == null) {
-            button.setVisibility(View.GONE);
-            button.setOnClickListener(null);
-        } else {
-            button.setVisibility(View.VISIBLE);
-            button.setText(text);
-            button.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    listener.onClick(view);
-                    dismiss();
-                }
-            });
-        }
-
+    public WPDialogSnackbar setNeutralButton(CharSequence text, View.OnClickListener listener) {
+        setButtonTextAndVisibility((TextView) mContentView.findViewById(R.id.button_neutral), text, listener);
         return this;
     }
 
-    public WPDialogSnackbar setPositiveButton(CharSequence text, final View.OnClickListener listener) {
-        TextView button = mContentView.findViewById(R.id.button_positive);
-
-        // Hide positive button when text is empty or listener is null.
-        if (TextUtils.isEmpty(text) || listener == null) {
-            button.setVisibility(View.GONE);
-            button.setOnClickListener(null);
-        } else {
-            button.setVisibility(View.VISIBLE);
-            button.setText(text);
-            button.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    listener.onClick(view);
-                    dismiss();
-                }
-            });
-        }
-
+    public WPDialogSnackbar setPositiveButton(CharSequence text, View.OnClickListener listener) {
+        setButtonTextAndVisibility((TextView) mContentView.findViewById(R.id.button_positive), text, listener);
         return this;
     }
 

--- a/WordPress/src/main/res/layout/dialog_snackbar.xml
+++ b/WordPress/src/main/res/layout/dialog_snackbar.xml
@@ -70,4 +70,21 @@
         style="?android:attr/borderlessButtonStyle" >
     </android.support.v7.widget.AppCompatButton>
 
+    <android.support.v7.widget.AppCompatButton
+        android:id="@+id/button_neutral"
+        android:fontFamily="sans-serif-medium"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:layout_below="@+id/message"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:layout_width="wrap_content"
+        android:minHeight="@dimen/dialog_snackbar_button_height"
+        android:textColor="@color/color_accent"
+        android:visibility="gone"
+        tools:text="Never"
+        tools:visibility="visible"
+        style="?android:attr/borderlessButtonStyle" >
+    </android.support.v7.widget.AppCompatButton>
+
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/dialog_snackbar.xml
+++ b/WordPress/src/main/res/layout/dialog_snackbar.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@color/grey_3"
+    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
+    android:padding="@dimen/margin_extra_large" >
+
+    <TextView
+        android:id="@+id/title"
+        android:fontFamily="sans-serif-medium"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_width="match_parent"
+        android:textColor="@color/white"
+        android:textSize="@dimen/text_sz_large"
+        android:visibility="gone"
+        tools:text="Add social media account"
+        tools:visibility="visible" >
+    </TextView>
+
+    <TextView
+        android:id="@+id/message"
+        android:layout_below="@+id/title"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:textColor="@color/grey_c"
+        android:textSize="@dimen/text_sz_medium"
+        android:visibility="gone"
+        tools:text="Connect your favorite social media services to automatically share new posts with friend"
+        tools:visibility="visible" >
+    </TextView>
+
+    <android.support.v7.widget.AppCompatButton
+        android:id="@+id/button_positive"
+        android:fontFamily="sans-serif-medium"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:layout_below="@+id/message"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/margin_medium"
+        android:layout_marginStart="@dimen/margin_medium"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:layout_width="wrap_content"
+        android:minHeight="@dimen/dialog_snackbar_button_height"
+        android:textColor="@color/color_accent"
+        android:visibility="gone"
+        tools:text="Yes, let's do it"
+        tools:visibility="visible"
+        style="?android:attr/borderlessButtonStyle" >
+    </android.support.v7.widget.AppCompatButton>
+
+    <android.support.v7.widget.AppCompatButton
+        android:id="@+id/button_negative"
+        android:fontFamily="sans-serif-medium"
+        android:layout_alignWithParentIfMissing="true"
+        android:layout_below="@+id/message"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:layout_toLeftOf="@+id/button_positive"
+        android:layout_toStartOf="@+id/button_positive"
+        android:layout_width="wrap_content"
+        android:minHeight="@dimen/dialog_snackbar_button_height"
+        android:textColor="@color/color_accent"
+        android:visibility="gone"
+        tools:text="Not now"
+        tools:visibility="visible"
+        style="?android:attr/borderlessButtonStyle" >
+    </android.support.v7.widget.AppCompatButton>
+
+</RelativeLayout>

--- a/WordPress/src/main/res/layout/dialog_snackbar.xml
+++ b/WordPress/src/main/res/layout/dialog_snackbar.xml
@@ -5,86 +5,99 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:background="@color/grey_3"
     android:layout_height="wrap_content"
-    android:layout_width="match_parent"
-    android:padding="@dimen/margin_extra_large" >
+    android:layout_width="match_parent" >
 
-    <TextView
-        android:id="@+id/title"
-        android:fontFamily="sans-serif-medium"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:layout_width="match_parent"
-        android:textColor="@color/white"
-        android:textSize="@dimen/text_sz_large"
-        android:visibility="gone"
-        tools:text="Add social media account"
-        tools:visibility="visible" >
-    </TextView>
-
-    <TextView
-        android:id="@+id/message"
-        android:layout_below="@+id/title"
+    <RelativeLayout
+        android:id="@+id/text"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
-        android:textColor="@color/grey_c"
-        android:textSize="@dimen/text_sz_medium"
-        android:visibility="gone"
-        tools:text="Connect your favorite social media services to automatically share new posts with friend"
-        tools:visibility="visible" >
-    </TextView>
+        android:paddingEnd="@dimen/margin_extra_large"
+        android:paddingLeft="@dimen/margin_extra_large"
+        android:paddingRight="@dimen/margin_extra_large"
+        android:paddingStart="@dimen/margin_extra_large"
+        android:paddingTop="@dimen/margin_extra_large" >
 
-    <android.support.v7.widget.AppCompatButton
-        android:id="@+id/button_positive"
-        android:fontFamily="sans-serif-medium"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
-        android:layout_below="@+id/message"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/margin_medium"
-        android:layout_marginStart="@dimen/margin_medium"
-        android:layout_marginTop="@dimen/margin_extra_large"
-        android:layout_width="wrap_content"
-        android:minHeight="@dimen/dialog_snackbar_button_height"
-        android:textColor="@color/color_accent"
-        android:visibility="gone"
-        tools:text="Yes, let's do it"
-        tools:visibility="visible"
-        style="?android:attr/borderlessButtonStyle" >
-    </android.support.v7.widget.AppCompatButton>
+        <TextView
+            android:id="@+id/title"
+            android:fontFamily="sans-serif-medium"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:layout_width="match_parent"
+            android:textColor="@color/white"
+            android:textSize="@dimen/text_sz_large"
+            android:visibility="gone"
+            tools:text="Add social media account"
+            tools:visibility="visible" >
+        </TextView>
 
-    <android.support.v7.widget.AppCompatButton
-        android:id="@+id/button_negative"
-        android:fontFamily="sans-serif-medium"
-        android:layout_alignWithParentIfMissing="true"
-        android:layout_below="@+id/message"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_extra_large"
-        android:layout_toLeftOf="@+id/button_positive"
-        android:layout_toStartOf="@+id/button_positive"
-        android:layout_width="wrap_content"
-        android:minHeight="@dimen/dialog_snackbar_button_height"
-        android:textColor="@color/color_accent"
-        android:visibility="gone"
-        tools:text="Not now"
-        tools:visibility="visible"
-        style="?android:attr/borderlessButtonStyle" >
-    </android.support.v7.widget.AppCompatButton>
+        <TextView
+            android:id="@+id/message"
+            android:layout_below="@+id/title"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:textColor="@color/grey_c"
+            android:textSize="@dimen/text_sz_medium"
+            android:visibility="gone"
+            tools:text="Connect your favorite social media services to automatically share new posts with friend"
+            tools:visibility="visible" >
+        </TextView>
 
-    <android.support.v7.widget.AppCompatButton
-        android:id="@+id/button_neutral"
-        android:fontFamily="sans-serif-medium"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_below="@+id/message"
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:layout_below="@+id/text"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_extra_large"
-        android:layout_width="wrap_content"
-        android:minHeight="@dimen/dialog_snackbar_button_height"
-        android:textColor="@color/color_accent"
-        android:visibility="gone"
-        tools:text="Never"
-        tools:visibility="visible"
-        style="?android:attr/borderlessButtonStyle" >
-    </android.support.v7.widget.AppCompatButton>
+        android:layout_width="match_parent"
+        android:padding="@dimen/margin_medium" >
+
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/button_positive"
+            android:fontFamily="sans-serif-medium"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/margin_medium"
+            android:layout_marginStart="@dimen/margin_medium"
+            android:layout_width="wrap_content"
+            android:minHeight="@dimen/dialog_snackbar_button_height"
+            android:textColor="@color/color_accent"
+            android:visibility="gone"
+            tools:text="Yes, let's do it"
+            tools:visibility="visible"
+            style="@style/Widget.AppCompat.Button.Borderless" >
+        </android.support.v7.widget.AppCompatButton>
+
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/button_negative"
+            android:fontFamily="sans-serif-medium"
+            android:layout_alignWithParentIfMissing="true"
+            android:layout_height="wrap_content"
+            android:layout_toLeftOf="@+id/button_positive"
+            android:layout_toStartOf="@+id/button_positive"
+            android:layout_width="wrap_content"
+            android:minHeight="@dimen/dialog_snackbar_button_height"
+            android:textColor="@color/color_accent"
+            android:visibility="gone"
+            tools:text="Not now"
+            tools:visibility="visible"
+            style="@style/Widget.AppCompat.Button.Borderless" >
+        </android.support.v7.widget.AppCompatButton>
+
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/button_neutral"
+            android:fontFamily="sans-serif-medium"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:minHeight="@dimen/dialog_snackbar_button_height"
+            android:textColor="@color/color_accent"
+            android:visibility="gone"
+            tools:text="Never ever"
+            tools:visibility="visible"
+            style="@style/Widget.AppCompat.Button.Borderless" >
+        </android.support.v7.widget.AppCompatButton>
+
+    </RelativeLayout>
 
 </RelativeLayout>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -56,6 +56,10 @@
 
     <color name="grey_text_min">#537994</color>
 
+    <!-- Standard Greys -->
+    <color name="grey_3">#333333</color>
+    <color name="grey_c">#cccccc</color>
+
     <!-- Oranges -->
     <color name="orange_jazzy">#f0821e</color>
     <color name="orange_fire">#d54e21</color>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -313,4 +313,6 @@
     <dimen name="add_avatar_button_size">24dp</dimen>
 
     <dimen name="padding_input_row_start">60dp</dimen>
+
+    <dimen name="dialog_snackbar_button_height">36dp</dimen>
 </resources>


### PR DESCRIPTION
### Fix
Add a custom class and layout to use for prompting the user with ***What's Next*** tasks as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7708.  See the screenshots below for illustration.

![custom_social](https://user-images.githubusercontent.com/3827611/39610134-80ae6b44-4f0b-11e8-8c19-b1b2b50486df.png)

![custom_connections](https://user-images.githubusercontent.com/3827611/39610136-8305529a-4f0b-11e8-8cea-3c7acafce240.png)

![custom_sharing](https://user-images.githubusercontent.com/3827611/39610137-85b8cdfa-4f0b-11e8-9b19-decdc5906481.png)