### PR TITLE
Fix talkback bottom navigation bar announcements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -83,7 +83,7 @@ class WPMainNavigationView @JvmOverloads constructor(
                 val txtLabel = customView.findViewById<TextView>(R.id.nav_label)
                 val imgIcon = customView.findViewById<ImageView>(R.id.nav_icon)
                 txtLabel.text = getTitleForPosition(i)
-                txtLabel.contentDescription = getContentDescriptionForPosition(i)
+                customView.contentDescription = getContentDescriptionForPosition(i)
                 imgIcon.setImageResource(getDrawableResForPosition(i))
             }
 


### PR DESCRIPTION
Fixes #7894 

Talkback announces correct accessibility description for items in the bottom navigation bar.
```My Site. View your site and manage it, including stats.
Me. View your profile and make changes.
New post. Write a new post.
Reader. Follow content from other sites.
Notifications. Manage your notifications.
```

To test:
1. Turn on TalkBack in the Accessibility Settings (system settings)
2. Open the app and click on each item in the bottom navigation bar
3. Make sure the correct description is announced
