### PR TITLE
Issue/5491 missing posts in reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -746,11 +746,12 @@ public class ReaderPostTable {
             String tagName = (tag != null ? tag.getTagSlug() : "");
             int tagType = (tag != null ? tag.tagType.toInt() : 0);
 
-            // we can safely assume there's no gap marker because any existing gap marker is
-            // already removed before posts are updated
-            boolean hasGapMarker = false;
+            ReaderBlogIdPostId postWithGapMarker = getGapMarkerIdsForTag(tag);
 
             for (ReaderPost post : posts) {
+                // keep the gapMarker flag
+                boolean hasGapMarker = postWithGapMarker != null && postWithGapMarker.getPostId() == post.postId
+                                       && postWithGapMarker.getBlogId() == post.blogId;
                 stmtPosts.bindLong(1, post.postId);
                 stmtPosts.bindLong(2, post.blogId);
                 stmtPosts.bindLong(3, post.feedId);

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -649,7 +649,7 @@ public class ReaderPostTable {
         }
 
         String dateColumn = getSortColumnForTag(tag);
-        String[] args = {gapMarkerDate, tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
+        String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt()), gapMarkerDate};
         String where = "tag_name=? AND tag_type=? AND " + dateColumn + " < ?";
         int numDeleted = ReaderDatabase.getWritableDb().delete("tbl_posts", where, args);
         if (numDeleted > 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -584,6 +584,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 });
                 break;
 
+            case OTHER:
             default:
                 // something else, so hide discover section
                 postHolder.mLayoutDiscover.setVisibility(View.GONE);
@@ -735,7 +736,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     @Override
     public int getItemCount() {
-        if (hasCustomFirstItem()) {
+        if (hasCustomFirstItem() || mGapMarkerPosition != -1) {
             return mPosts.size() + 1;
         }
         return mPosts.size();
@@ -916,6 +917,9 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private class LoadPostsTask extends AsyncTask<Void, Void, Boolean> {
         private ReaderPostList mAllPosts;
 
+        private boolean mCanRequestMorePostsTemp;
+        private int mGapMarkerPositionTemp;
+
         @Override
         protected void onPreExecute() {
             mIsTaskRunning = true;
@@ -955,10 +959,10 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
             // if we're not already displaying the max # posts, enable requesting more when
             // the user scrolls to the end of the list
-            mCanRequestMorePosts = (numExisting < ReaderConstants.READER_MAX_POSTS_TO_DISPLAY);
+            mCanRequestMorePostsTemp = (numExisting < ReaderConstants.READER_MAX_POSTS_TO_DISPLAY);
 
             // determine whether a gap marker exists - only applies to tagged posts
-            mGapMarkerPosition = getGapMarkerPosition();
+            mGapMarkerPositionTemp = getGapMarkerPosition();
 
             return true;
         }
@@ -998,6 +1002,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         @Override
         protected void onPostExecute(Boolean result) {
             if (result) {
+                ReaderPostAdapter.this.mGapMarkerPosition = mGapMarkerPositionTemp;
+                ReaderPostAdapter.this.mCanRequestMorePosts = mCanRequestMorePostsTemp;
                 mPosts.clear();
                 mPosts.addAll(mAllPosts);
                 notifyDataSetChanged();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -676,6 +676,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     public void clear() {
+        mGapMarkerPosition = -1;
         if (!mPosts.isEmpty()) {
             mPosts.clear();
             notifyDataSetChanged();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -977,26 +977,25 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 return -1;
             }
 
-            // find the position of the gap marker post
-            int gapPosition = mAllPosts.indexOfIds(gapMarkerIds);
-            if (gapPosition > -1) {
-                // increment it because we want the gap marker to appear *below* this post
-                gapPosition++;
-                // increment it again if there's a custom first item
-                if (hasCustomFirstItem()) {
-                    gapPosition++;
-                }
+            int gapMarkerPostPosition = mAllPosts.indexOfIds(gapMarkerIds);
+            int gapMarkerPosition = -1;
+            if (gapMarkerPostPosition > -1) {
                 // remove the gap marker if it's on the last post (edge case but
                 // it can happen following a purge)
-                if (gapPosition >= mAllPosts.size() - 1) {
-                    gapPosition = -1;
+                if (gapMarkerPostPosition == mAllPosts.size() - 1) {
                     AppLog.w(AppLog.T.READER, "gap marker at/after last post, removed");
                     ReaderPostTable.removeGapMarkerForTag(mCurrentTag);
                 } else {
-                    AppLog.d(AppLog.T.READER, "gap marker at position " + gapPosition);
+                    // we want the gap marker to appear *below* this post
+                    gapMarkerPosition = gapMarkerPostPosition + 1;
+                    // increment it if there's a custom first item
+                    if (hasCustomFirstItem()) {
+                        gapMarkerPosition++;
+                    }
+                    AppLog.d(AppLog.T.READER, "gap marker at position " + gapMarkerPostPosition);
                 }
             }
-            return gapPosition;
+            return gapMarkerPosition;
         }
 
         @Override


### PR DESCRIPTION
Fixes #5491 

This PR fixes several bugs which all had the same result - some posts in Reader were missing.

To test - since posts are fetched in batches (max 20 posts per request), it's quite difficult to manually test all the cases. To facilitate the testing I locally set the ReaderConstants.READER_MAX_POSTS_TO_REQUEST constant to '2' and I kept publishing posts on a blog which I followed.

Prerequisite: 
- have more than 4 posts in the reader "followed sites" stream
- set ReaderConstants.READER_MAX_POSTS_TO_REQUEST to 2

Case 'publish a post -> potential gap not detected'
1. Go to reader
2. Select 'followed sites' stream
3. Pull-to-refresh
4. Publish a post
5. Go to reader
6. Pull-to-refresh 
7. Notice the post is visible and the 'load more posts' button is not visible

Case 'publish two posts -> potential gap detected'
1. Go to reader
2. Select 'followed sites' stream
3. Pull-to-refresh
4. Publish two posts
5. Go to reader
6. Pull-to-refresh (One of the two published posts is displayed along with the "load more posts button")
7. Click on the "load more posts" button
8. Notice that both posts are visible

Case 'publish four posts -> potential gap detected'
1. Go to reader
2. Select 'followed sites' stream
3. Pull-to-refresh
4. Publish four posts
5. Go to reader
6. Pull-to-refresh (One of the four published posts is displayed along with the "load more posts button")
7. Click on the "load more posts" button
8. Notice that all four posts are visible

Case 'publish two posts + publish two posts -> two potential gaps detected'
1. Go to reader
2. Select 'followed sites' stream
3. Pull-to-refresh
4. Publish two posts
5. Go to reader
6. Pull-to-refresh (One of the two published posts is displayed along with the "load more posts button")
7. Publish another two posts
8. Go to reader
9. Pull-to-refresh -> second gap is detected -> the first gap is automagically filled (old posts are actually removed and fetched again)
10. Click on the "load more posts" button
11. Notice that all four posts are visible

Case 'publish two posts + publish a post -> one potential gap detected'
1. Go to reader
2. Select 'followed sites' stream
3. Pull-to-refresh
4. Publish two posts
5. Go to reader
6. Pull-to-refresh (One of the two published posts is displayed along with the "load more posts button")
7. Publish another post
8. Go to reader
9. Pull-to-refresh -> new posts is fetched, however the "load more posts" button is still visible
10. Click on the "load more posts" button
11. Notice that all three posts are visible

Case 'publish two posts -> potential gap detected but there is actually no gap'
1. Go to reader
2. Select 'followed sites' stream
3. Pull-to-refresh
4. Publish two posts
5. Go to reader
6. Pull-to-refresh (One of the two published posts is displayed along with the "load more posts button")
7. Pull-to-refresh again
8. Notice that both posts are displayed
9. Click on the "load more posts" button
11. Notice that the 'load more posts" button disappears

There might be some cases I didn't think of :).

