### PR TITLE
Replace unicode em dash with — so it doesn't cause troubles in GlotPress

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1484,7 +1484,7 @@
     <string name="reader_empty_followed_blogs_no_recent_posts_title">No recent posts</string>
     <string name="reader_empty_followed_blogs_no_recent_posts_description">The sites you follow haven\'t posted anything recently</string>
     <string name="reader_empty_posts_liked">You haven\'t liked any posts</string>
-    <string name="reader_empty_saved_posts_title">No posts saved \u2014 yet!</string>
+    <string name="reader_empty_saved_posts_title">No posts saved — yet!</string>
     <string name="reader_empty_saved_posts_description">Tap %s to save a post to your list.</string>
     <string name="reader_empty_comments">No comments yet</string>
     <string name="reader_empty_posts_in_blog">This blog is empty</string>


### PR DESCRIPTION
The unicode `\u2014` might confuse translators or even cause some troubles while exporting string resources. This PR replaces `/u2014` with `—`.



