### PR TITLE
Support for numeric-only tags in posts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '51fee5847ca60895772eb5e5e4ca64a275cac543'
+    fluxCVersion = 'dd17b47b2839e686f250324d612b7dbea0a3cce9'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'dd17b47b2839e686f250324d612b7dbea0a3cce9'
+    fluxCVersion = 'd379bc018621e33ca1cfc912bf6eb88438d8f534'
 }


### PR DESCRIPTION
Fixes #8008 

The solution to issue resides [on the FluxC side](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/847) so, no changes introduced in this PR other than pointing to the FluxC version with the fix.

I will update this PR after the FluxC side PR is merged.

To test:

1. Navigate to My Site > Blog Posts and edit a post.
2. Tap the three dots to the upper right of the post editor to get to "Post Settings".
3. Add multiple tags to the post, including some that only consist of numbers ("2018", for example).
4. Update your changes then view the post's tags.
5. The new tags should be there, both on the mobile and on the web