### PR TITLE
Replace Volley with Glide in the Reader Comment header view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderCommentsPostHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderCommentsPostHeaderView.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.reader.views;
 
 import android.content.Context;
 import android.util.AttributeSet;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -11,7 +12,8 @@ import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.GravatarUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 /**
  * topmost view in reader comment adapter - show info about the post
@@ -41,10 +43,10 @@ public class ReaderCommentsPostHeaderView extends LinearLayout {
             return;
         }
 
-        TextView txtTitle = (TextView) findViewById(R.id.text_post_title);
-        TextView txtBlogName = (TextView) findViewById(R.id.text_blog_name);
-        TextView txtDateline = (TextView) findViewById(R.id.text_post_dateline);
-        WPNetworkImageView imgAvatar = (WPNetworkImageView) findViewById(R.id.image_post_avatar);
+        TextView txtTitle = findViewById(R.id.text_post_title);
+        TextView txtBlogName = findViewById(R.id.text_blog_name);
+        TextView txtDateline = findViewById(R.id.text_post_dateline);
+        ImageView imgAvatar = findViewById(R.id.image_post_avatar);
 
         txtTitle.setText(post.getTitle());
         if (post.hasBlogName()) {
@@ -67,10 +69,10 @@ public class ReaderCommentsPostHeaderView extends LinearLayout {
         String avatarUrl;
         if (post.hasBlogUrl()) {
             avatarUrl = GravatarUtils.blavatarFromUrl(post.getBlogUrl(), avatarSz);
-            imgAvatar.setImageUrl(avatarUrl, WPNetworkImageView.ImageType.BLAVATAR);
+            ImageManager.getInstance().load(imgAvatar, ImageType.BLAVATAR, avatarUrl);
         } else {
             avatarUrl = post.getPostAvatarForDisplay(avatarSz);
-            imgAvatar.setImageUrl(avatarUrl, WPNetworkImageView.ImageType.AVATAR);
+            ImageManager.getInstance().loadIntoCircle(imgAvatar, ImageType.AVATAR, avatarUrl);
         }
     }
 }

--- a/WordPress/src/main/res/layout/reader_comments_post_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_comments_post_header_view.xml
@@ -42,14 +42,15 @@
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
 
-                <org.wordpress.android.widgets.WPNetworkImageView
+                <ImageView
                     android:id="@+id/image_post_avatar"
                     android:layout_width="16dp"
                     android:layout_height="16dp"
                     android:layout_gravity="center_vertical"
                     android:layout_marginRight="@dimen/margin_medium"
                     tools:src="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp"
-                    android:layout_marginEnd="@dimen/margin_medium"/>
+                    android:layout_marginEnd="@dimen/margin_medium"
+                    android:contentDescription="@null"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/text_blog_name"


### PR DESCRIPTION
Fixes #8080 

Replaces Volley with Glide in the Reader Comments Header View - just the tiny site/avatar icon. Since animated site icons/avatars are not supported, nothing should change from the user perspective.

To test:
1. Go to Reader
2. Click on the comment icon of any post
3. Make sure the tiny avatar/site icon in the header is displayed

Note: Can one of you review it please. Thanks!
