### PR TITLE
Issue/change photo color

### DIFF
--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -70,7 +70,7 @@
                     android:layout_height="wrap_content"
                     android:layout_centerHorizontal="true"
                     android:layout_below="@id/frame_avatar"
-                    android:textColor="@color/grey_darken_10"
+                    android:textColor="@color/blue_wordpress"
                     android:padding="8dp"
                     android:textAllCaps="true"
                     android:textSize="10sp"


### PR DESCRIPTION
### Fix
Update ***Change Photo*** text color to `#0087be` (i.e. `blue_wordpress`) since it is an action for consistency across the app.  See the screenshots below for illustration.

![change_photo](https://user-images.githubusercontent.com/3827611/41040552-5959d7ce-6962-11e8-94ed-8336f85b5e08.png)

### Test
1. Go to ***Me*** tab.
2. Notice ***Change Photo*** text color.