### PR TITLE
Issue/7998 update editor snackbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -227,7 +227,7 @@ public class UploadUtils {
                                                   View.OnClickListener onClickListener) {
         Snackbar.make(view, messageRes, Snackbar.LENGTH_LONG)
                 .setAction(buttonTitleRes, onClickListener).
-                        setActionTextColor(view.getResources().getColor(R.color.alert_yellow))
+                        setActionTextColor(view.getResources().getColor(R.color.orange_jazzy))
                 .show();
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1142,9 +1142,9 @@
     <string name="menu_publish_now">Publish Now</string>
     <string name="menu_preview">Preview</string>
     <string name="menu_html_mode">HTML Mode</string>
-    <string name="menu_html_mode_done_snackbar">Switched to HTML mode.</string>
+    <string name="menu_html_mode_done_snackbar">Switched to HTML mode</string>
     <string name="menu_visual_mode">Visual Mode</string>
-    <string name="menu_visual_mode_done_snackbar">Switched to Visual mode.</string>
+    <string name="menu_visual_mode_done_snackbar">Switched to Visual mode</string>
     <string name="menu_undo_snackbar_action">UNDO</string>
 
     <string name="menu_undo">Undo</string>


### PR DESCRIPTION
### Fix
Update snackbar action text color to `orange_jazzy` `#f0821e` and remove punctuation from message text when switching between HTML and Visual modes in the editor for app styling consistency as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7998.  See the screenshots below for illustration.

![snakbar_after](https://user-images.githubusercontent.com/3827611/42295692-415d163c-7faa-11e8-9027-21a3921afc39.png)

### Test
1. Tap ***Create*** bottom navigation button.
2. Tap overflow menu action.
3. Tap ***HTML Mode*** item.
4. Notice message has no punctuation and action text color is `orange_jazzy` `#f0821e`.
5. Tap overflow menu action.
6. Tap ***Visual Mode*** item.
7. Notice message has no punctuation and action text color is `orange_jazzy` `#f0821e`