### PR TITLE
Sort ‘Your Sites’ and ‘Followed Sites’ alphabetically

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -54,7 +54,6 @@ import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.SiteUtils;
-import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.UrlUtils;
@@ -504,6 +503,14 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         }
         mSiteCount = sites.size();
 
+        if (mSiteCount > 0) {
+            Collections.sort(sites, new Comparator<SiteModel>() {
+                @Override public int compare(SiteModel o1, SiteModel o2) {
+                    return SiteUtils.getSiteNameOrHomeURL(o1).compareToIgnoreCase(SiteUtils.getSiteNameOrHomeURL(o2));
+                }
+            });
+        }
+
         Context context = getActivity();
 
         blogsCategory.removeAll();
@@ -568,7 +575,8 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         if (mSubscriptionCount > 0) {
             Collections.sort(subscriptions, new Comparator<SubscriptionModel>() {
                 @Override public int compare(SubscriptionModel o1, SubscriptionModel o2) {
-                    return StringUtils.compareIgnoreCase(o1.getBlogName(), o2.getBlogName());
+                    return getSiteNameOrHostFromSubscription(o1)
+                            .compareToIgnoreCase(getSiteNameOrHostFromSubscription(o2));
                 }
             });
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -54,12 +54,15 @@ import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.SiteUtils;
+import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPActivityUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
@@ -561,6 +564,14 @@ public class NotificationsSettingsFragment extends PreferenceFragment
 
         int maxSitesToShow = showAll ? NO_MAXIMUM : MAX_SITES_TO_SHOW_ON_FIRST_SCREEN;
         int count = 0;
+
+        if (mSubscriptionCount > 0) {
+            Collections.sort(subscriptions, new Comparator<SubscriptionModel>() {
+                @Override public int compare(SubscriptionModel o1, SubscriptionModel o2) {
+                    return StringUtils.compareIgnoreCase(o1.getBlogName(), o2.getBlogName());
+                }
+            });
+        }
 
         for (final SubscriptionModel subscription : subscriptions) {
             if (context == null) {


### PR DESCRIPTION
Fixes #7660 - Sort Your Sites and Followed Sites Alphabetically in Notification Settings

To test:

1. Go to **Me** tab.
2. Tap **Notification Settings** item.
3. Notice how **Your Sites** and **Followed Sites** are sorted alphabetically

cc: @theck13 