### PR TITLE
Retain and restore when reader is refreshing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -58,6 +58,7 @@ public class ReaderConstants {
     static final String KEY_FIRST_LOAD = "first_load";
     static final String KEY_ACTIVITY_TITLE = "activity_title";
     static final String KEY_TRACKED_POSITIONS = "tracked_positions";
+    static final String KEY_IS_REFRESHING = "is_refreshing";
     static final String KEY_ACTIVE_SEARCH_TAB = "active_search_tab";
 
     static final String KEY_ALREADY_TRACKED_GLOBAL_RELATED_POSTS = "already_tracked_global_related_posts";

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -53,6 +53,7 @@ public class ReaderConstants {
     static final String KEY_FIRST_LOAD = "first_load";
     static final String KEY_ACTIVITY_TITLE = "activity_title";
     static final String KEY_TRACKED_POSITIONS = "tracked_positions";
+    static final String KEY_IS_REFRESHING = "is_refreshing";
 
     static final String KEY_ALREADY_TRACKED_GLOBAL_RELATED_POSTS = "already_tracked_global_related_posts";
     static final String KEY_ALREADY_TRACKED_LOCAL_RELATED_POSTS = "already_tracked_local_related_posts";

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -461,6 +461,7 @@ public class ReaderPostListFragment extends Fragment
         outState.putBoolean(ReaderConstants.KEY_WAS_PAUSED, mWasPaused);
         outState.putBoolean(ReaderConstants.KEY_ALREADY_UPDATED, mHasUpdatedPosts);
         outState.putBoolean(ReaderConstants.KEY_FIRST_LOAD, mFirstLoad);
+        outState.putBoolean(ReaderConstants.KEY_IS_REFRESHING, mRecyclerView.isRefreshing());
         outState.putInt(ReaderConstants.KEY_RESTORE_POSITION, getCurrentPosition());
         outState.putSerializable(ReaderConstants.ARG_POST_LIST_TYPE, getPostListType());
 
@@ -598,6 +599,11 @@ public class ReaderPostListFragment extends Fragment
         // progress bar that appears when loading more posts
         mProgress = rootView.findViewById(R.id.progress_footer);
         mProgress.setVisibility(View.GONE);
+
+        if (savedInstanceState != null && savedInstanceState.getBoolean(ReaderConstants.KEY_IS_REFRESHING)) {
+            mIsUpdating = true;
+            mRecyclerView.setRefreshing(true);
+        }
 
         return rootView;
     }
@@ -1066,7 +1072,6 @@ public class ReaderPostListFragment extends Fragment
             if (!isAdded()) {
                 return;
             }
-            mRecyclerView.setRefreshing(false);
             if (isEmpty) {
                 setEmptyTitleAndDescription(false);
                 showEmptyView();


### PR DESCRIPTION
Fixes #7882 - ensures that the reader RecyclerView's refreshing state is retained and restored after rotation, and that the correct empty message is displayed if there are no results yet while performing a search.

To test:
* Perform a search in the reader
* Rotate the device before the search completes
* Observe that the recycler continues to show that it's refreshing

For best results, I recommend testing this on an emulator with the networking speed reduced.