### PR TITLE
Fix invalid undo item in saved posts list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -15,6 +15,7 @@ import android.text.TextUtils;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.datasets.ReaderPostTable;
 import org.wordpress.android.datasets.ReaderTagTable;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -170,6 +171,7 @@ public class ActivityLauncher {
         if (!ReaderTagTable.getBookmarkTags().isEmpty()) {
             AppPrefs.setReaderTag(ReaderTagTable.getBookmarkTags().get(0));
         }
+        ReaderPostTable.purgeUnbookmarkedPostsWithBookmarkTag();
 
         Intent intent = new Intent(context, WPMainActivity.class);
         intent.putExtra(WPMainActivity.ARG_OPEN_PAGE, WPMainActivity.ARG_READER);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -568,6 +568,8 @@ public class ReaderPostListFragment extends Fragment
                         case BLOG_PREVIEW:
                             updatePostsInCurrentBlogOrFeed(UpdateAction.REQUEST_NEWER);
                             break;
+                        case SEARCH_RESULTS:
+                            break;
                     }
                     // make sure swipe-to-refresh progress shows since this is a manual refresh
                     mRecyclerView.setRefreshing(true);
@@ -1504,6 +1506,10 @@ public class ReaderPostListFragment extends Fragment
             case TAG_PREVIEW:
                 mTagPreviewHistory.push(tag.getTagSlug());
                 break;
+            case BLOG_PREVIEW:
+                break;
+            case SEARCH_RESULTS:
+                break;
         }
 
         getPostAdapter().setCurrentTag(tag);
@@ -1910,7 +1916,7 @@ public class ReaderPostListFragment extends Fragment
             return;
         }
         // clear 'post removed from saved posts' undo items
-        if (getPostListType() == ReaderPostListType.TAG_FOLLOWED && getCurrentTag().isBookmarked()) {
+        if (getPostListType() == ReaderPostListType.TAG_FOLLOWED) {
             ReaderPostTable.purgeUnbookmarkedPostsWithBookmarkTag();
         }
 


### PR DESCRIPTION
Fixes #7288 

Before this PR, when a post was unsaved in for example "Followed sites" list and the user navigated to "Saved posts list", an undo item was displayed.

After this PR, when a post is unsaved in other list than "Saved posts list", an undo item is not created.

To test
1. Go to Reader - Followed sites list
2. Save and unsave a post
3. Go to saved posts list
4. Observe an undo item is not displayed

Note: Sorry for the misleading commit message. However, I don't know if there is a way to change already pushed commit without a force push, which I don't want to use.
