### PR TITLE
Feature/save post for later button in post details

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -665,6 +665,7 @@ public class ReaderPost {
                && post.isLikedByCurrentUser == this.isLikedByCurrentUser
                && post.isCommentsOpen == this.isCommentsOpen
                && post.useExcerpt == this.useExcerpt
+               && post.isBookmarked == this.isBookmarked
                && post.getTitle().equals(this.getTitle())
                && post.getExcerpt().equals(this.getExcerpt())
                && post.getText().equals(this.getText());

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -665,7 +665,6 @@ public class ReaderPost {
                && post.isLikedByCurrentUser == this.isLikedByCurrentUser
                && post.isCommentsOpen == this.isCommentsOpen
                && post.useExcerpt == this.useExcerpt
-               && post.isBookmarked == this.isBookmarked
                && post.getTitle().equals(this.getTitle())
                && post.getExcerpt().equals(this.getExcerpt())
                && post.getText().equals(this.getText());

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPostList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPostList.java
@@ -74,6 +74,35 @@ public class ReaderPostList extends ArrayList<ReaderPost> {
         return true;
     }
 
+
+    /*
+     * Does passed list contain the same posts as this list?
+     * Also compares the bookmark flag that is not yet implemented on server
+     * We might want to use original isSameList when bookmarked flag will be implemented on server side and Post model
+     * updated.
+     */
+    public boolean isSameListWithBookmark(ReaderPostList posts) {
+        if (posts == null || posts.size() != this.size()) {
+            return false;
+        }
+
+        for (ReaderPost post : posts) {
+            int index = indexOfPost(post);
+
+            if (index == -1) {
+                return false;
+            }
+
+            ReaderPost postInsideList = this.get(index);
+
+            if (!post.isSamePost(postInsideList) || post.isBookmarked != postInsideList.isBookmarked) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     /*
      * returns posts in this list which are in the passed blog
      */

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -107,6 +107,7 @@ public class ReaderPostDetailFragment extends Fragment
     private View mLikingUsersDivider;
     private View mLikingUsersLabel;
     private WPTextView mSignInButton;
+    private ReaderBookmarkButton mReaderBookmarkButton;
 
     private ReaderSimplePostContainerView mGlobalRelatedPostsView;
     private ReaderSimplePostContainerView mLocalRelatedPostsView;
@@ -255,6 +256,8 @@ public class ReaderPostDetailFragment extends Fragment
 
         mSignInButton = (WPTextView) view.findViewById(R.id.nux_sign_in_button);
         mSignInButton.setOnClickListener(mSignInClickListener);
+
+        mReaderBookmarkButton = view.findViewById(R.id.bookmark_button);
 
         final ProgressBar progress = (ProgressBar) view.findViewById(R.id.progress_loading);
         if (mPostSlugsResolutionUnderway) {
@@ -426,6 +429,15 @@ public class ReaderPostDetailFragment extends Fragment
         }
     }
 
+    private void initBookmarkButton() {
+        updateBookmarkView();
+        mReaderBookmarkButton.setOnClickListener(new View.OnClickListener() {
+            @Override public void onClick(View v) {
+                toggleBookmark();
+            }
+        });
+    }
+
     /*
      * triggered when user taps the bookmark post button
      */
@@ -442,29 +454,21 @@ public class ReaderPostDetailFragment extends Fragment
 
         mPost = ReaderPostTable.getBlogPost(mPost.blogId, mPost.postId, false);
 
-        initBookmarkButton();
+        updateBookmarkView();
     }
 
-
-    private void initBookmarkButton() {
+    private void updateBookmarkView() {
         if (!isAdded() || !hasPost() || !canShowFooter()) {
             return;
         }
 
-        ReaderBookmarkButton bookmarkButton = getView().findViewById(R.id.bookmark_button);
         if (!canShowBookmarkButton()) {
-            bookmarkButton.setVisibility(View.GONE);
+            mReaderBookmarkButton.setVisibility(View.GONE);
         } else {
-            bookmarkButton.setVisibility(View.VISIBLE);
+            mReaderBookmarkButton.setVisibility(View.VISIBLE);
         }
 
-        bookmarkButton.setIsBookmarked(mPost.isBookmarked);
-
-        bookmarkButton.setOnClickListener(new View.OnClickListener() {
-            @Override public void onClick(View view) {
-                toggleBookmark();
-            }
-        });
+        mReaderBookmarkButton.setIsBookmarked(mPost.isBookmarked);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -442,8 +442,7 @@ public class ReaderPostDetailFragment extends Fragment
 
         mPost = ReaderPostTable.getBlogPost(mPost.blogId, mPost.postId, false);
 
-        ReaderBookmarkButton bookmarkButton = getView().findViewById(R.id.bookmark_button);
-        bookmarkButton.setIsBookmarked(mPost.isBookmarked);
+        initBookmarkButton();
     }
 
 
@@ -467,7 +466,6 @@ public class ReaderPostDetailFragment extends Fragment
             }
         });
     }
-
 
     /*
      * changes the like on the passed post

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -451,9 +451,8 @@ public class ReaderPostDetailFragment extends Fragment
             mReaderBookmarkButton.setVisibility(View.GONE);
         } else {
             mReaderBookmarkButton.setVisibility(View.VISIBLE);
+            mReaderBookmarkButton.setIsBookmarked(mPost.isBookmarked);
         }
-
-        mReaderBookmarkButton.setIsBookmarked(mPost.isBookmarked);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -430,12 +430,30 @@ public class ReaderPostDetailFragment extends Fragment
     }
 
     private void initBookmarkButton() {
+        if (!canShowFooter()) {
+            return;
+        }
+
         updateBookmarkView();
         mReaderBookmarkButton.setOnClickListener(new View.OnClickListener() {
             @Override public void onClick(View v) {
                 toggleBookmark();
             }
         });
+    }
+
+    private void updateBookmarkView() {
+        if (!isAdded() || !hasPost()) {
+            return;
+        }
+
+        if (!canShowBookmarkButton()) {
+            mReaderBookmarkButton.setVisibility(View.GONE);
+        } else {
+            mReaderBookmarkButton.setVisibility(View.VISIBLE);
+        }
+
+        mReaderBookmarkButton.setIsBookmarked(mPost.isBookmarked);
     }
 
     /*
@@ -455,20 +473,6 @@ public class ReaderPostDetailFragment extends Fragment
         mPost = ReaderPostTable.getBlogPost(mPost.blogId, mPost.postId, false);
 
         updateBookmarkView();
-    }
-
-    private void updateBookmarkView() {
-        if (!isAdded() || !hasPost() || !canShowFooter()) {
-            return;
-        }
-
-        if (!canShowBookmarkButton()) {
-            mReaderBookmarkButton.setVisibility(View.GONE);
-        } else {
-            mReaderBookmarkButton.setVisibility(View.VISIBLE);
-        }
-
-        mReaderBookmarkButton.setIsBookmarked(mPost.isBookmarked);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -427,6 +427,49 @@ public class ReaderPostDetailFragment extends Fragment
     }
 
     /*
+     * triggered when user taps the bookmark post button
+     */
+    private void toggleBookmark() {
+        if (!isAdded() || !hasPost()) {
+            return;
+        }
+
+        if (mPost.isBookmarked) {
+            ReaderPostActions.removeFromBookmarked(mPost);
+        } else {
+            ReaderPostActions.addToBookmarked(mPost);
+        }
+
+        mPost = ReaderPostTable.getBlogPost(mPost.blogId, mPost.postId, false);
+
+        ReaderBookmarkButton bookmarkButton = getView().findViewById(R.id.bookmark_button);
+        bookmarkButton.setIsBookmarked(mPost.isBookmarked);
+    }
+
+
+    private void initBookmarkButton() {
+        if (!isAdded() || !hasPost() || !canShowFooter()) {
+            return;
+        }
+
+        ReaderBookmarkButton bookmarkButton = getView().findViewById(R.id.bookmark_button);
+        if (!canShowBookmarkButton()) {
+            bookmarkButton.setVisibility(View.GONE);
+        } else {
+            bookmarkButton.setVisibility(View.VISIBLE);
+        }
+
+        bookmarkButton.setIsBookmarked(mPost.isBookmarked);
+
+        bookmarkButton.setOnClickListener(new View.OnClickListener() {
+            @Override public void onClick(View view) {
+                toggleBookmark();
+            }
+        });
+    }
+
+
+    /*
      * changes the like on the passed post
      */
     private void setPostLike(boolean isAskingToLike) {
@@ -1102,48 +1145,6 @@ public class ReaderPostDetailFragment extends Fragment
         }
     }
 
-
-    private void initBookmarkButton() {
-        if (!isAdded() || !hasPost() || !canShowFooter()) {
-            return;
-        }
-
-        ReaderBookmarkButton bookmarkButton = getView().findViewById(R.id.bookmark_button);
-        if (!canShowLikeCount()) {
-            bookmarkButton.setVisibility(View.GONE);
-        }
-
-        bookmarkButton.setIsBookmarked(mPost.isBookmarked);
-
-        bookmarkButton.setOnClickListener(new View.OnClickListener() {
-            @Override public void onClick(View view) {
-                toggleBookmark();
-            }
-        });
-    }
-
-    /*
-    * triggered when user taps the bookmark post button
-    */
-    private void toggleBookmark() {
-        ReaderBookmarkButton bookmarkButton = getView().findViewById(R.id.bookmark_button);
-
-        if (mPost.isBookmarked) {
-            ReaderPostActions.removeFromBookmarked(mPost);
-        } else {
-            ReaderPostActions.addToBookmarked(mPost);
-        }
-
-        mPost = ReaderPostTable.getBlogPost(mPost.blogId, mPost.postId, false);
-
-        bookmarkButton.setIsBookmarked(mPost.isBookmarked);
-
-//        if (mOnPostBookmarkedListener != null) {
-//            mOnPostBookmarkedListener
-//                    .onBookmarkedStateChanged(post.isBookmarked, blogId, postId, !isSavedPostsList());
-//        }
-    }
-
     /*
      * called by the web view when the content finishes loading - likes aren't displayed
      * until this is triggered, to avoid having them appear before the webView content
@@ -1362,6 +1363,10 @@ public class ReaderPostDetailFragment extends Fragment
         return mPost.isWP()
                && !mPost.isDiscoverPost()
                && (mPost.isCommentsOpen || mPost.numReplies > 0);
+    }
+
+    private boolean canShowBookmarkButton() {
+        return hasPost() && (mPost.isWP() || mPost.isJetpack) && !mPost.isDiscoverPost();
     }
 
     private boolean canShowLikeCount() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -451,7 +451,7 @@ public class ReaderPostDetailFragment extends Fragment
             mReaderBookmarkButton.setVisibility(View.GONE);
         } else {
             mReaderBookmarkButton.setVisibility(View.VISIBLE);
-            mReaderBookmarkButton.setIsBookmarked(mPost.isBookmarked);
+            mReaderBookmarkButton.updateIsBookmarkedState(mPost.isBookmarked);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -1018,7 +1018,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     return false;
             }
 
-            if (mPosts.isSameList(mAllPosts)) {
+            if (mPosts.isSameListWithBookmark(mAllPosts)) {
                 return false;
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderBookmarkButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderBookmarkButton.kt
@@ -1,0 +1,98 @@
+package org.wordpress.android.ui.reader.views
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.AnimatorSet
+import android.animation.ObjectAnimator
+import android.animation.ValueAnimator
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.view.animation.AccelerateDecelerateInterpolator
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import org.wordpress.android.R
+import org.wordpress.android.ui.reader.utils.ReaderUtils
+
+/**
+ * Bookmark button used in reader post detail
+ */
+class ReaderBookmarkButton : LinearLayout {
+    private var mBookmarkLabel: TextView? = null
+    private var mBookmarkIcon: ImageView? = null
+    private var mIsBookmarked: Boolean = false
+
+    constructor(context: Context) : super(context) {
+        initView(context, null)
+    }
+
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs) {
+        initView(context, attrs)
+    }
+
+    constructor(context: Context, attrs: AttributeSet, defStyle: Int) : super(context, attrs, defStyle) {
+        initView(context, attrs)
+    }
+
+    private fun initView(context: Context, attrs: AttributeSet?) {
+        View.inflate(context, R.layout.reader_bookmark_button, this)
+        mBookmarkLabel = findViewById<View>(R.id.text_bookmark_button) as TextView
+        mBookmarkIcon = findViewById<View>(R.id.icon_bookmark_button) as ImageView
+        ReaderUtils.setBackgroundToRoundRipple(mBookmarkIcon)
+    }
+
+    private fun updateBookmarkText() {
+        mBookmarkLabel!!.setText(if (mIsBookmarked) R.string.reader_btn_bookmarked else R.string.reader_btn_bookmark)
+        mBookmarkLabel!!.isSelected = mIsBookmarked
+        mBookmarkIcon!!.isSelected = mIsBookmarked
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        super.setEnabled(enabled)
+        mBookmarkLabel!!.isEnabled = enabled
+        mBookmarkIcon!!.isEnabled = enabled
+    }
+
+    fun setIsBookmarked(isBookmarked: Boolean) {
+        setIsBookmarked(isBookmarked, false)
+    }
+
+    fun setIsBookmarkedAnimated(isBookmarked: Boolean) {
+        setIsBookmarked(isBookmarked, true)
+    }
+
+    override fun setSelected(selected: Boolean) {
+        super.setSelected(selected)
+    }
+
+    private fun setIsBookmarked(isBookmarked: Boolean, animateChanges: Boolean) {
+        if (isBookmarked == mIsBookmarked && mBookmarkLabel!!.isSelected == isBookmarked) {
+            return
+        }
+
+        mIsBookmarked = isBookmarked
+
+        if (animateChanges) {
+            val anim = ObjectAnimator.ofFloat(this, View.SCALE_Y, 1f, 0f)
+            anim.repeatMode = ValueAnimator.REVERSE
+            anim.repeatCount = 1
+
+            anim.addListener(object : AnimatorListenerAdapter() {
+                override fun onAnimationRepeat(animation: Animator) {
+                    updateBookmarkText()
+                }
+            })
+
+            val duration = context.resources.getInteger(android.R.integer.config_shortAnimTime).toLong()
+            val set = AnimatorSet()
+            set.play(anim)
+            set.duration = duration
+            set.interpolator = AccelerateDecelerateInterpolator()
+
+            set.start()
+        } else {
+            updateBookmarkText()
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderBookmarkButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderBookmarkButton.kt
@@ -60,8 +60,4 @@ class ReaderBookmarkButton : LinearLayout {
         updateBookmarkText()
     }
 
-    override fun setSelected(selected: Boolean) {
-        super.setSelected(selected)
-    }
-
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderBookmarkButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderBookmarkButton.kt
@@ -3,20 +3,16 @@ package org.wordpress.android.ui.reader.views
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
-import android.widget.ImageView
 import android.widget.LinearLayout
-import android.widget.TextView
+import kotlinx.android.synthetic.main.reader_bookmark_button.view.*
 import org.wordpress.android.R
 import org.wordpress.android.ui.reader.utils.ReaderUtils
+import java.util.Locale
 
 /**
  * Bookmark button used in reader post detail
  */
 class ReaderBookmarkButton : LinearLayout {
-    private var mBookmarkLabel: TextView? = null
-    private var mBookmarkIcon: ImageView? = null
-    private var mIsBookmarked: Boolean = false
-
     constructor(context: Context) : super(context) {
         initView(context)
     }
@@ -31,36 +27,28 @@ class ReaderBookmarkButton : LinearLayout {
 
     private fun initView(context: Context) {
         View.inflate(context, R.layout.reader_bookmark_button, this)
-
-        mBookmarkLabel = findViewById<View>(R.id.text_bookmark_button) as TextView
-        mBookmarkIcon = findViewById<View>(R.id.icon_bookmark_button) as ImageView
-
-        ReaderUtils.setBackgroundToRoundRipple(mBookmarkIcon)
-    }
-
-    private fun updateButtonLabel() {
-        mBookmarkLabel!!.setText(if (mIsBookmarked) R.string.reader_btn_bookmarked else R.string.reader_btn_bookmark)
-
-        mBookmarkLabel!!.isSelected = mIsBookmarked
-        mBookmarkIcon!!.isSelected = mIsBookmarked
+        ReaderUtils.setBackgroundToRoundRipple(icon_bookmark_button)
     }
 
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
 
-        mBookmarkLabel!!.isEnabled = enabled
-        mBookmarkIcon!!.isEnabled = enabled
+        label_bookmark_button.isEnabled = enabled
+        icon_bookmark_button.isEnabled = enabled
     }
 
-    fun setIsBookmarked(isBookmarked: Boolean) {
-        mIsBookmarked = isBookmarked
+    fun updateIsBookmarkedState(isBookmarked: Boolean) {
+        val bookmarkButtonLabel = if (isBookmarked) R.string.reader_btn_bookmarked else R.string.reader_btn_bookmark
 
-        contentDescription = if (mIsBookmarked) {
+        label_bookmark_button.text = context.getString(bookmarkButtonLabel).toUpperCase(Locale.getDefault())
+
+        label_bookmark_button.isSelected = isBookmarked
+        icon_bookmark_button.isSelected = isBookmarked
+
+        contentDescription = if (isBookmarked) {
             context.getString(R.string.reader_remove_bookmark)
         } else {
             context.getString(R.string.reader_add_bookmark)
         }
-
-        updateButtonLabel()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderBookmarkButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderBookmarkButton.kt
@@ -1,14 +1,8 @@
 package org.wordpress.android.ui.reader.views
 
-import android.animation.Animator
-import android.animation.AnimatorListenerAdapter
-import android.animation.AnimatorSet
-import android.animation.ObjectAnimator
-import android.animation.ValueAnimator
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
-import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -55,44 +49,19 @@ class ReaderBookmarkButton : LinearLayout {
     }
 
     fun setIsBookmarked(isBookmarked: Boolean) {
-        setIsBookmarked(isBookmarked, false)
-    }
+        mIsBookmarked = isBookmarked
 
-    fun setIsBookmarkedAnimated(isBookmarked: Boolean) {
-        setIsBookmarked(isBookmarked, true)
+        contentDescription = if (mIsBookmarked) {
+            context.getString(R.string.reader_remove_bookmark)
+        } else {
+            context.getString(R.string.reader_add_bookmark)
+        }
+
+        updateBookmarkText()
     }
 
     override fun setSelected(selected: Boolean) {
         super.setSelected(selected)
     }
 
-    private fun setIsBookmarked(isBookmarked: Boolean, animateChanges: Boolean) {
-        if (isBookmarked == mIsBookmarked && mBookmarkLabel!!.isSelected == isBookmarked) {
-            return
-        }
-
-        mIsBookmarked = isBookmarked
-
-        if (animateChanges) {
-            val anim = ObjectAnimator.ofFloat(this, View.SCALE_Y, 1f, 0f)
-            anim.repeatMode = ValueAnimator.REVERSE
-            anim.repeatCount = 1
-
-            anim.addListener(object : AnimatorListenerAdapter() {
-                override fun onAnimationRepeat(animation: Animator) {
-                    updateBookmarkText()
-                }
-            })
-
-            val duration = context.resources.getInteger(android.R.integer.config_shortAnimTime).toLong()
-            val set = AnimatorSet()
-            set.play(anim)
-            set.duration = duration
-            set.interpolator = AccelerateDecelerateInterpolator()
-
-            set.start()
-        } else {
-            updateBookmarkText()
-        }
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderBookmarkButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderBookmarkButton.kt
@@ -59,5 +59,4 @@ class ReaderBookmarkButton : LinearLayout {
 
         updateBookmarkText()
     }
-
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderBookmarkButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderBookmarkButton.kt
@@ -18,32 +18,36 @@ class ReaderBookmarkButton : LinearLayout {
     private var mIsBookmarked: Boolean = false
 
     constructor(context: Context) : super(context) {
-        initView(context, null)
+        initView(context)
     }
 
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs) {
-        initView(context, attrs)
+        initView(context)
     }
 
     constructor(context: Context, attrs: AttributeSet, defStyle: Int) : super(context, attrs, defStyle) {
-        initView(context, attrs)
+        initView(context)
     }
 
-    private fun initView(context: Context, attrs: AttributeSet?) {
+    private fun initView(context: Context) {
         View.inflate(context, R.layout.reader_bookmark_button, this)
+
         mBookmarkLabel = findViewById<View>(R.id.text_bookmark_button) as TextView
         mBookmarkIcon = findViewById<View>(R.id.icon_bookmark_button) as ImageView
+
         ReaderUtils.setBackgroundToRoundRipple(mBookmarkIcon)
     }
 
-    private fun updateBookmarkText() {
+    private fun updateButtonLabel() {
         mBookmarkLabel!!.setText(if (mIsBookmarked) R.string.reader_btn_bookmarked else R.string.reader_btn_bookmark)
+
         mBookmarkLabel!!.isSelected = mIsBookmarked
         mBookmarkIcon!!.isSelected = mIsBookmarked
     }
 
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
+
         mBookmarkLabel!!.isEnabled = enabled
         mBookmarkIcon!!.isEnabled = enabled
     }
@@ -57,6 +61,6 @@ class ReaderBookmarkButton : LinearLayout {
             context.getString(R.string.reader_add_bookmark)
         }
 
-        updateBookmarkText()
+        updateButtonLabel()
     }
 }

--- a/WordPress/src/main/res/color/reader_bookmark_button_text.xml
+++ b/WordPress/src/main/res/color/reader_bookmark_button_text.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/blue_medium" android:state_selected="true" />
+    <item android:color="@color/grey_text_min" />
+</selector>

--- a/WordPress/src/main/res/drawable/ic_bookmark_selector_18dp.xml
+++ b/WordPress/src/main/res/drawable/ic_bookmark_selector_18dp.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_bookmark_18dp" android:state_selected="true" />
+    <item android:drawable="@drawable/ic_bookmark_outline_18dp"  />
+</selector>

--- a/WordPress/src/main/res/layout/reader_bookmark_button.xml
+++ b/WordPress/src/main/res/layout/reader_bookmark_button.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              android:id="@+id/frame_follow_button"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/icon_bookmark_button"
+        android:layout_width="@dimen/reader_count_icon"
+        android:layout_height="@dimen/reader_count_icon"
+        android:layout_gravity="center_vertical"
+        android:contentDescription="@null"
+        app:srcCompat="@drawable/ic_bookmark_selector_18dp"/>
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/text_bookmark_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:layout_marginLeft="@dimen/margin_small"
+        android:layout_marginStart="@dimen/margin_small"
+        android:text="@string/reader_btn_bookmark"
+        android:textColor="@color/reader_bookmark_button_text"
+        android:textSize="@dimen/text_sz_medium"/>
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/reader_bookmark_button.xml
+++ b/WordPress/src/main/res/layout/reader_bookmark_button.xml
@@ -14,7 +14,7 @@
         app:srcCompat="@drawable/ic_bookmark_selector_18dp"/>
 
     <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/text_bookmark_button"
+        android:id="@+id/label_bookmark_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"

--- a/WordPress/src/main/res/layout/reader_bookmark_button.xml
+++ b/WordPress/src/main/res/layout/reader_bookmark_button.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:app="http://schemas.android.com/apk/res-auto"
-              android:id="@+id/frame_follow_button"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:orientation="horizontal">
@@ -21,6 +20,7 @@
         android:layout_gravity="bottom"
         android:layout_marginLeft="@dimen/margin_small"
         android:layout_marginStart="@dimen/margin_small"
+        android:importantForAccessibility="no"
         android:text="@string/reader_btn_bookmark"
         android:textColor="@color/reader_bookmark_button_text"
         android:textSize="@dimen/text_sz_medium"/>

--- a/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
@@ -29,6 +29,17 @@
         android:layout_marginEnd="@dimen/reader_detail_margin"
         android:layout_marginStart="@dimen/reader_detail_margin">
 
+
+        <org.wordpress.android.ui.reader.views.ReaderBookmarkButton
+            android:id="@+id/bookmark_button"
+            android:layout_alignLeft="@+id/layout_icons"
+            android:layout_alignStart="@+id/layout_icons"
+            android:layout_centerVertical="true"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
         <LinearLayout
             android:id="@+id/layout_icons"
             android:layout_width="wrap_content"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
@@ -29,7 +29,6 @@
         android:layout_marginEnd="@dimen/reader_detail_margin"
         android:layout_marginStart="@dimen/reader_detail_margin">
 
-
         <org.wordpress.android.ui.reader.views.ReaderBookmarkButton
             android:id="@+id/bookmark_button"
             android:layout_alignLeft="@+id/layout_icons"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1362,8 +1362,8 @@
     <string name="reader_btn_unfollow">Following</string>
     <string name="reader_add_bookmark">Add to saved posts</string>
     <string name="reader_remove_bookmark">Remove from saved posts</string>
-    <string name="reader_btn_bookmark">SAVE</string>
-    <string name="reader_btn_bookmarked">SAVED</string>
+    <string name="reader_btn_bookmark">Save</string>
+    <string name="reader_btn_bookmarked">Saved</string>
 
     <!-- EditText hints -->
     <string name="reader_hint_comment_on_post">Reply to post…</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1362,6 +1362,8 @@
     <string name="reader_btn_unfollow">Following</string>
     <string name="reader_add_bookmark">Add to saved posts</string>
     <string name="reader_remove_bookmark">Remove from saved posts</string>
+    <string name="reader_btn_bookmark">SAVE</string>
+    <string name="reader_btn_bookmarked">SAVED</string>
 
     <!-- EditText hints -->
     <string name="reader_hint_comment_on_post">Reply to post…</string>


### PR DESCRIPTION
Fixes #7715 

Adds bookmark button to the post details.
![screenshot-2018-05-09_22 17 32 848](https://user-images.githubusercontent.com/728822/39850408-d4551d4a-53d6-11e8-9a34-12c27cb42494.png)

I deciede non to do separate caching, because 95% of time we should already have post cached in WebView.

To test:

1. Open bookmarkable post details.
2. Press the SAVE button.
3. Notice that the button changes to SAVED.
4. Navigate to Saved posts list and confirm that the bookmarked post is there.

