### PR TITLE
don't accept feed with no id and no url in updateFeedInfo

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -336,6 +336,17 @@ public class ReaderBlogActions {
     }
 
     public static void updateFeedInfo(long feedId, String feedUrl, final UpdateBlogInfoListener infoListener) {
+        // must pass either a valid id or url
+        final boolean hasFeedId = (feedId != 0);
+        final boolean hasFeedUrl = !TextUtils.isEmpty(feedUrl);
+        if (!hasFeedId && !hasFeedUrl) {
+            AppLog.w(T.READER, "cannot update Feed info without either id or url");
+            if (infoListener != null) {
+                infoListener.onResult(null);
+            }
+            return;
+        }
+
         RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
             public void onResponse(JSONObject jsonObject) {


### PR DESCRIPTION
Fixes #7992 by following the same pattern as in `updateBlogInfo` just a[ few lines above](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/7992-np-reader-followfeedbyid/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java#L293-L302) 


To test: N/A
cc @loremattei 