### PR TITLE
GIF Support - EditPostSettings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -766,9 +766,13 @@ public class EditPostSettingsFragment extends Fragment {
             case PRIVATE:
                 return 3;
             case TRASHED:
+                // fallthrough
             case UNKNOWN:
+                // fallthrough
             case PUBLISHED:
+                // fallthrough
             case SCHEDULED:
+                // fallthrough
             default:
                 return 0;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -9,7 +9,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.view.menu.MenuPopupHelper;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.PopupMenu;
@@ -21,6 +20,8 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.ImageView.ScaleType;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -39,6 +40,7 @@ import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.action.TaxonomyAction;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
@@ -54,6 +56,7 @@ import org.wordpress.android.fluxc.store.SiteStore.OnPostFormatsChanged;
 import org.wordpress.android.fluxc.store.TaxonomyStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
 import org.wordpress.android.ui.ActivityLauncher;
+import org.wordpress.android.ui.ImageManager;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaBrowserType;
 import org.wordpress.android.ui.posts.PostDatePickerDialogFragment.PickerDialogType;
@@ -69,8 +72,6 @@ import org.wordpress.android.util.GeocoderUtils;
 import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.WPMediaUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -112,7 +113,7 @@ public class EditPostSettingsFragment extends Fragment {
     private TextView mPostFormatTextView;
     private TextView mPasswordTextView;
     private TextView mPublishDateTextView;
-    private WPNetworkImageView mFeaturedImageView;
+    private ImageView mFeaturedImageView;
     private Button mFeaturedImageButton;
 
     private PostLocation mPostLocation;
@@ -124,6 +125,7 @@ public class EditPostSettingsFragment extends Fragment {
     @Inject MediaStore mMediaStore;
     @Inject TaxonomyStore mTaxonomyStore;
     @Inject Dispatcher mDispatcher;
+    @Inject ImageManager mImageManager;
 
 
     interface EditPostActivityHook {
@@ -210,26 +212,27 @@ public class EditPostSettingsFragment extends Fragment {
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.edit_post_settings_fragment, container, false);
 
         if (rootView == null) {
             return null;
         }
 
-        mExcerptTextView = (TextView) rootView.findViewById(R.id.post_excerpt);
-        mSlugTextView = (TextView) rootView.findViewById(R.id.post_slug);
-        mLocationTextView = (TextView) rootView.findViewById(R.id.post_location);
-        mCategoriesTextView = (TextView) rootView.findViewById(R.id.post_categories);
-        mTagsTextView = (TextView) rootView.findViewById(R.id.post_tags);
-        mStatusTextView = (TextView) rootView.findViewById(R.id.post_status);
-        mPostFormatTextView = (TextView) rootView.findViewById(R.id.post_format);
-        mPasswordTextView = (TextView) rootView.findViewById(R.id.post_password);
-        mPublishDateTextView = (TextView) rootView.findViewById(R.id.publish_date);
+        mExcerptTextView = rootView.findViewById(R.id.post_excerpt);
+        mSlugTextView = rootView.findViewById(R.id.post_slug);
+        mLocationTextView = rootView.findViewById(R.id.post_location);
+        mCategoriesTextView = rootView.findViewById(R.id.post_categories);
+        mTagsTextView = rootView.findViewById(R.id.post_tags);
+        mStatusTextView = rootView.findViewById(R.id.post_status);
+        mPostFormatTextView = rootView.findViewById(R.id.post_format);
+        mPasswordTextView = rootView.findViewById(R.id.post_password);
+        mPublishDateTextView = rootView.findViewById(R.id.publish_date);
 
-        mFeaturedImageView = (WPNetworkImageView) rootView.findViewById(R.id.post_featured_image);
-        mFeaturedImageButton = (Button) rootView.findViewById(R.id.post_add_featured_image_button);
-        CardView featuredImageCardView = (CardView) rootView.findViewById(R.id.post_featured_image_card_view);
+        mFeaturedImageView = rootView.findViewById(R.id.post_featured_image);
+        mFeaturedImageButton = rootView.findViewById(R.id.post_add_featured_image_button);
+        CardView featuredImageCardView = rootView.findViewById(R.id.post_featured_image_card_view);
 
         if (AppPrefs.isVisualEditorEnabled() || AppPrefs.isAztecEditorEnabled()) {
             registerForContextMenu(mFeaturedImageView);
@@ -249,7 +252,7 @@ public class EditPostSettingsFragment extends Fragment {
             featuredImageCardView.setVisibility(View.GONE);
         }
 
-        mExcerptContainer = (LinearLayout) rootView.findViewById(R.id.post_excerpt_container);
+        mExcerptContainer = rootView.findViewById(R.id.post_excerpt_container);
         mExcerptContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -257,7 +260,7 @@ public class EditPostSettingsFragment extends Fragment {
             }
         });
 
-        final LinearLayout slugContainer = (LinearLayout) rootView.findViewById(R.id.post_slug_container);
+        final LinearLayout slugContainer = rootView.findViewById(R.id.post_slug_container);
         slugContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -265,7 +268,7 @@ public class EditPostSettingsFragment extends Fragment {
             }
         });
 
-        final LinearLayout locationContainer = (LinearLayout) rootView.findViewById(R.id.post_location_container);
+        final LinearLayout locationContainer = rootView.findViewById(R.id.post_location_container);
         locationContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -273,7 +276,7 @@ public class EditPostSettingsFragment extends Fragment {
             }
         });
 
-        mCategoriesContainer = (LinearLayout) rootView.findViewById(R.id.post_categories_container);
+        mCategoriesContainer = rootView.findViewById(R.id.post_categories_container);
         mCategoriesContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -281,7 +284,7 @@ public class EditPostSettingsFragment extends Fragment {
             }
         });
 
-        mTagsContainer = (LinearLayout) rootView.findViewById(R.id.post_tags_container);
+        mTagsContainer = rootView.findViewById(R.id.post_tags_container);
         mTagsContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -289,7 +292,7 @@ public class EditPostSettingsFragment extends Fragment {
             }
         });
 
-        final LinearLayout statusContainer = (LinearLayout) rootView.findViewById(R.id.post_status_container);
+        final LinearLayout statusContainer = rootView.findViewById(R.id.post_status_container);
         statusContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -297,7 +300,7 @@ public class EditPostSettingsFragment extends Fragment {
             }
         });
 
-        mFormatContainer = (LinearLayout) rootView.findViewById(R.id.post_format_container);
+        mFormatContainer = rootView.findViewById(R.id.post_format_container);
         mFormatContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -305,7 +308,7 @@ public class EditPostSettingsFragment extends Fragment {
             }
         });
 
-        final LinearLayout passwordContainer = (LinearLayout) rootView.findViewById(R.id.post_password_container);
+        final LinearLayout passwordContainer = rootView.findViewById(R.id.post_password_container);
         passwordContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -313,7 +316,7 @@ public class EditPostSettingsFragment extends Fragment {
             }
         });
 
-        final LinearLayout publishDateContainer = (LinearLayout) rootView.findViewById(R.id.publish_date_container);
+        final LinearLayout publishDateContainer = rootView.findViewById(R.id.publish_date_container);
         publishDateContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -511,7 +514,7 @@ public class EditPostSettingsFragment extends Fragment {
         }
 
         int index = getCurrentPostStatusIndex();
-        FragmentManager fm = ((AppCompatActivity) getActivity()).getSupportFragmentManager();
+        FragmentManager fm = getActivity().getSupportFragmentManager();
         PostSettingsListDialogFragment fragment =
                 PostSettingsListDialogFragment.newInstance(DialogType.POST_STATUS, index);
         fragment.show(fm, PostSettingsListDialogFragment.TAG);
@@ -533,7 +536,7 @@ public class EditPostSettingsFragment extends Fragment {
             }
         }
 
-        FragmentManager fm = ((AppCompatActivity) getActivity()).getSupportFragmentManager();
+        FragmentManager fm = getActivity().getSupportFragmentManager();
         PostSettingsListDialogFragment fragment =
                 PostSettingsListDialogFragment.newInstance(DialogType.POST_FORMAT, checkedIndex);
         fragment.show(fm, PostSettingsListDialogFragment.TAG);
@@ -564,7 +567,7 @@ public class EditPostSettingsFragment extends Fragment {
         Calendar calendar = getCurrentPublishDateAsCalendar();
         PostDatePickerDialogFragment fragment =
                 PostDatePickerDialogFragment.newInstance(PickerDialogType.DATE_PICKER, getPost(), calendar);
-        FragmentManager fm = ((AppCompatActivity) getActivity()).getSupportFragmentManager();
+        FragmentManager fm = getActivity().getSupportFragmentManager();
         fragment.show(fm, PostDatePickerDialogFragment.TAG_DATE);
     }
 
@@ -576,7 +579,7 @@ public class EditPostSettingsFragment extends Fragment {
         Calendar calendar = getCurrentPublishDateAsCalendar();
         PostDatePickerDialogFragment fragment =
                 PostDatePickerDialogFragment.newInstance(PickerDialogType.TIME_PICKER, getPost(), calendar);
-        FragmentManager fm = ((AppCompatActivity) getActivity()).getSupportFragmentManager();
+        FragmentManager fm = getActivity().getSupportFragmentManager();
         fragment.show(fm, PostDatePickerDialogFragment.TAG_TIME);
     }
 
@@ -762,8 +765,11 @@ public class EditPostSettingsFragment extends Fragment {
                 return 2;
             case PRIVATE:
                 return 3;
+            case TRASHED:
+            case UNKNOWN:
+            case PUBLISHED:
+            case SCHEDULED:
             default:
-                // PUBLISHED, SCHEDULED, UNKNOWN
                 return 0;
         }
     }
@@ -856,7 +862,7 @@ public class EditPostSettingsFragment extends Fragment {
             mediaUri = PhotonUtils.getPhotonImageUrl(mediaUri, size, 0);
         }
 
-        WPMediaUtils.loadNetworkImage(mediaUri, mFeaturedImageView);
+        mImageManager.load(mFeaturedImageView, mediaUri, null, ScaleType.FIT_CENTER);
     }
 
     private void launchFeaturedMediaPicker() {
@@ -899,10 +905,8 @@ public class EditPostSettingsFragment extends Fragment {
             AppLog.e(T.POSTS, "An error occurred while updating taxonomy with type: " + event.error.type);
             return;
         }
-        switch (event.causeOfChange) {
-            case FETCH_CATEGORIES:
-                updateCategoriesTextView();
-                break;
+        if (event.causeOfChange == TaxonomyAction.FETCH_CATEGORIES) {
+            updateCategoriesTextView();
         }
     }
 

--- a/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
@@ -140,13 +140,14 @@
                         android:layout_height="wrap_content"
                         android:text="@string/post_settings_set_featured_image"/>
 
-                    <org.wordpress.android.widgets.WPNetworkImageView
+                    <ImageView
                         android:id="@+id/post_featured_image"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:maxHeight="@dimen/post_settings_featured_image_height_max"
                         android:minHeight="@dimen/post_settings_featured_image_height_min"
-                        android:scaleType="fitStart"
+                        android:contentDescription="@string/post_settings_featured_desc"
+                        android:adjustViewBounds="true"
                         android:visibility="gone"/>
                 </LinearLayout>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2118,6 +2118,7 @@
     <string name="plugin_detail_banner_desc">plugin banner</string>
     <string name="plugin_detail_logo_desc">plugin logo</string>
     <string name="post_cardview_featured_desc">featured image</string>
+    <string name="post_settings_featured_desc">featured image</string>
     <string name="reader_cardview_post_play_video_desc">play featured video</string>
     <string name="photo_picker_thumbnail_desc">Play video</string>
     <string name="reader_list_item_suggestion_remove_desc">delete</string>


### PR DESCRIPTION
Fixes #7967 

Replaces Volley with Glide in the EditPostSettings. 
Adds support for adding animated feature images.

To test:
1. Click on the `create post` button
2. Type any title


3. Click on three dots in the top right corner of the screen
4. Click on `Post Settings`
5. Click on the `Set feature image` button
6. Select any GIF image
7. Notice the animation is working and click on the `Publish` button
8. Go to Reader - Followed Sites
9. Make sure the post has animated GIF image

After a discussion with @nozomimimi, we've decided to change the scaling behavior a bit. Current solution should behave like `Proposed state 2` on the following image.
<img width="464" alt="screen shot 2018-06-22 at 13 15 46" src="https://user-images.githubusercontent.com/2261188/42101995-02c9956e-7bc5-11e8-8176-1b9db145f514.png">
