### PR TITLE
Issue/7787 update calypso dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -126,7 +126,7 @@ public class AddQuickPressShortcutActivity extends ListActivity {
 
     private void buildDialog(final int position) {
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(
-                new ContextThemeWrapper(this, R.style.Calypso_Dialog));
+                new ContextThemeWrapper(this, R.style.Calypso_Dialog_Alert));
         dialogBuilder.setTitle(R.string.quickpress_add_alert_title);
 
         final EditText quickPressShortcutName = new EditText(AddQuickPressShortcutActivity.this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -333,7 +333,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
                 // If the comment status is trash or spam, next deletion is a permanent deletion.
                 if (status == CommentStatus.TRASH || status == CommentStatus.SPAM) {
                     AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(
-                            new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                            new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
                     dialogBuilder.setTitle(getResources().getText(R.string.delete));
                     dialogBuilder.setMessage(getResources().getText(R.string.dlg_sure_to_delete_comment));
                     dialogBuilder.setPositiveButton(getResources().getText(R.string.yes),

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -419,7 +419,7 @@ public class CommentsListFragment extends Fragment {
     private void confirmDeleteComments() {
         if (mCommentStatusFilter == CommentStatusCriteria.TRASH) {
             AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(
-                    new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                    new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
             dialogBuilder.setTitle(getResources().getText(R.string.delete));
             int resId = getAdapter().getSelectedCommentCount() > 1 ? R.string.dlg_sure_to_delete_comments
                     : R.string.dlg_sure_to_delete_comment;
@@ -435,7 +435,7 @@ public class CommentsListFragment extends Fragment {
             dialogBuilder.create().show();
         } else {
             AlertDialog.Builder builder = new AlertDialog.Builder(
-                    new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                    new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
             builder.setMessage(R.string.dlg_confirm_trash_comments);
             builder.setTitle(R.string.trash);
             builder.setCancelable(true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
@@ -269,7 +269,7 @@ public class EditCommentActivity extends AppCompatActivity {
 
     private void showEditErrorAlert() {
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(
-                new ContextThemeWrapper(this, R.style.Calypso_Dialog));
+                new ContextThemeWrapper(this, R.style.Calypso_Dialog_Alert));
         dialogBuilder.setTitle(getResources().getText(R.string.error));
         dialogBuilder.setMessage(R.string.error_edit_comment);
         dialogBuilder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
@@ -309,7 +309,7 @@ public class EditCommentActivity extends AppCompatActivity {
         }
 
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(
-                new ContextThemeWrapper(this, R.style.Calypso_Dialog));
+                new ContextThemeWrapper(this, R.style.Calypso_Dialog_Alert));
         dialogBuilder.setTitle(getResources().getText(R.string.cancel_edit));
         dialogBuilder.setMessage(getResources().getText(R.string.sure_to_cancel_edit_comment));
         dialogBuilder.setPositiveButton(getResources().getText(R.string.yes),

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -324,7 +324,7 @@ public class MeFragment extends Fragment {
         String message = String.format(getString(R.string.sign_out_wpcom_confirm),
                                        mAccountStore.getAccount().getUserName());
 
-        new AlertDialog.Builder(new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog))
+        new AlertDialog.Builder(new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert))
                 .setMessage(message)
                 .setPositiveButton(R.string.signout, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int whichButton) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -634,7 +634,7 @@ public class SitePickerActivity extends AppCompatActivity
                     {getString(R.string.site_picker_create_wpcom),
                             getString(R.string.site_picker_add_self_hosted)};
             AlertDialog.Builder builder = new AlertDialog.Builder(
-                    new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                    new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
             builder.setTitle(R.string.site_picker_add_site);
             builder.setAdapter(
                     new ArrayAdapter<CharSequence>(getActivity(), R.layout.add_new_site_dialog_item, R.id.text, items) {
@@ -672,7 +672,7 @@ public class SitePickerActivity extends AppCompatActivity
 
     private void showRemoveSelfHostedSiteDialog(@NonNull final SiteModel site) {
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(
-                new ContextThemeWrapper(this, R.style.Calypso_Dialog));
+                new ContextThemeWrapper(this, R.style.Calypso_Dialog_Alert));
         dialogBuilder.setTitle(getResources().getText(R.string.remove_account));
         dialogBuilder.setMessage(getResources().getText(R.string.sure_to_remove_account));
         dialogBuilder.setPositiveButton(getResources().getText(R.string.yes), new DialogInterface.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -1032,7 +1032,8 @@ public class MediaSettingsActivity extends AppCompatActivity
             resId = R.string.confirm_delete_media_image;
         }
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(new ContextThemeWrapper(this, R.style.Calypso_Dialog))
+        AlertDialog.Builder builder = new AlertDialog.Builder(
+                new ContextThemeWrapper(this, R.style.Calypso_Dialog_Alert))
                 .setMessage(resId)
                 .setCancelable(true).setPositiveButton(
                         isMediaFromEditor() ? R.string.remove : R.string.delete, new DialogInterface.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -371,7 +371,8 @@ public class NotificationsUtils {
             return;
         }
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(new ContextThemeWrapper(context, R.style.Calypso_Dialog));
+        AlertDialog.Builder builder = new AlertDialog.Builder(
+                new ContextThemeWrapper(context, R.style.Calypso_Dialog_Alert));
         builder.setTitle(title).setMessage(message);
 
         builder.setPositiveButton(R.string.mnu_comment_approve, new DialogInterface.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -518,7 +518,7 @@ public class PeopleManagementActivity extends AppCompatActivity
             return;
         }
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.Calypso_Dialog);
+        AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.Calypso_Dialog_Alert);
         builder.setTitle(getString(R.string.person_remove_confirmation_title, person.getDisplayName()));
         if (person.getPersonType() == Person.PersonType.USER) {
             builder.setMessage(getString(R.string.user_remove_confirmation_message, person.getDisplayName()));

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/RoleChangeDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/RoleChangeDialogFragment.java
@@ -64,7 +64,7 @@ public class RoleChangeDialogFragment extends DialogFragment {
         final SiteModel site = (SiteModel) getArguments().getSerializable(WordPress.SITE);
 
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         builder.setTitle(R.string.role);
         builder.setNegativeButton(R.string.cancel, null);
         builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/RoleSelectDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/RoleSelectDialogFragment.java
@@ -40,7 +40,7 @@ public class RoleSelectDialogFragment extends DialogFragment {
         }
 
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         builder.setTitle(R.string.role);
         builder.setItems(stringRoles, new DialogInterface.OnClickListener() {
             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -653,7 +653,7 @@ public class PluginDetailActivity extends AppCompatActivity {
                 from,
                 to);
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.Calypso_Dialog);
+        AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.Calypso_Dialog_Alert);
         builder.setCancelable(true);
         builder.setAdapter(adapter, new DialogInterface.OnClickListener() {
             @Override
@@ -687,7 +687,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     }
 
     private void confirmRemovePlugin() {
-        AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.Calypso_Dialog);
+        AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.Calypso_Dialog_Alert);
         builder.setTitle(getResources().getText(R.string.plugin_remove_dialog_title));
         String confirmationMessage = getString(R.string.plugin_remove_dialog_message,
                 mPlugin.getDisplayName(),
@@ -1128,7 +1128,7 @@ public class PluginDetailActivity extends AppCompatActivity {
      * UI for it, so we get a confirmation first in this step.
      */
     private void confirmInstallPluginForAutomatedTransfer() {
-        AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.Calypso_Dialog);
+        AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.Calypso_Dialog_Alert);
         builder.setTitle(getResources().getText(R.string.plugin_install_first_plugin_confirmation_dialog_title));
         builder.setMessage(R.string.plugin_install_first_plugin_confirmation_dialog_message);
         builder.setPositiveButton(R.string.plugin_install_first_plugin_confirmation_dialog_install_btn,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/AddCategoryFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/AddCategoryFragment.java
@@ -47,7 +47,7 @@ public class AddCategoryFragment extends AppCompatDialogFragment {
         initSite(savedInstanceState);
 
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         // Get the layout inflater
         LayoutInflater inflater = getActivity().getLayoutInflater();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/BasicFragmentDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/BasicFragmentDialog.kt
@@ -70,7 +70,7 @@ class BasicFragmentDialog : AppCompatDialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val builder = Builder(ContextThemeWrapper(activity, R.style.Calypso_Dialog))
+        val builder = Builder(ContextThemeWrapper(activity, R.style.Calypso_Dialog_Alert))
         builder.setTitle(mTitle)
                 .setMessage(mMessage)
                 .setPositiveButton(mPositiveButtonLabel) { _, _ ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1577,7 +1577,7 @@ public class EditPostActivity extends AppCompatActivity implements
                                     account.getEmail());
 
             AlertDialog.Builder builder = new AlertDialog.Builder(
-                    new ContextThemeWrapper(this, R.style.Calypso_Dialog));
+                    new ContextThemeWrapper(this, R.style.Calypso_Dialog_Alert));
             builder.setTitle(R.string.editor_confirm_email_prompt_title)
                    .setMessage(message)
                    .setPositiveButton(android.R.string.ok,
@@ -2930,7 +2930,7 @@ public class EditPostActivity extends AppCompatActivity implements
         if (media == null) {
             AppLog.e(T.MEDIA, "Can't find media with local id: " + mediaId);
             AlertDialog.Builder builder = new AlertDialog.Builder(
-                    new ContextThemeWrapper(this, R.style.Calypso_Dialog));
+                    new ContextThemeWrapper(this, R.style.Calypso_Dialog_Alert));
             builder.setTitle(getString(R.string.cannot_retry_deleted_media_item));
             builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
                 public void onClick(DialogInterface dialog, int id) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.java
@@ -115,7 +115,7 @@ public class PostDatePickerDialogFragment extends DialogFragment {
         switch (mDialogType) {
             case DATE_PICKER:
                 final DatePickerDialog datePickerDialog = new DatePickerDialog(
-                        new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog),
+                        new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert),
                         null,
                         mYear,
                         mMonth,
@@ -161,7 +161,7 @@ public class PostDatePickerDialogFragment extends DialogFragment {
             case TIME_PICKER:
                 boolean is24HrFormat = DateFormat.is24HourFormat(getActivity());
                 TimePickerDialog timePickerDialog = new TimePickerDialog(
-                        new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog),
+                        new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert),
                         new TimePickerDialog.OnTimeSetListener() {
                             @Override
                             public void onTimeSet(TimePicker timePicker,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.java
@@ -115,7 +115,7 @@ public class PostDatePickerDialogFragment extends DialogFragment {
         switch (mDialogType) {
             case DATE_PICKER:
                 final DatePickerDialog datePickerDialog = new DatePickerDialog(
-                        new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert),
+                        new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog),
                         null,
                         mYear,
                         mMonth,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsInputDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsInputDialogFragment.java
@@ -79,7 +79,7 @@ public class PostSettingsInputDialogFragment extends DialogFragment implements T
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         LayoutInflater layoutInflater = LayoutInflater.from(getActivity());
         //noinspection InflateParams
         View dialogView = layoutInflater.inflate(R.layout.post_settings_input_dialog, null);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsListDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsListDialogFragment.java
@@ -70,7 +70,7 @@ public class PostSettingsListDialogFragment extends DialogFragment {
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
 
         DialogInterface.OnClickListener clickListener = new DialogInterface.OnClickListener() {
             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -560,7 +560,7 @@ public class PostsListFragment extends Fragment
                     }
 
                     AlertDialog.Builder builder = new AlertDialog.Builder(
-                            new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                            new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
                     builder.setTitle(post.isPage() ? getString(R.string.delete_page) : getString(R.string.delete_post))
                             .setMessage(message)
                             .setPositiveButton(R.string.delete, new DialogInterface.OnClickListener() {
@@ -574,7 +574,7 @@ public class PostsListFragment extends Fragment
                     builder.create().show();
                 } else {
                     AlertDialog.Builder builder = new AlertDialog.Builder(
-                            new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                            new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
                     builder.setTitle(post.isPage() ? getText(R.string.delete_page) : getText(R.string.delete_post))
                             .setMessage(R.string.dialog_confirm_cancel_post_media_uploading)
                             .setPositiveButton(R.string.delete, new DialogInterface.OnClickListener() {
@@ -593,7 +593,7 @@ public class PostsListFragment extends Fragment
 
     private void showPublishConfirmationDialog(final PostModel post) {
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         builder.setTitle(getResources().getText(R.string.dialog_confirm_publish_title))
                .setMessage(post.isPage() ? getString(R.string.dialog_confirm_publish_message_page)
                                    : getString(R.string.dialog_confirm_publish_message_post))

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DeleteSiteDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DeleteSiteDialogFragment.java
@@ -33,7 +33,7 @@ public class DeleteSiteDialogFragment extends DialogFragment implements TextWatc
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         retrieveSiteDomain();
         configureAlertViewBuilder(builder);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DetailListPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DetailListPreference.java
@@ -85,7 +85,7 @@ public class DetailListPreference extends ListPreference
     protected void showDialog(Bundle state) {
         Context context = getContext();
         Resources res = context.getResources();
-        AlertDialog.Builder builder = new AlertDialog.Builder(context, R.style.Calypso_Dialog);
+        AlertDialog.Builder builder = new AlertDialog.Builder(context, R.style.Calypso_Dialog_Alert);
 
         mWhichButtonClicked = DialogInterface.BUTTON_NEGATIVE;
         builder.setPositiveButton(android.R.string.ok, this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/NumberPickerDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/NumberPickerDialog.java
@@ -55,7 +55,7 @@ public class NumberPickerDialog extends DialogFragment
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         View view = View.inflate(getActivity(), R.layout.number_picker_dialog, null);
         TextView switchText = (TextView) view.findViewById(R.id.number_picker_text);
         mSwitch = (Switch) view.findViewById(R.id.number_picker_switch);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ProfileInputDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ProfileInputDialogFragment.java
@@ -48,7 +48,7 @@ public class ProfileInputDialogFragment extends DialogFragment {
         //noinspection InflateParams
         View promptView = layoutInflater.inflate(R.layout.my_profile_dialog, null);
         AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         alertDialogBuilder.setView(promptView);
 
         final WPTextView textView = (WPTextView) promptView.findViewById(R.id.my_profile_dialog_label);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/RelatedPostsDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/RelatedPostsDialog.java
@@ -94,7 +94,7 @@ public class RelatedPostsDialog extends DialogFragment
         toggleViews(mShowRelatedPosts.isChecked());
 
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         //noinspection InflateParams
         View titleView = inflater.inflate(R.layout.detail_list_preference_title, null);
         TextView titleText = ((TextView) titleView.findViewById(R.id.title));

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFormatDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFormatDialog.java
@@ -111,7 +111,7 @@ public class SiteSettingsFormatDialog extends DialogFragment implements DialogIn
         });
 
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         builder.setPositiveButton(android.R.string.ok, this);
         builder.setNegativeButton(R.string.cancel, this);
         builder.setView(view);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -570,7 +570,7 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void disconnectFromJetpack() {
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         builder.setMessage(R.string.jetpack_disconnect_confirmation_message);
         builder.setPositiveButton(R.string.jetpack_disconnect_confirm, new DialogInterface.OnClickListener() {
             @Override
@@ -1008,7 +1008,7 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void showExportContentDialog() {
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         builder.setTitle(R.string.export_your_content);
         String email = mAccountStore.getAccount().getEmail();
         builder.setMessage(getString(R.string.export_your_content_message, email));
@@ -1090,7 +1090,7 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void showPurchasesDialog() {
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         builder.setTitle(R.string.premium_upgrades_title);
         builder.setMessage(R.string.premium_upgrades_message);
         builder.setPositiveButton(R.string.show_purchases, new DialogInterface.OnClickListener() {
@@ -1130,7 +1130,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         }
 
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         builder.setTitle(R.string.delete_site_warning_title);
         String text = getString(R.string.delete_site_warning, "<b>" + UrlUtils.getHost(mSite.getUrl()) + "</b>")
                       + "<br><br>"
@@ -1510,7 +1510,7 @@ public class SiteSettingsFragment extends PreferenceFragment
             @Override
             public void onClick(View v) {
                 AlertDialog.Builder builder = new AlertDialog.Builder(
-                                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
                 final EditText input = new EditText(getActivity());
                 WPPrefUtils.layoutAsInput(input);
                 input.setWidth(getResources().getDimensionPixelSize(R.dimen.list_editor_input_max_width));
@@ -1776,7 +1776,7 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void showDeleteSiteErrorDialog() {
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         builder.setTitle(R.string.error_deleting_site);
         builder.setMessage(R.string.error_deleting_site_summary);
         builder.setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -372,7 +372,7 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
     private void confirmDeleteTag(@NonNull final TermModel term) {
         String message = String.format(getString(R.string.dlg_confirm_delete_tag), term.getName());
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(
-                new ContextThemeWrapper(this, R.style.Calypso_Dialog));
+                new ContextThemeWrapper(this, R.style.Calypso_Dialog_Alert));
         dialogBuilder.setMessage(message);
         dialogBuilder.setPositiveButton(getResources().getText(R.string.delete_yes),
                                         new DialogInterface.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTimezoneDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTimezoneDialog.java
@@ -126,7 +126,7 @@ public class SiteSettingsTimezoneDialog extends DialogFragment implements Dialog
         mProgressView = view.findViewById(R.id.progress_view);
 
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         builder.setPositiveButton(android.R.string.ok, this);
         builder.setNegativeButton(R.string.cancel, this);
         builder.setView(view);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SummaryEditTextPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SummaryEditTextPreference.java
@@ -108,7 +108,7 @@ public class SummaryEditTextPreference extends EditTextPreference implements Pre
     protected void showDialog(Bundle state) {
         Context context = getContext();
         Resources res = context.getResources();
-        AlertDialog.Builder builder = new AlertDialog.Builder(context, R.style.Calypso_Dialog);
+        AlertDialog.Builder builder = new AlertDialog.Builder(context, R.style.Calypso_Dialog_Alert);
         View titleView = View.inflate(getContext(), R.layout.detail_list_preference_title, null);
         mWhichButtonClicked = DialogInterface.BUTTON_NEGATIVE;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationSettingsFollowedDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationSettingsFollowedDialog.java
@@ -90,7 +90,7 @@ public class NotificationSettingsFollowedDialog extends DialogFragment implement
         }
 
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         builder.setTitle(getString(R.string.notification_settings_followed_dialog_title));
         builder.setPositiveButton(android.R.string.ok, this);
         builder.setNegativeButton(R.string.cancel, this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserDialogFragment.java
@@ -49,7 +49,7 @@ public class PublicizeAccountChooserDialogFragment extends DialogFragment
         View view = inflater.inflate(R.layout.publicize_account_chooser_dialog, null);
 
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         configureAlertDialog(view, builder);
         configureRecyclerViews(view);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -251,7 +251,8 @@ public class PublicizeListActivity extends AppCompatActivity
     }
 
     private void confirmDisconnect(final PublicizeConnection publicizeConnection) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(new ContextThemeWrapper(this, R.style.Calypso_Dialog));
+        AlertDialog.Builder builder = new AlertDialog.Builder(
+                new ContextThemeWrapper(this, R.style.Calypso_Dialog_Alert));
         builder.setMessage(
                 String.format(getString(R.string.dlg_confirm_publicize_disconnect), publicizeConnection.getLabel()));
         builder.setTitle(R.string.share_btn_disconnect);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionAdapter.java
@@ -164,7 +164,8 @@ public class ReaderSearchSuggestionAdapter extends CursorAdapter {
     }
 
     private void confirmClearSavedSearches(Context context) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(new ContextThemeWrapper(context, R.style.Calypso_Dialog));
+        AlertDialog.Builder builder = new AlertDialog.Builder(
+                new ContextThemeWrapper(context, R.style.Calypso_Dialog_Alert));
         builder.setMessage(R.string.dlg_confirm_clear_search_history)
                .setCancelable(true)
                .setNegativeButton(R.string.no, null)

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -349,7 +349,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
 
     private void showAlertDialogOnNewSettingNewTheme(ThemeModel newTheme) {
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(
-                new ContextThemeWrapper(this, R.style.Calypso_Dialog));
+                new ContextThemeWrapper(this, R.style.Calypso_Dialog_Alert));
 
         String thanksMessage = String.format(getString(R.string.theme_prompt), newTheme.getName());
         if (!TextUtils.isEmpty(newTheme.getAuthorName())) {

--- a/WordPress/src/main/java/org/wordpress/android/util/SelfSignedSSLUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SelfSignedSSLUtils.java
@@ -28,7 +28,8 @@ public class SelfSignedSSLUtils {
     public static void showSSLWarningDialog(@NonNull final Context context,
                                             @NonNull final MemorizingTrustManager memorizingTrustManager,
                                             @Nullable final Callback callback) {
-        AlertDialog.Builder alert = new AlertDialog.Builder(new ContextThemeWrapper(context, R.style.Calypso_Dialog));
+        AlertDialog.Builder alert = new AlertDialog.Builder(
+                new ContextThemeWrapper(context, R.style.Calypso_Dialog_Alert));
         alert.setTitle(context.getString(org.wordpress.android.R.string.ssl_certificate_error));
         alert.setMessage(context.getString(org.wordpress.android.R.string.ssl_certificate_ask_trust));
         alert.setPositiveButton(org.wordpress.android.R.string.yes, new DialogInterface.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -151,7 +151,7 @@ public class WPMediaUtils {
         };
 
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(activity, R.style.Calypso_Dialog));
+                new ContextThemeWrapper(activity, R.style.Calypso_Dialog_Alert));
         builder.setTitle(org.wordpress.android.R.string.image_optimization_promo_title);
         builder.setMessage(org.wordpress.android.R.string.image_optimization_promo_desc);
         builder.setPositiveButton(R.string.turn_on, onClickListener);
@@ -212,7 +212,7 @@ public class WPMediaUtils {
 
     private static void showSDCardRequiredDialog(Context context) {
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(
-                new ContextThemeWrapper(context, R.style.Calypso_Dialog));
+                new ContextThemeWrapper(context, R.style.Calypso_Dialog_Alert));
         dialogBuilder.setTitle(context.getResources().getText(R.string.sdcard_title));
         dialogBuilder.setMessage(context.getResources().getText(R.string.sdcard_message));
         dialogBuilder.setPositiveButton(context.getString(android.R.string.ok), new DialogInterface.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
@@ -179,7 +179,8 @@ public class WPPermissionUtils {
         String message = String.format(activity.getString(R.string.permissions_denied_message),
                 getPermissionName(activity, permission));
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(new ContextThemeWrapper(activity, R.style.Calypso_Dialog))
+        AlertDialog.Builder builder = new AlertDialog.Builder(
+                new ContextThemeWrapper(activity, R.style.Calypso_Dialog_Alert))
                 .setTitle(activity.getString(R.string.permissions_denied_title))
                 .setMessage(Html.fromHtml(message))
                 .setPositiveButton(R.string.button_edit_permissions, new DialogInterface.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/widgets/AuthErrorDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/AuthErrorDialogFragment.java
@@ -46,7 +46,8 @@ public class AuthErrorDialogFragment extends DialogFragment {
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        AlertDialog.Builder b = new AlertDialog.Builder(new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+        AlertDialog.Builder b = new AlertDialog.Builder(
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         b.setTitle(mTitleId);
         b.setMessage(mMessageId);
         b.setCancelable(true);

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPAlertDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPAlertDialogFragment.java
@@ -118,7 +118,7 @@ public class WPAlertDialogFragment extends DialogFragment implements DialogInter
         }
 
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
 
         builder.setTitle(title);
         builder.setMessage(message);

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPPrefView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPPrefView.java
@@ -407,7 +407,7 @@ public class WPPrefView extends LinearLayout implements
         }
 
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getContext(), R.style.Calypso_Dialog))
+                new ContextThemeWrapper(getContext(), R.style.Calypso_Dialog_Alert))
                 .setTitle(mTitleTextView.getText())
                 .setView(customView)
                 .setNegativeButton(android.R.string.cancel, null)
@@ -434,7 +434,7 @@ public class WPPrefView extends LinearLayout implements
         }
 
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getContext(), R.style.Calypso_Dialog))
+                new ContextThemeWrapper(getContext(), R.style.Calypso_Dialog_Alert))
                 .setTitle(mTitleTextView.getText())
                 .setNegativeButton(android.R.string.cancel, null)
                 .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
@@ -465,7 +465,7 @@ public class WPPrefView extends LinearLayout implements
         }
 
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getContext(), R.style.Calypso_Dialog))
+                new ContextThemeWrapper(getContext(), R.style.Calypso_Dialog_Alert))
                 .setTitle(mTitleTextView.getText())
                 .setNegativeButton(android.R.string.cancel, null)
                 .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -22,7 +22,7 @@
         <item name="colorButtonNormal">@color/light_gray</item>
 
         <item name="android:dialogTheme">@style/DialogTheme.WordPress</item>
-        <item name="android:alertDialogTheme">@style/Calypso.Dialog</item>
+        <item name="android:alertDialogTheme">@style/Calypso.Dialog.Alert</item>
         <item name="android:datePickerStyle">@style/DatePicker.WordPress</item>
         <item name="android:timePickerStyle">@style/TimePicker.WordPress</item>
 

--- a/WordPress/src/main/res/values/styles_calypso.xml
+++ b/WordPress/src/main/res/values/styles_calypso.xml
@@ -53,6 +53,15 @@
         <item name="android:background">@color/grey_darken_10</item>
     </style>
 
+    <style name="Calypso.Dialog" parent="@style/Theme.AppCompat.Light.Dialog">
+        <item name="colorPrimary">@color/color_primary</item>
+        <item name="colorPrimaryDark">@color/color_primary_dark</item>
+        <item name="colorAccent">@color/blue_medium</item>
+        <item name="actionModeStyle">@style/Calypso.ActionMode</item>
+        <item name="android:listDivider">@drawable/preferences_divider</item>
+        <item name="android:dividerHeight">@dimen/site_settings_divider_height</item>
+    </style>
+
     <style name="Calypso.Dialog.Alert" parent="@style/Theme.AppCompat.Light.Dialog.Alert">
         <item name="colorPrimary">@color/color_primary</item>
         <item name="colorPrimaryDark">@color/color_primary_dark</item>

--- a/WordPress/src/main/res/values/styles_calypso.xml
+++ b/WordPress/src/main/res/values/styles_calypso.xml
@@ -28,8 +28,8 @@
         <item name="colorPrimaryDark">@color/grey_darken_10</item>
 
         <item name="android:windowContentOverlay">@color/grey_lighten_30</item>
-        <item name="android:alertDialogTheme">@style/Calypso.Dialog</item>
-        <item name="dialogTheme">@style/Calypso.Dialog</item>
+        <item name="android:alertDialogTheme">@style/Calypso.Dialog.Alert</item>
+        <item name="dialogTheme">@style/Calypso.Dialog.Alert</item>
         <item name="colorControlActivated">@color/blue_medium</item>
         <item name="colorControlNormal">@color/grey_lighten_20</item>
         <item name="colorAccent">@color/orange_jazzy</item>
@@ -53,7 +53,7 @@
         <item name="android:background">@color/grey_darken_10</item>
     </style>
 
-    <style name="Calypso.Dialog" parent="@style/Theme.AppCompat.Light.Dialog">
+    <style name="Calypso.Dialog.Alert" parent="@style/Theme.AppCompat.Light.Dialog.Alert">
         <item name="colorPrimary">@color/color_primary</item>
         <item name="colorPrimaryDark">@color/color_primary_dark</item>
         <item name="colorAccent">@color/blue_medium</item>

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -676,7 +676,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     private void checkForFailedUploadAndSwitchToHtmlMode() {
         // Show an Alert Dialog asking the user if he wants to remove all failed media before upload
         if (hasFailedMediaUploads()) {
-            new AlertDialog.Builder(new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog))
+            new AlertDialog.Builder(new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert))
                     .setMessage(R.string.editor_failed_uploads_switch_html)
                     .setPositiveButton(R.string.editor_remove_failed_uploads, new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int id) {
@@ -1563,7 +1563,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             case ATTR_STATUS_UPLOADING:
                 // Display 'cancel upload' dialog
                 AlertDialog.Builder builder = new AlertDialog.Builder(
-                        new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                        new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
                 builder.setTitle(getString(R.string.stop_upload_dialog_title));
                 builder.setPositiveButton(R.string.stop_upload_dialog_button_yes,
                                           new DialogInterface.OnClickListener() {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -589,7 +589,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         // Show an Alert Dialog asking the user if he wants to remove all failed media before upload
         if (hasFailedMediaUploads()) {
             AlertDialog.Builder builder = new AlertDialog.Builder(
-                    new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                    new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
             builder.setMessage(R.string.editor_failed_uploads_switch_html)
                     .setPositiveButton(R.string.editor_remove_failed_uploads, new OnClickListener() {
                         public void onClick(DialogInterface dialog, int id) {
@@ -1364,7 +1364,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
                 // Display 'cancel upload' dialog
                 AlertDialog.Builder builder = new AlertDialog.Builder(
-                        new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                        new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
                 builder.setTitle(getString(R.string.stop_upload_dialog_title));
                 builder.setPositiveButton(
                         R.string.stop_upload_dialog_button_yes, new DialogInterface.OnClickListener() {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -322,7 +322,7 @@ public class ImageSettingsDialogFragment extends DialogFragment {
      */
     private void showDiscardChangesDialog() {
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         builder.setTitle(getString(R.string.image_settings_dismiss_dialog_title));
         builder.setPositiveButton(getString(R.string.discard), new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int id) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
@@ -622,7 +622,7 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
                                   final CheckBox featuredCheckBox, final CheckBox featuredInPostCheckBox,
                                   final int maxWidth, final Spinner alignmentSpinner, final WPImageSpan imageSpan) {
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         builder.setTitle(getString(R.string.image_settings));
         builder.setView(alertView);
         builder.setPositiveButton(getString(android.R.string.ok), new DialogInterface.OnClickListener() {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LinkDialogFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LinkDialogFragment.java
@@ -23,7 +23,7 @@ public class LinkDialogFragment extends DialogFragment {
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog));
+                new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert));
         LayoutInflater inflater = getActivity().getLayoutInflater();
         //noinspection InflateParams
         View view = inflater.inflate(R.layout.dialog_link, null);

--- a/libs/editor/WordPressEditor/src/main/res/values/styles.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/styles.xml
@@ -4,7 +4,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="Calypso.Dialog" parent="@style/Theme.AppCompat.Light.Dialog">
+    <style name="Calypso.Dialog.Alert" parent="@style/Theme.AppCompat.Light.Dialog.Alert">
         <item name="colorAccent">@color/blue_medium</item>
         <item name="colorPrimary">@color/blue_wordpress</item>
         <item name="colorPrimaryDark">@color/status_bar_tint</item>

--- a/libs/editor/WordPressEditor/src/main/res/values/styles.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/styles.xml
@@ -4,6 +4,12 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <style name="Calypso.Dialog" parent="@style/Theme.AppCompat.Light.Dialog">
+        <item name="colorAccent">@color/blue_medium</item>
+        <item name="colorPrimary">@color/blue_wordpress</item>
+        <item name="colorPrimaryDark">@color/status_bar_tint</item>
+    </style>
+
     <style name="Calypso.Dialog.Alert" parent="@style/Theme.AppCompat.Light.Dialog.Alert">
         <item name="colorAccent">@color/blue_medium</item>
         <item name="colorPrimary">@color/blue_wordpress</item>


### PR DESCRIPTION
### Fix
Update the `Calypso.Dialog` style to [`Calypso.Dialog.Alert`](https://github.com/wordpress-mobile/WordPress-Android/blob/3c3ac74b069a28af18be58193b5c6d8b64bf671c/WordPress/src/main/res/values/styles_calypso.xml#L65-L72) to avoid dialogs with a small width as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7787.  Add the [`Calypso.Dialog`](https://github.com/wordpress-mobile/WordPress-Android/blob/3c3ac74b069a28af18be58193b5c6d8b64bf671c/WordPress/src/main/res/values/styles_calypso.xml#L56-L63) style to avoid unwanted layout issue as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7787#issuecomment-390792044.  See the screenshots below for illustration.

![calypso_tagline](https://user-images.githubusercontent.com/3827611/40334987-87bffd28-5d1e-11e8-8a5b-76846fa58f73.png)

![calypso_privacy](https://user-images.githubusercontent.com/3827611/40334992-8a07d65a-5d1e-11e8-851a-d7d988bfe3e0.png)

![calypso_language](https://user-images.githubusercontent.com/3827611/40334993-8ba504a6-5d1e-11e8-982c-c109d6e7cdd5.png)

### Test
The only way to test is to simply trigger dialogs throughout the app.  Many dialogs are shown by tapping items on the ***Sites*** > ***Settings*** and ***Sites*** > ***Create*** > ***Post Settings*** screens.