### PR TITLE
Feature/add rewind progress to rewind service

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/RewindStateProgressWorkerController.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/RewindStateProgressWorkerController.kt
@@ -20,6 +20,8 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.activitylog.RewindStateProgressWorkerController.RewindStateProgressWorker.Companion.RESTORE_ID_KEY
 import org.wordpress.android.ui.activitylog.RewindStateProgressWorkerController.RewindStateProgressWorker.Companion.SITE_ID_KEY
 import org.wordpress.android.ui.activitylog.RewindStateProgressWorkerController.RewindStateProgressWorker.Companion.TAG
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.ACTIVITY_LOG
 import java.util.concurrent.TimeUnit.SECONDS
 import javax.inject.Inject
 
@@ -59,7 +61,12 @@ constructor() {
         @Inject lateinit var dispatcher: Dispatcher
 
         override fun doWork(): WorkerResult {
-            (applicationContext as WordPress).component().inject(this)
+            try {
+                (applicationContext as WordPress).component().inject(this)
+            } catch (e: IllegalStateException) {
+                AppLog.d(ACTIVITY_LOG, "Trying to start worker before the app is initialized")
+                return RETRY
+            }
             val siteId = inputData.getInt(SITE_ID_KEY, -1)
             val restoreId = inputData.getLong(RESTORE_ID_KEY, -1L)
             if (siteId != -1 && restoreId != -1L) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/activitylog/RewindStatusServiceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/activitylog/RewindStatusServiceTest.kt
@@ -60,7 +60,18 @@ class RewindStatusServiceTest {
     private val rewindId = "10"
     private val activityID = "activityId"
     private val published = Date()
-    private val activityLogModel = ActivityLogModel(activityID, "summary", "text", null, null, null, null, null, rewindId, published)
+    private val activityLogModel = ActivityLogModel(
+            activityID,
+            "summary",
+            "text",
+            null,
+            null,
+            null,
+            null,
+            null,
+            rewindId,
+            published
+    )
 
     private val activeRewindStatusModel = RewindStatusModel(
             state = ACTIVE,

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '5b04a8510e0e12ec4c29323f8726d7badd405a58'
+    fluxCVersion = '0d380ad6fcc121d16e95947de5417dcd36f54d11'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '0d380ad6fcc121d16e95947de5417dcd36f54d11'
+    fluxCVersion = '12097e56a163a5b850c854e2dd0a4a2b4367d308'
 }


### PR DESCRIPTION
- add `LiveData<RewindProgress>` to `RewindService` that contains all the information the progress bar needs
- use updated FluxC with fixed `Rewind` object
- fix crash when worker is triggered before the app is initialized (UserAgent initialized on non-UI thread)