### PR TITLE
Automate screenshots for all supported locales

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPLocaleTestRule.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPLocaleTestRule.java
@@ -1,0 +1,53 @@
+package org.wordpress.android.ui.screenshots;
+
+import android.support.test.InstrumentationRegistry;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.wordpress.android.util.LocaleManager;
+
+public class WPLocaleTestRule implements TestRule {
+    private static final String FASTLANE_TEST_LOCALE_KEY = "testLocale";
+    private static final String FASTLANE_ENDING_LOCALE_KEY = "endingLocale";
+
+    private String mTestLocaleCode;
+    private String mEndLocaleCode;
+
+    public WPLocaleTestRule() {
+        this(localeCodeFromInstrumentation(FASTLANE_TEST_LOCALE_KEY),
+                localeCodeFromInstrumentation(FASTLANE_ENDING_LOCALE_KEY));
+    }
+
+    public WPLocaleTestRule(String testLocaleCode, String endLocaleCode) {
+        mTestLocaleCode = testLocaleCode;
+        mEndLocaleCode = endLocaleCode;
+    }
+
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    if (mTestLocaleCode != null) {
+                        changeLocale(mTestLocaleCode);
+                    }
+                    base.evaluate();
+                } finally {
+                    if (mEndLocaleCode != null) {
+                        changeLocale(mEndLocaleCode);
+                    }
+                }
+            }
+        };
+    }
+
+    private static void changeLocale(String localeCode) {
+        LocaleManager.setNewLocale(InstrumentationRegistry.getTargetContext(), localeCode);
+    }
+
+    private static String localeCodeFromInstrumentation(String key) {
+        return InstrumentationRegistry.getArguments().getString(key);
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -1,8 +1,6 @@
 package org.wordpress.android.ui.screenshots;
 
 
-import android.content.Context;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.ViewInteraction;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
@@ -33,7 +31,6 @@ import org.wordpress.android.ui.WPLaunchActivity;
 
 import tools.fastlane.screengrab.Screengrab;
 import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
-import tools.fastlane.screengrab.locale.LocaleTestRule;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
@@ -47,7 +44,7 @@ public class WPScreenshotTest {
     private static final int WAITING_TIME = 300;
 
     @ClassRule
-    public static final LocaleTestRule LOCALE_TEST_RULE = new LocaleTestRule();
+    public static final WPLocaleTestRule LOCALE_TEST_RULE = new WPLocaleTestRule();
 
 
     @Rule

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -35,8 +35,6 @@ import tools.fastlane.screengrab.Screengrab;
 import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
 import tools.fastlane.screengrab.locale.LocaleTestRule;
 
-
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
 import static org.wordpress.android.BuildConfig.SCREENSHOT_LOGINPASSWORD;
@@ -108,17 +106,17 @@ public class WPScreenshotTest {
 
         // Next Button
         nextButton = onView(
-                allOf(withId(R.id.primary_button), withText("Next"),
-                        childAtPosition(allOf(withId(R.id.bottom_buttons),
-                                childAtPosition(withClassName(is("android.widget.RelativeLayout")), 2)), 1)));
+                allOf(withId(R.id.primary_button), childAtPosition(
+                        allOf(withId(R.id.bottom_buttons), childAtPosition(
+                                withClassName(is("android.widget.RelativeLayout")), 2)), 1)));
         waitForElementUntilDisplayed(nextButton).perform(click());
 
 
         // Continue with this log button
         ViewInteraction continueButton = onView(
-                allOf(withId(R.id.primary_button), withText("Continue"),
-                        childAtPosition(allOf(withId(R.id.bottom_buttons),
-                                childAtPosition(withClassName(is("android.widget.RelativeLayout")), 3)), 1)));
+                allOf(withId(R.id.primary_button), childAtPosition(
+                        allOf(withId(R.id.bottom_buttons), childAtPosition(
+                                withClassName(is("android.widget.RelativeLayout")), 3)), 1)));
         waitForElementUntilDisplayed(continueButton).perform(click());
     }
 
@@ -154,8 +152,10 @@ public class WPScreenshotTest {
                         withId(R.id.toolbar_with_spinner), 0)));
         waitForElementUntilDisplayed(spinner).perform(click());
 
-        ViewInteraction spinnerOption = onView(allOf(withId(R.id.text), withText("Discover")));
-        waitForElementUntilDisplayed(spinnerOption).perform(click());
+        ViewInteraction spinnerItem = onView(
+                allOf(withId(R.id.text), childAtPosition(
+                        withClassName(is("android.widget.DropDownListView")), 1)));
+        waitForElementUntilDisplayed(spinnerItem).perform(click());
 
         // Waiting for the blog articles to load
         try {
@@ -260,10 +260,10 @@ public class WPScreenshotTest {
                         withId(R.id.toolbar_filter), 0)));
         waitForElementUntilDisplayed(spinner).perform(click());
 
-        Context targetContext = InstrumentationRegistry.getTargetContext();
-        String daysOptionsString = targetContext.getResources().getString(R.string.stats_timeframe_days);
-        ViewInteraction spinnerOption = onView(allOf(withId(R.id.text), withText(daysOptionsString)));
-        waitForElementUntilDisplayed(spinnerOption).perform(click());
+        ViewInteraction spinnerItem = onView(
+                allOf(withId(R.id.text), childAtPosition(
+                        withClassName(is("android.widget.DropDownListView")), 1)));
+        waitForElementUntilDisplayed(spinnerItem).perform(click());
 
         // Wait a bit
         try {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,7 +34,8 @@ platform :android do
         tests_apk_path: "WordPress/build/outputs/apk/androidTest/vanilla/debug/WordPress-vanilla-debug-androidTest.apk", 
         use_tests_in_classes: "org.wordpress.android.ui.screenshots.WPScreenshotTest", 
         reinstall_app: true,
-        device_type: options[:device]
+        device_type: options[:device],
+        locales: ["ar", "de-DE", "en-US", "es-ES", "fr-CA", "fr-FR", "id", "it-IT", "iw-IL", "ja-JP", "ko-KR", "nl-NL", "pl-PL", "pt-BR", "ru-RU", "sr", "sv-SE", "th", "tr-TR", "vi", "zh-CN", "zh-TW"]
         )
         
     demo_mode_exit(device_serial: device.serial)


### PR DESCRIPTION
This PR makes the necessary changes for Fastlane to take screenshots across all of WordPress's locales.

I have introduced `WPLocaleTestRule` in place of Fastlane's default locale rule. The default rule does not work with WordPress without some ugly hacks. The new rule just uses the existing battle tested localisation switching logic (details in https://github.com/wordpress-mobile/WordPress-Android/pull/7413). I am open to discussion on this approach.

This is a step towards fixing https://github.com/wordpress-mobile/WordPress-Android/issues/8006

To test: `bundle exec fastlane screenshot` should now run and pass for all supported locales.