### PR TITLE
Rewind: Add placeholder numbering

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -763,14 +763,14 @@
     <string name="activity_log_button">Activity Log action button</string>
     <string name="activity_log_jetpack_icon">Jetpack icon</string>
     <string name="activity_log_empty_list">No events recorded yet</string>
-    <string name="activity_log_rewind_started_snackbar_message">Your site is being restored\nRewinding to %s %s</string>
-    <string name="activity_log_rewind_finished_snackbar_message">Your site has been successfully restored\nRewound to %s %s</string>
+    <string name="activity_log_rewind_started_snackbar_message">Your site is being restored\nRewinding to %1$s %2$s</string>
+    <string name="activity_log_rewind_finished_snackbar_message">Your site has been successfully restored\nRewound to %1$s %2$s</string>
     <string name="activity_log_rewind_finished_snackbar_message_no_dates">Your site has been successfully restored</string>
     <string name="activity_log_currently_restoring_title">Currently restoring your site</string>
-    <string name="activity_log_currently_restoring_message">Rewinding to %s %s</string>
+    <string name="activity_log_currently_restoring_message">Rewinding to %1$s %2$s</string>
     <string name="activity_log_currently_restoring_message_no_dates">Rewind in progress</string>
     <string name="activity_log_rewind_site">Rewind Site</string>
-    <string name="activity_log_rewind_dialog_message">Are you sure you want to rewind your site back to %s at %s? This will remove all content and options created or changed since then.</string>
+    <string name="activity_log_rewind_dialog_message">Are you sure you want to rewind your site back to %1$s at %2$s? This will remove all content and options created or changed since then.</string>
 
     <!-- stats: errors -->
     <string name="stats_no_blog">Stats couldn\'t be loaded for the required blog</string>


### PR DESCRIPTION
In rewind we have a number cases where we have multiple placeholders in a string. In some language it might be necessary to move the placeholders arround, i.e. have the second one appear before the first one.

This PR changes these strings to introduce this ability. See http://www.piwai.info/android-string-placeholders#Professional-Translation