### PR TITLE
Use glide instead of Volley on ReaderPostList screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ImageManager.kt
@@ -1,0 +1,103 @@
+package org.wordpress.android.ui
+
+import android.graphics.Bitmap
+import android.graphics.drawable.Drawable
+import android.support.annotation.DrawableRes
+import android.widget.ImageView
+import android.widget.ImageView.ScaleType
+import com.bumptech.glide.request.RequestOptions
+import org.wordpress.android.modules.GlideApp
+import org.wordpress.android.modules.GlideRequest
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Singleton for asynchronous image fetching/loading with support for placeholders, transformations and more.
+ */
+@Singleton
+class ImageManager @Inject constructor() {
+    @JvmOverloads
+    fun load(imageView: ImageView, imgUrl: String, @DrawableRes placeholder: Int? = null, scaleType: ImageView.ScaleType) {
+        val request = GlideApp.with(imageView.context)
+                .load(imgUrl)
+                .let { if (placeholder != null) it.fallback(placeholder) else it }
+        applyScaleType(request, scaleType)
+        request.into(imageView)
+    }
+
+    fun load(imageView: ImageView, bitmap: Bitmap, scaleType: ImageView.ScaleType) {
+        val request = GlideApp.with(imageView.context)
+                .load(bitmap)
+        applyScaleType(request, scaleType)
+        request.into(imageView)
+    }
+
+    fun load(imageView: ImageView, imgUrl: Drawable, scaleType: ImageView.ScaleType) {
+        val request = GlideApp.with(imageView.context)
+                .load(imgUrl)
+        applyScaleType(request, scaleType)
+        request.into(imageView)
+    }
+
+    @JvmOverloads
+    fun loadIntoCircle(imageView: ImageView, imgUrl: String, @DrawableRes placeholder: Int? = null) {
+        val request = GlideApp.with(imageView.context)
+                .load(imgUrl)
+                .let { if (placeholder != null) it.fallback(placeholder) else it }
+                .apply(RequestOptions().circleCrop())
+        request.into(imageView)
+    }
+
+
+    private fun applyScaleType(request: GlideRequest<Drawable>, scaleType: ScaleType) {
+        when (scaleType) {
+            ImageView.ScaleType.CENTER -> {
+            }// default
+            ImageView.ScaleType.MATRIX -> AppLog.e(AppLog.T.UTILS, "ScaleType matrix is not supported.")
+            ImageView.ScaleType.CENTER_CROP -> request.centerCrop()
+            ImageView.ScaleType.CENTER_INSIDE -> request.centerInside()
+            ImageView.ScaleType.FIT_CENTER -> request.fitCenter()
+            ImageView.ScaleType.FIT_END -> AppLog.e(AppLog.T.UTILS, "ScaleType fitEnd is not supported.")
+            ImageView.ScaleType.FIT_START -> AppLog.e(AppLog.T.UTILS, "ScaleType fitStart is not supported.")
+            ImageView.ScaleType.FIT_XY -> AppLog.e(AppLog.T.UTILS, "ScaleType fitXY is not supported.")
+        }
+    }
+
+    @Deprecated("Object for backward compatibility with code which doesn't support DI")
+    companion object {
+        @JvmStatic
+        @Deprecated("Use injected ImageManager",
+                ReplaceWith("imageManager.load(imageView, imgUrl, placeholder, scaleType)",
+                        "org.wordpress.android.ui.ImageManager"))
+        @JvmOverloads
+        fun loadImage(imageView: ImageView, imgUrl: String, @DrawableRes placeholder: Int? = null, scaleType: ImageView.ScaleType) {
+            ImageManager().load(imageView, imgUrl, placeholder, scaleType)
+        }
+
+        @JvmStatic
+        @Deprecated("Use injected ImageManager",
+                ReplaceWith("imageManager.load(imageView, bitmap, placeholder, scaleType)",
+                        "org.wordpress.android.ui.ImageManager"))
+        fun loadImage(imageView: ImageView, bitmap: Bitmap, scaleType: ImageView.ScaleType) {
+            ImageManager().load(imageView, bitmap, scaleType)
+        }
+
+        @JvmStatic
+        @Deprecated("Use injected ImageManager",
+                ReplaceWith("imageManager.load(imageView, drawable, placeholder, scaleType)",
+                        "org.wordpress.android.ui.ImageManager"))
+        fun loadImage(imageView: ImageView, drawable: Drawable, scaleType: ImageView.ScaleType) {
+            ImageManager().load(imageView, drawable, scaleType)
+        }
+
+        @JvmStatic
+        @Deprecated("Use injected ImageManager",
+                ReplaceWith("imageManager.loadIntoCircle(imageView, imgUrl, placeholder)",
+                        "org.wordpress.android.ui.ImageManager"))
+        @JvmOverloads
+        fun loadImageIntoCircle(imageView: ImageView, imgUrl: String, @DrawableRes placeholder: Int? = null) {
+            ImageManager().loadIntoCircle(imageView, imgUrl, placeholder)
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ImageManager.kt
@@ -49,6 +49,9 @@ class ImageManager @Inject constructor() {
         request.into(imageView)
     }
 
+    fun cancelRequestAndClearImageView(imageView: ImageView) {
+        GlideApp.with(imageView.context).clear(imageView)
+    }
 
     private fun applyScaleType(request: GlideRequest<Drawable>, scaleType: ScaleType) {
         when (scaleType) {
@@ -99,5 +102,15 @@ class ImageManager @Inject constructor() {
         fun loadImageIntoCircle(imageView: ImageView, imgUrl: String, @DrawableRes placeholder: Int? = null) {
             ImageManager().loadIntoCircle(imageView, imgUrl, placeholder)
         }
+
+        @JvmStatic
+        @Deprecated("Use injected ImageManager",
+                ReplaceWith("imageManager.clear(imageView)",
+                        "org.wordpress.android.ui.ImageManager"))
+        fun clear(imageView: ImageView) {
+            ImageManager().cancelRequestAndClearImageView(imageView)
+        }
+
+
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ImageManager.kt
@@ -5,7 +5,7 @@ import android.graphics.drawable.Drawable
 import android.support.annotation.DrawableRes
 import android.widget.ImageView
 import android.widget.ImageView.ScaleType
-import com.bumptech.glide.request.RequestOptions
+import android.widget.ImageView.ScaleType.CENTER
 import org.wordpress.android.modules.GlideApp
 import org.wordpress.android.modules.GlideRequest
 import org.wordpress.android.util.AppLog
@@ -22,26 +22,28 @@ class ImageManager @Inject constructor() {
         imageView: ImageView,
         imgUrl: String,
         @DrawableRes placeholder: Int? = null,
-        scaleType: ImageView.ScaleType
+        scaleType: ImageView.ScaleType = CENTER
     ) {
-        val request = GlideApp.with(imageView.context)
+        var request = GlideApp.with(imageView.context)
                 .load(imgUrl)
                 .let { if (placeholder != null) it.fallback(placeholder) else it }
-        applyScaleType(request, scaleType)
+        request = applyScaleType(request, scaleType)
         request.into(imageView)
     }
 
-    fun load(imageView: ImageView, bitmap: Bitmap, scaleType: ImageView.ScaleType) {
-        val request = GlideApp.with(imageView.context)
+    @JvmOverloads
+    fun load(imageView: ImageView, bitmap: Bitmap, scaleType: ImageView.ScaleType = CENTER) {
+        var request = GlideApp.with(imageView.context)
                 .load(bitmap)
-        applyScaleType(request, scaleType)
+        request = applyScaleType(request, scaleType)
         request.into(imageView)
     }
 
-    fun load(imageView: ImageView, imgUrl: Drawable, scaleType: ImageView.ScaleType) {
-        val request = GlideApp.with(imageView.context)
+    @JvmOverloads
+    fun load(imageView: ImageView, imgUrl: Drawable, scaleType: ImageView.ScaleType = CENTER) {
+        var request = GlideApp.with(imageView.context)
                 .load(imgUrl)
-        applyScaleType(request, scaleType)
+        request = applyScaleType(request, scaleType)
         request.into(imageView)
     }
 
@@ -50,7 +52,7 @@ class ImageManager @Inject constructor() {
         val request = GlideApp.with(imageView.context)
                 .load(imgUrl)
                 .let { if (placeholder != null) it.fallback(placeholder) else it }
-                .apply(RequestOptions().circleCrop())
+                .circleCrop()
         request.into(imageView)
     }
 
@@ -58,17 +60,22 @@ class ImageManager @Inject constructor() {
         GlideApp.with(imageView.context).clear(imageView)
     }
 
-    private fun applyScaleType(request: GlideRequest<Drawable>, scaleType: ScaleType) {
-        when (scaleType) {
-            ImageView.ScaleType.CENTER -> {
-            } // default
-            ImageView.ScaleType.MATRIX -> AppLog.e(AppLog.T.UTILS, "ScaleType matrix is not supported.")
+    private fun applyScaleType(
+        request: GlideRequest<Drawable>,
+        scaleType: ScaleType
+    ): GlideRequest<Drawable> {
+        return when (scaleType) {
             ImageView.ScaleType.CENTER_CROP -> request.centerCrop()
             ImageView.ScaleType.CENTER_INSIDE -> request.centerInside()
             ImageView.ScaleType.FIT_CENTER -> request.fitCenter()
-            ImageView.ScaleType.FIT_END -> AppLog.e(AppLog.T.UTILS, "ScaleType fitEnd is not supported.")
-            ImageView.ScaleType.FIT_START -> AppLog.e(AppLog.T.UTILS, "ScaleType fitStart is not supported.")
-            ImageView.ScaleType.FIT_XY -> AppLog.e(AppLog.T.UTILS, "ScaleType fitXY is not supported.")
+            ImageView.ScaleType.CENTER -> request
+            ImageView.ScaleType.FIT_END,
+            ImageView.ScaleType.FIT_START,
+            ImageView.ScaleType.FIT_XY,
+            ImageView.ScaleType.MATRIX -> {
+                AppLog.e(AppLog.T.UTILS, String.format("ScaleType %s is not supported.", scaleType.toString()))
+                request
+            }
         }
     }
 
@@ -92,7 +99,8 @@ class ImageManager @Inject constructor() {
         @Deprecated("Use injected ImageManager",
                 ReplaceWith("imageManager.load(imageView, bitmap, placeholder, scaleType)",
                         "org.wordpress.android.ui.ImageManager"))
-        fun loadImage(imageView: ImageView, bitmap: Bitmap, scaleType: ImageView.ScaleType) {
+        @JvmOverloads
+        fun loadImage(imageView: ImageView, bitmap: Bitmap, scaleType: ImageView.ScaleType = CENTER) {
             ImageManager().load(imageView, bitmap, scaleType)
         }
 
@@ -100,7 +108,8 @@ class ImageManager @Inject constructor() {
         @Deprecated("Use injected ImageManager",
                 ReplaceWith("imageManager.load(imageView, drawable, placeholder, scaleType)",
                         "org.wordpress.android.ui.ImageManager"))
-        fun loadImage(imageView: ImageView, drawable: Drawable, scaleType: ImageView.ScaleType) {
+        @JvmOverloads
+        fun loadImage(imageView: ImageView, drawable: Drawable, scaleType: ImageView.ScaleType = CENTER) {
             ImageManager().load(imageView, drawable, scaleType)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ImageManager.kt
@@ -18,7 +18,12 @@ import javax.inject.Singleton
 @Singleton
 class ImageManager @Inject constructor() {
     @JvmOverloads
-    fun load(imageView: ImageView, imgUrl: String, @DrawableRes placeholder: Int? = null, scaleType: ImageView.ScaleType) {
+    fun load(
+        imageView: ImageView,
+        imgUrl: String,
+        @DrawableRes placeholder: Int? = null,
+        scaleType: ImageView.ScaleType
+    ) {
         val request = GlideApp.with(imageView.context)
                 .load(imgUrl)
                 .let { if (placeholder != null) it.fallback(placeholder) else it }
@@ -56,7 +61,7 @@ class ImageManager @Inject constructor() {
     private fun applyScaleType(request: GlideRequest<Drawable>, scaleType: ScaleType) {
         when (scaleType) {
             ImageView.ScaleType.CENTER -> {
-            }// default
+            } // default
             ImageView.ScaleType.MATRIX -> AppLog.e(AppLog.T.UTILS, "ScaleType matrix is not supported.")
             ImageView.ScaleType.CENTER_CROP -> request.centerCrop()
             ImageView.ScaleType.CENTER_INSIDE -> request.centerInside()
@@ -74,7 +79,12 @@ class ImageManager @Inject constructor() {
                 ReplaceWith("imageManager.load(imageView, imgUrl, placeholder, scaleType)",
                         "org.wordpress.android.ui.ImageManager"))
         @JvmOverloads
-        fun loadImage(imageView: ImageView, imgUrl: String, @DrawableRes placeholder: Int? = null, scaleType: ImageView.ScaleType) {
+        fun loadImage(
+            imageView: ImageView,
+            imgUrl: String,
+            @DrawableRes placeholder: Int? = null,
+            scaleType: ImageView.ScaleType
+        ) {
             ImageManager().load(imageView, imgUrl, placeholder, scaleType)
         }
 
@@ -110,7 +120,5 @@ class ImageManager @Inject constructor() {
         fun clear(imageView: ImageView) {
             ImageManager().cancelRequestAndClearImageView(imageView)
         }
-
-
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -69,6 +69,7 @@ import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.EmptyViewMessageType;
 import org.wordpress.android.ui.FilteredRecyclerView;
+import org.wordpress.android.ui.ImageManager;
 import org.wordpress.android.ui.main.BottomNavController;
 import org.wordpress.android.ui.main.MainToolbarFragment;
 import org.wordpress.android.ui.main.WPMainActivity;
@@ -174,6 +175,7 @@ public class ReaderPostListFragment extends Fragment
     @Inject AccountStore mAccountStore;
     @Inject ReaderStore mReaderStore;
     @Inject Dispatcher mDispatcher;
+    @Inject ImageManager mImageManager;
 
     private static class HistoryStack extends Stack<String> {
         private final String mKeyName;
@@ -567,6 +569,8 @@ public class ReaderPostListFragment extends Fragment
                             break;
                         case BLOG_PREVIEW:
                             updatePostsInCurrentBlogOrFeed(UpdateAction.REQUEST_NEWER);
+                            break;
+                        case SEARCH_RESULTS:
                             break;
                     }
                     // make sure swipe-to-refresh progress shows since this is a manual refresh
@@ -1291,7 +1295,7 @@ public class ReaderPostListFragment extends Fragment
         }
     };
 
-    private ReaderInterfaces.OnPostBookmarkedListener mOnPostBookmarkedListener =
+    private final ReaderInterfaces.OnPostBookmarkedListener mOnPostBookmarkedListener =
             new ReaderInterfaces.OnPostBookmarkedListener() {
                 @Override public void onBookmarkedStateChanged(boolean isBookmarked, long blogId, long postId,
                                                                boolean isCachingActionRequired) {
@@ -1413,7 +1417,7 @@ public class ReaderPostListFragment extends Fragment
         if (mPostAdapter == null) {
             AppLog.d(T.READER, "reader post list > creating post adapter");
             Context context = WPActivityUtils.getThemedContext(getActivity());
-            mPostAdapter = new ReaderPostAdapter(context, getPostListType());
+            mPostAdapter = new ReaderPostAdapter(context, getPostListType(), mImageManager);
             mPostAdapter.setOnFollowListener(this);
             mPostAdapter.setOnPostSelectedListener(this);
             mPostAdapter.setOnPostPopupListener(this);
@@ -1503,6 +1507,10 @@ public class ReaderPostListFragment extends Fragment
                 break;
             case TAG_PREVIEW:
                 mTagPreviewHistory.push(tag.getTagSlug());
+                break;
+            case BLOG_PREVIEW:
+                break;
+            case SEARCH_RESULTS:
                 break;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -571,6 +571,7 @@ public class ReaderPostListFragment extends Fragment
                             updatePostsInCurrentBlogOrFeed(UpdateAction.REQUEST_NEWER);
                             break;
                         case SEARCH_RESULTS:
+                            // no-op
                             break;
                     }
                     // make sure swipe-to-refresh progress shows since this is a manual refresh
@@ -1509,8 +1510,8 @@ public class ReaderPostListFragment extends Fragment
                 mTagPreviewHistory.push(tag.getTagSlug());
                 break;
             case BLOG_PREVIEW:
-                break;
             case SEARCH_RESULTS:
+                // no-op
                 break;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -498,8 +498,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
                     @Override public void showPlaceholder() {
                         mImageManager.load(holder.mImgFeatured, new ColorDrawable(
-                                        ContextCompat.getColor(holder.mImgFeatured.getContext(), R.color.grey_lighten_30)),
-                                ScaleType.CENTER);
+                                        ContextCompat.getColor(holder.mImgFeatured.getContext(), R.color
+                                                .grey_lighten_30)), ScaleType.CENTER);
                     }
 
                     @Override public void cacheThumbnailUrl(String thumbnailUrl) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -392,7 +392,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         R.drawable.ic_placeholder_gravatar_grey_lighten_20_100dp);
 
         mImageManager.load(holder.mImgBlavatar, GravatarUtils.fixGravatarUrl(post.getBlogImageUrl(), mAvatarSzSmall),
-                R.drawable.ic_placeholder_blavatar_grey_lighten_20_40dp, ScaleType.CENTER);
+                R.drawable.ic_placeholder_blavatar_grey_lighten_20_40dp);
 
         holder.mTxtTitle.setText(ReaderXPostUtils.getXPostTitle(post));
         holder.mTxtSubtitle.setText(ReaderXPostUtils.getXPostSubtitleHtml(post));
@@ -440,7 +440,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             holder.mImgAvatarOrBlavatar.setVisibility(View.VISIBLE);
         } else if (post.hasBlogImageUrl()) {
             String imageUrl = GravatarUtils.fixGravatarUrl(post.getBlogImageUrl(), mAvatarSzMedium);
-            mImageManager.load(holder.mImgAvatarOrBlavatar, imageUrl, null, ScaleType.CENTER);
+            mImageManager.load(holder.mImgAvatarOrBlavatar, imageUrl, null);
             holder.mImgAvatarOrBlavatar.setVisibility(View.VISIBLE);
         } else {
             mImageManager.cancelRequestAndClearImageView(holder.mImgAvatarOrBlavatar);
@@ -470,7 +470,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             holder.mTxtPhotoTitle.setVisibility(View.VISIBLE);
             holder.mTxtPhotoTitle.setText(post.getTitle());
             mImageManager.load(holder.mImgFeatured, post.getFeaturedImageForDisplay(mPhotonWidth, mPhotonHeight),
-                    ScaleType.CENTER_CROP);
+                    null, ScaleType.CENTER_CROP);
             holder.mThumbnailStrip.setVisibility(View.GONE);
         } else {
             mImageManager.cancelRequestAndClearImageView(holder.mImgFeatured);
@@ -500,8 +500,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
                     @Override public void showPlaceholder() {
                         mImageManager.load(holder.mImgFeatured, new ColorDrawable(
-                                        ContextCompat.getColor(holder.mImgFeatured.getContext(), R.color
-                                                .grey_lighten_30)), ScaleType.CENTER);
+                                        ContextCompat.getColor(holder.mImgFeatured.getContext(),
+                                                R.color.grey_lighten_30)));
                     }
 
                     @Override public void cacheThumbnailUrl(String thumbnailUrl) {
@@ -513,7 +513,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 titleMargin = mMarginLarge;
             } else if (post.hasFeaturedImage()) {
                 mImageManager.load(holder.mImgFeatured, post.getFeaturedImageForDisplay(mPhotonWidth, mPhotonHeight),
-                        ScaleType.CENTER_CROP);
+                        null, ScaleType.CENTER_CROP);
                 holder.mFramePhoto.setVisibility(View.VISIBLE);
                 holder.mThumbnailStrip.setVisibility(View.GONE);
                 titleMargin = mMarginLarge;
@@ -643,7 +643,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 // BLAVATAR
                 mImageManager.load(postHolder.mImgDiscoverAvatar,
                         GravatarUtils.fixGravatarUrl(discoverData.getAvatarUrl(), mAvatarSzSmall),
-                        R.drawable.ic_placeholder_blavatar_grey_lighten_20_40dp, ScaleType.CENTER);
+                        R.drawable.ic_placeholder_blavatar_grey_lighten_20_40dp);
                 // site picks show "Visit [BlogName]" link - tapping opens the blog preview if
                 // we have the blogId, if not show blog in internal webView
                 postHolder.mLayoutDiscover.setOnClickListener(new View.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -443,6 +443,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             mImageManager.load(holder.mImgAvatarOrBlavatar, imageUrl, null, ScaleType.CENTER);
             holder.mImgAvatarOrBlavatar.setVisibility(View.VISIBLE);
         } else {
+            mImageManager.cancelRequestAndClearImageView(holder.mImgAvatarOrBlavatar);
             holder.mImgAvatarOrBlavatar.setVisibility(View.GONE);
         }
 
@@ -472,6 +473,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     ScaleType.CENTER_CROP);
             holder.mThumbnailStrip.setVisibility(View.GONE);
         } else {
+            mImageManager.cancelRequestAndClearImageView(holder.mImgFeatured);
             holder.mTxtTitle.setVisibility(View.VISIBLE);
             holder.mTxtTitle.setText(post.getTitle());
             holder.mTxtPhotoTitle.setVisibility(View.GONE);
@@ -658,6 +660,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
             case OTHER:
             default:
+                mImageManager.cancelRequestAndClearImageView(postHolder.mImgDiscoverAvatar);
                 // something else, so hide discover section
                 postHolder.mLayoutDiscover.setVisibility(View.GONE);
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
@@ -25,6 +25,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.ReaderThumbnailTable;
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils;
+import org.wordpress.android.ui.reader.utils.ReaderVideoUtils.FetchVideoThumbnailListener;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.ImageUtils;
@@ -154,7 +155,7 @@ public class WPNetworkImageView extends AppCompatImageView {
         } else if (ReaderVideoUtils.isVimeoLink(videoUrl)) {
             // vimeo videos require network request to get thumbnail
             showDefaultImage();
-            ReaderVideoUtils.requestVimeoThumbnail(videoUrl, new ReaderVideoUtils.VideoThumbnailListener() {
+            ReaderVideoUtils.requestVimeoThumbnail(videoUrl, new FetchVideoThumbnailListener() {
                 @Override
                 public void onResponse(boolean successful, String thumbnailUrl) {
                     if (successful) {
@@ -438,6 +439,10 @@ public class WPNetworkImageView extends AppCompatImageView {
             case PLUGIN_ICON:
                 showDefaultPluginIcon();
                 break;
+            case BLAVATAR:
+            case PHOTO:
+            case PHOTO_ROUNDED:
+            case VIDEO:
             default:
                 // light grey box for all others
                 setImageDrawable(new ColorDrawable(getColorRes(R.color.grey_light)));
@@ -468,6 +473,9 @@ public class WPNetworkImageView extends AppCompatImageView {
             case PLUGIN_ICON:
                 showDefaultPluginIcon();
                 break;
+            case PHOTO:
+            case PHOTO_ROUNDED:
+            case VIDEO:
             default:
                 // grey box for all others
                 setImageDrawable(new ColorDrawable(getColorRes(R.color.grey_lighten_30)));

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -34,14 +34,15 @@
             android:paddingEnd="@dimen/reader_card_content_padding"
             android:paddingTop="@dimen/margin_large" >
 
-            <org.wordpress.android.widgets.WPNetworkImageView
+            <ImageView
                 android:id="@+id/image_avatar_or_blavatar"
                 android:layout_centerVertical="true"
                 android:layout_marginEnd="@dimen/margin_large"
                 android:layout_marginRight="@dimen/margin_large"
                 app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
+                android:contentDescription="@string/reader_blavatar_desc"
                 style="@style/ReaderImageView.Avatar" >
-            </org.wordpress.android.widgets.WPNetworkImageView>
+            </ImageView>
 
             <org.wordpress.android.ui.reader.views.ReaderFollowButton
                 android:id="@+id/follow_button"
@@ -108,11 +109,11 @@
             android:layout_marginEnd="@dimen/reader_card_content_padding"
             android:layout_width="match_parent" >
 
-            <org.wordpress.android.widgets.WPNetworkImageView
+            <ImageView
                 android:id="@+id/image_featured"
                 android:contentDescription="@null"
                 style="@style/ReaderImageView.Featured.CardView" >
-            </org.wordpress.android.widgets.WPNetworkImageView>
+            </ImageView>
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/text_photo_title"
@@ -198,15 +199,16 @@
             android:visibility="gone"
             tools:visibility="gone" >
 
-            <org.wordpress.android.widgets.WPNetworkImageView
+            <ImageView
                 android:id="@+id/image_discover_avatar"
                 android:background="?android:selectableItemBackground"
                 android:layout_gravity="center_vertical"
                 android:layout_marginEnd="@dimen/margin_large"
                 android:layout_marginRight="@dimen/margin_large"
                 app:srcCompat="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp"
+                android:contentDescription="@string/reader_blavatar_desc"
                 style="@style/ReaderImageView.Avatar.Small" >
-            </org.wordpress.android.widgets.WPNetworkImageView>
+            </ImageView>
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/text_discover"

--- a/WordPress/src/main/res/layout/reader_cardview_xpost.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_xpost.xml
@@ -28,9 +28,9 @@
 
         <FrameLayout
             android:layout_width="wrap_content"
-            android:paddingLeft="@dimen/reader_xpost_padding_left"
+            android:layout_marginLeft="@dimen/reader_xpost_padding_left"
             android:layout_height="wrap_content"
-            android:paddingStart="@dimen/reader_xpost_padding_left">
+            android:layout_marginStart="@dimen/reader_xpost_padding_left">
 
             <ImageView
                 android:id="@+id/image_blavatar"

--- a/WordPress/src/main/res/layout/reader_cardview_xpost.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_xpost.xml
@@ -32,19 +32,21 @@
             android:layout_height="wrap_content"
             android:paddingStart="@dimen/reader_xpost_padding_left">
 
-            <org.wordpress.android.widgets.WPNetworkImageView
+            <ImageView
                 android:id="@+id/image_blavatar"
                 android:layout_width="@dimen/blavatar_sz"
                 android:layout_height="@dimen/blavatar_sz"
                 android:layout_gravity="top|start"
+                android:contentDescription="@string/reader_blavatar_desc"
                 app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp" />
 
-            <org.wordpress.android.widgets.WPNetworkImageView
+            <ImageView
                 android:id="@+id/image_avatar"
                 style="@style/ReaderImageView.Avatar.Small"
                 android:layout_gravity="bottom|end"
                 android:layout_marginLeft="14dp"
                 android:layout_marginTop="14dp"
+                android:contentDescription="@string/reader_avatar_desc"
                 app:srcCompat="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp"
                 android:layout_marginStart="14dp"/>
         </FrameLayout>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -80,7 +80,6 @@
     <style name="ReaderImageView.Featured.CardView" parent="ReaderImageView">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">@dimen/reader_featured_image_height_cardview</item>
-        <item name="android:scaleType">centerCrop</item>
     </style>
     <style name="ReaderImageView.Avatar" parent="ReaderImageView">
         <item name="android:layout_width">@dimen/avatar_sz_medium</item>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2152,6 +2152,9 @@
     <string name="stats_followers_zero_desc">zero followers</string>
     <string name="stats_followers_one_desc">one follower</string>
     <string name="stats_followers_many_desc">%d followers</string>
+    <string name="reader_blavatar_desc">site icon</string>
+    <string name="reader_avatar_desc">profile picture</string>
+
 
     <!-- Site Creation -->
     <string name="site_creation_title">Create New Site</string>


### PR DESCRIPTION
Fixes #7916 

Note: 
- #7910 needs to be merged before reviewing this PR as `feature/glide-reader-post-list` was created from the `feature/glide-auth-headers`.
- ReaderThumbnailStrip still uses Volley - I'll create another PR with a fix as this PR is already too big

This PR replaces Volley with Glide on the ReaderPostList screen - featured images, video thumbnails, profile images and site icons are now displayed using Glide.  

This PR also introduces ImageManager - a wrapper around Glide for loading images so we can easily replace glide with another library if we ever need to.

To test:
- make sure all images including images from private resources are loaded correctly in the ReaderPostList
- make sure video thumbnails are loaded correctly in the ReaderPostList
- make sure GIF featured images are being animated