### PR TITLE
Fix missing discover site icon

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -17,8 +18,12 @@ import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderBlogActions;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.PhotonUtils;
+import org.wordpress.android.util.PhotonUtils.Quality;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
 
 import javax.inject.Inject;
 
@@ -27,6 +32,8 @@ import javax.inject.Inject;
  * count, and follow button
  */
 public class ReaderSiteHeaderView extends LinearLayout {
+    private final int mBlavatarSz;
+
     public interface OnBlogInfoLoadedListener {
         void onBlogInfoLoaded(ReaderBlog blogInfo);
     }
@@ -39,6 +46,7 @@ public class ReaderSiteHeaderView extends LinearLayout {
     private OnFollowListener mFollowListener;
 
     @Inject AccountStore mAccountStore;
+    @Inject ImageManager mImageManager;
 
     public ReaderSiteHeaderView(Context context) {
         this(context, null);
@@ -51,6 +59,7 @@ public class ReaderSiteHeaderView extends LinearLayout {
     public ReaderSiteHeaderView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         ((WordPress) context.getApplicationContext()).component().inject(this);
+        mBlavatarSz = getResources().getDimensionPixelSize(R.dimen.blavatar_sz_small);
         initView(context);
     }
 
@@ -114,6 +123,7 @@ public class ReaderSiteHeaderView extends LinearLayout {
         TextView txtDomain = layoutInfo.findViewById(R.id.text_domain);
         TextView txtDescription = layoutInfo.findViewById(R.id.text_blog_description);
         TextView txtFollowCount = layoutInfo.findViewById(R.id.text_blog_follow_count);
+        ImageView blavatarImg = layoutInfo.findViewById(R.id.image_blavatar);
 
         if (blogInfo.hasName()) {
             txtBlogName.setText(blogInfo.getName());
@@ -133,6 +143,11 @@ public class ReaderSiteHeaderView extends LinearLayout {
             txtDescription.setVisibility(View.VISIBLE);
         } else {
             txtDescription.setVisibility(View.GONE);
+        }
+
+        if (blogInfo.hasImageUrl()) {
+            mImageManager.load(blavatarImg, ImageType.BLAVATAR,
+                    PhotonUtils.getPhotonImageUrl(blogInfo.getImageUrl(), mBlavatarSz, mBlavatarSz, Quality.MEDIUM));
         }
 
         txtFollowCount.setText(String.format(

--- a/WordPress/src/main/res/layout/reader_site_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_site_header_view.xml
@@ -23,13 +23,14 @@
         android:paddingEnd="@dimen/reader_card_content_padding"
         android:paddingStart="@dimen/reader_card_content_padding">
 
-        <org.wordpress.android.widgets.WPNetworkImageView
+        <ImageView
             android:id="@+id/image_blavatar"
             style="@style/ReaderImageView.Avatar"
             android:layout_centerVertical="true"
             android:layout_marginRight="@dimen/margin_large"
             app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
-            android:layout_marginEnd="@dimen/margin_large"/>
+            android:layout_marginEnd="@dimen/margin_large"
+            android:contentDescription="@null"/>
 
         <org.wordpress.android.widgets.WPTextView
             android:textAlignment="viewStart"


### PR DESCRIPTION
Fixes #8067

Fixes missing site icon in the Reader - Discover.

To test:
1. Go to Reader
2. Select `Discover` from the drop down
3. Make sure the site icon in the header is displayed
