### PR TITLE
Remove publish confirmation dialog when sending a post for review

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1058,9 +1058,11 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         hidePhotoPicker();
+        boolean userCanPublishPosts = userCanPublishPosts();
 
-        if (itemId == R.id.menu_save_post) {
-            if (AppPrefs.isAsyncPromoRequired() && PostStatus.fromPost(mPost) != PostStatus.DRAFT) {
+        if (itemId == R.id.menu_save_post || (itemId == R.id.menu_save_as_draft_or_publish && !userCanPublishPosts)) {
+            if (AppPrefs.isAsyncPromoRequired() && userCanPublishPosts
+                && PostStatus.fromPost(mPost) != PostStatus.DRAFT) {
                 showAsyncPromoDialog();
             } else {
                 showPublishConfirmationOrUpdateIfNotLocalDraft();
@@ -1157,7 +1159,8 @@ public class EditPostActivity extends AppCompatActivity implements
         // if post is a draft, first make sure to confirm the PUBLISH action, in case
         // the user tapped on it accidentally
         PostStatus status = PostStatus.fromPost(mPost);
-        if ((status == PostStatus.PUBLISHED || status == PostStatus.UNKNOWN) && mPost.isLocalDraft()) {
+        if (userCanPublishPosts() && (status == PostStatus.PUBLISHED || status == PostStatus.UNKNOWN)
+            && mPost.isLocalDraft()) {
             showPublishConfirmationDialog();
         } else {
             // otherwise, if they're updating a Post, just go ahead and save it to the server
@@ -3308,40 +3311,13 @@ public class EditPostActivity extends AppCompatActivity implements
     public void onPostUploaded(OnPostUploaded event) {
         final PostModel post = event.post;
         if (post != null && post.getId() == mPost.getId()) {
-            if (event.isError()) {
-                UploadUtils.showSnackbarError(findViewById(R.id.editor_activity), event.error.message);
-                return;
-            }
-
-            mPost = post;
-            mIsNewPost = false;
-            invalidateOptionsMenu();
-            switch (PostStatus.fromPost(post)) {
-                case PUBLISHED:
-                    // here show snackbar saying it was uploaded
-                    int messageRes = post.isPage() ? R.string.page_published : R.string.post_published;
-                    UploadUtils.showSnackbarSuccessAction(findViewById(R.id.editor_activity), messageRes,
-                            R.string.button_view, new View.OnClickListener() {
-                                @Override
-                                public void onClick(View view) {
-                                    // jump to Editor Preview mode to show this Post
-                                    ActivityLauncher.browsePostOrPage(EditPostActivity.this, mSite, post);
-                                }
-                            });
-                    break;
-                case DRAFT:
-                default:
-                    UploadUtils.showSnackbarSuccessAction(findViewById(R.id.editor_activity),
-                            R.string.editor_draft_saved_online,
-                            R.string.button_publish,
-                            new View.OnClickListener() {
-                                @Override
-                                public void onClick(View v) {
-                                    UploadUtils
-                                            .publishPost(EditPostActivity.this, post, mSite, mDispatcher);
-                                }
-                            });
-                    break;
+            View snackbarAttachView = findViewById(R.id.editor_activity);
+            UploadUtils.onPostUploadedSnackbarHandler(this, snackbarAttachView, event.isError(), post,
+                    event.isError() ? event.error.message : null, getSite(), mDispatcher);
+            if (!event.isError()) {
+                mPost = post;
+                mIsNewPost = false;
+                invalidateOptionsMenu();
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPMediaUtils;
 
@@ -271,6 +272,7 @@ public class UploadUtils {
                                                      final PostModel post,
                                                      final String errorMessage,
                                                      final SiteModel site, final Dispatcher dispatcher) {
+        boolean userCanPublish = SiteUtils.isAccessedViaWPComRest(site) ? site.getHasCapabilityPublishPosts() : true;
         if (isError) {
             if (errorMessage != null) {
                 // RETRY only available for Aztec
@@ -295,14 +297,18 @@ public class UploadUtils {
             if (post != null) {
                 boolean isDraft = PostStatus.fromPost(post) == PostStatus.DRAFT;
                 if (isDraft) {
-                    View.OnClickListener publishPostListener = new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            UploadUtils.publishPost(activity, post, site, dispatcher);
-                        }
-                    };
-                    UploadUtils.showSnackbarSuccessAction(snackbarAttachView, R.string.editor_draft_saved_online,
-                                                          R.string.button_publish, publishPostListener);
+                    if (userCanPublish) {
+                        View.OnClickListener publishPostListener = new View.OnClickListener() {
+                            @Override
+                            public void onClick(View v) {
+                                UploadUtils.publishPost(activity, post, site, dispatcher);
+                            }
+                        };
+                        UploadUtils.showSnackbarSuccessAction(snackbarAttachView, R.string.editor_draft_saved_online,
+                                R.string.button_publish, publishPostListener);
+                    } else {
+                        UploadUtils.showSnackbar(snackbarAttachView, R.string.editor_draft_saved_online);
+                    }
                 } else {
                     int messageRes = post.isPage() ? R.string.page_published : R.string.post_published;
                     UploadUtils.showSnackbarSuccessAction(snackbarAttachView, messageRes,

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -310,7 +310,8 @@ public class UploadUtils {
                         UploadUtils.showSnackbar(snackbarAttachView, R.string.editor_draft_saved_online);
                     }
                 } else {
-                    int messageRes = post.isPage() ? R.string.page_published : R.string.post_published;
+                    int messageRes = post.isPage() ? R.string.page_published
+                            : (userCanPublish ? R.string.post_published : R.string.post_submitted);
                     UploadUtils.showSnackbarSuccessAction(snackbarAttachView, messageRes,
                                                           R.string.button_view, new View.OnClickListener() {
                                 @Override

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -280,6 +280,7 @@
     <!-- post view -->
     <string name="draft_uploaded">Draft uploaded</string>
     <string name="post_published">Post published</string>
+    <string name="post_submitted">Post submitted</string>
     <string name="page_published">Page published</string>
     <string name="post_scheduled">Post scheduled</string>
     <string name="page_scheduled">Page scheduled</string>


### PR DESCRIPTION
Fixes #7698 

Publish confirmation dialog and publish promo dialog are not shown when the user is submitting a post for review.
"Publish" action not shown in SnackBar when the post was submitted for review.

To test:
1. create a post
2. click on the submit button in the toolbar
3. notice the publish confirmation dialog is not shown

1. create a post
2. select "submit" button from the toolbar overflow menu
3. notice the publish confirmation dialog is not shown
4. notice when the upload is completed, the snackbar "Publish" action is not shown