### PR TITLE
Validate that login strings are translatable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,5 @@ install:
   - cp libs/login/gradle.properties-example libs/login/gradle.properties
 
 script:
+  - ./tools/validate-login-strings.sh
   - ./gradlew -PdisablePreDex checkstyle ktlint assembleVanillaRelease lintVanillaRelease testVanillaRelease || (grep -A20 -B2 'severity="Error"' -r --include="*.xml" WordPress libs; exit 1)

--- a/tools/validate-login-strings.sh
+++ b/tools/validate-login-strings.sh
@@ -1,0 +1,27 @@
+grep -o '<string name=.*</string>' libs/login/WordPressLoginFlow/src/main/res/values/strings.xml > loginstrings.txt;
+
+declare -a exclusions=('default_web_client_id' 'notification_channel_normal_id' 'notification_channel_important_id')
+
+found_missing_string=false
+string_array=()
+IFS=$'\n'
+while read -r s; do
+  for item in "${exclusions[@]}"; do
+      # Skip lookup if login string is one of the exclusions
+      [[ $s == *$item* ]] && continue 2
+  done
+  s=$(echo $s | sed 's/\\/\\\\/g')
+  if ! grep -oqr "$s" WordPress/src/main/res/values/strings.xml; then
+    string_array+=( $(echo $s | sed 's/\\\\/\\/g') )
+    found_missing_string=true
+  fi;
+done <loginstrings.txt
+
+rm loginstrings.txt
+
+if [ "$found_missing_string" = true ] ; then
+  printf "The following string resources are defined in the login library but are missing or modified in the base app's strings.xml:\n\n"
+  printf '%s\n' "${string_array[@]}"
+  # Exit with error if any strings were missing
+  exit 1
+fi


### PR DESCRIPTION
Interim fix for #7878. This PR adds a script that verifies that every string in the login library's `strings.xml` both exists in the base app's `strings.xml` AND has the same value. It also calls the script from Travis, so that builds fail if any strings are out of order.

(The three exceptions are `default_web_client_id`, `notification_channel_normal_id`, `notification_channel_important_id`, which are placeholder values in the login library and aren't expected to have the same value in the host app.)

A better fix would be to move the translations to the login library, drop the duplicates in the host app, and set things up so our release scripts keep the login library translations up to date too. This is outlined a bit more in #7878 but is a bigger project that will have to be addressed later.

Note: Targeting `10.2` since this builds on #7879 and it's not merged into `develop` yet, but this can be updated to target `develop` instead after that's done, no need to wait for it for 10.2.

To test:

* Change or delete login library strings, ensure the script reports the problem
* Push a breaking string change in a test branch and verify that Travis fails it (here's an example: [link](https://travis-ci.org/wordpress-mobile/WordPress-Android/builds/390917510))

cc @mzorz @loremattei 