### PR TITLE
Fix publish with confidence shown when updating a draft

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1060,10 +1060,10 @@ public class EditPostActivity extends AppCompatActivity implements
         hidePhotoPicker();
 
         if (itemId == R.id.menu_save_post) {
-            if (!AppPrefs.isAsyncPromoRequired()) {
-                showPublishConfirmationOrUpdateIfNotLocalDraft();
-            } else {
+            if (AppPrefs.isAsyncPromoRequired() && PostStatus.fromPost(mPost) != PostStatus.DRAFT) {
                 showAsyncPromoDialog();
+            } else {
+                showPublishConfirmationOrUpdateIfNotLocalDraft();
             }
         } else {
             // Disable other action bar buttons while a media upload is in progress


### PR DESCRIPTION
Fixes #7675

Publish with confidence dialog is shown only when publishing a post (not when updating a draft).

To test:
1. Clear app data
2. Login
3. Open a draft - click on the "Update" button in the toolbar
4. Notice that the publish with confidence dialog is **not** shown

cc @mzorz 
