### PR TITLE
Show privacy settings links in browser instead of buggy dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
@@ -4,7 +4,9 @@ import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.content.res.TypedArray;
+import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.preference.Preference;
@@ -55,6 +57,7 @@ public class LearnMorePreference extends Preference implements View.OnClickListe
     private int mIcon = -1;
     private int mLayout = R.layout.learn_more_pref;
     private boolean mUseCustomJsFormatting;
+    private boolean mOpenInDialog;
 
     public LearnMorePreference(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -80,6 +83,8 @@ public class LearnMorePreference extends Preference implements View.OnClickListe
                 mIcon = array.getResourceId(index, -1);
             } else if (index == R.styleable.LearnMorePreference_layout) {
                 mLayout = array.getResourceId(index, -1);
+            } else if (index == R.styleable.LearnMorePreference_openInDialog) {
+                mOpenInDialog = array.getBoolean(index, false);
             }
         }
         array.recycle();
@@ -128,7 +133,9 @@ public class LearnMorePreference extends Preference implements View.OnClickListe
             super.onRestoreInstanceState(state);
         } else {
             super.onRestoreInstanceState(((SavedState) state).getSuperState());
-            showDialog();
+            if (mOpenInDialog) {
+                showDialog();
+            }
         }
     }
 
@@ -138,7 +145,14 @@ public class LearnMorePreference extends Preference implements View.OnClickListe
             return;
         }
         AnalyticsTracker.track(Stat.SITE_SETTINGS_LEARN_MORE_CLICKED);
-        showDialog();
+        if (mOpenInDialog) {
+            showDialog();
+        } else {
+            Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(mUrl));
+            if (browserIntent.resolveActivity(v.getContext().getPackageManager()) != null) {
+                v.getContext().startActivity(browserIntent);
+            }
+        }
     }
 
     private void showDialog() {

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -32,6 +32,7 @@
         <attr name="button" format="string" />
         <attr name="icon" format="reference" />
         <attr name="layout" format="reference" />
+        <attr name="openInDialog" format="boolean" />
         <attr name="useCustomJsFormatting" format="boolean" />
     </declare-styleable>
 

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -28,23 +28,20 @@
             android:title="@string/cookie_policy_learn_more_header"
             app:caption="@string/cookie_policy_learn_more_caption"
             app:url="https://www.automattic.com/cookies"
-            app:icon="@drawable/ic_info_outline_grey_min_24dp"
-            app:useCustomJsFormatting="true"/>
+            app:icon="@drawable/ic_info_outline_grey_min_24dp"/>
 
         <org.wordpress.android.ui.prefs.LearnMorePreference
             android:title="@string/privacy_policy_learn_more_header"
             app:caption="@string/privacy_policy_learn_more_caption"
             app:button="@string/privacy_policy_read"
             app:url="https://www.automattic.com/privacy"
-            app:icon="@drawable/ic_user_circle_grey_min_24dp"
-            app:useCustomJsFormatting="true"/>
+            app:icon="@drawable/ic_user_circle_grey_min_24dp"/>
 
         <org.wordpress.android.ui.prefs.LearnMorePreference
             android:title="@string/third_party_policy_learn_more_header"
             app:caption="@string/third_party_policy_learn_more_caption"
             app:url="https://www.automattic.com/cookies"
-            app:icon="@drawable/ic_briefcase_grey_min_24dp"
-            app:useCustomJsFormatting="true"/>
+            app:icon="@drawable/ic_briefcase_grey_min_24dp"/>
 
     </PreferenceScreen>
 

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -265,6 +265,7 @@
                     app:caption="@string/site_settings_learn_more_caption"
                     app:url="https://en.support.wordpress.com/settings/discussion-settings/#default-article-settings"
                     app:useCustomJsFormatting="true"
+                    app:openInDialog="true"
                     app:layout="@layout/learn_more_pref_old"/>
 
             </PreferenceCategory>
@@ -437,6 +438,7 @@
                     android:title="@string/site_settings_learn_more_header"
                     app:url="https://jetpack.com/support/sso/"
                     app:useCustomJsFormatting="false"
+                    app:openInDialog="true"
                     app:layout="@layout/learn_more_pref_old"/>
 
             </PreferenceCategory>


### PR DESCRIPTION
- the dialog doesn't work as expected (with all the links) so I'm opening privacy links directly in the browser instead. 
- I've added a flag that allows opening old `Learn more` prefs still in the dialog

To test 1:
- Go to `App settings/Privacy` settings
- Click on `Learn more`
- App opens `www.automattic.com/cookies` in the browser

To test 2:
- Go to `App settings/Privacy` settings
- Click on `Read privacy policy`
- App opens `www.automattic.com/privacy` in the browser

To test 3:
- Go to `Site settings/More` setttings
- Click `Learn more`
- App opens link in a dialog