### PR TITLE
Analytics: Tracks support identity feature usage.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -8,6 +8,8 @@ import android.view.MenuItem
 import kotlinx.android.synthetic.main.help_activity.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
@@ -67,10 +69,13 @@ class HelpActivity : AppCompatActivity() {
                 emailSuggestion = supportHelper
                         .getSupportEmailAndNameSuggestion(accountStore.account, selectedSiteFromExtras).first
             }
+
             supportHelper.showSupportIdentityInputDialog(this, emailSuggestion, isNameInputHidden = true) { email, _ ->
                 zendeskHelper.setSupportEmail(email)
                 refreshContactEmailText()
+                AnalyticsTracker.track(Stat.SUPPORT_IDENTITY_SET)
             }
+            AnalyticsTracker.track(Stat.SUPPORT_IDENTITY_FORM_VIEWED)
         }
     }
 

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -398,7 +398,9 @@ public final class AnalyticsTracker {
         AUTOMATED_TRANSFER_FLOW_COMPLETE,
         PUBLICIZE_SERVICE_CONNECTED,
         PUBLICIZE_SERVICE_DISCONNECTED,
-        SUPPORT_HELP_CENTER_VIEWED
+        SUPPORT_HELP_CENTER_VIEWED,
+        SUPPORT_IDENTITY_FORM_VIEWED,
+        SUPPORT_IDENTITY_SET,
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1131,6 +1131,10 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "publicize_service_disconnected";
             case SUPPORT_HELP_CENTER_VIEWED:
                 return "support_help_center_viewed";
+            case SUPPORT_IDENTITY_FORM_VIEWED:
+                return "support_identity_form_viewed";
+            case SUPPORT_IDENTITY_SET:
+                return "support_identity_set";
             default:
                 return null;
         }


### PR DESCRIPTION
This PR adds adds analytics for tracking support identity form usage.  One stat tracks viewing the form, another tracks when the support email value is set.  Note that we don't distinguish if the value has changed.

To test:
- Set break points where the new stats are being bumped.
- Launch the app.
- Navigate to Me > Help and Support
- Tap to set the support email.
- Confirm the "viewed" stat is bumped.
- Tap to save the form. 
- Confirm the "set" stat is bumped.
- Open the form again but this time cancel.
- Confirm that the set stat is not bumped.

cc @oguzkocer 

@malinajirka could I trouble you for a review of this one? 