### PR TITLE
Feature/aztec gif

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'com.android.support:support-v4:27.1.1'
     implementation 'com.android.support:design:27.1.1'
     implementation 'org.apache.commons:commons-lang3:3.5'
-    implementation 'org.wordpress:utils:1.18.1'
+    implementation 'org.wordpress:utils:1.22'
 
     api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.7')
     api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.3.7')

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -742,6 +742,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
         if (mSource.getVisibility() == View.VISIBLE) {
             updateFailedMediaList();
+        } else {
+            addOverlayToGifs();
         }
     }
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/gif_overlay_vector.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/gif_overlay_vector.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="72dp"
+        android:height="48dp"
+        android:viewportHeight="24.0"
+        android:viewportWidth="36.0">
+    <group
+        android:pivotX="18"
+        android:pivotY="12"
+        android:scaleX="0.5"
+        android:scaleY="0.5">
+        <path
+            android:fillAlpha="0.5"
+            android:fillColor="#ff2e4453"
+            android:fillType="evenOdd"
+            android:pathData="M6,0L30,0A6,6 0,0 1,36 6L36,16A6,6 0,0 1,30 22L6,22A6,6 0,0 1,0 16L0,6A6,6 0,0 1,6 0z"
+            android:strokeColor="#00000000"
+            android:strokeWidth="1"/>
+        <path
+            android:fillColor="#ffffffff"
+            android:fillType="evenOdd"
+            android:pathData="M16.2432,12.0488C16.2432,14.6123 14.5615,16.2461 11.9297,16.2461C9.0723,16.2461 7.2949,14.2637 7.2949,11.0645C7.2949,7.9063 9.0928,5.8896 11.9023,5.8896C14.1787,5.8896 15.8467,7.1885 16.1611,9.2051L14.4043,9.2051C14.0488,8.084 13.167,7.4619 11.9023,7.4619C10.1797,7.4619 9.0996,8.8359 9.0996,11.0508C9.0996,13.293 10.2002,14.6738 11.957,14.6738C13.4609,14.6738 14.4863,13.7578 14.5137,12.3975L14.5205,12.1924L12.1484,12.1924L12.1484,10.8115L16.2432,10.8115L16.2432,12.0488ZM20.0508,16L18.2871,16L18.2871,6.1357L20.0508,6.1357L20.0508,16ZM24.248,16L22.4844,16L22.4844,6.1357L28.7734,6.1357L28.7734,7.6602L24.248,7.6602L24.248,10.5313L28.3838,10.5313L28.3838,12.001L24.248,12.001L24.248,16Z"
+            android:strokeColor="#00000000"
+            android:strokeWidth="1"/>
+    </group>
+</vector>

--- a/libs/utils/README.md
+++ b/libs/utils/README.md
@@ -7,7 +7,7 @@ Collection of utility methods for Android and WordPress.
 * In your build.gradle:
 ```groovy
 dependencies {
-    compile 'org.wordpress:utils:1.19.0' // use version 1.19.0
+    compile 'org.wordpress:utils:1.22.0' // use version 1.22.0
 }
 ```
 

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -34,7 +34,7 @@ android {
     buildToolsVersion '27.0.3'
 
     defaultConfig {
-        versionName "1.21"
+        versionName "1.22"
         minSdkVersion 15
         targetSdkVersion 26
     }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -93,6 +93,10 @@ public class MediaUtils {
                || url.endsWith(".aiff") || url.endsWith(".aif") || url.endsWith(".aac") || url.endsWith(".m4a");
     }
 
+    public static boolean isGif(String url) {
+        return "gif".equals(MimeTypeMap.getFileExtensionFromUrl(url));
+    }
+
     /**
      * E.g. Jul 2, 2013 @ 21:57
      */


### PR DESCRIPTION
Fixes #8110 

Adds gif overlay to all GIF images in Aztec.

![screenshot_1532677219](https://user-images.githubusercontent.com/2261188/43308237-36610570-9181-11e8-845a-9ef98d4ad543.png)

To test:
1. Create new post
2. Add a gif image located on your device
3. Add a gif image located in your media library
4. Add a jpg/png image
5. Make sure both gif images have a gif overlay and the jpg/png image doesn't have it
6. Save post as draft
7. Go to My Site -> Blog Posts
8. Open the post and make sure both gif images have a gif overlay and the jpg/png image doesn't have it

Note:
Can at least one of you please review this PR. I've added the 10.6 milestone, but it doesn't really matter whether this feature makes it to 10.6 or 10.7. Thanks