### PR TITLE
Fix save for later icon

### DIFF
--- a/WordPress/src/main/res/drawable/ic_bookmark_grey_disabled_18dp.xml
+++ b/WordPress/src/main/res/drawable/ic_bookmark_grey_disabled_18dp.xml
@@ -1,13 +1,10 @@
-<vector
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="18dp"
-    android:width="18dp"
-    android:viewportHeight="24.0"
-    android:viewportWidth="24.0" >
-
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="18dp"
+        android:height="18dp"
+        android:viewportHeight="24"
+        android:viewportWidth="24">
     <path
         android:fillColor="@color/grey_disabled"
-        android:pathData="M17,3H7C5.895,3 5,3.896 5,5v16l7,-4l7,4V5C19,3.896 18.104,3 17,3z" >
-    </path>
-
+        android:pathData="M17,5v12.554l-5,-2.857l-5,2.857V5H17M17,3H7C5.895,3 5,3.896 5,5v16l7,-4l7,4V5C19,3.896 18.104,3 17,3L17,3z"/>
 </vector>
+

--- a/WordPress/src/main/res/drawable/ic_bookmark_grey_min_18dp.xml
+++ b/WordPress/src/main/res/drawable/ic_bookmark_grey_min_18dp.xml
@@ -1,13 +1,9 @@
-<vector
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="18dp"
-    android:width="18dp"
-    android:viewportHeight="24.0"
-    android:viewportWidth="24.0" >
-
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="18dp"
+        android:height="18dp"
+        android:viewportHeight="24"
+        android:viewportWidth="24">
     <path
         android:fillColor="@color/grey_text_min"
-        android:pathData="M17,3H7C5.895,3 5,3.896 5,5v16l7,-4l7,4V5C19,3.896 18.104,3 17,3z" >
-    </path>
-
+        android:pathData="M17,5v12.554l-5,-2.857l-5,2.857V5H17M17,3H7C5.895,3 5,3.896 5,5v16l7,-4l7,4V5C19,3.896 18.104,3 17,3L17,3z"/>
 </vector>


### PR DESCRIPTION
Fixes #7895 

Save for latter button uses outline version of the icon <img width="21" alt="outline" src="https://user-images.githubusercontent.com/2261188/41333134-f3db6c30-6ee0-11e8-9285-4c1a7698ab59.png"> instead of <img width="26" alt="bug" src="https://user-images.githubusercontent.com/2261188/41333138-f5eae8f2-6ee0-11e8-86c2-d8ab30063cb6.png">.


To Test
1. Go to reader
2. Notice the save for later button uses outline version of the icon
