### PR TITLE
Show a message when there are no activity events

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/ActivityLogListFragment.kt
@@ -19,6 +19,8 @@ import org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelp
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.viewmodel.activitylog.ActivityLogListItemViewModel
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel
+import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus.FETCHING
+import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus.LOADING_MORE
 import javax.inject.Inject
 
 class ActivityLogListFragment : Fragment() {
@@ -80,10 +82,14 @@ class ActivityLogListFragment : Fragment() {
             return
         }
         // We want to show the swipe refresher for the initial fetch but not while loading more
-        swipeToRefreshHelper.isRefreshing = eventListStatus === ActivityLogViewModel.ActivityLogListStatus.FETCHING
+        swipeToRefreshHelper.isRefreshing = eventListStatus === FETCHING
         // We want to show the progress bar at the bottom while loading more but not for initial fetch
-        val showLoadMore = eventListStatus === ActivityLogViewModel.ActivityLogListStatus.LOADING_MORE
+        val showLoadMore = eventListStatus === LOADING_MORE
         activityLogListProgress.visibility = if (showLoadMore) View.VISIBLE else View.GONE
+
+        emptyView.visibility = if (viewModel.events.value?.isNotEmpty() == false &&
+                eventListStatus !== LOADING_MORE &&
+                eventListStatus !== FETCHING) View.VISIBLE else View.GONE
     }
 
     private fun reloadEvents() {

--- a/WordPress/src/main/res/layout/activity_log_list_fragment.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_fragment.xml
@@ -21,6 +21,22 @@
 
     </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/emptyView"
+        style="@style/WordPress.EmptyList.Title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:animateLayoutChanges="true"
+        android:layout_marginBottom="@dimen/empty_list_title_bottom_margin"
+        android:layout_marginLeft="@dimen/empty_list_title_side_margin"
+        android:layout_marginRight="@dimen/empty_list_title_side_margin"
+        android:text="@string/activity_log_empty_list"
+        android:layout_centerInParent="true"
+        app:fixWidowWords="true"
+        android:layout_marginEnd="@dimen/empty_list_title_side_margin"
+        android:layout_marginStart="@dimen/empty_list_title_side_margin"/>
+
 
     <ProgressBar
         android:id="@+id/activityLogListProgress"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -758,6 +758,7 @@
     <string name="activity_log_event">Event</string>
     <string name="rewind">Rewind</string>
     <string name="activity_log_jetpack_icon">Jetpack icon</string>
+    <string name="activity_log_empty_list">No events recorded yet</string>
 
     <!-- stats: errors -->
     <string name="stats_no_blog">Stats couldn\'t be loaded for the required blog</string>


### PR DESCRIPTION
Fixes #7798.

To test:
1. Open a site with no activities
2. Tap on Activities in My site menu
3. Verify there is a message saying there are no events