### PR TITLE
Replace Volley with Glide in Notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -58,6 +58,7 @@ import org.wordpress.android.ui.media.MediaPreviewFragment;
 import org.wordpress.android.ui.media.MediaSettingsActivity;
 import org.wordpress.android.ui.media.services.MediaDeleteService;
 import org.wordpress.android.ui.notifications.NotificationsDetailActivity;
+import org.wordpress.android.ui.notifications.NotificationsDetailListFragment;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.ui.notifications.receivers.NotificationsPendingDraftsReceiver;
 import org.wordpress.android.ui.people.PeopleInviteFragment;
@@ -330,6 +331,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(NotificationsProcessingService object);
 
     void inject(NotificationsPendingDraftsReceiver object);
+
+    void inject(NotificationsDetailListFragment notificationsDetailListFragment);
 
     void inject(ReaderCommentListActivity object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -19,6 +19,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.NotificationsTable;
 import org.wordpress.android.datasets.ReaderCommentTable;
 import org.wordpress.android.datasets.ReaderPostTable;
@@ -41,10 +42,13 @@ import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.JSONUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.widgets.WPNetworkImageView.ImageType;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.inject.Inject;
 
 public class NotificationsDetailListFragment extends ListFragment implements NotificationFragment {
     private static final String KEY_NOTE_ID = "noteId";
@@ -63,6 +67,8 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
     private CommentUserNoteBlock.OnCommentStatusChangeListener mOnCommentStatusChangeListener;
     private NoteBlockAdapter mNoteBlockAdapter;
 
+    @Inject ImageManager mImageManager;
+
     public NotificationsDetailListFragment() {
     }
 
@@ -75,7 +81,7 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
+        ((WordPress) getActivity().getApplication()).component().inject(this);
         if (savedInstanceState != null && savedInstanceState.containsKey(KEY_NOTE_ID)) {
             // The note will be set in onResume()
             // See WordPress.deferredInit()
@@ -329,7 +335,8 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
                         mNote.getHeader(),
                         imageType,
                         mOnNoteBlockTextClickListener,
-                        mOnGravatarClickedListener
+                        mOnGravatarClickedListener,
+                        mImageManager
                 );
 
                 headerNoteBlock.setIsComment(mNote.isCommentType());
@@ -366,7 +373,8 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
                                         getActivity(),
                                         noteObject,
                                         mOnNoteBlockTextClickListener,
-                                        mOnGravatarClickedListener
+                                        mOnGravatarClickedListener,
+                                        mImageManager
                                 );
                                 pingbackUrl = noteBlock.getMetaSiteUrl();
 
@@ -380,7 +388,8 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
                                         getActivity(),
                                         noteObject,
                                         mOnNoteBlockTextClickListener,
-                                        mOnGravatarClickedListener
+                                        mOnGravatarClickedListener,
+                                        mImageManager
                                 );
                             }
                         } else if (isFooterBlock(noteObject)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -43,6 +43,7 @@ import org.wordpress.android.ui.notifications.utils.NotificationsActions;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
+import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 
 import javax.inject.Inject;
@@ -84,6 +85,7 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
     private boolean mShouldRefreshNotifications;
 
     @Inject AccountStore mAccountStore;
+    @Inject ImageManager mImageManager;
 
     public static NotificationsListFragment newInstance() {
         return new NotificationsListFragment();
@@ -264,7 +266,7 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
 
     private NotesAdapter getNotesAdapter() {
         if (mNotesAdapter == null) {
-            mNotesAdapter = new NotesAdapter(getActivity(), this, null);
+            mNotesAdapter = new NotesAdapter(getActivity(), this, null, mImageManager);
             mNotesAdapter.setOnNoteClickListener(mOnNoteClickListener);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -10,6 +10,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
@@ -20,8 +21,9 @@ import org.wordpress.android.ui.comments.CommentUtils;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.RtlUtils;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 import org.wordpress.android.widgets.NoticonTextView;
-import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,6 +39,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
     private final OnLoadMoreListener mOnLoadMoreListener;
     private final ArrayList<Note> mNotes = new ArrayList<>();
     private final ArrayList<Note> mFilteredNotes = new ArrayList<>();
+    private final ImageManager mImageManager;
 
     public enum FILTERS {
         FILTER_ALL, FILTER_LIKE, FILTER_COMMENT, FILTER_UNREAD,
@@ -55,9 +58,10 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
 
     private NotificationsListFragment.OnNoteClickListener mOnNoteClickListener;
 
-    public NotesAdapter(Context context, DataLoadedListener dataLoadedListener, OnLoadMoreListener onLoadMoreListener) {
+    public NotesAdapter(Context context, DataLoadedListener dataLoadedListener, OnLoadMoreListener onLoadMoreListener, ImageManager imageManager) {
         super();
 
+        mImageManager = imageManager;
         mDataLoadedListener = dataLoadedListener;
         mOnLoadMoreListener = onLoadMoreListener;
 
@@ -256,7 +260,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         }
 
         String avatarUrl = GravatarUtils.fixGravatarUrl(note.getIconURL(), mAvatarSz);
-        noteViewHolder.mImgAvatar.setImageUrl(avatarUrl, WPNetworkImageView.ImageType.AVATAR);
+        mImageManager.loadIntoCircle(noteViewHolder.mImgAvatar, ImageType.AVATAR, avatarUrl);
 
         boolean isUnread = note.isUnread();
 
@@ -332,19 +336,19 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         private final TextView mTxtSubject;
         private final TextView mTxtSubjectNoticon;
         private final TextView mTxtDetail;
-        private final WPNetworkImageView mImgAvatar;
+        private final ImageView mImgAvatar;
         private final NoticonTextView mNoteIcon;
 
         NoteViewHolder(View view) {
             super(view);
             mHeaderView = view.findViewById(R.id.time_header);
             mContentView = view.findViewById(R.id.note_content_container);
-            mHeaderText = (TextView) view.findViewById(R.id.header_date_text);
-            mTxtSubject = (TextView) view.findViewById(R.id.note_subject);
-            mTxtSubjectNoticon = (TextView) view.findViewById(R.id.note_subject_noticon);
-            mTxtDetail = (TextView) view.findViewById(R.id.note_detail);
-            mImgAvatar = (WPNetworkImageView) view.findViewById(R.id.note_avatar);
-            mNoteIcon = (NoticonTextView) view.findViewById(R.id.note_icon);
+            mHeaderText = view.findViewById(R.id.header_date_text);
+            mTxtSubject = view.findViewById(R.id.note_subject);
+            mTxtSubjectNoticon = view.findViewById(R.id.note_subject_noticon);
+            mTxtDetail = view.findViewById(R.id.note_detail);
+            mImgAvatar = view.findViewById(R.id.note_avatar);
+            mNoteIcon = view.findViewById(R.id.note_icon);
 
             itemView.setOnClickListener(mOnClickListener);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -58,7 +58,8 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
 
     private NotificationsListFragment.OnNoteClickListener mOnNoteClickListener;
 
-    public NotesAdapter(Context context, DataLoadedListener dataLoadedListener, OnLoadMoreListener onLoadMoreListener, ImageManager imageManager) {
+    public NotesAdapter(Context context, DataLoadedListener dataLoadedListener, OnLoadMoreListener onLoadMoreListener,
+                        ImageManager imageManager) {
         super();
 
         mImageManager = imageManager;

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
@@ -6,6 +6,7 @@ import android.support.v4.view.ViewCompat;
 import android.text.Html;
 import android.text.TextUtils;
 import android.view.View;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.json.JSONException;
@@ -16,7 +17,8 @@ import org.wordpress.android.fluxc.model.CommentStatus;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.GravatarUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 // A user block with slightly different formatting for display in a comment detail
 public class CommentUserNoteBlock extends UserNoteBlock {
@@ -35,8 +37,9 @@ public class CommentUserNoteBlock extends UserNoteBlock {
 
     public CommentUserNoteBlock(Context context, JSONObject noteObject,
                                 OnNoteBlockTextClickListener onNoteBlockTextClickListener,
-                                OnGravatarClickedListener onGravatarClickedListener) {
-        super(context, noteObject, onNoteBlockTextClickListener, onGravatarClickedListener);
+                                OnGravatarClickedListener onGravatarClickedListener,
+                                ImageManager imageManager) {
+        super(context, noteObject, onNoteBlockTextClickListener, onGravatarClickedListener, imageManager);
 
         if (context != null) {
             setAvatarSize(context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_small));
@@ -76,9 +79,9 @@ public class CommentUserNoteBlock extends UserNoteBlock {
 
         noteBlockHolder.mSiteTextView.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
 
+        String imageUrl = "";
         if (hasImageMediaItem()) {
-            String imageUrl = GravatarUtils.fixGravatarUrl(getNoteMediaItem().optString("url", ""), getAvatarSize());
-            noteBlockHolder.mAvatarImageView.setImageUrl(imageUrl, WPNetworkImageView.ImageType.AVATAR);
+            imageUrl = GravatarUtils.fixGravatarUrl(getNoteMediaItem().optString("url", ""), getAvatarSize());
             noteBlockHolder.mAvatarImageView.setContentDescription(
                     view.getContext().getString(R.string.profile_picture, getNoteText().toString()));
             if (!TextUtils.isEmpty(getUserUrl())) {
@@ -97,12 +100,12 @@ public class CommentUserNoteBlock extends UserNoteBlock {
                 noteBlockHolder.mAvatarImageView.setContentDescription(null);
             }
         } else {
-            noteBlockHolder.mAvatarImageView.showDefaultGravatarImageAndNullifyUrl();
             noteBlockHolder.mAvatarImageView.setOnClickListener(null);
             //noinspection AndroidLintClickableViewAccessibility
             noteBlockHolder.mAvatarImageView.setOnTouchListener(null);
             noteBlockHolder.mAvatarImageView.setContentDescription(null);
         }
+        mImageManager.loadIntoCircle(noteBlockHolder.mAvatarImageView, ImageType.AVATAR, imageUrl);
 
         noteBlockHolder.mCommentTextView.setText(getCommentTextOfNotification(noteBlockHolder));
 
@@ -191,7 +194,7 @@ public class CommentUserNoteBlock extends UserNoteBlock {
     }
 
     private class CommentUserNoteBlockHolder {
-        private final WPNetworkImageView mAvatarImageView;
+        private final ImageView mAvatarImageView;
         private final TextView mNameTextView;
         private final TextView mAgoTextView;
         private final TextView mBulletTextView;
@@ -200,14 +203,14 @@ public class CommentUserNoteBlock extends UserNoteBlock {
         private final View mDividerView;
 
         CommentUserNoteBlockHolder(View view) {
-            mNameTextView = (TextView) view.findViewById(R.id.user_name);
-            mAgoTextView = (TextView) view.findViewById(R.id.user_comment_ago);
+            mNameTextView = view.findViewById(R.id.user_name);
+            mAgoTextView = view.findViewById(R.id.user_comment_ago);
             mAgoTextView.setVisibility(View.VISIBLE);
-            mBulletTextView = (TextView) view.findViewById(R.id.user_comment_bullet);
-            mSiteTextView = (TextView) view.findViewById(R.id.user_comment_site);
-            mCommentTextView = (TextView) view.findViewById(R.id.user_comment);
+            mBulletTextView = view.findViewById(R.id.user_comment_bullet);
+            mSiteTextView = view.findViewById(R.id.user_comment_site);
+            mCommentTextView = view.findViewById(R.id.user_comment);
             mCommentTextView.setMovementMethod(new NoteBlockLinkMovementMethod());
-            mAvatarImageView = (WPNetworkImageView) view.findViewById(R.id.user_avatar);
+            mAvatarImageView = view.findViewById(R.id.user_avatar);
             mDividerView = view.findViewById(R.id.divider_view);
 
             mSiteTextView.setOnClickListener(new View.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/HeaderNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/HeaderNoteBlock.java
@@ -7,6 +7,7 @@ import android.text.TextUtils;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.animation.DecelerateInterpolator;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.json.JSONArray;
@@ -15,23 +16,27 @@ import org.wordpress.android.R;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.JSONUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 // Note header, displayed at top of detail view
 public class HeaderNoteBlock extends NoteBlock {
     private final JSONArray mHeaderArray;
 
     private final UserNoteBlock.OnGravatarClickedListener mGravatarClickedListener;
+    private final ImageManager mImageManager;
     private Boolean mIsComment;
     private int mAvatarSize;
 
-    private WPNetworkImageView.ImageType mImageType;
+    private ImageType mImageType;
 
-    public HeaderNoteBlock(Context context, JSONArray headerArray, WPNetworkImageView.ImageType imageType,
+    public HeaderNoteBlock(Context context, JSONArray headerArray, ImageType imageType,
                            OnNoteBlockTextClickListener onNoteBlockTextClickListener,
-                           UserNoteBlock.OnGravatarClickedListener onGravatarClickedListener) {
+                           UserNoteBlock.OnGravatarClickedListener onGravatarClickedListener,
+                           ImageManager imageManager) {
         super(new JSONObject(), onNoteBlockTextClickListener);
 
+        mImageManager = imageManager;
         mHeaderArray = headerArray;
         mImageType = imageType;
         mGravatarClickedListener = onGravatarClickedListener;
@@ -57,8 +62,12 @@ public class HeaderNoteBlock extends NoteBlock {
 
         Spannable spannable = NotificationsUtils.getSpannableContentForRanges(mHeaderArray.optJSONObject(0));
         noteBlockHolder.mNameTextView.setText(spannable);
+        if (mImageType == ImageType.AVATAR) {
+            mImageManager.loadIntoCircle(noteBlockHolder.mAvatarImageView, mImageType, getAvatarUrl());
+        } else {
+            mImageManager.load(noteBlockHolder.mAvatarImageView, mImageType, getAvatarUrl());
+        }
 
-        noteBlockHolder.mAvatarImageView.setImageUrl(getAvatarUrl(), mImageType);
         final long siteId = Long.valueOf(JSONUtils.queryJSON(mHeaderArray, "[0].ranges[0].site_id", 0));
         final long userId = Long.valueOf(JSONUtils.queryJSON(mHeaderArray, "[0].ranges[0].id", 0));
 
@@ -139,14 +148,14 @@ public class HeaderNoteBlock extends NoteBlock {
     private class NoteHeaderBlockHolder {
         private final TextView mNameTextView;
         private final TextView mSnippetTextView;
-        private final WPNetworkImageView mAvatarImageView;
+        private final ImageView mAvatarImageView;
 
         NoteHeaderBlockHolder(View view) {
             View rootView = view.findViewById(R.id.header_root_view);
             rootView.setOnClickListener(mOnClickListener);
-            mNameTextView = (TextView) view.findViewById(R.id.header_user);
-            mSnippetTextView = (TextView) view.findViewById(R.id.header_snippet);
-            mAvatarImageView = (WPNetworkImageView) view.findViewById(R.id.header_avatar);
+            mNameTextView = view.findViewById(R.id.header_user);
+            mSnippetTextView = view.findViewById(R.id.header_snippet);
+            mAvatarImageView = view.findViewById(R.id.header_avatar);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/UserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/UserNoteBlock.java
@@ -6,19 +6,22 @@ import android.text.TextUtils;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.animation.DecelerateInterpolator;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.json.JSONObject;
 import org.wordpress.android.R;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.JSONUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 /**
  * A block that displays information about a User (such as a user that liked a post)
  */
 public class UserNoteBlock extends NoteBlock {
     private final OnGravatarClickedListener mGravatarClickedListener;
+    protected final ImageManager mImageManager;
 
     private int mAvatarSz;
 
@@ -31,8 +34,10 @@ public class UserNoteBlock extends NoteBlock {
             Context context,
             JSONObject noteObject,
             OnNoteBlockTextClickListener onNoteBlockTextClickListener,
-            OnGravatarClickedListener onGravatarClickedListener) {
+            OnGravatarClickedListener onGravatarClickedListener,
+            ImageManager imageManager) {
         super(noteObject, onNoteBlockTextClickListener);
+        mImageManager = imageManager;
         if (context != null) {
             setAvatarSize(context.getResources().getDimensionPixelSize(R.dimen.notifications_avatar_sz));
         }
@@ -85,9 +90,9 @@ public class UserNoteBlock extends NoteBlock {
             noteBlockHolder.mTaglineTextView.setVisibility(View.GONE);
         }
 
+        String imageUrl = "";
         if (hasImageMediaItem()) {
-            String imageUrl = GravatarUtils.fixGravatarUrl(getNoteMediaItem().optString("url", ""), getAvatarSize());
-            noteBlockHolder.mAvatarImageView.setImageUrl(imageUrl, WPNetworkImageView.ImageType.AVATAR);
+            imageUrl = GravatarUtils.fixGravatarUrl(getNoteMediaItem().optString("url", ""), getAvatarSize());
             if (!TextUtils.isEmpty(getUserUrl())) {
                 //noinspection AndroidLintClickableViewAccessibility
                 noteBlockHolder.mAvatarImageView.setOnTouchListener(mOnGravatarTouchListener);
@@ -101,11 +106,11 @@ public class UserNoteBlock extends NoteBlock {
             }
         } else {
             noteBlockHolder.mRootView.setEnabled(false);
-            noteBlockHolder.mAvatarImageView.showDefaultGravatarImageAndNullifyUrl();
             noteBlockHolder.mRootView.setOnClickListener(null);
             //noinspection AndroidLintClickableViewAccessibility
             noteBlockHolder.mAvatarImageView.setOnTouchListener(null);
         }
+        mImageManager.loadIntoCircle(noteBlockHolder.mAvatarImageView, ImageType.AVATAR, imageUrl);
 
         return view;
     }
@@ -127,14 +132,14 @@ public class UserNoteBlock extends NoteBlock {
         private final TextView mNameTextView;
         private final TextView mUrlTextView;
         private final TextView mTaglineTextView;
-        private final WPNetworkImageView mAvatarImageView;
+        private final ImageView mAvatarImageView;
 
         UserActionNoteBlockHolder(View view) {
             mRootView = view.findViewById(R.id.user_block_root_view);
-            mNameTextView = (TextView) view.findViewById(R.id.user_name);
-            mUrlTextView = (TextView) view.findViewById(R.id.user_blog_url);
-            mTaglineTextView = (TextView) view.findViewById(R.id.user_blog_tagline);
-            mAvatarImageView = (WPNetworkImageView) view.findViewById(R.id.user_avatar);
+            mNameTextView = view.findViewById(R.id.user_name);
+            mUrlTextView = view.findViewById(R.id.user_blog_url);
+            mTaglineTextView = view.findViewById(R.id.user_blog_tagline);
+            mAvatarImageView = view.findViewById(R.id.user_avatar);
         }
     }
 

--- a/WordPress/src/main/res/layout/note_block_comment_user.xml
+++ b/WordPress/src/main/res/layout/note_block_comment_user.xml
@@ -17,10 +17,11 @@
         android:gravity="center_vertical"
         android:orientation="horizontal">
 
-        <org.wordpress.android.widgets.WPNetworkImageView
+        <ImageView
             android:id="@+id/user_avatar"
             android:layout_width="@dimen/avatar_sz_small"
-            android:layout_height="@dimen/avatar_sz_small" />
+            android:layout_height="@dimen/avatar_sz_small"
+            tools:ignore="ContentDescription"/>
 
         <LinearLayout
             android:id="@+id/user_name_wrapper"

--- a/WordPress/src/main/res/layout/note_block_header.xml
+++ b/WordPress/src/main/res/layout/note_block_header.xml
@@ -26,10 +26,11 @@
             android:paddingStart="@dimen/margin_extra_large"
             android:paddingEnd="@dimen/margin_extra_large">
 
-            <org.wordpress.android.widgets.WPNetworkImageView
+            <ImageView
                 android:id="@+id/header_avatar"
                 android:layout_width="@dimen/avatar_sz_small"
-                android:layout_height="@dimen/avatar_sz_small" />
+                android:layout_height="@dimen/avatar_sz_small"
+                tools:ignore="ContentDescription"/>
 
             <LinearLayout
                 android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/note_block_user.xml
+++ b/WordPress/src/main/res/layout/note_block_user.xml
@@ -26,7 +26,7 @@
             android:paddingBottom="@dimen/margin_medium"
             android:paddingTop="@dimen/margin_medium">
 
-            <org.wordpress.android.widgets.WPNetworkImageView
+            <ImageView
                 android:importantForAccessibility="no"
                 android:id="@+id/user_avatar"
                 android:layout_width="@dimen/notifications_avatar_sz"


### PR DESCRIPTION
Fixes #7958 

Replaces Volley with Glide in the Notifications section of the app. Since this sections contains only gravatar/blavatar images, which don't support GIF format, this PR shouldn't introduce any visible changes.

To test:
1. Go to Notifications
2. Make sure list items looks the same as they looked before this PR
3. Open detail of each notification type (comment, follow, like) and make sure the details look the same as they looked before this PR
