### PR TITLE
Security Exceptions when opening post with media file stored on the device

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -449,10 +449,14 @@ public class MediaUtils {
                 // TODO handle non-primary volumes
             } else if (isDownloadsDocument(uri)) { // DownloadsProvider
                 final String id = DocumentsContract.getDocumentId(uri);
-                final Uri contentUri = ContentUris.withAppendedId(
-                        Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
-
-                return getDataColumn(context, contentUri, null, null);
+                try {
+                    final Uri contentUri = ContentUris.withAppendedId(
+                            Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+                    return getDataColumn(context, contentUri, null, null);
+                } catch (NumberFormatException e) {
+                    AppLog.e(AppLog.T.UTILS, "Can't read the path for file with ID " + id);
+                    return null;
+                }
             } else if (isMediaDocument(uri)) { // MediaProvider
                 final String docId = DocumentsContract.getDocumentId(uri);
                 final String[] split = docId.split(":");
@@ -508,6 +512,8 @@ public class MediaUtils {
                     return cursor.getString(columnIndex);
                 }
             }
+        } catch (Exception errReadingContentResolver) {
+            AppLog.e(AppLog.T.UTILS, "Error reading _data column for URI: " + uri, errReadingContentResolver);
         } finally {
             if (cursor != null) {
                 cursor.close();

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -512,7 +512,7 @@ public class MediaUtils {
                     return cursor.getString(columnIndex);
                 }
             }
-        } catch (Exception errReadingContentResolver) {
+        } catch (SecurityException errReadingContentResolver) {
             AppLog.e(AppLog.T.UTILS, "Error reading _data column for URI: " + uri, errReadingContentResolver);
         } finally {
             if (cursor != null) {


### PR DESCRIPTION
I was testing the app for GB integration, and found a problem opening a post that is in a "bad state". Not quite sure how it ended up in that state, but I've a post on the device that has a picture with the following URL in it:
`content://com.android.providers.downloads.documents/document/raw%3A%2Fstorage%2Femulated%2F0%2FDownload%2FIMG_3224.JPG`

This post raised to 2 distinct crashes in the app, that are now fixed in this PR:
1 - NumberFormatException:
```
05-15 09:00:00.881 2892-2892/org.wordpress.android E/AndroidRuntime: FATAL EXCEPTION: main
    Process: org.wordpress.android, PID: 2892
    java.lang.NumberFormatException: For input string: "raw:/storage/emulated/0/Download/IMG_3224.JPG"
        at java.lang.Long.parseLong(Long.java:590)
        at java.lang.Long.valueOf(Long.java:804)
        at org.wordpress.android.util.MediaUtils.getDocumentProviderPathKitkatOrHigher(MediaUtils.java:453)
        at org.wordpress.android.util.MediaUtils.getPath(MediaUtils.java:417)
        at org.wordpress.android.util.MediaUtils.getRealPathFromURI(MediaUtils.java:397)
        at org.wordpress.android.util.ImageUtils.resizeImageAndWriteToStream(ImageUtils.java:422)
        at org.wordpress.android.util.ImageUtils.createThumbnailFromUri(ImageUtils.java:663)
        at org.wordpress.android.util.ImageUtils.getWPImageSpanThumbnailFromFilePath(ImageUtils.java:372)
        at org.wordpress.android.ui.posts.adapters.PostsListAdapter.showFeaturedImage(PostsListAdapter.java:346)
        at org.wordpress.android.ui.posts.adapters.PostsListAdapter.onBindViewHolder(PostsListAdapter.java:246)
        at android.support.v7.widget.RecyclerView$Adapter.onBindViewHolder(RecyclerView.java:6673)
        at android.support.v7.widget.RecyclerView$Adapter.bindViewHolder(RecyclerView.java:6714)
        at android.support.v7.widget.RecyclerView$Recycler.tryBindViewHolderByDeadline(RecyclerView.java:5647)
        at android.support.v7.widget.RecyclerView$Recycler.tryGetViewHolderForPositionByDeadline(RecyclerView.java:5913)
        at android.support.v7.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:5752)
        at android.support.v7.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:5748)
```
2 - security exception in `getDataColumn`.


Not quite sure how the reviewer can replicate the issue, but these are just additional checks we've already in place in other parts of the app, so those should not hurt.