### PR TITLE
Enable Activity Log on free sites with a footer 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogAdapter.kt
@@ -5,6 +5,7 @@ import android.support.v7.util.DiffUtil
 import android.support.v7.widget.RecyclerView.Adapter
 import android.view.ViewGroup
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Event
+import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Header
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Progress
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType
 
@@ -27,6 +28,7 @@ class ActivityLogAdapter(
         when (holder) {
             is EventItemViewHolder -> holder.bind(list[position] as Event)
             is ProgressItemViewHolder -> holder.bind(list[position] as Progress)
+            is HeaderItemViewHolder -> holder.bind(list[position] as Header)
             else -> throw IllegalArgumentException("Unexpected view holder in ActivityLog")
         }
     }
@@ -52,6 +54,7 @@ class ActivityLogAdapter(
         return when (item) {
             is ActivityLogListItem.Event -> item.activityId.hashCode().toLong()
             is ActivityLogListItem.Progress -> item.hashCode().toLong()
+            is ActivityLogListItem.Header -> item.hashCode().toLong()
         }
     }
 
@@ -63,6 +66,7 @@ class ActivityLogAdapter(
         return when (viewType) {
             ViewType.PROGRESS.id -> ProgressItemViewHolder(parent)
             ViewType.EVENT.id -> EventItemViewHolder(parent, itemClickListener, rewindClickListener)
+            ViewType.HEADER.id -> HeaderItemViewHolder(parent)
             else -> throw IllegalArgumentException("Unexpected view type in ActivityLog")
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogAdapter.kt
@@ -29,6 +29,7 @@ class ActivityLogAdapter(
             is EventItemViewHolder -> holder.bind(list[position] as Event)
             is ProgressItemViewHolder -> holder.bind(list[position] as Progress)
             is HeaderItemViewHolder -> holder.bind(list[position] as Header)
+            is FooterItemViewHolder -> {}
             else -> throw IllegalArgumentException("Unexpected view holder in ActivityLog")
         }
     }
@@ -55,6 +56,7 @@ class ActivityLogAdapter(
             is ActivityLogListItem.Event -> item.activityId.hashCode().toLong()
             is ActivityLogListItem.Progress -> item.hashCode().toLong()
             is ActivityLogListItem.Header -> item.hashCode().toLong()
+            ActivityLogListItem.Footer -> item.hashCode().toLong()
         }
     }
 
@@ -67,6 +69,7 @@ class ActivityLogAdapter(
             ViewType.PROGRESS.id -> ProgressItemViewHolder(parent)
             ViewType.EVENT.id -> EventItemViewHolder(parent, itemClickListener, rewindClickListener)
             ViewType.HEADER.id -> HeaderItemViewHolder(parent)
+            ViewType.FOOTER.id -> FooterItemViewHolder(parent)
             else -> throw IllegalArgumentException("Unexpected view type in ActivityLog")
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogDiffCallback.kt
@@ -12,7 +12,6 @@ class ActivityLogDiffCallback(
 ) : DiffUtil.Callback() {
     companion object {
         const val LIST_ITEM_BUTTON_VISIBILITY_KEY = "list_item_button_visibility_key"
-        const val LIST_ITEM_HEADER_VISIBILITY_KEY = "list_item_header_visibility_key"
     }
 
     override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
@@ -48,9 +47,6 @@ class ActivityLogDiffCallback(
             bundle.putBoolean(LIST_ITEM_BUTTON_VISIBILITY_KEY, newItem.isButtonVisible)
         }
 
-        if (oldItem.isHeaderVisible != newItem.isHeaderVisible) {
-            bundle.putBoolean(LIST_ITEM_HEADER_VISIBILITY_KEY, newItem.isHeaderVisible)
-        }
         if (bundle.size() == 0) return null
         return bundle
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
@@ -12,18 +12,14 @@ import java.util.Date
 import java.util.Locale
 
 sealed class ActivityLogListItem(val type: ViewType) {
-    abstract val title: String
-    abstract val description: String
-    abstract val header: String
-
     interface IActionableItem {
         val isButtonVisible: Boolean
     }
 
     data class Event(
         val activityId: String,
-        override val title: String,
-        override val description: String,
+        val title: String,
+        val description: String,
         private val gridIcon: String?,
         private val eventStatus: String?,
         val isRewindable: Boolean,
@@ -37,7 +33,6 @@ sealed class ActivityLogListItem(val type: ViewType) {
         val formattedTime: String = DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault()).format(date)
         val icon = Icon.fromValue(gridIcon)
         val status = Status.fromValue(eventStatus)
-        override val header = formattedDate
 
         constructor(model: ActivityLogModel, rewindDisabled: Boolean = false) : this(
                 model.activityID,
@@ -52,16 +47,11 @@ sealed class ActivityLogListItem(val type: ViewType) {
     }
 
     data class Progress(
-        override val title: String,
-        override val description: String,
-        override val header: String
+        val title: String,
+        val description: String
     ) : ActivityLogListItem(PROGRESS)
 
-    data class Header(val text: String): ActivityLogListItem(HEADER) {
-        override val title: String = ""
-        override val description: String = ""
-        override val header: String = ""
-    }
+    data class Header(val text: String): ActivityLogListItem(HEADER)
 
     enum class ViewType(val id: Int) {
         EVENT(0),

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
@@ -52,9 +52,9 @@ sealed class ActivityLogListItem(val type: ViewType) {
         val description: String
     ) : ActivityLogListItem(PROGRESS)
 
-    data class Header(val text: String): ActivityLogListItem(HEADER)
+    data class Header(val text: String) : ActivityLogListItem(HEADER)
 
-    object Footer: ActivityLogListItem(FOOTER)
+    object Footer : ActivityLogListItem(FOOTER)
 
     enum class ViewType(val id: Int) {
         EVENT(0),

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Icon.HISTORY
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.EVENT
+import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.FOOTER
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.HEADER
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.PROGRESS
 import java.text.DateFormat
@@ -53,10 +54,13 @@ sealed class ActivityLogListItem(val type: ViewType) {
 
     data class Header(val text: String): ActivityLogListItem(HEADER)
 
+    object Footer: ActivityLogListItem(FOOTER)
+
     enum class ViewType(val id: Int) {
         EVENT(0),
         PROGRESS(1),
-        HEADER(2)
+        HEADER(2),
+        FOOTER(3)
     }
 
     enum class Status(val value: String, @DrawableRes val color: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
@@ -4,16 +4,17 @@ import android.support.annotation.DrawableRes
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Icon.HISTORY
+import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.EVENT
+import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.HEADER
+import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.PROGRESS
 import java.text.DateFormat
 import java.util.Date
 import java.util.Locale
 
-sealed class ActivityLogListItem {
-    abstract var isHeaderVisible: Boolean
+sealed class ActivityLogListItem(val type: ViewType) {
     abstract val title: String
     abstract val description: String
     abstract val header: String
-    abstract val type: ViewType
 
     interface IActionableItem {
         val isButtonVisible: Boolean
@@ -29,16 +30,14 @@ sealed class ActivityLogListItem {
         val rewindId: String?,
         val date: Date,
         override val isButtonVisible: Boolean,
-        override var isHeaderVisible: Boolean = false,
         val buttonIcon: Icon = HISTORY,
         val isProgressBarVisible: Boolean = false
-    ) : ActivityLogListItem(), IActionableItem {
+    ) : ActivityLogListItem(EVENT), IActionableItem {
         val formattedDate: String = DateFormat.getDateInstance(DateFormat.LONG, Locale.getDefault()).format(date)
         val formattedTime: String = DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault()).format(date)
         val icon = Icon.fromValue(gridIcon)
         val status = Status.fromValue(eventStatus)
         override val header = formattedDate
-        override val type = ViewType.EVENT
 
         constructor(model: ActivityLogModel, rewindDisabled: Boolean = false) : this(
                 model.activityID,
@@ -55,15 +54,19 @@ sealed class ActivityLogListItem {
     data class Progress(
         override val title: String,
         override val description: String,
-        override val header: String,
-        override var isHeaderVisible: Boolean = false
-    ) : ActivityLogListItem() {
-        override val type = ViewType.PROGRESS
+        override val header: String
+    ) : ActivityLogListItem(PROGRESS)
+
+    data class Header(val text: String): ActivityLogListItem(HEADER) {
+        override val title: String = ""
+        override val description: String = ""
+        override val header: String = ""
     }
 
     enum class ViewType(val id: Int) {
         EVENT(0),
-        PROGRESS(1)
+        PROGRESS(1),
+        HEADER(2)
     }
 
     enum class Status(val value: String, @DrawableRes val color: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/EventItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/EventItemViewHolder.kt
@@ -20,17 +20,8 @@ class EventItemViewHolder(
     private val thumbnail: ImageView = itemView.findViewById(R.id.action_icon)
     private val container: View = itemView.findViewById(R.id.activity_content_container)
     private val actionButton: ImageButton = itemView.findViewById(R.id.action_button)
-    val header: TextView = itemView.findViewById(R.id.activity_header_text)
 
     override fun updateChanges(bundle: Bundle) {
-        if (bundle.containsKey(ActivityLogDiffCallback.LIST_ITEM_HEADER_VISIBILITY_KEY)) {
-            header.visibility =
-                    if (bundle.getBoolean(ActivityLogDiffCallback.LIST_ITEM_HEADER_VISIBILITY_KEY))
-                        View.VISIBLE
-                    else
-                        View.GONE
-        }
-
         if (bundle.containsKey(ActivityLogDiffCallback.LIST_ITEM_BUTTON_VISIBILITY_KEY)) {
             actionButton.visibility =
                     if (bundle.getBoolean(ActivityLogDiffCallback.LIST_ITEM_BUTTON_VISIBILITY_KEY))
@@ -43,9 +34,6 @@ class EventItemViewHolder(
     fun bind(activity: ActivityLogListItem.Event) {
         summary.text = activity.title
         text.text = activity.description
-        header.text = activity.header
-
-        header.visibility = if (activity.isHeaderVisible) View.VISIBLE else View.GONE
 
         if (activity.isButtonVisible) {
             ContextCompat.getDrawable(container.context, activity.buttonIcon.drawable)?.let { buttonIcon ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/FooterItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/FooterItemViewHolder.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.ui.activitylog.list
+
+import android.view.ViewGroup
+import org.wordpress.android.R
+
+class FooterItemViewHolder(parent: ViewGroup) : ActivityLogViewHolder(parent, R.layout.activity_log_list_footer_item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/HeaderItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/HeaderItemViewHolder.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.ui.activitylog.list
+
+import android.view.ViewGroup
+import android.widget.TextView
+import org.wordpress.android.R
+
+class HeaderItemViewHolder(parent: ViewGroup) : ActivityLogViewHolder(parent, R.layout.activity_log_list_header_item) {
+    private val header: TextView = itemView.findViewById(R.id.activity_header_text)
+
+    fun bind(item: ActivityLogListItem.Header) {
+        header.text = item.text
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ProgressItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ProgressItemViewHolder.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.activitylog.list
 
-import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import org.wordpress.android.R
@@ -9,13 +8,9 @@ class ProgressItemViewHolder(parent: ViewGroup) :
         ActivityLogViewHolder(parent, R.layout.activity_log_list_progress_item) {
     private val summary: TextView = itemView.findViewById(R.id.action_summary)
     private val text: TextView = itemView.findViewById(R.id.action_text)
-    private val header: TextView = itemView.findViewById(R.id.activity_header_text)
 
     fun bind(item: ActivityLogListItem.Progress) {
         summary.text = item.title
         text.text = item.description
-        header.text = item.header
-
-        header.visibility = if (item.isHeaderVisible) View.VISIBLE else View.GONE
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -159,7 +159,7 @@ public class MySiteFragment extends Fragment implements SiteSettingsListener,
 
         SiteModel site = getSelectedSite();
         if (site != null) {
-            if (site.getHasFreePlan() && !site.isJetpackConnected()) {
+            if (!site.isJetpackConnected()) {
                 mActivityLogContainer.setVisibility(View.GONE);
             } else {
                 mActivityLogContainer.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -159,7 +159,9 @@ public class MySiteFragment extends Fragment implements SiteSettingsListener,
 
         SiteModel site = getSelectedSite();
         if (site != null) {
-            if (!site.isJetpackConnected()) {
+            boolean isNotAdmin = !site.getHasCapabilityManageOptions();
+            boolean isSelfHostedWithoutJetpack = !SiteUtils.isAccessedViaWPComRest(site) && !site.isJetpackConnected();
+            if (isNotAdmin || isSelfHostedWithoutJetpack) {
                 mActivityLogContainer.setVisibility(View.GONE);
             } else {
                 mActivityLogContainer.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -189,7 +189,7 @@ class ActivityLogViewModel @Inject constructor(
             }
             items.add(currentItem)
         }
-        if (site.hasFreePlan && done) {
+        if (eventList.isNotEmpty() && site.hasFreePlan && done) {
             items.add(Footer)
         }
         areActionsEnabled = !disableActions

--- a/WordPress/src/main/res/layout/activity_log_list_event_item.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_event_item.xml
@@ -1,39 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:tools="http://schemas.android.com/tools"
+              android:id="@+id/activity_content_container"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
+              android:background="?android:selectableItemBackground"
               android:clickable="true"
               android:focusable="true"
               android:orientation="vertical">
 
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/activity_header_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:textColor="@color/grey_darken_20"
-        android:textAppearance="@style/Base.TextAppearance.AppCompat.Body2"
-        android:clickable="false"
-        android:visibility="gone"
-        tools:visibility="visible"
-        android:paddingTop="@dimen/margin_large"
-        android:paddingBottom="@dimen/margin_large"
-        android:paddingStart="@dimen/margin_extra_large"
-        android:paddingLeft="@dimen/margin_extra_large"
-        android:paddingEnd="@dimen/margin_extra_large"
-        android:paddingRight="@dimen/margin_extra_large"
-        tools:text="January 2, 2010" />
-
     <LinearLayout
-        android:id="@+id/activity_content_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="?android:selectableItemBackground"
-        android:orientation="vertical">
-
-        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="horizontal"
@@ -100,7 +76,5 @@
             android:layout_height="1px"
             android:layout_marginTop="1dp"
             android:background="@drawable/notifications_list_divider_full_width" />
-
-    </LinearLayout>
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/activity_log_list_footer_item.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_footer_item.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             android:layout_width="match_parent"
+             android:layout_height="wrap_content">
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/activity_header_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:clickable="false"
+        android:padding="@dimen/margin_extra_large"
+        android:textAppearance="@style/Base.TextAppearance.AppCompat.Body1"
+        android:textColor="@color/grey_darken_20"
+        android:text="@string/activity_log_limited_content_on_free_plan"/>
+
+</FrameLayout>

--- a/WordPress/src/main/res/layout/activity_log_list_header_item.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_header_item.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content">
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/activity_header_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:textColor="@color/grey_darken_20"
+        android:textAppearance="@style/Base.TextAppearance.AppCompat.Body2"
+        android:clickable="false"
+        android:paddingTop="@dimen/margin_large"
+        android:paddingBottom="@dimen/margin_large"
+        android:paddingStart="@dimen/margin_extra_large"
+        android:paddingLeft="@dimen/margin_extra_large"
+        android:paddingEnd="@dimen/margin_extra_large"
+        android:paddingRight="@dimen/margin_extra_large"
+        tools:text="Now" />
+
+</FrameLayout>

--- a/WordPress/src/main/res/layout/activity_log_list_progress_item.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_progress_item.xml
@@ -1,37 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
               xmlns:tools="http://schemas.android.com/tools"
+              android:id="@+id/activity_content_container"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
+              android:background="?android:selectableItemBackground"
               android:clickable="true"
               android:focusable="true"
               android:orientation="vertical">
-
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/activity_header_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:textColor="@color/grey_darken_20"
-        android:textAppearance="@style/Base.TextAppearance.AppCompat.Body2"
-        android:clickable="false"
-        android:visibility="gone"
-        tools:visibility="visible"
-        android:paddingTop="@dimen/margin_large"
-        android:paddingBottom="@dimen/margin_large"
-        android:paddingStart="@dimen/margin_extra_large"
-        android:paddingLeft="@dimen/margin_extra_large"
-        android:paddingEnd="@dimen/margin_extra_large"
-        android:paddingRight="@dimen/margin_extra_large"
-        tools:text="Now" />
-
-    <LinearLayout
-        android:id="@+id/activity_content_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="?android:selectableItemBackground"
-        android:orientation="vertical">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -112,7 +89,5 @@
             android:layout_height="1px"
             android:layout_marginTop="1dp"
             android:background="@drawable/notifications_list_divider_full_width" />
-
-    </LinearLayout>
 
 </LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -776,6 +776,7 @@
     <string name="activity_log_currently_restoring_message_no_dates">Rewind in progress</string>
     <string name="activity_log_rewind_site">Rewind Site</string>
     <string name="activity_log_rewind_dialog_message">Are you sure you want to rewind your site back to %1$s at %2$s? This will remove all content and options created or changed since then.</string>
+    <string name="activity_log_limited_content_on_free_plan">Since you\'re on a free plan, you\'ll see limited events in your activity.</string>
 
     <!-- stats: errors -->
     <string name="stats_no_blog">Stats couldn\'t be loaded for the required blog</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.activitylog.RewindStatusService
 import org.wordpress.android.ui.activitylog.RewindStatusService.RewindProgress
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Event
+import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Header
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus
 import java.util.Calendar
@@ -134,10 +135,17 @@ class ActivityLogViewModelTest {
         assertEquals(viewModel.eventListStatus.value, ActivityLogListStatus.DONE)
     }
 
-    private fun expectedActivityList(): List<Event> {
-        return activityLogList.mapIndexed { index, activityLogModel ->
-            Event(activityLogModel, true).copy(isHeaderVisible = index != 1)
-        }
+    private fun expectedActivityList(): List<ActivityLogListItem> {
+        val activityLogListItems = mutableListOf<ActivityLogListItem>()
+        val first = Event(activityLogList[0], true)
+        val second = Event(activityLogList[1], true)
+        val third = Event(activityLogList[2], true)
+        activityLogListItems.add(Header(first.formattedDate))
+        activityLogListItems.add(first)
+        activityLogListItems.add(second)
+        activityLogListItems.add(Header(third.formattedDate))
+        activityLogListItems.add(third)
+        return activityLogListItems
     }
 
     @Test
@@ -163,9 +171,8 @@ class ActivityLogViewModelTest {
         val canLoadMore = true
         viewModel.onEventsUpdated(OnActivityLogFetched(3, canLoadMore, FETCH_ACTIVITIES))
 
-        assertTrue(events.last()?.get(0)?.isHeaderVisible == true)
-        assertTrue(events.last()?.get(1)?.isHeaderVisible == false)
-        assertTrue(events.last()?.get(2)?.isHeaderVisible == true)
+        assertTrue(events.last()?.get(0) is Header)
+        assertTrue(events.last()?.get(3) is Header)
     }
 
     private fun assertFetchEvents(canLoadMore: Boolean = false) {


### PR DESCRIPTION
* Show activity log on all sites (except self-hosted sites without Jetpack) for Admins
* Show a footer on free sites explaining some activities might be missing from the view with the free plan.

![screenshot_1532677384](https://user-images.githubusercontent.com/1079756/43308318-7ee0d17c-9181-11e8-9266-3af0eb8c405a.png)

To test:
* Log in with a free site
* Link to Activity is visible from the main menu
* Click on Activity
* Activity Log is visible with a footer with explanation
 
