### PR TITLE
Localize the error message for invalid 2fa codes

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -376,7 +376,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
     private void handleAuthError(AuthenticationErrorType error, String errorMessage) {
         switch (error) {
             case INVALID_OTP:
-                show2FaError(errorMessage);
+                show2FaError(getString(R.string.invalid_verification_code));
                 break;
             case NEEDS_2FA:
                 // we get this error when requesting a verification code sent via SMS so, just ignore it.


### PR DESCRIPTION
Fixes #8070, using our own app error string for invalid 2fa codes instead of relying on the untranslated message from the server.

To test:
1. Switch device to another language
2. Log out and start logging into a WordPress.com account with 2fa enabled
3. At the 2fa screen, enter an invalid verification code
4. Confirm that the "Invalid verification code" error shown is localized