### PR TITLE
Replace Volley with Glide - site search result

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteSearchResultView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteSearchResultView.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -13,10 +14,11 @@ import org.wordpress.android.fluxc.model.ReaderSiteModel;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderBlogActions;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
-import org.wordpress.android.widgets.WPNetworkImageView;
-import org.wordpress.android.widgets.WPNetworkImageView.ImageType;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 /**
  * single feed search result
@@ -62,7 +64,7 @@ public class ReaderSiteSearchResultView extends LinearLayout {
 
         TextView txtTitle = findViewById(R.id.text_title);
         TextView txtUrl = findViewById(R.id.text_url);
-        WPNetworkImageView imgBlavatar = findViewById(R.id.image_blavatar);
+        ImageView imgBlavatar = findViewById(R.id.image_blavatar);
 
         if (!TextUtils.isEmpty(site.getTitle())) {
             txtTitle.setText(site.getTitle());
@@ -70,7 +72,7 @@ public class ReaderSiteSearchResultView extends LinearLayout {
             txtTitle.setText(R.string.untitled_in_parentheses);
         }
         txtUrl.setText(UrlUtils.getHost(site.getUrl()));
-        imgBlavatar.setImageUrl(site.getIconUrl(), ImageType.BLAVATAR);
+        ImageManager.getInstance().load(imgBlavatar, ImageType.BLAVATAR, StringUtils.notNullStr(site.getIconUrl()));
         mFollowButton.setIsFollowed(site.isFollowing());
     }
 

--- a/WordPress/src/main/res/layout/reader_site_search_result.xml
+++ b/WordPress/src/main/res/layout/reader_site_search_result.xml
@@ -15,11 +15,12 @@
         android:orientation="horizontal"
         android:padding="@dimen/margin_large">
 
-        <org.wordpress.android.widgets.WPNetworkImageView
+        <ImageView
             android:id="@+id/image_blavatar"
             android:layout_width="@dimen/avatar_sz_small"
             android:layout_height="@dimen/avatar_sz_small"
-            tools:src="@drawable/ic_placeholder_blavatar_grey_lighten_20_32dp"/>
+            tools:src="@drawable/ic_placeholder_blavatar_grey_lighten_20_32dp"
+            android:contentDescription="@null"/>
 
         <RelativeLayout
             android:layout_width="0dp"


### PR DESCRIPTION
Fixes #8090 

Replaces Volley with Glide in the Search - site screen. Nothing should change from the user perspective.

1. Go to Reader
2. Click on the `Search` icon
3. Type something
4. Select the `Site` tab
5. Make sure all the images are correctly loaded