### PR TITLE
New notifications channel: transient notifications sound

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -360,7 +360,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
             // or media upload)
             NotificationChannel transientChannel = new NotificationChannel(
                     getString(R.string.notification_channel_transient_id),
-                    getString(R.string.notification_channel_transient_title), NotificationManager.IMPORTANCE_LOW);
+                    getString(R.string.notification_channel_transient_title), NotificationManager.IMPORTANCE_DEFAULT);
             transientChannel.setSound(null, null);
             transientChannel.enableVibration(false);
             transientChannel.enableLights(false);

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -355,6 +355,18 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
             // Register the channel with the system; you can't change the importance
             // or other notification behaviors after this
             notificationManager.createNotificationChannel(importantChannel);
+
+            // Create the TRANSIENT channel (used for short-lived notifications such as processing a Like/Approve,
+            // or media upload)
+            NotificationChannel transientChannel = new NotificationChannel(
+                    getString(R.string.notification_channel_transient_id),
+                    getString(R.string.notification_channel_transient_title), NotificationManager.IMPORTANCE_LOW);
+            transientChannel.setSound(null, null);
+            transientChannel.enableVibration(false);
+            transientChannel.enableLights(false);
+            // Register the channel with the system; you can't change the importance
+            // or other notification behaviors after this
+            notificationManager.createNotificationChannel(transientChannel);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
@@ -18,9 +18,9 @@ public class NativeNotificationsUtils {
         showMessageToUser(message, false, pushId, context);
     }
 
-    public static void showMessageToUser(String message, boolean intermediateMessage, int pushId, Context context) {
+    private static void showMessageToUser(String message, boolean intermediateMessage, int pushId, Context context) {
         NotificationCompat.Builder builder = getBuilder(context,
-                context.getString(R.string.notification_channel_normal_id))
+                context.getString(R.string.notification_channel_transient_id))
                 .setContentText(message).setTicker(message)
                 .setOnlyAlertOnce(true);
         showMessageToUserWithBuilder(builder, message, intermediateMessage, pushId, context);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -75,7 +75,7 @@ class PostUploadNotifier {
         mNotificationManager = (NotificationManager) SystemServiceFactory.get(mContext,
                                                                               Context.NOTIFICATION_SERVICE);
         mNotificationBuilder = new NotificationCompat.Builder(mContext.getApplicationContext(),
-                context.getString(R.string.notification_channel_normal_id));
+                context.getString(R.string.notification_channel_transient_id));
         mNotificationBuilder.setSmallIcon(android.R.drawable.stat_sys_upload)
                             .setColor(context.getResources().getColor(R.color.blue_wordpress))
                             .setOnlyAlertOnce(true);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2074,9 +2074,9 @@
     <string name="notification_channel_important_title">Important</string>
     <string name="notification_channel_transient_title">Transient</string>
 
-    <string name="notification_channel_normal_id">wpandroid_notification_normal_channel_id</string>
-    <string name="notification_channel_important_id">wpandroid_notification_important_channel_id</string>
-    <string name="notification_channel_transient_id">wpandroid_notification_transient_channel_id</string>
+    <string name="notification_channel_normal_id" translatable="false">wpandroid_notification_normal_channel_id</string>
+    <string name="notification_channel_important_id" translatable="false">wpandroid_notification_important_channel_id</string>
+    <string name="notification_channel_transient_id" translatable="false">wpandroid_notification_transient_channel_id</string>
 
     <!-- Site Creation notifications -->
     <string name="notification_site_creation_title_success">Site created!</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2072,9 +2072,11 @@
     <!-- Android O notification channels, these show in the Android app settings -->
     <string name="notification_channel_general_title">General</string>
     <string name="notification_channel_important_title">Important</string>
+    <string name="notification_channel_transient_title">Transient</string>
 
     <string name="notification_channel_normal_id">wpandroid_notification_normal_channel_id</string>
     <string name="notification_channel_important_id">wpandroid_notification_important_channel_id</string>
+    <string name="notification_channel_transient_id">wpandroid_notification_transient_channel_id</string>
 
     <!-- Site Creation notifications -->
     <string name="notification_site_creation_title_success">Site created!</string>


### PR DESCRIPTION
Currently, when you start uploading media on a Post or tap on a notifications quick action, a progress notification is shown and it makes a sound. That sound is a bit distracting as you're already either on the app or at least conscious of what you're doing, so the sound seems to be coming from somewhere else (when it doesn't).

This PR creates a new Notification Channel that doesn't make any sound, and is used for transient operations that use notifications, for example media/post uploads and notifications quick action processing progress notifications (like/approve/publish) 

To Test:

Make sure your device is not silenced.

Media upload:
1. start a new draft
2. include some media items
3. observe the upload progress notification is displayed and sounds _(should not make sounds with this PR)_
4. wait until all media is uploaded
5. exit the editor, the Post should be uploaded and with that a new progress notification is created, sound should be heard  _(should not make sounds with this PR)_

Quick actions processing:
1. as a 3rd party, make a comment on a blog post you're an admin of
2. you should receive the new "comment" notification, a sound should be heard  
3. drag from the bottom edge of the notification and pull down to show the quick actions: LIKE/APPROVE
4. tap on any of the quick actions, a new transient notification is shown and makes a sound _(should not make sounds with this PR)_, and a final message notification is displayed once the action has finished (i.e. the like or approval).


