### PR TITLE
issue/5500 Default category/post format

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -116,7 +116,6 @@ import org.wordpress.android.ui.posts.services.AztecImageLoader;
 import org.wordpress.android.ui.posts.services.AztecVideoLoader;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.ReleaseNotesActivity;
-import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.ui.stockmedia.StockMediaPickerActivity;
 import org.wordpress.android.ui.uploads.PostEvents;
 import org.wordpress.android.ui.uploads.UploadService;
@@ -367,13 +366,6 @@ public class EditPostActivity extends AppCompatActivity implements
                 // Create a new post
                 List<Long> categories = new ArrayList<>();
                 String postFormat = "";
-                if (mSite.isUsingWpComRestApi()) {
-                    // TODO: replace SiteSettingsInterface.getX by calls to mSite.getDefaultCategory
-                    // and mSite.getDefaultFormat. We can get these from /me/sites endpoint for .com/jetpack sites.
-                    // There might be a way to get that information from a XMLRPC request as well.
-                    categories.add((long) SiteSettingsInterface.getDefaultCategory(WordPress.getContext()));
-                    postFormat = SiteSettingsInterface.getDefaultFormat(WordPress.getContext());
-                }
                 mPost = mPostStore.instantiatePostModel(mSite, mIsPage, categories, postFormat);
                 mPost.setStatus(PostStatus.PUBLISHED.toString());
                 EventBus.getDefault().postSticky(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -364,9 +364,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 }
 
                 // Create a new post
-                List<Long> categories = new ArrayList<>();
-                String postFormat = "";
-                mPost = mPostStore.instantiatePostModel(mSite, mIsPage, categories, postFormat);
+                mPost = mPostStore.instantiatePostModel(mSite, mIsPage, null, null);
                 mPost.setStatus(PostStatus.PUBLISHED.toString());
                 EventBus.getDefault().postSticky(
                         new PostEvents.PostOpenedInEditor(mPost.getLocalSiteId(), mPost.getId()));

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.prefs;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.os.Handler;
 import android.support.annotation.NonNull;
@@ -75,26 +74,6 @@ import javax.inject.Inject;
 
 public abstract class SiteSettingsInterface {
     /**
-     * Name of the {@link SharedPreferences} that is used to store local settings.
-     */
-    private static final String SITE_SETTINGS_PREFS = "site-settings-prefs";
-
-    /**
-     * Key used to access the language preference stored in {@link SharedPreferences}.
-     */
-    private static final String LANGUAGE_PREF_KEY = "site-settings-language-pref";
-
-    /**
-     * Key used to access the default category preference stored in {@link SharedPreferences}.
-     */
-    private static final String DEF_CATEGORY_PREF_KEY = "site-settings-category-pref";
-
-    /**
-     * Key used to access the default post format preference stored in {@link SharedPreferences}.
-     */
-    private static final String DEF_FORMAT_PREF_KEY = "site-settings-format-pref";
-
-    /**
      * Identifies an Ascending (oldest to newest) sort order.
      */
     static final int ASCENDING_SORT = 0;
@@ -138,27 +117,6 @@ public abstract class SiteSettingsInterface {
         }
 
         return new SelfHostedSiteSettings(host, site, listener);
-    }
-
-    /**
-     * Returns an instance of the {@link this#SITE_SETTINGS_PREFS} {@link SharedPreferences}.
-     */
-    public static SharedPreferences siteSettingsPreferences(Context context) {
-        return context.getSharedPreferences(SITE_SETTINGS_PREFS, Context.MODE_PRIVATE);
-    }
-
-    /**
-     * Gets the default category value stored in {@link SharedPreferences}, 0 by default.
-     */
-    public static int getDefaultCategory(Context context) {
-        return siteSettingsPreferences(context).getInt(DEF_CATEGORY_PREF_KEY, 1);
-    }
-
-    /**
-     * Gets the default post format value stored in {@link SharedPreferences}, "" by default.
-     */
-    public static String getDefaultFormat(Context context) {
-        return siteSettingsPreferences(context).getString(DEF_FORMAT_PREF_KEY, "");
     }
 
     /**
@@ -232,11 +190,6 @@ public abstract class SiteSettingsInterface {
 
     public void saveSettings() {
         SiteSettingsTable.saveSettings(mSettings);
-        siteSettingsPreferences(mContext).edit()
-                                         .putString(LANGUAGE_PREF_KEY, mSettings.language)
-                                         .putInt(DEF_CATEGORY_PREF_KEY, mSettings.defaultCategory)
-                                         .putString(DEF_FORMAT_PREF_KEY, mSettings.defaultPostFormat)
-                                         .apply();
     }
 
     public @NonNull String getTitle() {


### PR DESCRIPTION
Fixes #5500

Fixes issue when posts sent from the app didn't have correct default category and default post format. 

Removes SiteSettings shared preferences, since they didn't have any real usage. Moreover they were source of another bug -> out of date values were cached in the shared preferences, until the user went to the Site Settings and changed something. So when the user changed default category/post format on the web, the app would still use previous(out of date) settings.

To test:
1. Set default category to 'XYZ' and post format to 'Quote' using a web browser
2. Go to the app and publish a post
3. Notice that the post has category 'XYZ' and post format 'Quote'
