### PR TITLE
Issue/7794 fixed crash in nested settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/DialogExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/DialogExtensions.kt
@@ -6,7 +6,7 @@ import android.os.Build
 import android.view.View
 
 @SuppressLint("InlinedApi")
-fun Dialog.getContainerView(): View? {
+fun Dialog.getPreferenceDialogContainerView(): View? {
     val containerViewId = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
         android.R.id.list_container
     } else {

--- a/WordPress/src/main/java/org/wordpress/android/util/DialogExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/DialogExtensions.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.util
+
+import android.annotation.SuppressLint
+import android.app.Dialog
+import android.os.Build
+import android.view.View
+
+@SuppressLint("InlinedApi")
+fun Dialog.getContainerView(): View? {
+    val containerViewId = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        android.R.id.list_container
+    } else {
+        android.R.id.list
+    }
+
+    return findViewById(containerViewId)
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.util;
 
-import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.app.Fragment;
 import android.content.ComponentName;
@@ -31,28 +30,20 @@ public class WPActivityUtils {
             return;
         }
 
-        Toolbar toolbar;
-        if (dialog.findViewById(android.R.id.list) == null
-            && dialog.findViewById(android.R.id.list_container) == null) {
+        View dialogContainerView = DialogExtensionsKt.getContainerView(dialog);
+
+        if (dialogContainerView == null) {
             return;
         }
 
-        @SuppressLint("InlinedApi") View child = dialog.findViewById(android.R.id.list_container);
-        if (child == null) {
-            child = dialog.findViewById(android.R.id.list);
-            if (child == null) {
-                return;
-            }
-        }
-
         // find the root view, then make sure the toolbar doesn't already exist
-        ViewGroup root = (ViewGroup) child.getParent();
+        ViewGroup root = (ViewGroup) dialogContainerView.getParent();
         if (root.findViewById(R.id.toolbar) != null) {
             return;
         }
 
-        toolbar = (Toolbar) LayoutInflater.from(context.getActivity())
-                                          .inflate(org.wordpress.android.R.layout.toolbar, root, false);
+        Toolbar toolbar = (Toolbar) LayoutInflater.from(context.getActivity())
+                                                  .inflate(org.wordpress.android.R.layout.toolbar, root, false);
         root.addView(toolbar, 0);
 
         dialog.getWindow().setWindowAnimations(R.style.DialogAnimations);
@@ -85,7 +76,14 @@ public class WPActivityUtils {
             return;
         }
 
-        ViewGroup root = (ViewGroup) dialog.findViewById(android.R.id.list).getParent();
+        View dialogContainerView = DialogExtensionsKt.getContainerView(dialog);
+
+        if (dialogContainerView == null) {
+            return;
+        }
+
+        ViewGroup root = (ViewGroup) dialogContainerView.getParent();
+
         if (root.getChildAt(0) instanceof Toolbar) {
             root.removeViewAt(0);
         }
@@ -133,12 +131,12 @@ public class WPActivityUtils {
     public static void disableComponent(Context context, Class<?> klass) {
         PackageManager pm = context.getPackageManager();
         pm.setComponentEnabledSetting(new ComponentName(context, klass),
-                                      PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
+                PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
     }
 
     public static void enableComponent(Context context, Class<?> klass) {
         PackageManager pm = context.getPackageManager();
         pm.setComponentEnabledSetting(new ComponentName(context, klass),
-                                      PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP);
+                PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -19,6 +19,7 @@ import android.view.WindowManager;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
+import org.wordpress.android.util.AppLog.T;
 
 import java.util.List;
 
@@ -30,9 +31,10 @@ public class WPActivityUtils {
             return;
         }
 
-        View dialogContainerView = DialogExtensionsKt.getContainerView(dialog);
+        View dialogContainerView = DialogExtensionsKt.getPreferenceDialogContainerView(dialog);
 
         if (dialogContainerView == null) {
+            AppLog.e(T.SETTINGS, "Preference Dialog View was null when adding Toolbar");
             return;
         }
 
@@ -76,9 +78,10 @@ public class WPActivityUtils {
             return;
         }
 
-        View dialogContainerView = DialogExtensionsKt.getContainerView(dialog);
+        View dialogContainerView = DialogExtensionsKt.getPreferenceDialogContainerView(dialog);
 
         if (dialogContainerView == null) {
+            AppLog.e(T.SETTINGS, "Preference Dialog View was null when removing Toolbar");
             return;
         }
 


### PR DESCRIPTION
Fixes #7794 

The issue was caused by different ID used for parent view of Preference dialog (on api 24+) when adding/removing toolbar - toolbar was not removed when Fragment's view was destroyed and this caused a crash when fragment was restored.

To test:

1. On device with api >=24, With the dev options "re-create activities" set to ON, open any of the app's nested settings screen (ex. Discussion -> More), then switch to another app, then switch back to WP Android.
2. Make sure nothing is crashed or on fire.