### PR TITLE
Update testCompile to testImplementation

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -123,7 +123,7 @@ dependencies {
     // ViewModel and LiveData
     implementation "android.arch.lifecycle:extensions:$arch_components_version"
 
-    testCompile("android.arch.core:core-testing:$arch_components_version", {
+    testImplementation("android.arch.core:core-testing:$arch_components_version", {
         exclude group: 'com.android.support', module: 'support-compat'
         exclude group: 'com.android.support', module: 'support-annotations'
         exclude group: 'com.android.support', module: 'support-core-utils'


### PR DESCRIPTION
Fixes a build warning we've been getting, updating an errant `compile` to `implementation` in the gradle build config:

```
Configuration 'testCompile' is obsolete and has been replaced with 'testImplementation' and 'testApi'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```

### To test:

Run the unit tests.