### PR TITLE
Notifications Quick Actions processor: don't process if intent is null

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -285,6 +285,9 @@ public class NotificationsProcessingService extends Service {
         }
 
         private void getDataFromIntent() {
+            if (mIntent == null) {
+                return;
+            }
             // get all needed data from intent
             mNoteId = mIntent.getStringExtra(ARG_NOTE_ID);
             mActionType = mIntent.getStringExtra(ARG_ACTION_TYPE);


### PR DESCRIPTION
Fixes #7991

To test: N/A

cc @loremattei 