### PR TITLE
Issue/7892 save locally dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -16,6 +16,7 @@ import android.text.TextUtils;
 import android.view.MenuItem;
 import android.view.View;
 
+import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
@@ -30,6 +31,8 @@ import org.wordpress.android.models.Note;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.comments.CommentsListFragment.OnCommentSelectedListener;
 import org.wordpress.android.ui.notifications.NotificationFragment;
+import org.wordpress.android.ui.posts.BasicFragmentDialog;
+import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
 import org.wordpress.android.util.AccessibilityUtils;
@@ -41,7 +44,8 @@ import javax.inject.Inject;
 
 public class CommentsActivity extends AppCompatActivity
         implements OnCommentSelectedListener,
-        NotificationFragment.OnPostClickListener {
+        NotificationFragment.OnPostClickListener,
+        BasicFragmentDialog.BasicDialogPositiveClickInterface {
     static final String KEY_AUTO_REFRESHED = "has_auto_refreshed";
     static final String KEY_EMPTY_VIEW_MESSAGE = "empty_view_message";
     private static final String SAVED_COMMENTS_STATUS_TYPE = "saved_comments_status_type";
@@ -307,5 +311,13 @@ public class CommentsActivity extends AppCompatActivity
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void onPositiveClicked(@NotNull String instanceTag) {
+        Fragment fragmentById = getSupportFragmentManager().findFragmentById(R.id.layout_fragment_container);
+        if (fragmentById instanceof BasicFragmentDialog.BasicDialogPositiveClickInterface) {
+            ((BasicDialogPositiveClickInterface) fragmentById).onPositiveClicked(instanceTag);
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -17,6 +17,7 @@ import android.view.View;
 import android.view.WindowManager;
 import android.widget.ProgressBar;
 
+import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -36,6 +37,8 @@ import org.wordpress.android.ui.notifications.blocks.NoteBlockRangeType;
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter;
 import org.wordpress.android.ui.notifications.utils.NotificationsActions;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
+import org.wordpress.android.ui.posts.BasicFragmentDialog;
+import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
@@ -66,7 +69,8 @@ import static org.wordpress.android.models.Note.NOTE_FOLLOW_TYPE;
 import static org.wordpress.android.models.Note.NOTE_LIKE_TYPE;
 
 public class NotificationsDetailActivity extends AppCompatActivity implements
-        CommentActions.OnNoteCommentActionListener {
+        CommentActions.OnNoteCommentActionListener,
+        BasicFragmentDialog.BasicDialogPositiveClickInterface {
     private static final String ARG_TITLE = "activityTitle";
     private static final String DOMAIN_WPCOM = "wordpress.com";
 
@@ -463,6 +467,14 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
             // no note found
             showErrorToastAndFinish();
             return;
+        }
+    }
+
+    @Override
+    public void onPositiveClicked(@NotNull String instanceTag) {
+        Fragment fragment = mAdapter.getItem(mViewPager.getCurrentItem());
+        if (fragment instanceof BasicFragmentDialog.BasicDialogPositiveClickInterface) {
+            ((BasicDialogPositiveClickInterface) fragment).onPositiveClicked(instanceTag);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -125,6 +125,8 @@ public class AppPrefs {
         // When we need to show the async promo dialog
         ASYNC_PROMO_REQUIRED,
 
+        BOOKMARKS_SAVED_LOCALLY_DIALOG_SHOWN,
+
         // When we need to show the new image optimize promo dialog
         IMAGE_OPTIMIZE_PROMO_REQUIRED,
 
@@ -462,6 +464,14 @@ public class AppPrefs {
 
     public static void setAsyncPromoRequired(boolean required) {
         setBoolean(UndeletablePrefKey.ASYNC_PROMO_REQUIRED, required);
+    }
+
+    public static boolean shouldShowBookmarksSavedLocallyDialog() {
+        return getBoolean(UndeletablePrefKey.BOOKMARKS_SAVED_LOCALLY_DIALOG_SHOWN, true);
+    }
+
+    public static void setBookmarksSavedLocallyDialogShown() {
+        setBoolean(UndeletablePrefKey.BOOKMARKS_SAVED_LOCALLY_DIALOG_SHOWN, false);
     }
 
     public static boolean isImageOptimizePromoRequired() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -547,9 +547,9 @@ public class ReaderPostDetailFragment extends Fragment
 
     private void showBookmarksSavedLocallyDialog() {
         BasicFragmentDialog basicFragmentDialog = new BasicFragmentDialog();
-        basicFragmentDialog.initialize(BOOKMARKS_SAVED_LOCALLY_DIALOG, "Save Posts for Later",
-                "You can now save posts for later! For this version, saved posts are only saved to "
-                + "this device, but we are working on adding cross-device syncing!",
+        basicFragmentDialog.initialize(BOOKMARKS_SAVED_LOCALLY_DIALOG,
+                getString(R.string.reader_save_posts_locally_dialog_title),
+                getString(R.string.reader_save_posts_locally_dialog_message),
                 getString(R.string.dialog_button_ok),
                 null, null);
         basicFragmentDialog.show(getFragmentManager(), BOOKMARKS_SAVED_LOCALLY_DIALOG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -26,6 +26,7 @@ import android.widget.TextView;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
+import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -44,6 +45,8 @@ import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderPostDiscoverData;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.main.WPMainActivity;
+import org.wordpress.android.ui.posts.BasicFragmentDialog;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher.OpenUrlType;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher.PhotoViewerOption;
 import org.wordpress.android.ui.reader.ReaderInterfaces.AutoHideToolbarListener;
@@ -99,7 +102,9 @@ public class ReaderPostDetailFragment extends Fragment
         ReaderCustomViewListener,
         ReaderInterfaces.OnFollowListener,
         ReaderWebViewPageFinishedListener,
-        ReaderWebViewUrlClickListener {
+        ReaderWebViewUrlClickListener,
+        BasicFragmentDialog.BasicDialogPositiveClickInterface {
+    private static final String BOOKMARKS_SAVED_LOCALLY_DIALOG = "bookmarks_saved_locally_dialog";
     private long mPostId;
     private long mBlogId;
     private DirectOperation mDirectOperation;
@@ -526,12 +531,37 @@ public class ReaderPostDetailFragment extends Fragment
         } else {
             ReaderPostActions.addToBookmarked(mPost);
             AnalyticsTracker.track(AnalyticsTracker.Stat.READER_POST_SAVED_FROM_DETAILS);
-            showBookmarkSnackbar();
+            if (AppPrefs.shouldShowBookmarksSavedLocallyDialog()) {
+                AppPrefs.setBookmarksSavedLocallyDialogShown();
+                showBookmarksSavedLocallyDialog();
+            } else {
+                // show snackbar when not in saved posts list
+                showBookmarkSnackbar();
+            }
         }
 
         mPost = ReaderPostTable.getBlogPost(mPost.blogId, mPost.postId, false);
 
         updateBookmarkView();
+    }
+
+    private void showBookmarksSavedLocallyDialog() {
+        BasicFragmentDialog basicFragmentDialog = new BasicFragmentDialog();
+        basicFragmentDialog.initialize(BOOKMARKS_SAVED_LOCALLY_DIALOG, "Save Posts for Later",
+                "You can now save posts for later! For this version, saved posts are only saved to "
+                + "this device, but we are working on adding cross-device syncing!",
+                getString(R.string.dialog_button_ok),
+                null, null);
+        basicFragmentDialog.show(getFragmentManager(), BOOKMARKS_SAVED_LOCALLY_DIALOG);
+    }
+
+    @Override
+    public void onPositiveClicked(@NotNull String instanceTag) {
+        switch (instanceTag) {
+            case BOOKMARKS_SAVED_LOCALLY_DIALOG:
+            showBookmarkSnackbar();
+            break;
+        }
     }
 
     private void showBookmarkSnackbar() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1111,9 +1111,8 @@ public class ReaderPostListFragment extends Fragment
 
     private void showBookmarksSavedLocallyDialog() {
         mBookmarksSavedLocallyDialog = new AlertDialog.Builder(getActivity())
-                .setTitle("Save Posts for Later")
-                .setMessage("You can now save posts for later! For this version, saved posts are only saved to "
-                            + "this device, but we are working on adding cross-device syncing!")
+                .setTitle(getString(R.string.reader_save_posts_locally_dialog_title))
+                .setMessage(getString(R.string.reader_save_posts_locally_dialog_message))
                 .setPositiveButton(R.string.dialog_button_ok, new OnClickListener() {
                     @Override public void onClick(DialogInterface dialog, int which) {
                         showBookmarkSnackbar();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -21,6 +21,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ProgressBar;
 
+import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -31,6 +32,7 @@ import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.WPLaunchActivity;
+import org.wordpress.android.ui.posts.BasicFragmentDialog;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
@@ -74,7 +76,8 @@ import de.greenrobot.event.EventBus;
  * Will also handle jumping to the comments section, liking a commend and liking a post directly
  */
 public class ReaderPostPagerActivity extends AppCompatActivity
-        implements ReaderInterfaces.AutoHideToolbarListener {
+        implements ReaderInterfaces.AutoHideToolbarListener,
+        BasicFragmentDialog.BasicDialogPositiveClickInterface {
     /**
      * Type of URL intercepted
      */
@@ -964,6 +967,14 @@ public class ReaderPostPagerActivity extends AppCompatActivity
 
         if (requestCode == RequestCodes.DO_LOGIN && resultCode == Activity.RESULT_OK) {
             mBackFromLogin = true;
+        }
+    }
+
+    @Override
+    public void onPositiveClicked(@NotNull String instanceTag) {
+        ReaderPostDetailFragment fragment = getActiveDetailFragment();
+        if (fragment != null) {
+            fragment.onPositiveClicked(instanceTag);
         }
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1502,7 +1502,7 @@
 
     <!-- dialogs -->
     <string name="reader_save_posts_locally_dialog_title">Save Posts for Later</string>
-    <string name="reader_save_posts_locally_dialog_message">Save this post, and come back to read it whenever you\'d like. It will only be available here — saved posts don\'t sync to your other devices. (Yet! We\'re working on it.)</string>
+    <string name="reader_save_posts_locally_dialog_message">Save this post, and come back to read it whenever you\'d like. It will only be available on this device — saved posts don\'t sync to your other devices. (Yet! We\'re working on it.)</string>
 
     <!-- connection bar which appears on main activity when there's no connection -->
     <string name="connectionbar_no_connection">No connection</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1500,6 +1500,10 @@
     <string name="reader_discover_attribution_blog">Originally posted on %s</string>
     <string name="reader_discover_visit_blog">Visit %s</string>
 
+    <!-- dialogs -->
+    <string name="reader_save_posts_locally_dialog_title">Save Posts for Later</string>
+    <string name="reader_save_posts_locally_dialog_message">You can now save posts for later! For this version, saved posts are only saved to this device, but we are working on adding cross-device syncing!</string>
+
     <!-- connection bar which appears on main activity when there's no connection -->
     <string name="connectionbar_no_connection">No connection</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1502,7 +1502,7 @@
 
     <!-- dialogs -->
     <string name="reader_save_posts_locally_dialog_title">Save Posts for Later</string>
-    <string name="reader_save_posts_locally_dialog_message">You can now save posts for later! For this version, saved posts are only saved to this device, but we are working on adding cross-device syncing!</string>
+    <string name="reader_save_posts_locally_dialog_message">Save this post, and come back to read it whenever you\'d like. It will only be available here — saved posts don\'t sync to your other devices. (Yet! We\'re working on it.)</string>
 
     <!-- connection bar which appears on main activity when there's no connection -->
     <string name="connectionbar_no_connection">No connection</string>


### PR DESCRIPTION
Fixes #7892 

Show a warning dialog informing the user that posts are saved just locally when they save a post for the first time.

![screenshot_1528880124](https://user-images.githubusercontent.com/2261188/41343847-f352343c-6eff-11e8-86da-54ce7b6ae049.png)

To test:
1. Login
2. Go to reader
3. Click on the "save post" button
4. Dialog should be shown
5. Click on the "save post" button of another post
6. Dialog should not be shown
---
1. Clear app data
2. Go to reader
3. Open a post detail
4. Click on the "save post" button
5. Dialog should be shown

Note:
Dialog in the Reader list is not retained after configuration changes - ReaderFragment extends native android fragment instead of support fragment, so we can't use the BasicDialogFragment. 
Retaining basic alert dialog is also tricky, since we recreate the fragment from scratch after configuration change (without using savedInstanceState). 


cc @iamthomasbishop 