### PR TITLE
Add max length checks for translated metadata strings

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -64,10 +64,10 @@ desc "Downloads translated metadata from GlotPress"
 lane :download_metadata_strings do |options| 
   values = options[:version].split('.')
   files = {
-    "release_note_#{values[0]}#{values[1]}" => "changelogs/#{options[:build_number]}.txt",
-    play_store_promo: "short_description.txt",
-    play_store_desc: "full_description.txt",
-    play_store_app_title: "title.txt"
+    "release_note_#{values[0]}#{values[1]}" => {desc: "changelogs/#{options[:build_number]}.txt", max_size: 0},
+    play_store_promo: {desc:"short_description.txt", max_size: 80},
+    play_store_desc: {desc:"full_description.txt", max_size: 0},
+    play_store_app_title: {desc:"title.txt", max_size: 50}
   }
 
   metadata_locales = [

--- a/fastlane/helpers/metadata_download_helper.rb
+++ b/fastlane/helpers/metadata_download_helper.rb
@@ -30,7 +30,7 @@ module Fastlane
         delete_existing_metadata(target_locale)
 
         if (loc_data == nil)
-          puts "No translation available for #{target_locale}"
+          UI.message "No translation available for #{target_locale}"
           return
         end
 
@@ -39,7 +39,12 @@ module Fastlane
 
           target_files.each do | file |
             if (file[0].to_s == key)
-              save_metadata(target_locale, file[1], d[1])
+              data=file[1]
+              if (data[:max_size] != 0) && ((d[1].to_s.length - 3) > data[:max_size]) then
+                UI.message("Rejecting #{target_locale} traslation for #{key}: translation length: #{d[1].to_s.length} - max allowed length: #{data[:max_size]}")
+              else
+                save_metadata(target_locale, file[1][:desc], d[1])
+              end 
             end
           end
         end
@@ -55,7 +60,7 @@ module Fastlane
       # Some small helpers
       def delete_existing_metadata(target_locale)
         @target_files.each do | file |
-          file_path = get_target_file_path(target_locale, file[1])
+          file_path = get_target_file_path(target_locale, file[1][:desc])
           File.delete(file_path) if File.exists? file_path
         end
       end


### PR DESCRIPTION
Play Store imposes some restriction about the max length for some metadata. An error occurs when trying to upload strings that are too long.

This PR adds a check to the script that downloads the translated strings from GlotPress in order to skip translations that are too long. A warning message in displayed in the console in order to alert the user.

To Test:
1. Verify that there are strings that are too long in the GlotPress repository
2. Launch `fastlane download_metadata_strings version:<VV> build_number: <NN>` where _VV_ is the app public version and _NN_ is the build number.
3. Verify that the script skips the strings that are too long and that it updates the others.
