### PR TITLE
Redesign privacy settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -1,7 +1,9 @@
 package org.wordpress.android.ui.prefs;
 
+import android.app.Dialog;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.Preference;
@@ -13,6 +15,7 @@ import android.preference.SwitchPreference;
 import android.text.TextUtils;
 import android.util.Pair;
 import android.view.MenuItem;
+import android.widget.ListView;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -31,6 +34,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.util.WPPrefUtils;
 
@@ -57,6 +61,7 @@ public class AppSettingsFragment extends PreferenceFragment
     private WPSwitchPreference mOptimizedVideo;
     private DetailListPreference mVideoWidthPref;
     private DetailListPreference mVideoEncorderBitratePref;
+    private PreferenceScreen mPrivacySettings;
 
     @Inject SiteStore mSiteStore;
     @Inject AccountStore mAccountStore;
@@ -117,6 +122,8 @@ public class AppSettingsFragment extends PreferenceFragment
         mVideoEncorderBitratePref =
                 (DetailListPreference) WPPrefUtils
                         .getPrefAndSetChangeListener(this, R.string.pref_key_site_video_encoder_bitrate, this);
+        mPrivacySettings = (PreferenceScreen) WPPrefUtils
+                .getPrefAndSetClickListener(this, R.string.pref_key_privacy_settings, this);
 
         // Set Local settings
         mOptimizedImage.setChecked(AppPrefs.isImageOptimize());
@@ -218,6 +225,8 @@ public class AppSettingsFragment extends PreferenceFragment
             return handleAboutPreferenceClick();
         } else if (preferenceKey.equals(getString(R.string.pref_key_oss_licenses))) {
             return handleOssPreferenceClick();
+        } else if (preference == mPrivacySettings) {
+            setupPrivacySettings();
         }
 
         return false;
@@ -468,5 +477,32 @@ public class AppSettingsFragment extends PreferenceFragment
         pref.setValue(value);
         pref.setSummary(summary);
         pref.refreshAdapter();
+    }
+
+    private void setupPrivacySettings() {
+        if (mPrivacySettings == null || !isAdded()) {
+            return;
+        }
+        String title = getString(R.string.preference_privacy_settings);
+        Dialog dialog = mPrivacySettings.getDialog();
+        if (dialog != null) {
+            setupPreferenceList((ListView) dialog.findViewById(android.R.id.list), getResources());
+            WPActivityUtils.addToolbarToDialog(this, dialog, title);
+        }
+    }
+
+    private void setupPreferenceList(ListView prefList, Resources res) {
+        if (prefList == null || res == null) {
+            return;
+        }
+
+        // customize list dividers
+        //noinspection deprecation
+        prefList.setDivider(res.getDrawable(R.drawable.preferences_divider));
+        prefList.setDividerHeight(res.getDimensionPixelSize(R.dimen.site_settings_divider_height));
+        // remove footer divider bar
+        prefList.setFooterDividersEnabled(false);
+        //noinspection deprecation
+        prefList.setOverscrollFooter(res.getDrawable(R.color.transparent));
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
@@ -21,6 +21,8 @@ import android.webkit.WebResourceRequest;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.widget.Button;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
@@ -49,6 +51,8 @@ public class LearnMorePreference extends Preference implements View.OnClickListe
     private Dialog mDialog;
     private String mUrl;
     private String mCaption;
+    private String mButtonText;
+    private int mIcon = -1;
     private boolean mUseCustomJsFormatting;
 
     public LearnMorePreference(Context context, AttributeSet attrs) {
@@ -66,6 +70,13 @@ public class LearnMorePreference extends Preference implements View.OnClickListe
                 if (id != -1) {
                     mCaption = array.getResources().getString(id);
                 }
+            } else if (index == R.styleable.LearnMorePreference_button) {
+                int id = array.getResourceId(index, -1);
+                if (id != -1) {
+                    mButtonText = array.getResources().getString(id);
+                }
+            } else if (index == R.styleable.LearnMorePreference_learnMoreIcon) {
+                mIcon = array.getResourceId(index, -1);
             }
         }
         array.recycle();
@@ -75,12 +86,23 @@ public class LearnMorePreference extends Preference implements View.OnClickListe
     protected View onCreateView(@NonNull ViewGroup parent) {
         super.onCreateView(parent);
         View view = View.inflate(getContext(), R.layout.learn_more_pref, null);
-        view.setOnClickListener(this);
+        Button learnMoreButton = view.findViewById(R.id.learn_more_button);
+        learnMoreButton.setOnClickListener(this);
 
         if (!TextUtils.isEmpty(mCaption)) {
-            TextView captionView = (TextView) view.findViewById(R.id.learn_more_caption);
-            captionView.setText(mCaption);
-            captionView.setVisibility(View.VISIBLE);
+            TextView caption = view.findViewById(R.id.learn_more_caption);
+            caption.setText(mCaption);
+            caption.setVisibility(View.VISIBLE);
+        }
+
+        if (!TextUtils.isEmpty(mButtonText)) {
+            learnMoreButton.setText(mButtonText);
+        }
+
+        if (mIcon != -1) {
+            ImageView icon = view.findViewById(R.id.learn_more_icon);
+            icon.setImageResource(mIcon);
+            icon.setVisibility(View.VISIBLE);
         }
 
         return view;

--- a/WordPress/src/main/res/drawable/ic_briefcase_grey_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_briefcase_grey_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="@color/grey_text_min"
+        android:pathData="M14,15h-4v-2H2v6c0,1.105,0.895,2,2,2h16c1.105,0,2-0.895,2-2v-6h-8V15z M20,6h-2V4c0-1.105-0.895-2-2-2H8 C6.895,2,6,2.895,6,4v2H4C2.895,6,2,6.895,2,8v4h20V8C22,6.895,21.105,6,20,6z M16,6H8V4h8V6z" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/drawable/ic_info_outline_grey_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_info_outline_grey_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="@color/grey_text_min"
+        android:pathData="M13,9h-2V7h2V9z M13,11h-2v6h2V11z M12,4c-4.411,0-8,3.589-8,8s3.589,8,8,8s8-3.589,8-8S16.411,4,12,4 M12,2 c5.523,0,10,4.477,10,10s-4.477,10-10,10S2,17.523,2,12S6.477,2,12,2L12,2z" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/drawable/ic_stats_grey_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_stats_grey_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="@color/grey_text_min"
+        android:pathData="M19,3H5C3.895,3,3,3.895,3,5v14c0,1.105,0.895,2,2,2h14c1.105,0,2-0.895,2-2V5C21,3.895,20.105,3,19,3z M19,19H5V5h14V19z M9,17H7v-5h2V17z M13,17h-2V7h2V17z M17,17h-2v-7h2V17z" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/drawable/ic_user_circle_grey_text_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_user_circle_grey_text_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="@color/grey_text_min"
+        android:pathData="M12,2C6.477,2 2,6.477 2,12s4.477,10 10,10 10,-4.477 10,-10S17.523,2 12,2zM12,20.5c-4.694,0 -8.5,-3.806 -8.5,-8.5S7.306,3.5 12,3.5s8.5,3.806 8.5,8.5 -3.806,8.5 -8.5,8.5zM12,12.5c-3.038,0 -5.5,1.728 -5.5,3.5s2.462,3.5 5.5,3.5 5.5,-1.728 5.5,-3.5 -2.462,-3.5 -5.5,-3.5zM12,12c1.657,0 3,-1.343 3,-3s-1.343,-3 -3,-3 -3,1.343 -3,3 1.343,3 3,3z" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/layout/learn_more_pref.xml
+++ b/WordPress/src/main/res/layout/learn_more_pref.xml
@@ -1,38 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:paddingLeft="16dp"
-    android:paddingStart="12dp"
-    android:paddingRight="12dp"
-    android:paddingEnd="12dp"
-    android:paddingTop="16dp"
-    android:paddingBottom="16dp">
+    android:paddingStart="16dp"
+    android:paddingRight="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="16dp">
 
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/learn_more_caption"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:visibility="gone"
-        android:textSize="@dimen/text_sz_small"
-        android:textColor="@color/grey_darken_10" />
+        android:orientation="horizontal">
+
+        <ImageView
+            android:id="@+id/learn_more_icon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginEnd="24dp"
+            android:layout_marginRight="24dp"
+            android:contentDescription="@null"
+            android:visibility="gone"
+            tools:visibility="visible"
+            tools:src="@drawable/ic_info_grey_800_32dp"/>
+
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/learn_more_caption"
+            style="@style/TextAppearance.AppCompat.Body1"
+            android:textColor="@color/calypso_title_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            tools:visibility="visible"
+            tools:text="Learn more text"/>
+    </LinearLayout>
 
     <Button
         android:id="@+id/learn_more_button"
-        android:layout_width="match_parent"
+        android:textColor="@color/color_primary"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="-12dp"
-        android:gravity="start|center_vertical"
-        android:background="@color/transparent"
-        android:textStyle="bold"
-        android:textAllCaps="true"
+        android:gravity="end|center_vertical"
+        android:layout_gravity="end"
         android:text="@string/learn_more"
-        android:textSize="@dimen/text_sz_medium"
-        android:textColor="@color/blue_medium"
-        android:focusable="false"
-        android:clickable="false"
-        android:fontFamily="sans-serif-light" />
+        style="@style/Widget.AppCompat.Button.Borderless"/>
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/wp_preference_layout.xml
+++ b/WordPress/src/main/res/layout/wp_preference_layout.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="@dimen/margin_extra_large">
 
-    <LinearLayout
+<LinearLayout
         android:id="@+android:id/widget_frame"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
@@ -18,25 +20,42 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
         android:layout_toLeftOf="@android:id/widget_frame"
-        android:orientation="vertical"
-        android:layout_alignParentStart="true"
-        android:layout_toStartOf="@android:id/widget_frame">
+        android:layout_toStartOf="@android:id/widget_frame"
+        android:orientation="horizontal">
 
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+android:id/title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@color/calypso_title_text"
-            android:textSize="@dimen/text_sz_large" />
+        <ImageView
+            android:id="@+android:id/icon"
+            tools:src="@drawable/ic_info_grey_800_32dp"
+            tools:visibility="visible"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginEnd="24dp"
+            android:layout_marginRight="24dp"
+            android:contentDescription="@null"
+            android:visibility="gone"/>
 
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+android:id/summary"
+        <LinearLayout
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@color/calypso_subtitle_text"
-            android:textSize="@dimen/text_sz_medium" />
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+android:id/title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/calypso_title_text"
+                android:textSize="@dimen/text_sz_large"/>
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+android:id/summary"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/calypso_subtitle_text"
+                android:textSize="@dimen/text_sz_medium"/>
+        </LinearLayout>
 
     </LinearLayout>
 

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -29,6 +29,8 @@
     <declare-styleable name="LearnMorePreference">
         <attr name="url" format="string" />
         <attr name="caption" format="string" />
+        <attr name="button" format="string" />
+        <attr name="learnMoreIcon" format="reference" />
         <attr name="useCustomJsFormatting" format="boolean" />
     </declare-styleable>
 

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -15,7 +15,11 @@
     <string name="pref_key_app_settings_root" translatable="false">wp_pref_root</string>
     <string name="pref_key_passlock_section" translatable="false">wp_passcode_lock_category</string>
     <string name="pref_key_passlock" translatable="false" tools:ignore="UnusedResources">wp_pref_passlock_enabled</string>
+    <string name="pref_key_privacy_settings" translatable="false">wp_pref_privacy_settings</string>
     <string name="pref_key_send_usage" translatable="false">wp_pref_send_usage_stats</string>
+    <string name="pref_key_cookie_policy_learn_more" translatable="false">wp_pref_cookie_policy_learn_more</string>
+    <string name="pref_key_privacy_policy_learn_more" translatable="false">wp_pref_privacy_policy_learn_more</string>
+    <string name="pref_key_third_party_policy_learn_more" translatable="false">wp_pref_third_party_policy_learn_more</string>
     <string name="pref_key_device_settings" translatable="false">wp_pref_device_settings</string>
     <string name="pref_key_about_section" translatable="false">wp_pref_app_about_section</string>
     <string name="pref_key_language" translatable="false">wp_pref_language</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -715,6 +715,15 @@
     <string name="open_source_licenses">Open source licenses</string>
     <string name="preference_open_device_settings">Open device settings</string>
     <string name="preference_send_usage_stats">Send statistics</string>
+    <string name="preference_privacy_settings">Privacy settings</string>
+    <string name="preference_collect_information">Collect information</string>
+    <string name="cookie_policy_learn_more_header">Cookie Policy</string>
+    <string name="cookie_policy_learn_more_caption">Share information with our analytics tool about your use of services while logged in to your WordPress.com account.</string>
+    <string name="privacy_policy_learn_more_header">Privacy Policy</string>
+    <string name="privacy_policy_learn_more_caption">This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our privacy policy.</string>
+    <string name="third_party_policy_learn_more_header">Third Party Policy</string>
+    <string name="third_party_policy_learn_more_caption">We use other tracking tools, including some from third parties. Read about these and how to control them.</string>
+    <string name="privacy_policy_read">Read privacy policy</string>
     <string name="preference_send_usage_stats_summary">Automatically send usage statistics to help us improve WordPress for Android</string>
     <string name="preference_editor">Editor</string>
     <string name="preference_editor_type">Set editor type</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -715,8 +715,8 @@
     <string name="open_source_licenses">Open source licenses</string>
     <string name="preference_open_device_settings">Open device settings</string>
     <string name="preference_send_usage_stats">Send statistics</string>
-    <string name="preference_privacy_settings">Privacy settings</string>
     <string name="preference_collect_information">Collect information</string>
+    <string name="preference_privacy_settings">Privacy settings</string>
     <string name="cookie_policy_learn_more_header">Cookie Policy</string>
     <string name="cookie_policy_learn_more_caption">Share information with our analytics tool about your use of services while logged in to your WordPress.com account.</string>
     <string name="privacy_policy_learn_more_header">Privacy Policy</string>

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -11,13 +11,49 @@
         android:layout="@layout/wp_preference_layout"
         android:title="@string/interface_language"/>
 
-    <SwitchPreference
-        android:defaultValue="true"
-        android:key="@string/pref_key_send_usage"
-        android:layout="@layout/wp_preference_layout"
-        android:summary="@string/preference_send_usage_stats_summary"
-        android:title="@string/preference_send_usage_stats"
-        android:widgetLayout="@layout/wp_preference_switch"/>
+    <PreferenceScreen
+        android:id="@+id/pref_privacy_settings"
+        android:key="@string/pref_key_privacy_settings"
+        android:title="@string/preference_privacy_settings">
+
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/pref_key_send_usage"
+            android:layout="@layout/wp_preference_layout"
+            android:summary="@string/preference_send_usage_stats_summary"
+            android:title="@string/preference_send_usage_stats"
+            android:widgetLayout="@layout/wp_preference_switch"
+            app:preficon="@drawable/ic_stats_alt_grey_24dp"
+            />
+
+        <org.wordpress.android.ui.prefs.LearnMorePreference
+            android:id="@+id/pref_cookie_policy_learn_more"
+            android:key="@string/pref_key_cookie_policy_learn_more"
+            android:title="@string/cookie_policy_learn_more_header"
+            app:caption="@string/cookie_policy_learn_more_caption"
+            app:url="https://www.automattic.com/cookies"
+            app:preficon="@drawable/ic_info_grey_800_32dp"
+            app:useCustomJsFormatting="true"/>
+
+        <org.wordpress.android.ui.prefs.LearnMorePreference
+            android:id="@+id/pref_privacy_policy_learn_more"
+            android:key="@string/pref_key_privacy_policy_learn_more"
+            android:title="@string/privacy_policy_learn_more_header"
+            app:caption="@string/privacy_policy_learn_more_caption"
+            app:url="https://www.automattic.com/privacy"
+            app:preficon="@drawable/ic_user_circle_grey_24dp"
+            app:useCustomJsFormatting="true"/>
+
+        <org.wordpress.android.ui.prefs.LearnMorePreference
+            android:id="@+id/pref_third_party_policy_learn_more"
+            android:key="@string/pref_key_third_party_policy_learn_more"
+            android:title="@string/third_party_policy_learn_more_header"
+            app:caption="@string/third_party_policy_learn_more_caption"
+            app:url="https://www.automattic.com/cookies"
+            app:preficon="@drawable/ic_bell_alert_green_24dp"
+            app:useCustomJsFormatting="true"/>
+
+    </PreferenceScreen>
 
     <Preference
         android:key="@string/pref_key_device_settings"

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -21,10 +21,9 @@
             android:key="@string/pref_key_send_usage"
             android:layout="@layout/wp_preference_layout"
             android:summary="@string/preference_send_usage_stats_summary"
-            android:title="@string/preference_send_usage_stats"
+            android:title="@string/preference_collect_information"
             android:widgetLayout="@layout/wp_preference_switch"
-            app:preficon="@drawable/ic_stats_alt_grey_24dp"
-            />
+            android:icon="@drawable/ic_stats_grey_24dp"/>
 
         <org.wordpress.android.ui.prefs.LearnMorePreference
             android:id="@+id/pref_cookie_policy_learn_more"
@@ -32,7 +31,7 @@
             android:title="@string/cookie_policy_learn_more_header"
             app:caption="@string/cookie_policy_learn_more_caption"
             app:url="https://www.automattic.com/cookies"
-            app:preficon="@drawable/ic_info_grey_800_32dp"
+            app:learnMoreIcon="@drawable/ic_info_outline_grey_24dp"
             app:useCustomJsFormatting="true"/>
 
         <org.wordpress.android.ui.prefs.LearnMorePreference
@@ -40,8 +39,9 @@
             android:key="@string/pref_key_privacy_policy_learn_more"
             android:title="@string/privacy_policy_learn_more_header"
             app:caption="@string/privacy_policy_learn_more_caption"
+            app:button="@string/privacy_policy_read"
             app:url="https://www.automattic.com/privacy"
-            app:preficon="@drawable/ic_user_circle_grey_24dp"
+            app:learnMoreIcon="@drawable/ic_user_circle_grey_text_24dp"
             app:useCustomJsFormatting="true"/>
 
         <org.wordpress.android.ui.prefs.LearnMorePreference
@@ -50,7 +50,7 @@
             android:title="@string/third_party_policy_learn_more_header"
             app:caption="@string/third_party_policy_learn_more_caption"
             app:url="https://www.automattic.com/cookies"
-            app:preficon="@drawable/ic_bell_alert_green_24dp"
+            app:learnMoreIcon="@drawable/ic_briefcase_grey_24dp"
             app:useCustomJsFormatting="true"/>
 
     </PreferenceScreen>


### PR DESCRIPTION
Fixes #7743

New design of the Privacy settings with some links to learn more. 
Includes design changes to `LearnMorePreference` and added gridicons. Some things from the design are missing - white background because that would require changes all over the preferences + text color (the same thing). 

![screenshot_1526560839](https://user-images.githubusercontent.com/1079756/40177955-5f6ed2d6-59e0-11e8-9ff9-900081050fff.png)

To test:
* Go to app settings
* Go to Privacy settings
* Check/uncheck collect information
  * The check remains checked/unchecked when you leave the screen and come back
* Learn more takes you to page with extra information (not available yet)
