### PR TITLE
Make sure the pn token is sent to our servers after successful login

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -52,6 +52,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
+import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
@@ -543,6 +544,16 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
                     AnalyticsUtils.updateAnalyticsPreference(getContext(), mDispatcher, mAccountStore, true);
                 }
             }
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onAuthenticationChanged(OnAuthenticationChanged event) {
+        if (mAccountStore.hasAccessToken()) {
+            // Make sure the Push Notification token is sent to our servers after a successful login
+            GCMRegistrationIntentService.enqueueWork(this,
+                    new Intent(this, GCMRegistrationIntentService.class));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -715,9 +715,6 @@ public class WPMainActivity extends AppCompatActivity
         if (mAccountStore.hasAccessToken()) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNED_IN);
 
-            GCMRegistrationIntentService.enqueueWork(this,
-                    new Intent(this, GCMRegistrationIntentService.class));
-
             if (mIsMagicLinkLogin) {
                 if (mIsMagicLinkSignup) {
                     // Sets a flag that we need to track a magic link sign up.


### PR DESCRIPTION
Fixes #7921. This PR is a follow up to #7876. The issue it is trying to fix is, if we have a fresh install and the user logs in, the push notification device token wasn't sent to our servers. The problem with #7876 was that, an instance of `WPMainActivity` is not guaranteed to be alive at the moment of when `onAuthenticationChanged` event is dispatched.

I strongly believe that we should have a separate piece of code that handles these events, which controls the login/logout experience, however, that's not the goal of this PR.

It looks like we were already handling `onAccountChanged` event in the `WordPress` application, so I think it's fine to also handle the `onAuthenticationChanged` event in there, at least for now. The push notification token is probably not the only piece of code that should be moved there, but any others would require more exploration of the existing code which is not something I can do right now. So, this PR is a fix for #7921 and nothing else.

To test:
* Uninstall the app
* Do a fresh installation
* Login with email and password
* Trigger a push notification and verify you get it on the device/emulator