### PR TITLE
Aztec - Do not update post content if no changes made

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1253,9 +1253,14 @@ public class EditPostActivity extends AppCompatActivity implements
         boolean postTitleOrContentChanged = false;
         if (mEditorFragment != null) {
             if (mShowNewEditor || mShowAztecEditor) {
+                final String newContent;
+                if (mEditorFragment.shouldLoadContentFromEditor()) {
+                    newContent = (String) mEditorFragment.getContent();
+                } else {
+                    newContent = mPost.getContent();
+                }
                 postTitleOrContentChanged =
-                        updatePostContentNewEditor(isAutosave, (String) mEditorFragment.getTitle(),
-                                                   (String) mEditorFragment.getContent());
+                        updatePostContentNewEditor(isAutosave, (String) mEditorFragment.getTitle(), newContent);
             } else {
                 // TODO: Remove when legacy editor is dropped
                 postTitleOrContentChanged = updatePostContent(isAutosave);

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -53,9 +53,9 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'org.wordpress:utils:1.18.1'
 
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.3')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.3.3')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.3.3')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:97d7bfbb59f672c1fc0341499bc385298dc732d1')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:97d7bfbb59f672c1fc0341499bc385298dc732d1')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:97d7bfbb59f672c1fc0341499bc385298dc732d1')
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.1.4"

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -70,6 +70,7 @@ import org.wordpress.aztec.AztecAttributes;
 import org.wordpress.aztec.AztecExceptionHandler;
 import org.wordpress.aztec.AztecParser;
 import org.wordpress.aztec.AztecText;
+import org.wordpress.aztec.AztecText.EditorHasChanges;
 import org.wordpress.aztec.AztecTextFormat;
 import org.wordpress.aztec.Html;
 import org.wordpress.aztec.IHistoryListener;
@@ -1037,6 +1038,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     @Override
     public boolean hasFailedMediaUploads() {
         return (mFailedMediaIds.size() > 0);
+    }
+
+    @Override public boolean shouldLoadContentFromEditor() {
+        return mContent.hasChanges() != EditorHasChanges.NO_CHANGES;
     }
 
     @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1087,6 +1087,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         return (mFailedMediaIds.size() > 0);
     }
 
+    @Override public boolean shouldLoadContentFromEditor() {
+       return true;
+    }
+
     @Override
     public void removeAllFailedMediaUploads() {
         mWebView.execJavaScriptFromString("ZSSEditor.removeAllFailedMediaUploads();");

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -27,6 +27,9 @@ public abstract class EditorFragmentAbstract extends Fragment {
     public abstract boolean isUploadingMedia();
     public abstract boolean isActionInProgress();
     public abstract boolean hasFailedMediaUploads();
+    // Check whether we need to reload the content of the post from the editor or not.
+    // This was required since Aztec Visual->HTML can slightly change the content of the HTML. See #692 for details.
+    public abstract boolean shouldLoadContentFromEditor();
     public abstract void removeAllFailedMediaUploads();
     public abstract void removeMedia(String mediaId);
     public abstract void setTitlePlaceholder(CharSequence text);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
@@ -1187,6 +1187,10 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
         return false;
     }
 
+    @Override public boolean shouldLoadContentFromEditor() {
+        return true;
+    }
+
     @Override
     public void removeAllFailedMediaUploads() { }
 

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -449,10 +449,14 @@ public class MediaUtils {
                 // TODO handle non-primary volumes
             } else if (isDownloadsDocument(uri)) { // DownloadsProvider
                 final String id = DocumentsContract.getDocumentId(uri);
-                final Uri contentUri = ContentUris.withAppendedId(
-                        Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
-
-                return getDataColumn(context, contentUri, null, null);
+                try {
+                    final Uri contentUri = ContentUris.withAppendedId(
+                            Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+                    return getDataColumn(context, contentUri, null, null);
+                } catch (NumberFormatException e) {
+                    AppLog.e(AppLog.T.UTILS, "Can't read the path for file with ID " + id);
+                    return null;
+                }
             } else if (isMediaDocument(uri)) { // MediaProvider
                 final String docId = DocumentsContract.getDocumentId(uri);
                 final String[] split = docId.split(":");
@@ -508,6 +512,8 @@ public class MediaUtils {
                     return cursor.getString(columnIndex);
                 }
             }
+        } catch (SecurityException errReadingContentResolver) {
+            AppLog.e(AppLog.T.UTILS, "Error reading _data column for URI: " + uri, errReadingContentResolver);
         } finally {
             if (cursor != null) {
                 cursor.close();


### PR DESCRIPTION
This PR fixes an issue with Aztec that can easily produce small changes in the post HTML content even if there are no actual changes made by users. 

This happens because there is an internal conversion from HTML to Span(s) that doesn't preserve (and probably can't) the exact HTML code passed in input. The conversion back to HTML is done internally by Aztec, when we request the content again on exit, and the produced HTML can be slightly different (attributes order, inline tag not closed) from what we passed in input.

After tried different approaches on Aztec side, we decided to expose a simple `hasChanges` method, that should be invoked by hosting apps before getting the content back. If there are no changes made to the post, the host app (in this case wp-android) can skip the call to `getContent` and can use its internal copy of the post. 
The other approach we tried, that makes "all transparent" to the hosting app, required to retain a copy of the original HTML code in Aztec. We wanted to avoid that, to save memory that is already a problem with Aztec.