### PR TITLE
Don't include OAuth token in Android backups

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'd7607bbbb426a96b78d2d93d7e1c4a0462e03386'
+    fluxCVersion = '6ac92cd449142bd8222bad23112ab1e980e21d51'
 }


### PR DESCRIPTION
Fixes #7918, excluding the WordPress.com OAuth token from the Android auto-backup so that users aren't unexpectedly logged back in.

This updates the FluxC branch to the one used in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/833. This PR should be merged after the FluxC one.

With this change, a migration step is added that moves the WP.com oauth token to a non-default shared preferences location. This in turn means that the token is excluded from the [list](https://github.com/wordpress-mobile/WordPress-Android/blob/19d8591335de160e89df8e6de61c0e380662140a/WordPress/src/main/res/xml/backup_scheme.xml#L3-L6) of things backed up by the Android auto-backup feature:

https://github.com/wordpress-mobile/WordPress-Android/blob/19d8591335de160e89df8e6de61c0e380662140a/WordPress/src/main/res/xml/backup_scheme.xml#L3-L6

This solves the issue described in #7918 of being logged back in after clearing app data and/or reinstalling the app.

## To test:

### Token migration
1. Build the app on `develop`
2. Log into WordPress.com
3. Build this branch, run the app
4. Ensure that you're still logged in
5. Check that the token config is what it should be

You can do step 5 via Stetho - visit `chrome://inspect/` in Chrome on your desktop, find the connected device and click 'inspect' under the Android app in the list.

Under Resources > Local Storage you should see both `org.wordpress.android(.beta)_preferences` and `org.wordpress.android(.beta)_fluxc-preferences`, and the token should only exist in `_fluxc-preferences`.

### Auto backup

This one is a bit tricky. There [are tools](https://developer.android.com/guide/topics/data/testingbackup) for manually creating and restoring backups. I found the backup/restore process overall a bit finicky, sometimes it seemed like the backup wasn't actually updated and an older one was being used. It may take a few tries and some waiting to verify that everything is working as expected.

What worked for me in general (on a Pixel 2) were these steps:
 
Create backup using:

```shell
$ adb shell bmgr backupnow org.wordpress.android
```

Get your device's backup token using:

```
$ adb shell dumpsys backup
```

(The token is the hexidecimal string following the label `Current:`)

Restore from backup using:

```
$ adb shell bmgr restore <TOKEN> org.wordpress.android
```

I had some trouble getting this to work with wasabi builds - possibly I was doing something wrong, but it's enough to verify for vanilla builds. It's easiest to test with a debug build so you have access to Stetho, though it works for release builds as well.

I tested this on a real device as emulators won't necessarily have backups set up.

0. Read through [the backup testing instructions](https://developer.android.com/guide/topics/data/testingbackup), make sure your device is setup properly
1. Convince yourself that you can create and restore backups for the WordPress app on `develop` using a **vanilla** build (you should still be logged in after restoring, but you can verify that a backup restore happened because the database will be flushed - except for the `AccountModel` and `SiteModel` tables which are repopulated on load)
2. Build this branch
3. Repeat the same steps
4. You should be logged out, but inspection via Stetho (for debug builds) should show that other preferences (like `SELECTED_SITE_LOCAL_ID`, `LAST_ACTIVITY_STR`, and so on) are still set

You can also do step 4 for release builds by opening, e.g., the reader before starting the backup. After backup/restore and logging back in, you should be taken to the reader screen.