### PR TITLE
issue/7887-reader-search-results-come-back

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -446,13 +446,18 @@ public class ReaderPostListFragment extends Fragment
         if (mCurrentTag != null) {
             outState.putSerializable(ReaderConstants.ARG_TAG, mCurrentTag);
         }
+
         if (getPostListType() == ReaderPostListType.TAG_PREVIEW) {
             mTagPreviewHistory.saveInstance(outState);
+        } else if (getPostListType() == ReaderPostListType.SEARCH_RESULTS
+                   && mSearchView != null
+                   && mSearchView.getQuery() != null) {
+            String query = mSearchView.getQuery().toString();
+            outState.putString(ReaderConstants.ARG_SEARCH_QUERY, query);
         }
 
         outState.putLong(ReaderConstants.ARG_BLOG_ID, mCurrentBlogId);
         outState.putLong(ReaderConstants.ARG_FEED_ID, mCurrentFeedId);
-        outState.putString(ReaderConstants.ARG_SEARCH_QUERY, mCurrentSearchQuery);
         outState.putBoolean(ReaderConstants.KEY_WAS_PAUSED, mWasPaused);
         outState.putBoolean(ReaderConstants.KEY_ALREADY_UPDATED, mHasUpdatedPosts);
         outState.putBoolean(ReaderConstants.KEY_FIRST_LOAD, mFirstLoad);


### PR DESCRIPTION
Fixes #7887 - prior to this PR, if you performed a reader search and then cleared the results (by tapping the **X** icon), the results would come back if you rotated the device.

The solution was to change `onSaveInstanceState()` to save the query currently entered in the searchView.
