### PR TITLE
Retain the current fragment rather than recreate it

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -348,10 +348,11 @@ class WPMainNavigationView @JvmOverloads constructor(
             }
 
             val fragment = fragmentManager.findFragmentByTag(getTagForPosition(position))
-            return if (fragment != null) {
-                fragment
+            if (fragment != null) {
+                mFragments.put(position, fragment)
+                return fragment
             } else {
-                createFragment(position)
+                return createFragment(position)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -218,7 +218,7 @@ class WPMainNavigationView @JvmOverloads constructor(
         if (fragment != null) {
             fragmentManager
                     .beginTransaction()
-                    .replace(R.id.fragment_container, fragment)
+                    .replace(R.id.fragment_container, fragment, getTagForPosition(position))
                     .setTransition(TRANSIT_FRAGMENT_FADE)
                     .commit()
         }
@@ -265,6 +265,15 @@ class WPMainNavigationView @JvmOverloads constructor(
             else -> R.string.tabbar_accessibility_label_notifications
         }
         return context.getString(idRes)
+    }
+
+    private fun getTagForPosition(position: Int): String {
+        return when (position) {
+            PAGE_MY_SITE -> TAG_MY_SITE
+            PAGE_READER -> TAG_READER
+            PAGE_ME -> TAG_ME
+            else -> TAG_NOTIFS
+        }
     }
 
     private fun getTitleViewForPosition(position: Int): TextView? {
@@ -334,8 +343,13 @@ class WPMainNavigationView @JvmOverloads constructor(
         }
 
         internal fun getFragment(position: Int): Fragment? {
-            return if (isValidPosition(position) && mFragments.get(position) != null) {
-                mFragments.get(position)
+            if (isValidPosition(position) && mFragments.get(position) != null) {
+                return mFragments.get(position)
+            }
+
+            val fragment = fragmentManager.findFragmentByTag(getTagForPosition(position))
+            return if (fragment != null) {
+                fragment
             } else {
                 createFragment(position)
             }
@@ -350,5 +364,10 @@ class WPMainNavigationView @JvmOverloads constructor(
         internal const val PAGE_NEW_POST = 2
         internal const val PAGE_ME = 3
         internal const val PAGE_NOTIFS = 4
+
+        private const val TAG_MY_SITE = "my-site"
+        private const val TAG_READER = "reader"
+        private const val TAG_ME = "tag-me"
+        private const val TAG_NOTIFS = "tag-notifs"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -365,8 +365,8 @@ class WPMainNavigationView @JvmOverloads constructor(
         internal const val PAGE_ME = 3
         internal const val PAGE_NOTIFS = 4
 
-        private const val TAG_MY_SITE = "my-site"
-        private const val TAG_READER = "reader"
+        private const val TAG_MY_SITE = "tag-mysite"
+        private const val TAG_READER = "tag-reader"
         private const val TAG_ME = "tag-me"
         private const val TAG_NOTIFS = "tag-notifs"
     }


### PR DESCRIPTION
Fixes #7830 - prior to this PR, the active fragment would be recreated when the device is rotated. This PR addresses this by tagging each fragment, then using `findFragmentByTag()` to restore rather than recreate the active fragment.
