### PR TITLE
Replace Volley with Glide in the Theme browser

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationThemeAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationThemeAdapter.java
@@ -1,20 +1,26 @@
 package org.wordpress.android.ui.accounts.signup;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.ImageView.ScaleType;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.ThemeModel;
 import org.wordpress.android.ui.prefs.AppPrefs;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 import java.util.List;
+
+import javax.inject.Inject;
 
 public class SiteCreationThemeAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     private static final int VIEW_TYPE_HEADER = 0;
@@ -25,6 +31,8 @@ public class SiteCreationThemeAdapter extends RecyclerView.Adapter<RecyclerView.
     private @StringRes int mErrorMessage;
     private SiteCreationListener mSiteCreationListener;
 
+    @Inject ImageManager mImageManager;
+
     public static class HeaderViewHolder extends RecyclerView.ViewHolder {
         public final View progressContainer;
         public final View progress;
@@ -34,18 +42,18 @@ public class SiteCreationThemeAdapter extends RecyclerView.Adapter<RecyclerView.
             super(itemView);
             this.progressContainer = itemView.findViewById(R.id.progress_container);
             this.progress = itemView.findViewById(R.id.progress_bar);
-            this.label = (TextView) itemView.findViewById(R.id.progress_label);
+            this.label = itemView.findViewById(R.id.progress_label);
         }
     }
 
     public static class ThemeViewHolder extends RecyclerView.ViewHolder {
-        private final WPNetworkImageView mImageView;
+        private final ImageView mImageView;
         private final TextView mNameView;
 
         ThemeViewHolder(View view) {
             super(view);
-            mImageView = (WPNetworkImageView) view.findViewById(R.id.theme_grid_item_image);
-            mNameView = (TextView) view.findViewById(R.id.theme_grid_item_name);
+            mImageView = view.findViewById(R.id.theme_grid_item_image);
+            mNameView = view.findViewById(R.id.theme_grid_item_name);
         }
     }
 
@@ -64,7 +72,7 @@ public class SiteCreationThemeAdapter extends RecyclerView.Adapter<RecyclerView.
     }
 
     @Override
-    public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         if (viewType == VIEW_TYPE_HEADER) {
             View itemView = LayoutInflater.from(parent.getContext()).inflate(R.layout.site_creation_theme_header,
                                                                              parent, false);
@@ -77,7 +85,7 @@ public class SiteCreationThemeAdapter extends RecyclerView.Adapter<RecyclerView.
     }
 
     @Override
-    public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
         int viewType = getItemViewType(position);
 
         if (viewType == VIEW_TYPE_HEADER) {
@@ -127,20 +135,9 @@ public class SiteCreationThemeAdapter extends RecyclerView.Adapter<RecyclerView.
     private static final String THEME_IMAGE_PARAMETER = "?w=";
 
     private void configureImageView(ThemeViewHolder themeViewHolder, String screenshotURL) {
-        String requestURL = (String) themeViewHolder.mImageView.getTag();
-        if (requestURL == null) {
-            requestURL = screenshotURL;
-            themeViewHolder.mImageView.setDefaultImageResId(R.drawable.theme_loading);
-            themeViewHolder.mImageView.showDefaultImage(); // force showing the default image so layout is computed
-            themeViewHolder.mImageView.setTag(requestURL);
-        }
-
-        if (!requestURL.equals(screenshotURL)) {
-            requestURL = screenshotURL;
-        }
-
         int mViewWidth = AppPrefs.getThemeImageSizeWidth();
-        themeViewHolder.mImageView.setImageUrl(requestURL + THEME_IMAGE_PARAMETER + mViewWidth,
-                                               WPNetworkImageView.ImageType.PHOTO);
+        mImageManager
+                .load(themeViewHolder.mImageView, ImageType.THEME, screenshotURL + THEME_IMAGE_PARAMETER + mViewWidth,
+                        ScaleType.FIT_CENTER);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationThemeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationThemeFragment.java
@@ -49,7 +49,7 @@ public class SiteCreationThemeFragment extends SiteCreationBaseFormFragment<Site
     protected void setupContent(ViewGroup rootView) {
         // important for accessibility - talkback
         getActivity().setTitle(R.string.site_creation_theme_selection_title);
-        RecyclerView recyclerView = (RecyclerView) rootView.findViewById(R.id.recycler_view);
+        RecyclerView recyclerView = rootView.findViewById(R.id.recycler_view);
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
         recyclerView.setAdapter(mSiteCreationThemeAdapter);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserAdapter.java
@@ -16,6 +16,7 @@ import android.widget.Filterable;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.ImageView;
+import android.widget.ImageView.ScaleType;
 import android.widget.PopupMenu;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -169,7 +170,8 @@ class ThemeBrowserAdapter extends BaseAdapter implements Filterable {
     private void configureImageView(ThemeViewHolder themeViewHolder, String screenshotURL, final String themeId,
                                     final boolean isCurrent) {
         mImageManager
-                .load(themeViewHolder.mImageView, ImageType.THEME, screenshotURL + THEME_IMAGE_PARAMETER + mViewWidth);
+                .load(themeViewHolder.mImageView, ImageType.THEME, screenshotURL + THEME_IMAGE_PARAMETER + mViewWidth,
+                        ScaleType.FIT_CENTER);
 
         themeViewHolder.mCardView.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserAdapter.java
@@ -15,6 +15,7 @@ import android.widget.Filter;
 import android.widget.Filterable;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
+import android.widget.ImageView;
 import android.widget.PopupMenu;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -23,8 +24,9 @@ import org.wordpress.android.R;
 import org.wordpress.android.fluxc.model.ThemeModel;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.themes.ThemeBrowserFragment.ThemeBrowserFragmentCallback;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 import org.wordpress.android.widgets.HeaderGridView;
-import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,6 +38,7 @@ class ThemeBrowserAdapter extends BaseAdapter implements Filterable {
     private final Context mContext;
     private final LayoutInflater mInflater;
     private final ThemeBrowserFragmentCallback mCallback;
+    private final ImageManager mImageManager;
 
     private int mViewWidth;
     private String mQuery;
@@ -43,16 +46,17 @@ class ThemeBrowserAdapter extends BaseAdapter implements Filterable {
     private final List<ThemeModel> mAllThemes = new ArrayList<>();
     private final List<ThemeModel> mFilteredThemes = new ArrayList<>();
 
-    ThemeBrowserAdapter(Context context, ThemeBrowserFragmentCallback callback) {
+    ThemeBrowserAdapter(Context context, ThemeBrowserFragmentCallback callback, ImageManager imageManager) {
         mContext = context;
         mInflater = LayoutInflater.from(context);
         mCallback = callback;
         mViewWidth = AppPrefs.getThemeImageSizeWidth();
+        mImageManager = imageManager;
     }
 
     private static class ThemeViewHolder {
         private final CardView mCardView;
-        private final WPNetworkImageView mImageView;
+        private final ImageView mImageView;
         private final TextView mNameView;
         private final TextView mActiveView;
         private final TextView mPriceView;
@@ -164,19 +168,9 @@ class ThemeBrowserAdapter extends BaseAdapter implements Filterable {
 
     private void configureImageView(ThemeViewHolder themeViewHolder, String screenshotURL, final String themeId,
                                     final boolean isCurrent) {
-        String requestURL = (String) themeViewHolder.mImageView.getTag();
-        if (requestURL == null) {
-            requestURL = screenshotURL;
-            themeViewHolder.mImageView.setDefaultImageResId(R.drawable.theme_loading);
-            themeViewHolder.mImageView.setTag(requestURL);
-        }
+        mImageManager
+                .load(themeViewHolder.mImageView, ImageType.THEME, screenshotURL + THEME_IMAGE_PARAMETER + mViewWidth);
 
-        if (!requestURL.equals(screenshotURL)) {
-            requestURL = screenshotURL;
-        }
-
-        themeViewHolder.mImageView
-                .setImageUrl(requestURL + THEME_IMAGE_PARAMETER + mViewWidth, WPNetworkImageView.ImageType.PHOTO);
         themeViewHolder.mCardView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -13,13 +13,10 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AbsListView.RecyclerListener;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-
-import com.android.volley.VolleyError;
-import com.android.volley.toolbox.ImageLoader.ImageContainer;
-import com.android.volley.toolbox.ImageLoader.ImageListener;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -34,9 +31,9 @@ import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper.RefreshListener;
+import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 import org.wordpress.android.widgets.HeaderGridView;
-import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -96,6 +93,7 @@ public class ThemeBrowserFragment extends Fragment
     private ThemeBrowserFragmentCallback mCallback;
 
     @Inject ThemeStore mThemeStore;
+    @Inject ImageManager mImageManager;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -207,23 +205,9 @@ public class ThemeBrowserFragment extends Fragment
     @Override
     public void onMovedToScrapHeap(View view) {
         // cancel image fetch requests if the view has been moved to recycler.
-        WPNetworkImageView niv = view.findViewById(R.id.theme_grid_item_image);
+        ImageView niv = view.findViewById(R.id.theme_grid_item_image);
         if (niv != null) {
-            // this tag is set in the ThemeBrowserAdapter class
-            String requestUrl = (String) niv.getTag();
-            if (requestUrl != null) {
-                // need a listener to cancel request, even if the listener does nothing
-                ImageContainer container = WordPress.sImageLoader.get(requestUrl, new ImageListener() {
-                    @Override
-                    public void onErrorResponse(VolleyError error) {
-                    }
-
-                    @Override
-                    public void onResponse(ImageContainer response, boolean isImmediate) {
-                    }
-                });
-                container.cancelRequest();
-            }
+            mImageManager.cancelRequestAndClearImageView(niv);
         }
     }
 
@@ -344,7 +328,7 @@ public class ThemeBrowserFragment extends Fragment
 
     private ThemeBrowserAdapter getAdapter() {
         if (mAdapter == null) {
-            mAdapter = new ThemeBrowserAdapter(getActivity(), mCallback);
+            mAdapter = new ThemeBrowserAdapter(getActivity(), mCallback, mImageManager);
         }
         return mAdapter;
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
@@ -12,6 +12,7 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.VIDEO -> R.color.grey_lighten_30
             ImageType.AVATAR -> R.drawable.ic_placeholder_gravatar_grey_lighten_20_100dp
             ImageType.BLAVATAR -> R.drawable.ic_placeholder_blavatar_grey_lighten_20_40dp
+            ImageType.THEME -> R.color.grey_lighten_30
         }
     }
 
@@ -21,6 +22,7 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.VIDEO -> R.color.grey_light
             ImageType.AVATAR -> R.drawable.shape_oval_grey_light
             ImageType.BLAVATAR -> R.color.grey_light
+            ImageType.THEME -> R.drawable.theme_loading
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
@@ -4,5 +4,6 @@ enum class ImageType {
     PHOTO,
     VIDEO,
     AVATAR,
-    BLAVATAR
+    BLAVATAR,
+    THEME
 }

--- a/WordPress/src/main/res/layout/theme_grid_item.xml
+++ b/WordPress/src/main/res/layout/theme_grid_item.xml
@@ -34,7 +34,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/theme_browser_preview_image_height"
                     android:adjustViewBounds="true"
-                    android:scaleType="fitCenter"
                     android:contentDescription="@string/theme_image_desc"/>
 
             </FrameLayout>

--- a/WordPress/src/main/res/layout/theme_grid_item.xml
+++ b/WordPress/src/main/res/layout/theme_grid_item.xml
@@ -29,12 +29,13 @@
                 android:importantForAccessibility="noHideDescendants"
                 android:foreground="?android:attr/selectableItemBackground">
 
-                <org.wordpress.android.widgets.WPNetworkImageView
+                <ImageView
                     android:id="@+id/theme_grid_item_image"
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/theme_browser_preview_image_height"
                     android:adjustViewBounds="true"
-                    android:scaleType="fitCenter" />
+                    android:scaleType="fitCenter"
+                    android:contentDescription="@string/theme_image_desc"/>
 
             </FrameLayout>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2119,6 +2119,7 @@
 
     <!-- Content description for accessibility  -->
     <string name="featured_image_desc">featured image</string>
+    <string name="theme_image_desc">theme image</string>
     <string name="comment_checkmark_desc">check mark</string>
     <string name="profile_picture">%s\'s profile picture</string>
     <string name="invite_user_delete_desc">remove %s</string>


### PR DESCRIPTION
Fixes #7965 

Replaces Volley with Glide in the `My Site -> Theme` section of the app. Since this sections contains only gravatar/blavatar images, which don't support GIF format, this PR shouldn't introduce any visible changes.

To test:
1. Go to My Site
2. Go to Themes
3. Make sure all list items look the same as they looked before this PR


The layout for theme item is reused in the Site Creation flow, so I had to change it there as well.
1. Go to My Site
2. Click on the 'Switch Site'
3. Click on the Plus sign in the toolbar
4. Click on the 'Create WordPress.com site'
5. Click on 'Start a blog'
6. Make sure all list items look the same as they looked before this PR


