### PR TITLE
Replace Volley with Glide in Stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.stats.service.StatsServiceLogic;
 import org.wordpress.android.ui.stats.service.StatsServiceStarter;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.SiteUtils;
+import org.wordpress.android.util.image.ImageManager;
 
 import javax.inject.Inject;
 
@@ -48,6 +49,7 @@ public abstract class StatsAbstractFragment extends Fragment {
 
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
+    @Inject ImageManager mImageManager;
 
     /**
      * Wheter or not previous data is available.

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAuthorsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAuthorsFragment.java
@@ -16,7 +16,7 @@ import org.wordpress.android.ui.stats.models.StatsPostModel;
 import org.wordpress.android.ui.stats.service.StatsServiceLogic;
 import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.GravatarUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageType;
 
 import java.util.List;
 
@@ -254,8 +254,9 @@ public class StatsAuthorsFragment extends StatsAbstractListFragment {
 
             // icon
             // holder.showNetworkImage(icon);
-            holder.networkImageView.setImageUrl(GravatarUtils.fixGravatarUrl(icon, mResourceVars.mHeaderAvatarSizePx),
-                                                WPNetworkImageView.ImageType.AVATAR);
+            mImageManager.loadIntoCircle(holder.networkImageView, ImageType.AVATAR,
+                    GravatarUtils.fixGravatarUrl(icon, mResourceVars.mHeaderAvatarSizePx));
+
             holder.networkImageView.setVisibility(View.VISIBLE);
 
             final FollowDataModel followData = group.getFollowData();

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsClicksFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsClicksFragment.java
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.stats;
 
 import android.content.Context;
 import android.os.Bundle;
-import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,8 +13,6 @@ import org.wordpress.android.ui.stats.models.ClicksModel;
 import org.wordpress.android.ui.stats.models.SingleItemModel;
 import org.wordpress.android.ui.stats.service.StatsServiceLogic;
 import org.wordpress.android.util.FormatUtils;
-import org.wordpress.android.util.GravatarUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.util.List;
 
@@ -249,12 +246,6 @@ public class StatsClicksFragment extends StatsAbstractListFragment {
 
             // Site icon
             holder.networkImageView.setVisibility(View.GONE);
-            if (!TextUtils.isEmpty(icon)) {
-                holder.networkImageView.setImageUrl(
-                        GravatarUtils.fixGravatarUrl(icon, mResourceVars.mHeaderAvatarSizePx),
-                        WPNetworkImageView.ImageType.GONE_UNTIL_AVAILABLE
-                                                   );
-            }
 
             if (children == 0) {
                 holder.showLinkIcon();

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
@@ -20,7 +20,7 @@ import org.wordpress.android.ui.stats.service.StatsServiceLogic;
 import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.StringUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -234,9 +234,8 @@ public class StatsCommentsFragment extends StatsAbstractListFragment {
                             currentRowData.getViews()));
 
             // avatar
-            holder.networkImageView.setImageUrl(
-                    GravatarUtils.fixGravatarUrl(currentRowData.getAvatar(), mResourceVars.mHeaderAvatarSizePx),
-                    WPNetworkImageView.ImageType.AVATAR);
+            mImageManager.loadIntoCircle(holder.networkImageView, ImageType.AVATAR,
+                    GravatarUtils.fixGravatarUrl(currentRowData.getAvatar(), mResourceVars.mHeaderAvatarSizePx));
             holder.networkImageView.setVisibility(View.VISIBLE);
 
             final FollowDataModel followData = currentRowData.getFollowData();

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
@@ -22,7 +22,7 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.UrlUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageType;
 
 import java.util.HashMap;
 import java.util.List;
@@ -389,9 +389,8 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
                             holder.totalsTextView.getText()));
 
             // Avatar
-            holder.networkImageView.setImageUrl(
-                    GravatarUtils.fixGravatarUrl(currentRowData.getAvatar(), mResourceVars.mHeaderAvatarSizePx),
-                    WPNetworkImageView.ImageType.AVATAR);
+            mImageManager.loadIntoCircle(holder.networkImageView, ImageType.AVATAR,
+                    GravatarUtils.fixGravatarUrl(currentRowData.getAvatar(), mResourceVars.mHeaderAvatarSizePx));
             holder.networkImageView.setVisibility(View.VISIBLE);
 
             if (followData == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
@@ -25,7 +25,7 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.StringUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageType;
 
 import java.util.List;
 
@@ -283,9 +283,8 @@ public class StatsGeoviewsFragment extends StatsAbstractListFragment {
                 holder.alternativeImage.setVisibility(View.VISIBLE);
             } else {
                 // On other Android versions, use the Gravatar image
-                holder.networkImageView.setImageUrl(
-                        GravatarUtils.fixGravatarUrl(imageUrl, mResourceVars.mHeaderAvatarSizePx),
-                        WPNetworkImageView.ImageType.BLAVATAR);
+                mImageManager.load(holder.networkImageView, ImageType.BLAVATAR,
+                        GravatarUtils.fixGravatarUrl(imageUrl, mResourceVars.mHeaderAvatarSizePx));
                 holder.networkImageView.setVisibility(View.VISIBLE);
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsPublicizeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsPublicizeFragment.java
@@ -14,7 +14,7 @@ import org.wordpress.android.ui.stats.service.StatsServiceLogic;
 import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.StringUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageType;
 
 import java.util.List;
 
@@ -120,8 +120,6 @@ public class StatsPublicizeFragment extends StatsAbstractListFragment {
                 rowView = mInflater.inflate(R.layout.stats_list_cell, parent, false);
                 // configure view holder
                 holder = new StatsViewHolder(rowView);
-                holder.networkImageView.setErrorImageResId(R.drawable.ic_placeholder_blavatar_grey_lighten_20_32dp);
-                holder.networkImageView.setDefaultImageResId(R.drawable.ic_placeholder_blavatar_grey_lighten_20_32dp);
                 rowView.setTag(holder);
             } else {
                 holder = (StatsViewHolder) rowView.getTag();
@@ -145,9 +143,8 @@ public class StatsPublicizeFragment extends StatsAbstractListFragment {
                             currentRowData.getTotals()));
 
             // image
-            holder.networkImageView.setImageUrl(
-                    GravatarUtils.fixGravatarUrl(getServiceImage(serviceName), mResourceVars.mHeaderAvatarSizePx),
-                    WPNetworkImageView.ImageType.BLAVATAR);
+            mImageManager.load(holder.networkImageView, ImageType.BLAVATAR,
+                    GravatarUtils.fixGravatarUrl(getServiceImage(serviceName), mResourceVars.mHeaderAvatarSizePx));
             holder.networkImageView.setVisibility(View.VISIBLE);
 
             return rowView;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsReferrersFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsReferrersFragment.java
@@ -15,9 +15,7 @@ import org.wordpress.android.ui.stats.models.ReferrersModel;
 import org.wordpress.android.ui.stats.models.SingleItemModel;
 import org.wordpress.android.ui.stats.service.StatsServiceLogic;
 import org.wordpress.android.util.FormatUtils;
-import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.StringUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -233,11 +231,6 @@ public class StatsReferrersFragment extends StatsAbstractListFragment {
 
             // site icon
             holder.networkImageView.setVisibility(View.GONE);
-            if (!TextUtils.isEmpty(currentChild.icon)) {
-                holder.networkImageView.setImageUrl(
-                        GravatarUtils.fixGravatarUrl(currentChild.icon, mResourceVars.mHeaderAvatarSizePx),
-                        WPNetworkImageView.ImageType.GONE_UNTIL_AVAILABLE);
-            }
 
             // no more btm
             holder.imgMore.setVisibility(View.GONE);
@@ -307,13 +300,7 @@ public class StatsReferrersFragment extends StatsAbstractListFragment {
                             R.string.stats_views_many_desc,
                             total));
 
-            // Site icon
             holder.networkImageView.setVisibility(View.GONE);
-            if (!TextUtils.isEmpty(icon)) {
-                holder.networkImageView.setImageUrl(
-                        GravatarUtils.fixGravatarUrl(icon, mResourceVars.mHeaderAvatarSizePx),
-                        WPNetworkImageView.ImageType.GONE_UNTIL_AVAILABLE);
-            }
 
             if (children == 0) {
                 holder.showLinkIcon();

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsTagsAndCategoriesFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsTagsAndCategoriesFragment.java
@@ -180,8 +180,8 @@ public class StatsTagsAndCategoriesFragment extends StatsAbstractListFragment {
 
             // icon.
             holder.networkImageView.setVisibility(View.VISIBLE);
-            holder.networkImageView.setImageDrawable(getResources().getDrawable(R.drawable.ic_tag_blue_wordpress_12dp));
-
+            mImageManager
+                    .load(holder.networkImageView, getResources().getDrawable(R.drawable.ic_tag_blue_wordpress_12dp));
             return convertView;
         }
 
@@ -269,7 +269,9 @@ public class StatsTagsAndCategoriesFragment extends StatsAbstractListFragment {
                 int drawableResource = groupName.toString().equalsIgnoreCase("uncategorized")
                         ? R.drawable.ic_folder_blue_wordpress_12dp
                         : R.drawable.ic_tag_blue_wordpress_12dp;
-                holder.networkImageView.setImageDrawable(getResources().getDrawable(drawableResource));
+                mImageManager.load(holder.networkImageView, getResources().getDrawable(drawableResource));
+            } else {
+              mImageManager.cancelRequestAndClearImageView(holder.networkImageView);
             }
 
             return convertView;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewHolder.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewHolder.java
@@ -16,7 +16,6 @@ import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.stats.models.StatsPostModel;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.UrlUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
 
 /**
  * View holder for stats_list_cell layout
@@ -24,7 +23,7 @@ import org.wordpress.android.widgets.WPNetworkImageView;
 public class StatsViewHolder {
     public final TextView entryTextView;
     public final TextView totalsTextView;
-    public final WPNetworkImageView networkImageView;
+    public final ImageView networkImageView;
     public final TextView alternativeImage;
     public final ImageView chevronImageView;
     public final ImageView linkImageView;
@@ -32,14 +31,14 @@ public class StatsViewHolder {
     public final LinearLayout rowContent;
 
     public StatsViewHolder(View view) {
-        rowContent = (LinearLayout) view.findViewById(R.id.layout_content);
-        entryTextView = (TextView) view.findViewById(R.id.stats_list_cell_entry);
-        totalsTextView = (TextView) view.findViewById(R.id.stats_list_cell_total);
-        chevronImageView = (ImageView) view.findViewById(R.id.stats_list_cell_chevron);
-        linkImageView = (ImageView) view.findViewById(R.id.stats_list_cell_link);
-        networkImageView = (WPNetworkImageView) view.findViewById(R.id.stats_list_cell_image);
-        alternativeImage = (TextView) view.findViewById(R.id.stats_list_cell_image_alt);
-        imgMore = (ImageView) view.findViewById(R.id.image_more);
+        rowContent = view.findViewById(R.id.layout_content);
+        entryTextView = view.findViewById(R.id.stats_list_cell_entry);
+        totalsTextView = view.findViewById(R.id.stats_list_cell_total);
+        chevronImageView = view.findViewById(R.id.stats_list_cell_chevron);
+        linkImageView = view.findViewById(R.id.stats_list_cell_link);
+        networkImageView = view.findViewById(R.id.stats_list_cell_image);
+        alternativeImage = view.findViewById(R.id.stats_list_cell_image_alt);
+        imgMore = view.findViewById(R.id.image_more);
     }
 
     /*

--- a/WordPress/src/main/res/layout/stats_list_cell.xml
+++ b/WordPress/src/main/res/layout/stats_list_cell.xml
@@ -43,7 +43,7 @@
             android:contentDescription="@string/stats_list_cell_chevron_expand_desc"
             app:srcCompat="@drawable/ic_chevron_right_blue_wordpress_24dp" />
 
-        <org.wordpress.android.widgets.WPNetworkImageView
+        <ImageView
             android:id="@+id/stats_list_cell_image"
             android:layout_width="@dimen/avatar_sz_small"
             android:layout_height="@dimen/avatar_sz_small"


### PR DESCRIPTION
Fixes #7961 

Replaces Volley with Glide in the Stats.

Images which were using `WPNetworkImageView.ImageType.GONE_UNTIL_AVAILABLE`, were never visible due to a bug in the WPNetworkImageView. What I'm unsure about is whether it looks good when only some sites have an icon.  Wdyt @nozomimimi - should I fix the bug and start showing them or keep them hidden? 

First column is current state
Second column is after the bug fix

![stats](https://user-images.githubusercontent.com/2261188/42580247-64f9260a-852a-11e8-9a2d-dd86ecb44332.png)
 

To test:
1. Go to Stats
2. Make sure all the images are loaded correctly

Modified cardsViews:
tags and categories, publicize, referrers, comments, followers, authors, clicks
geoviews (modified only on Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)