### PR TITLE
Check the html editor for change as well

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2109,7 +2109,8 @@ public class EditPostActivity extends AppCompatActivity implements
             } catch (RuntimeException e) {
                 // A core android bug might cause an out of bounds exception, if so we'll just use the current editable
                 // See https://code.google.com/p/android/issues/detail?id=5164
-                postContent = new SpannableStringBuilder(StringUtils.notNullStr((String) mEditorFragment.getContent(null)));
+                postContent = new SpannableStringBuilder(
+                        StringUtils.notNullStr((String) mEditorFragment.getContent(null)));
             }
         } else {
             postContent = new SpannableStringBuilder(StringUtils.notNullStr((String) mEditorFragment.getContent(null)));

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1258,8 +1258,9 @@ public class EditPostActivity extends AppCompatActivity implements
         boolean postTitleOrContentChanged = false;
         if (mEditorFragment != null) {
             if (mShowNewEditor || mShowAztecEditor) {
-                updatePostContentNewEditor(isAutosave, (String) mEditorFragment.getTitle(),
-                        (String) mEditorFragment.getContent());
+                postTitleOrContentChanged =
+                        updatePostContentNewEditor(isAutosave, (String) mEditorFragment.getTitle(),
+                                (String) mEditorFragment.getContent(mPost.getContent()));
             } else {
                 // TODO: Remove when legacy editor is dropped
                 postTitleOrContentChanged = updatePostContent(isAutosave);
@@ -2108,10 +2109,10 @@ public class EditPostActivity extends AppCompatActivity implements
             } catch (RuntimeException e) {
                 // A core android bug might cause an out of bounds exception, if so we'll just use the current editable
                 // See https://code.google.com/p/android/issues/detail?id=5164
-                postContent = new SpannableStringBuilder(StringUtils.notNullStr((String) mEditorFragment.getContent()));
+                postContent = new SpannableStringBuilder(StringUtils.notNullStr((String) mEditorFragment.getContent(null)));
             }
         } else {
-            postContent = new SpannableStringBuilder(StringUtils.notNullStr((String) mEditorFragment.getContent()));
+            postContent = new SpannableStringBuilder(StringUtils.notNullStr((String) mEditorFragment.getContent(null)));
         }
 
         String content;

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -52,9 +52,9 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'org.wordpress:utils:1.18.1'
 
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:efd43ed795f4c321590f1f7ff720eb1c4d4390a7')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:efd43ed795f4c321590f1f7ff720eb1c4d4390a7')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:efd43ed795f4c321590f1f7ff720eb1c4d4390a7')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:7eeb8663f806b9307bd695c9de5fc7a030a0f2bc')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:7eeb8663f806b9307bd695c9de5fc7a030a0f2bc')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:7eeb8663f806b9307bd695c9de5fc7a030a0f2bc')
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.1.4"

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -52,9 +52,9 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'org.wordpress:utils:1.18.1'
 
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:18c5f848d5b28666f99d77873794ad4644b7c796')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:18c5f848d5b28666f99d77873794ad4644b7c796')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:18c5f848d5b28666f99d77873794ad4644b7c796')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:efd43ed795f4c321590f1f7ff720eb1c4d4390a7')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:efd43ed795f4c321590f1f7ff720eb1c4d4390a7')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:efd43ed795f4c321590f1f7ff720eb1c4d4390a7')
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.1.4"

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -52,9 +52,9 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'org.wordpress:utils:1.18.1'
 
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.5')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.3.5')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.3.5')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:18c5f848d5b28666f99d77873794ad4644b7c796')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:18c5f848d5b28666f99d77873794ad4644b7c796')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:18c5f848d5b28666f99d77873794ad4644b7c796')
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.1.4"

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -542,6 +542,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             mSource.setCalypsoMode(true);
         }
 
+        mSource.displayStyledAndFormattedHtml(postContent);
         mContent.fromHtml(postContent);
 
         updateFailedAndUploadingMedia();

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -542,6 +542,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             mSource.setCalypsoMode(true);
         }
 
+        // Initialize both editors (visual, source) with the same content. Need to do that so the starting point used in
+        //  their content diffing algorithm is the same. That's assumed by the Toolbar's mode-switching logic too.
         mSource.displayStyledAndFormattedHtml(postContent);
         mContent.fromHtml(postContent);
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -71,6 +71,7 @@ import org.wordpress.aztec.AztecAttributes;
 import org.wordpress.aztec.AztecExceptionHandler;
 import org.wordpress.aztec.AztecParser;
 import org.wordpress.aztec.AztecText;
+import org.wordpress.aztec.AztecText.EditorHasChanges;
 import org.wordpress.aztec.AztecTextFormat;
 import org.wordpress.aztec.Html;
 import org.wordpress.aztec.IHistoryListener;
@@ -855,15 +856,15 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
      * where possible.
      */
     @Override
-    public CharSequence getContent() {
+    public CharSequence getContent(CharSequence originalContent) {
         if (!isAdded()) {
             return "";
         }
 
         if (mContent.getVisibility() == View.VISIBLE) {
-            return mContent.toHtml(false);
+            return mContent.hasChanges() == EditorHasChanges.NO_CHANGES ? originalContent : mContent.toHtml(false);
         } else {
-            return mSource.getPureHtml(false);
+            return mSource.hasChanges() == EditorHasChanges.NO_CHANGES ? originalContent : mSource.getPureHtml(false);
         }
     }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -966,12 +966,16 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         return StringUtils.notNullStr(mTitle.replaceAll("&nbsp;$", ""));
     }
 
+    public CharSequence getContent() throws EditorFragmentNotAddedException {
+        return getContent(null);
+    }
+
     /**
      * Returns the contents of the content field from the JavaScript editor. Should be called from a background thread
      * where possible.
      */
     @Override
-    public CharSequence getContent() throws EditorFragmentNotAddedException {
+    public CharSequence getContent(CharSequence originalContent) throws EditorFragmentNotAddedException {
         if (!isAdded()) {
             throw new EditorFragmentNotAddedException();
         }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -22,7 +22,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
     public abstract void setTitle(CharSequence text);
     public abstract void setContent(CharSequence text);
     public abstract CharSequence getTitle() throws EditorFragmentNotAddedException;
-    public abstract CharSequence getContent() throws EditorFragmentNotAddedException;
+    public abstract CharSequence getContent(CharSequence originalContent) throws EditorFragmentNotAddedException;
     public abstract LiveData<Editable> getTitleOrContentChanged();
     public abstract void appendMediaFile(MediaFile mediaFile, String imageUrl, ImageLoader imageLoader);
     public abstract void appendGallery(MediaGallery mediaGallery);
@@ -30,6 +30,8 @@ public abstract class EditorFragmentAbstract extends Fragment {
     public abstract boolean isUploadingMedia();
     public abstract boolean isActionInProgress();
     public abstract boolean hasFailedMediaUploads();
+    // Check whether we need to reload the content of the post from the editor or not.
+    // This was required since Aztec Visual->HTML can slightly change the content of the HTML. See #692 for details.
     public abstract void removeAllFailedMediaUploads();
     public abstract void removeMedia(String mediaId);
     public abstract void setTitlePlaceholder(CharSequence text);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
@@ -128,7 +128,7 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
     }
 
     @Override
-    public CharSequence getContent() {
+    public CharSequence getContent(CharSequence originalContent) {
         if (mContentEditText != null) {
             return mContentEditText.getText().toString();
         }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/MediaToolbarAction.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/MediaToolbarAction.java
@@ -7,19 +7,26 @@ import org.wordpress.aztec.ITextFormat;
 import org.wordpress.aztec.toolbar.IToolbarAction;
 import org.wordpress.aztec.toolbar.ToolbarActionType;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 public enum MediaToolbarAction implements IToolbarAction {
-    GALLERY(R.id.media_bar_button_gallery, ToolbarActionType.OTHER, AztecTextFormat.FORMAT_NONE),
-    CAMERA(R.id.media_bar_button_camera, ToolbarActionType.OTHER, AztecTextFormat.FORMAT_NONE),
-    LIBRARY(R.id.media_bar_button_library, ToolbarActionType.OTHER, AztecTextFormat.FORMAT_NONE);
+    GALLERY(R.id.media_bar_button_gallery, ToolbarActionType.OTHER,
+            new HashSet<ITextFormat>(Collections.singletonList(AztecTextFormat.FORMAT_NONE))),
+    CAMERA(R.id.media_bar_button_camera, ToolbarActionType.OTHER,
+            new HashSet<ITextFormat>(Collections.singletonList(AztecTextFormat.FORMAT_NONE))),
+    LIBRARY(R.id.media_bar_button_library, ToolbarActionType.OTHER,
+            new HashSet<ITextFormat>(Collections.singletonList(AztecTextFormat.FORMAT_NONE)));
 
     private final int mButtonId;
     private final ToolbarActionType mActionType;
-    private final ITextFormat mTextFormat;
+    private final Set<ITextFormat> mTextFormats;
 
-    MediaToolbarAction(int buttonId, ToolbarActionType actionType, ITextFormat textFormat) {
+    MediaToolbarAction(int buttonId, ToolbarActionType actionType, Set<ITextFormat> textFormats) {
         this.mButtonId = buttonId;
         this.mActionType = actionType;
-        this.mTextFormat = textFormat;
+        this.mTextFormats = textFormats;
     }
 
     @Override
@@ -35,8 +42,8 @@ public enum MediaToolbarAction implements IToolbarAction {
 
     @NotNull
     @Override
-    public ITextFormat getTextFormat() {
-        return mTextFormat;
+    public Set<ITextFormat> getTextFormats() {
+        return mTextFormats;
     }
 
     @Override

--- a/libs/editor/example/src/test/java/org/wordpress/android/editor/EditorFragmentAbstractTest.java
+++ b/libs/editor/example/src/test/java/org/wordpress/android/editor/EditorFragmentAbstractTest.java
@@ -57,7 +57,7 @@ public class EditorFragmentAbstractTest {
         }
 
         @Override
-        public CharSequence getContent() {
+        public CharSequence getContent(CharSequence originalContent) {
             return null;
         }
 


### PR DESCRIPTION
Fixes #7819 

This PR uses the `hasChanges()` method [added to the html editor](https://github.com/wordpress-mobile/AztecEditor-Android/pull/704) to avoid marking the post as modified, unless the user has indeed introduced changes to the content while in the html editor.

The Aztec side PR needs to get merged first, after which this PR will get updated to point to the proper commit hash.

To test:
1. Run the app and make sure you're using the Beta editor (Aztec)
2. Open a published post that has an image in the content but don't make any changes
3. Switch to html mode
4. Tap "Back" to return to the post list and notice that the post has no "Local changes" label