### PR TITLE
Replace Volley with Glide in Activity Log

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -12,18 +12,20 @@ import android.view.ViewGroup
 import android.widget.TextView
 import kotlinx.android.synthetic.main.activity_log_item_detail.*
 import org.wordpress.android.R
-import org.wordpress.android.R.id.activityJetpackActorIcon
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.BasicFragmentDialog
+import org.wordpress.android.util.image.ImageManager
+import org.wordpress.android.util.image.ImageType.AVATAR
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_ID_KEY
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWIND_ID_KEY
 import org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModel
-import org.wordpress.android.widgets.WPNetworkImageView
 import javax.inject.Inject
 
 class ActivityLogDetailFragment : Fragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject lateinit var imageManager: ImageManager
+
     private lateinit var viewModel: ActivityLogDetailViewModel
 
     companion object {
@@ -103,7 +105,7 @@ class ActivityLogDetailFragment : Fragment() {
     private fun setActorIcon(actorIcon: String?, showJetpackIcon: Boolean?) {
         when {
             actorIcon != null && actorIcon != "" -> {
-                activityActorIcon.setImageUrl(actorIcon, WPNetworkImageView.ImageType.AVATAR)
+                imageManager.loadIntoCircle(activityActorIcon, AVATAR, actorIcon)
                 activityActorIcon.visibility = View.VISIBLE
                 activityJetpackActorIcon.visibility = View.GONE
             }
@@ -112,7 +114,7 @@ class ActivityLogDetailFragment : Fragment() {
                 activityActorIcon.visibility = View.GONE
             }
             else -> {
-                activityActorIcon.resetImage()
+                imageManager.cancelRequestAndClearImageView(activityActorIcon)
                 activityActorIcon.visibility = View.GONE
                 activityJetpackActorIcon.visibility = View.GONE
             }

--- a/WordPress/src/main/res/layout/activity_log_item_detail.xml
+++ b/WordPress/src/main/res/layout/activity_log_item_detail.xml
@@ -25,13 +25,14 @@
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
 
-                <org.wordpress.android.widgets.WPNetworkImageView
+                <ImageView
                     android:id="@+id/activityActorIcon"
                     android:layout_width="36dp"
                     android:layout_height="36dp"
                     android:layout_marginEnd="12dp"
                     android:layout_marginRight="12dp"
                     app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
+                    android:contentDescription="@null"
                     tools:src="@drawable/badge"/>
 
                 <ImageView


### PR DESCRIPTION
Fixes #8076 

Replaces Volley with Glide in the Activity Log. Nothing should change from the user perspective.

To test:
Use site with a paid plan
1. Go to My Site 
2. Activity
3. Select an item
4. Make sure the avatar is displayed