### PR TITLE
Issues/7856 refresh meta data

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -19,11 +19,6 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
-    public void trackCreatedAccount(AccountStore accountStore) {
-        AnalyticsUtils.trackAnalyticsAccountCreated(accountStore);
-    }
-
-    @Override
     public void trackCreatedAccount(String username, String email) {
         AnalyticsUtils.trackAnalyticsAccountCreated(username, email);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -15,7 +15,6 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     @Override
     public void trackAnalyticsSignIn(AccountStore accountStore, SiteStore siteStore, boolean isWpcom) {
         AnalyticsUtils.trackAnalyticsSignIn(accountStore, siteStore, isWpcom);
-        AnalyticsUtils.clearSignupEmail();
     }
 
     @Override
@@ -151,7 +150,7 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     @Override
     public void trackSignupMagicLinkSent(String email) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_MAGIC_LINK_SENT);
-        AnalyticsUtils.storeSignupEmail(email);
+        AnalyticsUtils.storeMagicLinkSignupEmail(email);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -148,7 +148,7 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
-    public void trackSignupMagicLinkSent(String email) {
+    public void trackSignupMagicLinkSent() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_MAGIC_LINK_SENT);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -19,8 +19,8 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
-    public void trackAnalyticsAccountCreatedRefreshingMetadata(AccountStore accountStore) {
-        AnalyticsUtils.trackAnalyticsAccountCreatedRefreshingMetadata(accountStore);
+    public void trackCreatedAccount(AccountStore accountStore) {
+        AnalyticsUtils.trackAnalyticsAccountCreated(accountStore);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -150,7 +150,6 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     @Override
     public void trackSignupMagicLinkSent(String email) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_MAGIC_LINK_SENT);
-        AnalyticsUtils.storeMagicLinkSignupEmail(email);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -24,8 +24,8 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
-    public void trackCreatedAccount() {
-        AnalyticsUtils.trackAnalyticsAccountCreated();
+    public void trackCreatedAccount(String username, String email) {
+        AnalyticsUtils.trackAnalyticsAccountCreated(username, email);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -13,13 +13,19 @@ import javax.inject.Singleton;
 @Singleton
 public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     @Override
-    public void trackAnalyticsSignIn(AccountStore accountStore, SiteStore siteStore, boolean isWpcomLogin) {
-        AnalyticsUtils.trackAnalyticsSignIn(accountStore, siteStore, isWpcomLogin);
+    public void trackAnalyticsSignIn(AccountStore accountStore, SiteStore siteStore, boolean isWpcom) {
+        AnalyticsUtils.trackAnalyticsSignIn(accountStore, siteStore, isWpcom);
+        AnalyticsUtils.clearSignupEmail();
+    }
+
+    @Override
+    public void trackAnalyticsAccountCreatedRefreshingMetadata(AccountStore accountStore) {
+        AnalyticsUtils.trackAnalyticsAccountCreatedRefreshingMetadata(accountStore);
     }
 
     @Override
     public void trackCreatedAccount() {
-        AnalyticsTracker.track(AnalyticsTracker.Stat.CREATED_ACCOUNT);
+        AnalyticsUtils.trackAnalyticsAccountCreated();
     }
 
     @Override
@@ -148,8 +154,9 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
-    public void trackSignupMagicLinkSent() {
+    public void trackSignupMagicLinkSent(String email) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_MAGIC_LINK_SENT);
+        AnalyticsUtils.storeSignupEmail(email);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -727,7 +727,7 @@ public class WPMainActivity extends AppCompatActivity
                 if (mIsMagicLinkSignup) {
                     mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
                     // While unlikely, its possible the app could be closed before the onAccountChanged event is
-                    // handled. Setting this flag let's us dispatch the event the next time the app opens.
+                    // handled. Setting this flag lets us dispatch the event the next time the app opens.
                     AppPrefs.setShouldTrackMagicLinkSignup(true);
 
                     if (mJetpackConnectSource != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -724,7 +724,7 @@ public class WPMainActivity extends AppCompatActivity
 
             if (mIsMagicLinkLogin) {
                 if (mIsMagicLinkSignup) {
-                    mLoginAnalyticsListener.trackAnalyticsAccountCreatedRefreshingMetadata(mAccountStore);
+                    mLoginAnalyticsListener.trackCreatedAccount(mAccountStore);
                     mLoginAnalyticsListener.trackSignupMagicLinkSucceeded();
 
                     if (mJetpackConnectSource != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -724,7 +724,7 @@ public class WPMainActivity extends AppCompatActivity
 
             if (mIsMagicLinkLogin) {
                 if (mIsMagicLinkSignup) {
-                    mLoginAnalyticsListener.trackCreatedAccount();
+                    mLoginAnalyticsListener.trackAnalyticsAccountCreatedRefreshingMetadata(mAccountStore);
                     mLoginAnalyticsListener.trackSignupMagicLinkSucceeded();
 
                     if (mJetpackConnectSource != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -26,6 +26,7 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
+import org.wordpress.android.fluxc.model.AccountModel;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
@@ -724,7 +725,8 @@ public class WPMainActivity extends AppCompatActivity
 
             if (mIsMagicLinkLogin) {
                 if (mIsMagicLinkSignup) {
-                    mLoginAnalyticsListener.trackCreatedAccount(mAccountStore);
+                    AccountModel account = mAccountStore.getAccount();
+                    mLoginAnalyticsListener.trackCreatedAccount(account.getUserName(), account.getEmail());
                     mLoginAnalyticsListener.trackSignupMagicLinkSucceeded();
 
                     if (mJetpackConnectSource != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -94,6 +94,9 @@ public class AppPrefs {
         VIDEO_OPTIMIZE_ENABLED,
         VIDEO_OPTIMIZE_WIDTH,
         VIDEO_OPTIMIZE_QUALITY, // Encoder max bitrate
+
+        // Used to flag the account created stat needs to be bumped after account information is synced.
+        SHOULD_TRACK_MAGIC_LINK_SIGNUP,
     }
 
     /**
@@ -671,5 +674,17 @@ public class AppPrefs {
 
     public static void setLastWpComThemeSync(long time) {
         setLong(UndeletablePrefKey.LAST_WP_COM_THEMES_SYNC, time);
+    }
+
+    public static void setShouldTrackMagicLinkSignup(Boolean shouldTrack) {
+        setBoolean(DeletablePrefKey.SHOULD_TRACK_MAGIC_LINK_SIGNUP, shouldTrack);
+    }
+
+    public static boolean getShouldTrackMagicLinkSignup() {
+        return getBoolean(DeletablePrefKey.SHOULD_TRACK_MAGIC_LINK_SIGNUP, false);
+    }
+
+    public static void removeShouldTrackMagicLinkSignup() {
+        remove(DeletablePrefKey.SHOULD_TRACK_MAGIC_LINK_SIGNUP);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
@@ -53,7 +53,7 @@ public class AnalyticsUtils {
     private static final String INTENT_DATA = "intent_data";
     private static final String INTERCEPTED_URI = "intercepted_uri";
     private static final String INTERCEPTOR_CLASSNAME = "interceptor_classname";
-    private static final String STORED_SIGNUP_EMAIL_KEY = "STORED_SIGNUP_EMAIL_KEY";
+    private static final String STORED_MAGICLINK_SIGNUP_EMAIL_KEY = "STORED_MAGICLINK_SIGNUP_EMAIL_KEY";
 
     public static void updateAnalyticsPreference(Context ctx,
                                                  Dispatcher mDispatcher,
@@ -435,6 +435,9 @@ public class AnalyticsUtils {
         if (!isWpcomLogin) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.ADDED_SELF_HOSTED_SITE);
         }
+        // Just in case a user attempted a magic link signin, but then changed their
+        // mind and logged in with a different account, clear any stored email.
+        AnalyticsUtils.clearMagicLinkSignupEmail();
     }
 
     /**
@@ -454,7 +457,7 @@ public class AnalyticsUtils {
             // SharedPrefs
             Context ctx = WordPress.getContext();
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
-            email = prefs.getString(STORED_SIGNUP_EMAIL_KEY, "");
+            email = prefs.getString(STORED_MAGICLINK_SIGNUP_EMAIL_KEY, "");
         }
 
         if (!email.isEmpty()) {
@@ -466,7 +469,7 @@ public class AnalyticsUtils {
         }
 
         // Clean up any stored magic link signup email.
-        clearSignupEmail();
+        clearMagicLinkSignupEmail();
 
         if (!username.isEmpty()) {
             // We at least have a good value for username so go ahead and refresh tracker metadata.
@@ -478,19 +481,19 @@ public class AnalyticsUtils {
         AnalyticsTracker.track(Stat.CREATED_ACCOUNT);
     }
 
-    public static void storeSignupEmail(String email) {
+    public static void storeMagicLinkSignupEmail(String email) {
         Context ctx = WordPress.getContext();
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
         final SharedPreferences.Editor editor = prefs.edit();
-        editor.putString(STORED_SIGNUP_EMAIL_KEY, email);
+        editor.putString(STORED_MAGICLINK_SIGNUP_EMAIL_KEY, email);
         editor.apply();
     }
 
-    public static void clearSignupEmail() {
+    public static void clearMagicLinkSignupEmail() {
         Context ctx = WordPress.getContext();
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
         final SharedPreferences.Editor editor = prefs.edit();
-        editor.remove(STORED_SIGNUP_EMAIL_KEY);
+        editor.remove(STORED_MAGICLINK_SIGNUP_EMAIL_KEY);
         editor.apply();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
@@ -437,7 +437,8 @@ public class AnalyticsUtils {
         }
     }
 
-    public static void trackAnalyticsAccountCreated() {
+    public static void trackAnalyticsAccountCreated(String username, String email) {
+        refreshMetadataNewUser(username, email);
         AnalyticsTracker.track(Stat.CREATED_ACCOUNT);
     }
 
@@ -457,15 +458,16 @@ public class AnalyticsUtils {
         }
         clearSignupEmail();
 
-        if (!email.isEmpty()) {
-            // Refresh if we have a usable values.
-            // Note: There are cases where this will set an email address for the
-            // analytics metadata's username property. This is fine, as Tracks will
-            // correctly identify the user with either value.
-            refreshMetadataNewUser(username, email);
+        if (email.isEmpty()) {
+            // We can't refresh meta data but we still want to bump the stat.
+            AnalyticsTracker.track(Stat.CREATED_ACCOUNT);
+            return;
         }
 
-        trackAnalyticsAccountCreated();
+        // Note: There are cases where this will set an email address for the
+        // analytics metadata's username property. This is fine, as Tracks will
+        // correctly identify the user with either value.
+        trackAnalyticsAccountCreated(username, email);
     }
 
     public static void storeSignupEmail(String email) {

--- a/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
@@ -437,11 +437,30 @@ public class AnalyticsUtils {
         }
     }
 
+    /**
+     * Refreshes analytics metadata with the supplied username and email address, then
+     * bumps the account created stat.
+     *
+     * @param username
+     * @param email
+     */
     public static void trackAnalyticsAccountCreated(String username, String email) {
         refreshMetadataNewUser(username, email);
         AnalyticsTracker.track(Stat.CREATED_ACCOUNT);
     }
 
+    /**
+     * Attempts to retrive a valid username and email address for signup from
+     * the passed accountStore, or if necessary from SharedPreferences, to use
+     * to refresh analytics meta data before bumping the account created stat.
+     *
+     * In the case of a new sign up, a retrieved email address will also be passed
+     * as the email address as either can be used  by tracks to identify a user.
+     *
+     * The stat is bumped regardless.
+     *
+     * @param accountStore
+     */
     public static void trackAnalyticsAccountCreated(AccountStore accountStore) {
         Context ctx = WordPress.getContext();
         String username = accountStore.getAccount().getUserName();
@@ -459,14 +478,11 @@ public class AnalyticsUtils {
         clearSignupEmail();
 
         if (email.isEmpty()) {
-            // We can't refresh meta data but we still want to bump the stat.
+            // We can't refresh meta data. Bump the stat anyway.
             AnalyticsTracker.track(Stat.CREATED_ACCOUNT);
             return;
         }
 
-        // Note: There are cases where this will set an email address for the
-        // analytics metadata's username property. This is fine, as Tracks will
-        // correctly identify the user with either value.
         trackAnalyticsAccountCreated(username, email);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
@@ -442,7 +442,7 @@ public class AnalyticsUtils {
         AnalyticsTracker.track(Stat.CREATED_ACCOUNT);
     }
 
-    public static void trackAnalyticsAccountCreatedRefreshingMetadata(AccountStore accountStore) {
+    public static void trackAnalyticsAccountCreated(AccountStore accountStore) {
         Context ctx = WordPress.getContext();
         String username = accountStore.getAccount().getUserName();
         String email = accountStore.getAccount().getEmail();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public interface LoginAnalyticsListener {
     void trackAnalyticsSignIn(AccountStore accountStore, SiteStore siteStore, boolean isWpcomLogin);
-    void trackAnalyticsAccountCreatedRefreshingMetadata(AccountStore accountStore);
+    void trackCreatedAccount(AccountStore accountStore);
     void trackCreatedAccount(String username, String email);
     void trackEmailFormViewed();
     void trackInsertedInvalidUrl();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 public interface LoginAnalyticsListener {
     void trackAnalyticsSignIn(AccountStore accountStore, SiteStore siteStore, boolean isWpcomLogin);
+    void trackAnalyticsAccountCreatedRefreshingMetadata(AccountStore accountStore);
     void trackCreatedAccount();
     void trackEmailFormViewed();
     void trackInsertedInvalidUrl();
@@ -33,7 +34,7 @@ public interface LoginAnalyticsListener {
     void trackSignupMagicLinkFailed();
     void trackSignupMagicLinkOpened();
     void trackSignupMagicLinkOpenEmailClientClicked();
-    void trackSignupMagicLinkSent();
+    void trackSignupMagicLinkSent(String email);
     void trackSignupMagicLinkSucceeded();
     void trackSignupSocialAccountsNeedConnecting();
     void trackSignupSocialButtonFailure();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -8,7 +8,7 @@ import java.util.Map;
 public interface LoginAnalyticsListener {
     void trackAnalyticsSignIn(AccountStore accountStore, SiteStore siteStore, boolean isWpcomLogin);
     void trackAnalyticsAccountCreatedRefreshingMetadata(AccountStore accountStore);
-    void trackCreatedAccount();
+    void trackCreatedAccount(String username, String email);
     void trackEmailFormViewed();
     void trackInsertedInvalidUrl();
     void trackLoginAccessed();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -7,7 +7,6 @@ import java.util.Map;
 
 public interface LoginAnalyticsListener {
     void trackAnalyticsSignIn(AccountStore accountStore, SiteStore siteStore, boolean isWpcomLogin);
-    void trackCreatedAccount(AccountStore accountStore);
     void trackCreatedAccount(String username, String email);
     void trackEmailFormViewed();
     void trackInsertedInvalidUrl();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -33,7 +33,7 @@ public interface LoginAnalyticsListener {
     void trackSignupMagicLinkFailed();
     void trackSignupMagicLinkOpened();
     void trackSignupMagicLinkOpenEmailClientClicked();
-    void trackSignupMagicLinkSent(String email);
+    void trackSignupMagicLinkSent();
     void trackSignupMagicLinkSucceeded();
     void trackSignupSocialAccountsNeedConnecting();
     void trackSignupSocialButtonFailure();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
@@ -168,7 +168,7 @@ public class SignupGoogleFragment extends GoogleFragment {
                     "SignupGoogleFragment.onAuthenticationChanged: " + event.error.type + " - " + event.error.message);
             // Continue with signup since account was created.
         } else if (event.createdAccount) {
-            mAnalyticsListener.trackCreatedAccount();
+            mAnalyticsListener.trackCreatedAccount(event.userName, mGoogleEmail);
             mGoogleListener.onGoogleSignupFinished(mDisplayName, mGoogleEmail, mPhotoUrl, event.userName);
             // Continue with login since existing account was selected.
         } else {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
@@ -247,7 +247,7 @@ public class SignupMagicLinkFragment extends Fragment {
                 AppLog.e(T.API, "OnAuthEmailSent error: " + event.error.type + " - " + event.error.message);
                 showErrorDialog(getString(R.string.signup_magic_link_error));
             } else {
-                mAnalyticsListener.trackSignupMagicLinkSent();
+                mAnalyticsListener.trackSignupMagicLinkSent(mEmail);
             }
         }
     }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
@@ -247,7 +247,7 @@ public class SignupMagicLinkFragment extends Fragment {
                 AppLog.e(T.API, "OnAuthEmailSent error: " + event.error.type + " - " + event.error.message);
                 showErrorDialog(getString(R.string.signup_magic_link_error));
             } else {
-                mAnalyticsListener.trackSignupMagicLinkSent(mEmail);
+                mAnalyticsListener.trackSignupMagicLinkSent();
             }
         }
     }


### PR DESCRIPTION
Fixes #7856

This PR ensures that analytics metadata is refreshed before bumping the `account_created` stat so that its not being sent as an anonymous user.

Since a username or email address is all that's needed to de-anonymize events, we either pass the username/email address (as in the Google sign up flow) or attempt to retrieve a saved email address from SharedPreferences (as in the email sign up flow). 

To test:
The easiest way to test this is to sign up with each flow, then check the live view for the `wpandroid_account_created` event in the Tracks dashboard and wait to see your event appear.

Alternatively set breakpoints in `AnalyticsTrackerNosara.refreshMetaData` and ensure that `mNosaraClient.trackAliasUser` is called when signing up.

~@hypest could I trouble you to take a peek at this one?~ Oguz has picked up the review after some early feedback from Stefanos. :)