### PR TITLE
Adds save for later button into reader lists

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -928,7 +928,7 @@ public class ReaderPostTable {
             return new ReaderBlogIdPostIdList();
         }
 
-        String sql = "SELECT blog_id, post_id FROM tbl_posts WHERE tag_name=? AND tag_type=?";
+        String sql = "SELECT blog_id, post_id FROM tbl_posts WHERE tag_type=?";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + Integer.toString(maxPosts);

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -89,6 +89,8 @@ public class ReaderTag implements Serializable, FilterCriteria {
         String tagSlug = getTagSlug();
         if (tagType == ReaderTagType.DEFAULT) {
             return tagSlug;
+        } else if (tagType == ReaderTagType.BOOKMARKED) {
+            return ReaderTagType.BOOKMARKED.name();
         } else if (tagSlug.length() >= 6) {
             return tagSlug.substring(0, 3) + "...";
         } else if (tagSlug.length() >= 4) {
@@ -103,7 +105,8 @@ public class ReaderTag implements Serializable, FilterCriteria {
     /*
      * used to ensure a tag name is valid before adding it
      */
-    private static final Pattern INVALID_CHARS = Pattern.compile("^.*[~#@*+%{}<>\\[\\]|\"\\_].*$");
+    @SuppressWarnings("RegExpRedundantEscape") private static final Pattern INVALID_CHARS =
+            Pattern.compile("^.*[~#@*+%{}<>\\[\\]|\"\\_].*$");
 
     public static boolean isValidTagName(String tagName) {
         return !TextUtils.isEmpty(tagName)
@@ -138,11 +141,8 @@ public class ReaderTag implements Serializable, FilterCriteria {
     }
 
     public static boolean isSameTag(ReaderTag tag1, ReaderTag tag2) {
-        if (tag1 == null || tag2 == null) {
-            return false;
-        }
-        return tag1.tagType == tag2.tagType
-               && tag1.getTagSlug().equalsIgnoreCase(tag2.getTagSlug());
+        return tag1 != null && tag2 != null && tag1.tagType == tag2.tagType && tag1.getTagSlug()
+                                                                                   .equalsIgnoreCase(tag2.getTagSlug());
     }
 
     public boolean isPostsILike() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -424,7 +424,7 @@ public class ReaderPostListFragment extends Fragment
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         final ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.reader_fragment_post_cards, container, false);
-        mRecyclerView = (FilteredRecyclerView) rootView.findViewById(R.id.reader_recycler_view);
+        mRecyclerView = rootView.findViewById(R.id.reader_recycler_view);
 
         Context context = container.getContext();
 
@@ -542,7 +542,7 @@ public class ReaderPostListFragment extends Fragment
         });
 
         // progress bar that appears when loading more posts
-        mProgress = (ProgressBar) rootView.findViewById(R.id.progress_footer);
+        mProgress = rootView.findViewById(R.id.progress_footer);
         mProgress.setVisibility(View.GONE);
 
         return rootView;
@@ -846,9 +846,9 @@ public class ReaderPostListFragment extends Fragment
             return;
         }
 
-        ImageView page1 = (ImageView) mEmptyView.findViewById(R.id.empty_tags_box_page1);
-        ImageView page2 = (ImageView) mEmptyView.findViewById(R.id.empty_tags_box_page2);
-        ImageView page3 = (ImageView) mEmptyView.findViewById(R.id.empty_tags_box_page3);
+        ImageView page1 = mEmptyView.findViewById(R.id.empty_tags_box_page1);
+        ImageView page2 = mEmptyView.findViewById(R.id.empty_tags_box_page2);
+        ImageView page3 = mEmptyView.findViewById(R.id.empty_tags_box_page3);
 
         page1.startAnimation(AnimationUtils.loadAnimation(getActivity(), R.anim.box_with_pages_slide_up_page1));
         page2.startAnimation(AnimationUtils.loadAnimation(getActivity(), R.anim.box_with_pages_slide_up_page2));
@@ -863,7 +863,11 @@ public class ReaderPostListFragment extends Fragment
         String title;
         String description = null;
 
-        if (!NetworkUtils.isNetworkAvailable(getActivity())) {
+        if (getPostListType() == ReaderPostListType.TAG_FOLLOWED && getCurrentTag().isBookmarked()) {
+            // only local bookmarks are currently supported, so if there are no data in the local database we can
+            // show an empty view
+            title = getString(R.string.reader_empty_posts_bookmarked);
+        } else if (!NetworkUtils.isNetworkAvailable(getActivity())) {
             title = getString(R.string.reader_empty_posts_no_connection);
         } else if (requestFailed) {
             title = getString(R.string.reader_empty_posts_request_failed);
@@ -905,7 +909,7 @@ public class ReaderPostListFragment extends Fragment
                                                     formattedQuery);
                     }
                     break;
-
+                case TAG_PREVIEW:
                 default:
                     title = getString(R.string.reader_empty_posts_in_tag);
                     break;
@@ -920,10 +924,10 @@ public class ReaderPostListFragment extends Fragment
             return;
         }
 
-        TextView titleView = (TextView) mEmptyView.findViewById(R.id.title_empty);
+        TextView titleView = mEmptyView.findViewById(R.id.title_empty);
         titleView.setText(title);
 
-        TextView descriptionView = (TextView) mEmptyView.findViewById(R.id.description_empty);
+        TextView descriptionView = mEmptyView.findViewById(R.id.description_empty);
         if (description == null) {
             descriptionView.setVisibility(View.INVISIBLE);
         } else {
@@ -1621,6 +1625,7 @@ public class ReaderPostListFragment extends Fragment
             ReaderTagList tagList = ReaderTagTable.getDefaultTags();
             tagList.addAll(ReaderTagTable.getCustomListTags());
             tagList.addAll(ReaderTagTable.getFollowedTags());
+            tagList.addAll(ReaderTagTable.getBookmarkTags());
             return tagList;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -131,7 +131,7 @@ public class ReaderPostPagerActivity extends AppCompatActivity
 
         setContentView(R.layout.reader_activity_post_pager);
 
-        mToolbar = (Toolbar) findViewById(R.id.toolbar);
+        mToolbar = findViewById(R.id.toolbar);
         setSupportActionBar(mToolbar);
 
         ActionBar actionBar = getSupportActionBar();
@@ -140,8 +140,8 @@ public class ReaderPostPagerActivity extends AppCompatActivity
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
 
-        mViewPager = (WPViewPager) findViewById(R.id.viewpager);
-        mProgress = (ProgressBar) findViewById(R.id.progress_loading);
+        mViewPager = findViewById(R.id.viewpager);
+        mProgress = findViewById(R.id.progress_loading);
 
         if (savedInstanceState != null) {
             mIsFeed = savedInstanceState.getBoolean(ReaderConstants.ARG_IS_FEED);
@@ -611,7 +611,8 @@ public class ReaderPostPagerActivity extends AppCompatActivity
         if (fragment != null && fragment.isCustomViewShowing()) {
             // if full screen video is showing, hide the custom view rather than navigate back
             fragment.hideCustomView();
-        } else if (fragment != null && fragment.goBackInPostHistory()) {
+        } else //noinspection StatementWithEmptyBody
+            if (fragment != null && fragment.goBackInPostHistory()) {
             // noop - fragment moved back to a previous post
         } else {
             super.onBackPressed();
@@ -674,6 +675,7 @@ public class ReaderPostPagerActivity extends AppCompatActivity
                         case BLOG_PREVIEW:
                             idList = ReaderPostTable.getBlogIdPostIdsInBlog(blogId, maxPosts);
                             break;
+                        case SEARCH_RESULTS:
                         default:
                             return;
                     }
@@ -917,7 +919,7 @@ public class ReaderPostPagerActivity extends AppCompatActivity
         }
 
         @Override
-        public Object instantiateItem(ViewGroup container, int position) {
+        public @NonNull Object instantiateItem(ViewGroup container, int position) {
             Object item = super.instantiateItem(container, position);
             if (item instanceof Fragment) {
                 mFragmentMap.put(position, (Fragment) item);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.reader.ReaderAnim;
 import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.reader.ReaderInterfaces;
 import org.wordpress.android.ui.reader.ReaderTypes;
+import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderBlogActions;
 import org.wordpress.android.ui.reader.actions.ReaderPostActions;
@@ -766,7 +767,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     private void showLikes(final ReaderPostViewHolder holder, final ReaderPost post) {
         boolean canShowLikes;
-        if (post.isDiscoverPost()) {
+        if (post.isDiscoverPost()
+            || (getPostListType() == ReaderPostListType.TAG_FOLLOWED && mCurrentTag.isBookmarked())) {
             canShowLikes = false;
         } else if (mIsLoggedOutReader) {
             canShowLikes = post.numLikes > 0;
@@ -826,7 +828,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     private void showComments(final ReaderPostViewHolder holder, final ReaderPost post) {
         boolean canShowComments;
-        if (post.isDiscoverPost()) {
+        if (post.isDiscoverPost()
+            || (getPostListType() == ReaderPostListType.TAG_FOLLOWED && mCurrentTag.isBookmarked())) {
             canShowComments = false;
         } else if (mIsLoggedOutReader) {
             canShowComments = post.numReplies > 0;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -2,10 +2,12 @@ package org.wordpress.android.ui.reader.adapters;
 
 import android.content.Context;
 import android.os.AsyncTask;
+import android.support.annotation.NonNull;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -105,11 +107,11 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         ReaderXPostViewHolder(View itemView) {
             super(itemView);
-            mCardView = (CardView) itemView.findViewById(R.id.card_view);
-            mImgAvatar = (WPNetworkImageView) itemView.findViewById(R.id.image_avatar);
-            mImgBlavatar = (WPNetworkImageView) itemView.findViewById(R.id.image_blavatar);
-            mTxtTitle = (TextView) itemView.findViewById(R.id.text_title);
-            mTxtSubtitle = (TextView) itemView.findViewById(R.id.text_subtitle);
+            mCardView = itemView.findViewById(R.id.card_view);
+            mImgAvatar = itemView.findViewById(R.id.image_avatar);
+            mImgBlavatar = itemView.findViewById(R.id.image_blavatar);
+            mTxtTitle = itemView.findViewById(R.id.text_title);
+            mTxtSubtitle = itemView.findViewById(R.id.text_subtitle);
 
             mCardView.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -137,6 +139,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         private final ReaderIconCountView mCommentCount;
         private final ReaderIconCountView mLikeCount;
+        private final ImageView mBtnBookmark;
 
         private final ImageView mImgMore;
         private final ImageView mImgVideoOverlay;
@@ -159,33 +162,34 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         ReaderPostViewHolder(View itemView) {
             super(itemView);
 
-            mCardView = (CardView) itemView.findViewById(R.id.card_view);
+            mCardView = itemView.findViewById(R.id.card_view);
 
-            mTxtTitle = (TextView) itemView.findViewById(R.id.text_title);
-            mTxtText = (TextView) itemView.findViewById(R.id.text_excerpt);
-            mTxtAuthorAndBlogName = (TextView) itemView.findViewById(R.id.text_author_and_blog_name);
-            mTxtDateline = (TextView) itemView.findViewById(R.id.text_dateline);
+            mTxtTitle = itemView.findViewById(R.id.text_title);
+            mTxtText = itemView.findViewById(R.id.text_excerpt);
+            mTxtAuthorAndBlogName = itemView.findViewById(R.id.text_author_and_blog_name);
+            mTxtDateline = itemView.findViewById(R.id.text_dateline);
 
-            mCommentCount = (ReaderIconCountView) itemView.findViewById(R.id.count_comments);
-            mLikeCount = (ReaderIconCountView) itemView.findViewById(R.id.count_likes);
+            mCommentCount = itemView.findViewById(R.id.count_comments);
+            mLikeCount = itemView.findViewById(R.id.count_likes);
+            mBtnBookmark = itemView.findViewById(R.id.bookmark);
 
-            mFramePhoto = (ViewGroup) itemView.findViewById(R.id.frame_photo);
-            mTxtPhotoTitle = (TextView) mFramePhoto.findViewById(R.id.text_photo_title);
-            mImgFeatured = (WPNetworkImageView) mFramePhoto.findViewById(R.id.image_featured);
-            mImgVideoOverlay = (ImageView) mFramePhoto.findViewById(R.id.image_video_overlay);
+            mFramePhoto = itemView.findViewById(R.id.frame_photo);
+            mTxtPhotoTitle = mFramePhoto.findViewById(R.id.text_photo_title);
+            mImgFeatured = mFramePhoto.findViewById(R.id.image_featured);
+            mImgVideoOverlay = mFramePhoto.findViewById(R.id.image_video_overlay);
 
-            mImgAvatarOrBlavatar = (WPNetworkImageView) itemView.findViewById(R.id.image_avatar_or_blavatar);
-            mImgMore = (ImageView) itemView.findViewById(R.id.image_more);
-            mVisit = (LinearLayout) itemView.findViewById(R.id.visit);
+            mImgAvatarOrBlavatar = itemView.findViewById(R.id.image_avatar_or_blavatar);
+            mImgMore = itemView.findViewById(R.id.image_more);
+            mVisit = itemView.findViewById(R.id.visit);
 
-            mLayoutDiscover = (ViewGroup) itemView.findViewById(R.id.layout_discover);
-            mImgDiscoverAvatar = (WPNetworkImageView) mLayoutDiscover.findViewById(R.id.image_discover_avatar);
-            mTxtDiscover = (TextView) mLayoutDiscover.findViewById(R.id.text_discover);
+            mLayoutDiscover = itemView.findViewById(R.id.layout_discover);
+            mImgDiscoverAvatar = mLayoutDiscover.findViewById(R.id.image_discover_avatar);
+            mTxtDiscover = mLayoutDiscover.findViewById(R.id.text_discover);
 
-            mThumbnailStrip = (ReaderThumbnailStrip) itemView.findViewById(R.id.thumbnail_strip);
+            mThumbnailStrip = itemView.findViewById(R.id.thumbnail_strip);
 
-            ViewGroup postHeaderView = (ViewGroup) itemView.findViewById(R.id.layout_post_header);
-            mFollowButton = (ReaderFollowButton) postHeaderView.findViewById(R.id.follow_button);
+            ViewGroup postHeaderView = itemView.findViewById(R.id.layout_post_header);
+            mFollowButton = postHeaderView.findViewById(R.id.follow_button);
 
             // show post in internal browser when "visit" is clicked
             View.OnClickListener visitListener = new View.OnClickListener() {
@@ -285,7 +289,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     @Override
-    public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    public @NonNull RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         Context context = parent.getContext();
         switch (viewType) {
             case VIEW_TYPE_SITE_HEADER:
@@ -308,7 +312,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     @Override
-    public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
         if (holder instanceof ReaderPostViewHolder) {
             renderPost(position, (ReaderPostViewHolder) holder);
         } else if (holder instanceof ReaderXPostViewHolder) {
@@ -453,6 +457,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         showLikes(holder, post);
         showComments(holder, post);
+        initBookmarkButton(holder.mBtnBookmark, post);
 
         // more menu only shows for followed tags
         if (!mIsLoggedOutReader && postListType == ReaderTypes.ReaderPostListType.TAG_FOLLOWED) {
@@ -791,6 +796,34 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
     }
 
+    private void initBookmarkButton(final View bookmarkButton, final ReaderPost post) {
+        updateBookmarkView(bookmarkButton, post);
+        bookmarkButton.setOnClickListener(new OnClickListener() {
+            @Override public void onClick(View v) {
+                toggleBookmark(v, post.blogId, post.postId);
+            }
+        });
+    }
+
+    private void updateBookmarkView(final View bookmarkButton, final ReaderPost post) {
+        Context context = bookmarkButton.getContext();
+
+        boolean canBookmarkPost = (post.isWP() || post.isJetpack) && !post.isDiscoverPost();
+        if (canBookmarkPost) {
+            bookmarkButton.setVisibility(View.VISIBLE);
+        } else {
+            bookmarkButton.setVisibility(View.GONE);
+        }
+        ((ImageView) bookmarkButton).setImageResource(post.isBookmarked ? R.drawable.ic_bookmark_18dp
+                : R.drawable.ic_bookmark_outline_18dp);
+        ReaderUtils.setBackgroundToRoundRipple(bookmarkButton);
+        if (post.isBookmarked) {
+            bookmarkButton.setContentDescription(context.getString(R.string.reader_remove_bookmark));
+        } else {
+            bookmarkButton.setContentDescription(context.getString(R.string.reader_add_bookmark));
+        }
+    }
+
     private void showComments(final ReaderPostViewHolder holder, final ReaderPost post) {
         boolean canShowComments;
         if (post.isDiscoverPost()) {
@@ -848,6 +881,26 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         if (updatedPost != null && position > -1) {
             mPosts.set(position, updatedPost);
             showLikes(holder, updatedPost);
+        }
+    }
+
+    /*
+     * triggered when user taps the bookmark post button
+     */
+    private void toggleBookmark(View bookmarkButton, long blogId, long postId) {
+        ReaderPost post = ReaderPostTable.getBlogPost(blogId, postId, false);
+        if (post.isBookmarked) {
+            ReaderPostActions.removeFromBookmarked(post);
+        } else {
+            ReaderPostActions.addToBookmarked(post);
+        }
+
+        // update post in array and on screen
+        post = ReaderPostTable.getBlogPost(blogId, postId, true);
+        int position = mPosts.indexOfPost(post);
+        if (post != null && position > -1) {
+            mPosts.set(position, post);
+            updateBookmarkView(bookmarkButton, post);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -6,6 +6,7 @@ import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
 
 import org.json.JSONObject;
+import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.ReaderBlogTable;
 import org.wordpress.android.datasets.ReaderDatabase;
@@ -121,10 +122,16 @@ public class ReaderUpdateLogic {
                     serverTopics.addAll(parseTags(jsonObject, "subscribed", ReaderTagType.FOLLOWED));
                 }
 
+                // manually insert Bookmark tag, as server doesn't support bookmarking yet
+                serverTopics.add(new ReaderTag("", "",
+                        WordPress.getContext().getString(R.string.reader_save_for_later_title), "",
+                        ReaderTagType.BOOKMARKED));
+
                 // parse topics from the response, detect whether they're different from local
                 ReaderTagList localTopics = new ReaderTagList();
                 localTopics.addAll(ReaderTagTable.getDefaultTags());
                 localTopics.addAll(ReaderTagTable.getFollowedTags());
+                localTopics.addAll(ReaderTagTable.getBookmarkTags());
                 localTopics.addAll(ReaderTagTable.getCustomListTags());
 
                 if (!localTopics.isSameList(serverTopics)) {

--- a/WordPress/src/main/res/color/button_medium_blue_tint_disabled.xml
+++ b/WordPress/src/main/res/color/button_medium_blue_tint_disabled.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/grey_lighten_10" android:state_pressed="false"/>
+    <item android:color="@color/blue_medium"/>
+</selector>

--- a/WordPress/src/main/res/color/button_medium_blue_tint_enabled.xml
+++ b/WordPress/src/main/res/color/button_medium_blue_tint_enabled.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/blue_medium" android:state_pressed="false"/>
+    <item android:color="@color/grey_lighten_10"/>
+</selector>

--- a/WordPress/src/main/res/drawable/ic_bookmark_18dp.xml
+++ b/WordPress/src/main/res/drawable/ic_bookmark_18dp.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="18dp"
+        android:height="18dp"
+        android:tint="@color/button_medium_blue_tint_enabled"
+        android:tintMode="multiply"
+        android:viewportHeight="24"
+        android:viewportWidth="24">
+    <path
+        android:fillColor="@color/white"
+        android:pathData="M17,3H7C5.895,3 5,3.896 5,5v16l7,-4l7,4V5C19,3.896 18.104,3 17,3z"/>
+</vector>

--- a/WordPress/src/main/res/drawable/ic_bookmark_outline_18dp.xml
+++ b/WordPress/src/main/res/drawable/ic_bookmark_outline_18dp.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="18dp"
+        android:height="18dp"
+        android:tint="@color/button_medium_blue_tint_disabled"
+        android:tintMode="multiply"
+        android:viewportHeight="24"
+        android:viewportWidth="24">
+    <path
+        android:fillColor="@color/white"
+        android:pathData="M17,5v12.554l-5,-2.857l-5,2.857V5H17M17,3H7C5.895,3 5,3.896 5,5v16l7,-4l7,4V5C19,3.896 18.104,3 17,3L17,3z"/>
+</vector>

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -64,17 +64,17 @@
                 android:layout_marginEnd="@dimen/margin_large">
 
                 <org.wordpress.android.widgets.WPTextView
-                    android:textAlignment="viewStart"
-                    android:gravity="start"
                     android:id="@+id/text_author_and_blog_name"
                     style="@style/ReaderTextView"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:ellipsize="end"
+                    android:gravity="start"
                     android:maxLines="1"
+                    android:textAlignment="viewStart"
                     android:textColor="@color/reader_hyperlink"
                     android:textSize="@dimen/text_sz_medium"
-                    tools:text="text_blog_name" />
+                    tools:text="text_blog_nametext_blog_name text_blog_name"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/text_dateline"
@@ -224,6 +224,27 @@
                     android:textColor="@color/reader_count_text"
                     android:textSize="@dimen/text_sz_medium" />
             </LinearLayout>
+
+            <ViewStub
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_toLeftOf="@+id/bookmark"
+                android:layout_toStartOf="@+id/bookmark"
+                android:layout_toRightOf="@+id/visit"
+                android:layout_toEndOf="@+id/visit"/>
+
+            <ImageView
+                android:id="@+id/bookmark"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_toLeftOf="@id/count_comments"
+                android:layout_toStartOf="@id/count_comments"
+                android:layout_alignWithParentIfMissing="true"
+                app:srcCompat="@drawable/ic_bookmark_18dp"
+                android:contentDescription="@string/reader_add_bookmark"
+                android:padding="@dimen/margin_medium"
+                android:layout_centerVertical="true"
+                />
 
             <org.wordpress.android.ui.reader.views.ReaderIconCountView
                 android:id="@+id/count_comments"

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -48,20 +48,22 @@
                 android:layout_height="wrap_content"
                 android:layout_alignParentRight="true"
                 android:layout_marginLeft="@dimen/margin_large"
-                android:paddingLeft="@dimen/reader_follow_button_padding"
                 android:layout_marginStart="@dimen/margin_large"
                 android:layout_alignParentEnd="true"
-                android:paddingStart="@dimen/reader_follow_button_padding"/>
+                android:paddingLeft="@dimen/reader_follow_button_padding"
+                android:paddingStart="@dimen/reader_follow_button_padding"
+                android:paddingRight="@dimen/reader_follow_button_padding"
+                android:paddingEnd="@dimen/reader_follow_button_padding"/>
 
             <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginRight="@dimen/margin_large"
+                android:layout_marginRight="@dimen/margin_medium"
                 android:layout_toLeftOf="@+id/follow_button"
                 android:layout_toRightOf="@+id/image_avatar_or_blavatar"
                 android:layout_toStartOf="@+id/follow_button"
                 android:layout_toEndOf="@+id/image_avatar_or_blavatar"
-                android:layout_marginEnd="@dimen/margin_large">
+                android:layout_marginEnd="@dimen/margin_medium">
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/text_author_and_blog_name"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1357,6 +1357,8 @@
     <string name="reader_btn_share">Share</string>
     <string name="reader_btn_follow">Follow</string>
     <string name="reader_btn_unfollow">Following</string>
+    <string name="reader_add_bookmark">Add to saved posts</string>
+    <string name="reader_remove_bookmark">Remove from saved posts</string>
 
     <!-- EditText hints -->
     <string name="reader_hint_comment_on_post">Reply to post…</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1308,6 +1308,7 @@
     <string name="passcode_turn_off">Turn PIN lock off</string>
     <string name="passcode_turn_on">Turn PIN lock on</string>
     <string name="passcodelock_prompt_message">Enter your PIN</string>
+    <!--suppress CheckTagEmptyBody -->
     <string name="passcodelock_hint"></string>
 
     <!--
@@ -1324,6 +1325,7 @@
     <!--
       reader strings
     -->
+    <string name="reader_save_for_later_title">Saved posts</string>
     <!-- timespan shown for posts/comments published within the past 60 seconds -->
     <string name="timespan_now">now</string>
 
@@ -1448,6 +1450,7 @@
     <string name="reader_empty_followed_blogs_no_recent_posts_title">No recent posts</string>
     <string name="reader_empty_followed_blogs_no_recent_posts_description">The sites you follow haven\'t posted anything recently</string>
     <string name="reader_empty_posts_liked">You haven\'t liked any posts</string>
+    <string name="reader_empty_posts_bookmarked">You haven\'t saved any posts</string>
     <string name="reader_empty_comments">No comments yet</string>
     <string name="reader_empty_posts_in_blog">This blog is empty</string>
     <string name="reader_empty_posts_in_search_title">No posts found</string>


### PR DESCRIPTION
Fixes #7687 

Adds saveForLater button for each item in the reader lists (discovery pots without postid and blogId are not supproted).

Hides like and comment buttons on list items in the Saved posts list.

To test:
1. Open the Reader
2. Select "Followed sites" from the dropdown filter
3. Click on the "Save for later" button on one of the posts
4. Select "Saved posts" from the dropdown filter
5. Notice the post saved in step 3 is shown
6. Notice the comment and likes buttons are not displayed

Related tickets #7719 #7720 

This PR is blocked by #7717 #7718 - feel free to remove "Not Ready for Review" label when those two PRs are merged.