### PR TITLE
Only use the AudioShortcodePlugin on Aztec for non-Gutenberg posts

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -550,16 +550,12 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     private void addAztecAudioShortcodePlugin() {
-        boolean foundAudioShortCodePlugin = false;
         for (IAztecPlugin plugin : mContent.getPlugins()) {
             if (plugin instanceof AudioShortcodePlugin) {
-                foundAudioShortCodePlugin = true;
-                break;
+                return;
             }
         }
-        if (!foundAudioShortCodePlugin) {
-            mContent.getPlugins().add(new AudioShortcodePlugin());
-        }
+        mContent.getPlugins().add(new AudioShortcodePlugin());
     }
 
     /*

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -338,7 +338,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 .addPlugin(new MoreToolbarButton(mContent))
                 .addPlugin(new CaptionShortcodePlugin(mContent))
                 .addPlugin(new VideoShortcodePlugin())
-                .addPlugin(new AudioShortcodePlugin())
                 .addPlugin(new HiddenGutenbergPlugin())
                 .addPlugin(mediaToolbarGalleryButton)
                 .addPlugin(mediaToolbarCameraButton)
@@ -537,6 +536,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             mContent.setCalypsoMode(false);
             mSource.setCalypsoMode(false);
         } else {
+            // only add the AudioShortCodePlugin when opening non-Gutenberg posts
+            addAztecAudioShortcodePlugin();
             mContent.setCalypsoMode(true);
             mSource.setCalypsoMode(true);
         }
@@ -546,6 +547,19 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         updateFailedAndUploadingMedia();
 
         mAztecReady = true;
+    }
+
+    private void addAztecAudioShortcodePlugin() {
+        boolean foundAudioShortCodePlugin = false;
+        for (IAztecPlugin plugin : mContent.getPlugins()) {
+            if (plugin instanceof AudioShortcodePlugin) {
+                foundAudioShortCodePlugin = true;
+                break;
+            }
+        }
+        if (!foundAudioShortCodePlugin) {
+            mContent.getPlugins().add(new AudioShortcodePlugin());
+        }
     }
 
     /*


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/AztecEditor-Android/issues/685

First tried to solve it on the side of Aztec, but realized the plugin itself is OK, and disabling the plugin makes Aztec just behave correctly (that is, preserves the Gutenberg audio block).

This PR instead takes advantage that we were already checking if the Post being opened containd a Gutenberg block, and only if it is not the case, adds the `AudioShortcodePlugin`  to Aztec's plugin list.

To test:
1. Write a post on Gutenberg web, and include an `audio`-type block, and an optional caption. The structure should be like this:

```
<!-- wp:audio {"id":435} -->
<figure class="wp-block-audio"><audio controls src="http://www.noiseaddicts.com/samples_1w72b820/4159.mp3"></audio> <figcaption>
  a caption
 </figcaption></figure>
<!-- /wp:audio -->
```
2. Open it on the device
3. Now switch to HTML-mode
4. Observe the structure for the <audio> tag is preserved as <audio> (note the `controls="controls"` is expected and not harmful):
```
<!-- wp:audio {"id":435} --><figure class="wp-block-audio">
 <audio controls="controls" src="http://www.noiseaddicts.com/samples_1w72b820/4159.mp3"></audio>
 <figcaption>
  a caption
 </figcaption></figure><!-- /wp:audio -->
```
5. Save the Post
6. Open again on Gutenberg web and verify the block didn't break.



