### PR TITLE
Add content description to images in StockLibrary

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
@@ -585,6 +585,8 @@ public class StockMediaPickerActivity extends AppCompatActivity implements Searc
             String imageUrl = PhotonUtils.getPhotonImageUrl(media.getThumbnail(), mThumbWidth, mThumbHeight);
             holder.mImageView.setImageUrl(imageUrl, WPNetworkImageView.ImageType.PHOTO);
 
+            holder.mImageView.setContentDescription(media.getTitle());
+
             boolean isSelected = isItemSelected(position);
             holder.mSelectionCountTextView.setSelected(isSelected);
             if (enableMultiselect()) {


### PR DESCRIPTION
Fixes #8046 

Adds meaningful content description (for TalkBack) for images in StockLibrary.

To test
1. Open editor
2. Click on the add media button
3. Choose from Free Photo library
4. Type something
5. Go to system settings and enable Talkback
6. Return back to the app
7. Focus one of the images
8. Notice TalkBack announces meaningful description for each image instead of "Unlabelled button ..."
