### PR TITLE
Fix/anr open notification detail take3

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -268,8 +268,10 @@ public class GCMMessageService extends GcmListenerService {
 
     // Mark all notifications as tapped
     public static synchronized void bumpPushNotificationsTappedAllAnalytics() {
-        for (int id : ACTIVE_NOTIFICATIONS_MAP.keySet()) {
-            Bundle noteBundle = ACTIVE_NOTIFICATIONS_MAP.get(id);
+        for (Iterator<Map.Entry<Integer, Bundle>> it = ACTIVE_NOTIFICATIONS_MAP.entrySet().iterator();
+             it.hasNext();) {
+            Map.Entry<Integer, Bundle> row = it.next();
+            Bundle noteBundle = row.getValue();
             bumpPushNotificationsAnalytics(Stat.PUSH_NOTIFICATION_TAPPED, noteBundle, null);
         }
         AnalyticsTracker.flush();

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -174,13 +174,13 @@ public class GCMMessageService extends GcmListenerService {
     }
 
     public static synchronized void clearNotifications() {
-        Bundle authPNBundle = ACTIVE_NOTIFICATIONS_MAP.remove(AUTH_PUSH_NOTIFICATION_ID);
-
-        ACTIVE_NOTIFICATIONS_MAP.clear();
-
-        // reinsert 2fa bundle if it was present
-        if (authPNBundle != null) {
-            ACTIVE_NOTIFICATIONS_MAP.put(AUTH_PUSH_NOTIFICATION_ID, authPNBundle);
+        for (Iterator<Map.Entry<Integer, Bundle>> it = ACTIVE_NOTIFICATIONS_MAP.entrySet().iterator(); it.hasNext();) {
+            Map.Entry<Integer, Bundle> row = it.next();
+            Integer pushId = row.getKey();
+            // don't cancel or remove the AUTH notification if it exists
+            if (!pushId.equals(AUTH_PUSH_NOTIFICATION_ID)) {
+                it.remove();
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -230,18 +230,16 @@ public class GCMMessageService extends GcmListenerService {
         }
 
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
-        Bundle authPNBundle = ACTIVE_NOTIFICATIONS_MAP.remove(AUTH_PUSH_NOTIFICATION_ID);
-        for (Integer pushId : ACTIVE_NOTIFICATIONS_MAP.keySet()) {
-            notificationManager.cancel(pushId);
+        for (Iterator<Map.Entry<Integer, Bundle>> it = ACTIVE_NOTIFICATIONS_MAP.entrySet().iterator(); it.hasNext();) {
+            Map.Entry<Integer, Bundle> row = it.next();
+            Integer pushId = row.getKey();
+            // don't cancel or remove the AUTH notification if it exists
+            if (!pushId.equals(AUTH_PUSH_NOTIFICATION_ID)) {
+                notificationManager.cancel(pushId);
+                it.remove();
+            }
         }
         notificationManager.cancel(GCMMessageService.GROUP_NOTIFICATION_ID);
-
-        // reinsert 2fa bundle if it was present
-        if (authPNBundle != null) {
-            ACTIVE_NOTIFICATIONS_MAP.put(AUTH_PUSH_NOTIFICATION_ID, authPNBundle);
-        }
-
-        clearNotifications();
     }
 
     public static synchronized void remove2FANotification(Context context) {

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -254,8 +254,10 @@ public class GCMMessageService extends GcmListenerService {
 
     // NoteID is the ID if the note in WordPress
     public static synchronized void bumpPushNotificationsTappedAnalytics(String noteID) {
-        for (int id : ACTIVE_NOTIFICATIONS_MAP.keySet()) {
-            Bundle noteBundle = ACTIVE_NOTIFICATIONS_MAP.get(id);
+        for (Iterator<Map.Entry<Integer, Bundle>> it = ACTIVE_NOTIFICATIONS_MAP.entrySet().iterator();
+             it.hasNext();) {
+            Map.Entry<Integer, Bundle> row = it.next();
+            Bundle noteBundle = row.getValue();
             if (noteBundle.getString(PUSH_ARG_NOTE_ID, "").equals(noteID)) {
                 bumpPushNotificationsAnalytics(Stat.PUSH_NOTIFICATION_TAPPED, noteBundle, null);
                 AnalyticsTracker.flush();

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -767,10 +767,10 @@ public class GCMMessageService extends GcmListenerService {
             Bundle authPNBundle = tmpMap.remove(AUTH_PUSH_NOTIFICATION_ID);
             if (authPNBundle != null) {
                 handlePushAuth(context, authPNBundle);
-                if (ACTIVE_NOTIFICATIONS_MAP.size() > 0 && noteType.equals(PUSH_TYPE_PUSH_AUTH)) {
+                if (tmpMap.size() > 0 && noteType.equals(PUSH_TYPE_PUSH_AUTH)) {
                     // get the data for the next notification in map for re-build
                     // because otherwise we would be keeping the PUSH_AUTH type note in `data`
-                    data = ACTIVE_NOTIFICATIONS_MAP.values().iterator().next();
+                    data = tmpMap.values().iterator().next();
                 } else if (noteType.equals(PUSH_TYPE_PUSH_AUTH)) {
                     // only note is the 2fa note, just return
                     return;

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -139,7 +139,9 @@ public class GCMMessageService extends GcmListenerService {
                                                                                         String noteId) {
         if (ACTIVE_NOTIFICATIONS_MAP.size() > 0) {
             // get the corresponding bundle for this noteId
-            for (Map.Entry<Integer, Bundle> row : ACTIVE_NOTIFICATIONS_MAP.entrySet()) {
+            // using a copy of the ArrayMap to iterate over on, as we might need to modify the original array
+            ArrayMap<Integer, Bundle> tmpMap = new ArrayMap(ACTIVE_NOTIFICATIONS_MAP);
+            for (Map.Entry<Integer, Bundle> row : tmpMap.entrySet()) {
                 Bundle noteBundle = row.getValue();
                 if (noteBundle.getString(PUSH_ARG_NOTE_ID, "").equals(noteId)) {
                     NOTIFICATION_HELPER.rebuildAndUpdateNotificationsOnSystemBar(context, noteBundle);


### PR DESCRIPTION
Comes from #7779 

> It seems more like someone inside the synchronized block ends up in an infinite loop or something like that.

After chat with @malinajirka we decided to first try to isolate the issue of the deadlock, by making access to . This PR sometimes uses a copy of the array to iterate over when possible, and actual iterators when it was detected a change to the original array was needed (i.e. use of `remove`).

Once we get an idea of how things behave with this PR, and if things go well, we'll move the `NotificationDismissedBroadcastReceiver` code to `NotificationsProcessingService` as in #7779. Putting that PR on hold for now.

**To test:** it should be enough to send yourself one notification and dismiss, then several so they get grouped and dismiss some of them, then again dismiss them all to see if functionality doen't get affected.