### PR TITLE
Issue/4670 migrate gcm to fcm

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -128,7 +128,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-core-utils'
     })
 
-    implementation 'com.google.android.gms:play-services-gcm:15.0.1'
+    implementation 'com.google.firebase:firebase-messaging:17.0.0'
     implementation 'com.google.android.gms:play-services-auth:15.0.1'
     implementation 'com.google.android.gms:play-services-places:15.0.1'
     implementation 'com.github.chrisbanes.photoview:library:1.2.4'

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -128,9 +128,9 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-core-utils'
     })
 
-    implementation 'com.google.android.gms:play-services-gcm:12.0.1'
-    implementation 'com.google.android.gms:play-services-auth:12.0.1'
-    implementation 'com.google.android.gms:play-services-places:12.0.1'
+    implementation 'com.google.android.gms:play-services-gcm:15.0.1'
+    implementation 'com.google.android.gms:play-services-auth:15.0.1'
+    implementation 'com.google.android.gms:play-services-places:15.0.1'
     implementation 'com.github.chrisbanes.photoview:library:1.2.4'
     implementation 'com.helpshift:android-helpshift-aar:6.4.1'
     implementation 'de.greenrobot:eventbus:2.4.0'

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -29,14 +29,7 @@
 
     <!-- GCM all build types configuration -->
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
-    <!-- self-defined permission prevents other apps to hijack PNs -->
-    <permission
-        android:name="${applicationId}.permission.C2D_MESSAGE"
-        android:protectionLevel="signature" />
-
-    <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
 
     <uses-feature
         android:name="android.hardware.camera"
@@ -671,16 +664,6 @@
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
-
-        <receiver
-            android:name="com.google.android.gms.gcm.GcmReceiver"
-            android:exported="true"
-            android:permission="com.google.android.c2dm.permission.SEND">
-            <intent-filter>
-                <action android:name="com.google.android.c2dm.intent.RECEIVE" />
-                <category android:name="${applicationId}" />
-            </intent-filter>
-        </receiver>
 
         <service
             android:name=".push.GCMRegistrationIntentService"

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -671,10 +671,9 @@
             android:exported="false" />
 
         <service
-            android:name=".push.GCMMessageService"
-            android:exported="false">
+            android:name=".push.GCMMessageService">
             <intent-filter>
-                <action android:name="com.google.android.c2dm.intent.RECEIVE" />
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
         <service

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -679,9 +679,9 @@
         </service>
         <service
             android:name=".push.InstanceIDService"
-            android:exported="false">
+            >
             <intent-filter>
-                <action android:name="com.google.android.gms.iid.InstanceID" />
+                <action android:name="com.google.firebase.INSTANCE_ID_EVENT" />
             </intent-filter>
         </service>
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -32,8 +32,7 @@ import com.google.android.gms.auth.api.Auth;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.api.GoogleApiClient;
-import com.google.android.gms.gcm.GoogleCloudMessaging;
-import com.google.android.gms.iid.InstanceID;
+import com.google.firebase.iid.FirebaseInstanceId;
 import com.wordpress.rest.RestClient;
 import com.yarolegovich.wellsql.WellSql;
 
@@ -560,10 +559,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
 
         NotificationsUtils.unregisterDevicePushNotifications(context);
         try {
-            String gcmId = BuildConfig.GCM_ID;
-            if (!TextUtils.isEmpty(gcmId)) {
-                InstanceID.getInstance(context).deleteToken(gcmId, GoogleCloudMessaging.INSTANCE_ID_SCOPE);
-            }
+            FirebaseInstanceId.getInstance().deleteInstanceId();
         } catch (Exception e) {
             AppLog.e(T.NOTIFS, "Could not delete GCM Token", e);
         }

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -39,6 +39,7 @@ import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
+import org.wordpress.android.util.HelpshiftHelper;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.StringUtils;
@@ -135,8 +136,7 @@ public class GCMMessageService extends FirebaseMessagingService {
 
         // Handle helpshift PNs
         if (TextUtils.equals((String) data.get("origin"), "helpshift")) {
-            // FIXME: implement Helpshift Firebase FCM handler
-            // HelpshiftHelper.getInstance().handlePush(this, new Intent().putExtras(data));
+            HelpshiftHelper.getInstance().handlePush(this, data);
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMRegistrationIntentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMRegistrationIntentService.java
@@ -8,10 +8,8 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.JobIntentService;
 import android.text.TextUtils;
 
-import com.google.android.gms.gcm.GoogleCloudMessaging;
-import com.google.android.gms.iid.InstanceID;
+import com.google.firebase.iid.FirebaseInstanceId;
 
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.store.AccountStore;
@@ -42,13 +40,7 @@ public class GCMRegistrationIntentService extends JobIntentService {
     @Override
     protected void onHandleWork(@NonNull Intent intent) {
         try {
-            InstanceID instanceID = InstanceID.getInstance(this);
-            String gcmId = BuildConfig.GCM_ID;
-            if (TextUtils.isEmpty(gcmId)) {
-                AppLog.e(T.NOTIFS, "GCM_ID must be configured in gradle.properties");
-                return;
-            }
-            String token = instanceID.getToken(gcmId, GoogleCloudMessaging.INSTANCE_ID_SCOPE, null);
+            String token = FirebaseInstanceId.getInstance().getToken();
             sendRegistrationToken(token);
         } catch (Exception e) {
             // SecurityException can happen on some devices without Google services (these devices probably strip

--- a/WordPress/src/main/java/org/wordpress/android/push/InstanceIDService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/InstanceIDService.java
@@ -2,9 +2,16 @@ package org.wordpress.android.push;
 
 import android.content.Intent;
 
-import com.google.android.gms.iid.InstanceIDListenerService;
+import com.google.firebase.iid.FirebaseInstanceIdService;
 
-public class InstanceIDService extends InstanceIDListenerService {
+public class InstanceIDService extends FirebaseInstanceIdService {
+    /**
+     * Called if InstanceID token is updated. This may occur if the security of
+     * the previous token had been compromised. Note that this is also called
+     * when the InstanceID token is initially generated, so this is where
+     * you retrieve the token.
+     */
+    // [START refresh_token]
     @Override
     public void onTokenRefresh() {
         // Register for Cloud messaging

--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -3,7 +3,6 @@ package org.wordpress.android.util;
 import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
-import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
@@ -284,8 +283,8 @@ public class HelpshiftHelper {
     /**
      * Handle push notification
      */
-    public void handlePush(Context context, Intent intent) {
-        Core.handlePush(context, intent);
+    public void handlePush(Context context, Map<String, String> data) {
+        Core.handlePush(context, data);
     }
 
     /**

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support:design:27.1.1'
 
-    implementation 'com.google.android.gms:play-services-auth:12.0.1'
+    implementation 'com.google.android.gms:play-services-auth:15.0.1'
 
     // Share FluxC version from host project if defined, otherwise fallback to default
     if (project.hasProperty("fluxCVersion")) {


### PR DESCRIPTION
Fixes #4670 

As the GCM service is [deprecated and planned to be switched off soon](https://android-developers.googleblog.com/2018/04/time-to-upgrade-from-gcm-to-fcm.html), we are forced to migrate to FCM rather sooner than later.

This PR follows each of the steps described by Google to [migrate from GCM to FCM](https://developers.google.com/cloud-messaging/android/android-migrate-fcm)

- [x] Updated the server URL to `https://fcm.googleapis.com/fcm/send` for Android on sandbox and verified it works alright for both `develop` and this branch (so we can rest assured messages won't be lost).
- [x] First, bumped goole play services library to 15.0.1 in 04f4b03
- [x] Replaced google play services GCM library with FCM in ad562a6
- [x] Removed GCM permissions from `AndroidManifest.xml` in 18d54b3
- [x] Migrated `InstanceID` service in 752d9d3
- [x] Migrated `GcmListenerService` in d740352. In this we are also converting the new `RemoteMessage`'s Map into  a `Bundle` as GCM used to pass to the listener, so to keep code changes in the whole Push Notifications handling logic to a minimum.
- [x] Migrate and test Helpshift plan
- [x] Produce diff for server code (D14519) and get that merged before merging this PR into `develop`, 
- [x] verify the patch works directly on prod.

Also, verified that the Firebase project console is up to date and contains the latest information for our application package.

### To test:

These are the minimum to test all possible paths to PNs on Android:
#### 2FA
1. log in to your app, and then send it to the background and bring it back to the foreground (unrelated issue found by @daniloercoli tracked in https://github.com/wordpress-mobile/WordPress-Android/issues/7873)
2. on the web, enable 2FA
3. logout of the web
4. try to login back on the web
5. you should be sent a 2fa push notification (regardless of which action you take now i.e. approve/ignore, receiving the notification means this PR worked).

#### Activity (Comments / likes)
1. log in to the app, and send it to the background
2. have a 3rd user like / comment on a post of yours
3. you should receive the comment/like notification

#### Badge reset (delete notification)
1. do steps as in section above (Comments / likes)
2. after receiving the notification on your device, leave it there.
3. open a web browser on your computer and go read the Notification for such a Comment/like
4. observe the notification on your device is removed from the system dashboard after a few seconds.

#### Helpshift:
1. start a new convo on Helpshift from the app
2. send the app to the background
3. go to Helpshift console and look for the chat
4. answer something
5. you should receive a Helpshift notification



