### PR TITLE
Replace Volley with Glide - login epilogue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverFragment.java
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.main.SitePickerAdapter.SiteList;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.util.ViewUtils;
+import org.wordpress.android.util.image.ImageManager;
 
 import javax.inject.Inject;
 
@@ -35,6 +36,7 @@ public class ShareIntentReceiverFragment extends Fragment {
     private static final String ARG_AFTER_LOGIN = "ARG_AFTER_LOGIN";
 
     @Inject AccountStore mAccountStore;
+    @Inject ImageManager mImageManager;
     private ShareIntentFragmentListener mShareIntentFragmentListener;
     private SitePickerAdapter mAdapter;
 
@@ -211,7 +213,7 @@ public class ShareIntentReceiverFragment extends Fragment {
         if (!isAdded()) {
             return;
         }
-        holder.updateLoggedInAsHeading(getContext(), mAfterLogin, mAccountStore.getAccount());
+        holder.updateLoggedInAsHeading(getContext(), mImageManager, mAfterLogin, mAccountStore.getAccount());
         holder.showSitesHeading(
                 getString(sites.size() == 1 ? R.string.share_intent_adding_to : R.string.share_intent_pick_site));
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -25,8 +25,11 @@ import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ViewUtils;
+import org.wordpress.android.util.image.ImageManager;
 
 import java.util.ArrayList;
+
+import javax.inject.Inject;
 
 public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueListener> {
     public static final String TAG = "login_epilogue_fragment_tag";
@@ -46,6 +49,8 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     private ArrayList<Integer> mOldSitesIds;
 
     private LoginEpilogueListener mLoginEpilogueListener;
+
+    @Inject ImageManager mImageManager;
 
     public static LoginEpilogueFragment newInstance(boolean doLoginUpdate, boolean showAndReturn,
                                                     ArrayList<Integer> oldSitesIds) {
@@ -88,9 +93,9 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
         mBottomShadow = rootView.findViewById(R.id.bottom_shadow);
 
         mBottomButtonsContainer = rootView.findViewById(R.id.bottom_buttons);
-        mConnectMore = (Button) mBottomButtonsContainer.findViewById(R.id.secondary_button);
+        mConnectMore = mBottomButtonsContainer.findViewById(R.id.secondary_button);
 
-        mSitesList = (RecyclerView) rootView.findViewById(R.id.recycler_view);
+        mSitesList = rootView.findViewById(R.id.recycler_view);
         mSitesList.setLayoutManager(new LinearLayoutManager(getActivity()));
         mSitesList.setScrollBarStyle(View.SCROLLBARS_OUTSIDE_OVERLAY);
         mSitesList.setItemAnimator(null);
@@ -220,7 +225,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
         final boolean isWpcom = mAccountStore.hasAccessToken();
 
         if (isWpcom) {
-            holder.updateLoggedInAsHeading(getContext(), true, mAccountStore.getAccount());
+            holder.updateLoggedInAsHeading(getContext(), mImageManager, true, mAccountStore.getAccount());
         } else if (sites.size() != 0) {
             SiteModel site = mSiteStore.getSiteByLocalId(sites.get(0).getLocalId());
             int avatarSz = getResources().getDimensionPixelSize(R.dimen.avatar_sz_large);
@@ -229,7 +234,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
             String username = site.getUsername();
             String displayName = site.getDisplayName();
 
-            holder.updateLoggedInAsHeading(getContext(), true, avatarUrl, username, displayName);
+            holder.updateLoggedInAsHeading(getContext(), mImageManager, true, avatarUrl, username, displayName);
         }
 
         if (sites.size() == 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginHeaderViewHolder.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginHeaderViewHolder.java
@@ -4,12 +4,15 @@ import android.content.Context;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
 import android.view.View;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.fluxc.model.AccountModel;
 import org.wordpress.android.util.GravatarUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 /**
  * ViewHolder for a RecyclerView header used on screens shown after a user logs in.
@@ -17,7 +20,7 @@ import org.wordpress.android.widgets.WPNetworkImageView;
 public class LoginHeaderViewHolder extends RecyclerView.ViewHolder {
     private final View mLoggedInAsHeading;
     private final View mUserDetailsCard;
-    private final WPNetworkImageView mAvatarImageView;
+    private final ImageView mAvatarImageView;
     private final TextView mDisplayNameTextView;
     private final TextView mUsernameTextView;
     private final TextView mMySitesHeadingTextView;
@@ -26,25 +29,24 @@ public class LoginHeaderViewHolder extends RecyclerView.ViewHolder {
         super(view);
         mLoggedInAsHeading = view.findViewById(R.id.logged_in_as_heading);
         mUserDetailsCard = view.findViewById(R.id.user_details_card);
-        mAvatarImageView = (WPNetworkImageView) view.findViewById(R.id.avatar);
-        mDisplayNameTextView = (TextView) view.findViewById(R.id.display_name);
-        mUsernameTextView = (TextView) view.findViewById(R.id.username);
-        mMySitesHeadingTextView = (TextView) view.findViewById(R.id.my_sites_heading);
+        mAvatarImageView = view.findViewById(R.id.avatar);
+        mDisplayNameTextView = view.findViewById(R.id.display_name);
+        mUsernameTextView = view.findViewById(R.id.username);
+        mMySitesHeadingTextView = view.findViewById(R.id.my_sites_heading);
     }
 
-    public void updateLoggedInAsHeading(Context context, boolean isAfterLogin, AccountModel defaultAccount) {
-        updateLoggedInAsHeading(context, isAfterLogin, constructGravatarUrl(context, defaultAccount),
+    public void updateLoggedInAsHeading(Context context, ImageManager imageManager, boolean isAfterLogin,
+                                        AccountModel defaultAccount) {
+        updateLoggedInAsHeading(context, imageManager, isAfterLogin, constructGravatarUrl(context, defaultAccount),
                                 defaultAccount.getUserName(), defaultAccount.getDisplayName());
     }
 
-    public void updateLoggedInAsHeading(Context context, boolean isAfterLogin, String avatarUrl, String username,
-                                        String displayName) {
+    public void updateLoggedInAsHeading(Context context, ImageManager imageManager, boolean isAfterLogin,
+                                        String avatarUrl, String username, String displayName) {
         if (isAfterLogin) {
             mLoggedInAsHeading.setVisibility(View.VISIBLE);
             mUserDetailsCard.setVisibility(View.VISIBLE);
-
-            mAvatarImageView.setImageUrl(avatarUrl, WPNetworkImageView.ImageType.AVATAR, null);
-
+            imageManager.loadIntoCircle(mAvatarImageView, ImageType.AVATAR, StringUtils.notNullStr(avatarUrl));
             mUsernameTextView.setText(context.getString(R.string.login_username_at, username));
 
             if (!TextUtils.isEmpty(displayName)) {
@@ -53,6 +55,7 @@ public class LoginHeaderViewHolder extends RecyclerView.ViewHolder {
                 mDisplayNameTextView.setText(username);
             }
         } else {
+            imageManager.cancelRequestAndClearImageView(mAvatarImageView);
             mLoggedInAsHeading.setVisibility(View.GONE);
             mUserDetailsCard.setVisibility(View.GONE);
         }

--- a/WordPress/src/main/res/layout/login_epilogue_header.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_header.xml
@@ -45,13 +45,13 @@
             android:paddingStart="@dimen/margin_extra_large"
             android:paddingEnd="@dimen/margin_extra_large">
 
-            <org.wordpress.android.widgets.WPNetworkImageView
+            <ImageView
                 android:id="@+id/avatar"
                 android:layout_width="@dimen/avatar_sz_inner_circle"
                 android:layout_height="@dimen/avatar_sz_inner_circle"
                 android:layout_marginTop="@dimen/margin_extra_medium_large"
                 android:layout_marginBottom="@dimen/margin_medium"
-                app:wpDefaultImageDrawable="@drawable/ic_gridicons_user_circle_100dp"/>
+                android:contentDescription="@null"/>
 
             <org.wordpress.android.widgets.WPTextView
                 style="@style/LoginTheme.Subhead"


### PR DESCRIPTION
Fixes #8088 

Replace Volley with Glide in the Login Epilogue screen. Nothing should change from the user perspective.

To test:
1. Open the app
2. Click on the `Log in` button
3. Enter an email address and click on the `next` button
4. Login either using a magic link or a password
5. Make sure the avatar image in the header is correctly displayed 
