### PR TITLE
Issue/sites layout clipping

### DIFF
--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -10,12 +10,13 @@
         android:layout_height="wrap_content">
 
         <LinearLayout
+            android:clipToPadding="false"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/content_margin"
-            android:layout_marginLeft="@dimen/content_margin"
-            android:layout_marginRight="@dimen/content_margin"
-            android:layout_marginStart="@dimen/content_margin"
+            android:paddingEnd="@dimen/content_margin"
+            android:paddingLeft="@dimen/content_margin"
+            android:paddingRight="@dimen/content_margin"
+            android:paddingStart="@dimen/content_margin"
             android:orientation="vertical">
 
             <android.support.v7.widget.CardView


### PR DESCRIPTION
### Fix
Update `my_site_fragment.xml` layout margin to padding and remove view clipping with `android:clipToPadding="false"` for ***Sites***.  See the screenshots below for illustration.

![shadow_clipping](https://user-images.githubusercontent.com/3827611/40918168-236d89be-67cb-11e8-8a1f-510e6bc8eee7.png)

### Test
1. Go to ***Sites*** tab.
2. Notice top card view shadow is not clipped.