### PR TITLE
Issue/crash subscription error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'd82478c66e24cf6a50a714b7261a68c99ccf7145'
+    fluxCVersion = '52eacc4f2d6a41ef583456bf093a1b4174e292d4'
 }


### PR DESCRIPTION
### Fix
Update the [`handleUpdatedSubscription` method ](https://github.com/wordpress-mobile/WordPress-FluxC-Android/compare/issue/crash-subscription-error?expand=1#diff-21a42e5cb9fc1d9531f135b868bc3e3aR1191) to solve a `NullPointerException` crash when `event.error` is `null` as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7796.

### Test
1. Follow WordPress.com site.
#### on mobile
2. Go to ***Me*** tab.
3. Tap ***Notification Settings*** item.
4. Tap site followed in Step 1.
#### on web
5. Deactivate site in Step 1.
#### on mobile
6. Change setting in ***Notifications*** dialog.
7. Tap ***OK*** button.
8. Notice app does not crash.
