### PR TITLE
Add Locale param to /notifications endpoint

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -45,6 +45,7 @@ import org.wordpress.android.ui.notifications.utils.PendingDraftsNotificationsUt
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.LocaleManager;
 
 import java.util.HashMap;
 
@@ -493,6 +494,7 @@ public class NotificationsProcessingService extends Service {
             }
 
             HashMap<String, String> params = new HashMap<>();
+            params.put("locale", LocaleManager.getLanguage(mContext));
             WordPress.getRestClientUtils().getNotification(params,
                                                            noteId, listener, errorListener
                                                           );

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateJobService.java
@@ -3,9 +3,11 @@ package org.wordpress.android.ui.notifications.services;
 import android.annotation.TargetApi;
 import android.app.job.JobParameters;
 import android.app.job.JobService;
+import android.content.Context;
 
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.LocaleManager;
 
 @TargetApi(21)
 public class NotificationsUpdateJobService extends JobService
@@ -13,6 +15,11 @@ public class NotificationsUpdateJobService extends JobService
     public static final String IS_TAPPED_ON_NOTIFICATION = "is-tapped-on-notification";
 
     private NotificationsUpdateLogic mNotificationsUpdateLogic;
+
+    @Override
+    protected void attachBaseContext(Context newBase) {
+        super.attachBaseContext(LocaleManager.setLocale(newBase));
+    }
 
     @TargetApi(22)
     @Override
@@ -38,7 +45,7 @@ public class NotificationsUpdateJobService extends JobService
     public void onCreate() {
         super.onCreate();
         AppLog.i(AppLog.T.NOTIFS, "notifications update job service > created");
-        mNotificationsUpdateLogic = new NotificationsUpdateLogic(this);
+        mNotificationsUpdateLogic = new NotificationsUpdateLogic(LocaleManager.getLanguage(this), this);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateLogic.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.notifications.services;
 
+import android.text.TextUtils;
+
 import com.android.volley.NetworkResponse;
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
@@ -29,8 +31,10 @@ public class NotificationsUpdateLogic {
     private boolean mRunning = false;
     private String mNoteId;
     private boolean mIsStartedByTappingOnNotification = false;
+    private String mLocale;
 
-    public NotificationsUpdateLogic(ServiceCompletionListener listener) {
+    public NotificationsUpdateLogic(String locale, ServiceCompletionListener listener) {
+        mLocale = locale;
         mCompletionListener = listener;
     }
 
@@ -46,6 +50,9 @@ public class NotificationsUpdateLogic {
         params.put("number", "200");
         params.put("num_note_items", "20");
         params.put("fields", RestClientUtils.NOTIFICATION_FIELDS);
+        if (!TextUtils.isEmpty(mLocale)) {
+            params.put("locale", mLocale);
+        }
         RestListener listener = new RestListener();
         WordPress.getRestClientUtilsV1_1().getNotifications(params, listener, listener);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateService.java
@@ -1,16 +1,23 @@
 package org.wordpress.android.ui.notifications.services;
 
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
 
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.LocaleManager;
 
 public class NotificationsUpdateService extends Service implements NotificationsUpdateLogic.ServiceCompletionListener {
     public static final String IS_TAPPED_ON_NOTIFICATION = "is-tapped-on-notification";
 
     private NotificationsUpdateLogic mNotificationsUpdateLogic;
+
+    @Override
+    protected void attachBaseContext(Context newBase) {
+        super.attachBaseContext(LocaleManager.setLocale(newBase));
+    }
 
     @Override
     public IBinder onBind(Intent intent) {
@@ -21,7 +28,7 @@ public class NotificationsUpdateService extends Service implements Notifications
     public void onCreate() {
         super.onCreate();
         AppLog.i(AppLog.T.NOTIFS, "notifications update service > created");
-        mNotificationsUpdateLogic = new NotificationsUpdateLogic(this);
+        mNotificationsUpdateLogic = new NotificationsUpdateLogic(LocaleManager.getLanguage(this), this);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/util/LocaleManager.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/LocaleManager.java
@@ -73,7 +73,7 @@ public class LocaleManager {
      * language code, else just return the device default language code.
      * @return The 2-letter language code (example "en")
      */
-    private static String getLanguage(Context context) {
+    public static String getLanguage(Context context) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         return prefs.getString(LANGUAGE_KEY, LanguageUtils.getCurrentDeviceLanguageCode());
     }


### PR DESCRIPTION
Fixes #7982

To test:
1. Start the app
2. Verify the `locale` param is sent in requests to `/notifications` endpoint. Place a breakpoint [here](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/7982-notifications-locale-param/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateLogic.java#L53).
3. change the app's language (Me tab-> app settings -> language) and verify going to the Notifications tab and doing pull-to-refresh sends the right locale (inspect the `mLocale` variable while on the breakpoint).

The server-side counterpart will land in [production shortly](https://github.com/wordpress-mobile/WordPress-iOS/issues/9813#issuecomment-406641288)

