### PR TITLE
Issue/7810 retain reader db on logout

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -532,6 +532,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
                 long lastUserId = AppPrefs.getLastUsedUserId();
                 if (thisUserId != lastUserId) {
                     AppPrefs.setLastUsedUserId(thisUserId);
+                    AppLog.i(T.READER, "User changed, resetting reader db");
                     ReaderDatabase.reset();
                 }
             } else if (event.causeOfChange == AccountAction.FETCH_SETTINGS) {

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -49,6 +49,7 @@ import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.generated.ThemeActionBuilder;
+import org.wordpress.android.fluxc.model.AccountModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 import org.wordpress.android.fluxc.store.AccountStore;
@@ -307,6 +308,13 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
                 .addApi(Auth.CREDENTIALS_API)
                 .build();
         mCredentialsClient.connect();
+
+        // if we haven't saved the previous user id, save it now if the user is logged in
+        if (AppPrefs.getLastUsedUserId() == 0
+            && mAccountStore.hasAccessToken()
+            && mAccountStore.getAccount() != null) {
+            AppPrefs.setLastUsedUserId(mAccountStore.getAccount().getUserId());
+        }
     }
 
     protected void initDaggerComponent() {
@@ -564,9 +572,8 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         // delete wpcom and jetpack sites
         mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());
 
-        // reset all reader-related prefs & data
+        // reset all prefs
         AppPrefs.reset();
-        ReaderDatabase.reset();
 
         // Reset Stats Data
         StatsDatabaseHelper.getDatabase(context).reset();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -149,7 +149,10 @@ public class AppPrefs {
         ASKED_PERMISSION_LOCATION_FINE,
 
         // Updated after WP.com themes have been fetched
-        LAST_WP_COM_THEMES_SYNC
+        LAST_WP_COM_THEMES_SYNC,
+
+        // user id last used to login with
+        LAST_USED_USER_ID
     }
 
     private static SharedPreferences prefs() {
@@ -337,6 +340,14 @@ public class AppPrefs {
 
     public static void setLastAppVersionCode(int versionCode) {
         setInt(UndeletablePrefKey.LAST_APP_VERSION_INDEX, versionCode);
+    }
+
+    public static long getLastUsedUserId() {
+        return getLong(UndeletablePrefKey.LAST_USED_USER_ID);
+    }
+
+    public static void setLastUsedUserId(long userId) {
+        setLong(UndeletablePrefKey.LAST_USED_USER_ID, userId);
     }
 
     /**


### PR DESCRIPTION
Fixes #7810 - This PR is in preparation for the "save posts for later" feature. Right now the reader database is reset whenever the user logs out, but that means saved posts would be lost. So instead we detect when the user changes and only then reset the database.
