### PR TITLE
Quick start tasks

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -96,6 +96,11 @@ android {
     }
 }
 
+// allows us to use cool things like @Parcelize annotations
+androidExtensions {
+    experimental = true
+}
+
 dependencies {
     implementation('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
         transitive = true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -154,7 +154,7 @@ public class MySiteFragment extends Fragment implements
 
         if (savedInstanceState != null) {
             mActiveTutorialPrompt =
-                    (InitialTutorialPrompts) savedInstanceState.getSerializable(InitialTutorialPrompts.KEY);
+                    (QuickStartMySitePrompts) savedInstanceState.getSerializable(QuickStartMySitePrompts.KEY);
         }
     }
 
@@ -185,7 +185,7 @@ public class MySiteFragment extends Fragment implements
 
     @Override public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putSerializable(InitialTutorialPrompts.KEY, mActiveTutorialPrompt);
+        outState.putSerializable(QuickStartMySitePrompts.KEY, mActiveTutorialPrompt);
     }
 
     private void initSiteSettings() {
@@ -909,7 +909,7 @@ public class MySiteFragment extends Fragment implements
             int horizontalOffset;
             int verticalOffset;
 
-            if (InitialTutorialPrompts.isTargetingBottomNavBar(mActiveTutorialPrompt.getTask())) {
+            if (QuickStartMySitePrompts.isTargetingBottomNavBar(mActiveTutorialPrompt.getTask())) {
                 horizontalOffset = (quickStartTarget.getWidth() / 2) - focusPointSize + getResources()
                         .getDimensionPixelOffset(R.dimen.quick_start_focus_point_bottom_nav_offset);
                 verticalOffset = 0;
@@ -923,7 +923,7 @@ public class MySiteFragment extends Fragment implements
                     verticalOffset);
 
             // highlighting MySite row and scrolling to it
-            if (!InitialTutorialPrompts.isTargetingBottomNavBar(mActiveTutorialPrompt.getTask())) {
+            if (!QuickStartMySitePrompts.isTargetingBottomNavBar(mActiveTutorialPrompt.getTask())) {
                 mScrollView.post(new Runnable() {
                     @Override public void run() {
                         mScrollView.smoothScrollTo(0, quickStartTarget.getBottom());

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -670,7 +670,6 @@ public class MySiteFragment extends Fragment implements
         int settingsVisibility = (isAdminOrSelfHosted || site.getHasCapabilityListUsers()) ? View.VISIBLE : View.GONE;
         mConfigurationHeader.setVisibility(settingsVisibility);
 
-
         boolean isQuickStartAvailable = site.getHasCapabilityManageOptions()
                                         && ThemeBrowserActivity.isAccessible(site)
                                         && SiteUtils.isAccessedViaWPComRest(site);
@@ -962,6 +961,7 @@ public class MySiteFragment extends Fragment implements
         return hasActiveQuickStartTask() && mActiveTutorialPrompt.getTask() == task;
     }
 
+    // we might need to call this one when the fragment is not attached to WPMainActivity
     public void completeQuickStarTask(int siteId, QuickStartTask quickStartTask) {
         removeQuickStartFocusPoint();
         mQuickStartStore.setDoneTask(siteId, quickStartTask, true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -250,9 +250,8 @@ public class MySiteFragment extends Fragment implements
         rootView.findViewById(R.id.row_view_site).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (isQuickStartTaskActive(QuickStartTask.VIEW_SITE)) {
-                    completeActiveQuickStartTask();
-                }
+                // TODO check if Quick Start completed
+                completeQuickStarTask(QuickStartTask.VIEW_SITE);
                 ActivityLauncher.viewCurrentSite(getActivity(), getSelectedSite(), false);
             }
         });
@@ -342,8 +341,9 @@ public class MySiteFragment extends Fragment implements
         mThemesContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (isQuickStartTaskActive(QuickStartTask.CHOOSE_THEME)
-                    || isQuickStartTaskActive(QuickStartTask.CUSTOMIZE_SITE)) {
+                // TODO check if Quick Start completed
+                completeQuickStarTask(QuickStartTask.CHOOSE_THEME);
+                if (isQuickStartTaskActive(QuickStartTask.CUSTOMIZE_SITE)) {
                     requestNextStepOfActiveQuickStartTask();
                 }
                 ActivityLauncher.viewCurrentBlogThemes(getActivity(), getSelectedSite());
@@ -962,19 +962,15 @@ public class MySiteFragment extends Fragment implements
         return hasActiveQuickStartTask() && mActiveTutorialPrompt.getTask() == task;
     }
 
-    // we might need to call this one when the fragment is not attached to WPMainActivity
-    public void completeActiveQuickStartTask(int siteId) {
-        if (!hasActiveQuickStartTask()) {
-            return;
-        }
+    public void completeQuickStarTask(int siteId, QuickStartTask quickStartTask) {
         removeQuickStartFocusPoint();
-        mQuickStartStore.setDoneTask(siteId, mActiveTutorialPrompt.getTask(), true);
+        mQuickStartStore.setDoneTask(siteId, quickStartTask, true);
         clearActiveQuickStartTask();
     }
 
-    public void completeActiveQuickStartTask() {
+    private void completeQuickStarTask(QuickStartTask quickStartTask) {
         if (getSelectedSite() != null) {
-            completeActiveQuickStartTask(getSelectedSite().getId());
+            completeQuickStarTask(getSelectedSite().getId(), quickStartTask);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -52,9 +52,9 @@ import org.wordpress.android.ui.posts.PromoDialog.PromoDialogClickInterface;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface.SiteSettingsListener;
-import org.wordpress.android.ui.quickstart.QuickStartMySitePrompts;
 import org.wordpress.android.ui.quickstart.QuickStartActivity;
 import org.wordpress.android.ui.quickstart.QuickStartEvent;
+import org.wordpress.android.ui.quickstart.QuickStartMySitePrompts;
 import org.wordpress.android.ui.stats.service.StatsService;
 import org.wordpress.android.ui.themes.ThemeBrowserActivity;
 import org.wordpress.android.ui.uploads.UploadService;
@@ -112,6 +112,7 @@ public class MySiteFragment extends Fragment implements
     private LinearLayout mPlanContainer;
     private LinearLayout mPluginsContainer;
     private LinearLayout mActivityLogContainer;
+    private View mQuickStartContainer;
     private WPTextView mConfigurationHeader;
     private View mSettingsView;
     private LinearLayout mAdminView;
@@ -221,6 +222,7 @@ public class MySiteFragment extends Fragment implements
         mNoSiteDrakeImageView = rootView.findViewById(R.id.my_site_no_site_view_drake);
         mCurrentPlanNameTextView = rootView.findViewById(R.id.my_site_current_plan_text_view);
         mPageView = rootView.findViewById(R.id.row_pages);
+        mQuickStartContainer = rootView.findViewById(R.id.row_quick_start);
 
         setupClickListeners(rootView);
 
@@ -255,7 +257,7 @@ public class MySiteFragment extends Fragment implements
             }
         });
 
-        rootView.findViewById(R.id.row_quick_start).setOnClickListener(new View.OnClickListener() {
+        mQuickStartContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 ActivityLauncher.viewQuickStartForResult(getActivity());
@@ -667,6 +669,13 @@ public class MySiteFragment extends Fragment implements
         // if either people or settings is visible, configuration header should be visible
         int settingsVisibility = (isAdminOrSelfHosted || site.getHasCapabilityListUsers()) ? View.VISIBLE : View.GONE;
         mConfigurationHeader.setVisibility(settingsVisibility);
+
+
+        boolean isQuickStartAvailable = site.getHasCapabilityManageOptions()
+                                        && ThemeBrowserActivity.isAccessible(site)
+                                        && SiteUtils.isAccessedViaWPComRest(site);
+
+        mQuickStartContainer.setVisibility(isQuickStartAvailable ? View.VISIBLE : View.GONE);
 
         mBlavatarImageView.setImageUrl(SiteUtils.getSiteIconUrl(site, mBlavatarSz), WPNetworkImageView
                 .ImageType.BLAVATAR);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -537,7 +537,7 @@ public class MySiteFragment extends Fragment implements
                     QuickStartTask task =
                             (QuickStartTask) data.getSerializableExtra(QuickStartActivity.ARG_QUICK_START_TASK);
 
-                    // remove any existing quick start indicator if necessary
+                    // remove existing quick start indicator if necessary
                     if (mActiveTutorialPrompt != null) {
                         removeQuickStartFocusPoint();
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -963,9 +963,11 @@ public class MySiteFragment extends Fragment implements
 
     // we might need to call this one when the fragment is not attached to WPMainActivity
     public void completeQuickStarTask(int siteId, QuickStartTask quickStartTask) {
-        removeQuickStartFocusPoint();
         mQuickStartStore.setDoneTask(siteId, quickStartTask, true);
-        clearActiveQuickStartTask();
+        if (mActiveTutorialPrompt != null && mActiveTutorialPrompt.getTask() == quickStartTask) {
+            removeQuickStartFocusPoint();
+            clearActiveQuickStartTask();
+        }
     }
 
     private void completeQuickStarTask(QuickStartTask quickStartTask) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -15,6 +15,7 @@ import android.support.v4.app.RemoteInput;
 import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.TextView;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -35,6 +36,7 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
@@ -83,6 +85,7 @@ import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ProfilingUtils;
+import org.wordpress.android.util.QuickStartUtils;
 import org.wordpress.android.util.ShortcutUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
@@ -501,11 +504,24 @@ public class WPMainActivity extends AppCompatActivity implements
     public void onPageChanged(int position) {
         updateTitle(position);
         trackLastVisiblePage(position, true);
+        if (position == PAGE_READER && getMySiteFragment() != null
+            && getMySiteFragment().isQuickStartTaskActive(QuickStartTask.FOLLOW_SITE)) {
+            // MySite fragment might not be attached to activity, so we need to remove focus point from here
+            QuickStartUtils.removeQuickStartFocusPoint((ViewGroup) findViewById(R.id.root_view_main));
+            getMySiteFragment().requestNextStepOfActiveQuickStartTask();
+        }
     }
 
     // user tapped the new post button in the bottom navbar
     @Override
     public void onNewPostButtonClicked() {
+        if (getSelectedSite() != null
+            && getMySiteFragment() != null && getMySiteFragment().isQuickStartTaskActive(QuickStartTask.PUBLISH_POST)) {
+            // MySite fragment might not be attached to activity, so we need to remove focus point from here
+            QuickStartUtils.removeQuickStartFocusPoint((ViewGroup) findViewById(R.id.root_view_main));
+            getMySiteFragment().completeActiveQuickStartTask(getSelectedSite().getId());
+        }
+
         ActivityLauncher.addNewPostOrPageForResult(this, getSelectedSite(), false, false);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -515,10 +515,11 @@ public class WPMainActivity extends AppCompatActivity implements
     // user tapped the new post button in the bottom navbar
     @Override
     public void onNewPostButtonClicked() {
-        if (getSelectedSite() != null
-            && getMySiteFragment() != null) {
-            // MySite fragment might not be attached to activity, so we need to remove focus point from here
-            QuickStartUtils.removeQuickStartFocusPoint((ViewGroup) findViewById(R.id.root_view_main));
+        if (getSelectedSite() != null && getMySiteFragment() != null) {
+            if (getMySiteFragment().isQuickStartTaskActive(QuickStartTask.PUBLISH_POST)) {
+                // MySite fragment might not be attached to activity, so we need to remove focus point from here
+                QuickStartUtils.removeQuickStartFocusPoint((ViewGroup) findViewById(R.id.root_view_main));
+            }
             getMySiteFragment().completeQuickStarTask(getSelectedSite().getId(), QuickStartTask.PUBLISH_POST);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -516,10 +516,10 @@ public class WPMainActivity extends AppCompatActivity implements
     @Override
     public void onNewPostButtonClicked() {
         if (getSelectedSite() != null
-            && getMySiteFragment() != null && getMySiteFragment().isQuickStartTaskActive(QuickStartTask.PUBLISH_POST)) {
+            && getMySiteFragment() != null) {
             // MySite fragment might not be attached to activity, so we need to remove focus point from here
             QuickStartUtils.removeQuickStartFocusPoint((ViewGroup) findViewById(R.id.root_view_main));
-            getMySiteFragment().completeActiveQuickStartTask(getSelectedSite().getId());
+            getMySiteFragment().completeQuickStarTask(getSelectedSite().getId(), QuickStartTask.PUBLISH_POST);
         }
 
         ActivityLauncher.addNewPostOrPageForResult(this, getSelectedSite(), false, false);
@@ -717,7 +717,7 @@ public class WPMainActivity extends AppCompatActivity implements
                 getString(R.string.quick_start_dialog_need_help_button_negative),
                 "",
                 getString(R.string.quick_start_dialog_need_help_button_neutral)
-        );
+                              );
 
         promoDialog.show(getSupportFragmentManager(), tag);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -144,6 +144,9 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
 
                     quickStartTarget.post(new Runnable() {
                         @Override public void run() {
+                            if (getView() == null) {
+                                return;
+                            }
                             ViewGroup focusPointContainer = getView().findViewById(R.id.publicize_scroll_view_child);
                             int focusPointSize =
                                     getResources().getDimensionPixelOffset(R.dimen.quick_start_focus_point_size);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -4,22 +4,35 @@ import android.app.Activity;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
+import android.text.Spannable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
 import android.widget.TextView;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.QuickStartStore;
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask;
+import org.wordpress.android.models.PublicizeService;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter.OnAdapterLoadedListener;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter.OnServiceClickListener;
+import org.wordpress.android.ui.quickstart.QuickStartEvent;
+import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.QuickStartUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.widgets.WPDialogSnackbar;
 
 import javax.inject.Inject;
+
+import de.greenrobot.event.EventBus;
 
 public class PublicizeListFragment extends PublicizeBaseFragment {
     public interface PublicizeButtonPrefsListener {
@@ -32,7 +45,10 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
     private RecyclerView mRecycler;
     private TextView mEmptyView;
 
+    private QuickStartEvent mQuickStartEvent;
+
     @Inject AccountStore mAccountStore;
+    @Inject QuickStartStore mQuickStartStore;
 
     public static PublicizeListFragment newInstance(@NonNull SiteModel site) {
         Bundle args = new Bundle();
@@ -55,6 +71,10 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
         if (mSite == null) {
             ToastUtils.showToast(getActivity(), R.string.blog_not_found, ToastUtils.Duration.SHORT);
             getActivity().finish();
+        }
+
+        if (savedInstanceState != null) {
+            mQuickStartEvent = savedInstanceState.getParcelable(QuickStartEvent.KEY);
         }
     }
 
@@ -86,7 +106,64 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
             }
         });
 
+        if (mQuickStartEvent != null) {
+            showQuickStartFocusPoint();
+        }
+
         return rootView;
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
+    public void onEvent(final QuickStartEvent event) {
+        if (!isAdded() || getView() == null) {
+            return;
+        }
+
+        mQuickStartEvent = event;
+        EventBus.getDefault().removeStickyEvent(event);
+
+        if (mQuickStartEvent.getTask() == QuickStartTask.SHARE_SITE) {
+            showQuickStartFocusPoint();
+
+            Spannable title = QuickStartUtils.stylizeQuickStartPrompt(getActivity(),
+                    R.string.quick_start_dialog_share_site_message_short_connections);
+
+            WPDialogSnackbar.make(getView(), title, AccessibilityUtils.getSnackbarDuration(getActivity(),
+                    getResources().getInteger(R.integer.quick_start_snackbar_duration_ms))).show();
+        }
+    }
+
+    private void showQuickStartFocusPoint() {
+        // we are waiting for RecyclerView to populate itself with views and then grab the first one when it's ready
+        mRecycler.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+            @Override public void onGlobalLayout() {
+                RecyclerView.ViewHolder holder = mRecycler.findViewHolderForAdapterPosition(0);
+                if (holder != null) {
+                    final View quickStartTarget = holder.itemView;
+
+                    quickStartTarget.post(new Runnable() {
+                        @Override public void run() {
+                            ViewGroup focusPointContainer = getView().findViewById(R.id.publicize_scroll_view_child);
+                            int focusPointSize =
+                                    getResources().getDimensionPixelOffset(R.dimen.quick_start_focus_point_size);
+
+                            int verticalOffset = (((quickStartTarget.getHeight()) - focusPointSize) / 2);
+
+                            QuickStartUtils.addQuickStartFocusPointAboveTheView(focusPointContainer, quickStartTarget,
+                                    0, verticalOffset);
+                        }
+                    });
+                    mRecycler.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                }
+            }
+        });
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putParcelable(QuickStartEvent.KEY, mQuickStartEvent);
     }
 
     @Override
@@ -132,7 +209,16 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
                     mAccountStore.getAccount().getUserId());
             mAdapter.setOnAdapterLoadedListener(mAdapterLoadedListener);
             if (getActivity() instanceof OnServiceClickListener) {
-                mAdapter.setOnServiceClickListener((OnServiceClickListener) getActivity());
+                mAdapter.setOnServiceClickListener(new OnServiceClickListener() {
+                    @Override public void onServiceClicked(PublicizeService service) {
+                        mQuickStartStore.setDoneTask(mSite.getId(), mQuickStartEvent.getTask(), true);
+                        if (getView() != null) {
+                            QuickStartUtils.removeQuickStartFocusPoint((ViewGroup) getView());
+                        }
+                        mQuickStartEvent = null;
+                        ((OnServiceClickListener) getActivity()).onServiceClicked(service);
+                    }
+                });
             }
         }
         return mAdapter;
@@ -140,5 +226,15 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
 
     void reload() {
         getAdapter().reload();
+    }
+
+    @Override public void onStart() {
+        super.onStart();
+        EventBus.getDefault().registerSticky(this);
+    }
+
+    @Override public void onStop() {
+        super.onStop();
+        EventBus.getDefault().unregister(this);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -214,7 +214,8 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
             if (getActivity() instanceof OnServiceClickListener) {
                 mAdapter.setOnServiceClickListener(new OnServiceClickListener() {
                     @Override public void onServiceClicked(PublicizeService service) {
-                        mQuickStartStore.setDoneTask(mSite.getId(), mQuickStartEvent.getTask(), true);
+                        // TODO check if Quick Start completed
+                        mQuickStartStore.setDoneTask(mSite.getId(), QuickStartTask.SHARE_SITE, true);
                         if (getView() != null) {
                             QuickStartUtils.removeQuickStartFocusPoint((ViewGroup) getView());
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartEvent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartEvent.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.ui.quickstart
+
+import android.annotation.SuppressLint
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
+
+/**
+ * Container for passing around QuickStartTask to destinations and retaining it there
+ **/
+@Parcelize
+@SuppressLint("ParcelCreator")
+class QuickStartEvent(val task: QuickStartTask) : Parcelable {
+    companion object {
+        const val KEY = "quick_start_event"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartFragment.kt
@@ -149,56 +149,43 @@ class QuickStartFragment : Fragment() {
     private fun crossOutTask(task: QuickStartTask) {
         val titleView: TextView
         val checkMarkView: View
-        val containerView: View
 
         when (task) {
             CREATE_SITE -> {
                 titleView = title_create_site
                 checkMarkView = done_create_site
-                containerView = layout_create_site
             }
             VIEW_SITE -> {
                 titleView = title_view_site
                 checkMarkView = done_view_site
-                containerView = layout_view_site
             }
             CHOOSE_THEME -> {
                 titleView = title_browse_themes
                 checkMarkView = done_browse_themes
-                containerView = layout_browse_themes
             }
             CUSTOMIZE_SITE -> {
                 titleView = title_customize_site
                 checkMarkView = done_customize_site
-                containerView = layout_customize_site
             }
             SHARE_SITE -> {
                 titleView = title_share_site
                 checkMarkView = done_share_site
-                containerView = layout_share_site
             }
             PUBLISH_POST -> {
                 titleView = title_publish_post
                 checkMarkView = done_publish_post
-                containerView = layout_publish_post
             }
             FOLLOW_SITE -> {
                 titleView = title_follow_site
                 checkMarkView = done_follow_site
-                containerView = layout_follow_site
             }
         }
 
         visuallyMarkTaskAsCompleted(titleView, checkMarkView)
-        disableTaskContainer(containerView)
     }
 
     private fun visuallyMarkTaskAsCompleted(taskTitleTextView: TextView, taskDoneCheckMark: View) {
         taskTitleTextView.let { it.paintFlags = it.paintFlags or Paint.STRIKE_THRU_TEXT_FLAG }
         taskDoneCheckMark.visibility = View.VISIBLE
-    }
-
-    private fun disableTaskContainer(container: View) {
-        container.isClickable = false
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -9,6 +9,7 @@ import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
 import android.support.design.widget.TabLayout;
 import android.support.design.widget.TabLayout.OnTabSelectedListener;
@@ -53,10 +54,13 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.ReaderActionBuilder;
 import org.wordpress.android.fluxc.model.ReaderSiteModel;
+import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AddOrDeleteSubscriptionPayload;
 import org.wordpress.android.fluxc.store.AccountStore.AddOrDeleteSubscriptionPayload.SubscriptionAction;
 import org.wordpress.android.fluxc.store.AccountStore.OnSubscriptionUpdated;
+import org.wordpress.android.fluxc.store.QuickStartStore;
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask;
 import org.wordpress.android.fluxc.store.ReaderStore;
 import org.wordpress.android.fluxc.store.ReaderStore.OnReaderSitesSearched;
 import org.wordpress.android.fluxc.store.ReaderStore.ReaderSearchSitesPayload;
@@ -74,6 +78,7 @@ import org.wordpress.android.ui.main.BottomNavController;
 import org.wordpress.android.ui.main.MainToolbarFragment;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.prefs.AppPrefs;
+import org.wordpress.android.ui.quickstart.QuickStartEvent;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderBlogActions;
@@ -98,6 +103,7 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.QuickStartUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
@@ -171,11 +177,13 @@ public class ReaderPostListFragment extends Fragment
     private final HistoryStack mTagPreviewHistory = new HistoryStack("tag_preview_history");
 
     private AlertDialog mBookmarksSavedLocallyDialog;
+    private QuickStartEvent mQuickStartEvent;
 
     @Inject AccountStore mAccountStore;
     @Inject ReaderStore mReaderStore;
     @Inject Dispatcher mDispatcher;
     @Inject ImageManager mImageManager;
+    @Inject QuickStartStore mQuickStartStore;
 
     private static class HistoryStack extends Stack<String> {
         private final String mKeyName;
@@ -258,6 +266,14 @@ public class ReaderPostListFragment extends Fragment
         return fragment;
     }
 
+    public @Nullable SiteModel getSelectedSite() {
+        if (getActivity() instanceof WPMainActivity) {
+            WPMainActivity mainActivity = (WPMainActivity) getActivity();
+            return mainActivity.getSelectedSite();
+        }
+        return null;
+    }
+
     @Override
     public void setArguments(Bundle args) {
         super.setArguments(args);
@@ -312,6 +328,7 @@ public class ReaderPostListFragment extends Fragment
             mHasUpdatedPosts = savedInstanceState.getBoolean(ReaderConstants.KEY_ALREADY_UPDATED);
             mFirstLoad = savedInstanceState.getBoolean(ReaderConstants.KEY_FIRST_LOAD);
             mSearchTabsPos = savedInstanceState.getInt(ReaderConstants.KEY_ACTIVE_SEARCH_TAB, NO_POSITION);
+            mQuickStartEvent = savedInstanceState.getParcelable(QuickStartEvent.KEY);
         }
     }
 
@@ -399,7 +416,7 @@ public class ReaderPostListFragment extends Fragment
     public void onStart() {
         super.onStart();
         mDispatcher.register(this);
-        EventBus.getDefault().register(this);
+        EventBus.getDefault().registerSticky(this);
 
         reloadTags();
 
@@ -476,6 +493,27 @@ public class ReaderPostListFragment extends Fragment
         }
     }
 
+    @SuppressWarnings("unused")
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
+    public void onEvent(final QuickStartEvent event) {
+        if (!isAdded() || getView() == null) {
+            return;
+        }
+
+        mQuickStartEvent = event;
+        EventBus.getDefault().removeStickyEvent(event);
+
+        if (mQuickStartEvent.getTask() == QuickStartTask.FOLLOW_SITE) {
+            Spannable title = QuickStartUtils.stylizeQuickStartPrompt(getActivity(),
+                    R.string.quick_start_dialog_follow_sites_message_short_search,
+                    R.drawable.ic_search_grey_24dp);
+
+            if (getActivity() != null && getActivity() instanceof WPMainActivity) {
+                ((WPMainActivity) getActivity()).showQuickStartSnackBar(title);
+            }
+        }
+    }
+
     @Override
     public void onSaveInstanceState(Bundle outState) {
         AppLog.d(T.READER, "reader post list > saving instance state");
@@ -501,6 +539,7 @@ public class ReaderPostListFragment extends Fragment
         outState.putBoolean(ReaderConstants.KEY_IS_REFRESHING, mRecyclerView.isRefreshing());
         outState.putInt(ReaderConstants.KEY_RESTORE_POSITION, getCurrentPosition());
         outState.putSerializable(ReaderConstants.ARG_POST_LIST_TYPE, getPostListType());
+        outState.putParcelable(QuickStartEvent.KEY, mQuickStartEvent);
 
         if (isSearchTabsShowing()) {
             int tabPosition = getSearchTabsPosition();
@@ -703,6 +742,11 @@ public class ReaderPostListFragment extends Fragment
                 // hide the bottom navigation when search is active
                 if (mBottomNavController != null) {
                     mBottomNavController.onRequestHideBottomNavigation();
+                }
+
+                if (mQuickStartEvent != null
+                    && mQuickStartEvent.getTask() == QuickStartTask.FOLLOW_SITE && getSelectedSite() != null) {
+                    mQuickStartStore.setDoneTask(getSelectedSite().getId(), mQuickStartEvent.getTask(), true);
                 }
 
                 return true;
@@ -914,6 +958,7 @@ public class ReaderPostListFragment extends Fragment
                         }
                     }
                 }
+
                 @Override public void onTabUnselected(Tab tab) {
                     if (tab.getPosition() == TAB_POSTS) {
                         mPostSearchAdapterPos = mRecyclerView.getCurrentPosition();
@@ -921,6 +966,7 @@ public class ReaderPostListFragment extends Fragment
                         mSiteSearchAdapterPos = mRecyclerView.getCurrentPosition();
                     }
                 }
+
                 @Override public void onTabReselected(Tab tab) {
                     mRecyclerView.smoothScrollToPosition(0);
                 }
@@ -1454,6 +1500,7 @@ public class ReaderPostListFragment extends Fragment
                     ReaderActivityLauncher.showReaderBlogOrFeedPreview(
                             getActivity(), site.getSiteId(), site.getFeedId());
                 }
+
                 @Override
                 public void onLoadMore(int offset) {
                     showLoadingProgress(true);
@@ -2158,4 +2205,3 @@ public class ReaderPostListFragment extends Fragment
         }
     }
 }
-

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -744,9 +744,9 @@ public class ReaderPostListFragment extends Fragment
                     mBottomNavController.onRequestHideBottomNavigation();
                 }
 
-                if (mQuickStartEvent != null
-                    && mQuickStartEvent.getTask() == QuickStartTask.FOLLOW_SITE && getSelectedSite() != null) {
-                    mQuickStartStore.setDoneTask(getSelectedSite().getId(), mQuickStartEvent.getTask(), true);
+                // TODO check if Quick Start completed
+                if (getSelectedSite() != null) {
+                    mQuickStartStore.setDoneTask(getSelectedSite().getId(), QuickStartTask.FOLLOW_SITE, true);
                 }
 
                 return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -166,6 +166,9 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
 
     @Override
     public void onTryAndCustomizeSelected(String themeId) {
+        if (mThemeBrowserFragment != null) {
+            mThemeBrowserFragment.completeQuickStartCustomizeTask();
+        }
         startWebActivity(themeId, ThemeWebActivity.ThemeWebActivityType.PREVIEW);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -351,7 +351,6 @@ public class ThemeBrowserFragment extends Fragment
             public void onClick(View v) {
                 AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.THEMES_CUSTOMIZE_ACCESSED, mSite);
                 mCallback.onTryAndCustomizeSelected(mCurrentThemeId);
-
             }
         });
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -201,9 +201,7 @@ public class ThemeBrowserFragment extends Fragment
         EventBus.getDefault().removeStickyEvent(event);
         mQuickStartEvent = event;
 
-        if (mQuickStartEvent.getTask() == QuickStartTask.CHOOSE_THEME) {
-            mQuickStartStore.setDoneTask(mSite.getId(), mQuickStartEvent.getTask(), true);
-        } else if (mQuickStartEvent.getTask() == QuickStartTask.CUSTOMIZE_SITE) {
+        if (mQuickStartEvent.getTask() == QuickStartTask.CUSTOMIZE_SITE) {
             getView().post(new Runnable() {
                 @Override public void run() {
                     showQuickStartFocusPoint();
@@ -353,9 +351,10 @@ public class ThemeBrowserFragment extends Fragment
             public void onClick(View v) {
                 AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.THEMES_CUSTOMIZE_ACCESSED, mSite);
                 mCallback.onTryAndCustomizeSelected(mCurrentThemeId);
+                // TODO check if Quick Start completed
+                mQuickStartStore.setDoneTask(mSite.getId(), QuickStartTask.CUSTOMIZE_SITE, true);
 
                 if (mQuickStartEvent != null && mQuickStartEvent.getTask() == QuickStartTask.CUSTOMIZE_SITE) {
-                    mQuickStartStore.setDoneTask(mSite.getId(), mQuickStartEvent.getTask(), true);
                     if (getView() != null) {
                         QuickStartUtils.removeQuickStartFocusPoint((ViewGroup) getView());
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -374,7 +374,7 @@ public class ThemeBrowserFragment extends Fragment
         mGridView.addHeaderView(header);
     }
 
-    public void completeQuickStartCustomizeTask(){
+    public void completeQuickStartCustomizeTask() {
         // TODO check if Quick Start completed
         mQuickStartStore.setDoneTask(mSite.getId(), QuickStartTask.CUSTOMIZE_SITE, true);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -351,15 +351,7 @@ public class ThemeBrowserFragment extends Fragment
             public void onClick(View v) {
                 AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.THEMES_CUSTOMIZE_ACCESSED, mSite);
                 mCallback.onTryAndCustomizeSelected(mCurrentThemeId);
-                // TODO check if Quick Start completed
-                mQuickStartStore.setDoneTask(mSite.getId(), QuickStartTask.CUSTOMIZE_SITE, true);
 
-                if (mQuickStartEvent != null && mQuickStartEvent.getTask() == QuickStartTask.CUSTOMIZE_SITE) {
-                    if (getView() != null) {
-                        QuickStartUtils.removeQuickStartFocusPoint((ViewGroup) getView());
-                    }
-                    mQuickStartEvent = null;
-                }
             }
         });
 
@@ -381,6 +373,19 @@ public class ThemeBrowserFragment extends Fragment
 
         mGridView.addHeaderView(header);
     }
+
+    public void completeQuickStartCustomizeTask(){
+        // TODO check if Quick Start completed
+        mQuickStartStore.setDoneTask(mSite.getId(), QuickStartTask.CUSTOMIZE_SITE, true);
+
+        if (mQuickStartEvent != null && mQuickStartEvent.getTask() == QuickStartTask.CUSTOMIZE_SITE) {
+            if (getView() != null) {
+                QuickStartUtils.removeQuickStartFocusPoint((ViewGroup) getView());
+            }
+            mQuickStartEvent = null;
+        }
+    }
+
 
     private void setThemeNameIfAlreadyAvailable() {
         ThemeModel currentTheme = mThemeStore.getActiveThemeForSite(mSite);

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.os.Bundle;
 import android.support.v7.widget.SearchView;
+import android.text.Spannable;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -21,21 +22,29 @@ import com.android.volley.VolleyError;
 import com.android.volley.toolbox.ImageLoader.ImageContainer;
 import com.android.volley.toolbox.ImageLoader.ImageListener;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.ThemeModel;
+import org.wordpress.android.fluxc.store.QuickStartStore;
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask;
 import org.wordpress.android.fluxc.store.ThemeStore;
 import org.wordpress.android.ui.plans.PlansConstants;
+import org.wordpress.android.ui.quickstart.QuickStartEvent;
+import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.QuickStartUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper.RefreshListener;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 import org.wordpress.android.widgets.HeaderGridView;
+import org.wordpress.android.widgets.WPDialogSnackbar;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.util.ArrayList;
@@ -43,6 +52,8 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.inject.Inject;
+
+import de.greenrobot.event.EventBus;
 
 import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
 
@@ -94,8 +105,10 @@ public class ThemeBrowserFragment extends Fragment
     private SearchView mSearchView;
 
     private ThemeBrowserFragmentCallback mCallback;
+    private QuickStartEvent mQuickStartEvent;
 
     @Inject ThemeStore mThemeStore;
+    @Inject QuickStartStore mQuickStartStore;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -112,6 +125,7 @@ public class ThemeBrowserFragment extends Fragment
 
         if (savedInstanceState != null) {
             mLastSearch = savedInstanceState.getString(KEY_LAST_SEARCH);
+            mQuickStartEvent = savedInstanceState.getParcelable(QuickStartEvent.KEY);
         }
     }
 
@@ -148,6 +162,36 @@ public class ThemeBrowserFragment extends Fragment
         return view;
     }
 
+    @SuppressWarnings("unused")
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
+    public void onEvent(final QuickStartEvent event) {
+        if (!isAdded() || getView() == null) {
+            return;
+        }
+
+        EventBus.getDefault().removeStickyEvent(event);
+        mQuickStartEvent = event;
+
+        if (mQuickStartEvent.getTask() == QuickStartTask.CHOOSE_THEME) {
+            mQuickStartStore.setDoneTask(mSite.getId(), mQuickStartEvent.getTask(), true);
+        } else if (mQuickStartEvent.getTask() == QuickStartTask.CUSTOMIZE_SITE) {
+            getView().post(new Runnable() {
+                @Override public void run() {
+                    LinearLayout customize = getView().findViewById(R.id.customize);
+                    customize.setPressed(true);
+
+                    Spannable title = QuickStartUtils.stylizeQuickStartPrompt(getActivity(),
+                            R.string.quick_start_dialog_customize_site_message_short_customize,
+                            R.drawable.ic_customize_white_24dp);
+
+                    WPDialogSnackbar.make(getView(), title,
+                            AccessibilityUtils.getSnackbarDuration(getActivity(),
+                                    getResources().getInteger(R.integer.quick_start_snackbar_duration_ms))).show();
+                }
+            });
+        }
+    }
+
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
@@ -163,6 +207,7 @@ public class ThemeBrowserFragment extends Fragment
         if (mSearchMenuItem != null && mSearchMenuItem.isActionViewExpanded()) {
             outState.putString(KEY_LAST_SEARCH, mSearchView.getQuery().toString());
         }
+        outState.putParcelable(QuickStartEvent.KEY, mQuickStartEvent);
     }
 
     @Override
@@ -280,8 +325,17 @@ public class ThemeBrowserFragment extends Fragment
             public void onClick(View v) {
                 AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.THEMES_CUSTOMIZE_ACCESSED, mSite);
                 mCallback.onTryAndCustomizeSelected(mCurrentThemeId);
+
+                if (mQuickStartEvent != null && mQuickStartEvent.getTask() == QuickStartTask.CUSTOMIZE_SITE) {
+                    mQuickStartStore.setDoneTask(mSite.getId(), mQuickStartEvent.getTask(), true);
+                    mQuickStartEvent = null;
+                }
             }
         });
+
+        if (mQuickStartEvent != null && mQuickStartEvent.getTask() == QuickStartTask.CUSTOMIZE_SITE) {
+            customize.setPressed(true);
+        }
 
         LinearLayout details = header.findViewById(R.id.details);
         details.setOnClickListener(new View.OnClickListener() {
@@ -451,5 +505,15 @@ public class ThemeBrowserFragment extends Fragment
                || planId == PlansConstants.BUSINESS_PLAN_ID
                || planId == PlansConstants.JETPACK_PREMIUM_PLAN_ID
                || planId == PlansConstants.JETPACK_BUSINESS_PLAN_ID;
+    }
+
+    @Override public void onStart() {
+        super.onStart();
+        EventBus.getDefault().registerSticky(this);
+    }
+
+    @Override public void onStop() {
+        super.onStop();
+        EventBus.getDefault().unregister(this);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.util
 
 import android.content.Context
+import android.content.res.Resources
+import android.graphics.drawable.Drawable
 import android.support.v4.content.ContextCompat
 import android.support.v4.graphics.drawable.DrawableCompat
 import android.text.Spannable
@@ -24,9 +26,14 @@ class QuickStartUtils {
          * @param iconId resource if of the icon that goes before the highlighted area
          */
         @JvmStatic
-        fun stylizeQuickStartPrompt(context: Context, messageId: Int, iconId: Int): Spannable {
+        @JvmOverloads
+        fun stylizeQuickStartPrompt(context: Context, messageId: Int, iconId: Int = -1): Spannable {
             val message = context.resources.getString(messageId)
-            val icon = ContextCompat.getDrawable(context, iconId)
+            val icon : Drawable? = try{
+                ContextCompat.getDrawable(context, iconId)
+            }catch (e: Resources.NotFoundException){
+                null
+            }
 
             val highlightColor = ContextCompat.getColor(context, R.color.blue_light)
 

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -28,7 +28,7 @@ class QuickStartUtils {
          */
         @JvmStatic
         @JvmOverloads
-        fun stylizeQuickStartPrompt(context: Context, messageId: Int, iconId: Int): Spannable {
+        fun stylizeQuickStartPrompt(context: Context, messageId: Int, iconId: Int = -1): Spannable {
             val spanTagOpen = context.resources.getString(R.string.quick_start_span_start)
             val spanTagEnd = context.resources.getString(R.string.quick_start_span_end)
             val formattedMessage = context.resources.getString(messageId, spanTagOpen, spanTagEnd)

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -65,7 +65,13 @@ class QuickStartUtils {
                     icon.setBounds(0, 0, iconSize, iconSize)
 
                     DrawableCompat.setTint(icon, highlightColor)
-                    mutableSpannedMessage.setSpan(ImageSpan(icon), startOfHighlight - 1, startOfHighlight,
+                    if (startOfHighlight > 0) {
+                        mutableSpannedMessage.insert(startOfHighlight - 1, "  ")
+                    } else {
+                        mutableSpannedMessage.insert(startOfHighlight, "  ")
+                    }
+
+                    mutableSpannedMessage.setSpan(ImageSpan(icon), startOfHighlight, startOfHighlight + 1,
                             Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
                 }
             }

--- a/WordPress/src/main/res/layout/publicize_list_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_list_fragment.xml
@@ -7,6 +7,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
+    <!-- used to host quick start focus view - must be RelativeLayout or FrameLayout -->
     <RelativeLayout
         android:id="@+id/publicize_scroll_view_child"
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/publicize_list_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_list_fragment.xml
@@ -1,141 +1,147 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:card_view="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:wp="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            xmlns:card_view="http://schemas.android.com/apk/res-auto"
+            xmlns:tools="http://schemas.android.com/tools"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
-    <LinearLayout
+    <RelativeLayout
+        android:id="@+id/publicize_scroll_view_child"
         android:layout_width="match_parent"
-        android:orientation="vertical"
         android:layout_height="wrap_content">
 
-        <android.support.v7.widget.CardView
-            android:id="@+id/card_view"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            card_view:cardBackgroundColor="@color/white"
-            card_view:cardCornerRadius="@dimen/cardview_default_radius"
-            tools:targetApi="LOLLIPOP">
+            android:orientation="vertical"
+            tools:ignore="UselessParent">
 
-            <LinearLayout
+            <android.support.v7.widget.CardView
+                android:id="@+id/card_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_large"
-                android:layout_marginLeft="@dimen/content_margin"
-                android:layout_marginRight="@dimen/content_margin"
-                android:layout_marginTop="@dimen/margin_large"
-                android:orientation="vertical"
-                android:paddingLeft="@dimen/margin_medium"
-                android:paddingRight="@dimen/margin_medium"
-                android:layout_marginStart="@dimen/content_margin"
-                android:paddingEnd="@dimen/margin_medium"
-                android:paddingStart="@dimen/margin_medium"
-                android:layout_marginEnd="@dimen/content_margin">
-
-                <org.wordpress.android.widgets.WPTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/margin_medium"
-                    android:text="@string/connections_label"
-                    android:textColor="@color/blue_wordpress"
-                    android:textSize="@dimen/text_sz_medium"
-                    android:textStyle="bold" />
-
-                <org.wordpress.android.widgets.WPTextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/margin_large"
-                    android:text="@string/connections_description"
-                    android:textColor="@color/grey_text_min"
-                    android:textSize="@dimen/text_sz_medium" />
-
-                <org.wordpress.android.ui.reader.views.ReaderRecyclerView
-                    android:id="@+id/recycler_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-                <org.wordpress.android.widgets.WPTextView
-                    android:id="@+id/empty_view"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:textColor="@color/grey_darken_20"
-                    android:layout_marginTop="@dimen/margin_extra_large"
-                    android:textSize="@dimen/text_sz_extra_large"
-                    android:visibility="gone"
-                    tools:text="@string/empty_list_default"
-                    tools:visibility="visible" />
-
-            </LinearLayout>
-
-        </android.support.v7.widget.CardView>
-
-        <android.support.v7.widget.CardView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_large"
-            card_view:cardBackgroundColor="@color/white"
-            card_view:cardCornerRadius="@dimen/cardview_default_radius"
-            tools:targetApi="LOLLIPOP">
-
-            <RelativeLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/sharing_module"
-                android:layout_marginBottom="@dimen/margin_extra_large"
-                android:layout_marginLeft="@dimen/content_margin"
-                android:layout_marginRight="@dimen/content_margin"
-                android:paddingLeft="@dimen/margin_medium"
-                android:paddingRight="@dimen/margin_medium"
-                android:layout_marginStart="@dimen/content_margin"
-                android:paddingStart="@dimen/margin_medium"
-                android:layout_marginEnd="@dimen/content_margin"
-                android:paddingEnd="@dimen/margin_medium">
-
-                <org.wordpress.android.widgets.WPTextView
-                    android:id="@+id/text_manage_label"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/margin_large"
-                    android:layout_marginTop="@dimen/margin_large"
-                    android:text="@string/sharing_buttons"
-                    android:textColor="@color/blue_wordpress"
-                    android:textSize="@dimen/text_sz_medium"
-                    android:textStyle="bold" />
+                card_view:cardBackgroundColor="@color/white"
+                card_view:cardCornerRadius="@dimen/cardview_default_radius"
+                tools:targetApi="LOLLIPOP">
 
                 <LinearLayout
-                    android:id="@+id/container_manage"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_below="@+id/text_manage_label"
-                    android:background="?android:selectableItemBackground"
-                    android:orientation="horizontal">
-
-                    <ImageView
-                        android:id="@+id/image_manage"
-                        android:layout_width="24dp"
-                        android:layout_height="24dp"
-                        android:layout_gravity="center_vertical"
-                        android:contentDescription="@null"
-                        app:srcCompat="@drawable/ic_cog_blue_wordpress_24dp" />
+                    android:layout_marginBottom="@dimen/margin_large"
+                    android:layout_marginEnd="@dimen/content_margin"
+                    android:layout_marginLeft="@dimen/content_margin"
+                    android:layout_marginRight="@dimen/content_margin"
+                    android:layout_marginStart="@dimen/content_margin"
+                    android:layout_marginTop="@dimen/margin_large"
+                    android:orientation="vertical"
+                    android:paddingEnd="@dimen/margin_medium"
+                    android:paddingLeft="@dimen/margin_medium"
+                    android:paddingRight="@dimen/margin_medium"
+                    android:paddingStart="@dimen/margin_medium">
 
                     <org.wordpress.android.widgets.WPTextView
-                        android:id="@+id/text_manage_button"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_gravity="center_vertical"
-                        android:layout_marginLeft="@dimen/margin_extra_large"
-                        android:text="@string/manage"
-                        android:textColor="@color/grey_dark"
-                        android:textSize="@dimen/text_sz_large"
-                        android:layout_marginStart="@dimen/margin_extra_large"/>
-                </LinearLayout>
-            </RelativeLayout>
-        </android.support.v7.widget.CardView>
+                        android:layout_marginBottom="@dimen/margin_medium"
+                        android:text="@string/connections_label"
+                        android:textColor="@color/blue_wordpress"
+                        android:textSize="@dimen/text_sz_medium"
+                        android:textStyle="bold"/>
 
-    </LinearLayout>
+                    <org.wordpress.android.widgets.WPTextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/margin_large"
+                        android:text="@string/connections_description"
+                        android:textColor="@color/grey_text_min"
+                        android:textSize="@dimen/text_sz_medium"/>
+
+                    <org.wordpress.android.ui.reader.views.ReaderRecyclerView
+                        android:id="@+id/recycler_view"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"/>
+
+                    <org.wordpress.android.widgets.WPTextView
+                        android:id="@+id/empty_view"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:layout_marginTop="@dimen/margin_extra_large"
+                        android:textColor="@color/grey_darken_20"
+                        android:textSize="@dimen/text_sz_extra_large"
+                        android:visibility="gone"
+                        tools:text="@string/empty_list_default"
+                        tools:visibility="visible"/>
+
+                </LinearLayout>
+
+            </android.support.v7.widget.CardView>
+
+            <android.support.v7.widget.CardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_large"
+                card_view:cardBackgroundColor="@color/white"
+                card_view:cardCornerRadius="@dimen/cardview_default_radius"
+                tools:targetApi="LOLLIPOP">
+
+                <RelativeLayout
+                    android:id="@+id/sharing_module"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/margin_extra_large"
+                    android:layout_marginEnd="@dimen/content_margin"
+                    android:layout_marginLeft="@dimen/content_margin"
+                    android:layout_marginRight="@dimen/content_margin"
+                    android:layout_marginStart="@dimen/content_margin"
+                    android:paddingEnd="@dimen/margin_medium"
+                    android:paddingLeft="@dimen/margin_medium"
+                    android:paddingRight="@dimen/margin_medium"
+                    android:paddingStart="@dimen/margin_medium">
+
+                    <org.wordpress.android.widgets.WPTextView
+                        android:id="@+id/text_manage_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/margin_large"
+                        android:layout_marginTop="@dimen/margin_large"
+                        android:text="@string/sharing_buttons"
+                        android:textColor="@color/blue_wordpress"
+                        android:textSize="@dimen/text_sz_medium"
+                        android:textStyle="bold"/>
+
+                    <LinearLayout
+                        android:id="@+id/container_manage"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@+id/text_manage_label"
+                        android:background="?android:selectableItemBackground"
+                        android:orientation="horizontal">
+
+                        <ImageView
+                            android:id="@+id/image_manage"
+                            android:layout_width="24dp"
+                            android:layout_height="24dp"
+                            android:layout_gravity="center_vertical"
+                            android:contentDescription="@null"
+                            app:srcCompat="@drawable/ic_cog_blue_wordpress_24dp"/>
+
+                        <org.wordpress.android.widgets.WPTextView
+                            android:id="@+id/text_manage_button"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_vertical"
+                            android:layout_marginLeft="@dimen/margin_extra_large"
+                            android:layout_marginStart="@dimen/margin_extra_large"
+                            android:text="@string/manage"
+                            android:textColor="@color/grey_dark"
+                            android:textSize="@dimen/text_sz_large"/>
+                    </LinearLayout>
+                </RelativeLayout>
+            </android.support.v7.widget.CardView>
+
+        </LinearLayout>
+    </RelativeLayout>
 </ScrollView>

--- a/WordPress/src/main/res/layout/theme_browser_fragment.xml
+++ b/WordPress/src/main/res/layout/theme_browser_fragment.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- used to host quick start focus view - must be RelativeLayout or FrameLayout -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+                xmlns:app="http://schemas.android.com/apk/res-auto"
+                xmlns:tools="http://schemas.android.com/tools"
+                android:id="@+id/root_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
     <TextView
         android:id="@+id/theme_no_search_result_text"
@@ -11,7 +13,7 @@
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/margin_extra_large"
         android:text="@string/theme_no_search_result_found"
-        android:visibility="gone" />
+        android:visibility="gone"/>
 
     <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
         android:id="@+id/ptr_layout"
@@ -46,7 +48,7 @@
             android:layout_centerHorizontal="true"
             android:adjustViewBounds="true"
             android:contentDescription="@string/theme_no_search_result_found"
-            app:srcCompat="@drawable/drake_empty_results_400dp" />
+            app:srcCompat="@drawable/drake_empty_results_400dp"/>
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/text_empty"
@@ -56,7 +58,7 @@
             android:layout_below="@id/drake_empty_results"
             android:layout_centerHorizontal="true"
             android:text="@string/themes_fetching"
-            app:fixWidowWords="true" />
+            app:fixWidowWords="true"/>
     </RelativeLayout>
 
 </RelativeLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2255,7 +2255,7 @@
     <string name="quick_start_sites">Quick Start</string>
     <string name="quick_start_sites_progress" tools:ignore="UnusedResources" translatable="false">%1$d/%2$d</string>
     <string name="quick_start_span_end" translatable="false">&lt;/span&gt;</string>
-    <string name="quick_start_span_start" translatable="false">&#160;&lt;span style=&quot;color:#0&quot;&gt;</string>
+    <string name="quick_start_span_start" translatable="false">&lt;span style=&quot;color:#0&quot;&gt;</string>
     <string name="quick_start_focus_point_description" tools:ignore="UnusedResources">tap here</string>
 
 </resources>


### PR DESCRIPTION
Part of #7707

This PR adds actual Quick Start tasks and allows you to complete them as long as you are followinf the instructions.

I opted to use EvenBus to reduce the coupling and extra boilerplate code required to pass tasks to fragments.

To test:

1. Navigate to Quick Start activity from My Site fragment.
2. Click on each tutorial, make sure the directions and visual clues of tasks are correct, and that following them results in a completion of a task (task will be marked as completed in Quick Start list).


