### PR TITLE
Fix ConcurrentModificationExceptions in AppLog

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -322,7 +322,7 @@ public class AppLog {
         items.add("<strong>" + getAppInfoHeaderText(context) + "</strong>");
         items.add("<strong>" + getDeviceInfoHeaderText(context) + "</strong>");
 
-        Iterator<LogEntry> it = mLogEntries.iterator();
+        Iterator<LogEntry> it = new ArrayList<>(mLogEntries).iterator();
         while (it.hasNext()) {
             items.add(it.next().toHtml());
         }
@@ -341,7 +341,7 @@ public class AppLog {
         sb.append(getAppInfoHeaderText(context)).append("\n")
           .append(getDeviceInfoHeaderText(context)).append("\n\n");
 
-        Iterator<LogEntry> it = mLogEntries.iterator();
+        Iterator<LogEntry> it = new ArrayList<>(mLogEntries).iterator();
         int lineNum = 1;
         while (it.hasNext()) {
             LogEntry entry = it.next();


### PR DESCRIPTION
Fixes #7906. If a list is modified, either by adding or removing items, while iterating over it, it'll cause a `ConcurrentModificationException`. By copying the list before the iteration, we ensure that it'll not be modified.

This solution is not the most efficient one. A better solution might be to lock the log entries while `toPlainText` or `toHtmlList` is going on and keep a separate list of entries to add once it's done. I'd prefer to leave that to a potential `AppLog` rework, hopefully with Kotlin. I think this solution is good enough for fixing the crash. I also don't have the bandwidth to work on it right now.

**To test:**
I couldn't find a way a reliable way to reproduce the crash. However, I was able to frequently reproduce it by adding the following code to `HelpActivity.onCreate` (or anywhere else):

```
for (int i = 0; i < 50; i++) {
    AppLog.e(T.MAIN, "some random logs");
    AppLog.e(T.MAIN, "some random logs");
    AppLog.toPlainText(this);
    AppLog.e(T.MAIN, "some random logs");
    AppLog.e(T.MAIN, "some random logs");
    AppLog.e(T.MAIN, "some random logs");
    AppLog.e(T.MAIN, "some random logs");
}
```

The `toHtmlList` is possible to test similarly as well, but I think it's less likely to happen just because string building is a much more costly operation than creating a new list. Increasing the iteration count to 1000 seems to help reproduce it.