### PR TITLE
issue/7774-settings-toolbar-dup

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -45,7 +45,12 @@ public class WPActivityUtils {
             }
         }
 
+        // find the root view, then make sure the toolbar doesn't already exist
         ViewGroup root = (ViewGroup) child.getParent();
+        if (root.findViewById(R.id.toolbar) != null) {
+            return;
+        }
+
         toolbar = (Toolbar) LayoutInflater.from(context.getActivity())
                                           .inflate(org.wordpress.android.R.layout.toolbar, root, false);
         root.addView(toolbar, 0);


### PR DESCRIPTION
Fixes #7774 - to test, follow the steps in [the issue](https://github.com/wordpress-mobile/WordPress-Android/issues/7774) and ensure an extra toolbar isn't added.