### PR TITLE
Issue/7841 fixed unresponsive switch preference

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPSwitchPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPSwitchPreference.java
@@ -3,8 +3,7 @@ package org.wordpress.android.ui.prefs;
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
+import android.os.Build;
 import android.preference.SwitchPreference;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
@@ -53,7 +52,7 @@ public class WPSwitchPreference extends SwitchPreference implements PreferenceHi
         }
 
         // style custom switch preference
-        if (VERSION.SDK_INT >= VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             Switch switchControl = getSwitch((ViewGroup) view);
             if (switchControl != null) {
                 switchControl.setThumbTintList(ContextCompat.getColorStateList(this.getContext(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPSwitchPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPSwitchPreference.java
@@ -3,13 +3,18 @@ package org.wordpress.android.ui.prefs;
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import android.preference.SwitchPreference;
 import android.support.annotation.NonNull;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewCompat;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Switch;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
@@ -35,7 +40,7 @@ public class WPSwitchPreference extends SwitchPreference implements PreferenceHi
     protected void onBindView(@NonNull View view) {
         super.onBindView(view);
 
-        TextView titleView = (TextView) view.findViewById(android.R.id.title);
+        TextView titleView = view.findViewById(android.R.id.title);
         if (titleView != null) {
             Resources res = getContext().getResources();
             titleView.setTextSize(TypedValue.COMPLEX_UNIT_PX, res.getDimensionPixelSize(R.dimen.text_sz_large));
@@ -46,6 +51,31 @@ public class WPSwitchPreference extends SwitchPreference implements PreferenceHi
                 ViewCompat.setPaddingRelative(titleView, res.getDimensionPixelSize(R.dimen.margin_large), 0, 0, 0);
             }
         }
+
+        // style custom switch preference
+        if (VERSION.SDK_INT >= VERSION_CODES.M) {
+            Switch switchControl = getSwitch((ViewGroup) view);
+            if (switchControl != null) {
+                switchControl.setThumbTintList(ContextCompat.getColorStateList(this.getContext(),
+                        R.color.dialog_compound_button));
+            }
+        }
+    }
+
+    private Switch getSwitch(ViewGroup parentView) {
+        for (int i = 0; i < parentView.getChildCount(); i++) {
+            View childView = parentView.getChildAt(i);
+
+            if (childView instanceof Switch) {
+                return (Switch) childView;
+            } else if (childView instanceof ViewGroup) {
+                Switch theSwitch = getSwitch((ViewGroup) childView);
+                if (theSwitch != null) {
+                    return theSwitch;
+                }
+            }
+        }
+        return null;
     }
 
     @Override

--- a/WordPress/src/main/res/layout/wp_preference_switch.xml
+++ b/WordPress/src/main/res/layout/wp_preference_switch.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Switch xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+android:id/switch_widget"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:focusable="false"
-        android:clickable="false"
-        android:thumbTint="@color/dialog_compound_button"
-        android:background="@null" />

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -16,12 +16,11 @@
         android:key="@string/pref_key_privacy_settings"
         android:title="@string/preference_privacy_settings">
 
-        <SwitchPreference
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
             android:defaultValue="true"
             android:key="@string/pref_key_send_usage"
             android:layout="@layout/wp_preference_layout"
             android:title="@string/preference_collect_information"
-            android:widgetLayout="@layout/wp_preference_switch"
             android:icon="@drawable/ic_stats_grey_min_24dp"/>
 
         <org.wordpress.android.ui.prefs.LearnMorePreference
@@ -75,8 +74,7 @@
             android:key="@string/pref_key_optimize_image"
             android:layout="@layout/wp_preference_layout"
             android:summary="@string/site_settings_optimize_images_summary"
-            android:title="@string/site_settings_optimize_images"
-            android:widgetLayout="@layout/wp_preference_switch"/>
+            android:title="@string/site_settings_optimize_images"/>
 
         <org.wordpress.android.ui.prefs.DetailListPreference
             android:id="@+id/pref_default_image_width"
@@ -101,8 +99,7 @@
             android:key="@string/pref_key_optimize_video"
             android:layout="@layout/wp_preference_layout"
             android:summary="@string/site_settings_optimize_video_summary"
-            android:title="@string/site_settings_optimize_videos"
-            android:widgetLayout="@layout/wp_preference_switch"/>
+            android:title="@string/site_settings_optimize_videos"/>
 
         <org.wordpress.android.ui.prefs.DetailListPreference
             android:id="@+id/pref_default_video_size"
@@ -135,8 +132,7 @@
             android:key="@string/pref_key_passcode_toggle"
             android:layout="@layout/wp_preference_layout"
             android:persistent="false"
-            android:title="@string/passcode_turn_on"
-            android:widgetLayout="@layout/wp_preference_switch"/>
+            android:title="@string/passcode_turn_on"/>
 
         <Preference
             android:key="@string/pref_key_change_passcode"

--- a/WordPress/src/main/res/xml/notifications_settings.xml
+++ b/WordPress/src/main/res/xml/notifications_settings.xml
@@ -19,11 +19,11 @@
         android:layout="@layout/wp_preference_category"
         android:title="@string/notification_settings_category_other" >
 
-        <PreferenceScreen
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
             android:key="@string/pref_notification_other_blogs"
             android:title="@string/notification_settings_item_other_comments_other_blogs" />
 
-        <SwitchPreference
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
             android:key="@string/pref_key_notification_pending_drafts"
             android:defaultValue="true"
             android:title="@string/notification_settings_item_other_pending_drafts" />
@@ -42,13 +42,12 @@
             android:showDefault="true"
             android:title="@string/notification_settings_item_sights_and_sounds_choose_sound" />
 
-        <SwitchPreference
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
             android:key="@string/wp_pref_notification_vibrate"
             android:defaultValue="false"
             android:title="@string/notification_settings_item_sights_and_sounds_vibrate_device" />
 
-        <SwitchPreference
-            android:widgetLayout="@layout/wp_preference_switch"
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
             android:key="@string/wp_pref_notification_light"
             android:defaultValue="true"
             android:title="@string/notification_settings_item_sights_and_sounds_blink_light" />

--- a/WordPress/src/main/res/xml/notifications_settings.xml
+++ b/WordPress/src/main/res/xml/notifications_settings.xml
@@ -19,7 +19,7 @@
         android:layout="@layout/wp_preference_category"
         android:title="@string/notification_settings_category_other" >
 
-        <org.wordpress.android.ui.prefs.WPSwitchPreference
+        <PreferenceScreen
             android:key="@string/pref_notification_other_blogs"
             android:title="@string/notification_settings_item_other_comments_other_blogs" />
 

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -154,16 +154,14 @@
                 android:key="@string/pref_key_serve_images_from_our_servers"
                 android:layout="@layout/wp_preference_layout"
                 android:summary="@string/site_settings_serve_images_from_our_servers_summary"
-                android:title="@string/site_settings_serve_images_from_our_servers"
-                android:widgetLayout="@layout/wp_preference_switch"/>
+                android:title="@string/site_settings_serve_images_from_our_servers"/>
 
             <org.wordpress.android.ui.prefs.WPSwitchPreference
                 android:id="@+id/pref_lazy_load_images"
                 android:key="@string/pref_key_lazy_load_images"
                 android:layout="@layout/wp_preference_layout"
                 android:summary="@string/site_settings_lazy_load_images_summary"
-                android:title="@string/site_settings_lazy_load_images"
-                android:widgetLayout="@layout/wp_preference_switch"/>
+                android:title="@string/site_settings_lazy_load_images"/>
         </PreferenceScreen>
 
 
@@ -194,8 +192,7 @@
             android:id="@+id/pref_toggle_amp"
             android:key="@string/pref_key_site_amp"
             android:summary="@string/site_settings_amp_summary"
-            android:title="@string/site_settings_amp_title"
-            android:widgetLayout="@layout/wp_preference_switch"/>
+            android:title="@string/site_settings_amp_title"/>
 
     </PreferenceCategory>
 
@@ -210,21 +207,18 @@
             android:id="@+id/pref_allow_comments"
             android:key="@string/pref_key_site_allow_comments"
             android:title="@string/site_settings_allow_comments_title"
-            android:widgetLayout="@layout/wp_preference_switch"
             app:longClickHint="@string/site_settings_allow_comments_hint"/>
 
         <org.wordpress.android.ui.prefs.WPSwitchPreference
             android:id="@+id/pref_send_pingbacks"
             android:key="@string/pref_key_site_send_pingbacks"
             android:title="@string/site_settings_send_pingbacks_title"
-            android:widgetLayout="@layout/wp_preference_switch"
             app:longClickHint="@string/site_settings_send_pingbacks_hint"/>
 
         <org.wordpress.android.ui.prefs.WPSwitchPreference
             android:id="@+id/pref_receive_pingbacks"
             android:key="@string/pref_key_site_receive_pingbacks"
             android:title="@string/site_settings_receive_pingbacks_title"
-            android:widgetLayout="@layout/wp_preference_switch"
             app:longClickHint="@string/site_settings_receive_pingbacks_hint"/>
 
         <PreferenceScreen
@@ -241,21 +235,18 @@
                     android:id="@+id/pref_allow_comments_nested"
                     android:key="@string/pref_key_site_allow_comments_nested"
                     android:title="@string/site_settings_allow_comments_title"
-                    android:widgetLayout="@layout/wp_preference_switch"
                     app:longClickHint="@string/site_settings_allow_comments_hint"/>
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_send_pingbacks_nested"
                     android:key="@string/pref_key_site_send_pingbacks_nested"
                     android:title="@string/site_settings_send_pingbacks_title"
-                    android:widgetLayout="@layout/wp_preference_switch"
                     app:longClickHint="@string/site_settings_send_pingbacks_hint"/>
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_receive_pingbacks_nested"
                     android:key="@string/pref_key_site_receive_pingbacks_nested"
                     android:title="@string/site_settings_receive_pingbacks_title"
-                    android:widgetLayout="@layout/wp_preference_switch"
                     app:longClickHint="@string/site_settings_receive_pingbacks_hint"/>
 
                 <org.wordpress.android.ui.prefs.LearnMorePreference
@@ -263,10 +254,10 @@
                     android:key="@string/pref_key_site_learn_more"
                     android:title="@string/site_settings_learn_more_header"
                     app:caption="@string/site_settings_learn_more_caption"
-                    app:url="https://en.support.wordpress.com/settings/discussion-settings/#default-article-settings"
-                    app:useCustomJsFormatting="true"
+                    app:layout="@layout/learn_more_pref_old"
                     app:openInDialog="true"
-                    app:layout="@layout/learn_more_pref_old"/>
+                    app:url="https://en.support.wordpress.com/settings/discussion-settings/#default-article-settings"
+                    app:useCustomJsFormatting="true"/>
 
             </PreferenceCategory>
 
@@ -278,14 +269,12 @@
                     android:id="@+id/pref_identity_required"
                     android:key="@string/pref_key_site_identity_required"
                     android:title="@string/site_settings_identity_required_title"
-                    android:widgetLayout="@layout/wp_preference_switch"
                     app:longClickHint="@string/site_settings_identity_required_hint"/>
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_user_account_required"
                     android:key="@string/pref_key_site_user_account_required"
                     android:title="@string/site_settings_account_required_title"
-                    android:widgetLayout="@layout/wp_preference_switch"
                     app:longClickHint="@string/site_settings_user_account_required_hint"/>
 
                 <org.wordpress.android.ui.prefs.WPPreference
@@ -366,24 +355,21 @@
                 android:id="@+id/pref_monitor_uptime"
                 android:key="@string/pref_key_jetpack_monitor_uptime"
                 android:layout="@layout/wp_preference_layout"
-                android:title="@string/jetpack_monitor_uptime_title"
-                android:widgetLayout="@layout/wp_preference_switch"/>
+                android:title="@string/jetpack_monitor_uptime_title"/>
 
             <org.wordpress.android.ui.prefs.WPSwitchPreference
                 android:id="@+id/pref_jetpack_send_email_notifications"
                 android:dependency="@string/pref_key_jetpack_monitor_uptime"
                 android:key="@string/pref_key_jetpack_send_email_notifications"
                 android:layout="@layout/wp_preference_layout"
-                android:title="@string/jetpack_send_email_notifications_title"
-                android:widgetLayout="@layout/wp_preference_switch"/>
+                android:title="@string/jetpack_send_email_notifications_title"/>
 
             <org.wordpress.android.ui.prefs.WPSwitchPreference
                 android:id="@+id/pref_jetpack_send_wp_notifications"
                 android:dependency="@string/pref_key_jetpack_monitor_uptime"
                 android:key="@string/pref_key_jetpack_send_wp_notifications"
                 android:layout="@layout/wp_preference_layout"
-                android:title="@string/jetpack_send_wp_notifications_title"
-                android:widgetLayout="@layout/wp_preference_switch"/>
+                android:title="@string/jetpack_send_wp_notifications_title"/>
 
             <PreferenceCategory
                 android:id="@+id/pref_category_jetpack_brute_force"
@@ -393,8 +379,7 @@
                     android:id="@+id/pref_prevent_brute_force"
                     android:key="@string/pref_key_jetpack_prevent_brute_force"
                     android:layout="@layout/wp_preference_layout"
-                    android:title="@string/jetpack_prevent_brute_force_title"
-                    android:widgetLayout="@layout/wp_preference_switch"/>
+                    android:title="@string/jetpack_prevent_brute_force_title"/>
 
                 <org.wordpress.android.ui.prefs.WPPreference
                     android:id="@+id/pref_brute_force_whitelist"
@@ -413,33 +398,30 @@
                     android:id="@+id/pref_allow_wpcom_sign_in"
                     android:key="@string/pref_key_jetpack_allow_wpcom_sign_in"
                     android:layout="@layout/wp_preference_layout"
-                    android:title="@string/jetpack_allow_wpcom_sign_in_title"
-                    android:widgetLayout="@layout/wp_preference_switch"/>
+                    android:title="@string/jetpack_allow_wpcom_sign_in_title"/>
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_jetpack_match_wpcom_email"
                     android:dependency="@string/pref_key_jetpack_allow_wpcom_sign_in"
                     android:key="@string/pref_key_jetpack_match_via_email"
                     android:layout="@layout/wp_preference_layout"
-                    android:title="@string/jetpack_match_wpcom_via_email_title"
-                    android:widgetLayout="@layout/wp_preference_switch"/>
+                    android:title="@string/jetpack_match_wpcom_via_email_title"/>
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_jetpack_require_two_factor"
                     android:dependency="@string/pref_key_jetpack_allow_wpcom_sign_in"
                     android:key="@string/pref_key_jetpack_require_two_factor"
                     android:layout="@layout/wp_preference_layout"
-                    android:title="@string/jetpack_require_two_factor_title"
-                    android:widgetLayout="@layout/wp_preference_switch"/>
+                    android:title="@string/jetpack_require_two_factor_title"/>
 
                 <org.wordpress.android.ui.prefs.LearnMorePreference
                     android:id="@+id/pref_jetpack_learn_more"
                     android:key="@string/pref_key_jetpack_learn_more"
                     android:title="@string/site_settings_learn_more_header"
-                    app:url="https://jetpack.com/support/sso/"
-                    app:useCustomJsFormatting="false"
+                    app:layout="@layout/learn_more_pref_old"
                     app:openInDialog="true"
-                    app:layout="@layout/learn_more_pref_old"/>
+                    app:url="https://jetpack.com/support/sso/"
+                    app:useCustomJsFormatting="false"/>
 
             </PreferenceCategory>
         </PreferenceScreen>


### PR DESCRIPTION
Fixes #7841

The issue was caused by the wrong id (`switchWidget` on api <= 22 instead of `switch_widget`) of switch view passed to the Switch preference.

Turns out preferences are messy (duh) and the easiest solution was just to find a native switch view inside preference and change it's color. Same as with original implementation, the color will be changed only on api 23+.

To test:

1. On the device with api <= 22 open Site settings, App settings or Notification Setings.
2. Make sure the switch preferences work there.


