### PR TITLE
Update with FluxC UserAgent changes

### DIFF
--- a/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
+++ b/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
@@ -18,7 +18,7 @@ import dagger.android.support.AndroidSupportInjectionModule;
 @Singleton
 @Component(modules = {
         ApplicationModule.class,
-        AppSecretsModule.class,
+        AppConfigModule.class,
         ReleaseBaseModule.class,
         DebugOkHttpClientModule.class,
         InterceptorModule.class,

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -615,7 +615,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
      * Safari/537.36 wp-android/4.7"
      * Note that app versions prior to 2.7 simply used "wp-android" as the user agent
      **/
-    private static final String USER_AGENT_APPNAME = "wp-android";
+    public static final String USER_AGENT_APPNAME = "wp-android";
     private static String mUserAgent;
 
     public static String getUserAgent() {

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -135,7 +135,7 @@ import dagger.android.support.AndroidSupportInjectionModule;
 @Singleton
 @Component(modules = {
         ApplicationModule.class,
-        AppSecretsModule.class,
+        AppConfigModule.class,
         ReleaseBaseModule.class,
         ReleaseOkHttpClientModule.class,
         ReleaseNetworkModule.class,

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppConfigModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppConfigModule.java
@@ -1,15 +1,24 @@
 package org.wordpress.android.modules;
 
+import android.content.Context;
+
 import org.wordpress.android.BuildConfig;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 
 import dagger.Module;
 import dagger.Provides;
 
 @Module
-public class AppSecretsModule {
+public class AppConfigModule {
     @Provides
     public AppSecrets provideAppSecrets() {
         return new AppSecrets(BuildConfig.OAUTH_APP_ID, BuildConfig.OAUTH_APP_SECRET);
+    }
+
+    @Provides
+    public UserAgent provideUserAgent(Context appContext) {
+        return new UserAgent(appContext, WordPress.USER_AGENT_APPNAME);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'd4e583f21840111065f12e743cbf31de4307266b'
+    fluxCVersion = 'e940e07386a4ef413cf34f1f54ba2cb97593c7dc'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'e940e07386a4ef413cf34f1f54ba2cb97593c7dc'
+    fluxCVersion = 'd82478c66e24cf6a50a714b7261a68c99ccf7145'
 }


### PR DESCRIPTION
Brings in the breaking changes from https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/814. This extracts a hard-coded app ID string that FluxC was appending to the user agent header, and makes it part of the app-side configuration.

https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/814 should be reviewed and merged first, and the FluxC hash updated to latest `develop`.

The hardcoded string was the one WPAndroid wants to use anyway, so no behavior was changed.

#### To test:
Make a request that uses FluxC (e.g. loading the post list), and verify that the user agent is unchanged before/after this PR.