### PR TITLE
Preserve translator comments when the metadata .po file is updated

### DIFF
--- a/fastlane/actions/update_metadata_source.rb
+++ b/fastlane/actions/update_metadata_source.rb
@@ -97,11 +97,19 @@ module Fastlane
           end
         end
 
+        if (is_comment(line))
+          @current_block = @blocks.first
+        end
+
         @current_block.handle_line(fw, line)
       end
 
       def self.is_block_id(line)
         line.start_with?('msgctxt')
+      end
+
+      def self.is_comment(line)
+        line.start_with?('#')
       end
 
 


### PR DESCRIPTION
Fixes #8050.

To Test:
1. Run `fastlane update_ps_strings`
2. When asked for a version for the release notes, put the higher that's currently in the PlayStoreString.po file (i.e. 10.4 if in the file there are `release_note_104` and `release_note_103` keys)
3. Verify that nothing changes in the file after the script completes.