### PR TITLE
Issue/sites header layout

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -94,14 +94,14 @@ public class MySiteFragment extends Fragment implements SiteSettingsListener,
     private ProgressBar mBlavatarProgressBar;
     private WPTextView mBlogTitleTextView;
     private WPTextView mBlogSubtitleTextView;
-    private LinearLayout mLookAndFeelHeader;
+    private WPTextView mLookAndFeelHeader;
     private LinearLayout mThemesContainer;
     private LinearLayout mPeopleView;
     private LinearLayout mPageView;
     private LinearLayout mPlanContainer;
     private LinearLayout mPluginsContainer;
     private LinearLayout mActivityLogContainer;
-    private View mConfigurationHeader;
+    private WPTextView mConfigurationHeader;
     private View mSettingsView;
     private LinearLayout mAdminView;
     private LinearLayout mNoSiteView;
@@ -185,7 +185,7 @@ public class MySiteFragment extends Fragment implements SiteSettingsListener,
         mPlanContainer = rootView.findViewById(R.id.row_plan);
         mPluginsContainer = rootView.findViewById(R.id.row_plugins);
         mActivityLogContainer = rootView.findViewById(R.id.row_activity_log);
-        mConfigurationHeader = rootView.findViewById(R.id.row_configuration);
+        mConfigurationHeader = rootView.findViewById(R.id.my_site_configuration_header);
         mSettingsView = rootView.findViewById(R.id.row_settings);
         mSharingView = rootView.findViewById(R.id.row_sharing);
         mAdminView = rootView.findViewById(R.id.row_admin);

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -194,7 +194,7 @@
             <!--Publish-->
             <org.wordpress.android.widgets.WPTextView
                 android:text="@string/my_site_header_publish"
-                style="@style/MySiteListHeaderTextView" >
+                style="@style/MySiteListHeader" >
             </org.wordpress.android.widgets.WPTextView>
 
             <!--Pages-->
@@ -278,7 +278,7 @@
             <!--Look and Feel-->
             <org.wordpress.android.widgets.WPTextView
                 android:text="@string/my_site_header_look_and_feel"
-                style="@style/MySiteListHeaderTextView" >
+                style="@style/MySiteListHeader" >
             </org.wordpress.android.widgets.WPTextView>
 
             <!--Themes-->
@@ -302,7 +302,7 @@
             <!--Configuration-->
             <org.wordpress.android.widgets.WPTextView
                 android:text="@string/my_site_header_configuration"
-                style="@style/MySiteListHeaderTextView" >
+                style="@style/MySiteListHeader" >
             </org.wordpress.android.widgets.WPTextView>
 
             <!--People-->
@@ -380,7 +380,7 @@
             <!--External-->
             <org.wordpress.android.widgets.WPTextView
                 android:text="@string/my_site_header_external"
-                style="@style/MySiteListHeaderTextView" >
+                style="@style/MySiteListHeader" >
             </org.wordpress.android.widgets.WPTextView>
 
             <!--View Site-->

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -277,6 +277,7 @@
 
             <!--Look and Feel-->
             <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/my_site_look_and_feel_header"
                 android:text="@string/my_site_header_look_and_feel"
                 style="@style/MySiteListHeader" >
             </org.wordpress.android.widgets.WPTextView>
@@ -301,6 +302,7 @@
 
             <!--Configuration-->
             <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/my_site_configuration_header"
                 android:text="@string/my_site_header_configuration"
                 style="@style/MySiteListHeader" >
             </org.wordpress.android.widgets.WPTextView>

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -191,16 +191,11 @@
 
             </LinearLayout>
 
-            <!--PUBLISH-->
-            <LinearLayout style="@style/MySiteListHeaderLayout">
-
-                <org.wordpress.android.widgets.WPTextView
-                    style="@style/MySiteListHeaderTextView"
-                    android:text="@string/my_site_header_publish"/>
-
-                <View style="@style/MySiteListSectionDividerView"/>
-
-            </LinearLayout>
+            <!--Publish-->
+            <org.wordpress.android.widgets.WPTextView
+                android:text="@string/my_site_header_publish"
+                style="@style/MySiteListHeaderTextView" >
+            </org.wordpress.android.widgets.WPTextView>
 
             <!--Pages-->
             <LinearLayout
@@ -280,18 +275,11 @@
 
             </LinearLayout>
 
-            <!--Look & Feel-->
-            <LinearLayout
-                android:id="@+id/my_site_look_and_feel_header"
-                style="@style/MySiteListHeaderLayout">
-
-                <org.wordpress.android.widgets.WPTextView
-                    style="@style/MySiteListHeaderTextView"
-                    android:text="@string/my_site_header_look_and_feel"/>
-
-                <View style="@style/MySiteListSectionDividerView"/>
-
-            </LinearLayout>
+            <!--Look and Feel-->
+            <org.wordpress.android.widgets.WPTextView
+                android:text="@string/my_site_header_look_and_feel"
+                style="@style/MySiteListHeaderTextView" >
+            </org.wordpress.android.widgets.WPTextView>
 
             <!--Themes-->
             <LinearLayout
@@ -312,17 +300,10 @@
             </LinearLayout>
 
             <!--Configuration-->
-            <LinearLayout
-                android:id="@+id/row_configuration"
-                style="@style/MySiteListHeaderLayout">
-
-                <org.wordpress.android.widgets.WPTextView
-                    style="@style/MySiteListHeaderTextView"
-                    android:text="@string/my_site_header_configuration"/>
-
-                <View style="@style/MySiteListSectionDividerView"/>
-
-            </LinearLayout>
+            <org.wordpress.android.widgets.WPTextView
+                android:text="@string/my_site_header_configuration"
+                style="@style/MySiteListHeaderTextView" >
+            </org.wordpress.android.widgets.WPTextView>
 
             <!--People-->
             <LinearLayout
@@ -396,17 +377,11 @@
 
             </LinearLayout>
 
-            <!--EXTERNAL-->
-
-            <LinearLayout style="@style/MySiteListHeaderLayout">
-
-                <org.wordpress.android.widgets.WPTextView
-                    style="@style/MySiteListHeaderTextView"
-                    android:text="@string/my_site_header_external"/>
-
-                <View style="@style/MySiteListSectionDividerView"/>
-
-            </LinearLayout>
+            <!--External-->
+            <org.wordpress.android.widgets.WPTextView
+                android:text="@string/my_site_header_external"
+                style="@style/MySiteListHeaderTextView" >
+            </org.wordpress.android.widgets.WPTextView>
 
             <!--View Site-->
             <LinearLayout

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -355,7 +355,7 @@
         <item name="android:layout_height">wrap_content</item>
     </style>
 
-    <style name="MySiteListHeaderTextView">
+    <style name="MySiteListHeader">
         <item name="android:fontFamily">sans-serif-medium</item>
         <item name="android:layout_centerVertical">true</item>
         <item name="android:layout_height">wrap_content</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -350,11 +350,6 @@
         <item name="android:tint">@color/grey_darken_30</item>
     </style>
 
-    <style name="MySiteListHeaderLayout">
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">wrap_content</item>
-    </style>
-
     <style name="MySiteListHeader">
         <item name="android:fontFamily">sans-serif-medium</item>
         <item name="android:layout_centerVertical">true</item>
@@ -366,17 +361,6 @@
         <item name="android:paddingTop">@dimen/my_site_margin_general</item>
         <item name="android:textColor">@color/grey_darken_10</item>
         <item name="android:textSize">@dimen/text_sz_medium</item>
-    </style>
-
-    <style name="MySiteListSectionDividerView">
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">1dp</item>
-        <item name="android:layout_gravity">center_vertical</item>
-        <item name="android:layout_marginLeft">@dimen/margin_large</item>
-        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">@dimen/margin_large</item>
-        <item name="android:background">@color/grey_lighten_20</item>
-        <item name="android:layout_marginRight">@dimen/margin_extra_large</item>
-        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">@dimen/margin_extra_large</item>
     </style>
 
     <style name="MeListRowLayout">

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -351,6 +351,7 @@
     </style>
 
     <style name="MySiteListHeader">
+        <item name="android:ellipsize">end</item>
         <item name="android:fontFamily">sans-serif-medium</item>
         <item name="android:layout_centerVertical">true</item>
         <item name="android:layout_height">wrap_content</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -353,19 +353,19 @@
     <style name="MySiteListHeaderLayout">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
+    </style>
+
+    <style name="MySiteListHeaderTextView">
+        <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="android:layout_centerVertical">true</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_width">match_parent</item>
         <item name="android:paddingBottom">@dimen/my_site_margin_general</item>
         <item name="android:paddingLeft">@dimen/my_site_list_row_padding_left</item>
         <item name="android:paddingStart" tools:targetApi="jelly_bean_mr1">@dimen/my_site_list_row_padding_left</item>
         <item name="android:paddingTop">@dimen/my_site_margin_general</item>
-    </style>
-
-    <style name="MySiteListHeaderTextView">
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_centerVertical">true</item>
         <item name="android:textColor">@color/grey_darken_10</item>
         <item name="android:textSize">@dimen/text_sz_medium</item>
-        <item name="android:textAllCaps">true</item>
     </style>
 
     <style name="MySiteListSectionDividerView">


### PR DESCRIPTION
### Fix
Update header view layout in ***Sites*** to match settings style.  See the screenshots below for illustration.

![header_layout](https://user-images.githubusercontent.com/3827611/40931491-f1704f98-67f0-11e8-9558-ae844fc971d1.png)

### Test
1. Go to ***Sites*** tab.
2. Notice headers mimic settings style.