### PR TITLE
Replaces Volley with Glide in ReaderPostDetail section

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderLikingUsersView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderLikingUsersView.java
@@ -5,6 +5,7 @@ import android.os.Handler;
 import android.util.AttributeSet;
 import android.view.Gravity;
 import android.view.LayoutInflater;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 
 import org.wordpress.android.R;
@@ -14,7 +15,9 @@ import org.wordpress.android.datasets.ReaderUserTable;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderUserIdList;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 import java.util.ArrayList;
 
@@ -27,6 +30,7 @@ public class ReaderLikingUsersView extends LinearLayout {
     private final int mLikeAvatarSz;
 
     @Inject AccountStore mAccountStore;
+    @Inject ImageManager mImageManager;
 
     public ReaderLikingUsersView(Context context) {
         this(context, null);
@@ -100,15 +104,15 @@ public class ReaderLikingUsersView extends LinearLayout {
         int index = 0;
         LayoutInflater inflater = LayoutInflater.from(getContext());
         for (String url : avatarUrls) {
-            WPNetworkImageView imgAvatar;
+            ImageView imgAvatar;
             // reuse existing view when possible, otherwise inflate a new one
             if (index < numExistingViews) {
-                imgAvatar = (WPNetworkImageView) getChildAt(index);
+                imgAvatar = (ImageView) getChildAt(index);
             } else {
-                imgAvatar = (WPNetworkImageView) inflater.inflate(R.layout.reader_like_avatar, this, false);
+                imgAvatar = (ImageView) inflater.inflate(R.layout.reader_like_avatar, this, false);
                 addView(imgAvatar);
             }
-            imgAvatar.setImageUrl(url, WPNetworkImageView.ImageType.AVATAR);
+            mImageManager.loadIntoCircle(imgAvatar, ImageType.AVATAR, StringUtils.notNullStr(url));
             index++;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -19,7 +20,9 @@ import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
+
 
 /**
  * topmost view in post detail - shows blavatar + avatar, author name, blog name, and follow button
@@ -114,6 +117,7 @@ public class ReaderPostDetailHeaderView extends LinearLayout {
     }
 
     private void showBlavatarAndAvatar(String blavatarUrl, String avatarUrl) {
+        ImageManager imageManager = ImageManager.getInstance();
         boolean hasBlavatar = !TextUtils.isEmpty(blavatarUrl);
         boolean hasAvatar = !TextUtils.isEmpty(avatarUrl);
 
@@ -122,8 +126,10 @@ public class ReaderPostDetailHeaderView extends LinearLayout {
         int frameSize = getResources().getDimensionPixelSize(R.dimen.reader_detail_header_avatar_frame);
 
         View avatarFrame = findViewById(R.id.frame_avatar);
-        WPNetworkImageView imgBlavatar = findViewById(R.id.image_header_blavatar);
-        WPNetworkImageView imgAvatar = findViewById(R.id.image_header_avatar);
+        ImageView imgBlavatar = findViewById(R.id.image_header_blavatar);
+        ImageView imgAvatar = findViewById(R.id.image_header_avatar);
+        imageManager.cancelRequestAndClearImageView(imgBlavatar);
+        imageManager.cancelRequestAndClearImageView(imgAvatar);
 
         /*
          * - if there's a blavatar and an avatar, show both of them overlaid using default sizing
@@ -135,24 +141,21 @@ public class ReaderPostDetailHeaderView extends LinearLayout {
             int blavatarSz = getResources().getDimensionPixelSize(R.dimen.reader_detail_header_blavatar);
             imgBlavatar.getLayoutParams().height = blavatarSz;
             imgBlavatar.getLayoutParams().width = blavatarSz;
-            imgBlavatar.setImageUrl(
-                    PhotonUtils.getPhotonImageUrl(blavatarUrl, blavatarSz, blavatarSz),
-                    WPNetworkImageView.ImageType.BLAVATAR);
+            imageManager.load(imgBlavatar, ImageType.BLAVATAR,
+                    PhotonUtils.getPhotonImageUrl(blavatarUrl, blavatarSz, blavatarSz));
             imgBlavatar.setVisibility(View.VISIBLE);
 
             int avatarSz = getResources().getDimensionPixelSize(R.dimen.reader_detail_header_avatar);
             imgAvatar.getLayoutParams().height = avatarSz;
             imgAvatar.getLayoutParams().width = avatarSz;
-            imgAvatar.setImageUrl(
-                    GravatarUtils.fixGravatarUrl(avatarUrl, avatarSz),
-                    WPNetworkImageView.ImageType.AVATAR);
+            imageManager.loadIntoCircle(imgAvatar, ImageType.AVATAR,
+                    GravatarUtils.fixGravatarUrl(avatarUrl, avatarSz));
             imgAvatar.setVisibility(View.VISIBLE);
         } else if (hasBlavatar) {
             imgBlavatar.getLayoutParams().height = frameSize;
             imgBlavatar.getLayoutParams().width = frameSize;
-            imgBlavatar.setImageUrl(
-                    PhotonUtils.getPhotonImageUrl(blavatarUrl, frameSize, frameSize),
-                    WPNetworkImageView.ImageType.BLAVATAR);
+            imageManager.load(imgBlavatar, ImageType.BLAVATAR,
+                    PhotonUtils.getPhotonImageUrl(blavatarUrl, frameSize, frameSize));
             imgBlavatar.setVisibility(View.VISIBLE);
 
             imgAvatar.setVisibility(View.GONE);
@@ -161,9 +164,8 @@ public class ReaderPostDetailHeaderView extends LinearLayout {
 
             imgAvatar.getLayoutParams().height = frameSize;
             imgAvatar.getLayoutParams().width = frameSize;
-            imgAvatar.setImageUrl(
-                    GravatarUtils.fixGravatarUrl(avatarUrl, frameSize),
-                    WPNetworkImageView.ImageType.AVATAR);
+            imageManager.loadIntoCircle(imgAvatar, ImageType.AVATAR,
+                    GravatarUtils.fixGravatarUrl(avatarUrl, frameSize));
             imgAvatar.setVisibility(View.VISIBLE);
         } else {
             imgBlavatar.setVisibility(View.GONE);

--- a/WordPress/src/main/res/layout/reader_like_avatar.xml
+++ b/WordPress/src/main/res/layout/reader_like_avatar.xml
@@ -3,9 +3,12 @@
 <!--
     single avatar image inserted into post detail when showing liking users
 -->
-<org.wordpress.android.widgets.WPNetworkImageView xmlns:android="http://schemas.android.com/apk/res/android"
+<ImageView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/image_like_avatar"
     android:layout_width="@dimen/avatar_sz_small"
     android:layout_height="@dimen/avatar_sz_small"
     android:layout_marginRight="@dimen/margin_small"
-    android:layout_marginEnd="@dimen/margin_small"/>
+    android:layout_marginEnd="@dimen/margin_small"
+    tools:ignore="ContentDescription"/>

--- a/WordPress/src/main/res/layout/reader_post_detail_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_post_detail_header_view.xml
@@ -2,7 +2,6 @@
 
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content" >
@@ -15,21 +14,23 @@
         android:layout_marginRight="@dimen/margin_extra_large"
         android:layout_marginEnd="@dimen/margin_extra_large">
 
-        <org.wordpress.android.widgets.WPNetworkImageView
+        <ImageView
             android:id="@+id/image_header_blavatar"
             android:layout_width="@dimen/reader_detail_header_blavatar"
             android:layout_height="@dimen/reader_detail_header_blavatar"
             android:layout_gravity="top|start"
-            app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp" />
+            tools:src="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
+            android:contentDescription="@null"/>
 
-        <org.wordpress.android.widgets.WPNetworkImageView
+        <ImageView
             android:id="@+id/image_header_avatar"
             android:layout_width="@dimen/reader_detail_header_avatar"
             android:layout_height="@dimen/reader_detail_header_avatar"
             android:layout_gravity="bottom|end"
             android:background="@drawable/shape_oval_white"
             android:padding="2dp"
-            app:srcCompat="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp" />
+            tools:src="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp"
+            android:contentDescription="@null"/>
     </FrameLayout>
 
 

--- a/WordPress/src/main/res/layout/reader_simple_post_view.xml
+++ b/WordPress/src/main/res/layout/reader_simple_post_view.xml
@@ -8,16 +8,16 @@
     android:layout_marginBottom="@dimen/margin_extra_large"
     android:background="?android:selectableItemBackground">
 
-    <org.wordpress.android.widgets.WPNetworkImageView
+    <ImageView
         android:id="@+id/image_featured"
         android:layout_width="@dimen/reader_simple_post_image_width"
         android:layout_height="match_parent"
         android:layout_marginRight="@dimen/margin_large"
-        android:scaleType="centerCrop"
         android:visibility="gone"
         tools:src="@drawable/box_with_pages_top"
         tools:visibility="visible"
-        android:layout_marginEnd="@dimen/margin_large"/>
+        android:layout_marginEnd="@dimen/margin_large"
+        android:contentDescription="@null"/>
 
     <RelativeLayout
         android:id="@+id/layout_simple_post_site_header"
@@ -42,13 +42,14 @@
             android:layout_alignParentEnd="true"
             android:layout_marginStart="@dimen/margin_medium"/>
 
-        <org.wordpress.android.widgets.WPNetworkImageView
+        <ImageView
             android:id="@+id/image_avatar"
             style="@style/ReaderImageView.Avatar.ExtraSmall"
             android:layout_centerVertical="true"
             android:layout_marginRight="@dimen/margin_medium"
             tools:src="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp"
-            android:layout_marginEnd="@dimen/margin_medium"/>
+            android:layout_marginEnd="@dimen/margin_medium"
+            android:contentDescription="@null"/>
 
         <LinearLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #8074 

Replaces Volley with Glide in the Reader Post Detail. 

- Avatar/Blavatar in the header is displayed with Glide - no change from the user perspective
- Liked by section avatars are displayed with glide - no change from the user perspective
- More in XYZ blog/More on WordPress.com avatar/blavatar/feature images are displayed with Glide - feature images can theoretically contain animated gif, however I'm not sure how to test it, since this section is picked 'randomly'. Nevertheless the `ImageManager.load(..)` method is used in many other places in the app and it loads GIF images correctly, so I'd just assume it'll work here as well.

The content of the post is displayed in a default WebView, so Glide is not used for images in the content area.

To test:
1. Open detail of a post in Reader
1. Make sure all the images mentioned above are correctly loaded.

Note: Can one of you review it please. Thanks!
