### PR TITLE
NotificationsDetailActivity: avoid blocking Activity onCreate() method

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -256,7 +256,8 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
         new Thread(new Runnable() {
             @Override
             public void run() {
-                GCMMessageService.removeNotificationWithNoteIdFromSystemBar(NotificationsDetailActivity.this, note.getId());
+                GCMMessageService.removeNotificationWithNoteIdFromSystemBar(
+                        NotificationsDetailActivity.this, note.getId());
                 // mark the note as read if it's unread
                 if (note.isUnread()) {
                     NotificationsActions.markNoteAsRead(note);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -252,15 +252,20 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
         finish();
     }
 
-    private void markNoteAsRead(Note note) {
-        GCMMessageService.removeNotificationWithNoteIdFromSystemBar(this, note.getId());
-        // mark the note as read if it's unread
-        if (note.isUnread()) {
-            NotificationsActions.markNoteAsRead(note);
-            note.setRead();
-            NotificationsTable.saveNote(note);
-            EventBus.getDefault().post(new NotificationEvents.NotificationsChanged());
-        }
+    private void markNoteAsRead(final Note note) {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                GCMMessageService.removeNotificationWithNoteIdFromSystemBar(NotificationsDetailActivity.this, note.getId());
+                // mark the note as read if it's unread
+                if (note.isUnread()) {
+                    NotificationsActions.markNoteAsRead(note);
+                    note.setRead();
+                    NotificationsTable.saveNote(note);
+                    EventBus.getDefault().post(new NotificationEvents.NotificationsChanged());
+                }
+            }
+        }).start();
     }
 
     private void setActionBarTitleForNote(Note note) {


### PR DESCRIPTION
While I haven't been able to exactly reproduce the situation, this PR fixes the deadlock problem posed by calling a `synchronized` (mutex'ed ) static method from within an `onCreate()` Activity lifecycle override, which would end up causing an ANR (and a black screen for the user).

### Description
There was a potential deadlock between the calls to `removeNotificationWithNoteIdFromSystemBar` in `handleBadgeResetPN` and the same call being called from `NotificationsDetailActivity.onCreate()`, thus preventing the actual activity from finished being created and displayed. Marking the Note as read would in turn make the backend produce a new `badge-reset` push notification, which would again call the same method `GCMMessageService.removeNotificationWithNoteIdFromSystemBar` to make sure the notification is dismissed from the system bar. While technically it is OK for the to be called from both sides, the potential problem (which should not last more than a few moments) can be a problem for the UI, which is exactly what was happening as the main UI thread was executing one of the calls in NotificationsDetailActivity's `onCreate`.

This PR wraps the body of `markNoteAsRead()` in `NotificationsDetailActivity` into a new thread, so this can get taken care of in parallel, without blocking the UI.

### ANR report

```
"main" prio=5 tid=1 Blocked
  | group="main" sCount=1 dsCount=0 flags=1 obj=0x74945170 self=0x7f2b2c2a00
  | sysTid=32342 nice=0 cgrp=default sched=0/0 handle=0x7f2fa269b0
  | state=S schedstat=( 910556026 143293026 1299 ) utm=66 stm=25 core=5 HZ=100
  | stack=0x7fef96d000-0x7fef96f000 stackSize=8MB
  | held mutexes=
  at org.wordpress.android.push.GCMMessageService.removeNotificationWithNoteIdFromSystemBar (GCMMessageService.java)
- waiting to lock <0x015a8731> (a java.lang.Class<org.wordpress.android.push.GCMMessageService>) held by thread 65
  at org.wordpress.android.ui.notifications.NotificationsDetailActivity.markNoteAsRead (NotificationsDetailActivity.java:256)
  at org.wordpress.android.ui.notifications.NotificationsDetailActivity.updateUIAndNote (NotificationsDetailActivity.java:169)
  at org.wordpress.android.ui.notifications.NotificationsDetailActivity.onCreate (NotificationsDetailActivity.java:118)
  at android.app.Activity.performCreate (Activity.java:6986)
  at android.app.Instrumentation.callActivityOnCreate (Instrumentation.java:1232)
  at android.app.ActivityThread.performLaunchActivity (ActivityThread.java:2863)
  at android.app.ActivityThread.handleLaunchActivity (ActivityThread.java:2985)
  at android.app.ActivityThread.-wrap11 (ActivityThread.java)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1649)
  at android.os.Handler.dispatchMessage (Handler.java:105)
  at android.os.Looper.loop (Looper.java:180)
  at android.app.ActivityThread.main (ActivityThread.java:6950)
  at java.lang.reflect.Method.invoke (Native method)
  at com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:240)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:835)
```

