### PR TITLE
Replace Volley with Glide in the PostsListAdapter

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
@@ -44,7 +44,7 @@ public class PostsListActivity extends AppCompatActivity {
 
         setContentView(R.layout.post_list_activity);
 
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
         if (savedInstanceState == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -23,11 +23,13 @@ import android.view.animation.AccelerateInterpolator;
 import android.view.animation.DecelerateInterpolator;
 import android.widget.AdapterView;
 import android.widget.ImageView;
+import android.widget.ImageView.ScaleType;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
@@ -53,8 +55,9 @@ import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.SiteUtils;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 import org.wordpress.android.widgets.PostListButton;
-import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -110,6 +113,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     @Inject protected PostStore mPostStore;
     @Inject protected MediaStore mMediaStore;
     @Inject protected UploadStore mUploadStore;
+    @Inject protected ImageManager mImageManager;
 
     public PostsListAdapter(Context context, @NonNull SiteModel site, boolean isPage) {
         ((WordPress) context.getApplicationContext()).component().inject(this);
@@ -160,7 +164,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     }
 
     @Override
-    public void onAttachedToRecyclerView(RecyclerView recyclerView) {
+    public void onAttachedToRecyclerView(@NonNull RecyclerView recyclerView) {
         super.onAttachedToRecyclerView(recyclerView);
         mRecyclerView = recyclerView;
     }
@@ -183,7 +187,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     }
 
     @Override
-    public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         if (viewType == VIEW_TYPE_ENDLIST_INDICATOR) {
             View view = mLayoutInflater.inflate(R.layout.endlist_indicator, parent, false);
             view.getLayoutParams().height = mEndlistIndicatorHeight;
@@ -210,7 +214,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     }
 
     @Override
-    public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
         // nothing to do if this is the static endlist indicator
         if (getItemViewType(position) == VIEW_TYPE_ENDLIST_INDICATOR) {
             return;
@@ -333,24 +337,25 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         });
     }
 
-    private void showFeaturedImage(int postId, WPNetworkImageView imgFeatured) {
+    private void showFeaturedImage(int postId, ImageView imgFeatured) {
         String imageUrl = mFeaturedImageUrls.get(postId);
         if (imageUrl == null) {
             imgFeatured.setVisibility(View.GONE);
+            mImageManager.cancelRequestAndClearImageView(imgFeatured);
         } else if (imageUrl.startsWith("http")) {
             String photonUrl = ReaderUtils.getResizedImageUrl(
                     imageUrl, mPhotonWidth, mPhotonHeight, !SiteUtils.isPhotonCapable(mSite));
             imgFeatured.setVisibility(View.VISIBLE);
-            imgFeatured.setImageUrl(photonUrl, WPNetworkImageView.ImageType.PHOTO);
+            mImageManager.load(imgFeatured, ImageType.PHOTO, photonUrl, ScaleType.CENTER_CROP);
         } else {
             Bitmap bmp = ImageUtils.getWPImageSpanThumbnailFromFilePath(
                     imgFeatured.getContext(), imageUrl, mPhotonWidth);
             if (bmp != null) {
-                imgFeatured.setImageUrl(null, WPNetworkImageView.ImageType.NONE);
                 imgFeatured.setVisibility(View.VISIBLE);
-                imgFeatured.setImageBitmap(bmp);
+                mImageManager.load(imgFeatured, bmp);
             } else {
                 imgFeatured.setVisibility(View.GONE);
+                mImageManager.cancelRequestAndClearImageView(imgFeatured);
             }
         }
     }
@@ -431,6 +436,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         if ((PostStatus.fromPost(post) == PostStatus.PUBLISHED) && !post.isLocalDraft() && !post.isLocallyChanged()) {
             txtStatus.setVisibility(View.GONE);
             imgStatus.setVisibility(View.GONE);
+            mImageManager.cancelRequestAndClearImageView(imgStatus);
         } else {
             int statusTextResId = 0;
             int statusIconResId = 0;
@@ -490,6 +496,16 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                         statusIconResId = R.drawable.ic_gridicons_page;
                         statusColorResId = R.color.alert_red;
                         break;
+                    case UNKNOWN:
+                        // no-op
+                        break;
+                    case PUBLISHED:
+                        // no-op
+                        break;
+                    default:
+                        if (BuildConfig.DEBUG) {
+                            throw new IllegalStateException("Missing switch case.");
+                        }
                 }
             }
 
@@ -506,10 +522,11 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             if (drawable != null) {
                 drawable = DrawableCompat.wrap(drawable);
                 DrawableCompat.setTint(drawable, resources.getColor(statusColorResId));
-                imgStatus.setImageDrawable(drawable);
                 imgStatus.setVisibility(View.VISIBLE);
+                mImageManager.load(imgStatus, drawable);
             } else {
                 imgStatus.setVisibility(View.GONE);
+                mImageManager.cancelRequestAndClearImageView(imgStatus);
             }
         }
     }
@@ -731,7 +748,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         private final PostListButton mBtnTrash;
         private final PostListButton mBtnBack;
 
-        private final WPNetworkImageView mImgFeatured;
+        private final ImageView mImgFeatured;
         private final ViewGroup mLayoutButtons;
 
         private final View mDisabledOverlay;
@@ -741,27 +758,27 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         PostViewHolder(View view) {
             super(view);
 
-            mTxtTitle = (TextView) view.findViewById(R.id.text_title);
-            mTxtExcerpt = (TextView) view.findViewById(R.id.text_excerpt);
-            mTxtDate = (TextView) view.findViewById(R.id.text_date);
-            mTxtStatus = (TextView) view.findViewById(R.id.text_status);
-            mImgStatus = (ImageView) view.findViewById(R.id.image_status);
+            mTxtTitle = view.findViewById(R.id.text_title);
+            mTxtExcerpt = view.findViewById(R.id.text_excerpt);
+            mTxtDate = view.findViewById(R.id.text_date);
+            mTxtStatus = view.findViewById(R.id.text_status);
+            mImgStatus = view.findViewById(R.id.image_status);
 
-            mBtnEdit = (PostListButton) view.findViewById(R.id.btn_edit);
-            mBtnView = (PostListButton) view.findViewById(R.id.btn_view);
-            mBtnPublish = (PostListButton) view.findViewById(R.id.btn_publish);
-            mBtnMore = (PostListButton) view.findViewById(R.id.btn_more);
+            mBtnEdit = view.findViewById(R.id.btn_edit);
+            mBtnView = view.findViewById(R.id.btn_view);
+            mBtnPublish = view.findViewById(R.id.btn_publish);
+            mBtnMore = view.findViewById(R.id.btn_more);
 
-            mBtnStats = (PostListButton) view.findViewById(R.id.btn_stats);
-            mBtnTrash = (PostListButton) view.findViewById(R.id.btn_trash);
-            mBtnBack = (PostListButton) view.findViewById(R.id.btn_back);
+            mBtnStats = view.findViewById(R.id.btn_stats);
+            mBtnTrash = view.findViewById(R.id.btn_trash);
+            mBtnBack = view.findViewById(R.id.btn_back);
 
-            mImgFeatured = (WPNetworkImageView) view.findViewById(R.id.image_featured);
-            mLayoutButtons = (ViewGroup) view.findViewById(R.id.layout_buttons);
+            mImgFeatured = view.findViewById(R.id.image_featured);
+            mLayoutButtons = view.findViewById(R.id.layout_buttons);
 
             mDisabledOverlay = view.findViewById(R.id.disabled_overlay);
 
-            mProgressBar = (ProgressBar) view.findViewById(R.id.post_upload_progress);
+            mProgressBar = view.findViewById(R.id.post_upload_progress);
         }
     }
 
@@ -778,15 +795,15 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
         PageViewHolder(View view) {
             super(view);
-            mTxtTitle = (TextView) view.findViewById(R.id.text_title);
-            mTxtStatus = (TextView) view.findViewById(R.id.text_status);
-            mImgStatus = (ImageView) view.findViewById(R.id.image_status);
+            mTxtTitle = view.findViewById(R.id.text_title);
+            mTxtStatus = view.findViewById(R.id.text_status);
+            mImgStatus = view.findViewById(R.id.image_status);
             mBtnMore = view.findViewById(R.id.btn_more);
             mDividerTop = view.findViewById(R.id.divider_top);
-            mDateHeader = (ViewGroup) view.findViewById(R.id.header_date);
-            mTxtDate = (TextView) mDateHeader.findViewById(R.id.text_date);
+            mDateHeader = view.findViewById(R.id.header_date);
+            mTxtDate = mDateHeader.findViewById(R.id.text_date);
             mDisabledOverlay = view.findViewById(R.id.disabled_overlay);
-            mProgressBar = (ProgressBar) view.findViewById(R.id.post_upload_progress);
+            mProgressBar = view.findViewById(R.id.post_upload_progress);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -906,7 +906,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         } else {
             bookmarkButton.setVisibility(View.GONE);
         }
-        bookmarkButton.setImageResource(post.isBookmarked
+        mImageManager.load(bookmarkButton, post.isBookmarked
                 ? R.drawable.ic_bookmark_blue_medium_18dp
                 : R.drawable.ic_bookmark_grey_min_18dp);
         if (post.isBookmarked) {

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -47,6 +47,14 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
                 .into(imageView)
     }
 
+    @JvmOverloads
+    fun load(imageView: ImageView, resourceId: Int, scaleType: ImageView.ScaleType = CENTER) {
+        GlideApp.with(imageView.context)
+                .load(resourceId)
+                .applyScaleType(scaleType)
+                .into(imageView)
+    }
+
     fun loadIntoCircle(imageView: ImageView, imageType: ImageType, imgUrl: String) {
         GlideApp.with(imageView.context)
                 .load(imgUrl)
@@ -119,6 +127,15 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
         @JvmOverloads
         fun loadImage(imageView: ImageView, drawable: Drawable, scaleType: ImageView.ScaleType = CENTER) {
             ImageManager(ImagePlaceholderManager()).load(imageView, drawable, scaleType)
+        }
+
+        @JvmStatic
+        @Deprecated("Use injected ImageManager",
+                ReplaceWith("imageManager.load(imageView, resourceId, scaleType)",
+                        "org.wordpress.android.util.image.ImageManager"))
+        @JvmOverloads
+        fun loadImage(imageView: ImageView, resourceId: Int, scaleType: ImageView.ScaleType = CENTER) {
+            ImageManager(ImagePlaceholderManager()).load(imageView, resourceId, scaleType)
         }
 
         @JvmStatic

--- a/WordPress/src/main/res/layout/post_cardview.xml
+++ b/WordPress/src/main/res/layout/post_cardview.xml
@@ -17,11 +17,10 @@
         android:background="?android:selectableItemBackground"
         android:orientation="vertical">
 
-        <org.wordpress.android.widgets.WPNetworkImageView
+        <ImageView
             android:id="@+id/image_featured"
             android:layout_width="match_parent"
             android:layout_height="@dimen/postlist_featured_image_height"
-            android:scaleType="centerCrop"
             android:visibility="gone"
             android:contentDescription="@string/post_cardview_featured_desc"
             tools:visibility="visible" />


### PR DESCRIPTION
Fixes #7960 

Replaces Volley with Glide on the `My Site -> Site Pages` and `My Site -> Blog Posts`. Adds support for animated feature images. Otherwise nothing should change from the user perspective.

To test:
1. Publish a post with a GIF feature image
2. Go to My Site -> Blog Posts
3. Notice the feature images is being animated
4. Check everything else looks the same as before
5. Go to My Site -> Site Pages
6. Check everything looks the same as before