### PR TITLE
Revert 7767 and do not use Aztec internal methods to check if post changed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1258,14 +1258,8 @@ public class EditPostActivity extends AppCompatActivity implements
         boolean postTitleOrContentChanged = false;
         if (mEditorFragment != null) {
             if (mShowNewEditor || mShowAztecEditor) {
-                final String newContent;
-                if (mEditorFragment.shouldLoadContentFromEditor()) {
-                    newContent = (String) mEditorFragment.getContent();
-                } else {
-                    newContent = mPost.getContent();
-                }
-                postTitleOrContentChanged =
-                        updatePostContentNewEditor(isAutosave, (String) mEditorFragment.getTitle(), newContent);
+                updatePostContentNewEditor(isAutosave, (String) mEditorFragment.getTitle(),
+                        (String) mEditorFragment.getContent());
             } else {
                 // TODO: Remove when legacy editor is dropped
                 postTitleOrContentChanged = updatePostContent(isAutosave);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -71,7 +71,6 @@ import org.wordpress.aztec.AztecAttributes;
 import org.wordpress.aztec.AztecExceptionHandler;
 import org.wordpress.aztec.AztecParser;
 import org.wordpress.aztec.AztecText;
-import org.wordpress.aztec.AztecText.EditorHasChanges;
 import org.wordpress.aztec.AztecTextFormat;
 import org.wordpress.aztec.Html;
 import org.wordpress.aztec.IHistoryListener;
@@ -1049,10 +1048,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     @Override
     public boolean hasFailedMediaUploads() {
         return (mFailedMediaIds.size() > 0);
-    }
-
-    @Override public boolean shouldLoadContentFromEditor() {
-        return mContent.hasChanges() != EditorHasChanges.NO_CHANGES;
     }
 
     @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1097,10 +1097,6 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         return (mFailedMediaIds.size() > 0);
     }
 
-    @Override public boolean shouldLoadContentFromEditor() {
-       return true;
-    }
-
     @Override
     public void removeAllFailedMediaUploads() {
         mWebView.execJavaScriptFromString("ZSSEditor.removeAllFailedMediaUploads();");

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -30,9 +30,6 @@ public abstract class EditorFragmentAbstract extends Fragment {
     public abstract boolean isUploadingMedia();
     public abstract boolean isActionInProgress();
     public abstract boolean hasFailedMediaUploads();
-    // Check whether we need to reload the content of the post from the editor or not.
-    // This was required since Aztec Visual->HTML can slightly change the content of the HTML. See #692 for details.
-    public abstract boolean shouldLoadContentFromEditor();
     public abstract void removeAllFailedMediaUploads();
     public abstract void removeMedia(String mediaId);
     public abstract void setTitlePlaceholder(CharSequence text);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
@@ -1198,10 +1198,6 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
         return false;
     }
 
-    @Override public boolean shouldLoadContentFromEditor() {
-        return true;
-    }
-
     @Override
     public void removeAllFailedMediaUploads() { }
 


### PR DESCRIPTION
This PR revert #7767 since methods exposed by Aztec to check if the user has made changes to the current post are not working as expected.
