### PR TITLE
Issue/crash compound drawable

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartFragment.kt
@@ -5,6 +5,7 @@ import android.arch.lifecycle.ViewModelProvider
 import android.arch.lifecycle.ViewModelProviders
 import android.graphics.Paint
 import android.os.Bundle
+import android.support.graphics.drawable.VectorDrawableCompat
 import android.support.v4.app.Fragment
 import android.support.v7.app.AlertDialog
 import android.support.v7.app.AlertDialog.Builder
@@ -60,6 +61,8 @@ class QuickStartFragment : Fragment() {
             }
 
             if (allTasksCompleted) {
+                val drawableRight = VectorDrawableCompat.create(resources, R.drawable.img_emoji_party_popper_24sp, null)
+                text_list_complete_title.setCompoundDrawablesWithIntrinsicBounds(null, null, drawableRight, null)
                 layout_list_complete.visibility = View.VISIBLE
                 layout_skip_all.visibility = View.GONE
             }

--- a/WordPress/src/main/res/layout/quick_start_fragment.xml
+++ b/WordPress/src/main/res/layout/quick_start_fragment.xml
@@ -34,14 +34,14 @@
                 android:id="@+id/text_list_complete_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:drawableEnd="@drawable/img_emoji_party_popper_24sp"
                 android:drawablePadding="@dimen/margin_small_medium"
-                android:drawableRight="@drawable/img_emoji_party_popper_24sp"
                 android:fontFamily="sans-serif-medium"
                 android:gravity="bottom"
                 android:text="@string/quick_start_list_complete_title"
                 android:textColor="@color/grey_dark"
-                android:textSize="@dimen/quick_start_completed_text">
+                android:textSize="@dimen/quick_start_completed_text"
+                tools:drawableEnd="@drawable/img_emoji_party_popper_24sp"
+                tools:drawableRight="@drawable/img_emoji_party_popper_24sp">
             </TextView>
 
             <TextView


### PR DESCRIPTION
### Fix
Move the compound drawable assignment of the list complete title view on the ***Quick Start*** screen from XML layout to Java code to avoid crashes due to vector drawables on devices running API 16.

### Test
0. Use device running API 16.
1. Go to ***My Sites*** tab.
2. Tap ***Quick Start*** item.
3. Notice app doesn't crash.

#### Note
This pull request has no milestone since it's targeting a feature branch (i.e. `feature/whats-next`).