### PR TITLE
Replace Volley with Glide in custom reader tag header view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.java
@@ -3,6 +3,8 @@ package org.wordpress.android.ui.reader.views;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
+import android.widget.ImageView;
+import android.widget.ImageView.ScaleType;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
@@ -18,7 +20,8 @@ import org.wordpress.android.ui.reader.models.ReaderTagHeaderInfo;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.JSONUtils;
 import org.wordpress.android.util.PhotonUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 import java.util.HashMap;
 
@@ -26,7 +29,7 @@ import java.util.HashMap;
  * topmost view in post adapter when showing tag preview - displays tag name and follow button
  */
 public class ReaderTagHeaderView extends RelativeLayout {
-    private WPNetworkImageView mImageView;
+    private ImageView mImageView;
     private TextView mTxtAttribution;
     private ReaderTag mCurrentTag;
 
@@ -49,8 +52,8 @@ public class ReaderTagHeaderView extends RelativeLayout {
 
     private void initView(Context context) {
         View view = inflate(context, R.layout.reader_tag_header_view, this);
-        mImageView = (WPNetworkImageView) view.findViewById(R.id.image_tag_header);
-        mTxtAttribution = (TextView) view.findViewById(R.id.text_attribution);
+        mImageView = view.findViewById(R.id.image_tag_header);
+        mTxtAttribution = view.findViewById(R.id.text_attribution);
     }
 
     public void setCurrentTag(final ReaderTag tag) {
@@ -62,11 +65,11 @@ public class ReaderTagHeaderView extends RelativeLayout {
 
         if (isTagChanged) {
             mTxtAttribution.setText(null);
-            mImageView.resetImage();
+            ImageManager.getInstance().cancelRequestAndClearImageView(mImageView);
             mCurrentTag = tag;
         }
 
-        TextView txtTagName = (TextView) findViewById(R.id.text_tag);
+        TextView txtTagName = findViewById(R.id.text_tag);
         txtTagName.setText(tag.getLabel());
 
         // use cached info if it's available, otherwise request it if the tag has changed
@@ -81,7 +84,7 @@ public class ReaderTagHeaderView extends RelativeLayout {
         int imageWidth = mImageView.getWidth();
         int imageHeight = getContext().getResources().getDimensionPixelSize(R.dimen.reader_tag_header_image_height);
         String photonUrl = PhotonUtils.getPhotonImageUrl(info.getImageUrl(), imageWidth, imageHeight);
-        mImageView.setImageUrl(photonUrl, WPNetworkImageView.ImageType.PHOTO);
+        ImageManager.getInstance().load(mImageView, ImageType.PHOTO, photonUrl, ScaleType.CENTER_CROP);
 
         // show attribution line - author name when available, otherwise blog name or nothing
         if (info.hasAuthorName()) {

--- a/WordPress/src/main/res/layout/reader_tag_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_tag_header_view.xml
@@ -6,11 +6,11 @@
     android:layout_height="@dimen/reader_tag_header_image_height"
     android:layout_marginBottom="@dimen/margin_extra_small">
 
-    <org.wordpress.android.widgets.WPNetworkImageView
+    <ImageView
         android:id="@+id/image_tag_header"
         android:layout_width="match_parent"
         android:layout_height="@dimen/reader_tag_header_image_height"
-        android:scaleType="centerCrop" />
+        android:contentDescription="@null"/>
 
     <View
         android:id="@+id/view_overlay"


### PR DESCRIPTION
Fixes #8082 

Replaces Volley with Glide in the Custom Reader tag header view. Nothing should change from the user perspective.

To test:
1. Go to Reader
2. Click on the gear icon
3. Add a custom tag (for example `android`)
4. Go back to reader
5. Select the custom tag from the drop down
6. Make sure the image in the header is displayed

Note: Can one of you review it please. Thanks!