### PR TITLE
DO NOT MERGE: Zendesk WIP: Push Notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -547,6 +547,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         VolleyUtils.cancelAllRequests(sRequestQueue);
 
         NotificationsUtils.unregisterDevicePushNotifications(context);
+        ZendeskHelper.disablePushNotifications();
         try {
             String gcmId = BuildConfig.GCM_ID;
             if (!TextUtils.isEmpty(gcmId)) {

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -273,8 +273,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
                     new String[]{"org.wordpress.android.ui.ShareIntentReceiverActivity"});
         }
 
-        ZendeskHelper.setupZendesk(this, BuildConfig.ZENDESK_DOMAIN, BuildConfig.ZENDESK_APP_ID,
-                BuildConfig.ZENDESK_OAUTH_CLIENT_ID, LocaleManager.getSafeLocale(this));
+        ZendeskHelper.setupZendesk(this, LocaleManager.getSafeLocale(this));
 
         ApplicationLifecycleMonitor applicationLifecycleMonitor = new ApplicationLifecycleMonitor();
         registerComponentCallbacks(applicationLifecycleMonitor);

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -273,7 +273,8 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
                     new String[]{"org.wordpress.android.ui.ShareIntentReceiverActivity"});
         }
 
-        ZendeskHelper.setupZendesk(this, LocaleManager.getSafeLocale(this));
+        ZendeskHelper.setupZendesk(this, BuildConfig.ZENDESK_DOMAIN, BuildConfig.ZENDESK_APP_ID,
+                BuildConfig.ZENDESK_OAUTH_CLIENT_ID, LocaleManager.getSafeLocale(this));
 
         ApplicationLifecycleMonitor applicationLifecycleMonitor = new ApplicationLifecycleMonitor();
         registerComponentCallbacks(applicationLifecycleMonitor);

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -28,6 +28,7 @@ import org.wordpress.android.fluxc.model.CommentStatus;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.Note;
+import org.wordpress.android.support.ZendeskHelper;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.notifications.NotificationDismissBroadcastReceiver;
 import org.wordpress.android.ui.notifications.NotificationEvents;
@@ -44,8 +45,10 @@ import org.wordpress.android.util.StringUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -121,10 +124,10 @@ public class GCMMessageService extends GcmListenerService {
             return;
         }
 
-        // Handle helpshift PNs
-        if (TextUtils.equals(data.getString("origin"), "helpshift")) {
-            // TODO: Handle Zendesk PNs instead
-//            HelpshiftHelper.getInstance().handlePush(this, new Intent().putExtras(data));
+        // Handle Zendesk PNs
+        if (TextUtils.equals(data.getString("type"), "zendesk")) {
+            // TODO: show notification that with a button that opens the ticket
+            ZendeskHelper.handlePush(this, data, zendeskNotificationBackStack(this));
             return;
         }
 
@@ -303,6 +306,15 @@ public class GCMMessageService extends GcmListenerService {
 
     private static void addAuthPushNotificationToNotificationMap(Bundle data) {
         ACTIVE_NOTIFICATIONS_MAP.put(AUTH_PUSH_NOTIFICATION_ID, data);
+    }
+
+    // TODO: What if the user is logged out? Instead of this, can we use the current back stack?
+    private static List<Intent> zendeskNotificationBackStack(Context context) {
+        Intent main = new Intent(context, WPMainActivity.class);
+        main.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        main.putExtra(WPMainActivity.ARG_OPEN_PAGE, WPMainActivity.ARG_ME);
+
+        return Collections.singletonList(main);
     }
 
     private static class NotificationHelper {

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -77,7 +77,6 @@ public class GCMMessageService extends GcmListenerService {
     private static final String PUSH_ARG_TYPE = "type";
     private static final String PUSH_ARG_TITLE = "title";
     private static final String PUSH_ARG_MSG = "msg";
-    private static final String PUSH_ARG_ZENDESK_REQUEST_ID = "zendesk_sdk_request_id";
     public static final String PUSH_ARG_NOTE_ID = "note_id";
     public static final String PUSH_ARG_NOTE_FULL_DATA = "note_full_data";
 
@@ -125,7 +124,9 @@ public class GCMMessageService extends GcmListenerService {
         }
 
         // Handle Zendesk PNs
+        // TODO: Move the contents of this to a helper
         if (TextUtils.equals(data.getString("type"), "zendesk")) {
+            // TODO: Is it possible to keep the current `WPMainActivity`? App opening animation can be distracting
             Intent resultIntent = new Intent(this, WPMainActivity.class);
             resultIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             resultIntent.putExtra(WPMainActivity.ARG_OPEN_PAGE, WPMainActivity.ARG_ME);

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMRegistrationIntentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMRegistrationIntentService.java
@@ -59,7 +59,7 @@ public class GCMRegistrationIntentService extends JobIntentService {
     @Override
     public boolean onStopCurrentWork() {
         // if this job is stopped, we really need this to be re-scheduled and re-register the token with
-        // our servers and Helpshift in order to keep receiving notifications, so let's just return `true`.
+        // our servers and Zendesk in order to keep receiving notifications, so let's just return `true`.
         return true;
     }
 
@@ -80,8 +80,6 @@ public class GCMRegistrationIntentService extends JobIntentService {
             }
 
             // Register to other kind of notifications
-            // TODO: Handle Zendesk PNs instead
-//            HelpshiftHelper.getInstance().registerDeviceToken(this, gcmToken);
             AnalyticsTracker.registerPushNotificationToken(gcmToken);
         } else {
             AppLog.w(T.NOTIFS, "Empty GCM token, can't register the id on remote services");

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMRegistrationIntentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMRegistrationIntentService.java
@@ -15,6 +15,7 @@ import org.wordpress.android.BuildConfig;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.support.ZendeskHelper;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -80,6 +81,9 @@ public class GCMRegistrationIntentService extends JobIntentService {
             }
 
             // Register to other kind of notifications
+            if (mAccountStore.hasAccessToken()) {
+                ZendeskHelper.enablePushNotifications();
+            }
             AnalyticsTracker.registerPushNotificationToken(gcmToken);
         } else {
             AppLog.w(T.NOTIFS, "Empty GCM token, can't register the id on remote services");

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -3,13 +3,10 @@
 package org.wordpress.android.support
 
 import android.content.Context
-import android.content.Intent
 import android.net.ConnectivityManager
-import android.os.Bundle
 import android.preference.PreferenceManager
 import android.telephony.TelephonyManager
 import com.zendesk.logger.Logger
-import com.zendesk.sdk.deeplinking.ZendeskDeepLinking
 import com.zendesk.sdk.feedback.BaseZendeskFeedbackConfiguration
 import com.zendesk.sdk.feedback.ui.ContactZendeskActivity
 import com.zendesk.sdk.model.access.AnonymousIdentity
@@ -47,7 +44,6 @@ val isZendeskEnabled: Boolean
     get() = zendeskInstance.isInitialized
 
 private const val zendeskNeedsToBeEnabledError = "Zendesk needs to be setup before this method can be called"
-private const val zendeskPushNotificationKeyTicketId = "zendesk_sdk_request_id"
 
 fun setupZendesk(context: Context, deviceLocale: Locale) {
     require(!isZendeskEnabled) {
@@ -139,27 +135,6 @@ fun showAllTickets(
         configureZendesk(context, email, name, accountStore, siteStore, selectedSite)
         RequestActivity.startActivity(context, zendeskFeedbackConfiguration(siteStore.sites, origin, extraTags))
     }
-}
-
-fun handlePush(context: Context, bundle: Bundle, backStackActivities: List<Intent>) {
-    require(isZendeskEnabled) {
-        zendeskNeedsToBeEnabledError
-    }
-    val (zendeskUrl, applicationId, oauthClientId) = zendeskCredentials()
-    if (zendeskUrl.isEmpty() || applicationId.isEmpty() || oauthClientId.isEmpty()) {
-        return
-    }
-    val supportEmail = AppPrefs.getSupportEmail()
-    if (supportEmail.isNullOrEmpty()) {
-        // we don't have a valid Zendesk identity to show the ticket for
-        return
-    }
-    zendeskInstance.setIdentity(zendeskIdentity(supportEmail, AppPrefs.getSupportName()))
-
-    val requestId = bundle.getString(zendeskPushNotificationKeyTicketId)
-    val intent = ZendeskDeepLinking.INSTANCE.getRequestIntent(context, requestId, ZendeskConstants.ticketSubject,
-            ArrayList(backStackActivities), null, zendeskUrl, applicationId, oauthClientId)
-    context.sendBroadcast(intent)
 }
 
 // Helpers

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -45,11 +45,16 @@ val isZendeskEnabled: Boolean
 
 private const val zendeskNeedsToBeEnabledError = "Zendesk needs to be setup before this method can be called"
 
-fun setupZendesk(context: Context, deviceLocale: Locale) {
+fun setupZendesk(
+    context: Context,
+    zendeskUrl: String,
+    applicationId: String,
+    oauthClientId: String,
+    deviceLocale: Locale
+) {
     require(!isZendeskEnabled) {
         "Zendesk shouldn't be initialized more than once!"
     }
-    val (zendeskUrl, applicationId, oauthClientId) = zendeskCredentials()
     if (zendeskUrl.isEmpty() || applicationId.isEmpty() || oauthClientId.isEmpty()) {
         return
     }
@@ -138,9 +143,6 @@ fun showAllTickets(
 }
 
 // Helpers
-
-private fun zendeskCredentials(): Triple<String, String, String> =
-        Triple(BuildConfig.ZENDESK_DOMAIN, BuildConfig.ZENDESK_APP_ID, BuildConfig.ZENDESK_OAUTH_CLIENT_ID)
 
 private fun configureZendesk(
     context: Context,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -110,6 +110,7 @@ public class WPMainActivity extends AppCompatActivity
     public static final String ARG_SHOW_SIGNUP_EPILOGUE = "show_signup_epilogue";
     public static final String ARG_OPEN_PAGE = "open_page";
     public static final String ARG_NOTIFICATIONS = "show_notifications";
+    public static final String ARG_ME = "show_me";
 
     private WPMainNavigationView mBottomNav;
     private Toolbar mToolbar;
@@ -290,6 +291,9 @@ public class WPMainActivity extends AppCompatActivity
             switch (pagePosition) {
                 case ARG_NOTIFICATIONS:
                     mBottomNav.setCurrentPosition(PAGE_NOTIFS);
+                    break;
+                case ARG_ME:
+                    mBottomNav.setCurrentPosition(PAGE_ME);
                     break;
             }
         } else {


### PR DESCRIPTION
This PR adds support for Zendesk push notifications which will open the `Me` page. It started as an experimental branch and there is still some stuff to figure out. In order to make it easier to discuss and ask feedback I decided to open an early PR for this one.

The only goal of this PR is to get a simple version of Zendesk Push Notifications working. While reviewing, let's focus on the notifications and not how Zendesk is configured (as it'll be changed).

**How it works**

* Because of the way our server is setup, Zendesk PNs will only work for WordPress.com users while they are logged in. Hopefully that'll be fixed on the server side, but until then, the client is setup in a way to work with that.
* We enable push notifications during Zendesk configuration if the Zendesk identity is available. The way identity is setup will be changed soon, so that part can be disregarded. We'll also need to enable push notifications if a user logins after Zendesk is setup or if their Zendesk identity is set. Both of these will be handled in a later PR.
* When the user logs out, Zendesk PNs will be disabled (unregister)
* If a Zendesk notification is received, `Me` page will be shown. We have some improvements in mind, read about it in #7839.

**Questions**

1. It looks like we normally use the wpcom notification id for the push notification id. I assume we'll need to come up with a different way to do that for Zendesk PNs. (check the todo in code)
2. Tapping on a Zendesk PN currently launches the `WPMainActivity` with the `Me` page which looks kind of weird if the app is already running. Is there a smoother way to do that?
3. I think Zendesk always sends the same push notification `There has been a reply to your message` in both the message and the title. If that's the case, should we use our own localized string instead? @SylvesterWilmott 
4. If I understand correctly, there are two type of notifications, single and group and we normally send both. I don't really understand the difference and how it works. @mzorz I am not even sure what to ask about that, could you check the current implementation and let me know your thoughts, see if I missed anything?

@daniloercoli @mzorz I was hoping you two could do a quick review on the PR and give me some feedback as this is the first time I am working with PNs on Android. Sorry for the messy PR, but I wanted to get your feedback as soon as possible. Thanks!