### PR TITLE
Replace Volley with Glide in Site picker fragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -99,11 +99,7 @@ public class AddQuickPressShortcutActivity extends ListActivity {
                 blogNames[i] = SiteUtils.getSiteNameOrHomeURL(site);
                 accountUsers[i] = site.getUsername();
                 siteIds[i] = site.getId();
-                if (site.getUrl() != null) {
-                    blavatars[i] = SiteUtils.getSiteIconUrl(site, 60);
-                } else {
-                    blavatars[i] = "";
-                }
+                blavatars[i] = SiteUtils.getSiteIconUrl(site, 60);
                 accountNames.add(i, blogNames[i]);
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -12,6 +12,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.RadioButton;
 import android.widget.TextView;
 
@@ -24,7 +25,8 @@ import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.StringUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -97,12 +99,13 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
+    @Inject ImageManager mImageManager;
 
     class SiteViewHolder extends RecyclerView.ViewHolder {
         private final ViewGroup mLayoutContainer;
         private final TextView mTxtTitle;
         private final TextView mTxtDomain;
-        private final WPNetworkImageView mImgBlavatar;
+        private final ImageView mImgBlavatar;
         private final View mDivider;
         private Boolean mIsSiteHidden;
         private final RadioButton mSelectedRadioButton;
@@ -233,7 +236,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         final SiteViewHolder holder = (SiteViewHolder) viewHolder;
         holder.mTxtTitle.setText(site.getBlogNameOrHomeURL());
         holder.mTxtDomain.setText(site.mHomeURL);
-        holder.mImgBlavatar.setImageUrl(site.mBlavatarUrl, WPNetworkImageView.ImageType.BLAVATAR);
+        mImageManager.load(holder.mImgBlavatar, ImageType.BLAVATAR, site.mBlavatarUrl);
 
         if (site.mLocalId == mCurrentLocalId || (mIsMultiSelectEnabled && isItemSelected(position))) {
             holder.mLayoutContainer.setBackgroundDrawable(mSelectedItemBackground);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureAdapter.java
@@ -9,6 +9,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
@@ -17,7 +18,8 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.main.SitePickerAdapter.SiteRecord;
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -48,21 +50,22 @@ public class StatsWidgetConfigureAdapter extends RecyclerView.Adapter<StatsWidge
 
     private OnSiteClickListener mSiteSelectedListener;
     @Inject SiteStore mSiteStore;
+    @Inject ImageManager mImageManager;
 
     class SiteViewHolder extends RecyclerView.ViewHolder {
         private final ViewGroup mLayoutContainer;
         private final TextView mTxtTitle;
         private final TextView mTxtDomain;
-        private final WPNetworkImageView mImgBlavatar;
+        private final ImageView mImgBlavatar;
         private final View mDivider;
         private Boolean mIsSiteHidden;
 
         SiteViewHolder(View view) {
             super(view);
-            mLayoutContainer = (ViewGroup) view.findViewById(R.id.layout_container);
-            mTxtTitle = (TextView) view.findViewById(R.id.text_title);
-            mTxtDomain = (TextView) view.findViewById(R.id.text_domain);
-            mImgBlavatar = (WPNetworkImageView) view.findViewById(R.id.image_blavatar);
+            mLayoutContainer = view.findViewById(R.id.layout_container);
+            mTxtTitle = view.findViewById(R.id.text_title);
+            mTxtDomain = view.findViewById(R.id.text_domain);
+            mImgBlavatar = view.findViewById(R.id.image_blavatar);
             mDivider = view.findViewById(R.id.divider);
             mIsSiteHidden = null;
 
@@ -127,7 +130,7 @@ public class StatsWidgetConfigureAdapter extends RecyclerView.Adapter<StatsWidge
 
         holder.mTxtTitle.setText(site.getBlogNameOrHomeURL());
         holder.mTxtDomain.setText(site.getHomeURL());
-        holder.mImgBlavatar.setImageUrl(site.getBlavatarUrl(), WPNetworkImageView.ImageType.BLAVATAR);
+        mImageManager.load(holder.mImgBlavatar, ImageType.BLAVATAR, site.getBlavatarUrl());
 
         if (site.getLocalId() == mPrimarySiteId) {
             holder.mLayoutContainer.setBackgroundDrawable(mSelectedItemBackground);

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -44,11 +44,7 @@ public class SiteUtils {
     }
 
     public static String getSiteIconUrl(SiteModel site, int size) {
-        if (!TextUtils.isEmpty(site.getIconUrl())) {
-            return PhotonUtils.getPhotonImageUrl(site.getIconUrl(), size, size, PhotonUtils.Quality.HIGH);
-        } else {
-            return null;
-        }
+        return PhotonUtils.getPhotonImageUrl(site.getIconUrl(), size, size, PhotonUtils.Quality.HIGH);
     }
 
     public static ArrayList<Integer> getCurrentSiteIds(SiteStore siteStore, boolean selfhostedOnly) {

--- a/WordPress/src/main/res/layout/site_picker_listitem.xml
+++ b/WordPress/src/main/res/layout/site_picker_listitem.xml
@@ -16,7 +16,7 @@
         android:paddingBottom="@dimen/margin_large"
         android:paddingTop="@dimen/margin_large">
 
-        <org.wordpress.android.widgets.WPNetworkImageView
+        <ImageView
             android:id="@+id/image_blavatar"
             android:layout_width="@dimen/blavatar_sz"
             android:layout_height="@dimen/blavatar_sz"
@@ -28,7 +28,8 @@
             android:background="@color/white"
             android:gravity="center_vertical"
             android:padding="1dp"
-            app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"/>
+            app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
+            android:contentDescription="@string/blavatar_desc"/>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2120,6 +2120,7 @@
     <!-- Content description for accessibility  -->
     <string name="featured_image_desc">featured image</string>
     <string name="theme_image_desc">theme image</string>
+    <string name="blavatar_desc">site icon</string>
     <string name="comment_checkmark_desc">check mark</string>
     <string name="profile_picture">%s\'s profile picture</string>
     <string name="invite_user_delete_desc">remove %s</string>


### PR DESCRIPTION
Fixes #8028

Replaces Volley with Glide in the Site picker fragment and StatsWidgetSettings. Nothing should change from the user perspective.

To test:
1. Go to My Site
2. Click on 'Switch Site'
3. Make sure Site Icons are loaded 
-----------------------------
1. Add a Stats Widget
2. Stats Widget settings is automatically displayed
3. Make sure Site Icons are loaded

@khaykov Could you please review this PR? Thanks!