### PR TITLE
Fix crash during layout inflation on asus devices

### DIFF
--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -150,7 +150,7 @@
     <style name="MediaSettings.TextInputStyle">
         <item name="android:layout_marginTop">@dimen/margin_medium</item>
     </style>
-    <style name="MediaSettings.TextInputTheme" parent="TextAppearance.AppCompat">
+    <style name="MediaSettings.TextInputTheme" parent="ThemeOverlay.AppCompat.Light">
         <!-- Hint color and label color in FALSE state -->
         <item name="android:textColorHint">@color/grey_darken_10</item>
         <!-- Label color in TRUE state and bar color FALSE and TRUE State -->
@@ -158,10 +158,7 @@
         <item name="colorControlActivated">@color/blue_wordpress</item>
         <item name="android:textAlignment">viewStart</item>
         <item name="android:gravity">start</item>
-
-        <!-- Fix for crash on ASUS devices - https://github.com/wordpress-mobile/WordPress-Android/issues/7038 -->
-        <item name="android:textColorHighlight">@color/transparent</item>
-        <item name="android:textColorLink">@color/transparent</item>
+        <item name="android:textSize">@dimen/text_sz_medium</item>
     </style>
     <style name="MediaSettings.Divider">
         <item name="android:background">@color/divider_grey</item>


### PR DESCRIPTION
Fixes #7145

The app keeps crashing on Asus devices with Android 5.x. I don't have such device, so I can't really make sure the fix works. However after investigating the issue, I believe the app crashes on media settings screen in the editor. The issue is that we use a theme which uses attributes which are missing on Asus device with Android 5.x. I've changed the theme to AppCompat so it shouldn't cause any troubles anymore.

To test:
1. Go to editor
2. Insert an image
3. Click on the image (open media settings)
4. Make sure the EditTexts looks still the same as before.

@maxme might worth cherry picking into the next release.