### PR TITLE
issue/7762-reader-post-list-bottomnav-crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -336,8 +336,11 @@ public class ReaderPostListFragment extends Fragment
     public void onAttach(Context context) {
         super.onAttach(context);
 
-        // this will throw if parent activity doesn't implement the bottomnav controller interface
-        mBottonNavController = (BottomNavController) context;
+        // detect the bottom nav controller when this fragment is hosted in the main activity - this is used to
+        // hide the bottom nav when the user searches from the reader
+        if (context instanceof BottomNavController) {
+            mBottonNavController = (BottomNavController) context;
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #7762 

To test:
* Go to the reader list in the app
* Tap the header on a post to show all posts in that same blog
* The app should function correctly

Prior to this PR, those actions would crash the app
cc @khaykov 
