### PR TITLE
Register FCM token as soon as user credentials get updated

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -717,6 +717,9 @@ public class WPMainActivity extends AppCompatActivity
         if (mAccountStore.hasAccessToken()) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNED_IN);
 
+            GCMRegistrationIntentService.enqueueWork(this,
+                    new Intent(this, GCMRegistrationIntentService.class));
+
             if (mIsMagicLinkLogin) {
                 if (mIsMagicLinkSignup) {
                     mLoginAnalyticsListener.trackCreatedAccount();


### PR DESCRIPTION

Fixes #7873 

Basically, the cloud messaging token was not being sent to our servers right after signin/login, but only after sending the app to the background and making it back to the foreground.
With this PR, the token is sent right away, so the user can log in to the app and start receiving notifications right on the stop without having to send the app to the background or any other further contraption

To test:
1. if you're logged in to the app, please logout
2. check you don't have a device token registered on the server,  either by using the `mc` internal tool or by producing a notification (like or comment on a blog of the user)
3. log back in to the app, it will register the device token to cloud messaging once logged in and token obtained
4. produce a notification by having  a 3rd user like/comment on a blog of the recently logged in user
5. observe the notification arrives and is displayed on the phone's dashboard.
