### PR TITLE
Issue/notification header clipped

### DIFF
--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -32,8 +32,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
-                android:layout_marginLeft="-3dp"
-                android:layout_marginStart="-3dp"
                 android:layout_marginBottom="-1dp"
                 android:textColor="@color/grey_darken_10"
                 android:textSize="18sp"


### PR DESCRIPTION
### Fix
Remove the `-3dp` left/start margin value from `NoticonTextView` in the `notifications_list_item` layout to avoid clipping the view.  See the screenshots below for illustration.

![notification_header_clipped](https://user-images.githubusercontent.com/3827611/42334325-406d2c04-803a-11e8-8ac3-efe86b810879.png)

### Test
1. Go to ***Notifications*** tab.
2. Notice header views are not clipped.