### PR TITLE
Added snackbar when coming from Zendesk notfication

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -1056,6 +1056,7 @@ public class GCMMessageService extends FirebaseMessagingService {
             Intent resultIntent = new Intent(context, WPMainActivity.class);
             resultIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             resultIntent.putExtra(WPMainActivity.ARG_OPEN_PAGE, WPMainActivity.ARG_ME);
+            resultIntent.putExtra(WPMainActivity.ARG_SHOW_ZENDESK_HINT_SNACKBAR, true);
             showSimpleNotification(context, title, message, resultIntent, ZENDESK_PUSH_NOTIFICATION_ID);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -294,7 +294,7 @@ public class WPMainActivity extends AppCompatActivity
                     break;
                 case ARG_ME:
                     mBottomNav.setCurrentPosition(PAGE_ME);
-                    if (intent.hasExtra(WPMainActivity.ARG_SHOW_ZENDESK_HINT_SNACKBAR)) {
+                    if (intent.getBooleanExtra(WPMainActivity.ARG_SHOW_ZENDESK_HINT_SNACKBAR, false)) {
                         Snackbar.make(findViewById(R.id.coordinator),
                                 R.string.support_push_notification_message_hint_snackbar, Snackbar.LENGTH_LONG).show();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -296,7 +296,7 @@ public class WPMainActivity extends AppCompatActivity
                     mBottomNav.setCurrentPosition(PAGE_ME);
                     if (intent.getBooleanExtra(WPMainActivity.ARG_SHOW_ZENDESK_HINT_SNACKBAR, false)) {
                         Snackbar.make(findViewById(R.id.coordinator),
-                                R.string.support_push_notification_message_hint_snackbar, Snackbar.LENGTH_LONG).show();
+                                R.string.support_push_notification_message_hint_snackbar, 5000).show();
                     }
                     break;
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.RemoteInput;
 import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
@@ -115,6 +116,7 @@ public class WPMainActivity extends AppCompatActivity
     public static final String ARG_OPEN_PAGE = "open_page";
     public static final String ARG_NOTIFICATIONS = "show_notifications";
     public static final String ARG_READER = "show_reader";
+    public static final String ARG_SHOW_ZENDESK_HINT_SNACKBAR = "show_zendesk_hint_snackbar";
     public static final String ARG_ME = "show_me";
 
     private WPMainNavigationView mBottomNav;
@@ -292,6 +294,11 @@ public class WPMainActivity extends AppCompatActivity
                     break;
                 case ARG_ME:
                     mBottomNav.setCurrentPosition(PAGE_ME);
+                    if (intent.hasExtra(WPMainActivity.ARG_SHOW_ZENDESK_HINT_SNACKBAR)) {
+                        Snackbar.make(findViewById(R.id.coordinator),
+                                R.string.support_push_notification_message_hint_snackbar, Snackbar.LENGTH_LONG).show();
+
+                    }
                     break;
             }
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -297,7 +297,6 @@ public class WPMainActivity extends AppCompatActivity
                     if (intent.getBooleanExtra(WPMainActivity.ARG_SHOW_ZENDESK_HINT_SNACKBAR, false)) {
                         Snackbar.make(findViewById(R.id.coordinator),
                                 R.string.support_push_notification_message_hint_snackbar, Snackbar.LENGTH_LONG).show();
-
                     }
                     break;
             }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1549,6 +1549,7 @@
     <string name="support_contact_email_not_set">Not set</string>
     <string name="support_push_notification_title">WordPress</string>
     <string name="support_push_notification_message">New message from \'Help &amp; Support\'</string>
+    <string name="support_push_notification_message_hint_snackbar">Find your support conversation by tapping \'Help &amp; Support\' and then \'My Tickets\'</string>
 
     <!--My Site-->
     <string name="my_site_header_external">External</string>


### PR DESCRIPTION
While testing notifications for WPAndroid 10.4 we identified a (what seemed to us broken) flow when tapping a Zendesk notification that only brings you to the `Me` screen in WPAndroid, leaving it up to the user to figure out that they have to tap on `Help & Support` and then `My Tickets`, then finally select the conversation to be able to take it up from there.

From conversations with @oguzkocer and @aerych it looks like there were many hurdles with this integration, and this was actually a expected behavior as explained in https://github.com/wordpress-mobile/WordPress-Android/issues/7839 and was so described in the tests steps in https://github.com/wordpress-mobile/WordPress-Android/pull/7955

This PR adds a snackbar that explains the user a bit more as to what they need to do in order to complete the desired action (_to look into an HE answer to a question they initiated through `Help & Support -> Contact Us` section of the app_).

BEFORE:
![zendesksnackbarno](https://user-images.githubusercontent.com/6597771/42782828-729f7486-8920-11e8-9dce-fc0809ae84c9.gif)


AFTER:
![zendesksnackbar](https://user-images.githubusercontent.com/6597771/42782835-76ae8bf2-8920-11e8-91a3-fb9eab6fc973.gif)
(see even on a  screen not so small, the `Help & Support` section of the app is not even shown, so it's even harder to decide what to do next weren't it for the snackbar).

To test:
1. initiate a conversation on Zendesk by going to the `Me` tab, then tap `Help & Support` and finally `Contact us`.
2. Send the app to the background (even ideally, just exist the section by tapping `back` twice).
3. have a HE answer your message
4. Observe the push notification is received, and a notification is shown
5. Tap on the notification and see the WP app is opened in the `Me` tab and a snackbar appears, explaining what to do next in order to complete the desired action.

cc-ing @SylvesterWilmott by recommendation from @aerych: even if there's not much space of action here, I'd love to hear your feedback - feel free to please recommend a better message if needed, and we can also make the length to which the Snackbar stays on screen to a specific amount of time (for example, 5 seconds).
Maybe not as urgently, if I may request, do you think there might be better way to explain / close the gap in this flow while we still don't have [proper deep-linking](https://github.com/wordpress-mobile/WordPress-Android/issues/7839) (i.e. a way to make  a tap on the notification directly open the conversation within context)?. Thanks in advance.

cc @oguzkocer for code review

cc @loremattei so we keep an eye on it before full rollout of 10.4
