### PR TITLE
Feature/media upload audio files

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -34,6 +34,7 @@ public class RequestCodes {
     public static final int MULTI_SELECT_MEDIA_PICKER = 2600;
     public static final int SINGLE_SELECT_MEDIA_PICKER = 2601;
     public static final int MEDIA_SETTINGS = 2700;
+    public static final int AUDIO_LIBRARY = 2800;
 
     // Jetpack
     public static final int REQUEST_JETPACK = 3000;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -365,7 +365,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         WPMediaUtils.fetchMediaAndDoNext(this, imageUri, new WPMediaUtils.MediaFetchDoNext() {
             @Override
             public void doNext(Uri uri) {
-                //We don't want to optimize if file is audio
+                // We don't want to optimize if file is audio
                 if (requestCode != RequestCodes.AUDIO_LIBRARY) {
                     uri = getOptimizedPictureIfNecessary(uri);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -93,7 +93,7 @@ public class FluxCUtils {
 
         MediaModel media = mediaStore.instantiateMediaModel();
         String filename = org.wordpress.android.fluxc.utils.MediaUtils.getFileName(path);
-        String fileExtension = org.wordpress.android.fluxc.utils.MediaUtils.getExtension(path);
+        String fileExtension = org.wordpress.android.fluxc.utils.MediaUtils.getExtension(filename);
 
         if (TextUtils.isEmpty(mimeType)) {
             mimeType = context.getContentResolver().getType(uri);

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -42,6 +42,8 @@ public class WPMediaUtils {
     public static final int OPTIMIZE_VIDEO_MAX_WIDTH = 1280;
     public static final int OPTIMIZE_VIDEO_ENCODER_BITRATE_KB = 3000;
 
+    private static final String MIME_DATA_TYPE_AUDIO = "audio/*";
+
     public static Uri getOptimizedMedia(Activity activity, String path, boolean isVideo) {
         if (isVideo) {
             return null;
@@ -256,6 +258,24 @@ public class WPMediaUtils {
     private static Intent preparePictureLibraryIntent(String title, boolean multiSelect) {
         Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
         intent.setType("image/*");
+        if (multiSelect) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+                intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+            }
+        }
+        return Intent.createChooser(intent, title);
+    }
+
+    public static void launchAudioLibrary(Activity activity, boolean multiSelect) {
+        AppLockManager.getInstance().setExtendedTimeout();
+        activity.startActivityForResult(
+            prepareAudioLibraryIntent(activity.getString(R.string.pick_audio), multiSelect),
+            RequestCodes.AUDIO_LIBRARY);
+    }
+
+    private static Intent prepareAudioLibraryIntent(String title, boolean multiSelect) {
+        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+        intent.setType(MIME_DATA_TYPE_AUDIO);
         if (multiSelect) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
                 intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -141,6 +141,7 @@
     <string name="wp_media_title">WordPress media</string>
     <string name="pick_photo">Select photo</string>
     <string name="pick_video">Select video</string>
+    <string name="pick_audio">Select audio</string>
     <string name="capture_or_pick_photo">Capture or select photo</string>
     <string name="reader_toast_err_get_post">Unable to retrieve this post</string>
     <string name="media_error_no_permission">You don\'t have permission to view the media library</string>
@@ -1938,6 +1939,7 @@
     <string name="photo_picker_title">Choose photo</string>
     <string name="photo_picker_choose_photo">Choose photo from device</string>
     <string name="photo_picker_choose_video">Choose video from device</string>
+    <string name="photo_picker_choose_audio">Choose audio from device</string>
     <string name="photo_picker_capture_photo">Take photo</string>
     <string name="photo_picker_capture_video">Take video</string>
     <string name="photo_picker_stock_media">Choose from Free Photo Library</string>

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '51fee5847ca60895772eb5e5e4ca64a275cac543'
+    fluxCVersion = '06a11f4fee4eeda8b7d4b778684b778e367f4b7a'
 }


### PR DESCRIPTION
Part of [#4842](https://github.com/wordpress-mobile/WordPress-Android/issues/4842)

This PR adds ability to upload audio files in Media.
Also it demanded changes in FluxC project which is described in this [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/837). For testing purpose this PR has FluxC hash code of temp branch so that it can be build against FluxC changes.

Testing instructions 

Visually tutorials look like this:

**1. Navigate to My site**
![device-2018-07-12-012833](https://user-images.githubusercontent.com/28219092/42605643-7fe377e6-8579-11e8-877d-5593c5151a15.png)

**2. Open Media section**
![device-2018-07-12-012901](https://user-images.githubusercontent.com/28219092/42605664-95179cd2-8579-11e8-9b66-ee75961bd25b.png)

**3. Click on the "+"  button in top right corner**
![device-2018-07-12-012913](https://user-images.githubusercontent.com/28219092/42605682-ac90463e-8579-11e8-953d-24ddaeb742bf.png)

**4. Click on "Choose audio from device"**
![device-2018-07-12-012947](https://user-images.githubusercontent.com/28219092/42605703-c683b508-8579-11e8-8d79-f1d7b4aa0d72.png)

**5. Choose some audio file from your device**
![device-2018-07-12-012958](https://user-images.githubusercontent.com/28219092/42605712-d4d8d912-8579-11e8-832e-084e4630d712.png)

**6. With a bit of luck upload will pass with success**
![device-2018-07-12-013024](https://user-images.githubusercontent.com/28219092/42605783-27db9ae6-857a-11e8-94bc-4a2b1eb72b7e.png)


