### PR TITLE
Issue/7751 crash resume page

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -542,12 +542,14 @@ public class MySiteFragment extends Fragment implements SiteSettingsListener,
     }
 
     private void showSiteIconProgressBar(boolean isVisible) {
-        if (isVisible) {
-            mBlavatarProgressBar.setVisibility(View.VISIBLE);
-            mBlavatarImageView.setVisibility(View.INVISIBLE);
-        } else {
-            mBlavatarProgressBar.setVisibility(View.GONE);
-            mBlavatarImageView.setVisibility(View.VISIBLE);
+        if (mBlavatarProgressBar != null && mBlavatarImageView != null) {
+            if (isVisible) {
+                mBlavatarProgressBar.setVisibility(View.VISIBLE);
+                mBlavatarImageView.setVisibility(View.INVISIBLE);
+            } else {
+                mBlavatarProgressBar.setVisibility(View.GONE);
+                mBlavatarImageView.setVisibility(View.VISIBLE);
+            }
         }
     }
 


### PR DESCRIPTION
### Fix
Add `null` check to `ProgressBar` and `ImageView` views on ***Sites*** to resolve the `NullPointerException` described in https://github.com/wordpress-mobile/WordPress-Android/issues/7751.

### Test
1. Launch app.
2. Go to page other than ***Sites***.
3. Exit app.
4. Launch app.
5. Notice no crash.