### PR TITLE
Add source post link to pingback

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -6,7 +6,6 @@ package org.wordpress.android.ui.notifications;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.ListFragment;
 import android.text.TextUtils;
 import android.view.Gravity;
@@ -336,6 +335,7 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
                 headerNoteBlock.setIsComment(mNote.isCommentType());
                 noteList.add(headerNoteBlock);
             }
+            String pingbackUrl = null;
 
             boolean isPingback = isPingback(mNote);
             if (bodyArray != null && bodyArray.length() > 0) {
@@ -368,6 +368,7 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
                                         mOnNoteBlockTextClickListener,
                                         mOnGravatarClickedListener
                                 );
+                                pingbackUrl = noteBlock.getMetaSiteUrl();
 
                                 // Set listener for comment status changes, so we can update bg and text colors
                                 CommentUserNoteBlock commentUserNoteBlock = (CommentUserNoteBlock) noteBlock;
@@ -416,7 +417,8 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
             if (isPingback) {
                 // Remove this when we start receiving "Read more block" from the backend
                 NoteBlock generatedBlock =
-                        buildGeneratedLinkBlock(getActivity(), new JSONObject(), mOnNoteBlockTextClickListener);
+                        buildGeneratedLinkBlock(mOnNoteBlockTextClickListener, pingbackUrl,
+                                getActivity().getString(R.string.comment_read_source_post));
                 generatedBlock.setIsPingback();
                 noteList.add(generatedBlock);
             }
@@ -445,13 +447,13 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
             return hasRangeOfTypePost && hasRangeOfTypeSite;
         }
 
-        private NoteBlock buildGeneratedLinkBlock(FragmentActivity activity,
-                                                  JSONObject noteObject,
-                                                  OnNoteBlockTextClickListener onNoteBlockTextClickListener) {
+        private NoteBlock buildGeneratedLinkBlock(OnNoteBlockTextClickListener onNoteBlockTextClickListener,
+                                                  String pingbackUrl,
+                                                  String message) {
             return new GeneratedNoteBlock(
-                    activity.getString(R.string.comment_read_source_post),
-                    noteObject,
-                    onNoteBlockTextClickListener);
+                    message,
+                    onNoteBlockTextClickListener,
+                    pingbackUrl);
         }
 
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -415,7 +415,7 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
             }
 
             if (isPingback) {
-                // Remove this when we start receiving "Read more block" from the backend
+                // Remove this when we start receiving "Read the source post block" from the backend
                 NoteBlock generatedBlock =
                         buildGeneratedLinkBlock(mOnNoteBlockTextClickListener, pingbackUrl,
                                 getActivity().getString(R.string.comment_read_source_post));

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
@@ -6,6 +6,7 @@ import android.support.v4.view.ViewCompat;
 import android.text.Html;
 import android.text.TextUtils;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.widget.TextView;
 
 import org.json.JSONException;
@@ -61,10 +62,12 @@ public class CommentUserNoteBlock extends UserNoteBlock {
         noteBlockHolder.mNameTextView.setText(Html.fromHtml("<strong>" + getNoteText().toString() + "</strong>"));
         noteBlockHolder.mAgoTextView.setText(DateTimeUtils.timeSpanFromTimestamp(getTimestamp(),
                                                                                  WordPress.getContext()));
-        if (!TextUtils.isEmpty(getMetaHomeTitle()) || !TextUtils.isEmpty(getMetaSiteUrl())) {
+        boolean hasMetaSiteUrl = !TextUtils.isEmpty(getMetaSiteUrl());
+        boolean hasMetaHomeTitle = !TextUtils.isEmpty(getMetaHomeTitle());
+        if (hasMetaHomeTitle || hasMetaSiteUrl) {
             noteBlockHolder.mBulletTextView.setVisibility(View.VISIBLE);
             noteBlockHolder.mSiteTextView.setVisibility(View.VISIBLE);
-            if (!TextUtils.isEmpty(getMetaHomeTitle())) {
+            if (hasMetaHomeTitle) {
                 noteBlockHolder.mSiteTextView.setText(getMetaHomeTitle());
             } else {
                 noteBlockHolder.mSiteTextView.setText(getMetaSiteUrl().replace("http://", "").replace("https://", ""));
@@ -73,6 +76,10 @@ public class CommentUserNoteBlock extends UserNoteBlock {
             noteBlockHolder.mBulletTextView.setVisibility(View.GONE);
             noteBlockHolder.mSiteTextView.setVisibility(View.GONE);
         }
+
+        boolean isPingback = hasMetaSiteUrl && !hasMetaHomeTitle;
+//        noteBlockHolder.mBtnReadSource.setVisibility(isPingback ? View.VISIBLE : View.GONE);
+//        noteBlockHolder.mBtnSourceDividerView.setVisibility(isPingback ? View.VISIBLE : View.GONE);
 
         noteBlockHolder.mSiteTextView.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
 
@@ -188,6 +195,8 @@ public class CommentUserNoteBlock extends UserNoteBlock {
         private final TextView mSiteTextView;
         private final TextView mCommentTextView;
         private final View mDividerView;
+//        private final View mBtnReadSource;
+//        private final View mBtnSourceDividerView;
 
         CommentUserNoteBlockHolder(View view) {
             mNameTextView = (TextView) view.findViewById(R.id.user_name);
@@ -199,15 +208,19 @@ public class CommentUserNoteBlock extends UserNoteBlock {
             mCommentTextView.setMovementMethod(new NoteBlockLinkMovementMethod());
             mAvatarImageView = (WPNetworkImageView) view.findViewById(R.id.user_avatar);
             mDividerView = view.findViewById(R.id.divider_view);
+//            mBtnSourceDividerView = view.findViewById(R.id.btn_source_divider_view);
+//            mBtnReadSource = view.findViewById(R.id.btn_read_source_post);
 
-            mSiteTextView.setOnClickListener(new View.OnClickListener() {
+            OnClickListener sourceListener = new OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     if (getOnNoteBlockTextClickListener() != null) {
                         getOnNoteBlockTextClickListener().showSitePreview(getMetaSiteId(), getMetaSiteUrl());
                     }
                 }
-            });
+            };
+//            mBtnReadSource.setOnClickListener(sourceListener);
+            mSiteTextView.setOnClickListener(sourceListener);
 
             // show all comments on this post when user clicks the comment text
             mCommentTextView.setOnClickListener(new View.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
@@ -6,7 +6,6 @@ import android.support.v4.view.ViewCompat;
 import android.text.Html;
 import android.text.TextUtils;
 import android.view.View;
-import android.view.View.OnClickListener;
 import android.widget.TextView;
 
 import org.json.JSONException;
@@ -62,12 +61,10 @@ public class CommentUserNoteBlock extends UserNoteBlock {
         noteBlockHolder.mNameTextView.setText(Html.fromHtml("<strong>" + getNoteText().toString() + "</strong>"));
         noteBlockHolder.mAgoTextView.setText(DateTimeUtils.timeSpanFromTimestamp(getTimestamp(),
                                                                                  WordPress.getContext()));
-        boolean hasMetaSiteUrl = !TextUtils.isEmpty(getMetaSiteUrl());
-        boolean hasMetaHomeTitle = !TextUtils.isEmpty(getMetaHomeTitle());
-        if (hasMetaHomeTitle || hasMetaSiteUrl) {
+        if (!TextUtils.isEmpty(getMetaHomeTitle()) || !TextUtils.isEmpty(getMetaSiteUrl())) {
             noteBlockHolder.mBulletTextView.setVisibility(View.VISIBLE);
             noteBlockHolder.mSiteTextView.setVisibility(View.VISIBLE);
-            if (hasMetaHomeTitle) {
+            if (!TextUtils.isEmpty(getMetaHomeTitle())) {
                 noteBlockHolder.mSiteTextView.setText(getMetaHomeTitle());
             } else {
                 noteBlockHolder.mSiteTextView.setText(getMetaSiteUrl().replace("http://", "").replace("https://", ""));
@@ -76,10 +73,6 @@ public class CommentUserNoteBlock extends UserNoteBlock {
             noteBlockHolder.mBulletTextView.setVisibility(View.GONE);
             noteBlockHolder.mSiteTextView.setVisibility(View.GONE);
         }
-
-        boolean isPingback = hasMetaSiteUrl && !hasMetaHomeTitle;
-//        noteBlockHolder.mBtnReadSource.setVisibility(isPingback ? View.VISIBLE : View.GONE);
-//        noteBlockHolder.mBtnSourceDividerView.setVisibility(isPingback ? View.VISIBLE : View.GONE);
 
         noteBlockHolder.mSiteTextView.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
 
@@ -195,8 +188,6 @@ public class CommentUserNoteBlock extends UserNoteBlock {
         private final TextView mSiteTextView;
         private final TextView mCommentTextView;
         private final View mDividerView;
-//        private final View mBtnReadSource;
-//        private final View mBtnSourceDividerView;
 
         CommentUserNoteBlockHolder(View view) {
             mNameTextView = (TextView) view.findViewById(R.id.user_name);
@@ -208,19 +199,15 @@ public class CommentUserNoteBlock extends UserNoteBlock {
             mCommentTextView.setMovementMethod(new NoteBlockLinkMovementMethod());
             mAvatarImageView = (WPNetworkImageView) view.findViewById(R.id.user_avatar);
             mDividerView = view.findViewById(R.id.divider_view);
-//            mBtnSourceDividerView = view.findViewById(R.id.btn_source_divider_view);
-//            mBtnReadSource = view.findViewById(R.id.btn_read_source_post);
 
-            OnClickListener sourceListener = new OnClickListener() {
+            mSiteTextView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     if (getOnNoteBlockTextClickListener() != null) {
                         getOnNoteBlockTextClickListener().showSitePreview(getMetaSiteId(), getMetaSiteUrl());
                     }
                 }
-            };
-//            mBtnReadSource.setOnClickListener(sourceListener);
-            mSiteTextView.setOnClickListener(sourceListener);
+            });
 
             // show all comments on this post when user clicks the comment text
             mCommentTextView.setOnClickListener(new View.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/GeneratedNoteBlock.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/GeneratedNoteBlock.kt
@@ -1,0 +1,58 @@
+package org.wordpress.android.ui.notifications.blocks
+
+import android.graphics.Typeface
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.StyleSpan
+import android.view.View
+import org.json.JSONObject
+import org.wordpress.android.WordPress
+import org.wordpress.android.ui.notifications.blocks.BlockType.UNKNOWN
+
+class GeneratedNoteBlock(
+    val text: String,
+    noteObject: JSONObject,
+    onNoteBlockTextClickListener: OnNoteBlockTextClickListener
+) : NoteBlock(noteObject, onNoteBlockTextClickListener) {
+    override fun getNoteText(): Spannable {
+        val spannableStringBuilder = SpannableStringBuilder(text)
+        val shouldLink = onNoteBlockTextClickListener != null
+
+        // Process Ranges to add links and text formatting
+        val map = mapOf("url" to metaSiteUrl)
+        val rangeObject = JSONObject(map)
+        val clickableSpan = object : NoteBlockClickableSpan(WordPress.getContext(), rangeObject,
+                shouldLink, false) {
+            override fun onClick(widget: View) {
+                if (onNoteBlockTextClickListener != null) {
+                    onNoteBlockTextClickListener.onNoteBlockTextClicked(this)
+                }
+            }
+        }
+
+        val indices = arrayOf(0, spannableStringBuilder.length)
+        if (indices.size == 2 && indices[0] <= spannableStringBuilder.length
+                && indices[1] <= spannableStringBuilder.length) {
+            spannableStringBuilder
+                    .setSpan(clickableSpan, indices[0], indices[1], Spanned.SPAN_INCLUSIVE_INCLUSIVE)
+
+            // Add additional styling if the range wants it
+            if (clickableSpan.spanStyle != Typeface.NORMAL) {
+                val styleSpan = StyleSpan(clickableSpan.spanStyle)
+                spannableStringBuilder
+                        .setSpan(styleSpan, indices[0], indices[1], Spanned.SPAN_INCLUSIVE_INCLUSIVE)
+            }
+        }
+
+        return spannableStringBuilder
+    }
+
+    override fun hasImageMediaItem(): Boolean {
+        return false
+    }
+
+    override fun getBlockType(): BlockType {
+        return UNKNOWN
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/GeneratedNoteBlock.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/GeneratedNoteBlock.kt
@@ -40,6 +40,10 @@ class GeneratedNoteBlock(
         return spannableStringBuilder
     }
 
+    override fun getMetaSiteUrl(): String {
+        return pingbackUrl
+    }
+
     override fun hasImageMediaItem(): Boolean {
         return false
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/GeneratedNoteBlock.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/GeneratedNoteBlock.kt
@@ -29,17 +29,13 @@ class GeneratedNoteBlock(
             }
         }
 
-        val indices = arrayOf(0, spannableStringBuilder.length)
-        if (indices.size == 2 && indices[0] <= spannableStringBuilder.length
-                && indices[1] <= spannableStringBuilder.length) {
-            spannableStringBuilder
-                    .setSpan(clickableSpan, indices[0], indices[1], Spanned.SPAN_INCLUSIVE_INCLUSIVE)
+        val start = 0
+        val end = spannableStringBuilder.length
+        spannableStringBuilder.setSpan(clickableSpan, start, end, Spanned.SPAN_INCLUSIVE_INCLUSIVE)
 
-            // Add additional styling if the range wants it
-            val styleSpan = StyleSpan(Typeface.ITALIC)
-            spannableStringBuilder
-                    .setSpan(styleSpan, indices[0], indices[1], Spanned.SPAN_INCLUSIVE_INCLUSIVE)
-        }
+        // Add additional styling if the range wants it
+        val styleSpan = StyleSpan(Typeface.ITALIC)
+        spannableStringBuilder.setSpan(styleSpan, start, end, Spanned.SPAN_INCLUSIVE_INCLUSIVE)
 
         return spannableStringBuilder
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/GeneratedNoteBlock.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/GeneratedNoteBlock.kt
@@ -10,7 +10,7 @@ import org.json.JSONObject
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.notifications.blocks.BlockType.BASIC
 
-@Deprecated("This should be removed once we receive a Pingback notification from the backend")
+@Deprecated("This should be removed once we start receiving Read the source block from the backend")
 class GeneratedNoteBlock(
     val text: String,
     val clickListener: OnNoteBlockTextClickListener,

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/GeneratedNoteBlock.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/GeneratedNoteBlock.kt
@@ -8,26 +8,24 @@ import android.text.style.StyleSpan
 import android.view.View
 import org.json.JSONObject
 import org.wordpress.android.WordPress
-import org.wordpress.android.ui.notifications.blocks.BlockType.UNKNOWN
+import org.wordpress.android.ui.notifications.blocks.BlockType.BASIC
 
+@Deprecated("This should be removed once we receive a Pingback notification from the backend")
 class GeneratedNoteBlock(
     val text: String,
-    noteObject: JSONObject,
-    onNoteBlockTextClickListener: OnNoteBlockTextClickListener
-) : NoteBlock(noteObject, onNoteBlockTextClickListener) {
+    val clickListener: OnNoteBlockTextClickListener,
+    val pingbackUrl: String
+) : NoteBlock(JSONObject(), clickListener) {
     override fun getNoteText(): Spannable {
         val spannableStringBuilder = SpannableStringBuilder(text)
-        val shouldLink = onNoteBlockTextClickListener != null
 
         // Process Ranges to add links and text formatting
-        val map = mapOf("url" to metaSiteUrl)
+        val map = mapOf("url" to pingbackUrl)
         val rangeObject = JSONObject(map)
         val clickableSpan = object : NoteBlockClickableSpan(WordPress.getContext(), rangeObject,
-                shouldLink, false) {
+                true, false) {
             override fun onClick(widget: View) {
-                if (onNoteBlockTextClickListener != null) {
-                    onNoteBlockTextClickListener.onNoteBlockTextClicked(this)
-                }
+                clickListener.onNoteBlockTextClicked(this)
             }
         }
 
@@ -38,11 +36,9 @@ class GeneratedNoteBlock(
                     .setSpan(clickableSpan, indices[0], indices[1], Spanned.SPAN_INCLUSIVE_INCLUSIVE)
 
             // Add additional styling if the range wants it
-            if (clickableSpan.spanStyle != Typeface.NORMAL) {
-                val styleSpan = StyleSpan(clickableSpan.spanStyle)
-                spannableStringBuilder
-                        .setSpan(styleSpan, indices[0], indices[1], Spanned.SPAN_INCLUSIVE_INCLUSIVE)
-            }
+            val styleSpan = StyleSpan(Typeface.ITALIC)
+            spannableStringBuilder
+                    .setSpan(styleSpan, indices[0], indices[1], Spanned.SPAN_INCLUSIVE_INCLUSIVE)
         }
 
         return spannableStringBuilder
@@ -53,6 +49,6 @@ class GeneratedNoteBlock(
     }
 
     override fun getBlockType(): BlockType {
-        return UNKNOWN
+        return BASIC
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
@@ -87,7 +87,7 @@ public class NoteBlock {
         return JSONUtils.queryJSON(mNoteData, "meta.ids.site", -1);
     }
 
-    String getMetaSiteUrl() {
+    public String getMetaSiteUrl() {
         return JSONUtils.queryJSON(mNoteData, "meta.links.home", "");
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
@@ -202,7 +202,7 @@ public class NoteBlock {
                     @Override
                     public void onClick(View v) {
                         if (getOnNoteBlockTextClickListener() != null) {
-                            getOnNoteBlockTextClickListener().showSitePreview(getMetaSiteId(), getMetaSiteUrl());
+                            getOnNoteBlockTextClickListener().showSitePreview(0, getMetaSiteUrl());
                         }
                     }
                 });

--- a/WordPress/src/main/res/layout/note_block_basic.xml
+++ b/WordPress/src/main/res/layout/note_block_basic.xml
@@ -4,20 +4,45 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:layout_gravity="center"
-              android:paddingLeft="@dimen/margin_extra_large"
-              android:paddingRight="@dimen/margin_extra_large"
-              android:paddingTop="@dimen/margin_medium"
-              android:paddingBottom="@dimen/margin_medium"
-              android:orientation="vertical"
-    android:paddingEnd="@dimen/margin_extra_large"
-    android:paddingStart="@dimen/margin_extra_large">
+              android:orientation="vertical">
 
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/note_text"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:textSize="@dimen/text_sz_large"
-        android:textColor="@color/grey_dark"
-        android:textColorLink="@color/grey_dark"
-        app:fixWidowWords="true"/>
+        android:layout_gravity="center"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/margin_medium"
+        android:paddingEnd="@dimen/margin_extra_large"
+        android:paddingLeft="@dimen/margin_extra_large"
+        android:paddingRight="@dimen/margin_extra_large"
+        android:paddingStart="@dimen/margin_extra_large"
+        android:paddingTop="@dimen/margin_medium">
+
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/note_text"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:textColor="@color/grey_dark"
+            android:textColorLink="@color/grey_dark"
+            android:textSize="@dimen/text_sz_large"
+            app:fixWidowWords="true"/>
+
+        <Button
+            android:id="@+id/note_button"
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:gravity="end|center_vertical"
+            android:text="@string/comment_read_source_post"
+            android:textColor="@color/blue_medium"
+            android:visibility="gone"/>
+    </LinearLayout>
+
+    <View
+        android:id="@+id/divider_view"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@drawable/notifications_list_divider"
+        android:visibility="gone"/>
 </LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -339,6 +339,7 @@
     <string name="comment_spam_talkback">Comment marked as spam</string>
     <string name="comment_unspam_talkback">Comment marked as not spam</string>
     <string name="comment_title">%s on %s</string>
+    <string name="comment_read_source_post">Read the source post</string>
 
     <!-- comment menu and buttons on comment detail - keep these short! -->
     <string name="mnu_comment_approve">Approve</string>


### PR DESCRIPTION
Fixes #7852 
This solution adds "Read the source post" button to Pingbacks. In future we might start getting the block from the backend so I've tried to make the code generating the block as separated as possible. 
I have implemented the designs in a bit hacky way ("If the comment is a pingback, show button instead of the code") but I can easily revert it - @jleandroperez and @elibud 

Solution with the design hack:

![screenshot_1528366094](https://user-images.githubusercontent.com/1079756/41096475-fc3ce326-6a54-11e8-84d4-a8466c61b547.png)

Solution without the design hack:

![screenshot_1528368181](https://user-images.githubusercontent.com/1079756/41096498-0c2d935c-6a55-11e8-8ab0-fded494ce195.png)


To test:
* Open a pingback notification
* You see a "Read the source post" button
* If you click it, you get redirected to the source post of the pingback
