### PR TITLE
Issue/7820 post uploaded snackbars

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -26,8 +26,6 @@ import android.widget.ScrollView;
 import com.yalantis.ucrop.UCrop;
 import com.yalantis.ucrop.UCropActivity;
 
-import org.greenrobot.eventbus.Subscribe;
-import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -40,7 +38,6 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.PostStore;
-import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
 import org.wordpress.android.login.LoginMode;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
@@ -787,22 +784,6 @@ public class MySiteFragment extends Fragment implements SiteSettingsListener,
                     UploadUtils.onMediaUploadedSnackbarHandler(getActivity(),
                             getActivity().findViewById(R.id.coordinator), false,
                             event.mediaModelList, site, event.successMessage);
-                }
-            }
-        }
-    }
-
-    // FluxC events
-    @SuppressWarnings("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onPostUploaded(OnPostUploaded event) {
-        if (isAdded() && event.post != null) {
-            SiteModel site = getSelectedSite();
-            if (site != null) {
-                if (event.post.getLocalSiteId() == site.getId()) {
-                    UploadUtils.onPostUploadedSnackbarHandler(getActivity(),
-                            getActivity().findViewById(R.id.coordinator),
-                            event.isError(), event.post, null, site, mDispatcher);
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -33,7 +33,6 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
-import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.MediaStore;
@@ -48,7 +47,6 @@ import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource;
 import org.wordpress.android.ui.plugins.PluginUtils;
 import org.wordpress.android.ui.posts.BasicFragmentDialog;
-import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface.SiteSettingsListener;
@@ -139,13 +137,6 @@ public class MySiteFragment extends Fragment implements SiteSettingsListener,
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
-        mDispatcher.register(this);
-    }
-
-    @Override
-    public void onDestroy() {
-        mDispatcher.unregister(this);
-        super.onDestroy();
     }
 
     @Override
@@ -423,36 +414,6 @@ public class MySiteFragment extends Fragment implements SiteSettingsListener,
                 if (resultCode == Activity.RESULT_OK) {
                     // reset comments status filter
                     AppPrefs.setCommentsStatusFilter(CommentStatusCriteria.ALL);
-                }
-                break;
-            case RequestCodes.EDIT_POST:
-                if (resultCode != Activity.RESULT_OK || data == null || !isAdded()) {
-                    return;
-                }
-                // if user returned from adding a post and it was saved as a local draft,
-                // briefly animate the background of the "Blog posts" view to give the
-                // user a cue as to where to go to return to that post
-                if (getView() != null && data.getBooleanExtra(EditPostActivity.EXTRA_SAVED_AS_LOCAL_DRAFT, false)) {
-                    showAlert(getView().findViewById(R.id.postsGlowBackground));
-                }
-
-                final PostModel post = mPostStore.
-                                                         getPostByLocalPostId(
-                                                                 data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID,
-                                                                                  0));
-
-                if (post != null) {
-                    final SiteModel site = getSelectedSite();
-                    UploadUtils.handleEditPostResultSnackbars(getActivity(),
-                                                              getActivity().findViewById(R.id.coordinator), resultCode,
-                                                              data, post, site,
-                                                              new View.OnClickListener() {
-                                                                  @Override
-                                                                  public void onClick(View v) {
-                                                                      UploadUtils.publishPost(getActivity(), post, site,
-                                                                                              mDispatcher);
-                                                                  }
-                                                              });
                 }
                 break;
             case RequestCodes.PHOTO_PICKER:

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -15,9 +15,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
-import android.view.animation.AlphaAnimation;
-import android.view.animation.Animation;
-import android.view.animation.Interpolator;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
@@ -539,35 +536,6 @@ public class MySiteFragment extends Fragment implements SiteSettingsListener,
              .withAspectRatio(1, 1)
              .withOptions(options)
              .start(getActivity(), this);
-    }
-
-    private void showAlert(View view) {
-        if (isAdded() && view != null) {
-            Animation highlightAnimation = new AlphaAnimation(0.0f, 1.0f);
-            highlightAnimation.setInterpolator(new Interpolator() {
-                private float bounce(float t) {
-                    return t * t * 24.0f;
-                }
-
-                public float getInterpolation(float t) {
-                    t *= 1.1226f;
-                    if (t < 0.184f) {
-                        return bounce(t);
-                    } else if (t < 0.545f) {
-                        return bounce(t - 0.40719f);
-                    } else if (t < 0.7275f) {
-                        return -bounce(t - 0.6126f) + 1.0f;
-                    } else {
-                        return 0.0f;
-                    }
-                }
-            });
-            highlightAnimation.setStartOffset(ALERT_ANIM_OFFSET_MS);
-            highlightAnimation.setRepeatCount(1);
-            highlightAnimation.setRepeatMode(Animation.RESTART);
-            highlightAnimation.setDuration(ALERT_ANIM_DURATION_MS);
-            view.startAnimation(highlightAnimation);
-        }
     }
 
     private void refreshSelectedSiteDetails(SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -33,6 +33,7 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload;
 import org.wordpress.android.fluxc.store.PostStore;
+import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
@@ -66,6 +67,7 @@ import org.wordpress.android.ui.prefs.AppSettingsFragment;
 import org.wordpress.android.ui.prefs.SiteSettingsFragment;
 import org.wordpress.android.ui.reader.ReaderPostListFragment;
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity;
+import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
@@ -847,6 +849,23 @@ public class WPMainActivity extends AppCompatActivity
         }
 
         // Else no site selected
+    }
+
+    // FluxC events
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onPostUploaded(OnPostUploaded event) {
+        SiteModel site = getSelectedSite();
+        if (site != null && event.post != null && event.post.getLocalSiteId() == site.getId()) {
+            UploadUtils.onPostUploadedSnackbarHandler(
+                    this,
+                    findViewById(R.id.coordinator),
+                    event.isError(),
+                    event.post,
+                    null,
+                    site,
+                    mDispatcher);
+        }
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -603,7 +603,6 @@ public class WPMainActivity extends AppCompatActivity
                     UploadUtils.handleEditPostResultSnackbars(
                             this,
                             findViewById(R.id.coordinator),
-                            resultCode,
                             data,
                             post,
                             site,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -596,14 +596,6 @@ public class WPMainActivity extends AppCompatActivity
                 if (resultCode != Activity.RESULT_OK || data == null || isFinishing()) {
                     return;
                 }
-                // if user returned from adding a post and it was saved as a local draft,
-                // briefly animate the background of the "Blog posts" view to give the
-                // user a cue as to where to go to return to that post
-                // TODO
-                /*if (getView() != null && data.getBooleanExtra(EditPostActivity.EXTRA_SAVED_AS_LOCAL_DRAFT, false)) {
-                    showAlert(getView().findViewById(R.id.postsGlowBackground));
-                }*/
-
                 int localId = data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0);
                 final SiteModel site = getSelectedSite();
                 final PostModel post = mPostStore.getPostByLocalPostId(localId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.main;
 
+import android.app.Activity;
 import android.app.Fragment;
 import android.content.Context;
 import android.content.Intent;
@@ -62,6 +63,7 @@ import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.notifications.utils.PendingDraftsNotificationsUtils;
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogNegativeClickInterface;
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface;
+import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.AppSettingsFragment;
 import org.wordpress.android.ui.prefs.SiteSettingsFragment;
@@ -591,13 +593,38 @@ public class WPMainActivity extends AppCompatActivity
         super.onActivityResult(requestCode, resultCode, data);
         switch (requestCode) {
             case RequestCodes.EDIT_POST:
-                MySiteFragment mySiteFragment = getMySiteFragment();
-                if (mySiteFragment != null) {
-                    mySiteFragment.onActivityResult(requestCode, resultCode, data);
+                if (resultCode != Activity.RESULT_OK || data == null || isFinishing()) {
+                    return;
+                }
+                // if user returned from adding a post and it was saved as a local draft,
+                // briefly animate the background of the "Blog posts" view to give the
+                // user a cue as to where to go to return to that post
+                // TODO
+                /*if (getView() != null && data.getBooleanExtra(EditPostActivity.EXTRA_SAVED_AS_LOCAL_DRAFT, false)) {
+                    showAlert(getView().findViewById(R.id.postsGlowBackground));
+                }*/
+
+                int localId = data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0);
+                final SiteModel site = getSelectedSite();
+                final PostModel post = mPostStore.getPostByLocalPostId(localId);
+                if (site != null && post != null) {
+                    UploadUtils.handleEditPostResultSnackbars(
+                            this,
+                            findViewById(R.id.coordinator),
+                            resultCode,
+                            data,
+                            post,
+                            site,
+                            new View.OnClickListener() {
+                                @Override
+                                public void onClick(View v) {
+                                    UploadUtils.publishPost(WPMainActivity.this, post, site, mDispatcher);
+                                }
+                            });
                 }
                 break;
             case RequestCodes.CREATE_SITE:
-                mySiteFragment = getMySiteFragment();
+                MySiteFragment mySiteFragment = getMySiteFragment();
                 if (mySiteFragment != null) {
                     mySiteFragment.onActivityResult(requestCode, resultCode, data);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -228,9 +228,10 @@ public class PostsListFragment extends Fragment
         int localId = data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0);
         final PostModel post = mPostStore.getPostByLocalPostId(localId);
 
-        if ((post == null)
-                && !data.getBooleanExtra(EditPostActivity.EXTRA_IS_DISCARDABLE, false)) {
-            ToastUtils.showToast(getActivity(), R.string.post_not_found, ToastUtils.Duration.LONG);
+        if (post == null) {
+            if (!data.getBooleanExtra(EditPostActivity.EXTRA_IS_DISCARDABLE, false)) {
+                ToastUtils.showToast(getActivity(), R.string.post_not_found, ToastUtils.Duration.LONG);
+            }
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -225,9 +225,8 @@ public class PostsListFragment extends Fragment
             return;
         }
 
-        final PostModel post = mPostStore.
-                                                 getPostByLocalPostId(
-                                                         data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0));
+        int localId = data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0);
+        final PostModel post = mPostStore.getPostByLocalPostId(localId);
 
         if ((post == null)
                 && !data.getBooleanExtra(EditPostActivity.EXTRA_IS_DISCARDABLE, false)) {
@@ -236,15 +235,17 @@ public class PostsListFragment extends Fragment
         }
 
         UploadUtils.handleEditPostResultSnackbars(getActivity(),
-                                                  getActivity().findViewById(R.id.coordinator), resultCode, data, post,
-                                                  mSite,
-                                                  new View.OnClickListener() {
-                                                      @Override
-                                                      public void onClick(View v) {
-                                                          UploadUtils
-                                                                  .publishPost(getActivity(), post, mSite, mDispatcher);
-                                                      }
-                                                  });
+                getActivity().findViewById(R.id.coordinator),
+                data,
+                post,
+                mSite,
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        UploadUtils
+                                .publishPost(getActivity(), post, mSite, mDispatcher);
+                    }
+                });
     }
 
     private void initSwipeToRefreshHelper(View view) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -127,7 +127,7 @@ public class UploadUtils {
             return;
         }
 
-        boolean isScheduledPost = post != null && PostStatus.fromPost(post) == PostStatus.SCHEDULED;
+        boolean isScheduledPost = PostStatus.fromPost(post) == PostStatus.SCHEDULED;
         if (isScheduledPost) {
             // if it's a scheduled post, we only want to show a "Sync" button if it's locally saved
             if (savedLocally) {
@@ -137,7 +137,7 @@ public class UploadUtils {
             return;
         }
 
-        boolean isPublished = post != null && PostStatus.fromPost(post) == PostStatus.PUBLISHED;
+        boolean isPublished = PostStatus.fromPost(post) == PostStatus.PUBLISHED;
         if (isPublished) {
             // if it's a published post, we only want to show a "Sync" button if it's locally saved
             if (savedLocally) {
@@ -149,7 +149,7 @@ public class UploadUtils {
             return;
         }
 
-        boolean isDraft = post != null && PostStatus.fromPost(post) == PostStatus.DRAFT;
+        boolean isDraft = PostStatus.fromPost(post) == PostStatus.DRAFT;
         if (isDraft) {
             if (PostUtils.isPublishable(post)) {
                 // if the post is publishable, we offer the PUBLISH button

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -95,13 +95,12 @@ public class UploadUtils {
         return uploadError != null && uploadError.mediaError != null;
     }
 
-    public static void handleEditPostResultSnackbars(final Activity activity, View snackbarAttachView,
-                                                     int resultCode, Intent data,
-                                                     final PostModel post, final SiteModel site,
+    public static void handleEditPostResultSnackbars(@NonNull final Activity activity,
+                                                     @NonNull View snackbarAttachView,
+                                                     @NonNull Intent data,
+                                                     @NonNull final PostModel post,
+                                                     @NonNull final SiteModel site,
                                                      View.OnClickListener publishPostListener) {
-        if (resultCode != Activity.RESULT_OK || data == null) {
-            return;
-        }
         boolean hasChanges = data.getBooleanExtra(EditPostActivity.EXTRA_HAS_CHANGES, false);
         if (!hasChanges) {
             // if there are no changes, we don't need to do anything

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -127,7 +127,9 @@ public class UploadUtils {
             return;
         }
 
-        boolean isScheduledPost = PostStatus.fromPost(post) == PostStatus.SCHEDULED;
+        PostStatus postStatus = PostStatus.fromPost(post);
+
+        boolean isScheduledPost = postStatus == PostStatus.SCHEDULED;
         if (isScheduledPost) {
             // if it's a scheduled post, we only want to show a "Sync" button if it's locally saved
             if (savedLocally) {
@@ -137,7 +139,7 @@ public class UploadUtils {
             return;
         }
 
-        boolean isPublished = PostStatus.fromPost(post) == PostStatus.PUBLISHED;
+        boolean isPublished = postStatus == PostStatus.PUBLISHED;
         if (isPublished) {
             // if it's a published post, we only want to show a "Sync" button if it's locally saved
             if (savedLocally) {
@@ -149,7 +151,7 @@ public class UploadUtils {
             return;
         }
 
-        boolean isDraft = PostStatus.fromPost(post) == PostStatus.DRAFT;
+        boolean isDraft = postStatus == PostStatus.DRAFT;
         if (isDraft) {
             if (PostUtils.isPublishable(post)) {
                 // if the post is publishable, we offer the PUBLISH button

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -225,14 +225,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
-                <View
-                    android:id="@+id/postsGlowBackground"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:alpha="1"
-                    android:background="@color/grey_lighten_20_translucent_50"
-                    android:visibility="invisible"/>
-
                 <LinearLayout
                     android:id="@+id/row_blog_posts"
                     style="@style/MySiteListRowLayout">


### PR DESCRIPTION
Fixes #7820 - moves the handling of post-related snackbars from `MySiteFragment` to `WPMainActivity`.

To test: follow the steps outlined in [the issue](https://github.com/wordpress-mobile/WordPress-Android/issues/7820) and note that the snackbars appear regardless of which fragment is active.
