### PR TITLE
Issue/7683 bottom nav snackbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -10,7 +10,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.design.widget.Snackbar;
 import android.support.v4.app.RemoteInput;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -265,8 +264,6 @@ public class WPMainActivity extends AppCompatActivity
                                                         .getStringExtra(SignupEpilogueActivity.EXTRA_SIGNUP_USERNAME),
                                                 false);
         }
-
-        Snackbar.make(findViewById(R.id.coordinator), "Snackbar", 0).show();
     }
 
     private @Nullable String getAuthToken() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -487,6 +487,7 @@ public class WPMainActivity extends AppCompatActivity
 
     private void showBottomNav(boolean show) {
         mBottomNav.setVisibility(show ? View.VISIBLE : View.GONE);
+        findViewById(R.id.navbar_separator).setVisibility(show ? View.VISIBLE : View.GONE);
     }
 
     // user switched pages in the bottom navbar

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.RemoteInput;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -111,7 +112,6 @@ public class WPMainActivity extends AppCompatActivity
     public static final String ARG_OPEN_PAGE = "open_page";
     public static final String ARG_NOTIFICATIONS = "show_notifications";
 
-    private View mBottomNavContainer;
     private WPMainNavigationView mBottomNav;
     private Toolbar mToolbar;
 
@@ -162,8 +162,6 @@ public class WPMainActivity extends AppCompatActivity
         mToolbar = findViewById(R.id.toolbar);
         mToolbar.setTitle(R.string.app_title);
         setSupportActionBar(mToolbar);
-
-        mBottomNavContainer = findViewById(R.id.navbar_container);
 
         mBottomNav = findViewById(R.id.bottom_navigation);
         mBottomNav.init(getFragmentManager(), this);
@@ -267,6 +265,8 @@ public class WPMainActivity extends AppCompatActivity
                                                         .getStringExtra(SignupEpilogueActivity.EXTRA_SIGNUP_USERNAME),
                                                 false);
         }
+
+        Snackbar.make(findViewById(R.id.coordinator), "Snackbar", -2).show();
     }
 
     private @Nullable String getAuthToken() {
@@ -477,15 +477,20 @@ public class WPMainActivity extends AppCompatActivity
 
     @Override
     public void onRequestShowBottomNavigation() {
-        mBottomNavContainer.setVisibility(View.VISIBLE);
+        showBottomNav(true);
     }
 
     @Override
     public void onRequestHideBottomNavigation() {
         // we only hide the bottom navigation when there's not a hardware keyboard present
         if (!DeviceUtils.getInstance().hasHardwareKeyboard(this)) {
-            mBottomNavContainer.setVisibility(View.GONE);
+            showBottomNav(false);
         }
+    }
+
+    private void showBottomNav(boolean show) {
+        mBottomNav.setVisibility(show ? View.VISIBLE : View.GONE);
+        findViewById(R.id.bottom_navigation_separator).setVisibility(show ? View.VISIBLE : View.GONE);
     }
 
     // user switched pages in the bottom navbar

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -266,7 +266,7 @@ public class WPMainActivity extends AppCompatActivity
                                                 false);
         }
 
-        Snackbar.make(findViewById(R.id.coordinator), "Snackbar", -2).show();
+        Snackbar.make(findViewById(R.id.coordinator), "Snackbar", 0).show();
     }
 
     private @Nullable String getAuthToken() {
@@ -490,7 +490,6 @@ public class WPMainActivity extends AppCompatActivity
 
     private void showBottomNav(boolean show) {
         mBottomNav.setVisibility(show ? View.VISIBLE : View.GONE);
-        findViewById(R.id.bottom_navigation_separator).setVisibility(show ? View.VISIBLE : View.GONE);
     }
 
     // user switched pages in the bottom navbar

--- a/WordPress/src/main/res/layout/main_activity.xml
+++ b/WordPress/src/main/res/layout/main_activity.xml
@@ -20,7 +20,7 @@
     <FrameLayout
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_above="@+id/bottom_container"
         android:layout_below="@+id/toolbar"/>
 
@@ -46,27 +46,18 @@
             android:visibility="gone"
             tools:visibility="visible"/>
 
-        <View
-            android:id="@+id/bottom_navigation_separator"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@color/grey_lighten_20"/>
-
         <!-- this coordinator exists only for snackbars -->
         <android.support.design.widget.CoordinatorLayout
             android:id="@+id/coordinator"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"/>
 
-            <org.wordpress.android.ui.main.WPMainNavigationView
-                android:id="@+id/bottom_navigation"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@color/white"
-                app:elevation="0dp"
-                app:menu="@menu/bottom_nav_main"/>
-        </android.support.design.widget.CoordinatorLayout>
+        <org.wordpress.android.ui.main.WPMainNavigationView
+            android:id="@+id/bottom_navigation"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/white"
+            app:menu="@menu/bottom_nav_main"/>
     </LinearLayout>
-
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/main_activity.xml
+++ b/WordPress/src/main/res/layout/main_activity.xml
@@ -21,52 +21,52 @@
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_above="@+id/connection_bar"
+        android:layout_above="@+id/bottom_container"
         android:layout_below="@+id/toolbar"/>
 
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/connection_bar"
+    <LinearLayout
+        android:id="@+id/bottom_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_above="@+id/navbar_container"
         android:layout_alignParentBottom="true"
-        android:background="@color/alert_yellow"
-        android:gravity="center"
-        android:paddingBottom="@dimen/margin_medium"
-        android:paddingTop="@dimen/margin_medium"
-        android:text="@string/connectionbar_no_connection"
-        android:textAllCaps="true"
-        android:textColor="@color/white"
-        android:textSize="@dimen/text_sz_small"
-        android:visibility="gone"
-        tools:visibility="visible"/>
+        android:orientation="vertical">
 
-    <RelativeLayout
-        android:id="@+id/navbar_container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true">
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/connection_bar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/alert_yellow"
+            android:gravity="center"
+            android:paddingBottom="@dimen/margin_medium"
+            android:paddingTop="@dimen/margin_medium"
+            android:text="@string/connectionbar_no_connection"
+            android:textAllCaps="true"
+            android:textColor="@color/white"
+            android:textSize="@dimen/text_sz_small"
+            android:visibility="gone"
+            tools:visibility="visible"/>
 
         <View
-            android:id="@+id/navbar_separator"
+            android:id="@+id/bottom_navigation_separator"
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:background="@color/grey_lighten_20"/>
 
-        <org.wordpress.android.ui.main.WPMainNavigationView
-            android:id="@+id/bottom_navigation"
+        <!-- this coordinator exists only for snackbars -->
+        <android.support.design.widget.CoordinatorLayout
+            android:id="@+id/coordinator"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/white"
-            android:layout_below="@+id/navbar_separator"
-            app:elevation="0dp"
-            app:menu="@menu/bottom_nav_main"/>
-    </RelativeLayout>
+            android:layout_height="match_parent">
 
-    <!-- this coordinator exists only for snackbars -->
-    <android.support.design.widget.CoordinatorLayout
-        android:id="@+id/coordinator"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+            <org.wordpress.android.ui.main.WPMainNavigationView
+                android:id="@+id/bottom_navigation"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/white"
+                app:elevation="0dp"
+                app:menu="@menu/bottom_nav_main"/>
+        </android.support.design.widget.CoordinatorLayout>
+    </LinearLayout>
+
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/main_activity.xml
+++ b/WordPress/src/main/res/layout/main_activity.xml
@@ -52,11 +52,18 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"/>
 
+        <View
+            android:id="@+id/navbar_separator"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/grey_lighten_20"/>
+
         <org.wordpress.android.ui.main.WPMainNavigationView
             android:id="@+id/bottom_navigation"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/white"
+            app:elevation="0dp"
             app:menu="@menu/bottom_nav_main"/>
     </LinearLayout>
 


### PR DESCRIPTION
Fixes #7683 - updates the main activity so that snackbars appear above the bottom navigation. A simple way to test this is to add the following line at the end of the main activity's `onResume()`:
```
Snackbar.make(findViewById(R.id.coordinator), "Snackbar", 0).show();
```

Before and after shots below.

![before](https://user-images.githubusercontent.com/3903757/40255117-041e05c6-5ab4-11e8-9190-feb505d1fccc.png)

![after](https://user-images.githubusercontent.com/3903757/40255123-07c11600-5ab4-11e8-9496-7b8c32aeae90.png)

