### PR TITLE
Remove temporary workaround for jcenter not synced

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ allprojects {
         maven {
             url "https://maven.google.com"
         }
-        maven { url "https://dl.bintray.com/wordpress-mobile/maven" }
     }
 
     task checkstyle(type: Checkstyle) {


### PR DESCRIPTION
WordPress-lint project was not synchronized with jcenter. We've added dl.bintray repo as a temporary workaround. Synchronization is fixed now, so we can safely remove dl.bintray repo.

To test - nothing to test, successful build is enough.