### PR TITLE
Replace Volley with Glide in Comments - suggestions list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -121,6 +121,7 @@ import org.wordpress.android.ui.stats.StatsWidgetConfigureAdapter;
 import org.wordpress.android.ui.stats.StatsWidgetProvider;
 import org.wordpress.android.ui.stats.service.StatsServiceLogic;
 import org.wordpress.android.ui.stockmedia.StockMediaPickerActivity;
+import org.wordpress.android.ui.suggestion.adapters.SuggestionAdapter;
 import org.wordpress.android.ui.themes.ThemeBrowserActivity;
 import org.wordpress.android.ui.themes.ThemeBrowserFragment;
 import org.wordpress.android.ui.uploads.MediaUploadHandler;
@@ -388,6 +389,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(PluginListFragment object);
 
     void inject(PluginDetailActivity object);
+
+    void inject(SuggestionAdapter object);
 
     void inject(WordPressGlideModule object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/adapters/SuggestionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/adapters/SuggestionAdapter.java
@@ -7,16 +7,21 @@ import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.Filter;
 import android.widget.Filterable;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Suggestion;
 import org.wordpress.android.util.GravatarUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+
+import javax.inject.Inject;
 
 public class SuggestionAdapter extends BaseAdapter implements Filterable {
     private final LayoutInflater mInflater;
@@ -25,7 +30,10 @@ public class SuggestionAdapter extends BaseAdapter implements Filterable {
     private List<Suggestion> mOrigSuggestionList;
     private int mAvatarSz;
 
+    protected @Inject ImageManager mImageManager;
+
     public SuggestionAdapter(Context context) {
+        ((WordPress) context.getApplicationContext()).component().inject(this);
         mAvatarSz = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_small);
         mInflater = LayoutInflater.from(context);
     }
@@ -71,7 +79,7 @@ public class SuggestionAdapter extends BaseAdapter implements Filterable {
 
         if (suggestion != null) {
             String avatarUrl = GravatarUtils.fixGravatarUrl(suggestion.getImageUrl(), mAvatarSz);
-            holder.mImgAvatar.setImageUrl(avatarUrl, WPNetworkImageView.ImageType.AVATAR);
+            mImageManager.loadIntoCircle(holder.mImgAvatar, ImageType.AVATAR, avatarUrl);
             holder.mTxtUserLogin
                     .setText(convertView.getResources().getString(R.string.at_username, suggestion.getUserLogin()));
             holder.mTxtDisplayName.setText(suggestion.getDisplayName());
@@ -90,14 +98,14 @@ public class SuggestionAdapter extends BaseAdapter implements Filterable {
     }
 
     private class SuggestionViewHolder {
-        private final WPNetworkImageView mImgAvatar;
+        private final ImageView mImgAvatar;
         private final TextView mTxtUserLogin;
         private final TextView mTxtDisplayName;
 
         SuggestionViewHolder(View row) {
-            mImgAvatar = (WPNetworkImageView) row.findViewById(R.id.suggest_list_row_avatar);
-            mTxtUserLogin = (TextView) row.findViewById(R.id.suggestion_list_row_user_login_label);
-            mTxtDisplayName = (TextView) row.findViewById(R.id.suggestion_list_row_display_name_label);
+            mImgAvatar = row.findViewById(R.id.suggest_list_row_avatar);
+            mTxtUserLogin = row.findViewById(R.id.suggestion_list_row_user_login_label);
+            mTxtDisplayName = row.findViewById(R.id.suggestion_list_row_display_name_label);
         }
     }
 
@@ -113,7 +121,7 @@ public class SuggestionAdapter extends BaseAdapter implements Filterable {
                 results.values = mOrigSuggestionList;
                 results.count = mOrigSuggestionList.size();
             } else {
-                List<Suggestion> nSuggestionList = new ArrayList<Suggestion>();
+                List<Suggestion> nSuggestionList = new ArrayList<>();
 
                 for (Suggestion suggestion : mOrigSuggestionList) {
                     String lowerCaseConstraint = constraint.toString().toLowerCase(Locale.getDefault());

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/adapters/SuggestionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/adapters/SuggestionAdapter.java
@@ -30,7 +30,7 @@ public class SuggestionAdapter extends BaseAdapter implements Filterable {
     private List<Suggestion> mOrigSuggestionList;
     private int mAvatarSz;
 
-    protected @Inject ImageManager mImageManager;
+    @Inject protected ImageManager mImageManager;
 
     public SuggestionAdapter(Context context) {
         ((WordPress) context.getApplicationContext()).component().inject(this);

--- a/WordPress/src/main/res/layout/suggestion_list_row.xml
+++ b/WordPress/src/main/res/layout/suggestion_list_row.xml
@@ -8,11 +8,12 @@
     android:orientation="horizontal"
     android:padding="@dimen/margin_large">
 
-    <org.wordpress.android.widgets.WPNetworkImageView
+    <ImageView
         android:id="@+id/suggest_list_row_avatar"
         android:layout_width="@dimen/avatar_sz_small"
         android:layout_height="@dimen/avatar_sz_small"
-        android:gravity="center_vertical" />
+        android:gravity="center_vertical"
+        android:contentDescription="@null"/>
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/suggestion_list_row_user_login_label"


### PR DESCRIPTION
Fixes #8078 

Replaces Volley with Glide in the Comments - suggestion adapter. Since animated avatars are not supported, nothing should change from the user perspective.

To test:
1. Go to My Site (Site must have multiple users)
2. Comments
3. Select a comment
4. Focus Reply edit text
5. Type '@' and start typing a username (for example `@mal`)  
6. Make sure user avatars are correctly loaded
