### PR TITLE
Notifications now refresh periodically

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -114,16 +114,13 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
 
         mIsReaderSwipeToNavigateShown = AppPrefs.isReaderSwipeToNavigateShown();
 
+        Note note = NotificationsTable.getNoteById(mNoteId);
+        updateUIAndNote(note == null);
+
         // Hide the keyboard, unless we arrived here from the 'Reply' action in a push notification
         if (!getIntent().getBooleanExtra(NotificationsListFragment.NOTE_INSTANT_REPLY_EXTRA, false)) {
             getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN);
         }
-    }
-
-    @Override protected void onResume() {
-        super.onResume();
-        Note note = NotificationsTable.getNoteById(mNoteId);
-        updateUIAndNote(note == null);
     }
 
     private void updateUIAndNote(boolean doRefresh) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -114,13 +114,16 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
 
         mIsReaderSwipeToNavigateShown = AppPrefs.isReaderSwipeToNavigateShown();
 
-        Note note = NotificationsTable.getNoteById(mNoteId);
-        updateUIAndNote(note == null);
-
         // Hide the keyboard, unless we arrived here from the 'Reply' action in a push notification
         if (!getIntent().getBooleanExtra(NotificationsListFragment.NOTE_INSTANT_REPLY_EXTRA, false)) {
             getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN);
         }
+    }
+
+    @Override protected void onResume() {
+        super.onResume();
+        Note note = NotificationsTable.getNoteById(mNoteId);
+        updateUIAndNote(note == null);
     }
 
     private void updateUIAndNote(boolean doRefresh) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -74,6 +74,7 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
 
     private long mRestoredScrollNoteID;
     private boolean mIsAnimatingOutNewNotificationsBar;
+    private boolean mShouldRefreshNotifications;
 
     @Inject AccountStore mAccountStore;
 
@@ -92,6 +93,7 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
+        mShouldRefreshNotifications = true;
     }
 
     @Override
@@ -198,11 +200,14 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (resultCode == RESULT_OK) {
-            String noteId = data.getStringExtra(NOTE_MODERATE_ID_EXTRA);
-            String newStatus = data.getStringExtra(NOTE_MODERATE_STATUS_EXTRA);
-            if (!TextUtils.isEmpty(noteId) && !TextUtils.isEmpty(newStatus)) {
-                updateNote(noteId, CommentStatus.fromString(newStatus));
+        if (requestCode == RequestCodes.NOTE_DETAIL) {
+            mShouldRefreshNotifications = false;
+            if (resultCode == RESULT_OK) {
+                String noteId = data.getStringExtra(NOTE_MODERATE_ID_EXTRA);
+                String newStatus = data.getStringExtra(NOTE_MODERATE_STATUS_EXTRA);
+                if (!TextUtils.isEmpty(noteId) && !TextUtils.isEmpty(newStatus)) {
+                    updateNote(noteId, CommentStatus.fromString(newStatus));
+                }
             }
         }
     }
@@ -223,7 +228,15 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
             mFilterRadioGroup.setVisibility(View.GONE);
         } else {
             getNotesAdapter().reloadNotesFromDBAsync();
+            if (mShouldRefreshNotifications) {
+                fetchNotesFromRemote();
+            }
         }
+    }
+
+    @Override public void onPause() {
+        super.onPause();
+        mShouldRefreshNotifications = true;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -234,7 +234,8 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
         }
     }
 
-    @Override public void onPause() {
+    @Override
+    public void onPause() {
         super.onPause();
         mShouldRefreshNotifications = true;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -105,7 +105,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         return new NoteViewHolder(view);
     }
 
-    // Instead of building the filterd notes list dinamically, create it once and re-use it.
+    // Instead of building the filtered notes list dynamically, create it once and re-use it.
     // Otherwise it's re-created so many times during layout.
     public static void buildFilteredNotesList(ArrayList<Note> filteredNotes, ArrayList<Note> notes, FILTERS filter) {
         filteredNotes.clear();


### PR DESCRIPTION
Fixes #7851

Ignore the title of the issue. The problem is us getting the most recent edits of comments.

I went back and forth between multiple solutions, including refreshing every time someone tapped a notification and we went into the detail activity. The problem with that is if a user is scrolling through multiple notifications they'll be making a ton of calls. Also it introduces a delay when clicking a notification which is most likely up-to-date.

The way this implementation works:

1. When a user goes to the notification screen for the first time since app booting we sync the notifications with server.
2. If a user goes into a specific notification and comes back, there is no refresh.
3. If a user goes into another tab and comes back to the notification list, we refresh.

This guarantees we always show the most-correct list of notifications when the user comes into the notifications list.

If you have any other suggestions I'm open to it!

To test:
1. Send the user a notification by commenting on a post
2. Verify you got a notification and click into the notification
3. Edit the comment from the web
4. Go back into the notifications list and select the notification again. It should show the old text.
5. Go back and select a different tab (Reader)
6. Select the notifications tab and tap the same notification. The comment should be updated.
