### PR TITLE
Fix forgotten WpNetworkImageView in xmls

### DIFF
--- a/WordPress/src/main/res/layout/login_epilogue_sites_listitem.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_sites_listitem.xml
@@ -14,7 +14,7 @@
     android:layout_marginTop="@dimen/margin_medium"
     android:layout_marginBottom="@dimen/margin_medium">
 
-    <org.wordpress.android.widgets.WPNetworkImageView
+    <ImageView
         android:id="@+id/image_blavatar"
         android:layout_width="@dimen/blavatar_sz"
         android:layout_height="@dimen/blavatar_sz"
@@ -22,7 +22,8 @@
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:gravity="center_vertical"
         android:background="@drawable/blavatar_border"
-        app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp" />
+        app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
+        android:contentDescription="@null"/>
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -81,13 +81,14 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="1dp">
 
-                <org.wordpress.android.widgets.WPNetworkImageView
+                <ImageView
                     android:id="@+id/note_avatar"
                     android:layout_width="@dimen/notifications_avatar_sz"
                     android:layout_height="@dimen/notifications_avatar_sz"
                     android:layout_marginRight="@dimen/notifications_adjusted_font_margin"
                     android:layout_marginEnd="@dimen/notifications_adjusted_font_margin"
-                    android:layout_marginTop="@dimen/margin_small" />
+                    android:layout_marginTop="@dimen/margin_small"
+                    android:contentDescription="@null"/>
 
                 <org.wordpress.android.widgets.NoticonTextView
                     android:id="@+id/note_icon"

--- a/WordPress/src/main/res/layout/site_creation_theme_item.xml
+++ b/WordPress/src/main/res/layout/site_creation_theme_item.xml
@@ -20,12 +20,13 @@
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/cardview_default_radius">
 
-        <org.wordpress.android.widgets.WPNetworkImageView
+        <ImageView
             android:id="@+id/theme_grid_item_image"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:adjustViewBounds="true"
-            android:scaleType="fitCenter" />
+            android:scaleType="fitCenter"
+            android:contentDescription="@null"/>
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/theme_grid_item_name"


### PR DESCRIPTION
I forgot to change some xml tags while migrating from Volley to Glide. 

To test:
Please make sure the xml layouts are only used with ImageLoader and are **not** used with WPNetworkImage view.
