### PR TITLE
Issue/5681 discard changes action

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -123,6 +123,7 @@ class HelpActivity : AppCompatActivity() {
         SIGNUP_SCREEN("origin:signup-screen"),
         ME_SCREEN_HELP("origin:me-screen-help"),
         DELETE_SITE("origin:delete-site"),
+        DISCARD_CHANGES("origin:discard-changes"),
         FEEDBACK_AZTEC("origin:aztec-feedback"),
         LOGIN_EMAIL("origin:login-email"),
         LOGIN_MAGIC_LINK("origin:login-magic-link"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -112,6 +112,7 @@ import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.Shortcut;
+import org.wordpress.android.ui.accounts.HelpActivity.Origin;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaBrowserType;
 import org.wordpress.android.ui.media.MediaSettingsActivity;
@@ -1181,7 +1182,11 @@ public class EditPostActivity extends AppCompatActivity implements
         new AlertDialog.Builder(new ContextThemeWrapper(this, R.style.Calypso_Dialog_Alert))
                 .setMessage(R.string.local_changes_discarding_error)
                 .setNegativeButton(R.string.cancel, null)
-                .setPositiveButton(R.string.contact_support, null)
+                .setPositiveButton(R.string.contact_support, new DialogInterface.OnClickListener() {
+                    @Override public void onClick(DialogInterface dialog, int which) {
+                        mZendeskHelper.createNewTicket(EditPostActivity.this, Origin.DISCARD_CHANGES, mSite);
+                    }
+                })
                 .setOnCancelListener(new OnCancelListener() {
                     @Override public void onCancel(DialogInterface dialog) {
                         mIsDialogErrorShown = false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1163,6 +1163,7 @@ public class EditPostActivity extends AppCompatActivity implements
                             });
                 }
             } else if (itemId == R.id.menu_discard_changes) {
+                AnalyticsTracker.track(Stat.EDITOR_DISCARDED_CHANGES);
                 showDialogProgress(true);
                 mPostWithLocalChanges = mPost.clone();
                 mIsDiscardingChanges = true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3410,6 +3410,7 @@ public class EditPostActivity extends AppCompatActivity implements
                         Snackbar.make(mViewPager, getString(R.string.local_changes_discarded), Snackbar.LENGTH_LONG)
                                 .setAction(getString(R.string.undo), new OnClickListener() {
                                     @Override public void onClick(View view) {
+                                        AnalyticsTracker.track(Stat.EDITOR_DISCARDED_CHANGES_UNDO);
                                         RemotePostPayload payload = new RemotePostPayload(mPostWithLocalChanges, mSite);
                                         mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(payload));
                                         mPost = mPostWithLocalChanges.clone();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -964,6 +964,7 @@ public class EditPostActivity extends AppCompatActivity implements
         MenuItem settingsMenuItem = menu.findItem(R.id.menu_post_settings);
         MenuItem saveAsDraftMenuItem = menu.findItem(R.id.menu_save_as_draft_or_publish);
         MenuItem viewHtmlModeMenuItem = menu.findItem(R.id.menu_html_mode);
+        MenuItem discardChanges = menu.findItem(R.id.menu_discard_changes);
 
         if (previewMenuItem != null) {
             previewMenuItem.setVisible(showMenuItems);
@@ -983,6 +984,14 @@ public class EditPostActivity extends AppCompatActivity implements
         if (viewHtmlModeMenuItem != null) {
             viewHtmlModeMenuItem.setVisible(mEditorFragment instanceof AztecEditorFragment && showMenuItems);
             viewHtmlModeMenuItem.setTitle(mHtmlModeMenuStateOn ? R.string.menu_visual_mode : R.string.menu_html_mode);
+        }
+
+        if (discardChanges != null) {
+            if (mPost != null) {
+                discardChanges.setVisible(showMenuItems && mPost.isLocallyChanged());
+            } else {
+                discardChanges.setVisible(false);
+            }
         }
 
         // Set text of the save button in the ActionBar

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -20,6 +20,7 @@ import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -41,6 +42,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.RelativeLayout;
@@ -3344,6 +3346,19 @@ public class EditPostActivity extends AppCompatActivity implements
                     mIsUpdatingPost = false;
                     mPost = mPostStore.getPostByLocalPostId(mPost.getId());
                     refreshEditorContent();
+
+                    if (mViewPager != null) {
+                        Snackbar.make(mViewPager, getString(R.string.local_changes_discarded), Snackbar.LENGTH_LONG)
+                                .setAction(getString(R.string.undo), new OnClickListener() {
+                                    @Override public void onClick(View view) {
+                                        RemotePostPayload payload = new RemotePostPayload(mPostWithLocalChanges, mSite);
+                                        mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(payload));
+                                        mPost = mPostWithLocalChanges.clone();
+                                        refreshEditorContent();
+                                    }
+                                })
+                                .show();
+                    }
                 }
 
                 if (mIsDiscardingChanges) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -222,15 +222,15 @@ public class PostPreviewActivity extends AppCompatActivity {
             }
         });
 
-        // revert applies to only local changes
-        View btnRevert = messageView.findViewById(R.id.btn_revert);
-        btnRevert.setVisibility(mPost.isLocallyChanged() ? View.VISIBLE : View.GONE);
+        // discard changes applies to only local changes
+        View btnDiscardChanges = messageView.findViewById(R.id.btn_discard_changes);
+        btnDiscardChanges.setVisibility(mPost.isLocallyChanged() ? View.VISIBLE : View.GONE);
         if (mPost.isLocallyChanged()) {
-            btnRevert.setOnClickListener(new View.OnClickListener() {
+            btnDiscardChanges.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     AniUtils.animateBottomBar(messageView, false);
-                    revertPost();
+                    discardChanges();
                     AnalyticsTracker.track(Stat.EDITOR_DISCARDED_CHANGES);
                 }
             });
@@ -266,9 +266,9 @@ public class PostPreviewActivity extends AppCompatActivity {
     }
 
     /*
-     * reverts local changes for this post, replacing it with the latest version from the server
+     * discard local changes for this post, replacing it with the latest version from the server
      */
-    private void revertPost() {
+    private void discardChanges() {
         if (isFinishing() || !NetworkUtils.checkConnection(this)) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -4,6 +4,7 @@ import android.app.Fragment;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
 import android.content.Context;
+import android.os.Build.VERSION;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v7.app.ActionBar;
@@ -239,9 +240,17 @@ public class PostPreviewActivity extends AppCompatActivity {
         // if both buttons are visible, show them below the message instead of to the right of it
         if (mPost.isLocallyChanged()) {
             RelativeLayout.LayoutParams paramsMessage = (RelativeLayout.LayoutParams) messageText.getLayoutParams();
-            // passing "0" removes the param (necessary since removeRule() is API 17+)
-            paramsMessage.addRule(RelativeLayout.LEFT_OF, 0);
-            paramsMessage.addRule(RelativeLayout.CENTER_VERTICAL, 0);
+
+            if (VERSION.SDK_INT < 17) {
+                // passing "0" removes the param (necessary since removeRule() is API 17+)
+                paramsMessage.addRule(RelativeLayout.LEFT_OF, 0);
+                paramsMessage.addRule(RelativeLayout.CENTER_VERTICAL, 0);
+            } else {
+                paramsMessage.removeRule(RelativeLayout.LEFT_OF);
+                paramsMessage.removeRule(RelativeLayout.START_OF);
+                paramsMessage.removeRule(RelativeLayout.CENTER_VERTICAL);
+            }
+
             ViewGroup.MarginLayoutParams marginsMessage = (ViewGroup.MarginLayoutParams) messageText.getLayoutParams();
             marginsMessage.bottomMargin = getResources().getDimensionPixelSize(R.dimen.margin_small);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -358,6 +358,7 @@ public class PostPreviewActivity extends AppCompatActivity {
                         Snackbar.make(mMessageView, getString(R.string.local_changes_discarded), Snackbar.LENGTH_LONG)
                                 .setAction(getString(R.string.undo), new OnClickListener() {
                                     @Override public void onClick(View view) {
+                                        AnalyticsTracker.track(Stat.EDITOR_DISCARDED_CHANGES_UNDO);
                                         RemotePostPayload payload = new RemotePostPayload(mPostWithLocalChanges, mSite);
                                         mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(payload));
                                         mPost = mPostWithLocalChanges.clone();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -4,13 +4,18 @@ import android.app.Fragment;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
 import android.content.Context;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnCancelListener;
+import android.content.DialogInterface.OnDismissListener;
 import android.os.Build.VERSION;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.ActionBar;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.view.ContextThemeWrapper;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -35,7 +40,9 @@ import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged;
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
+import org.wordpress.android.support.ZendeskHelper;
 import org.wordpress.android.ui.ActivityLauncher;
+import org.wordpress.android.ui.accounts.HelpActivity.Origin;
 import org.wordpress.android.ui.uploads.PostEvents;
 import org.wordpress.android.ui.uploads.UploadService;
 import org.wordpress.android.util.AnalyticsUtils;
@@ -55,6 +62,9 @@ import de.greenrobot.event.EventBus;
 import static org.wordpress.android.ui.posts.EditPostActivity.EXTRA_POST_LOCAL_ID;
 
 public class PostPreviewActivity extends AppCompatActivity {
+    private static final String STATE_KEY_IS_DIALOG_ERROR_SHOWN = "stateIsDialogErrorShown";
+
+    private boolean mIsDialogErrorShown;
     private boolean mIsDiscardingChanges;
     private boolean mIsUpdatingPost;
 
@@ -65,6 +75,7 @@ public class PostPreviewActivity extends AppCompatActivity {
 
     @Inject Dispatcher mDispatcher;
     @Inject PostStore mPostStore;
+    @Inject ZendeskHelper mZendeskHelper;
 
     @Override
     protected void attachBaseContext(Context newBase) {
@@ -93,6 +104,11 @@ public class PostPreviewActivity extends AppCompatActivity {
         } else {
             mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
             localPostId = savedInstanceState.getInt(EXTRA_POST_LOCAL_ID);
+            mIsDialogErrorShown = savedInstanceState.getBoolean(STATE_KEY_IS_DIALOG_ERROR_SHOWN, false);
+
+            if (mIsDialogErrorShown) {
+                showDialogError();
+            }
         }
         mPost = mPostStore.getPostByLocalPostId(localPostId);
         if (mSite == null || mPost == null) {
@@ -171,6 +187,7 @@ public class PostPreviewActivity extends AppCompatActivity {
     protected void onSaveInstanceState(Bundle outState) {
         outState.putSerializable(WordPress.SITE, mSite);
         outState.putSerializable(EXTRA_POST_LOCAL_ID, mPost.getId());
+        outState.putBoolean(STATE_KEY_IS_DIALOG_ERROR_SHOWN, mIsDialogErrorShown);
         super.onSaveInstanceState(outState);
     }
 
@@ -342,6 +359,30 @@ public class PostPreviewActivity extends AppCompatActivity {
         }
     }
 
+    private void showDialogError() {
+        new AlertDialog.Builder(new ContextThemeWrapper(this, R.style.Calypso_Dialog_Alert))
+                .setMessage(R.string.local_changes_discarding_error)
+                .setNegativeButton(R.string.cancel, null)
+                .setPositiveButton(R.string.contact_support, new DialogInterface.OnClickListener() {
+                    @Override public void onClick(DialogInterface dialog, int which) {
+                        mZendeskHelper.createNewTicket(PostPreviewActivity.this, Origin.DISCARD_CHANGES, mSite);
+                    }
+                })
+                .setOnCancelListener(new OnCancelListener() {
+                    @Override public void onCancel(DialogInterface dialog) {
+                        mIsDialogErrorShown = false;
+                    }
+                })
+                .setOnDismissListener(new OnDismissListener() {
+                    @Override public void onDismiss(DialogInterface dialog) {
+                        mIsDialogErrorShown = false;
+                    }
+                })
+                .show();
+
+        mIsDialogErrorShown = true;
+    }
+
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPostChanged(OnPostChanged event) {
@@ -378,6 +419,7 @@ public class PostPreviewActivity extends AppCompatActivity {
             } else {
                 mIsDiscardingChanges = false;
                 mIsUpdatingPost = false;
+                showDialogError();
                 AppLog.e(AppLog.T.POSTS, "UPDATE_POST failed: " + event.error.type + " - " + event.error.message);
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -89,7 +89,7 @@ public class PostPreviewActivity extends AppCompatActivity {
 
         setContentView(R.layout.post_preview_activity);
 
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
@@ -216,7 +216,7 @@ public class PostPreviewActivity extends AppCompatActivity {
      * states mean, and hook up the publish and revert buttons
      */
     private void showMessageViewIfNecessary() {
-        mMessageView = (ViewGroup) findViewById(R.id.message_container);
+        mMessageView = findViewById(R.id.message_container);
 
         if (mPost == null
             || mIsUpdatingPost
@@ -227,7 +227,7 @@ public class PostPreviewActivity extends AppCompatActivity {
             return;
         }
 
-        TextView messageText = (TextView) mMessageView.findViewById(R.id.message_text);
+        TextView messageText = mMessageView.findViewById(R.id.message_text);
         if (mPost.isLocallyChanged()) {
             messageText.setText(R.string.local_changes_explainer);
         } else if (mPost.isLocalDraft()) {
@@ -277,7 +277,7 @@ public class PostPreviewActivity extends AppCompatActivity {
             ViewGroup.MarginLayoutParams marginsMessage = (ViewGroup.MarginLayoutParams) messageText.getLayoutParams();
             marginsMessage.bottomMargin = getResources().getDimensionPixelSize(R.dimen.margin_small);
 
-            ViewGroup buttonsView = (ViewGroup) mMessageView.findViewById(R.id.layout_buttons);
+            ViewGroup buttonsView = mMessageView.findViewById(R.id.layout_buttons);
             RelativeLayout.LayoutParams paramsButtons = (RelativeLayout.LayoutParams) buttonsView.getLayoutParams();
             paramsButtons.addRule(RelativeLayout.BELOW, R.id.message_text);
             ViewGroup.MarginLayoutParams marginsButtons = (ViewGroup.MarginLayoutParams) buttonsView.getLayoutParams();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -741,27 +741,27 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         PostViewHolder(View view) {
             super(view);
 
-            mTxtTitle = (TextView) view.findViewById(R.id.text_title);
-            mTxtExcerpt = (TextView) view.findViewById(R.id.text_excerpt);
-            mTxtDate = (TextView) view.findViewById(R.id.text_date);
-            mTxtStatus = (TextView) view.findViewById(R.id.text_status);
-            mImgStatus = (ImageView) view.findViewById(R.id.image_status);
+            mTxtTitle = view.findViewById(R.id.text_title);
+            mTxtExcerpt = view.findViewById(R.id.text_excerpt);
+            mTxtDate = view.findViewById(R.id.text_date);
+            mTxtStatus = view.findViewById(R.id.text_status);
+            mImgStatus = view.findViewById(R.id.image_status);
 
-            mBtnEdit = (PostListButton) view.findViewById(R.id.btn_edit);
-            mBtnView = (PostListButton) view.findViewById(R.id.btn_view);
-            mBtnPublish = (PostListButton) view.findViewById(R.id.btn_publish);
-            mBtnMore = (PostListButton) view.findViewById(R.id.btn_more);
+            mBtnEdit = view.findViewById(R.id.btn_edit);
+            mBtnView = view.findViewById(R.id.btn_view);
+            mBtnPublish = view.findViewById(R.id.btn_publish);
+            mBtnMore = view.findViewById(R.id.btn_more);
 
-            mBtnStats = (PostListButton) view.findViewById(R.id.btn_stats);
-            mBtnTrash = (PostListButton) view.findViewById(R.id.btn_trash);
-            mBtnBack = (PostListButton) view.findViewById(R.id.btn_back);
+            mBtnStats = view.findViewById(R.id.btn_stats);
+            mBtnTrash = view.findViewById(R.id.btn_trash);
+            mBtnBack = view.findViewById(R.id.btn_back);
 
-            mImgFeatured = (WPNetworkImageView) view.findViewById(R.id.image_featured);
-            mLayoutButtons = (ViewGroup) view.findViewById(R.id.layout_buttons);
+            mImgFeatured = view.findViewById(R.id.image_featured);
+            mLayoutButtons = view.findViewById(R.id.layout_buttons);
 
             mDisabledOverlay = view.findViewById(R.id.disabled_overlay);
 
-            mProgressBar = (ProgressBar) view.findViewById(R.id.post_upload_progress);
+            mProgressBar = view.findViewById(R.id.post_upload_progress);
         }
     }
 
@@ -778,15 +778,15 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
         PageViewHolder(View view) {
             super(view);
-            mTxtTitle = (TextView) view.findViewById(R.id.text_title);
-            mTxtStatus = (TextView) view.findViewById(R.id.text_status);
-            mImgStatus = (ImageView) view.findViewById(R.id.image_status);
+            mTxtTitle = view.findViewById(R.id.text_title);
+            mTxtStatus = view.findViewById(R.id.text_status);
+            mImgStatus = view.findViewById(R.id.image_status);
             mBtnMore = view.findViewById(R.id.btn_more);
             mDividerTop = view.findViewById(R.id.divider_top);
-            mDateHeader = (ViewGroup) view.findViewById(R.id.header_date);
-            mTxtDate = (TextView) mDateHeader.findViewById(R.id.text_date);
+            mDateHeader = view.findViewById(R.id.header_date);
+            mTxtDate = mDateHeader.findViewById(R.id.text_date);
             mDisabledOverlay = view.findViewById(R.id.disabled_overlay);
-            mProgressBar = (ProgressBar) view.findViewById(R.id.post_upload_progress);
+            mProgressBar = view.findViewById(R.id.post_upload_progress);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -460,17 +460,17 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             } else if (post.isLocalDraft()) {
                 statusTextResId = R.string.local_draft;
                 statusIconResId = R.drawable.ic_gridicons_page;
-                statusColorResId = R.color.alert_yellow;
+                statusColorResId = R.color.alert_yellow_dark;
             } else if (post.isLocallyChanged()) {
                 statusTextResId = R.string.local_changes;
                 statusIconResId = R.drawable.ic_gridicons_page;
-                statusColorResId = R.color.alert_yellow;
+                statusColorResId = R.color.alert_yellow_dark;
             } else {
                 switch (PostStatus.fromPost(post)) {
                     case DRAFT:
                         statusTextResId = R.string.post_status_draft;
                         statusIconResId = R.drawable.ic_gridicons_page;
-                        statusColorResId = R.color.alert_yellow;
+                        statusColorResId = R.color.alert_yellow_dark;
                         break;
                     case PRIVATE:
                         statusTextResId = R.string.post_status_post_private;
@@ -478,7 +478,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                     case PENDING:
                         statusTextResId = R.string.post_status_pending_review;
                         statusIconResId = R.drawable.ic_gridicons_page;
-                        statusColorResId = R.color.alert_yellow;
+                        statusColorResId = R.color.alert_yellow_dark;
                         break;
                     case SCHEDULED:
                         statusTextResId = R.string.post_status_scheduled;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -7,7 +7,6 @@ import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.Snackbar;
-import android.support.v4.content.ContextCompat;
 import android.text.InputType;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -191,8 +190,6 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
                 mEmailSnackbar = Snackbar
                         .make(getView(), "", Snackbar.LENGTH_INDEFINITE)
                         .setAction(getString(R.string.button_discard), clickListener);
-                mEmailSnackbar.getView().setBackgroundColor(ContextCompat.getColor(getActivity(), R.color.grey_dark));
-                mEmailSnackbar.setActionTextColor(ContextCompat.getColor(getActivity(), R.color.blue_medium));
                 TextView textView =
                         (TextView) mEmailSnackbar.getView().findViewById(android.support.design.R.id.snackbar_text);
                 textView.setMaxLines(4);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -190,7 +190,7 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
 
                 mEmailSnackbar = Snackbar
                         .make(getView(), "", Snackbar.LENGTH_INDEFINITE)
-                        .setAction(getString(R.string.button_revert), clickListener);
+                        .setAction(getString(R.string.button_discard), clickListener);
                 mEmailSnackbar.getView().setBackgroundColor(ContextCompat.getColor(getActivity(), R.color.grey_dark));
                 mEmailSnackbar.setActionTextColor(ContextCompat.getColor(getActivity(), R.color.blue_medium));
                 TextView textView =

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -85,7 +85,7 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View coordinatorView = inflater.inflate(R.layout.preference_coordinator, container, false);
-        CoordinatorLayout coordinator = (CoordinatorLayout) coordinatorView.findViewById(R.id.coordinator);
+        CoordinatorLayout coordinator = coordinatorView.findViewById(R.id.coordinator);
         View preferenceView = super.onCreateView(inflater, coordinator, savedInstanceState);
         coordinator.addView(preferenceView);
         return coordinatorView;
@@ -190,8 +190,7 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
                 mEmailSnackbar = Snackbar
                         .make(getView(), "", Snackbar.LENGTH_INDEFINITE)
                         .setAction(getString(R.string.button_discard), clickListener);
-                TextView textView =
-                        (TextView) mEmailSnackbar.getView().findViewById(android.support.design.R.id.snackbar_text);
+                TextView textView = mEmailSnackbar.getView().findViewById(android.support.design.R.id.snackbar_text);
                 textView.setMaxLines(4);
             }
             // instead of creating a new snackbar, update the current one to avoid the jumping animation

--- a/WordPress/src/main/res/layout/post_preview_activity.xml
+++ b/WordPress/src/main/res/layout/post_preview_activity.xml
@@ -53,7 +53,7 @@
             android:layout_alignParentEnd="true">
 
             <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/btn_revert"
+                android:id="@+id/btn_discard_changes"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
@@ -62,7 +62,7 @@
                 android:paddingLeft="@dimen/margin_extra_large"
                 android:paddingRight="@dimen/margin_extra_large"
                 android:paddingTop="@dimen/margin_medium"
-                android:text="@string/button_revert"
+                android:text="@string/button_discard_changes"
                 android:textAllCaps="true"
                 android:textColor="@color/color_accent"
                 android:textSize="@dimen/text_sz_small"

--- a/WordPress/src/main/res/layout/post_preview_activity.xml
+++ b/WordPress/src/main/res/layout/post_preview_activity.xml
@@ -53,7 +53,7 @@
             android:layout_alignParentEnd="true">
 
             <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/btn_publish"
+                android:id="@+id/btn_revert"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
@@ -62,7 +62,7 @@
                 android:paddingLeft="@dimen/margin_extra_large"
                 android:paddingRight="@dimen/margin_extra_large"
                 android:paddingTop="@dimen/margin_medium"
-                android:text="@string/button_publish"
+                android:text="@string/button_revert"
                 android:textAllCaps="true"
                 android:textColor="@color/color_accent"
                 android:textSize="@dimen/text_sz_small"
@@ -70,7 +70,7 @@
                 android:paddingEnd="@dimen/margin_extra_large"/>
 
             <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/btn_revert"
+                android:id="@+id/btn_publish"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
@@ -79,7 +79,7 @@
                 android:paddingLeft="@dimen/margin_large"
                 android:paddingRight="@dimen/margin_large"
                 android:paddingTop="@dimen/margin_medium"
-                android:text="@string/button_revert"
+                android:text="@string/button_publish"
                 android:textAllCaps="true"
                 android:textColor="@color/color_accent"
                 android:textSize="@dimen/text_sz_small"

--- a/WordPress/src/main/res/menu/edit_post.xml
+++ b/WordPress/src/main/res/menu/edit_post.xml
@@ -6,25 +6,27 @@
         app:showAsAction="always"
         android:title="@string/post_status_publish_post"/>
 
-    <group android:id="@+id/group_save_preview" android:orderInCategory="1">
+    <group
+        android:orderInCategory="1" >
         <item
             android:id="@+id/menu_save_as_draft_or_publish"
             android:title="@string/menu_save_as_draft"/>
         <item
             android:id="@+id/menu_preview_post"
             android:title="@string/menu_preview"/>
-    </group>
-
-    <group android:id="@+id/group_html_mode" android:orderInCategory="1">
         <item
             android:id="@+id/menu_html_mode"
             android:title="@string/menu_html_mode"/>
-    </group>
-
-    <group android:id="@+id/group_post_settings" android:orderInCategory="1">
         <item
             android:id="@+id/menu_post_settings"
             android:title="@string/post_settings"/>
+    </group>
+
+    <group
+        android:orderInCategory="2" >
+        <item
+            android:id="@+id/menu_discard_changes"
+            android:title="@string/menu_discard_changes"/>
     </group>
 
 </menu>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -62,6 +62,7 @@
 
     <!-- Alerts -->
     <color name="alert_yellow">#f0b849</color>
+    <color name="alert_yellow_dark">#d89511</color>
     <color name="alert_red">#d94f4f</color>
     <color name="alert_green">#4ab866</color>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1244,6 +1244,7 @@
 
     <!-- Remote Post Changes -->
     <string name="local_changes">Local changes</string>
+    <string name="local_changes_discarded">Local changes discarded</string>
 
     <!-- message on post preview explaining what local changes, local drafts and drafts are -->
     <string name="local_changes_explainer">This post has local changes which haven\'t been published</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1848,7 +1848,7 @@
     <string name="confirm_delete_site_prompt">Please type in %1$s in the field below to confirm. Your site will then be gone forever.</string>
     <string name="site_settings_export_content_title">Export content</string>
     <string name="error_deleting_site">Error deleting site</string>
-    <string name="error_deleting_site_summary">There was an error in deleting your site. Please contact support for more assistance</string>
+    <string name="error_deleting_site_summary">There was an error in deleting your site. Please contact support for more assistance.</string>
     <string name="primary_domain">Primary Domain</string>
     <string name="export_site_hint">Export your site to an XML file</string>
     <string name="delete_site_warning_title">Delete site?</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1245,6 +1245,7 @@
     <!-- Remote Post Changes -->
     <string name="local_changes">Local changes</string>
     <string name="local_changes_discarded">Local changes discarded</string>
+    <string name="local_changes_discarding">Discarding local changes</string>
 
     <!-- message on post preview explaining what local changes, local drafts and drafts are -->
     <string name="local_changes_explainer">This post has local changes which haven\'t been published</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1147,6 +1147,7 @@
     <string name="menu_visual_mode">Visual Mode</string>
     <string name="menu_visual_mode_done_snackbar">Switched to Visual mode.</string>
     <string name="menu_undo_snackbar_action">UNDO</string>
+    <string name="menu_discard_changes">Discard Local Changes</string>
 
     <string name="menu_undo">Undo</string>
     <string name="menu_redo">Redo</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -247,6 +247,7 @@
     <string name="button_delete" translatable="false">@string/delete</string>
     <string name="button_more" translatable="false">@string/more</string>
     <string name="button_back">Back</string>
+    <string name="button_discard_changes">Discard Changes</string>
     <string name="button_revert">Revert</string>
     <string name="button_retry">Retry</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1246,6 +1246,7 @@
     <string name="local_changes">Local changes</string>
     <string name="local_changes_discarded">Local changes discarded</string>
     <string name="local_changes_discarding">Discarding local changes</string>
+    <string name="local_changes_discarding_error">There was an error in discarding your local changes. Please contact support for more assistance.</string>
 
     <!-- message on post preview explaining what local changes, local drafts and drafts are -->
     <string name="local_changes_explainer">This post has local changes which haven\'t been published</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -247,8 +247,8 @@
     <string name="button_delete" translatable="false">@string/delete</string>
     <string name="button_more" translatable="false">@string/more</string>
     <string name="button_back">Back</string>
+    <string name="button_discard">Discard</string>
     <string name="button_discard_changes">Discard Changes</string>
-    <string name="button_revert">Revert</string>
     <string name="button_retry">Retry</string>
 
     <!-- post uploads -->

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -111,6 +111,7 @@ public final class AnalyticsTracker {
         EDITOR_PUBLISHED_POST,
         EDITOR_SAVED_DRAFT,
         EDITOR_DISCARDED_CHANGES,
+        EDITOR_DISCARDED_CHANGES_UNDO,
         EDITOR_EDITED_IMAGE, // Visual editor only
         EDITOR_HYBRID_ENABLED, // Visual editor only
         EDITOR_HYBRID_TOGGLED_OFF, // Visual editor only

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -492,6 +492,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "editor_draft_saved";
             case EDITOR_DISCARDED_CHANGES:
                 return "editor_discarded_changes";
+            case EDITOR_DISCARDED_CHANGES_UNDO:
+                return "editor_discarded_changes_undo";
             case EDITOR_EDITED_IMAGE:
                 return "editor_image_edited";
             case EDITOR_HYBRID_ENABLED:


### PR DESCRIPTION
### Fix
Add action to overflow menu to discard local changes and snackbar with undo action to revert discarded changes to post editor and preview to address https://github.com/wordpress-mobile/WordPress-Android/issues/5681.  See the screenshots and animation below for illustration.

![discard_changes](https://user-images.githubusercontent.com/3827611/42412465-04d89c6e-81ca-11e8-9c9a-985efee2a103.png)

<img src="https://user-images.githubusercontent.com/3827611/42406999-dece6e1c-8170-11e8-950d-30dbf4f4f146.gif" width="360">

### Test
1. Go to ***My Site*** tab.
2. Tap ***Blog Posts*** item under ***Publish*** section.
3. Tap post with local changes.
4. Notice local changes in post editor.
5. Tap overflow menu action.
6. Tap ***Discard Local Changes*** action.
7. Notice local changes are removed in post editor.
8. Notice ***Local changes discarded*** snackbar with ***Undo*** action.
9. Tap ***Undo*** action.
10. Notice local changes are added in post editor.