### PR TITLE
Don't fetch account settings if there is no account in AppSettings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -152,7 +152,7 @@ public class AppSettingsFragment extends PreferenceFragment
     @Override
     public void onResume() {
         super.onResume();
-        if (NetworkUtils.isNetworkAvailable(getActivity())) {
+        if (mAccountStore.hasAccessToken() && NetworkUtils.isNetworkAvailable(getActivity())) {
             mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
         }
     }


### PR DESCRIPTION
To test:
1. Logout of the app
2. Add a self-hosted site (if you don't already have one)
3. Go to "Me -> App Settings"
4. Verify that there is no toast error with "Couldn't retrieve your account settings" message