### PR TITLE
Add toolbar with only back button to About App screen

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -149,7 +149,7 @@
         <activity
             android:name=".ui.prefs.AboutActivity"
             android:label="@string/about_the_app"
-            android:theme="@style/Theme.AppCompat.NoActionBar" />
+            android:theme="@style/WordPress.TransparentToolbarTheme" />
         <activity
             android:name=".ui.prefs.BlogPreferencesActivity"
             android:configChanges="orientation|screenSize"

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AboutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AboutActivity.java
@@ -30,6 +30,7 @@ public class AboutActivity extends AppCompatActivity implements OnClickListener 
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
+        getSupportActionBar().setHomeAsUpIndicator(R.drawable.ic_close_white_24dp);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setDisplayShowHomeEnabled(true);
         getSupportActionBar().setDisplayShowTitleEnabled(false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AboutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AboutActivity.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.prefs;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -26,25 +27,32 @@ public class AboutActivity extends AppCompatActivity implements OnClickListener 
     public void onCreate(Bundle icicle) {
         super.onCreate(icicle);
         setContentView(R.layout.about_activity);
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
 
-        WPTextView version = (WPTextView) findViewById(R.id.about_version);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setDisplayShowHomeEnabled(true);
+        getSupportActionBar().setDisplayShowTitleEnabled(false);
+        getSupportActionBar().setElevation(0);
+
+        WPTextView version = findViewById(R.id.about_version);
         version.setText(getString(R.string.version_with_name_param, WordPress.versionName));
 
-        WPTextView tos = (WPTextView) findViewById(R.id.about_tos);
+        WPTextView tos = findViewById(R.id.about_tos);
         tos.setOnClickListener(this);
 
-        WPTextView pp = (WPTextView) findViewById(R.id.about_privacy);
+        WPTextView pp = findViewById(R.id.about_privacy);
         pp.setOnClickListener(this);
 
-        WPTextView publisher = (WPTextView) findViewById(R.id.about_publisher);
+        WPTextView publisher = findViewById(R.id.about_publisher);
         publisher.setText(getString(R.string.publisher_with_company_param, getString(R.string.automattic_inc)));
 
-        WPTextView copyright = (WPTextView) findViewById(R.id.about_copyright);
+        WPTextView copyright = findViewById(R.id.about_copyright);
         copyright.setText(
                 getString(R.string.copyright_with_year_and_company_params, Calendar.getInstance().get(Calendar.YEAR),
                         getString(R.string.automattic_inc)));
 
-        WPTextView about = (WPTextView) findViewById(R.id.about_url);
+        WPTextView about = findViewById(R.id.about_url);
         about.setOnClickListener(this);
     }
 

--- a/WordPress/src/main/res/layout/about_activity.xml
+++ b/WordPress/src/main/res/layout/about_activity.xml
@@ -1,92 +1,121 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/main_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/nux_background"
     android:fillViewport="true">
 
-    <org.wordpress.android.widgets.WPLinearLayoutSizeBound
-        app:maxWidth="@dimen/nux_width"
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/appBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:gravity="center">
+        android:fitsSystemWindows="true"
+        app:elevation="0dp"
+        android:theme="@style/ThemeOverlay.AppCompat.ActionBar">
 
-        <LinearLayout
-            android:layout_width="wrap_content"
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/transparent"
+            android:theme="@style/WordPress.TransparentToolbar"
+            app:layout_scrollFlags="scroll|enterAlways"
+            tools:targetApi="LOLLIPOP"/>
+
+    </android.support.design.widget.AppBarLayout>
+
+    <android.support.v4.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <org.wordpress.android.widgets.WPLinearLayoutSizeBound
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="16dp"
-            android:layout_marginRight="16dp"
-            android:orientation="vertical"
+            android:layout_gravity="center"
+            android:paddingBottom="?attr/actionBarSize"
             android:gravity="center"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp">
+            app:maxWidth="@dimen/nux_width">
 
-            <ImageView
-                android:id="@+id/nux_fragment_icon"
-                android:layout_width="50dp"
-                android:layout_height="50dp"
-                app:srcCompat="@drawable/ic_my_sites_white_50dp"
-                android:importantForAccessibility="no"
-                android:layout_marginTop="@dimen/margin_medium"/>
-
-            <org.wordpress.android.widgets.WPTextView
-                style="@style/WordPress.NUXTitle"
-                android:id="@+id/about_first_line"
-                android:text="@string/app_title"
-                android:fontFamily="sans-serif-light"
-                android:layout_marginTop="@dimen/margin_extra_large"
-                android:layout_marginBottom="@dimen/margin_small"/>
-
-            <org.wordpress.android.widgets.WPTextView
-                style="@style/WordPress.NUXGreyButtonNoBg"
-                android:id="@+id/about_version"
-                android:text="@string/version"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
-
-            <org.wordpress.android.widgets.WPTextView
-                style="@style/WordPress.NUXGreyButtonNoBg"
-                android:id="@+id/about_publisher"
-                android:text="@string/publisher"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_extra_large"/>
-
-            <org.wordpress.android.widgets.WPTextView
-                style="@style/WordPress.NUXGreyButtonNoBg"
-                android:id="@+id/about_copyright"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
-
-            <org.wordpress.android.widgets.WPTextView
-                style="@style/WordPress.NUXPrimaryButton"
-                android:id="@+id/about_privacy"
-                android:text="@string/privacy_policy"
-                android:layout_width="match_parent"
-                android:gravity="center"
-                android:layout_marginTop="@dimen/margin_medium"/>
-
-            <org.wordpress.android.widgets.WPTextView
-                style="@style/WordPress.NUXPrimaryButton"
-                android:id="@+id/about_tos"
-                android:text="@string/tos"
-                android:layout_width="match_parent"
-                android:gravity="center"/>
-
-            <org.wordpress.android.widgets.WPTextView
-                style="@style/WordPress.NUXGreyButtonNoBg"
-                android:id="@+id/about_url"
-                android:text="@string/automattic_url"
-                android:clickable="true"
-                android:focusable="true"
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_medium"
-                android:layout_marginBottom="@dimen/margin_medium"/>
-        </LinearLayout>
+                android:layout_marginEnd="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginStart="16dp"
+                android:gravity="center"
+                android:orientation="vertical">
 
-    </org.wordpress.android.widgets.WPLinearLayoutSizeBound>
-</ScrollView>
+                <ImageView
+                    android:id="@+id/nux_fragment_icon"
+                    android:layout_width="50dp"
+                    android:layout_height="50dp"
+                    android:layout_marginTop="@dimen/margin_medium"
+                    android:importantForAccessibility="no"
+                    app:srcCompat="@drawable/ic_my_sites_white_50dp"/>
+
+                <org.wordpress.android.widgets.WPTextView
+                    android:id="@+id/about_first_line"
+                    style="@style/WordPress.NUXTitle"
+                    android:layout_marginBottom="@dimen/margin_small"
+                    android:layout_marginTop="@dimen/margin_extra_large"
+                    android:fontFamily="sans-serif-light"
+                    android:text="@string/app_title"/>
+
+                <org.wordpress.android.widgets.WPTextView
+                    android:id="@+id/about_version"
+                    style="@style/WordPress.NUXGreyButtonNoBg"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/version"/>
+
+                <org.wordpress.android.widgets.WPTextView
+                    android:id="@+id/about_publisher"
+                    style="@style/WordPress.NUXGreyButtonNoBg"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_extra_large"
+                    android:text="@string/publisher"/>
+
+                <org.wordpress.android.widgets.WPTextView
+                    android:id="@+id/about_copyright"
+                    style="@style/WordPress.NUXGreyButtonNoBg"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"/>
+
+                <org.wordpress.android.widgets.WPTextView
+                    android:id="@+id/about_privacy"
+                    style="@style/WordPress.NUXPrimaryButton"
+                    android:layout_width="match_parent"
+                    android:layout_marginTop="@dimen/margin_medium"
+                    android:gravity="center"
+                    android:text="@string/privacy_policy"/>
+
+                <org.wordpress.android.widgets.WPTextView
+                    android:id="@+id/about_tos"
+                    style="@style/WordPress.NUXPrimaryButton"
+                    android:layout_width="match_parent"
+                    android:gravity="center"
+                    android:text="@string/tos"/>
+
+                <org.wordpress.android.widgets.WPTextView
+                    android:id="@+id/about_url"
+                    style="@style/WordPress.NUXGreyButtonNoBg"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/margin_medium"
+                    android:layout_marginTop="@dimen/margin_medium"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:text="@string/automattic_url"/>
+            </LinearLayout>
+
+        </org.wordpress.android.widgets.WPLinearLayoutSizeBound>
+    </android.support.v4.widget.NestedScrollView>
+</android.support.design.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/site_creation_form_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_form_screen.xml
@@ -15,7 +15,6 @@
         app:contentInsetLeft="@dimen/toolbar_content_offset"
         app:contentInsetStart="@dimen/toolbar_content_offset"
         app:titleTextColor="@color/white"
-        app:theme="@style/LoginTheme.Toolbar"
         tools:targetApi="LOLLIPOP"/>
 
     <ViewStub

--- a/WordPress/src/main/res/layout/site_creation_form_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_form_screen.xml
@@ -15,6 +15,7 @@
         app:contentInsetLeft="@dimen/toolbar_content_offset"
         app:contentInsetStart="@dimen/toolbar_content_offset"
         app:titleTextColor="@color/white"
+        app:theme="@style/LoginTheme.Toolbar"
         tools:targetApi="LOLLIPOP"/>
 
     <ViewStub

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -679,4 +679,16 @@
         <item name="android:textSize">@dimen/text_sz_small</item>
     </style>
 
+    <style name="WordPress.TransparentToolbarTheme" parent="WordPress">
+        <item name="windowActionBar">false</item>
+        <item name="windowActionBarOverlay">true</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="WordPress.TransparentToolbar" parent="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+        <item name="android:windowActionBarOverlay">true</item>
+        <!-- Support library compatibility -->
+        <item name="windowActionBarOverlay">true</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Fixes #7799 

Does it look ok this way @SylvesterWilmott ? The text is under a transparent toolbar

![screenshot_20180612-145258](https://user-images.githubusercontent.com/1079756/41291637-8474ad06-6e50-11e8-94bd-1520349441c7.png)

To test:
- Open `About App` screen
- There is a back button in the transparent toolbar
- Clicking it closes the `About App` screen