### PR TITLE
Add progress bar to Site creation creating screen

### DIFF
--- a/WordPress/src/main/res/layout/site_creation_creating_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_creating_screen.xml
@@ -77,6 +77,13 @@
                     android:gravity="center"
                     android:enabled="false"
                     android:text="@string/site_creation_creating_preparing_frontend"/>
+
+                <ProgressBar
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginTop="@dimen/margin_extra_large"/>
+
             </LinearLayout>
 
             <LinearLayout


### PR DESCRIPTION
Fixes #7510 

This adds a progress bar to the Site creating screen. When the process is slow, it might be hard to understand something is happening. I've used the same progress bar used in other parts of the site creation process.

![screenshot_1528445621](https://user-images.githubusercontent.com/1079756/41147161-f2179182-6b05-11e8-97e3-d0d06d282102.png)

To test:
* Trigger the site creation
* In the step 4 there is a progress bar under the steps that are running when creating a site.
