### PR TITLE
Use Activity instead of app Context to launch JobIntentService

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -408,8 +408,8 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
 
         if (isGooglePlayServicesAvailable(activity)) {
             // Register for Cloud messaging
-            GCMRegistrationIntentService.enqueueWork(this,
-                    new Intent(this, GCMRegistrationIntentService.class));
+            GCMRegistrationIntentService.enqueueWork(activity,
+                    new Intent(activity, GCMRegistrationIntentService.class));
         }
 
         // Refresh account informations


### PR DESCRIPTION
Fixes #8000

It's been observed by others that JobIntentService makes apps crash on Android 8.0 but work well when launched from an Activity or another Service, and this happened to be the only occurrence where the `Context` passed wasn't an Activity/Service itself. 

To test: 
1. put a breakpoint in `onActivityResumed` in `WordPress.java`
2. put a breakpoint in `onHandleWork` in `GCMRegistrationIntentService` 
3. run the app, , making sure the call to `deferredInit()` in `WordPress.java` gets executed once.
4. observe the breakpoint in `onHandleWork` is executed as well.
