### PR TITLE
Prevent saved posts from getting deleted after language change.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -12,6 +12,7 @@ import java.util.regex.Pattern;
 public class ReaderTag implements Serializable, FilterCriteria {
     private static final String TAG_TITLE_DISCOVER = "Discover";
     public static final String TAG_TITLE_FOLLOWED_SITES = "Followed Sites";
+    public static final String TAG_SLUG_BOOKMARKED = "bookmarked-posts";
     public static final String TAG_TITLE_DEFAULT = TAG_TITLE_FOLLOWED_SITES;
 
     private String mTagSlug; // tag for API calls
@@ -29,7 +30,9 @@ public class ReaderTag implements Serializable, FilterCriteria {
         // we need a slug since it's used to uniquely ID the tag (including setting it as the
         // primary key in the tag table)
         if (TextUtils.isEmpty(slug)) {
-            if (!TextUtils.isEmpty(title)) {
+            if (tagType == ReaderTagType.BOOKMARKED) {
+                setTagSlug(TAG_SLUG_BOOKMARKED);
+            } else if (!TextUtils.isEmpty(title)) {
                 setTagSlug(ReaderUtils.sanitizeWithDashes(title));
             } else {
                 setTagSlug(getTagSlugFromEndpoint(endpoint));


### PR DESCRIPTION
Until we will have a server side implementation, use a hardcoded locale independent slug for the bookmarked posts.

To test:

1. Add a  `reader_save_for_later_title` to `strings.xml` of some locale other than English (eg. "Le Saved posts" to French).
2. While the app is in English, bookmark some post.
3. Change app language to French.
4. Notice that the posts are not gone.

PS: there is unrelated issue with Reader list filter reseting and posts not updating to reflect this. This issues shouldn't be present in `develop` branch.