### PR TITLE
Zendesk: Push Notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMRegistrationIntentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMRegistrationIntentService.java
@@ -12,6 +12,7 @@ import com.google.firebase.iid.FirebaseInstanceId;
 
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.support.ZendeskHelper;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -24,6 +25,7 @@ import static org.wordpress.android.JobServiceId.JOB_GCM_REG_SERVICE_ID;
 
 public class GCMRegistrationIntentService extends JobIntentService {
     @Inject AccountStore mAccountStore;
+    @Inject ZendeskHelper mZendeskHelper;
 
     @Override
     public void onCreate() {
@@ -70,8 +72,7 @@ public class GCMRegistrationIntentService extends JobIntentService {
                 NotificationsUtils.registerDeviceForPushNotifications(this, gcmToken);
             }
 
-            // Register to other kind of notifications
-            // TODO: Handle Zendesk PNs
+            mZendeskHelper.enablePushNotifications();
         } else {
             AppLog.w(T.NOTIFS, "Empty GCM token, can't register the id on remote services");
             PreferenceManager.getDefaultSharedPreferences(this).edit()

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -115,6 +115,7 @@ public class WPMainActivity extends AppCompatActivity
     public static final String ARG_OPEN_PAGE = "open_page";
     public static final String ARG_NOTIFICATIONS = "show_notifications";
     public static final String ARG_READER = "show_reader";
+    public static final String ARG_ME = "show_me";
 
     private WPMainNavigationView mBottomNav;
 
@@ -288,6 +289,9 @@ public class WPMainActivity extends AppCompatActivity
                     break;
                 case ARG_READER:
                     mBottomNav.setCurrentPosition(PAGE_READER);
+                    break;
+                case ARG_ME:
+                    mBottomNav.setCurrentPosition(PAGE_ME);
                     break;
             }
         } else {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1538,6 +1538,8 @@
     <string name="application_log_button">Application log</string>
     <string name="support_contact_email">Contact email</string>
     <string name="support_contact_email_not_set">Not set</string>
+    <string name="support_push_notification_title">WordPress</string>
+    <string name="support_push_notification_message">New message from \'Help &amp; Support\'</string>
 
     <!--My Site-->
     <string name="my_site_header_external">External</string>

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -47,7 +47,8 @@ public class AppLog {
         PEOPLE,
         SHARING,
         PLUGINS,
-        ACTIVITY_LOG
+        ACTIVITY_LOG,
+        SUPPORT
     }
 
     public static final String TAG = "WordPress";


### PR DESCRIPTION
This PR implements push notifications for Zendesk and is a follow up to #7933 which needs to be merged first and the base branch needs to be updated. I've previously opened #7840 to get some feedback on this feature, so feel free to check that PR out for some history.

As mentioned in #7933, I've had these changes working in the `issue/zendesk-push-notifications` branch, however I felt that the PR was a bit bigger than I'd like, so I removed the push notification specific changes in #7933 which I am adding back in this PR. It's a single commit PR, but the actual commits are still in the git history which will be merged as part of #7933.

--------

**How It Works:**

When Happiness Engineers reply to tickets on Zendesk, they will let our backend know about it which then will send a push notification to the user's device. It requires the user to be logged in with WordPress.com because of the way things are setup in our backend. This will hopefully change in the future.

Zendesk doesn't send any details about the ticket the HEs replied to and they always send the same title and message in the push notification data. So, we use our own title and message strings for the push notification. Tapping the notification will open the `Me` page. We use a single `id` for the notification since all Zendesk notifications have the same title/message and all of them do the same thing. All these has been discussed, mostly in the previous PR #7840.

--------

**Enabling Notifications**

As far as I understand from the [docs](https://developer.zendesk.com/embeddables/docs/android-support-sdk/handle_push_notifications_wh#application-integration) and from my testing, the identity needs to be set before enabling the notifications. We also need the user to be logged in with WordPress.com. We try to enable push notifications as soon as possible. However, since these requirements may not be met at the time of we get the device token, we try to ensure it by trying to enable again when the identity changes and before a ticket might be created. It's a bit excessive, but I couldn't find a better way to ensure pns always(?) work. I can see an argument for enabling push notifications when it makes sense and accept that sometimes it'll not work and I am open to that option as well.

**Gotchas**

It has been a frustrating experience to work on this feature to say the least. I definitely didn't miss working with closed source SDKs. I'll share a few notes about my tests so far, however take them with a bit of salt as my tests may have not be very reliable as I kept changing the code, specifically how pns were enabled.

* I _think_ the push notification tokens are attached to tickets and not to Zendesk identities. So, for example, if the user opens a ticket, change the email (which will reset their identity and remove all their tickets), they'll still get push notifications for the previous ticket even though they can not actually access it.
* If we disable notifications for Zendesk and then re-enable them, they'll still get the notifications for tickets they opened before we disabled pns. So, this is not a solution for the above problem.
* If the user opens a ticket, logs out, logs back in with a different user, they don't seem to get the pns for the ticket. I believe this is due to how notifications are sent from our back-end as the WordPress.com user changes in this scenario.
* If the push notifications are not properly enabled before creating a ticket, the user doesn't seem to get push notifications for them even if pns are enabled after the ticket creation. This is one of the reasons why I think tokens are attached to tickets.

**To Test:**

* Start with a fresh install for the first test
* Login to WordPress.com
* Open a Zendesk ticket (when you are setting your support identity, make sure to use an email that's not your Zendesk account email, if you have one)
* Reply to it from dashboard (ping me if you don't have the right to reply)
* Verify that you get a notification for it.

--

* Log out of WordPress.com
* Open a ticket from the login/signup screen
* Reply to it from dashboard
* Verify that you DON'T get a notification for it. (This test doesn't accomplish much and you don't even have to run it, but it documents the way Zendesk PNs work, so it's still useful to have here)

--

* Login with WordPress.com
* Reply to the previous ticket (the one created while logged out)
* Verify that you DON'T get a notification for it. (Again, useful to document, not a great test)
* Check "My Tickets" section and verify that your ticket is there with a reply 🤦‍♂️ 
* I'd have expected this to work, because the Zendesk identity doesn't change and we do enable push notifications afterwards, but it doesn't 😞 

Test any other scenario you can think of that might affect whether you get a notification or not.

---------

Here is a screenshot of the notification:

![screenshot_1529591412](https://user-images.githubusercontent.com/662023/41728220-3eae6b40-7544-11e8-95c6-a8e7b8d9ba3a.png)

/cc @aerych 

_P.S:_ This PR targets a WIP branch, that's why it doesn't have a milestone.