### PR TITLE
Issue/8012 discard changes additions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -7,8 +7,6 @@ import android.arch.lifecycle.Observer;
 import android.content.ClipData;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.DialogInterface.OnCancelListener;
-import android.content.DialogInterface.OnDismissListener;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
@@ -213,11 +211,11 @@ public class EditPostActivity extends AppCompatActivity implements
     private static final String STATE_KEY_DROPPED_MEDIA_URIS = "stateKeyDroppedMediaUri";
     private static final String STATE_KEY_POST_LOCAL_ID = "stateKeyPostModelLocalId";
     private static final String STATE_KEY_POST_REMOTE_ID = "stateKeyPostModelRemoteId";
-    private static final String STATE_KEY_IS_DIALOG_ERROR_SHOWN = "stateIsDialogErrorShown";
     private static final String STATE_KEY_IS_DIALOG_PROGRESS_SHOWN = "stateIsDialogProgressShown";
     private static final String STATE_KEY_IS_NEW_POST = "stateKeyIsNewPost";
     private static final String STATE_KEY_IS_PHOTO_PICKER_VISIBLE = "stateKeyPhotoPickerVisible";
     private static final String STATE_KEY_HTML_MODE_ON = "stateKeyHtmlModeOn";
+    private static final String TAG_DISCARDING_CHANGES_ERROR_DIALOG = "tag_discarding_changes_error_dialog";
     private static final String TAG_PUBLISH_CONFIRMATION_DIALOG = "tag_publish_confirmation_dialog";
     private static final String TAG_REMOVE_FAILED_UPLOADS_DIALOG = "tag_remove_failed_uploads_dialog";
 
@@ -278,7 +276,6 @@ public class EditPostActivity extends AppCompatActivity implements
     private boolean mIsNewPost;
     private boolean mIsPage;
     private boolean mHasSetPostContent;
-    private boolean mIsDialogErrorShown;
     private boolean mIsDialogProgressShown;
     private boolean mIsDiscardingChanges;
     private boolean mIsUpdatingPost;
@@ -404,13 +401,8 @@ public class EditPostActivity extends AppCompatActivity implements
             mDroppedMediaUris = savedInstanceState.getParcelable(STATE_KEY_DROPPED_MEDIA_URIS);
             mIsNewPost = savedInstanceState.getBoolean(STATE_KEY_IS_NEW_POST, false);
             mIsDialogProgressShown = savedInstanceState.getBoolean(STATE_KEY_IS_DIALOG_PROGRESS_SHOWN, false);
-            mIsDialogErrorShown = savedInstanceState.getBoolean(STATE_KEY_IS_DIALOG_ERROR_SHOWN, false);
 
             showDialogProgress(mIsDialogProgressShown);
-
-            if (mIsDialogErrorShown) {
-                showDialogError();
-            }
 
             // if we have a remote id saved, let's first try with that, as the local Id might have changed
             // after FETCH_POSTS
@@ -681,7 +673,6 @@ public class EditPostActivity extends AppCompatActivity implements
             outState.putLong(STATE_KEY_POST_REMOTE_ID, mPost.getRemotePostId());
         }
         outState.putBoolean(STATE_KEY_IS_DIALOG_PROGRESS_SHOWN, mIsDialogProgressShown);
-        outState.putBoolean(STATE_KEY_IS_DIALOG_ERROR_SHOWN, mIsDialogErrorShown);
         outState.putBoolean(STATE_KEY_IS_NEW_POST, mIsNewPost);
         outState.putBoolean(STATE_KEY_IS_PHOTO_PICKER_VISIBLE, isPhotoPickerShowing());
         outState.putBoolean(STATE_KEY_HTML_MODE_ON, mHtmlModeMenuStateOn);
@@ -1181,27 +1172,10 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private void showDialogError() {
-        new AlertDialog.Builder(new ContextThemeWrapper(this, R.style.Calypso_Dialog_Alert))
-                .setMessage(R.string.local_changes_discarding_error)
-                .setNegativeButton(R.string.cancel, null)
-                .setPositiveButton(R.string.contact_support, new DialogInterface.OnClickListener() {
-                    @Override public void onClick(DialogInterface dialog, int which) {
-                        mZendeskHelper.createNewTicket(EditPostActivity.this, Origin.DISCARD_CHANGES, mSite);
-                    }
-                })
-                .setOnCancelListener(new OnCancelListener() {
-                    @Override public void onCancel(DialogInterface dialog) {
-                        mIsDialogErrorShown = false;
-                    }
-                })
-                .setOnDismissListener(new OnDismissListener() {
-                    @Override public void onDismiss(DialogInterface dialog) {
-                        mIsDialogErrorShown = false;
-                    }
-                })
-                .show();
-
-        mIsDialogErrorShown = true;
+        BasicFragmentDialog dialog = new BasicFragmentDialog();
+        dialog.initialize(TAG_DISCARDING_CHANGES_ERROR_DIALOG, "", getString(R.string.local_changes_discarding_error),
+                getString(R.string.contact_support), getString(R.string.cancel), null);
+        dialog.show(getSupportFragmentManager(), TAG_DISCARDING_CHANGES_ERROR_DIALOG);
     }
 
     private void showDialogProgress(boolean show) {
@@ -1452,6 +1426,9 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override
     public void onPositiveClicked(@NonNull String instanceTag) {
         switch (instanceTag) {
+            case TAG_DISCARDING_CHANGES_ERROR_DIALOG:
+                mZendeskHelper.createNewTicket(this, Origin.DISCARD_CHANGES, mSite);
+                break;
             case TAG_PUBLISH_CONFIRMATION_DIALOG:
                 mPost.setStatus(PostStatus.PUBLISHED.toString());
                 publishPost();
@@ -1473,6 +1450,7 @@ public class EditPostActivity extends AppCompatActivity implements
     public void onNegativeClicked(@NonNull String instanceTag) {
         switch (instanceTag) {
             case ASYNC_PROMO_DIALOG_TAG:
+            case TAG_DISCARDING_CHANGES_ERROR_DIALOG:
             case TAG_PUBLISH_CONFIRMATION_DIALOG:
             case TAG_REMOVE_FAILED_UPLOADS_DIALOG:
                 // the dialog is automatically dismissed

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3410,10 +3410,13 @@ public class EditPostActivity extends AppCompatActivity implements
                     mIsUpdatingPost = true;
                 }
             } else {
+                if (mIsDiscardingChanges) {
+                    showDialogError();
+                }
+
                 mIsDiscardingChanges = false;
                 mIsUpdatingPost = false;
                 showDialogProgress(false);
-                showDialogError();
                 AppLog.e(AppLog.T.POSTS, "UPDATE_POST failed: " + event.error.type + " - " + event.error.message);
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -131,6 +131,7 @@ import org.wordpress.android.ui.uploads.PostEvents;
 import org.wordpress.android.ui.uploads.UploadService;
 import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.ui.uploads.VideoOptimizer;
+import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
@@ -3407,7 +3408,8 @@ public class EditPostActivity extends AppCompatActivity implements
                     refreshEditorContent();
 
                     if (mViewPager != null) {
-                        Snackbar.make(mViewPager, getString(R.string.local_changes_discarded), Snackbar.LENGTH_LONG)
+                        Snackbar.make(mViewPager, getString(R.string.local_changes_discarded),
+                                AccessibilityUtils.getSnackbarDuration(EditPostActivity.this, Snackbar.LENGTH_LONG))
                                 .setAction(getString(R.string.undo), new OnClickListener() {
                                     @Override public void onClick(View view) {
                                         AnalyticsTracker.track(Stat.EDITOR_DISCARDED_CHANGES_UNDO);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -275,7 +275,7 @@ public class PostPreviewActivity extends AppCompatActivity {
             }
 
             ViewGroup.MarginLayoutParams marginsMessage = (ViewGroup.MarginLayoutParams) messageText.getLayoutParams();
-            marginsMessage.bottomMargin = getResources().getDimensionPixelSize(R.dimen.margin_small);
+            marginsMessage.bottomMargin = getResources().getDimensionPixelSize(R.dimen.snackbar_message_margin_bottom);
 
             ViewGroup buttonsView = mMessageView.findViewById(R.id.layout_buttons);
             RelativeLayout.LayoutParams paramsButtons = (RelativeLayout.LayoutParams) buttonsView.getLayoutParams();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -45,6 +45,7 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.accounts.HelpActivity.Origin;
 import org.wordpress.android.ui.uploads.PostEvents;
 import org.wordpress.android.ui.uploads.UploadService;
+import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
@@ -396,7 +397,8 @@ public class PostPreviewActivity extends AppCompatActivity {
                     refreshPreview();
 
                     if (mMessageView != null) {
-                        Snackbar.make(mMessageView, getString(R.string.local_changes_discarded), Snackbar.LENGTH_LONG)
+                        Snackbar.make(mMessageView, getString(R.string.local_changes_discarded),
+                                AccessibilityUtils.getSnackbarDuration(PostPreviewActivity.this, Snackbar.LENGTH_LONG))
                                 .setAction(getString(R.string.undo), new OnClickListener() {
                                     @Override public void onClick(View view) {
                                         AnalyticsTracker.track(Stat.EDITOR_DISCARDED_CHANGES_UNDO);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -4,18 +4,13 @@ import android.app.Fragment;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
 import android.content.Context;
-import android.content.DialogInterface;
-import android.content.DialogInterface.OnCancelListener;
-import android.content.DialogInterface.OnDismissListener;
 import android.os.Build.VERSION;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.ActionBar;
-import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
-import android.view.ContextThemeWrapper;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -26,6 +21,7 @@ import android.widget.TextView;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
+import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -49,6 +45,7 @@ import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -62,10 +59,11 @@ import de.greenrobot.event.EventBus;
 
 import static org.wordpress.android.ui.posts.EditPostActivity.EXTRA_POST_LOCAL_ID;
 
-public class PostPreviewActivity extends AppCompatActivity {
-    private static final String STATE_KEY_IS_DIALOG_ERROR_SHOWN = "stateIsDialogErrorShown";
+public class PostPreviewActivity extends AppCompatActivity implements
+        BasicFragmentDialog.BasicDialogNegativeClickInterface,
+        BasicFragmentDialog.BasicDialogPositiveClickInterface {
+    private static final String TAG_DISCARDING_CHANGES_ERROR_DIALOG = "tag_discarding_changes_error_dialog";
 
-    private boolean mIsDialogErrorShown;
     private boolean mIsDiscardingChanges;
     private boolean mIsUpdatingPost;
 
@@ -105,11 +103,6 @@ public class PostPreviewActivity extends AppCompatActivity {
         } else {
             mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
             localPostId = savedInstanceState.getInt(EXTRA_POST_LOCAL_ID);
-            mIsDialogErrorShown = savedInstanceState.getBoolean(STATE_KEY_IS_DIALOG_ERROR_SHOWN, false);
-
-            if (mIsDialogErrorShown) {
-                showDialogError();
-            }
         }
         mPost = mPostStore.getPostByLocalPostId(localPostId);
         if (mSite == null || mPost == null) {
@@ -188,7 +181,6 @@ public class PostPreviewActivity extends AppCompatActivity {
     protected void onSaveInstanceState(Bundle outState) {
         outState.putSerializable(WordPress.SITE, mSite);
         outState.putSerializable(EXTRA_POST_LOCAL_ID, mPost.getId());
-        outState.putBoolean(STATE_KEY_IS_DIALOG_ERROR_SHOWN, mIsDialogErrorShown);
         super.onSaveInstanceState(outState);
     }
 
@@ -361,27 +353,34 @@ public class PostPreviewActivity extends AppCompatActivity {
     }
 
     private void showDialogError() {
-        new AlertDialog.Builder(new ContextThemeWrapper(this, R.style.Calypso_Dialog_Alert))
-                .setMessage(R.string.local_changes_discarding_error)
-                .setNegativeButton(R.string.cancel, null)
-                .setPositiveButton(R.string.contact_support, new DialogInterface.OnClickListener() {
-                    @Override public void onClick(DialogInterface dialog, int which) {
-                        mZendeskHelper.createNewTicket(PostPreviewActivity.this, Origin.DISCARD_CHANGES, mSite);
-                    }
-                })
-                .setOnCancelListener(new OnCancelListener() {
-                    @Override public void onCancel(DialogInterface dialog) {
-                        mIsDialogErrorShown = false;
-                    }
-                })
-                .setOnDismissListener(new OnDismissListener() {
-                    @Override public void onDismiss(DialogInterface dialog) {
-                        mIsDialogErrorShown = false;
-                    }
-                })
-                .show();
+        BasicFragmentDialog dialog = new BasicFragmentDialog();
+        dialog.initialize(TAG_DISCARDING_CHANGES_ERROR_DIALOG, "", getString(R.string.local_changes_discarding_error),
+                getString(R.string.contact_support), getString(R.string.cancel), null);
+        dialog.show(getSupportFragmentManager(), TAG_DISCARDING_CHANGES_ERROR_DIALOG);
+    }
 
-        mIsDialogErrorShown = true;
+    @Override
+    public void onNegativeClicked(@NotNull String tag) {
+        switch (tag) {
+            case TAG_DISCARDING_CHANGES_ERROR_DIALOG:
+                // noop
+                break;
+            default:
+                AppLog.e(T.EDITOR, "Dialog tag is not recognized");
+                throw new UnsupportedOperationException("Dialog tag is not recognized");
+        }
+    }
+
+    @Override
+    public void onPositiveClicked(@NotNull String tag) {
+        switch (tag) {
+            case TAG_DISCARDING_CHANGES_ERROR_DIALOG:
+                mZendeskHelper.createNewTicket(this, Origin.DISCARD_CHANGES, mSite);
+                break;
+            default:
+                AppLog.e(T.EDITOR, "Dialog tag is not recognized");
+                throw new UnsupportedOperationException("Dialog tag is not recognized");
+        }
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -418,9 +418,12 @@ public class PostPreviewActivity extends AppCompatActivity implements
                     mIsUpdatingPost = true;
                 }
             } else {
+                if (mIsDiscardingChanges) {
+                    showDialogError();
+                }
+
                 mIsDiscardingChanges = false;
                 mIsUpdatingPost = false;
-                showDialogError();
                 AppLog.e(AppLog.T.POSTS, "UPDATE_POST failed: " + event.error.type + " - " + event.error.message);
             }
         }

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -314,4 +314,6 @@
     <!-- activity log -->
     <dimen name="activity_log_icon_size">40dp</dimen>
     <dimen name="activity_log_icon_margin">16dp</dimen>
+
+    <dimen name="snackbar_message_margin_bottom">18dp</dimen>
 </resources>


### PR DESCRIPTION
### Fix
Add the following to the ***Discard Local Changes*** feature as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8012.
- `18dp` spacing between snackbar message text and action button for two-button layout
- `AccessibilityUtils.getSnackbarDuration()` for snackbar durations
- `BasicFragmentDialog` for error when discarding changes

See the screenshots below for illustration.

![discard_changes_preview_margin](https://user-images.githubusercontent.com/3827611/42638323-e8e5c81e-85b2-11e8-8cb4-ed477ee65a93.png)

### Test
#### Snackbar Spacing
1. Go to ***My Site*** tab.
2. Tap ***Blog Posts*** item under ***Publish*** section.
3. Tap ***Preview*** button on a post with local changes.
4. Notice snackbar with updated spacing.

#### Dialog Fragment
0. Disable network connection.
1. Go to ***My Site*** tab.
2. Tap ***Blog Posts*** item under ***Publish*** section.
3. Tap post with local changes.
4. Tap overflow menu action.
5. Tap ***Discard Local Changes*** item.
6. Notice error dialog.
7. Rotate device.
8. Notice error dialog.