### PR TITLE
Replace volley with glide in Publicize section

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -94,11 +94,14 @@ import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.ui.prefs.SiteSettingsTagDetailFragment;
 import org.wordpress.android.ui.prefs.SiteSettingsTagListActivity;
 import org.wordpress.android.ui.prefs.notifications.NotificationsSettingsFragment;
+import org.wordpress.android.ui.publicize.PublicizeAccountChooserListAdapter;
 import org.wordpress.android.ui.publicize.PublicizeButtonPrefsFragment;
 import org.wordpress.android.ui.publicize.PublicizeDetailFragment;
 import org.wordpress.android.ui.publicize.PublicizeListActivity;
 import org.wordpress.android.ui.publicize.PublicizeListFragment;
 import org.wordpress.android.ui.publicize.PublicizeWebViewFragment;
+import org.wordpress.android.ui.publicize.adapters.PublicizeConnectionAdapter;
+import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter;
 import org.wordpress.android.ui.reader.ReaderCommentListActivity;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
 import org.wordpress.android.ui.reader.ReaderPostListFragment;
@@ -387,6 +390,12 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(PluginDetailActivity object);
 
     void inject(WordPressGlideModule object);
+
+    void inject(PublicizeAccountChooserListAdapter object);
+
+    void inject(PublicizeConnectionAdapter object);
+
+    void inject(PublicizeServiceAdapter object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserDialogFragment.java
@@ -67,7 +67,7 @@ public class PublicizeAccountChooserDialogFragment extends DialogFragment
 
     private void configureRecyclerViews(View view) {
         PublicizeAccountChooserListAdapter notConnectedAdapter =
-                new PublicizeAccountChooserListAdapter(mNotConnectedAccounts, this, false);
+                new PublicizeAccountChooserListAdapter(getActivity(), mNotConnectedAccounts, this, false);
         notConnectedAdapter.setHasStableIds(true);
         mNotConnectedRecyclerView = (RecyclerView) view.findViewById(R.id.not_connected_recyclerview);
         mNotConnectedRecyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
@@ -88,7 +88,7 @@ public class PublicizeAccountChooserDialogFragment extends DialogFragment
     private void populateConnectedListView(View view) {
         RecyclerView listViewConnected = (RecyclerView) view.findViewById(R.id.connected_recyclerview);
         PublicizeAccountChooserListAdapter connectedAdapter =
-                new PublicizeAccountChooserListAdapter(mConnectedAccounts, null, true);
+                new PublicizeAccountChooserListAdapter(getActivity(), mConnectedAccounts, null, true);
 
         listViewConnected.setLayoutManager(new LinearLayoutManager(getActivity()));
         listViewConnected.setAdapter(connectedAdapter);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserListAdapter.java
@@ -1,17 +1,23 @@
 package org.wordpress.android.ui.publicize;
 
+import android.content.Context;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.RadioButton;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
 import org.wordpress.android.models.PublicizeConnection;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 import java.util.List;
+
+import javax.inject.Inject;
 
 public class PublicizeAccountChooserListAdapter
         extends RecyclerView.Adapter<PublicizeAccountChooserListAdapter.ViewHolder> {
@@ -20,8 +26,11 @@ public class PublicizeAccountChooserListAdapter
     private boolean mAreAccountsConnected;
     private int mSelectedPosition;
 
-    public PublicizeAccountChooserListAdapter(List<PublicizeConnection> connectionItems,
+    @Inject ImageManager mImageManager;
+
+    public PublicizeAccountChooserListAdapter(Context context, List<PublicizeConnection> connectionItems,
                                               OnPublicizeAccountChooserListener listener, boolean isConnected) {
+        ((WordPress) context.getApplicationContext()).component().inject(this);
         mConnectionItems = connectionItems;
         mListener = listener;
         mAreAccountsConnected = isConnected;
@@ -39,8 +48,7 @@ public class PublicizeAccountChooserListAdapter
     @Override
     public void onBindViewHolder(final ViewHolder holder, int position) {
         final PublicizeConnection connection = mConnectionItems.get(position);
-        holder.mProfileImageView
-                .setImageUrl(connection.getExternalProfilePictureUrl(), WPNetworkImageView.ImageType.PHOTO);
+        mImageManager.load(holder.mProfileImageView, ImageType.PHOTO, connection.getExternalProfilePictureUrl());
         holder.mNameTextView.setText(connection.getExternalDisplayName());
         holder.mRadioButton.setChecked(position == mSelectedPosition);
 
@@ -65,17 +73,17 @@ public class PublicizeAccountChooserListAdapter
     }
 
     public class ViewHolder extends RecyclerView.ViewHolder {
-        public final View mView;
-        public final RadioButton mRadioButton;
-        public final WPNetworkImageView mProfileImageView;
-        public final TextView mNameTextView;
+        final View mView;
+        final RadioButton mRadioButton;
+        final ImageView mProfileImageView;
+        final TextView mNameTextView;
 
         public ViewHolder(View view) {
             super(view);
             mView = view;
-            mRadioButton = (RadioButton) view.findViewById(R.id.radio_button);
-            mProfileImageView = (WPNetworkImageView) view.findViewById(R.id.profile_pic);
-            mNameTextView = (TextView) view.findViewById(R.id.name);
+            mRadioButton = view.findViewById(R.id.radio_button);
+            mProfileImageView = view.findViewById(R.id.profile_pic);
+            mNameTextView = view.findViewById(R.id.name);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeConnectionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeConnectionAdapter.java
@@ -5,9 +5,11 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.PublicizeTable;
 import org.wordpress.android.models.PublicizeConnection;
 import org.wordpress.android.models.PublicizeConnectionList;
@@ -15,7 +17,10 @@ import org.wordpress.android.ui.publicize.ConnectButton;
 import org.wordpress.android.ui.publicize.PublicizeActions;
 import org.wordpress.android.ui.publicize.PublicizeConstants;
 import org.wordpress.android.util.StringUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
+
+import javax.inject.Inject;
 
 public class PublicizeConnectionAdapter extends RecyclerView.Adapter<PublicizeConnectionAdapter.ConnectionViewHolder> {
     public interface OnAdapterLoadedListener {
@@ -31,8 +36,11 @@ public class PublicizeConnectionAdapter extends RecyclerView.Adapter<PublicizeCo
     private PublicizeActions.OnPublicizeActionListener mActionListener;
     private OnAdapterLoadedListener mLoadedListener;
 
+    @Inject ImageManager mImageManager;
+
     public PublicizeConnectionAdapter(Context context, long siteId, String serviceId, long currentUserId) {
         super();
+        ((WordPress) context.getApplicationContext()).component().inject(this);
         mSiteId = siteId;
         mServiceId = StringUtils.notNullStr(serviceId);
         mCurrentUserId = currentUserId;
@@ -91,12 +99,7 @@ public class PublicizeConnectionAdapter extends RecyclerView.Adapter<PublicizeCo
         holder.mTxtUser.setText(connection.getExternalDisplayName());
         holder.mDivider.setVisibility(position == 0 ? View.GONE : View.VISIBLE);
 
-        if (connection.hasExternalProfilePictureUrl()) {
-            holder.mImgAvatar.setImageUrl(connection.getExternalProfilePictureUrl(),
-                                          WPNetworkImageView.ImageType.AVATAR);
-        } else {
-            holder.mImgAvatar.showDefaultGravatarImageAndNullifyUrl();
-        }
+        mImageManager.loadIntoCircle(holder.mImgAvatar, ImageType.AVATAR, connection.getExternalProfilePictureUrl());
 
         holder.mBtnConnect.setAction(PublicizeConstants.ConnectAction.DISCONNECT);
         holder.mBtnConnect.setOnClickListener(new View.OnClickListener() {
@@ -112,14 +115,14 @@ public class PublicizeConnectionAdapter extends RecyclerView.Adapter<PublicizeCo
     class ConnectionViewHolder extends RecyclerView.ViewHolder {
         private final TextView mTxtUser;
         private final ConnectButton mBtnConnect;
-        private final WPNetworkImageView mImgAvatar;
+        private final ImageView mImgAvatar;
         private final View mDivider;
 
         ConnectionViewHolder(View view) {
             super(view);
-            mTxtUser = (TextView) view.findViewById(R.id.text_user);
-            mImgAvatar = (WPNetworkImageView) view.findViewById(R.id.image_avatar);
-            mBtnConnect = (ConnectButton) view.findViewById(R.id.button_connect);
+            mTxtUser = view.findViewById(R.id.text_user);
+            mImgAvatar = view.findViewById(R.id.image_avatar);
+            mBtnConnect = view.findViewById(R.id.button_connect);
             mDivider = view.findViewById(R.id.divider);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
@@ -9,9 +9,11 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.PublicizeTable;
 import org.wordpress.android.models.PublicizeConnection;
 import org.wordpress.android.models.PublicizeConnectionList;
@@ -19,10 +21,13 @@ import org.wordpress.android.models.PublicizeService;
 import org.wordpress.android.models.PublicizeServiceList;
 import org.wordpress.android.ui.publicize.PublicizeConstants;
 import org.wordpress.android.util.PhotonUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 import java.util.Collections;
 import java.util.Comparator;
+
+import javax.inject.Inject;
 
 public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServiceAdapter.SharingViewHolder> {
     public interface OnAdapterLoadedListener {
@@ -44,9 +49,11 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
     private OnAdapterLoadedListener mAdapterLoadedListener;
     private OnServiceClickListener mServiceClickListener;
 
+    @Inject ImageManager mImageManager;
+
     public PublicizeServiceAdapter(Context context, long siteId, long currentUserId) {
         super();
-
+        ((WordPress) context.getApplicationContext()).component().inject(this);
         mSiteId = siteId;
         mBlavatarSz = context.getResources().getDimensionPixelSize(R.dimen.blavatar_sz_small);
         mCurrentUserId = currentUserId;
@@ -112,7 +119,7 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
 
         holder.mTxtService.setText(service.getLabel());
         String iconUrl = PhotonUtils.getPhotonImageUrl(service.getIconUrl(), mBlavatarSz, mBlavatarSz);
-        holder.mImgIcon.setImageUrl(iconUrl, WPNetworkImageView.ImageType.BLAVATAR);
+        mImageManager.load(holder.mImgIcon, ImageType.BLAVATAR, iconUrl);
 
         if (connections.size() > 0) {
             holder.mTxtUser.setText(connections.getUserDisplayNames());
@@ -142,13 +149,13 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
         private final TextView mTxtService;
         private final TextView mTxtUser;
         private final View mDivider;
-        private final WPNetworkImageView mImgIcon;
+        private final ImageView mImgIcon;
 
         SharingViewHolder(View view) {
             super(view);
-            mTxtService = (TextView) view.findViewById(R.id.text_service);
-            mTxtUser = (TextView) view.findViewById(R.id.text_user);
-            mImgIcon = (WPNetworkImageView) view.findViewById(R.id.image_icon);
+            mTxtService = view.findViewById(R.id.text_service);
+            mTxtUser = view.findViewById(R.id.text_user);
+            mImgIcon = view.findViewById(R.id.image_icon);
             mDivider = view.findViewById(R.id.divider);
         }
     }

--- a/WordPress/src/main/res/layout/publicize_connection_list_item.xml
+++ b/WordPress/src/main/res/layout/publicize_connection_list_item.xml
@@ -13,10 +13,11 @@
         android:layout_height="match_parent"
         android:clickable="false" />
 
-    <org.wordpress.android.widgets.WPNetworkImageView
+    <ImageView
         android:id="@+id/profile_pic"
         android:layout_width="@dimen/publicize_pic_width"
-        android:layout_height="@dimen/publicize_pic_width" />
+        android:layout_height="@dimen/publicize_pic_width"
+        android:contentDescription="@null"/>
 
     <TextView
         android:id="@+id/name"

--- a/WordPress/src/main/res/layout/publicize_listitem_connection.xml
+++ b/WordPress/src/main/res/layout/publicize_listitem_connection.xml
@@ -6,14 +6,15 @@
     android:layout_height="wrap_content"
     android:background="?android:selectableItemBackground">
 
-    <org.wordpress.android.widgets.WPNetworkImageView
+    <ImageView
         android:id="@+id/image_avatar"
         android:layout_width="@dimen/avatar_sz_small"
         android:layout_height="@dimen/avatar_sz_small"
         android:layout_centerVertical="true"
         android:layout_marginRight="@dimen/margin_large"
         tools:src="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp"
-        android:layout_marginEnd="@dimen/margin_large"/>
+        android:layout_marginEnd="@dimen/margin_large"
+        android:contentDescription="@null"/>
 
     <View
         android:id="@+id/divider"

--- a/WordPress/src/main/res/layout/publicize_listitem_service.xml
+++ b/WordPress/src/main/res/layout/publicize_listitem_service.xml
@@ -6,14 +6,15 @@
     android:layout_height="wrap_content"
     android:background="?android:selectableItemBackground">
 
-    <org.wordpress.android.widgets.WPNetworkImageView
+    <ImageView
         android:id="@+id/image_icon"
         android:layout_width="@dimen/blavatar_sz_small"
         android:layout_height="@dimen/blavatar_sz_small"
         android:layout_centerVertical="true"
         android:layout_marginRight="@dimen/margin_large"
         tools:src="@drawable/ic_placeholder_blavatar_grey_lighten_20_32dp"
-        android:layout_marginEnd="@dimen/margin_large"/>
+        android:layout_marginEnd="@dimen/margin_large"
+        android:contentDescription="@null"/>
 
     <View
         android:id="@+id/divider"


### PR DESCRIPTION
Fixes #8063 

Replaces Volley with Glide in the Publicize section of the app. Since social site icons don't support animated gifs, nothing should change from the user perspective.

To test:
*I'm not sure how to make the app make me choose from multiple facebook connection. I thought I'd need to create a company account on Facebook and connect it with my primary account, but it didn't help. So I just used debugger and I manually displayed `PublicizeAccountChooserDialogFragment.java` so I could test whether it works as expected.
1. Go to My Site -> Sharing
2. Make sure all the social icons are correctly loaded
3. Click on Facebook for example
4. Click on Connect and login
5. Make sure your profile picture is correctly loaded 
Don't forget to disconnect the account:-).

@0nko  Could you please review this PR. Thanks!