### PR TITLE
moved new Handler() creation to class member declaration

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -228,7 +228,7 @@ public class EditPostActivity extends AppCompatActivity implements
         STOCK_PHOTO_LIBRARY
     }
 
-    private Handler mHandler;
+    private Handler mHandler = new Handler();
     private int mDebounceCounter = 0;
     private boolean mShowAztecEditor;
     private boolean mShowNewEditor;
@@ -569,7 +569,6 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override
     protected void onResume() {
         super.onResume();
-        mHandler = new Handler();
 
         EventBus.getDefault().register(this);
 
@@ -615,8 +614,6 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override
     protected void onPause() {
         super.onPause();
-
-        mHandler = null;
 
         EventBus.getDefault().unregister(this);
     }


### PR DESCRIPTION
Fixes #7791 

To test:
While I haven't been able to repro, just to double check make sure this doesn't introduce a new bug:
1. set your developer options to always recreate Activities
2. start a new draft
3. start writing and rotate the device several times while writing, lock the screen / unlock, etc

