### PR TITLE
Allow saving posts from selfhosted non-jetpack sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -1432,7 +1432,7 @@ public class ReaderPostDetailFragment extends Fragment
      * can we show the footer bar which contains the like & comment counts?
      */
     private boolean canShowFooter() {
-        return canShowLikeCount() || canShowCommentCount();
+        return canShowLikeCount() || canShowCommentCount() || canShowBookmarkButton();
     }
 
     private boolean canShowCommentCount() {
@@ -1448,7 +1448,7 @@ public class ReaderPostDetailFragment extends Fragment
     }
 
     private boolean canShowBookmarkButton() {
-        return hasPost() && (mPost.isWP() || mPost.isJetpack) && !mPost.isDiscoverPost();
+        return hasPost() && !mPost.isDiscoverPost();
     }
 
     private boolean canShowLikeCount() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -893,7 +893,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         final ImageView bookmarkButton = holder.mBtnBookmark;
         Context context = holder.mBtnBookmark.getContext();
 
-        boolean canBookmarkPost = (post.isWP() || post.isJetpack) && !post.isDiscoverPost();
+        boolean canBookmarkPost = !post.isDiscoverPost();
         if (canBookmarkPost) {
             bookmarkButton.setVisibility(View.VISIBLE);
         } else {


### PR DESCRIPTION
Fixes #7890 

Make the `save for later` button visible even for posts from self-hosted non-jetpack sites.

To test
1. Show list of posts from followed sites in the reader
2. Notice save for later button is shown even for posts from self-hosted non-jetpack sites (eg. posts from http://blog.dilbert.com/)
3. Open detail of a post from self-hosted non-jetpack site
4. Notice the save for later button is also shown
5. Save the post
6. Go to saved posts list and make sure the post is there