### PR TITLE
Register PN Token Analytics cleanup

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMRegistrationIntentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMRegistrationIntentService.java
@@ -74,7 +74,6 @@ public class GCMRegistrationIntentService extends JobIntentService {
 
             // Register to other kind of notifications
             HelpshiftHelper.getInstance().registerDeviceToken(this, gcmToken);
-            AnalyticsTracker.registerPushNotificationToken(gcmToken);
         } else {
             AppLog.w(T.NOTIFS, "Empty GCM token, can't register the id on remote services");
             PreferenceManager.getDefaultSharedPreferences(this).edit()

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMRegistrationIntentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMRegistrationIntentService.java
@@ -11,7 +11,6 @@ import android.text.TextUtils;
 import com.google.firebase.iid.FirebaseInstanceId;
 
 import org.wordpress.android.WordPress;
-import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.util.AppLog;

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -482,15 +482,6 @@ public final class AnalyticsTracker {
         }
     }
 
-    public static void registerPushNotificationToken(String regId) {
-        if (mHasUserOptedOut) {
-            return;
-        }
-        for (Tracker tracker : TRACKERS) {
-            tracker.registerPushNotificationToken(regId);
-        }
-    }
-
     public static void clearAllData() {
         for (Tracker tracker : TRACKERS) {
             tracker.clearAllData();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -380,10 +380,6 @@ public class AnalyticsTrackerNosara extends Tracker {
         mNosaraClient.clearQueues();
     }
 
-    @Override
-    public void registerPushNotificationToken(String regId) {
-    }
-
     @SuppressWarnings("checkstyle:methodlength")
     public static String getEventNameForStat(AnalyticsTracker.Stat stat) {
         if (!isValidEvent(stat)) {

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/Tracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/Tracker.java
@@ -21,8 +21,6 @@ public abstract class Tracker {
 
     abstract void refreshMetadata(AnalyticsMetadata metadata);
 
-    abstract void registerPushNotificationToken(String regId);
-
     abstract String getAnonIdPrefKey();
 
     private String mAnonID = null; // do not access this variable directly. Use methods.


### PR DESCRIPTION
Fix #7881 by removing the interface and empty method in Nosara impl. that was used to bump push tokens in Analytics. Probably a left over from Mixpanel.
