### PR TITLE
added group alert behavior setting to notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -654,6 +654,7 @@ public class GCMMessageService extends GcmListenerService {
                         String.format(context.getString(R.string.new_notifications), ACTIVE_NOTIFICATIONS_MAP.size());
                 NotificationCompat.Builder groupBuilder = new NotificationCompat.Builder(context,
                         context.getString(R.string.notification_channel_normal_id))
+                        .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
                         .setSmallIcon(R.drawable.ic_my_sites_24dp)
                         .setColor(context.getResources().getColor(R.color.blue_wordpress))
                         .setGroup(NOTIFICATION_GROUP_KEY)
@@ -667,7 +668,8 @@ public class GCMMessageService extends GcmListenerService {
                 showNotificationForBuilder(groupBuilder, context, wpcomNoteID, GROUP_NOTIFICATION_ID, false);
             } else {
                 // Set the individual notification we've already built as the group summary
-                builder.setGroupSummary(true);
+                builder.setGroupSummary(true)
+                        .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN);
                 showNotificationForBuilder(builder, context, wpcomNoteID, GROUP_NOTIFICATION_ID, false);
             }
             // reinsert 2fa bundle if it was present


### PR DESCRIPTION
Fixes multiple notification sounds

As originally reported by @theck13 , the app would make 2 sounds for each notification received. The culprit was that actually 2 notifications were updated per each push notification, one for the individual detailed notification and another one to update the grouped notification. The alert behavior is set channel-wide as opposed to be per-notification since Android Oreo, and given both use the same channel the sound was being played twice.

This PR fixes this by using [`setGroupAlertBehavior`](https://developer.android.com/reference/android/app/Notification.Builder#setgroupalertbehavior) and setting the group notification alert behavior to `NotificationCompat.GROUP_ALERT_CHILDREN` to make sure the grouped alert does not make any sounds.

To test:
1. log in to the app, and then send the app to the background
2. on a different device / computer log in with another user, and make a comment on a blog post authored by user in point 1
3. check the notification is displayed and the notification sound is played only once
4. repeat step 2 and 3 once more, just to make sure the grouped notification sounds only once for 2 or more notifications as well (it's a different code path).

Follow these steps both on Android O and pre O.

cc @theck13 
