### PR TITLE
Properly placed pages - Part 1 - Setup architecture

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -230,6 +230,10 @@
             android:theme="@style/Calypso.NoActionBar"
             android:label="" />
         <activity
+            android:name=".ui.pages.PageListActivity"
+            android:theme="@style/Calypso.NoActionBar"
+            android:label="@string/pages" />
+        <activity
             android:name=".ui.posts.PostPreviewActivity"
             android:label="@string/preview_post"
             android:theme="@style/Calypso.NoActionBar" />

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -230,7 +230,7 @@
             android:theme="@style/Calypso.NoActionBar"
             android:label="" />
         <activity
-            android:name=".ui.pages.PageListActivity"
+            android:name=".ui.pages.PagesActivity"
             android:theme="@style/Calypso.NoActionBar"
             android:label="@string/pages" />
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -60,6 +60,8 @@ import org.wordpress.android.ui.media.services.MediaDeleteService;
 import org.wordpress.android.ui.notifications.NotificationsDetailActivity;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.ui.notifications.receivers.NotificationsPendingDraftsReceiver;
+import org.wordpress.android.ui.pages.PageListFragment;
+import org.wordpress.android.ui.pages.PagesFragment;
 import org.wordpress.android.ui.people.PeopleInviteFragment;
 import org.wordpress.android.ui.people.PeopleListFragment;
 import org.wordpress.android.ui.people.PeopleManagementActivity;
@@ -383,6 +385,10 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(PluginDetailActivity object);
 
     void inject(WordPressGlideModule object);
+
+    void inject(PagesFragment object);
+
+    void inject(PageListFragment object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -3,6 +3,8 @@ package org.wordpress.android.modules;
 import android.arch.lifecycle.ViewModel;
 import android.arch.lifecycle.ViewModelProvider;
 
+import org.wordpress.android.ui.pages.PageListViewModel;
+import org.wordpress.android.ui.pages.PagesViewModel;
 import org.wordpress.android.viewmodel.PluginBrowserViewModel;
 import org.wordpress.android.viewmodel.ViewModelFactory;
 import org.wordpress.android.viewmodel.ViewModelKey;
@@ -29,6 +31,16 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(ActivityLogDetailViewModel.class)
     abstract ViewModel activityLogDetailViewModel(ActivityLogDetailViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(PagesViewModel.class)
+    abstract ViewModel pagesViewModel(PagesViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(PageListViewModel.class)
+    abstract ViewModel pageListViewModel(PageListViewModel viewModel);
 
     @Binds
     abstract ViewModelProvider.Factory provideViewModelFactory(ViewModelFactory viewModelFactory);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -32,7 +32,7 @@ import org.wordpress.android.ui.main.SitePickerActivity;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaBrowserType;
-import org.wordpress.android.ui.pages.PageListActivity;
+import org.wordpress.android.ui.pages.PagesActivity;
 import org.wordpress.android.ui.people.PeopleManagementActivity;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment;
@@ -219,7 +219,7 @@ public class ActivityLauncher {
     }
 
     public static void viewCurrentBlogPages(Context context, SiteModel site) {
-        Intent intent = new Intent(context, PageListActivity.class);
+        Intent intent = new Intent(context, PagesActivity.class);
         intent.putExtra(WordPress.SITE, site);
         context.startActivity(intent);
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_PAGES, site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -32,6 +32,7 @@ import org.wordpress.android.ui.main.SitePickerActivity;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaBrowserType;
+import org.wordpress.android.ui.pages.PageListActivity;
 import org.wordpress.android.ui.people.PeopleManagementActivity;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment;
@@ -218,9 +219,8 @@ public class ActivityLauncher {
     }
 
     public static void viewCurrentBlogPages(Context context, SiteModel site) {
-        Intent intent = new Intent(context, PostsListActivity.class);
+        Intent intent = new Intent(context, PageListActivity.class);
         intent.putExtra(WordPress.SITE, site);
-        intent.putExtra(PostsListActivity.EXTRA_VIEW_PAGES, true);
         context.startActivity(intent);
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_PAGES, site);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListActivity.kt
@@ -1,0 +1,29 @@
+package org.wordpress.android.ui.pages
+
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import android.view.MenuItem
+import kotlinx.android.synthetic.main.toolbar.*
+import org.wordpress.android.R
+
+class PageListActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(R.layout.pages_activity)
+
+        setSupportActionBar(toolbar)
+        supportActionBar?.let {
+            it.setHomeButtonEnabled(true)
+            it.setDisplayHomeAsUpEnabled(true)
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            onBackPressed()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -79,7 +79,6 @@ class PageListFragment : Fragment() {
         }
         recyclerView.layoutManager = linearLayoutManager
 
-
         swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(pullToRefresh) { viewModel.refresh() }
         (activity?.application as WordPress).component()?.inject(this)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -18,6 +18,7 @@ import javax.inject.Inject
 class PageListFragment : Fragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: PageListViewModel
+    private var linearLayoutManager: LinearLayoutManager? = null
 
     private val listStateKey = "list_state"
 
@@ -74,11 +75,12 @@ class PageListFragment : Fragment() {
     }
 
     private fun initRecyclerView(savedInstanceState: Bundle?) {
-        val linearLayoutManager = LinearLayoutManager(activity, LinearLayoutManager.VERTICAL, false)
+        val layoutManager = LinearLayoutManager(activity, LinearLayoutManager.VERTICAL, false)
         savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
-            linearLayoutManager.onRestoreInstanceState(it)
+            layoutManager.onRestoreInstanceState(it)
         }
         recyclerView.layoutManager = linearLayoutManager
+        linearLayoutManager = layoutManager
 
         (activity?.application as WordPress).component()?.inject(this)
     }
@@ -95,7 +97,7 @@ class PageListFragment : Fragment() {
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        outState.putParcelable(listStateKey, recyclerView.layoutManager.onSaveInstanceState())
+        linearLayoutManager?.let { outState.putParcelable(listStateKey, it.onSaveInstanceState()) }
         super.onSaveInstanceState(outState)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -1,0 +1,137 @@
+package org.wordpress.android.ui.pages
+
+import android.arch.lifecycle.Observer
+import android.arch.lifecycle.ViewModelProvider
+import android.arch.lifecycle.ViewModelProviders
+import android.os.Bundle
+import android.os.Parcelable
+import android.support.v4.app.Fragment
+import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView.Adapter
+import android.support.v7.widget.RecyclerView.ViewHolder
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import kotlinx.android.synthetic.main.pages_list_fragment.*
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.util.WPSwipeToRefreshHelper
+import org.wordpress.android.util.helpers.SwipeToRefreshHelper
+import javax.inject.Inject
+
+class PageListFragment : Fragment() {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var viewModel: PageListViewModel
+    private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
+
+    private val listStateKey = "list_state"
+
+    companion object {
+        const val fragmentKey = "fragment_key"
+        const val typeKey = "type_key"
+
+        enum class Type(val text: Int) {
+            PUBLISHED(R.string.pages_published),
+            DRAFTS(R.string.pages_drafts),
+            SCHEDULED(R.string.pages_scheduled),
+            TRASH(R.string.pages_trashed);
+
+            companion object {
+                fun getType(position: Int): Type {
+                    if (position >= values().size) {
+                        throw IllegalArgumentException("Selected position $position is out of range of page list types")
+                    }
+                    return values()[position]
+                }
+            }
+        }
+
+        fun newInstance(key: String, type: Type): PageListFragment {
+            val fragment = PageListFragment()
+            val bundle = Bundle()
+            bundle.putString(fragmentKey, key)
+            bundle.putSerializable(typeKey, type)
+            fragment.arguments = bundle
+            return fragment
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        (activity?.application as WordPress).component()?.inject(this)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.pages_list_fragment, container, false)
+    }
+
+    override fun onDestroyView() {
+        viewModel.detach()
+        super.onDestroyView()
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val linearLayoutManager = LinearLayoutManager(activity, LinearLayoutManager.VERTICAL, false)
+        savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
+            linearLayoutManager.onRestoreInstanceState(it)
+        }
+        recyclerView.layoutManager = linearLayoutManager
+
+
+        swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(
+                pullToRefresh,
+                { viewModel.refresh() }
+        )
+
+        (activity?.application as WordPress).component()?.inject(this)
+
+        val key = arguments?.getString(fragmentKey)
+        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+                .get<PageListViewModel>(checkNotNull(key), PageListViewModel::class.java)
+
+        viewModel.attach()
+
+        val site = (savedInstanceState?.getSerializable(WordPress.SITE)
+                ?: activity?.intent?.getSerializableExtra(WordPress.SITE)) as SiteModel
+
+        viewModel.state.observe(this, Observer { state ->
+            Log.d("page_list", "State: $state")
+            val refreshing = state?.refreshing == true
+            if (swipeToRefreshHelper.isRefreshing != refreshing) {
+                swipeToRefreshHelper.isRefreshing = refreshing
+            }
+        })
+
+        viewModel.data.observe(this, Observer { data ->
+            Log.d("page_list", "Data: $data")
+        })
+
+        viewModel.start(site)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putParcelable(listStateKey, recyclerView.layoutManager.onSaveInstanceState())
+        super.onSaveInstanceState(outState)
+    }
+}
+
+class PostListAdapter : Adapter<PostViewHolder>() {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PostViewHolder {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getItemCount(): Int {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun onBindViewHolder(holder: PostViewHolder, position: Int) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+}
+
+class PostViewHolder(itemView: View) : ViewHolder(itemView) {
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -68,6 +68,12 @@ class PageListFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        initRecyclerView(savedInstanceState)
+
+        initViewModel(savedInstanceState)
+    }
+
+    private fun initRecyclerView(savedInstanceState: Bundle?) {
         val linearLayoutManager = LinearLayoutManager(activity, LinearLayoutManager.VERTICAL, false)
         savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
             linearLayoutManager.onRestoreInstanceState(it)
@@ -75,7 +81,9 @@ class PageListFragment : Fragment() {
         recyclerView.layoutManager = linearLayoutManager
 
         (activity?.application as WordPress).component()?.inject(this)
+    }
 
+    private fun initViewModel(savedInstanceState: Bundle?) {
         val key = arguments?.getString(fragmentKey)
         viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
                 .get<PageListViewModel>(checkNotNull(key), PageListViewModel::class.java)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -7,8 +7,6 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.support.v4.app.Fragment
 import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.RecyclerView.Adapter
-import android.support.v7.widget.RecyclerView.ViewHolder
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -30,7 +28,7 @@ class PageListFragment : Fragment() {
 
     companion object {
         const val fragmentKey = "fragment_key"
-        const val typeKey = "type_key"
+        private const val typeKey = "type_key"
 
         enum class Type(val text: Int) {
             PUBLISHED(R.string.pages_published),
@@ -82,11 +80,7 @@ class PageListFragment : Fragment() {
         recyclerView.layoutManager = linearLayoutManager
 
 
-        swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(
-                pullToRefresh,
-                { viewModel.refresh() }
-        )
-
+        swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(pullToRefresh) { viewModel.refresh() }
         (activity?.application as WordPress).component()?.inject(this)
 
         val key = arguments?.getString(fragmentKey)
@@ -117,21 +111,4 @@ class PageListFragment : Fragment() {
         outState.putParcelable(listStateKey, recyclerView.layoutManager.onSaveInstanceState())
         super.onSaveInstanceState(outState)
     }
-}
-
-class PostListAdapter : Adapter<PostViewHolder>() {
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PostViewHolder {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
-
-    override fun getItemCount(): Int {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
-
-    override fun onBindViewHolder(holder: PostViewHolder, position: Int) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
-}
-
-class PostViewHolder(itemView: View) : ViewHolder(itemView) {
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListViewModel.kt
@@ -7,13 +7,13 @@ import javax.inject.Inject
 
 class PageListViewModel
 @Inject constructor(val dispatcher: Dispatcher) : ViewModel() {
-    private var initialized: Boolean = false
+    private var isStarted: Boolean = false
     private var site: SiteModel? = null
 
     fun start(site: SiteModel) {
         this.site = site
-        if (!initialized) {
-            initialized = true
+        if (!isStarted) {
+            isStarted = true
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListViewModel.kt
@@ -1,80 +1,25 @@
 package org.wordpress.android.ui.pages
 
-import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
-import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.PostAction
-import org.wordpress.android.fluxc.generated.PostActionBuilder
-import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.PostStore
-import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload
-import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
 import javax.inject.Inject
 
 class PageListViewModel
-@Inject constructor(val dispatcher: Dispatcher, private val postStore: PostStore) : ViewModel() {
+@Inject constructor(val dispatcher: Dispatcher) : ViewModel() {
     private var initialized: Boolean = false
-    private val mutableData = MutableLiveData<UiModel>()
-    private val mutableState = MutableLiveData<UiState>()
     private var site: SiteModel? = null
 
-    val data: LiveData<UiModel> = mutableData
-    val state: LiveData<UiState> = mutableState
-
-    fun attach() {
-        dispatcher.register(this)
-    }
-
     fun start(site: SiteModel) {
+        dispatcher.register(this)
         this.site = site
-        mutableData.postValue(UiModel(pages = postStore.getPagesForSite(site)))
         if (!initialized) {
-            mutableState.postValue(UiState(loading = true))
-            dispatcher.dispatch(PostActionBuilder.newFetchPagesAction(FetchPostsPayload(site)))
             initialized = true
         }
     }
 
-    fun nextPage() {
-        if (mutableState.value?.hasMore == true) {
-            mutableState.postValue(UiState(loadingNext = true))
-            dispatcher.dispatch(PostActionBuilder.newFetchPagesAction(FetchPostsPayload(site, true)))
-        }
-    }
-
-    fun refresh() {
-        mutableState.postValue(UiState(refreshing = true))
-        dispatcher.dispatch(PostActionBuilder.newFetchPagesAction(FetchPostsPayload(site)))
-    }
-
-    fun detach() {
+    fun stop() {
         this.site = null
         dispatcher.unregister(this)
     }
-
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onPostChanged(event: OnPostChanged) {
-        if (event.causeOfChange == PostAction.FETCH_PAGES) {
-            mutableState.postValue(UiState(error = event.error?.message, hasMore = event.canLoadMore))
-            if (!event.isError) {
-                mutableData.postValue(UiModel(pages = postStore.getPagesForSite(site)))
-            }
-        }
-    }
-
-    data class UiModel(
-        val pages: List<PostModel>
-    )
-
-    data class UiState(
-        val loading: Boolean = false,
-        val refreshing: Boolean = false,
-        val loadingNext: Boolean = false,
-        val hasMore: Boolean = false,
-        val error: String? = null
-    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListViewModel.kt
@@ -11,7 +11,6 @@ class PageListViewModel
     private var site: SiteModel? = null
 
     fun start(site: SiteModel) {
-        dispatcher.register(this)
         this.site = site
         if (!initialized) {
             initialized = true
@@ -20,6 +19,5 @@ class PageListViewModel
 
     fun stop() {
         this.site = null
-        dispatcher.unregister(this)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListViewModel.kt
@@ -1,0 +1,83 @@
+package org.wordpress.android.ui.pages
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.ViewModel
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.PostAction
+import org.wordpress.android.fluxc.generated.PostActionBuilder
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload
+import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
+import javax.inject.Inject
+
+class PageListViewModel
+@Inject constructor(
+    val dispatcher: Dispatcher,
+    private val postStore: PostStore
+) : ViewModel() {
+    private var initialized: Boolean = false
+    private val mutableData = MutableLiveData<UiModel>()
+    private val mutableState = MutableLiveData<UiState>()
+    private var site: SiteModel? = null
+
+    val data: LiveData<UiModel> = mutableData
+    val state: LiveData<UiState> = mutableState
+
+    fun attach() {
+        dispatcher.register(this)
+    }
+
+    fun start(site: SiteModel) {
+        this.site = site
+        mutableData.postValue(UiModel(pages = postStore.getPagesForSite(site)))
+        if (!initialized) {
+            mutableState.postValue(UiState(loading = true))
+            dispatcher.dispatch(PostActionBuilder.newFetchPagesAction(FetchPostsPayload(site)))
+            initialized = true
+        }
+    }
+
+    fun nextPage() {
+        if (mutableState.value?.hasMore == true) {
+            mutableState.postValue(UiState(loadingNext = true))
+            dispatcher.dispatch(PostActionBuilder.newFetchPagesAction(FetchPostsPayload(site, true)))
+        }
+    }
+
+    fun refresh() {
+        mutableState.postValue(UiState(refreshing = true))
+        dispatcher.dispatch(PostActionBuilder.newFetchPagesAction(FetchPostsPayload(site)))
+    }
+
+    fun detach() {
+        this.site = null
+        dispatcher.unregister(this)
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onPostChanged(event: OnPostChanged) {
+        if (event.causeOfChange == PostAction.FETCH_PAGES) {
+            mutableState.postValue(UiState(error = event.error?.message, hasMore = event.canLoadMore))
+            if (!event.isError) {
+                mutableData.postValue(UiModel(pages = postStore.getPagesForSite(site)))
+            }
+        }
+    }
+
+    data class UiModel(
+        val pages: List<PostModel>
+    )
+
+    data class UiState(
+        val loading: Boolean = false,
+        val refreshing: Boolean = false,
+        val loadingNext: Boolean = false,
+        val hasMore: Boolean = false,
+        val error: String? = null
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListViewModel.kt
@@ -16,10 +16,7 @@ import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
 import javax.inject.Inject
 
 class PageListViewModel
-@Inject constructor(
-    val dispatcher: Dispatcher,
-    private val postStore: PostStore
-) : ViewModel() {
+@Inject constructor(val dispatcher: Dispatcher, private val postStore: PostStore) : ViewModel() {
     private var initialized: Boolean = false
     private val mutableData = MutableLiveData<UiModel>()
     private val mutableState = MutableLiveData<UiState>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
@@ -6,7 +6,7 @@ import android.view.MenuItem
 import kotlinx.android.synthetic.main.toolbar.*
 import org.wordpress.android.R
 
-class PageListActivity : AppCompatActivity() {
+class PagesActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -84,7 +84,7 @@ class PagesFragment : Fragment() {
         super.onCreateOptionsMenu(menu, inflater)
         inflater.inflate(R.menu.menu_search, menu)
         val myActionMenuItem = menu?.findItem(R.id.action_search)
-        myActionMenuItem?.setOnActionExpandListener(object: OnActionExpandListener {
+        myActionMenuItem?.setOnActionExpandListener(object : OnActionExpandListener {
             override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
                 return viewModel.searchExpanded()
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -19,7 +19,6 @@ import android.view.MenuItem.OnActionExpandListener
 import android.view.View
 import android.view.ViewGroup
 import kotlinx.android.synthetic.main.pages_fragment.*
-import kotlinx.android.synthetic.main.pages_list_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.pages.PageListFragment.Companion.Type
@@ -47,17 +46,6 @@ class PagesFragment : Fragment() {
         super.onActivityCreated(savedInstanceState)
         viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
                 .get<PagesViewModel>(PagesViewModel::class.java)
-        viewModel.searchExpanded.observe(activity!!, Observer {
-            if (it == true) {
-                pages_pager.visibility = View.GONE
-                tabLayout.visibility = View.GONE
-                pages_search_result.visibility = View.VISIBLE
-            } else {
-                pages_pager.visibility = View.VISIBLE
-                tabLayout.visibility = View.VISIBLE
-                pages_search_result.visibility = View.GONE
-            }
-        })
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -86,6 +74,23 @@ class PagesFragment : Fragment() {
         val myActionMenuItem = checkNotNull(menu.findItem(R.id.action_search)) {
             "Menu does not contain mandatory search item"
         }
+        viewModel.searchExpanded.observe(activity!!, Observer {
+            if (it == true) {
+                pages_pager.visibility = View.GONE
+                tabLayout.visibility = View.GONE
+                pages_search_result.visibility = View.VISIBLE
+                if (!myActionMenuItem.isActionViewExpanded) {
+                    myActionMenuItem.expandActionView()
+                }
+            } else {
+                pages_pager.visibility = View.VISIBLE
+                tabLayout.visibility = View.VISIBLE
+                pages_search_result.visibility = View.GONE
+                if (myActionMenuItem.isActionViewExpanded) {
+                    myActionMenuItem.collapseActionView()
+                }
+            }
+        })
 
         myActionMenuItem.setOnActionExpandListener(object : OnActionExpandListener {
             override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
@@ -106,11 +111,6 @@ class PagesFragment : Fragment() {
                 return viewModel.onSearchTextChange(newText)
             }
         })
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        outState.putParcelable(listStateKey, recyclerView.layoutManager.onSaveInstanceState())
-        super.onSaveInstanceState(outState)
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -25,8 +25,6 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.ui.pages.PageListFragment.Companion.Type
 import javax.inject.Inject
 
-
-
 class PagesFragment : Fragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: PagesViewModel
@@ -80,32 +78,19 @@ class PagesFragment : Fragment() {
             }
         }
         tabLayout.setupWithViewPager(pages_pager)
-//        tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
-//            override fun onTabSelected(tab: TabLayout.Tab) {
-//            }
-//
-//            override fun onTabUnselected(tab: TabLayout.Tab) {
-//            }
-//
-//            override fun onTabReselected(tab: TabLayout.Tab) {
-//            }
-//        })
     }
 
     override fun onCreateOptionsMenu(menu: Menu?, inflater: MenuInflater) {
         super.onCreateOptionsMenu(menu, inflater)
         inflater.inflate(R.menu.menu_search, menu)
-
         val myActionMenuItem = menu?.findItem(R.id.action_search)
         myActionMenuItem?.setOnActionExpandListener(object: OnActionExpandListener {
             override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
-                viewModel.searchOpen()
-                return true
+                return viewModel.searchExpanded()
             }
 
             override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
-                viewModel.searchClose()
-                return true
+                return viewModel.searchCollapsed()
             }
         })
         val searchView = myActionMenuItem?.actionView as SearchView

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -1,0 +1,139 @@
+package org.wordpress.android.ui.pages
+
+import android.arch.lifecycle.Observer
+import android.arch.lifecycle.ViewModelProvider
+import android.arch.lifecycle.ViewModelProviders
+import android.content.Context
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentManager
+import android.support.v4.app.FragmentPagerAdapter
+import android.support.v7.app.AppCompatActivity
+import android.support.v7.widget.SearchView
+import android.support.v7.widget.Toolbar
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.MenuItem.OnActionExpandListener
+import android.view.View
+import android.view.ViewGroup
+import kotlinx.android.synthetic.main.pages_fragment.*
+import kotlinx.android.synthetic.main.pages_list_fragment.*
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.ui.pages.PageListFragment.Companion.Type
+import javax.inject.Inject
+
+
+
+class PagesFragment : Fragment() {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var viewModel: PagesViewModel
+
+    private val listStateKey = "list_state"
+
+    companion object {
+        fun newInstance(): PagesFragment {
+            return PagesFragment()
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        (activity?.application as WordPress).component()?.inject(this)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+                .get<PagesViewModel>(PagesViewModel::class.java)
+        viewModel.searchExpanded.observe(activity!!, Observer {
+            if (it == true) {
+                pages_pager.visibility = View.GONE
+                tabLayout.visibility = View.GONE
+                pages_search_result.visibility = View.VISIBLE
+            } else {
+                pages_pager.visibility = View.VISIBLE
+                tabLayout.visibility = View.VISIBLE
+                pages_search_result.visibility = View.GONE
+            }
+        })
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.pages_fragment, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val toolbar = view.findViewById<Toolbar>(org.wordpress.android.login.R.id.toolbar)
+        (activity as AppCompatActivity).apply {
+            setSupportActionBar(toolbar)
+            supportActionBar?.setHomeButtonEnabled(true)
+        }
+
+        pages_pager.adapter = activity?.let { fragmentActivity ->
+            fragmentActivity.supportFragmentManager?.let { manager ->
+                PagesPagerAdapter(fragmentActivity, manager)
+            }
+        }
+        tabLayout.setupWithViewPager(pages_pager)
+//        tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+//            override fun onTabSelected(tab: TabLayout.Tab) {
+//            }
+//
+//            override fun onTabUnselected(tab: TabLayout.Tab) {
+//            }
+//
+//            override fun onTabReselected(tab: TabLayout.Tab) {
+//            }
+//        })
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.menu_search, menu)
+
+        val myActionMenuItem = menu?.findItem(R.id.action_search)
+        myActionMenuItem?.setOnActionExpandListener(object: OnActionExpandListener {
+            override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
+                viewModel.searchOpen()
+                return true
+            }
+
+            override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
+                viewModel.searchClose()
+                return true
+            }
+        })
+        val searchView = myActionMenuItem?.actionView as SearchView
+        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+            override fun onQueryTextSubmit(query: String?): Boolean {
+                return viewModel.onSearchTextSubmit(query)
+            }
+
+            override fun onQueryTextChange(newText: String?): Boolean {
+                return viewModel.onSearchTextChange(newText)
+            }
+        })
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putParcelable(listStateKey, recyclerView.layoutManager.onSaveInstanceState())
+        super.onSaveInstanceState(outState)
+    }
+}
+
+class PagesPagerAdapter(val context: Context, fm: FragmentManager) : FragmentPagerAdapter(fm) {
+    override fun getCount(): Int = 4
+
+    override fun getItem(position: Int): Fragment {
+        return PageListFragment.newInstance("key$position", Type.getType(position))
+    }
+
+    override fun getPageTitle(position: Int): CharSequence? {
+        return Type.getType(position).text.let { context.getString(it) }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -80,11 +80,14 @@ class PagesFragment : Fragment() {
         tabLayout.setupWithViewPager(pages_pager)
     }
 
-    override fun onCreateOptionsMenu(menu: Menu?, inflater: MenuInflater) {
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         super.onCreateOptionsMenu(menu, inflater)
         inflater.inflate(R.menu.menu_search, menu)
-        val myActionMenuItem = menu?.findItem(R.id.action_search)
-        myActionMenuItem?.setOnActionExpandListener(object : OnActionExpandListener {
+        val myActionMenuItem = checkNotNull(menu.findItem(R.id.action_search)) {
+            "Menu does not contain mandatory search item"
+        }
+
+        myActionMenuItem.setOnActionExpandListener(object : OnActionExpandListener {
             override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
                 return viewModel.searchExpanded()
             }
@@ -93,7 +96,7 @@ class PagesFragment : Fragment() {
                 return viewModel.searchCollapsed()
             }
         })
-        val searchView = myActionMenuItem?.actionView as SearchView
+        val searchView = myActionMenuItem.actionView as SearchView
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String?): Boolean {
                 return viewModel.onSearchTextSubmit(query)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesViewModel.kt
@@ -1,0 +1,27 @@
+package org.wordpress.android.ui.pages
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.ViewModel
+import javax.inject.Inject
+
+class PagesViewModel
+@Inject constructor() : ViewModel() {
+    private val mutableSearchExpanded: MutableLiveData<Boolean> = MutableLiveData()
+    val searchExpanded: LiveData<Boolean> = mutableSearchExpanded
+    fun onSearchTextSubmit(query: String?): Boolean {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    fun onSearchTextChange(newText: String?): Boolean {
+        return true
+    }
+
+    fun searchOpen() {
+        mutableSearchExpanded.postValue(true)
+    }
+
+    fun searchClose() {
+        mutableSearchExpanded.postValue(false)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesViewModel.kt
@@ -10,7 +10,7 @@ class PagesViewModel
     private val mutableSearchExpanded: MutableLiveData<Boolean> = MutableLiveData()
     val searchExpanded: LiveData<Boolean> = mutableSearchExpanded
     fun onSearchTextSubmit(query: String?): Boolean {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     fun onSearchTextChange(newText: String?): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesViewModel.kt
@@ -17,11 +17,13 @@ class PagesViewModel
         return true
     }
 
-    fun searchOpen() {
+    fun searchExpanded(): Boolean {
         mutableSearchExpanded.postValue(true)
+        return true
     }
 
-    fun searchClose() {
+    fun searchCollapsed(): Boolean {
         mutableSearchExpanded.postValue(false)
+        return true
     }
 }

--- a/WordPress/src/main/res/layout/pages_activity.xml
+++ b/WordPress/src/main/res/layout/pages_activity.xml
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<fragment
     xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_container"
+    android:name="org.wordpress.android.ui.pages.PagesFragment"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
-
-    <fragment
-        android:id="@+id/fragment_container"
-        android:name="org.wordpress.android.ui.pages.PagesFragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
-
-</android.support.design.widget.CoordinatorLayout>
+    android:layout_height="match_parent"/>

--- a/WordPress/src/main/res/layout/pages_activity.xml
+++ b/WordPress/src/main/res/layout/pages_activity.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <fragment
+        android:id="@+id/fragment_container"
+        android:name="org.wordpress.android.ui.pages.PagesFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/pages_fragment.xml
+++ b/WordPress/src/main/res/layout/pages_fragment.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.design.widget.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:animateLayoutChanges="true"
+        android:fitsSystemWindows="true">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:layout_collapseMode="pin"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed"
+            app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+            app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+            tools:targetApi="LOLLIPOP"/>
+
+        <android.support.design.widget.TabLayout
+            android:id="@+id/tabLayout"
+            app:theme="@style/Base.Widget.Design.TabLayout"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:layout_gravity="start"
+            android:background="@color/color_primary"
+            app:tabSelectedTextColor="@color/white"
+            app:tabTextColor="@color/white"
+            app:tabIndicatorColor="@color/white"
+            app:tabGravity="fill"
+            app:tabMode="scrollable"/>
+
+    </android.support.design.widget.AppBarLayout>
+
+    <android.support.v4.view.ViewPager
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/pages_pager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+
+    <include
+        android:id="@+id/pages_search_result"
+        layout="@layout/pages_list_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/pages_list_fragment.xml
+++ b/WordPress/src/main/res/layout/pages_list_fragment.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
-        android:id="@+id/activityLogPullToRefresh"
+        android:id="@+id/pullToRefresh"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/toolbar">
+        android:layout_below="@id/toolbar"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <android.support.v7.widget.RecyclerView
-            android:id="@+id/activityLogList"
+            android:id="@+id/recyclerView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:scrollbars="vertical"/>
@@ -25,20 +27,20 @@
         style="@style/WordPress.EmptyList.Title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:visibility="gone"
-        android:animateLayoutChanges="true"
+        android:layout_centerInParent="true"
         android:layout_marginBottom="@dimen/empty_list_title_bottom_margin"
+        android:layout_marginEnd="@dimen/empty_list_title_side_margin"
         android:layout_marginLeft="@dimen/empty_list_title_side_margin"
         android:layout_marginRight="@dimen/empty_list_title_side_margin"
+        android:layout_marginStart="@dimen/empty_list_title_side_margin"
+        android:animateLayoutChanges="true"
         android:text="@string/activity_log_empty_list"
-        android:layout_centerInParent="true"
-        app:fixWidowWords="true"
-        android:layout_marginEnd="@dimen/empty_list_title_side_margin"
-        android:layout_marginStart="@dimen/empty_list_title_side_margin"/>
+        android:visibility="gone"
+        app:fixWidowWords="true"/>
 
 
     <ProgressBar
-        android:id="@+id/activityLogListProgress"
+        android:id="@+id/progress"
         style="?android:attr/progressBarStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -46,6 +48,6 @@
         android:layout_centerHorizontal="true"
         android:layout_marginBottom="@dimen/margin_extra_large"
         android:visibility="gone"
-        tools:visibility="visible" />
+        tools:visibility="visible"/>
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/pages_list_fragment.xml
+++ b/WordPress/src/main/res/layout/pages_list_fragment.xml
@@ -22,23 +22,6 @@
 
     </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/emptyView"
-        style="@style/WordPress.EmptyList.Title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:layout_marginBottom="@dimen/empty_list_title_bottom_margin"
-        android:layout_marginEnd="@dimen/empty_list_title_side_margin"
-        android:layout_marginLeft="@dimen/empty_list_title_side_margin"
-        android:layout_marginRight="@dimen/empty_list_title_side_margin"
-        android:layout_marginStart="@dimen/empty_list_title_side_margin"
-        android:animateLayoutChanges="true"
-        android:text="@string/activity_log_empty_list"
-        android:visibility="gone"
-        app:fixWidowWords="true"/>
-
-
     <ProgressBar
         android:id="@+id/progress"
         style="?android:attr/progressBarStyle"

--- a/WordPress/src/main/res/menu/menu_search.xml
+++ b/WordPress/src/main/res/menu/menu_search.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_search"
+        android:icon="@drawable/ic_search_white_24dp"
+        app:showAsAction="always|collapseActionView"
+        app:actionViewClass="android.support.v7.widget.SearchView"
+        android:title="@string/search"/>
+</menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <string name="app_name" translatable="false">WordPress</string>
 
@@ -2195,8 +2195,8 @@
     <string name="site_creation_epilogue_write">Write first post</string>
 
     <!-- Pages -->
-    <string name="pages_published">Published</string>
-    <string name="pages_drafts">Drafts</string>
-    <string name="pages_scheduled">Scheduled</string>
-    <string name="pages_trashed">Trashed</string>
+    <string name="pages_published" tools:ignore="UnusedResources">Published</string>
+    <string name="pages_drafts" tools:ignore="UnusedResources">Drafts</string>
+    <string name="pages_scheduled" tools:ignore="UnusedResources">Scheduled</string>
+    <string name="pages_trashed" tools:ignore="UnusedResources">Trashed</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -226,6 +226,7 @@
     <string name="title">Title</string>
     <string name="pages_empty_list">No pages yet. Why not create one?</string>
     <string name="page_settings">Page settings</string>
+    <string name="pages">Pages</string>
 
     <!-- posts tab -->
     <string name="untitled">Untitled</string>
@@ -2192,4 +2193,10 @@
     <string name="site_creation_epilogue_congrats">Congratulations!\nYour site is ready.</string>
     <string name="site_creation_epilogue_configure">Configure</string>
     <string name="site_creation_epilogue_write">Write first post</string>
+
+    <!-- Pages -->
+    <string name="pages_published">Published</string>
+    <string name="pages_drafts">Drafts</string>
+    <string name="pages_scheduled">Scheduled</string>
+    <string name="pages_trashed">Trashed</string>
 </resources>


### PR DESCRIPTION
- create `PagesFragment` containing the search results and view pager with different page filters. 
- add logic that hides view pager and shows search results when the user clicks the magnifying glass
- create layouts and `ViewModels`

![pages_redesign_1](https://user-images.githubusercontent.com/1079756/41650700-00ebfdce-747f-11e8-9478-fef768b449a7.gif)


