### PR TITLE
Init HiddenGutenbergPlugin with the visual editor

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -340,7 +340,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 .addPlugin(new CaptionShortcodePlugin(mContent))
                 .addPlugin(new VideoShortcodePlugin())
                 .addPlugin(new AudioShortcodePlugin())
-                .addPlugin(new HiddenGutenbergPlugin())
+                .addPlugin(new HiddenGutenbergPlugin(mContent))
                 .addPlugin(mediaToolbarGalleryButton)
                 .addPlugin(mediaToolbarCameraButton)
                 .addPlugin(mediaToolbarLibraryButton);


### PR DESCRIPTION
Fixes #7930 

This PR fixes the GB self-closing blocks rendering problem by properly initializing the `HiddenGutenbergPlugin` plugin that's handling the GB comment delimiters.

To test:
1. Insert this code as the sole Post content: 
```
<!-- wp:latest-posts /-->
```
2. Open the Visual Mode and verify that there's a "?" icon visible only