### PR TITLE
Adds Android Zendesk tag

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -429,7 +429,7 @@ private fun buildZendeskTags(allSites: List<SiteModel>?, origin: Origin, extraTa
     }
     tags.add(origin.toString())
     // Add Android tag to make it easier to filter tickets by platform
-    tags.add(ZendeskConstants.androidTag)
+    tags.add(ZendeskConstants.platformTag)
     extraTags?.let {
         tags.addAll(it)
     }
@@ -464,7 +464,6 @@ private val wpcomPushNotificationDeviceToken: String?
 
 private object ZendeskConstants {
     const val articleLabel = "Android"
-    const val androidTag = "Android"
     const val blogSeparator = "\n----------\n"
     const val jetpackTag = "jetpack"
     const val mobileCategoryId = 360000041586
@@ -474,6 +473,8 @@ private object ZendeskConstants {
     const val networkCarrierLabel = "Carrier:"
     const val networkCountryCodeLabel = "Country Code:"
     const val noneValue = "none"
+    // We rely on this platform tag to filter tickets in Zendesk, so should be kept separate from the `articleLabel`
+    const val platformTag = "Android"
     const val ticketSubject = "WordPress for Android Support"
     const val wpComTag = "wpcom"
     const val unknownValue = "unknown"

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -428,6 +428,8 @@ private fun buildZendeskTags(allSites: List<SiteModel>?, origin: Origin, extraTa
         tags.addAll(plans)
     }
     tags.add(origin.toString())
+    // Add Android tag to make it easier to filter tickets by platform
+    tags.add(ZendeskConstants.androidTag)
     extraTags?.let {
         tags.addAll(it)
     }
@@ -462,6 +464,7 @@ private val wpcomPushNotificationDeviceToken: String?
 
 private object ZendeskConstants {
     const val articleLabel = "Android"
+    const val androidTag = "Android"
     const val blogSeparator = "\n----------\n"
     const val jetpackTag = "jetpack"
     const val mobileCategoryId = 360000041586


### PR DESCRIPTION
HEs have requested to add `Android` tag to every Zendesk ticket to make it easier to filter tickets by platform.

To test:
1. Put a breakpoint [here](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/add-android-zendesk-tag/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt#L433)
2. Go to Help page and tap on Contact Us
3. Verify that the `tags` list has the `Android` value in it.

/cc @ScoutHarris 