### PR TITLE
Allow activating premium themes on premium/business plans

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserAdapter.java
@@ -201,12 +201,10 @@ class ThemeBrowserAdapter extends BaseAdapter implements Filterable {
             public boolean onMenuItemClick(MenuItem item) {
                 int i = item.getItemId();
                 if (i == R.id.menu_activate) {
-                    if (!isPremium || (mSitePlanId == PlansConstants.PREMIUM_PLAN_ID
-                                      || mSitePlanId == PlansConstants.BUSINESS_PLAN_ID)) {
-                        // Activate the theme directly if it's a free one or the site is on the premium|business plan
+                    if (canActivateThemeDirectly(isPremium, mSitePlanId)) {
                         mCallback.onActivateSelected(themeId);
                     } else {
-                        // Need to forward the user online to purchase the theme
+                        // forward the user online to complete the activation
                         mCallback.onDetailsSelected(themeId);
                     }
                 } else if (i == R.id.menu_try_and_customize) {
@@ -228,6 +226,21 @@ class ThemeBrowserAdapter extends BaseAdapter implements Filterable {
                 popupMenu.show();
             }
         });
+    }
+
+    private boolean canActivateThemeDirectly(final boolean isPremiumTheme, final long sitePlanId) {
+        if (!isPremiumTheme) {
+            // It's a free theme so, can always activate directly
+            return true;
+        }
+
+        if (sitePlanId == PlansConstants.PREMIUM_PLAN_ID || mSitePlanId == PlansConstants.BUSINESS_PLAN_ID) {
+            // Can activate any theme on a Premium and Business site plan
+            return true;
+        }
+
+        // Theme cannot be activated directly and needs to be purchased
+        return false;
     }
 
     private void configureMenuForTheme(Menu menu, boolean isCurrent) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserAdapter.java
@@ -23,6 +23,7 @@ import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.fluxc.model.ThemeModel;
+import org.wordpress.android.ui.plans.PlansConstants;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.themes.ThemeBrowserFragment.ThemeBrowserFragmentCallback;
 import org.wordpress.android.util.image.ImageManager;
@@ -37,6 +38,7 @@ class ThemeBrowserAdapter extends BaseAdapter implements Filterable {
     private static final String THEME_IMAGE_PARAMETER = "?w=";
 
     private final Context mContext;
+    private final long mSitePlanId;
     private final LayoutInflater mInflater;
     private final ThemeBrowserFragmentCallback mCallback;
     private final ImageManager mImageManager;
@@ -47,8 +49,10 @@ class ThemeBrowserAdapter extends BaseAdapter implements Filterable {
     private final List<ThemeModel> mAllThemes = new ArrayList<>();
     private final List<ThemeModel> mFilteredThemes = new ArrayList<>();
 
-    ThemeBrowserAdapter(Context context, ThemeBrowserFragmentCallback callback, ImageManager imageManager) {
+    ThemeBrowserAdapter(Context context, long sitePlanId, ThemeBrowserFragmentCallback callback,
+                        ImageManager imageManager) {
         mContext = context;
+        mSitePlanId = sitePlanId;
         mInflater = LayoutInflater.from(context);
         mCallback = callback;
         mViewWidth = AppPrefs.getThemeImageSizeWidth();
@@ -197,10 +201,13 @@ class ThemeBrowserAdapter extends BaseAdapter implements Filterable {
             public boolean onMenuItemClick(MenuItem item) {
                 int i = item.getItemId();
                 if (i == R.id.menu_activate) {
-                    if (isPremium) {
-                        mCallback.onDetailsSelected(themeId);
-                    } else {
+                    if (!isPremium || (mSitePlanId == PlansConstants.PREMIUM_PLAN_ID
+                                      || mSitePlanId == PlansConstants.BUSINESS_PLAN_ID)) {
+                        // Activate the theme directly if it's a free one or the site is on the premium|business plan
                         mCallback.onActivateSelected(themeId);
+                    } else {
+                        // Need to forward the user online to purchase the theme
+                        mCallback.onDetailsSelected(themeId);
                     }
                 } else if (i == R.id.menu_try_and_customize) {
                     mCallback.onTryAndCustomizeSelected(themeId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -328,7 +328,7 @@ public class ThemeBrowserFragment extends Fragment
 
     private ThemeBrowserAdapter getAdapter() {
         if (mAdapter == null) {
-            mAdapter = new ThemeBrowserAdapter(getActivity(), mCallback, mImageManager);
+            mAdapter = new ThemeBrowserAdapter(getActivity(), mSite.getPlanId(), mCallback, mImageManager);
         }
         return mAdapter;
     }


### PR DESCRIPTION
Fixes #7152 

Sites on the premium or business plans should be able to quickly activate a premium theme so, this PR adds the extra conditionals to make it so.

Implementation details:
* Passing the site plan ID to the `ThemeBrowserAdapter`
* The conditional in `ThemeBrowserAdapter` checks and allows premium and business plans to directly activate any theme

To test:
1. With a site that is on the premium or the business plan
2. head over to the themes directory (MySite > Themes)
3. Locate a premium theme (with some non-zero price attached to it), hit the three-dots button on the lower-right edge of the theme's card and select "Activate"
4. A popup should come up thanking you for choosing the particular theme