### PR TITLE
Reader: localized filters (ReaderTag)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTagList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTagList.java
@@ -42,6 +42,8 @@ public class ReaderTagList extends ArrayList<ReaderTag> {
                 return false;
             } else if (!otherTag.getEndpoint().equals(this.get(i).getEndpoint())) {
                 return false;
+            } else if (!otherTag.getTagTitle().equals(this.get(i).getTagTitle())) {
+                return false;
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -372,7 +372,7 @@ public class AppSettingsFragment extends PreferenceFragment
         getActivity().setResult(LANGUAGE_CHANGED);
         getActivity().finish();
 
-        // update Reader tags as they need be localized - use the app context as the Activity is being finished
+        // update Reader tags as they need be localized
         ReaderUpdateServiceStarter.startService(WordPress.getContext(), EnumSet.of(ReaderUpdateLogic.UpdateTask.TAGS));
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -27,6 +27,8 @@ import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic;
+import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.LocaleManager;
@@ -36,6 +38,7 @@ import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.util.WPPrefUtils;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -368,6 +371,9 @@ public class AppSettingsFragment extends PreferenceFragment
         startActivity(refresh);
         getActivity().setResult(LANGUAGE_CHANGED);
         getActivity().finish();
+
+        // update Reader tags as they need be localized - use the app context as the Activity is being finished
+        ReaderUpdateServiceStarter.startService(WordPress.getContext(), EnumSet.of(ReaderUpdateLogic.UpdateTask.TAGS));
     }
 
     private void updateLanguagePreference(String languageCode) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateJobService.java
@@ -3,10 +3,12 @@ package org.wordpress.android.ui.reader.services.update;
 import android.annotation.TargetApi;
 import android.app.job.JobParameters;
 import android.app.job.JobService;
+import android.content.Context;
 
 import org.wordpress.android.WordPress;
 import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.LocaleManager;
 
 import java.util.EnumSet;
 
@@ -15,6 +17,11 @@ import static org.wordpress.android.ui.reader.services.update.ReaderUpdateServic
 @TargetApi(21)
 public class ReaderUpdateJobService extends JobService implements ServiceCompletionListener {
     private ReaderUpdateLogic mReaderUpdateLogic;
+
+    @Override
+    protected void attachBaseContext(Context newBase) {
+        super.attachBaseContext(LocaleManager.setLocale(newBase));
+    }
 
     @Override
     public boolean onStartJob(JobParameters params) {
@@ -40,7 +47,7 @@ public class ReaderUpdateJobService extends JobService implements ServiceComplet
     @Override
     public void onCreate() {
         super.onCreate();
-        mReaderUpdateLogic = new ReaderUpdateLogic((WordPress) getApplication(), this);
+        mReaderUpdateLogic = new ReaderUpdateLogic(this, (WordPress) getApplication(), this);
         AppLog.i(AppLog.T.READER, "reader job service > created");
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -52,13 +52,15 @@ public class ReaderUpdateLogic {
     private ServiceCompletionListener mCompletionListener;
     private Object mListenerCompanion;
     private String mLanguage;
+    private Context mContext;
 
     @Inject AccountStore mAccountStore;
 
-    public ReaderUpdateLogic(WordPress app, ServiceCompletionListener listener) {
+    public ReaderUpdateLogic(Context context, WordPress app, ServiceCompletionListener listener) {
         mCompletionListener = listener;
         app.component().inject(this);
         mLanguage = LocaleManager.getLanguage(app);
+        mContext = context;
     }
 
     public void performTasks(EnumSet<UpdateTask> tasks, Object companion) {
@@ -131,7 +133,7 @@ public class ReaderUpdateLogic {
 
                 // manually insert Bookmark tag, as server doesn't support bookmarking yet
                 serverTopics.add(new ReaderTag("", "",
-                        WordPress.getContext().getString(R.string.reader_save_for_later_title), "",
+                        mContext.getString(R.string.reader_save_for_later_title), "",
                         ReaderTagType.BOOKMARKED));
 
                 // parse topics from the response, detect whether they're different from local

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader.services.update;
 
+import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 
 import com.android.volley.VolleyError;
@@ -23,8 +24,10 @@ import org.wordpress.android.ui.reader.ReaderEvents;
 import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.JSONUtils;
+import org.wordpress.android.util.LocaleManager;
 
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Iterator;
 
 import javax.inject.Inject;
@@ -48,12 +51,14 @@ public class ReaderUpdateLogic {
     private EnumSet<UpdateTask> mCurrentTasks;
     private ServiceCompletionListener mCompletionListener;
     private Object mListenerCompanion;
+    private String mLanguage;
 
     @Inject AccountStore mAccountStore;
 
     public ReaderUpdateLogic(WordPress app, ServiceCompletionListener listener) {
         mCompletionListener = listener;
         app.component().inject(this);
+        mLanguage = LocaleManager.getLanguage(app);
     }
 
     public void performTasks(EnumSet<UpdateTask> tasks, Object companion) {
@@ -105,7 +110,9 @@ public class ReaderUpdateLogic {
             }
         };
         AppLog.d(AppLog.T.READER, "reader service > updating tags");
-        WordPress.getRestClientUtilsV1_2().get("read/menu", null, null, listener, errorListener);
+        HashMap<String, String> params = new HashMap<>();
+        params.put("locale", mLanguage);
+        WordPress.getRestClientUtilsV1_2().get("read/menu", params, null, listener, errorListener);
     }
 
     private void handleUpdateTagsResponse(final JSONObject jsonObject) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateService.java
@@ -1,12 +1,14 @@
 package org.wordpress.android.ui.reader.services.update;
 
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
 
 import org.wordpress.android.WordPress;
 import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.LocaleManager;
 
 import java.util.EnumSet;
 
@@ -27,9 +29,14 @@ public class ReaderUpdateService extends Service implements ServiceCompletionLis
     }
 
     @Override
+    protected void attachBaseContext(Context newBase) {
+        super.attachBaseContext(LocaleManager.setLocale(newBase));
+    }
+
+    @Override
     public void onCreate() {
         super.onCreate();
-        mReaderUpdateLogic = new ReaderUpdateLogic((WordPress) getApplication(), this);
+        mReaderUpdateLogic = new ReaderUpdateLogic(this, (WordPress) getApplication(), this);
         AppLog.i(AppLog.T.READER, "reader service > created");
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/LocaleManager.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/LocaleManager.java
@@ -73,7 +73,7 @@ public class LocaleManager {
      * language code, else just return the device default language code.
      * @return The 2-letter language code (example "en")
      */
-    private static String getLanguage(Context context) {
+    public static String getLanguage(Context context) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         return prefs.getString(LANGUAGE_KEY, LanguageUtils.getCurrentDeviceLanguageCode());
     }


### PR DESCRIPTION
Fixes #8069

This PR does a few things:
- first, it adds a `locale` param when fetching Reader Tags from the server `/read/menu` endpoint so the titles can be properly localized (68c2526)
- second, it forces a server call update when the user changes the app's language and makes sure to retrieve things in the right locale (https://github.com/wordpress-mobile/WordPress-Android/commit/d0bd21e136f64c568bedba1625ae82ec339a5668)
- finally, given we take a default string for `"Saved posts" ` from the app resources and append it to the Tag filter list in the database `ReaderTagTable` table, we're now also taking the Tag's `title` into account when comparing lists, to account for potential locale changes. (a5d6245)


### BEFORE
![readertagbefore](https://user-images.githubusercontent.com/6597771/43080067-318543aa-8e65-11e8-9aef-ac1efcb81b87.gif)


### AFTER
![readertag](https://user-images.githubusercontent.com/6597771/43079492-a71d0d52-8e63-11e8-8d7b-b676a14b7e9d.gif)


To test:
1. go to the Reader's tab and check the filters are all in the configured language.
2. go to the Me tab, then App Settings, then change your locale to something else
3. go back to the Reader's tab and check the filters are all in the newly configured language.


