### PR TITLE
Replace Volley with Glide - liked by section

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -108,6 +108,7 @@ import org.wordpress.android.ui.reader.ReaderPostListFragment;
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity;
 import org.wordpress.android.ui.reader.adapters.ReaderCommentAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderPostAdapter;
+import org.wordpress.android.ui.reader.adapters.ReaderUserAdapter;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic;
 import org.wordpress.android.ui.reader.views.ReaderLikingUsersView;
 import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView;
@@ -373,6 +374,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
 
     void inject(SelectCategoriesActivity object);
 
+    void inject(ReaderUserAdapter object);
+
     void inject(AddCategoryFragment object);
 
     void inject(HtmlToSpannedConverter object);
@@ -396,6 +399,7 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(PublicizeConnectionAdapter object);
 
     void inject(PublicizeServiceAdapter object);
+
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -400,7 +400,6 @@ public interface AppComponent extends AndroidInjector<WordPress> {
 
     void inject(PublicizeServiceAdapter object);
 
-
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph
     @Component.Builder

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderUserAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderUserAdapter.java
@@ -5,15 +5,20 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
 import org.wordpress.android.models.ReaderUser;
 import org.wordpress.android.models.ReaderUserList;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderInterfaces.DataLoadedListener;
 import org.wordpress.android.util.GravatarUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
+
+import javax.inject.Inject;
 
 /**
  * owner must call setUsers() with the list of
@@ -24,8 +29,11 @@ public class ReaderUserAdapter extends RecyclerView.Adapter<ReaderUserAdapter.Us
     private DataLoadedListener mDataLoadedListener;
     private final int mAvatarSz;
 
+    @Inject ImageManager mImageManager;
+
     public ReaderUserAdapter(Context context) {
         super();
+        ((WordPress) context.getApplicationContext()).component().inject(this);
         mAvatarSz = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_small);
         setHasStableIds(true);
     }
@@ -75,13 +83,8 @@ public class ReaderUserAdapter extends RecyclerView.Adapter<ReaderUserAdapter.Us
             holder.itemView.setOnClickListener(null);
         }
 
-        if (user.hasAvatarUrl()) {
-            holder.mImgAvatar.setImageUrl(
-                    GravatarUtils.fixGravatarUrl(user.getAvatarUrl(), mAvatarSz),
-                    WPNetworkImageView.ImageType.AVATAR);
-        } else {
-            holder.mImgAvatar.showDefaultGravatarImageAndNullifyUrl();
-        }
+        mImageManager.loadIntoCircle(holder.mImgAvatar, ImageType.AVATAR,
+                GravatarUtils.fixGravatarUrl(user.getAvatarUrl(), mAvatarSz));
     }
 
     @Override
@@ -92,15 +95,15 @@ public class ReaderUserAdapter extends RecyclerView.Adapter<ReaderUserAdapter.Us
     class UserViewHolder extends RecyclerView.ViewHolder {
         private final TextView mTxtName;
         private final TextView mTxtUrl;
-        private final WPNetworkImageView mImgAvatar;
+        private final ImageView mImgAvatar;
         private final View mRootView;
 
         UserViewHolder(View view) {
             super(view);
             mRootView = view;
-            mTxtName = (TextView) view.findViewById(R.id.text_name);
-            mTxtUrl = (TextView) view.findViewById(R.id.text_url);
-            mImgAvatar = (WPNetworkImageView) view.findViewById(R.id.image_avatar);
+            mTxtName = view.findViewById(R.id.text_name);
+            mTxtUrl = view.findViewById(R.id.text_url);
+            mImgAvatar = view.findViewById(R.id.image_avatar);
         }
     }
 

--- a/WordPress/src/main/res/layout/reader_listitem_user.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_user.xml
@@ -15,10 +15,11 @@
         android:orientation="horizontal"
         android:padding="@dimen/margin_large">
 
-        <org.wordpress.android.widgets.WPNetworkImageView
+        <ImageView
             android:id="@+id/image_avatar"
             android:layout_width="@dimen/avatar_sz_small"
-            android:layout_height="@dimen/avatar_sz_small" />
+            android:layout_height="@dimen/avatar_sz_small"
+            android:contentDescription="@null"/>
 
         <RelativeLayout
             android:layout_width="0dp"


### PR DESCRIPTION
Fixes #8084 

Replace Volley with Glide in the Liked By section of the Reader. Animated Avatars are not supported, so nothing should change from the user perspective.

To test
1. Go to Reader
2. Open a post
3. scroll down to 'liked by' section
4. Click on it
5. Make sure all the avatars are correctly loaded