### PR TITLE
Zendesk small fixes and push notification improvements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -377,8 +377,17 @@ private fun buildZendeskCustomFields(
  * authentication. More information can be found in their documentation:
  * https://developer.zendesk.com/embeddables/docs/android-support-sdk/sdk_set_identity#setting-a-unique-identity
  */
-private fun createZendeskIdentity(email: String?, name: String?): Identity =
-        AnonymousIdentity.Builder().withEmailIdentifier(email).withNameIdentifier(name).build()
+private fun createZendeskIdentity(email: String?, name: String?): Identity {
+    val identity = AnonymousIdentity.Builder()
+    if (!email.isNullOrEmpty()) {
+        identity.withEmailIdentifier(email)
+    }
+    if (!name.isNullOrEmpty()) {
+        identity.withNameIdentifier(name)
+    }
+    return identity.build()
+}
+
 
 /**
  * This is a small helper function which just joins the `logInformation` of all the sites passed in with a separator.

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -170,6 +170,13 @@ class ZendeskHelper(
     }
 
     /**
+     * This function refreshes the Zendesk's request activity if it's currently being displayed. It'll return true if
+     * it's successful. We'll use the return value to decide whether to show a push notification or not.
+     */
+    fun refreshRequest(context: Context, requestId: String?): Boolean =
+            Support.INSTANCE.refreshRequest(requestId, context)
+
+    /**
      * This function should be called when the user logs out of WordPress.com. Push notifications are only available
      * for WordPress.com users, so they'll be disabled. We'll also clear the Zendesk identity of the user on logout
      * and it will need to be set again when the user wants to create a new ticket.
@@ -387,7 +394,6 @@ private fun createZendeskIdentity(email: String?, name: String?): Identity {
     }
     return identity.build()
 }
-
 
 /**
  * This is a small helper function which just joins the `logInformation` of all the sites passed in with a separator.

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -35,8 +35,11 @@ import zendesk.support.UiConfig
 import zendesk.support.guide.HelpCenterActivity
 import zendesk.support.request.RequestActivity
 import zendesk.support.requestlist.RequestListActivity
+import java.util.Timer
+import kotlin.concurrent.schedule
 
 private const val zendeskNeedsToBeEnabledError = "Zendesk needs to be setup before this method can be called"
+private const val enablePushNotificationsDelayAfterIdentityChange: Long = 2500
 
 class ZendeskHelper(
     private val accountStore: AccountStore,
@@ -52,6 +55,10 @@ class ZendeskHelper(
     private val zendeskPushRegistrationProvider: PushRegistrationProvider?
         get() = zendeskInstance.provider()?.pushRegistrationProvider()
 
+    private val timer: Timer by lazy {
+        Timer()
+    }
+
     /**
      * These two properties are used to keep track of the Zendesk identity set. Since we allow users' to change their
      * supportEmail and reset their identity on logout, we need to ensure that the correct identity is set all times.
@@ -59,8 +66,14 @@ class ZendeskHelper(
      */
     private var supportEmail: String? = null
     private var supportName: String? = null
-    private val isIdentityAvailable: Boolean
-        get() = !supportEmail.isNullOrEmpty()
+
+    /**
+     * Although rare, Zendesk SDK might reset the identity due to a 401 error. This seems to happen if the identity
+     * is changed and another Zendesk action happens before the identity change could be completed. In order to avoid
+     * such issues, we check both Zendesk identity and the [supportEmail] to decide whether identity is set.
+     */
+    private val isIdentitySet: Boolean
+        get() = !supportEmail.isNullOrEmpty() && zendeskInstance.identity != null
 
     /**
      * This function sets up the Zendesk singleton instance with the passed in credentials. This step is required
@@ -104,11 +117,11 @@ class ZendeskHelper(
         }
         val builder = HelpCenterActivity.builder()
                 .withArticlesForCategoryIds(ZendeskConstants.mobileCategoryId)
-                .withContactUsButtonVisible(isIdentityAvailable)
+                .withContactUsButtonVisible(isIdentitySet)
                 .withLabelNames(ZendeskConstants.articleLabel)
-                .withShowConversationsMenuButton(isIdentityAvailable)
+                .withShowConversationsMenuButton(isIdentitySet)
         AnalyticsTracker.track(Stat.SUPPORT_HELP_CENTER_VIEWED)
-        if (isIdentityAvailable) {
+        if (isIdentitySet) {
             builder.show(context, buildZendeskConfig(context, siteStore.sites, origin, selectedSite, extraTags))
         } else {
             builder.show(context)
@@ -174,7 +187,7 @@ class ZendeskHelper(
         require(isZendeskEnabled) {
             zendeskNeedsToBeEnabledError
         }
-        if (!isIdentityAvailable) {
+        if (!isIdentitySet) {
             // identity should be set before registering the device token
             return
         }
@@ -202,6 +215,10 @@ class ZendeskHelper(
         require(isZendeskEnabled) {
             zendeskNeedsToBeEnabledError
         }
+        if (!isIdentitySet) {
+            // identity should be set before removing the device token
+            return
+        }
         zendeskPushRegistrationProvider?.unregisterDevice(
                 object : ZendeskCallback<Void>() {
                     override fun onSuccess(response: Void?) {
@@ -217,15 +234,11 @@ class ZendeskHelper(
 
     /**
      * This function provides a way to change the support email for the Zendesk identity. Due to the way Zendesk
-     * anonymous identity works, this will reset the users' tickets. If the user hasn't used Zendesk yet, their identity
-     * might not be created. It'll attempt to enable push notifications for Zendesk for such a case.
+     * anonymous identity works, this will reset the users' tickets.
      */
     fun setSupportEmail(email: String?) {
         AppPrefs.setSupportEmail(email)
         refreshIdentity()
-
-        // The identity might not be available previously, this will ensure that push notifications is enabled
-        enablePushNotifications()
     }
 
     /**
@@ -239,8 +252,17 @@ class ZendeskHelper(
         selectedSite: SiteModel?,
         onIdentitySet: () -> Unit
     ) {
-        if (isIdentityAvailable) {
+        if (isIdentitySet) {
             // identity already available
+            onIdentitySet()
+            return
+        }
+        if (!AppPrefs.getSupportEmail().isNullOrEmpty()) {
+            /**
+             * Zendesk SDK reset the identity, but we already know the email of the user, we can simply refresh
+             * the identity. Check out the documentation for [isIdentitySet] for more details.
+             */
+            refreshIdentity()
             onIdentitySet()
             return
         }
@@ -250,7 +272,6 @@ class ZendeskHelper(
             AppPrefs.setSupportEmail(email)
             AppPrefs.setSupportName(name)
             refreshIdentity()
-            enablePushNotifications()
             onIdentitySet()
         }
     }
@@ -264,10 +285,27 @@ class ZendeskHelper(
         }
         val email = AppPrefs.getSupportEmail()
         val name = AppPrefs.getSupportName()
-        if (supportEmail != email || supportName != name) {
+        /**
+         * We refresh the Zendesk identity if the email or the name has been updated. We also check whether
+         * Zendesk SDK has cleared the identity. Check out the documentation for [isIdentitySet] for more details.
+         */
+        if (supportEmail != email || supportName != name || zendeskInstance.identity == null) {
             supportEmail = email
             supportName = name
             zendeskInstance.setIdentity(createZendeskIdentity(email, name))
+
+            /**
+             * When we change the identity in Zendesk, it seems to be making an asynchronous call to a server to
+             * receive a different access token. During this time, if there is a call to Zendesk with the previous
+             * access token, it could fail with a 401 error which seems to be clearing the identity. In order to avoid
+             * such cases, we put a delay on enabling push notifications for the new identity.
+             *
+             * [enablePushNotifications] will check if the identity is set, before making the actual call, so if the
+             * identity is cleared through [clearIdentity], this call will simply be ignored.
+             */
+            timer.schedule(enablePushNotificationsDelayAfterIdentityChange) {
+                enablePushNotifications()
+            }
         }
     }
 
@@ -277,11 +315,9 @@ class ZendeskHelper(
      * works, this will clear all the users' tickets.
      */
     private fun clearIdentity() {
-        supportEmail = null
-        supportName = null
         AppPrefs.removeSupportEmail()
         AppPrefs.removeSupportName()
-        zendeskInstance.setIdentity(createZendeskIdentity(null, null))
+        refreshIdentity()
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -69,6 +69,7 @@ class HelpActivity : AppCompatActivity() {
             }
             supportHelper.showSupportIdentityInputDialog(this, emailSuggestion, isNameInputHidden = true) { email, _ ->
                 zendeskHelper.setSupportEmail(email)
+                refreshContactEmailText()
             }
         }
     }
@@ -102,8 +103,10 @@ class HelpActivity : AppCompatActivity() {
 
     private fun refreshContactEmailText() {
         val supportEmail = AppPrefs.getSupportEmail()
-        if (!supportEmail.isNullOrEmpty()) {
-            contactEmailAddress.text = supportEmail
+        contactEmailAddress.text = if (!supportEmail.isNullOrEmpty()) {
+            supportEmail
+        } else {
+            getString(R.string.support_contact_email_not_set)
         }
     }
 


### PR DESCRIPTION
This PR addresses a few small issues about Zendesk. Since they are all small changes, I combined them into one PR, but I'll be explaining each one separately.

---

Fixes #7942. While reviewing #7937 @khaykov found an issue documented in #7942. This turned out to be a very tricky issue to figure out. The way I understand it, here is what happens:

1. When the support email changes, we change the Zendesk identity. This is a synchronous method call. However, it looks like it's actually asynchronous in the Zendesk SDK as it seems to be hitting their server to get a new access token.
2. Since it's a synchronous method call to change the identity, we try to enable the push notifications immediately after. The problem is, this call will most likely start with the old access token and it (sometimes) results in a 401 error.
3. When Zendesk SDK receives the 401 error, it seems to be clearing the identity in the app which results in this limbo state where you tap on FAQ, Contact us, etc. and nothing happens.

In order to address this issue, we had to make several changes.

* `isIdentitySet`: We used to have a helper property `isIdentityAvailable` which checked the support email. Since we recently found out that the Zendesk identity could be cleared, we now check both the support email and the identity set in the Zendesk instance.
* `requireIdentity` now gracefully handles the Zendesk identity being cleared when we already know the support email of the user. We simply reset the identity with the credentials we have.
* `refreshIdentity` now handles the Zendesk identity being cleared. It's now the only method that calls `setIdentity` and handles enabling push notifications with a 2.5 seconds delay if the identity has changed. The delay is there to try to ensure that the identity change in Zendesk's system goes through. We handle the identity being cleared gracefully, but we'd still prefer if it didn't happen.

To test:

I got the testing steps from #7942 and made some minor changes to it. Since we couldn't reliably reproduce the original issue, you should run this test a few times:

1. Go to "Help & Support" page, change your email.
2. Go back to Me fragment, and back to "Help & Support" page.
3. Change your email to the one used previously. (afaik, it doesn't matter what the email is changed to)
4. Go back to Me fragment, and back to "Help & Support" page.
5. Verify that "Contact us", "Browse our FAQ" and "My Tickets" are clickable. (checking one is enough)

---

Fixed an issue where changing the contact email wasn't reflected in the `Contact email` row in `HelpActivity`.

To test:

1. Go to "Help & Support" page
2. Change your email
3. Verify that your `Contact email` is the one you changed to.

---

When we receive a push notification for a Zendesk ticket, we used to always show a notification even if the user is currently viewing that ticket. Now, we try to refresh the ticket and only show the notification if that fails.

To test:

1. Open a new Zendesk ticket and don't close the page
2. Reply to it from the Zendesk dashboard.
3. Verify that you see the response and you don't see any notifications

---

@khaykov I tried to implement the deep linking again, but I can't seem to get it to work. It should be very simple to do so according to [their docs](https://developer.zendesk.com/embeddables/docs/android-support-sdk/handle_push_notifications_wh#ticket-deep-linking), but this is an area where I don't have any previous experience in. [Here](https://gist.github.com/oguzkocer/4198ea20a992989d4dbc540f7d6be3b1) is the patch I tried which results in this log when I tap on the notification:

```
06-27 15:36:35.359 1686-3637/system_process I/ActivityManager: START u0 {cmp=org.wordpress.android.beta/zendesk.support.DeepLinkingBroadcastReceiver (has extras)} from uid 10090
```

Just to make sure I am not missing anything, do you mind taking a look at this as well?

---

That's all of it. Sorry for the long PR description. I suggest reviewing this PR commit by commit. Each commit (almost) should match to a section here.

/cc @aerych 