### PR TITLE
Migrate ThumbnailStrip from Volley to Glide

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderThumbnailStrip.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderThumbnailStrip.java
@@ -7,6 +7,8 @@ import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.ImageView.ScaleType;
 import android.widget.LinearLayout;
 
 import org.wordpress.android.R;
@@ -19,7 +21,8 @@ import org.wordpress.android.ui.reader.utils.ReaderImageScanner;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.PhotonUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 import java.util.EnumSet;
 
@@ -88,11 +91,11 @@ public class ReaderThumbnailStrip extends LinearLayout {
         LayoutInflater inflater = LayoutInflater.from(getContext());
         for (final String imageUrl : imageList) {
             View view = inflater.inflate(R.layout.reader_thumbnail_strip_image, mView, false);
-            WPNetworkImageView imageView = (WPNetworkImageView) view.findViewById(R.id.thumbnail_strip_image);
+            ImageView imageView = view.findViewById(R.id.thumbnail_strip_image);
             mView.addView(view);
 
             String photonUrl = PhotonUtils.getPhotonImageUrl(imageUrl, mThumbnailWidth, mThumbnailHeight);
-            imageView.setImageUrl(photonUrl, WPNetworkImageView.ImageType.PHOTO);
+            ImageManager.loadImage(imageView, ImageType.PHOTO, photonUrl, ScaleType.CENTER_CROP);
 
             // tapping a thumbnail opens the photo viewer
             imageView.setOnClickListener(new OnClickListener() {

--- a/WordPress/src/main/res/layout/reader_thumbnail_strip_image.xml
+++ b/WordPress/src/main/res/layout/reader_thumbnail_strip_image.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<org.wordpress.android.widgets.WPNetworkImageView xmlns:android="http://schemas.android.com/apk/res/android"
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/thumbnail_strip_image"
     android:layout_width="0dp"
     android:layout_height="@dimen/reader_thumbnail_strip_image_height"
     android:layout_margin="1dp"
     android:layout_weight="1"
     android:background="@drawable/reader_image_border"
-    android:padding="1dp"
-    android:scaleType="centerCrop" />
+    android:contentDescription="@string/reader_gallery_images_desc"
+    android:padding="1dp" />

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2168,6 +2168,7 @@
     <string name="stats_followers_many_desc">%d followers</string>
     <string name="reader_blavatar_desc">site icon</string>
     <string name="reader_avatar_desc">profile picture</string>
+    <string name="reader_gallery_images_desc">image gallery</string>
 
 
     <!-- Site Creation -->


### PR DESCRIPTION
Fixes #7984 

Replaces Volley with Glide in the ReaderThumbnailStrip.
![gallery-strip](https://user-images.githubusercontent.com/2261188/42210472-65bd7408-7eb1-11e8-8ee7-ebb79a682d02.png)

To test:
I'm still not sure how the server determines whether a post has cardtype Gallery or not. However, I was able to create a post with 4 thumbnails. You can use my [post](https://upm59krakatit.wordpress.com/2018/07/03/gallery-callypso-4/).
1. Follow upm59krakatit.wordpress.com
2. Go to Reader -> Followed Sites
3. Find a post with name 'Gallery-callypso-4'
4. Make sure everything is rendered correctly and the Gif image is being animated (there is just one gif)
