### PR TITLE
Fix crash when publishing a post with failed media upload

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -389,7 +389,7 @@ public class MySiteFragment extends Fragment implements SiteSettingsListener,
         dialog.show(((AppCompatActivity) getActivity()).getSupportFragmentManager(), tag);
     }
 
-    private void showEditingSiteIconRequiresPermissionDialog(String message) {
+    private void showEditingSiteIconRequiresPermissionDialog(@NonNull String message) {
         BasicFragmentDialog dialog = new BasicFragmentDialog();
         String tag = TAG_EDIT_SITE_ICON_PERMISSIONS_DIALOG;
         dialog.initialize(tag, getString(R.string.my_site_icon_dialog_title),

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1662,7 +1662,7 @@ public class EditPostActivity extends AppCompatActivity implements
         BasicFragmentDialog removeFailedUploadsDialog = new BasicFragmentDialog();
         removeFailedUploadsDialog.initialize(
                 TAG_REMOVE_FAILED_UPLOADS_DIALOG,
-                null,
+                "",
                 getString(R.string.editor_toast_failed_uploads),
                 getString(R.string.editor_remove_failed_uploads),
                 getString(android.R.string.cancel),


### PR DESCRIPTION
Fixes #7803 

Fixes crash when a user tries to publish a post with an image which wasn't uploaded to the server. 

To test:
1. Create a new post
2. Type any title
3. Turn on Airplane mode
4. Try to upload an image
5. Turn off Airplane mode
6. Click on the publish button
7. Notice a dialog is shown - "Some media uploads have failed. You can't save or publish your post in this state. Would you like to remove all failed media?"
