### PR TITLE
Add bookmarked posts into reader's dropdown spinner

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -89,6 +89,8 @@ public class ReaderTag implements Serializable, FilterCriteria {
         String tagSlug = getTagSlug();
         if (tagType == ReaderTagType.DEFAULT) {
             return tagSlug;
+        } else if (tagType == ReaderTagType.BOOKMARKED) {
+            return ReaderTagType.BOOKMARKED.name();
         } else if (tagSlug.length() >= 6) {
             return tagSlug.substring(0, 3) + "...";
         } else if (tagSlug.length() >= 4) {
@@ -103,7 +105,8 @@ public class ReaderTag implements Serializable, FilterCriteria {
     /*
      * used to ensure a tag name is valid before adding it
      */
-    private static final Pattern INVALID_CHARS = Pattern.compile("^.*[~#@*+%{}<>\\[\\]|\"\\_].*$");
+    @SuppressWarnings("RegExpRedundantEscape") private static final Pattern INVALID_CHARS =
+            Pattern.compile("^.*[~#@*+%{}<>\\[\\]|\"\\_].*$");
 
     public static boolean isValidTagName(String tagName) {
         return !TextUtils.isEmpty(tagName)
@@ -138,11 +141,8 @@ public class ReaderTag implements Serializable, FilterCriteria {
     }
 
     public static boolean isSameTag(ReaderTag tag1, ReaderTag tag2) {
-        if (tag1 == null || tag2 == null) {
-            return false;
-        }
-        return tag1.tagType == tag2.tagType
-               && tag1.getTagSlug().equalsIgnoreCase(tag2.getTagSlug());
+        return tag1 != null && tag2 != null && tag1.tagType == tag2.tagType && tag1.getTagSlug()
+                                                                                   .equalsIgnoreCase(tag2.getTagSlug());
     }
 
     public boolean isPostsILike() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -424,7 +424,7 @@ public class ReaderPostListFragment extends Fragment
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         final ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.reader_fragment_post_cards, container, false);
-        mRecyclerView = (FilteredRecyclerView) rootView.findViewById(R.id.reader_recycler_view);
+        mRecyclerView = rootView.findViewById(R.id.reader_recycler_view);
 
         Context context = container.getContext();
 
@@ -542,7 +542,7 @@ public class ReaderPostListFragment extends Fragment
         });
 
         // progress bar that appears when loading more posts
-        mProgress = (ProgressBar) rootView.findViewById(R.id.progress_footer);
+        mProgress = rootView.findViewById(R.id.progress_footer);
         mProgress.setVisibility(View.GONE);
 
         return rootView;
@@ -846,9 +846,9 @@ public class ReaderPostListFragment extends Fragment
             return;
         }
 
-        ImageView page1 = (ImageView) mEmptyView.findViewById(R.id.empty_tags_box_page1);
-        ImageView page2 = (ImageView) mEmptyView.findViewById(R.id.empty_tags_box_page2);
-        ImageView page3 = (ImageView) mEmptyView.findViewById(R.id.empty_tags_box_page3);
+        ImageView page1 = mEmptyView.findViewById(R.id.empty_tags_box_page1);
+        ImageView page2 = mEmptyView.findViewById(R.id.empty_tags_box_page2);
+        ImageView page3 = mEmptyView.findViewById(R.id.empty_tags_box_page3);
 
         page1.startAnimation(AnimationUtils.loadAnimation(getActivity(), R.anim.box_with_pages_slide_up_page1));
         page2.startAnimation(AnimationUtils.loadAnimation(getActivity(), R.anim.box_with_pages_slide_up_page2));
@@ -863,7 +863,11 @@ public class ReaderPostListFragment extends Fragment
         String title;
         String description = null;
 
-        if (!NetworkUtils.isNetworkAvailable(getActivity())) {
+        if (getPostListType() == ReaderPostListType.TAG_FOLLOWED && getCurrentTag().isBookmarked()) {
+            // only local bookmarks are currently supported, so if there are no data in the local database we can
+            // show an empty view
+            title = getString(R.string.reader_empty_posts_bookmarked);
+        } else if (!NetworkUtils.isNetworkAvailable(getActivity())) {
             title = getString(R.string.reader_empty_posts_no_connection);
         } else if (requestFailed) {
             title = getString(R.string.reader_empty_posts_request_failed);
@@ -905,7 +909,7 @@ public class ReaderPostListFragment extends Fragment
                                                     formattedQuery);
                     }
                     break;
-
+                case TAG_PREVIEW:
                 default:
                     title = getString(R.string.reader_empty_posts_in_tag);
                     break;
@@ -920,10 +924,10 @@ public class ReaderPostListFragment extends Fragment
             return;
         }
 
-        TextView titleView = (TextView) mEmptyView.findViewById(R.id.title_empty);
+        TextView titleView = mEmptyView.findViewById(R.id.title_empty);
         titleView.setText(title);
 
-        TextView descriptionView = (TextView) mEmptyView.findViewById(R.id.description_empty);
+        TextView descriptionView = mEmptyView.findViewById(R.id.description_empty);
         if (description == null) {
             descriptionView.setVisibility(View.INVISIBLE);
         } else {
@@ -1621,6 +1625,7 @@ public class ReaderPostListFragment extends Fragment
             ReaderTagList tagList = ReaderTagTable.getDefaultTags();
             tagList.addAll(ReaderTagTable.getCustomListTags());
             tagList.addAll(ReaderTagTable.getFollowedTags());
+            tagList.addAll(ReaderTagTable.getBookmarkTags());
             return tagList;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -6,6 +6,7 @@ import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
 
 import org.json.JSONObject;
+import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.ReaderBlogTable;
 import org.wordpress.android.datasets.ReaderDatabase;
@@ -121,10 +122,16 @@ public class ReaderUpdateLogic {
                     serverTopics.addAll(parseTags(jsonObject, "subscribed", ReaderTagType.FOLLOWED));
                 }
 
+                // manually insert Bookmark tag, as server doesn't support bookmarking yet
+                serverTopics.add(new ReaderTag("", "",
+                        WordPress.getContext().getString(R.string.reader_save_for_later_title), "",
+                        ReaderTagType.BOOKMARKED));
+
                 // parse topics from the response, detect whether they're different from local
                 ReaderTagList localTopics = new ReaderTagList();
                 localTopics.addAll(ReaderTagTable.getDefaultTags());
                 localTopics.addAll(ReaderTagTable.getFollowedTags());
+                localTopics.addAll(ReaderTagTable.getBookmarkTags());
                 localTopics.addAll(ReaderTagTable.getCustomListTags());
 
                 if (!localTopics.isSameList(serverTopics)) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1308,6 +1308,7 @@
     <string name="passcode_turn_off">Turn PIN lock off</string>
     <string name="passcode_turn_on">Turn PIN lock on</string>
     <string name="passcodelock_prompt_message">Enter your PIN</string>
+    <!--suppress CheckTagEmptyBody -->
     <string name="passcodelock_hint"></string>
 
     <!--
@@ -1324,6 +1325,7 @@
     <!--
       reader strings
     -->
+    <string name="reader_save_for_later_title">Saved posts</string>
     <!-- timespan shown for posts/comments published within the past 60 seconds -->
     <string name="timespan_now">now</string>
 
@@ -1448,6 +1450,7 @@
     <string name="reader_empty_followed_blogs_no_recent_posts_title">No recent posts</string>
     <string name="reader_empty_followed_blogs_no_recent_posts_description">The sites you follow haven\'t posted anything recently</string>
     <string name="reader_empty_posts_liked">You haven\'t liked any posts</string>
+    <string name="reader_empty_posts_bookmarked">You haven\'t saved any posts</string>
     <string name="reader_empty_comments">No comments yet</string>
     <string name="reader_empty_posts_in_blog">This blog is empty</string>
     <string name="reader_empty_posts_in_search_title">No posts found</string>


### PR DESCRIPTION
Fixes #7688 

Adds "Saved posts" into the Reader's dropdown filter. The Bookmark tag is not supported on the server yet, therefore the Bookmark tag is manually added to tags retrieved from the server.

To test:
1. Go to reader
2. Open the dropdown spinner
3. Click on the "Saved posts" item
4. Observe that the view displays valid empty error message
