### PR TITLE
Issue/reader post layout

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -1072,8 +1072,8 @@ public class ReaderPostDetailFragment extends Fragment
                 txtExcerptFooter.setText(Html.fromHtml(linkText));
 
                 // we can't set the vector drawable in the layout because it will crash pre-API21
-                Drawable drawableRight =
-                        VectorDrawableCompat.create(txtExcerptFooter.getResources(), R.drawable.reader_visit, null);
+                Drawable drawableRight = VectorDrawableCompat.create(
+                        txtExcerptFooter.getResources(), R.drawable.ic_external_grey_min_24dp, null);
                 txtExcerptFooter.setCompoundDrawablesWithIntrinsicBounds(null, null, drawableRight, null);
 
                 txtExcerptFooter.setOnClickListener(new View.OnClickListener() {

--- a/WordPress/src/main/res/drawable/ic_external_blue_light_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_external_blue_light_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="@dimen/reader_button_icon"
+    android:width="@dimen/reader_button_icon"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="@color/blue_light"
+        android:pathData="M19,13v6c0,1.105 -0.895,2 -2,2H5c-1.105,0 -2,-0.895 -2,-2V7c0,-1.105 0.895,-2 2,-2h6v2H5v12h12v-6H19zM13,3v2h4.586l-7.793,7.793l1.414,1.414L19,6.414V11h2V3H13z" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/drawable/ic_external_grey_min_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_external_grey_min_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="@dimen/reader_button_icon"
+    android:width="@dimen/reader_button_icon"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="@color/grey_text_min"
+        android:pathData="M19,13v6c0,1.105 -0.895,2 -2,2H5c-1.105,0 -2,-0.895 -2,-2V7c0,-1.105 0.895,-2 2,-2h6v2H5v12h12v-6H19zM13,3v2h4.586l-7.793,7.793l1.414,1.414L19,6.414V11h2V3H13z" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/drawable/reader_button_visit.xml
+++ b/WordPress/src/main/res/drawable/reader_button_visit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/ic_external_blue_light_24dp" android:state_pressed="true" />
+    <item android:drawable="@drawable/ic_external_blue_light_24dp" android:state_selected="true" />
+    <item android:drawable="@drawable/ic_external_grey_min_24dp" />
+
+</selector>

--- a/WordPress/src/main/res/drawable/reader_visit.xml
+++ b/WordPress/src/main/res/drawable/reader_visit.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="@dimen/reader_button_icon"
-        android:height="@dimen/reader_button_icon"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
-    <path
-        android:fillColor="@color/grey_text_min"
-        android:pathData="M19,13v6c0,1.105 -0.895,2 -2,2H5c-1.105,0 -2,-0.895 -2,-2V7c0,-1.105 0.895,-2 2,-2h6v2H5v12h12v-6H19zM13,3v2h4.586l-7.793,7.793l1.414,1.414L19,6.414V11h2V3H13z"/>
-</vector>

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -195,34 +195,37 @@
 
             <LinearLayout
                 android:id="@+id/visit"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:contentDescription="@string/view_in_browser"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
                 android:layout_centerVertical="true"
-                android:orientation="horizontal"
-                android:contentDescription="@string/view_in_browser">
+                android:layout_height="wrap_content"
+                android:layout_width="wrap_content"
+                android:orientation="horizontal" >
 
                 <ImageView
-                    android:layout_gravity="center_vertical"
                     android:id="@+id/image_visit_icon"
-                    android:layout_width="@dimen/reader_count_icon"
+                    android:background="?android:selectableItemBackgroundBorderless"
+                    android:contentDescription="@null"
+                    android:layout_gravity="center_vertical"
                     android:layout_height="@dimen/reader_count_icon"
+                    android:layout_marginEnd="@dimen/margin_extra_small"
                     android:layout_marginLeft="-2dp"
                     android:layout_marginRight="@dimen/margin_extra_small"
-                    android:background="?android:selectableItemBackground"
-                    android:contentDescription="@null"
-                    app:srcCompat="@drawable/reader_visit"
-                    android:layout_marginEnd="@dimen/margin_extra_small"
-                    android:layout_marginStart="-2dp"/>
+                    android:layout_marginStart="-2dp"
+                    android:layout_width="@dimen/reader_count_icon"
+                    app:srcCompat="@drawable/reader_button_visit" />
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/text_visit"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:background="?android:selectableItemBackground"
+                    android:ellipsize="end"
                     android:gravity="center_vertical"
+                    android:layout_height="wrap_content"
+                    android:layout_width="fill_parent"
                     android:text="@string/reader_label_visit"
                     android:textColor="@color/reader_count_text"
                     android:textSize="@dimen/text_sz_medium" />
+
             </LinearLayout>
 
             <org.wordpress.android.ui.reader.views.ReaderIconCountView
@@ -250,17 +253,17 @@
 
             <ImageView
                 android:id="@+id/image_more"
-                android:layout_width="@dimen/reader_more_icon"
-                android:layout_height="@dimen/reader_more_icon"
+                android:background="?android:selectableItemBackgroundBorderless"
+                android:contentDescription="@string/show_more_desc"
+                android:layout_alignParentEnd="true"
                 android:layout_alignParentRight="true"
                 android:layout_centerVertical="true"
-                android:background="?android:selectableItemBackground"
-                android:contentDescription="@string/show_more_desc"
+                android:layout_height="@dimen/reader_more_icon"
+                android:layout_width="@dimen/reader_more_icon"
                 android:paddingBottom="@dimen/margin_medium"
                 android:paddingTop="@dimen/margin_medium"
                 android:tint="@color/grey_text_min"
-                app:srcCompat="@drawable/ic_ellipsis_grey_lighten_10_24dp"
-                android:layout_alignParentEnd="true"/>
+                app:srcCompat="@drawable/ic_ellipsis_grey_lighten_10_24dp" />
 
         </RelativeLayout>
 

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -205,7 +205,7 @@
 
                 <ImageView
                     android:id="@+id/image_visit_icon"
-                    android:background="?android:selectableItemBackgroundBorderless"
+                    android:background="?attr/selectableItemBackgroundBorderless"
                     android:contentDescription="@null"
                     android:layout_gravity="center_vertical"
                     android:layout_height="@dimen/reader_count_icon"
@@ -253,7 +253,7 @@
 
             <ImageView
                 android:id="@+id/image_more"
-                android:background="?android:selectableItemBackgroundBorderless"
+                android:background="?attr/selectableItemBackgroundBorderless"
                 android:contentDescription="@string/show_more_desc"
                 android:layout_alignParentEnd="true"
                 android:layout_alignParentRight="true"


### PR DESCRIPTION
### Fix
Update the post list card layout in the ***Reader*** tab by making the ***Visit*** button touch feedback consistent with the other action buttons (i.e. Comment and Like) and fixing a potential button text overlap due to localization.  See the screenshots below for illustration.

![reader_list](https://user-images.githubusercontent.com/3827611/39900031-6d728346-547c-11e8-89e6-ccebde9ff2bd.png)

### Test
1. Go to ***Reader*** tab.
2. Long-press on ***Visit*** button.
3. Notice icon background and color.
4. Long-press on ***Comment*** button.
5. Notice icon background and color.
6. Long-press on ***Like*** button.
7. Notice icon background and color.