### PR TITLE
Replace Volley with Glide in Plugins

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -41,11 +41,12 @@ import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 import org.wordpress.android.viewmodel.PluginBrowserViewModel;
 import org.wordpress.android.viewmodel.PluginBrowserViewModel.PluginListType;
-import org.wordpress.android.widgets.WPNetworkImageView;
-import org.wordpress.android.widgets.WPNetworkImageView.ImageType;
 
 import java.util.HashMap;
 import java.util.List;
@@ -57,6 +58,7 @@ public class PluginBrowserActivity extends AppCompatActivity
         implements SearchView.OnQueryTextListener,
         MenuItem.OnActionExpandListener {
     @Inject ViewModelProvider.Factory mViewModelFactory;
+    @Inject ImageManager mImageManager;
     private PluginBrowserViewModel mViewModel;
 
     private RecyclerView mSitePluginsRecycler;
@@ -410,7 +412,7 @@ public class PluginBrowserActivity extends AppCompatActivity
 
             holder.mNameText.setText(plugin.getDisplayName());
             holder.mAuthorText.setText(plugin.getAuthorName());
-            holder.mIcon.setImageUrl(plugin.getIcon(), ImageType.PLUGIN_ICON);
+            mImageManager.load(holder.mIcon, ImageType.PLUGIN, StringUtils.notNullStr(plugin.getIcon()));
 
             if (plugin.isInstalled()) {
                 @StringRes int textResId;
@@ -453,7 +455,7 @@ public class PluginBrowserActivity extends AppCompatActivity
             private final ViewGroup mStatusContainer;
             private final TextView mStatusText;
             private final ImageView mStatusIcon;
-            private final WPNetworkImageView mIcon;
+            private final ImageView mIcon;
             private final RatingBar mRatingBar;
 
             PluginBrowserViewHolder(View view) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -28,6 +28,7 @@ import android.view.ViewGroup;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.ImageView;
+import android.widget.ImageView.ScaleType;
 import android.widget.ProgressBar;
 import android.widget.RatingBar;
 import android.widget.RelativeLayout;
@@ -78,7 +79,8 @@ import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.WPLinkMovementMethod;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -93,8 +95,6 @@ import java.util.TimeZone;
 
 import javax.inject.Inject;
 
-import static org.wordpress.android.widgets.WPNetworkImageView.ImageType.PHOTO;
-import static org.wordpress.android.widgets.WPNetworkImageView.ImageType.PLUGIN_ICON;
 
 public class PluginDetailActivity extends AppCompatActivity {
     public static final String KEY_PLUGIN_SLUG = "KEY_PLUGIN_SLUG";
@@ -141,8 +141,8 @@ public class PluginDetailActivity extends AppCompatActivity {
     protected TextView mFaqTextView;
     protected ImageView mFaqChevron;
 
-    private WPNetworkImageView mImageBanner;
-    private WPNetworkImageView mImageIcon;
+    private ImageView mImageBanner;
+    private ImageView mImageIcon;
 
     private boolean mIsConfiguringPlugin;
     private boolean mIsInstallingPlugin;
@@ -159,6 +159,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     @Inject PluginStore mPluginStore;
     @Inject SiteStore mSiteStore;
     @Inject Dispatcher mDispatcher;
+    @Inject ImageManager mImageManager;
 
     @Override
     protected void attachBaseContext(Context newBase) {
@@ -470,8 +471,9 @@ public class PluginDetailActivity extends AppCompatActivity {
         }
 
         mTitleTextView.setText(mPlugin.getDisplayName());
-        mImageBanner.setImageUrl(mPlugin.getBanner(), PHOTO);
-        mImageIcon.setImageUrl(mPlugin.getIcon(), PLUGIN_ICON);
+        mImageManager.load(mImageBanner, ImageType.PHOTO, StringUtils.notNullStr(mPlugin.getBanner()),
+                ScaleType.CENTER_CROP);
+        mImageManager.load(mImageIcon, ImageType.PLUGIN, StringUtils.notNullStr(mPlugin.getIcon()));
         if (mPlugin.doesHaveWPOrgPluginDetails()) {
             mWPOrgPluginDetailsContainer.setVisibility(View.VISIBLE);
             setCollapsibleHtmlText(mDescriptionTextView, mPlugin.getDescriptionAsHtml());

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -31,12 +31,14 @@ import org.wordpress.android.fluxc.model.plugin.ImmutablePluginModel;
 import org.wordpress.android.models.networkresource.ListState;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 import org.wordpress.android.viewmodel.PluginBrowserViewModel;
 import org.wordpress.android.viewmodel.PluginBrowserViewModel.PluginListType;
-import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.util.List;
 
@@ -48,6 +50,7 @@ public class PluginListFragment extends Fragment {
     public static final String TAG = PluginListFragment.class.getName();
 
     @Inject ViewModelProvider.Factory mViewModelFactory;
+    @Inject ImageManager mImageManager;
 
     private static final String ARG_LIST_TYPE = "list_type";
 
@@ -254,7 +257,7 @@ public class PluginListFragment extends Fragment {
             PluginViewHolder holder = (PluginViewHolder) viewHolder;
             holder.mName.setText(plugin.getDisplayName());
             holder.mAuthor.setText(plugin.getAuthorName());
-            holder.mIcon.setImageUrl(plugin.getIcon(), WPNetworkImageView.ImageType.PLUGIN_ICON);
+            mImageManager.load(holder.mIcon, ImageType.PLUGIN, StringUtils.notNullStr(plugin.getIcon()));
 
             if (plugin.isInstalled()) {
                 @StringRes int textResId;
@@ -300,7 +303,7 @@ public class PluginListFragment extends Fragment {
             private final TextView mAuthor;
             private final TextView mStatusText;
             private final ImageView mStatusIcon;
-            private final WPNetworkImageView mIcon;
+            private final ImageView mIcon;
             private final RatingBar mRatingBar;
 
             PluginViewHolder(View view) {

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
@@ -13,6 +13,7 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.AVATAR -> R.drawable.ic_placeholder_gravatar_grey_lighten_20_100dp
             ImageType.BLAVATAR -> R.drawable.ic_placeholder_blavatar_grey_lighten_20_40dp
             ImageType.THEME -> R.color.grey_lighten_30
+            ImageType.PLUGIN -> R.drawable.plugin_placeholder
         }
     }
 
@@ -23,6 +24,7 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.AVATAR -> R.drawable.shape_oval_grey_light
             ImageType.BLAVATAR -> R.color.grey_light
             ImageType.THEME -> R.drawable.theme_loading
+            ImageType.PLUGIN -> R.drawable.plugin_placeholder
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
@@ -5,5 +5,6 @@ enum class ImageType {
     VIDEO,
     AVATAR,
     BLAVATAR,
-    THEME
+    THEME,
+    PLUGIN
 }

--- a/WordPress/src/main/res/layout/plugin_browser_row.xml
+++ b/WordPress/src/main/res/layout/plugin_browser_row.xml
@@ -10,7 +10,7 @@
     android:paddingRight="@dimen/margin_medium"
     android:paddingStart="@dimen/margin_medium" >
 
-    <org.wordpress.android.widgets.WPNetworkImageView
+    <ImageView
         android:id="@+id/plugin_icon"
         android:layout_width="@dimen/plugin_row_width"
         android:layout_height="@dimen/plugin_row_width"

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -30,13 +30,12 @@
                 android:layout_height="wrap_content"
                 app:layout_collapseMode="parallax">
 
-                <org.wordpress.android.widgets.WPNetworkImageView
+                <ImageView
                     android:id="@+id/image_banner"
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/plugin_banner_size"
                     android:background="@color/grey_lighten_20"
-                    android:contentDescription="@string/plugin_detail_banner_desc"
-                    android:scaleType="centerCrop" />
+                    android:contentDescription="@string/plugin_detail_banner_desc" />
 
                 <ImageView
                     android:id="@+id/image_gradient_scrim"
@@ -84,7 +83,7 @@
                         android:background="@color/grey_lighten_30"
                         android:padding="@dimen/margin_extra_large">
 
-                        <org.wordpress.android.widgets.WPNetworkImageView
+                        <ImageView
                             android:id="@+id/image_icon"
                             android:layout_width="@dimen/plugin_icon_size"
                             android:layout_height="@dimen/plugin_icon_size"

--- a/WordPress/src/main/res/layout/plugin_list_row.xml
+++ b/WordPress/src/main/res/layout/plugin_list_row.xml
@@ -12,7 +12,7 @@
     android:paddingStart="@dimen/margin_extra_large"
     android:paddingTop="@dimen/margin_extra_large">
 
-    <org.wordpress.android.widgets.WPNetworkImageView
+    <ImageView
         android:id="@+id/plugin_icon"
         android:layout_width="@dimen/plugin_icon_size"
         android:layout_height="@dimen/plugin_icon_size"


### PR DESCRIPTION
Fixes #8023 

Replaces Volley with Glide in the Plugins section. Since plugin icons don't support gif drawables, nothing should change from the user perspective.

To test:
1. Go to My Site -> Plugins
2. Make sure all the icons are correctly loaded
3. Click on the `Manage` button
4. Make sure all the icons are loaded
5. Click on one of the plugins 
6. Make sure the icon in the header is correctly loaded

@hypest Could you please review this PR. Thanks!
