### PR TITLE
Limit the max length of support name to 50 for Zendesk

### DIFF
--- a/WordPress/src/main/res/layout/support_email_and_name_dialog.xml
+++ b/WordPress/src/main/res/layout/support_email_and_name_dialog.xml
@@ -35,6 +35,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:inputType="text"
+        android:maxLength="@integer/max_length_support_name"
         android:textColor="@color/grey_dark"
         android:textSize="@dimen/text_sz_medium"/>
 </LinearLayout>

--- a/WordPress/src/main/res/values/integers.xml
+++ b/WordPress/src/main/res/values/integers.xml
@@ -22,4 +22,7 @@
     <!-- People Management -->
     <integer name="invite_message_char_limit">500</integer>
 
+    <!-- Support -->
+    <integer name="max_length_support_name">50</integer>
+
 </resources>


### PR DESCRIPTION
This PR adds a limit of 50 to the `EditText` for name in the support identity dialog. This was requested by the HEs on Slack.

To test:
1. Uninstall and reinstall the app
2. Go the Help page and tap on Contact Us
3. Verify that you can't enter more than 50 characters in the `Name` field

Please note that this will not change the existing support names.

@aerych I requested the review from you since it's less of a code review and more of a decision one, however feel free to reassign it to anyone.