### PR TITLE
Issue/publicize button layout

### DIFF
--- a/WordPress/src/main/res/layout/publicize_connect_button.xml
+++ b/WordPress/src/main/res/layout/publicize_connect_button.xml
@@ -5,12 +5,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:background="?android:selectableItemBackground"
     android:layout_height="wrap_content"
-    android:layout_width="wrap_content" >
+    android:layout_width="match_parent" >
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/text_connect"
         android:layout_height="wrap_content"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:paddingBottom="@dimen/margin_large"
         android:paddingEnd="@dimen/margin_extra_large"
         android:paddingLeft="@dimen/margin_extra_large"

--- a/WordPress/src/main/res/layout/publicize_connect_button.xml
+++ b/WordPress/src/main/res/layout/publicize_connect_button.xml
@@ -1,19 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="wrap_content"
+    android:background="?android:selectableItemBackground"
     android:layout_height="wrap_content"
-    android:background="?android:selectableItemBackground">
+    android:layout_width="wrap_content" >
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/text_connect"
-        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:paddingBottom="@dimen/margin_large"
+        android:paddingEnd="@dimen/margin_extra_large"
+        android:paddingLeft="@dimen/margin_extra_large"
+        android:paddingRight="@dimen/margin_extra_large"
+        android:paddingStart="@dimen/margin_extra_large"
+        android:paddingTop="@dimen/margin_large"
         android:textAllCaps="true"
         android:textColor="@color/blue_wordpress"
         android:textSize="@dimen/text_sz_medium"
         android:textStyle="bold"
-        tools:text="text_connect" />
+        tools:text="Connect" >
+    </org.wordpress.android.widgets.WPTextView>
 
 </FrameLayout>

--- a/WordPress/src/main/res/layout/publicize_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_detail_fragment.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:clipToPadding="false"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginLeft="@dimen/content_margin"
-    android:layout_marginRight="@dimen/content_margin"
     android:orientation="vertical"
-    android:layout_marginStart="@dimen/content_margin"
-    android:layout_marginEnd="@dimen/content_margin">
+    android:paddingBottom="@dimen/content_margin"
+    android:paddingEnd="@dimen/content_margin"
+    android:paddingLeft="@dimen/content_margin"
+    android:paddingRight="@dimen/content_margin"
+    android:paddingStart="@dimen/content_margin" >
 
     <android.support.v7.widget.CardView
         android:id="@+id/card_view_connections"

--- a/WordPress/src/main/res/layout/publicize_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_detail_fragment.xml
@@ -103,7 +103,7 @@
 
             <org.wordpress.android.ui.publicize.ConnectButton
                 android:id="@+id/button_connect"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
         </LinearLayout>

--- a/WordPress/src/main/res/layout/publicize_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_detail_fragment.xml
@@ -103,15 +103,8 @@
 
             <org.wordpress.android.ui.publicize.ConnectButton
                 android:id="@+id/button_connect"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/margin_extra_large"
-                android:layout_marginStart="@dimen/margin_extra_large"
-                android:layout_marginEnd="@dimen/margin_extra_large"
-                android:layout_marginRight="@dimen/margin_extra_large"
-                android:paddingBottom="@dimen/margin_extra_large"
-                android:paddingTop="@dimen/margin_extra_large"
-                />
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
 
         </LinearLayout>
     </android.support.v7.widget.CardView>


### PR DESCRIPTION
### Fix
Update ***Connect***/***Disconnect*** button layout in ***Publicize*** including margin, padding, and background.

![publicize_button](https://user-images.githubusercontent.com/3827611/40921100-24dbde6e-67d4-11e8-9a8b-3098a4227037.png)

### Test
1. Go to ***Sites*** tab.
2. Tap ***Sharing*** item under ***Configuration*** section.
3. Tap item under ***Connections*** section.
4. Notice ***Connect*** button.
5. Long-press ***Connect*** button.
6. Notice ***Connect*** button background.
7. Enter social media account credentials.
8. Notice ***Connect Another Account*** button.
9. Long-press ***Connect Another Account*** button.
10. Notice ***Connect Another Account*** button background.
11. Notice ***Disconnect*** button.
12. Long-press ***Disconnect*** button.
13. Notice ***Disconnect*** button background.