### PR TITLE
Added method to return parent view for snackbars

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -873,10 +873,22 @@ public class ReaderPostListFragment extends Fragment
                 refreshPosts();
             }
         };
-        Snackbar.make(getView(), getString(R.string.reader_toast_blog_blocked),
+        Snackbar.make(getSnackbarParent(), getString(R.string.reader_toast_blog_blocked),
                 AccessibilityUtils.getSnackbarDuration(getActivity()))
                 .setAction(R.string.undo, undoListener)
                 .show();
+    }
+
+    /*
+     * returns the parent view for snackbars - if this fragment is hosted in the main activity we want the
+     * parent to be the main activity's CoordinatorLayout
+     */
+    private View getSnackbarParent() {
+        View coordinator = getActivity().findViewById(R.id.coordinator);
+        if (coordinator != null) {
+            return coordinator;
+        }
+        return getView();
     }
 
     /*
@@ -1652,7 +1664,7 @@ public class ReaderPostListFragment extends Fragment
                 ? getString(R.string.reader_followed_blog_notifications_this)
                 : blogName;
 
-        Snackbar.make(view, Html.fromHtml(getString(R.string.reader_followed_blog_notifications,
+        Snackbar.make(getSnackbarParent(), Html.fromHtml(getString(R.string.reader_followed_blog_notifications,
                         "<b>", blog, "</b>")), AccessibilityUtils.getSnackbarDuration(getActivity()))
                 .setAction(getString(R.string.reader_followed_blog_notifications_action),
                     new View.OnClickListener() {


### PR DESCRIPTION
Fixes #7815 - this PR adds a method which returns the parent view to use for snackbars. When the reader post list fragment is hosted in the main activity we want the parent to be the main activity's `CoordinatorLayout` so the snackbars appear above the bottom navigation.
