### PR TITLE
Track when reader tag is loaded at startup

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -191,6 +191,7 @@ public class ReaderPostListFragment extends Fragment
 
         ReaderPostListFragment fragment = new ReaderPostListFragment();
         fragment.setArguments(args);
+        fragment.trackTagLoaded(tag);
 
         return fragment;
     }
@@ -1662,8 +1663,11 @@ public class ReaderPostListFragment extends Fragment
     }
 
     private void trackTagLoaded(ReaderTag tag) {
-        AnalyticsTracker.Stat stat = null;
+        if (tag == null) {
+            return;
+        }
 
+        AnalyticsTracker.Stat stat;
         if (tag.isDiscover()) {
             stat = AnalyticsTracker.Stat.READER_DISCOVER_VIEWED;
         } else if (tag.isTagTopic()) {
@@ -1672,9 +1676,7 @@ public class ReaderPostListFragment extends Fragment
             stat = AnalyticsTracker.Stat.READER_LIST_LOADED;
         } else if (tag.isBookmarked()) {
             stat = AnalyticsTracker.Stat.READER_SAVED_LIST_VIEWED_FROM_FILTER;
-        }
-
-        if (stat == null) {
+        } else {
             return;
         }
 


### PR DESCRIPTION
Fixes #7828 - adds tracking which tag is loaded when the reader starts.