### PR TITLE
Facebook Publicize disable selection of profiles

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -173,7 +173,7 @@ public class WordPressDB {
                 mDb.execSQL(SiteSettingsModel.ADD_SITE_ICON);
             case 65:
                 // add external users only to publicize services table
-                mDb.execSQL(PublicizeTable.ADD_EXTERNAL_USERS_ONLY);
+                PublicizeTable.resetServicesTable(mDb);
         }
         mDb.setVersion(DATABASE_VERSION);
     }

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -172,8 +172,8 @@ public class WordPressDB {
                 // add site icon
                 mDb.execSQL(SiteSettingsModel.ADD_SITE_ICON);
             case 65:
-                // reset publicize services table
-                PublicizeTable.reset();
+                // add external users only to publicize services table
+                mDb.execSQL(PublicizeTable.ADD_EXTERNAL_USERS_ONLY);
         }
         mDb.setVersion(DATABASE_VERSION);
     }

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -6,6 +6,7 @@ import android.database.sqlite.SQLiteDatabase;
 
 import org.wordpress.android.datasets.NotificationsTable;
 import org.wordpress.android.datasets.PeopleTable;
+import org.wordpress.android.datasets.PublicizeTable;
 import org.wordpress.android.datasets.SiteSettingsTable;
 import org.wordpress.android.datasets.SuggestionTable;
 import org.wordpress.android.models.SiteSettingsModel;
@@ -21,7 +22,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 public class WordPressDB {
-    private static final int DATABASE_VERSION = 65;
+    private static final int DATABASE_VERSION = 66;
 
 
     // Warning if you rename DATABASE_NAME, that could break previous App backups (see: xml/backup_scheme.xml)
@@ -170,6 +171,9 @@ public class WordPressDB {
             case 64:
                 // add site icon
                 mDb.execSQL(SiteSettingsModel.ADD_SITE_ICON);
+            case 65:
+                // reset publicize services table
+                PublicizeTable.reset();
         }
         mDb.setVersion(DATABASE_VERSION);
     }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java
@@ -25,8 +25,6 @@ public class PublicizeTable {
                    + " genericon TEXT NOT NULL,"
                    + " icon_url TEXT NOT NULL,"
                    + " connect_url TEXT NOT NULL,"
-                   + " has_multiple_external_user_id_support INTEGER DEFAULT 0,"
-                   + " is_external_users_only INTEGER DEFAULT 0,"
                    + " is_jetpack_supported INTEGER DEFAULT 0,"
                    + " is_multi_user_id_supported INTEGER DEFAULT 0,"
                    + " PRIMARY KEY (id))");
@@ -112,11 +110,9 @@ public class PublicizeTable {
                     + " genericon," // 4
                     + " icon_url," // 5
                     + " connect_url," // 6
-                    + " has_multiple_external_user_id_support," // 7
-                    + " is_external_users_only," // 8
-                    + " is_jetpack_supported," // 9
-                    + " is_multi_user_id_supported)" // 10
-                    + " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)");
+                    + " is_jetpack_supported," // 7
+                    + " is_multi_user_id_supported)" // 8
+                    + " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)");
             for (PublicizeService service : serviceList) {
                 stmt.bindString(1, service.getId());
                 stmt.bindString(2, service.getLabel());
@@ -124,10 +120,8 @@ public class PublicizeTable {
                 stmt.bindString(4, service.getGenericon());
                 stmt.bindString(5, service.getIconUrl());
                 stmt.bindString(6, service.getConnectUrl());
-                stmt.bindLong(7, SqlUtils.boolToSql(service.getHasMultipleExternalUserIdSupport()));
-                stmt.bindLong(8, SqlUtils.boolToSql(service.getIsExternalUsersOnly()));
-                stmt.bindLong(9, SqlUtils.boolToSql(service.isJetpackSupported()));
-                stmt.bindLong(10, SqlUtils.boolToSql(service.isMultiExternalUserIdSupported()));
+                stmt.bindLong(7, SqlUtils.boolToSql(service.isJetpackSupported()));
+                stmt.bindLong(8, SqlUtils.boolToSql(service.isMultiExternalUserIdSupported()));
                 stmt.executeInsert();
             }
 
@@ -147,8 +141,6 @@ public class PublicizeTable {
         service.setGenericon(c.getString(c.getColumnIndex("genericon")));
         service.setIconUrl(c.getString(c.getColumnIndex("icon_url")));
         service.setConnectUrl(c.getString(c.getColumnIndex("connect_url")));
-        service.setHasMultipleExternalUserIdSupport(SqlUtils.sqlToBool(c.getColumnIndex("has_multiple_external_user_id_support")));
-        service.setHasMultipleExternalUserIdSupport(SqlUtils.sqlToBool(c.getColumnIndex("is_external_users_only")));
         service.setIsJetpackSupported(SqlUtils.sqlToBool(c.getColumnIndex("is_jetpack_supported")));
         service.setIsMultiExternalUserIdSupported(SqlUtils.sqlToBool(c.getColumnIndex("is_multi_user_id_supported")));
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java
@@ -138,6 +138,11 @@ public class PublicizeTable {
         }
     }
 
+    private static boolean getBooleanFromCursor(Cursor cursor, String columnName) {
+        int columnIndex = cursor.getColumnIndex(columnName);
+        return columnIndex != -1 && cursor.getInt(columnIndex) != 0;
+    }
+
     private static PublicizeService getServiceFromCursor(Cursor c) {
         PublicizeService service = new PublicizeService();
 
@@ -147,9 +152,9 @@ public class PublicizeTable {
         service.setGenericon(c.getString(c.getColumnIndex("genericon")));
         service.setIconUrl(c.getString(c.getColumnIndex("icon_url")));
         service.setConnectUrl(c.getString(c.getColumnIndex("connect_url")));
-        service.setIsJetpackSupported(SqlUtils.sqlToBool(c.getColumnIndex("is_jetpack_supported")));
-        service.setIsMultiExternalUserIdSupported(SqlUtils.sqlToBool(c.getColumnIndex("is_multi_user_id_supported")));
-        service.setIsExternalUsersOnly(SqlUtils.sqlToBool(c.getColumnIndex("is_external_users_only")));
+        service.setIsJetpackSupported(getBooleanFromCursor(c, "is_jetpack_supported"));
+        service.setIsMultiExternalUserIdSupported(getBooleanFromCursor(c, "is_multi_user_id_supported"));
+        service.setIsExternalUsersOnly(getBooleanFromCursor(c, "is_external_users_only"));
 
         return service;
     }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java
@@ -16,6 +16,10 @@ import org.wordpress.android.util.SqlUtils;
 public class PublicizeTable {
     private static final String SERVICES_TABLE = "tbl_publicize_services";
     private static final String CONNECTIONS_TABLE = "tbl_publicize_connections";
+    private static final String IS_EXTERNAL_USERS_ONLY_COLUMN_NAME = "is_external_users_only";
+
+    public static final String ADD_EXTERNAL_USERS_ONLY = "alter table " + SERVICES_TABLE
+                                                 + " add " + IS_EXTERNAL_USERS_ONLY_COLUMN_NAME + " BOOLEAN;";
 
     public static void createTables(SQLiteDatabase db) {
         db.execSQL("CREATE TABLE IF NOT EXISTS " + SERVICES_TABLE + " ("
@@ -111,8 +115,9 @@ public class PublicizeTable {
                     + " icon_url," // 5
                     + " connect_url," // 6
                     + " is_jetpack_supported," // 7
-                    + " is_multi_user_id_supported)" // 8
-                    + " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)");
+                    + " is_multi_user_id_supported," // 8
+                    + " is_external_users_only)" // 9
+                    + " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)");
             for (PublicizeService service : serviceList) {
                 stmt.bindString(1, service.getId());
                 stmt.bindString(2, service.getLabel());
@@ -122,6 +127,7 @@ public class PublicizeTable {
                 stmt.bindString(6, service.getConnectUrl());
                 stmt.bindLong(7, SqlUtils.boolToSql(service.isJetpackSupported()));
                 stmt.bindLong(8, SqlUtils.boolToSql(service.isMultiExternalUserIdSupported()));
+                stmt.bindLong(9, SqlUtils.boolToSql(service.isExternalUsersOnly()));
                 stmt.executeInsert();
             }
 
@@ -143,6 +149,7 @@ public class PublicizeTable {
         service.setConnectUrl(c.getString(c.getColumnIndex("connect_url")));
         service.setIsJetpackSupported(SqlUtils.sqlToBool(c.getColumnIndex("is_jetpack_supported")));
         service.setIsMultiExternalUserIdSupported(SqlUtils.sqlToBool(c.getColumnIndex("is_multi_user_id_supported")));
+        service.setIsExternalUsersOnly(SqlUtils.sqlToBool(c.getColumnIndex("is_external_users_only")));
 
         return service;
     }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java
@@ -16,10 +16,6 @@ import org.wordpress.android.util.SqlUtils;
 public class PublicizeTable {
     private static final String SERVICES_TABLE = "tbl_publicize_services";
     private static final String CONNECTIONS_TABLE = "tbl_publicize_connections";
-    private static final String IS_EXTERNAL_USERS_ONLY_COLUMN_NAME = "is_external_users_only";
-
-    public static final String ADD_EXTERNAL_USERS_ONLY = "alter table " + SERVICES_TABLE
-                                                 + " add " + IS_EXTERNAL_USERS_ONLY_COLUMN_NAME + " BOOLEAN;";
 
     public static void createTables(SQLiteDatabase db) {
         db.execSQL("CREATE TABLE IF NOT EXISTS " + SERVICES_TABLE + " ("
@@ -31,6 +27,7 @@ public class PublicizeTable {
                    + " connect_url TEXT NOT NULL,"
                    + " is_jetpack_supported INTEGER DEFAULT 0,"
                    + " is_multi_user_id_supported INTEGER DEFAULT 0,"
+                   + " is_external_users_only INTEGER DEFAULT 0,"
                    + " PRIMARY KEY (id))");
 
         db.execSQL("CREATE TABLE IF NOT EXISTS " + CONNECTIONS_TABLE + " ("
@@ -59,13 +56,8 @@ public class PublicizeTable {
         return WordPress.wpDB.getDatabase();
     }
 
-    /*
-     * for testing purposes - clears then recreates tables
-     */
-    public static void reset() {
-        getWritableDb().execSQL("DROP TABLE IF EXISTS " + SERVICES_TABLE);
-        getWritableDb().execSQL("DROP TABLE IF EXISTS " + CONNECTIONS_TABLE);
-        createTables(getWritableDb());
+    public static void resetServicesTable(SQLiteDatabase db) {
+        db.execSQL("DROP TABLE IF EXISTS " + SERVICES_TABLE);
     }
 
     public static PublicizeService getService(String serviceId) {

--- a/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java
@@ -25,6 +25,8 @@ public class PublicizeTable {
                    + " genericon TEXT NOT NULL,"
                    + " icon_url TEXT NOT NULL,"
                    + " connect_url TEXT NOT NULL,"
+                   + " has_multiple_external_user_id_support INTEGER DEFAULT 0,"
+                   + " is_external_users_only INTEGER DEFAULT 0,"
                    + " is_jetpack_supported INTEGER DEFAULT 0,"
                    + " is_multi_user_id_supported INTEGER DEFAULT 0,"
                    + " PRIMARY KEY (id))");
@@ -110,9 +112,11 @@ public class PublicizeTable {
                     + " genericon," // 4
                     + " icon_url," // 5
                     + " connect_url," // 6
-                    + " is_jetpack_supported," // 7
-                    + " is_multi_user_id_supported)" // 8
-                    + " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)");
+                    + " has_multiple_external_user_id_support," // 7
+                    + " is_external_users_only," // 8
+                    + " is_jetpack_supported," // 9
+                    + " is_multi_user_id_supported)" // 10
+                    + " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)");
             for (PublicizeService service : serviceList) {
                 stmt.bindString(1, service.getId());
                 stmt.bindString(2, service.getLabel());
@@ -120,8 +124,10 @@ public class PublicizeTable {
                 stmt.bindString(4, service.getGenericon());
                 stmt.bindString(5, service.getIconUrl());
                 stmt.bindString(6, service.getConnectUrl());
-                stmt.bindLong(7, SqlUtils.boolToSql(service.isJetpackSupported()));
-                stmt.bindLong(8, SqlUtils.boolToSql(service.isMultiExternalUserIdSupported()));
+                stmt.bindLong(7, SqlUtils.boolToSql(service.getHasMultipleExternalUserIdSupport()));
+                stmt.bindLong(8, SqlUtils.boolToSql(service.getIsExternalUsersOnly()));
+                stmt.bindLong(9, SqlUtils.boolToSql(service.isJetpackSupported()));
+                stmt.bindLong(10, SqlUtils.boolToSql(service.isMultiExternalUserIdSupported()));
                 stmt.executeInsert();
             }
 
@@ -141,6 +147,8 @@ public class PublicizeTable {
         service.setGenericon(c.getString(c.getColumnIndex("genericon")));
         service.setIconUrl(c.getString(c.getColumnIndex("icon_url")));
         service.setConnectUrl(c.getString(c.getColumnIndex("connect_url")));
+        service.setHasMultipleExternalUserIdSupport(SqlUtils.sqlToBool(c.getColumnIndex("has_multiple_external_user_id_support")));
+        service.setHasMultipleExternalUserIdSupport(SqlUtils.sqlToBool(c.getColumnIndex("is_external_users_only")));
         service.setIsJetpackSupported(SqlUtils.sqlToBool(c.getColumnIndex("is_jetpack_supported")));
         service.setIsMultiExternalUserIdSupported(SqlUtils.sqlToBool(c.getColumnIndex("is_multi_user_id_supported")));
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java
@@ -154,6 +154,16 @@ public class PublicizeTable {
         return service;
     }
 
+    public static boolean onlyExternalConnections(String serviceId) {
+        if (serviceId == null && serviceId.isEmpty()) {
+            return false;
+        }
+
+        String sql = "SELECT is_external_users_only FROM " + SERVICES_TABLE + " WHERE id=?";
+        String[] args = {serviceId};
+        return SqlUtils.boolForQuery(getReadableDb(), sql, args);
+    }
+
     public static String getConnectUrlForService(String serviceId) {
         if (TextUtils.isEmpty(serviceId)) {
             return "";

--- a/WordPress/src/main/java/org/wordpress/android/models/PublicizeConnection.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/PublicizeConnection.java
@@ -131,6 +131,8 @@ public class PublicizeConnection {
     public ConnectStatus getStatusEnum() {
         if (getStatus().equalsIgnoreCase(ConnectStatus.BROKEN.toString())) {
             return ConnectStatus.BROKEN;
+        } else if (getStatus().equalsIgnoreCase(ConnectStatus.MUST_DISCONNECT.toString())) {
+            return ConnectStatus.MUST_DISCONNECT;
         } else {
             return ConnectStatus.OK;
         }

--- a/WordPress/src/main/java/org/wordpress/android/models/PublicizeConnection.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/PublicizeConnection.java
@@ -238,6 +238,16 @@ public class PublicizeConnection {
         return connection;
     }
 
+    public static void updateConnectionfromExternalJson(PublicizeConnection connection, JSONObject json) {
+        if (connection == null) {
+            return;
+        }
+
+        connection.mExternalId = json.optString("external_ID");
+        connection.mExternalName = json.optString("external_name");
+        connection.mExternalProfilePictureUrl = json.optString("external_profile_picture");
+    }
+
     private static long[] getSitesArrayFromJson(JSONArray jsonArray) throws JSONException {
         long[] sitesArray = new long[jsonArray.length()];
         for (int i = 0; i < jsonArray.length(); i++) {

--- a/WordPress/src/main/java/org/wordpress/android/models/PublicizeConnection.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/PublicizeConnection.java
@@ -20,6 +20,9 @@ public class PublicizeConnection {
             public String toString() {
                 return "broken";
             }
+        },
+        MUST_DISCONNECT {
+            public String toString() { return "must-disconnect"; }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/models/PublicizeConnection.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/PublicizeConnection.java
@@ -22,7 +22,9 @@ public class PublicizeConnection {
             }
         },
         MUST_DISCONNECT {
-            public String toString() { return "must-disconnect"; }
+            public String toString() {
+                return "must-disconnect";
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/models/PublicizeService.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/PublicizeService.java
@@ -9,7 +9,6 @@ public class PublicizeService {
     private String mGenericon;
     private String mIconUrl;
     private String mConnectUrl;
-    private boolean mhasMultipleExternalUserIdSupport;
     private boolean mIsExternalUsersOnly;
 
     private boolean mIsJetpackSupported;
@@ -63,22 +62,6 @@ public class PublicizeService {
         mConnectUrl = StringUtils.notNullStr(url);
     }
 
-    public boolean getHasMultipleExternalUserIdSupport() {
-        return mhasMultipleExternalUserIdSupport;
-    }
-
-    public void setHasMultipleExternalUserIdSupport(boolean hasMultipleExternalUserIdSupport) {
-        this.mhasMultipleExternalUserIdSupport = mhasMultipleExternalUserIdSupport;
-    }
-
-    public boolean getIsExternalUsersOnly() {
-        return mIsExternalUsersOnly;
-    }
-
-    public void setIsExternalUsersOnly(boolean isExternalUsersOnly) {
-        mIsExternalUsersOnly = isExternalUsersOnly;
-    }
-
     public boolean isJetpackSupported() {
         return mIsJetpackSupported;
     }
@@ -95,6 +78,14 @@ public class PublicizeService {
         mIsMultiExternalUserIdSupported = supported;
     }
 
+    public boolean isExternalUsersOnly() {
+        return mIsExternalUsersOnly;
+    }
+
+    public void setIsExternalUsersOnly(boolean isExternalUsersOnly) {
+        mIsExternalUsersOnly = isExternalUsersOnly;
+    }
+
     public boolean isSameAs(PublicizeService other) {
         return other != null
                && other.getId().equals(this.getId())
@@ -103,8 +94,7 @@ public class PublicizeService {
                && other.getGenericon().equals(this.getGenericon())
                && other.getIconUrl().equals(this.getIconUrl())
                && other.getConnectUrl().equals(this.getConnectUrl())
-               && other.getHasMultipleExternalUserIdSupport() == this.getHasMultipleExternalUserIdSupport()
-               && other.getIsExternalUsersOnly() == this.getIsExternalUsersOnly()
+               && other.isExternalUsersOnly() == this.isExternalUsersOnly()
                && other.isJetpackSupported() == this.isJetpackSupported();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/PublicizeService.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/PublicizeService.java
@@ -9,6 +9,8 @@ public class PublicizeService {
     private String mGenericon;
     private String mIconUrl;
     private String mConnectUrl;
+    private boolean mhasMultipleExternalUserIdSupport;
+    private boolean mIsExternalUsersOnly;
 
     private boolean mIsJetpackSupported;
     private boolean mIsMultiExternalUserIdSupported;
@@ -61,6 +63,22 @@ public class PublicizeService {
         mConnectUrl = StringUtils.notNullStr(url);
     }
 
+    public boolean getHasMultipleExternalUserIdSupport() {
+        return mhasMultipleExternalUserIdSupport;
+    }
+
+    public void setHasMultipleExternalUserIdSupport(boolean hasMultipleExternalUserIdSupport) {
+        this.mhasMultipleExternalUserIdSupport = mhasMultipleExternalUserIdSupport;
+    }
+
+    public boolean getIsExternalUsersOnly() {
+        return mIsExternalUsersOnly;
+    }
+
+    public void setIsExternalUsersOnly(boolean isExternalUsersOnly) {
+        mIsExternalUsersOnly = isExternalUsersOnly;
+    }
+
     public boolean isJetpackSupported() {
         return mIsJetpackSupported;
     }
@@ -85,6 +103,8 @@ public class PublicizeService {
                && other.getGenericon().equals(this.getGenericon())
                && other.getIconUrl().equals(this.getIconUrl())
                && other.getConnectUrl().equals(this.getConnectUrl())
+               && other.getHasMultipleExternalUserIdSupport() == this.getHasMultipleExternalUserIdSupport()
+               && other.getIsExternalUsersOnly() == this.getIsExternalUsersOnly();
                && other.isJetpackSupported() == this.isJetpackSupported();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/PublicizeService.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/PublicizeService.java
@@ -104,7 +104,7 @@ public class PublicizeService {
                && other.getIconUrl().equals(this.getIconUrl())
                && other.getConnectUrl().equals(this.getConnectUrl())
                && other.getHasMultipleExternalUserIdSupport() == this.getHasMultipleExternalUserIdSupport()
-               && other.getIsExternalUsersOnly() == this.getIsExternalUsersOnly();
+               && other.getIsExternalUsersOnly() == this.getIsExternalUsersOnly()
                && other.isJetpackSupported() == this.isJetpackSupported();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/PublicizeServiceList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/PublicizeServiceList.java
@@ -41,20 +41,21 @@ public class PublicizeServiceList extends ArrayList<PublicizeService> {
      * passed JSON is the response from /meta/external-services?type=publicize
          "services": {
                 "facebook":{
-                     "ID":"facebook",
-                     "label":"Facebook",
-                     "type":"publicize",
-                     "description":"Publish your posts to your Facebook timeline or page.",
-                     "genericon":{
-                        "class":"facebook-alt",
-                        "unicode":"\\f203"
-                     },
-                     "icon":"http:\/\/i.wordpress.com\/wp-content\/admin-plugins\/publicize\/assets\/publicize-fb-2x.png",
-                     "connect_URL":"https:\/\/public-api.wordpress.com\/connect\/?action=request&kr_nonce=a1e2ad2b80&nonce=c4b69a25c1&for=connect&service=facebook&kr_blog_nonce=0ae2027be9&magic=keyring&blog=90298630",
-                     "multiple_external_user_ID_support":true,
-                     "external_users_only":true,
-                     "jetpack_support":true,
-                     "jetpack_module_required":"publicize"
+                 "ID":"facebook",
+                 "label":"Facebook",
+                 "type":"publicize",
+                 "description":"Publish your posts to your Facebook timeline or page.",
+                 "genericon":{
+                    "class":"facebook-alt",
+                    "unicode":"\\f203"
+                 },
+                 "icon":"http:\/\/i.wordpress.com\/wp-content\/admin-plugins\/publicize\/assets\/publicize-fb-2x.png",
+                 "connect_URL":"https:\/\/public-api.wordpress.com\/connect\/?action=request&kr_nonce=a1e2ad2b80
+                 &nonce=c4b69a25c1&for=connect&service=facebook&kr_blog_nonce=0ae2027be9&magic=keyring&blog=90298630",
+                 "multiple_external_user_ID_support":true,
+                 "external_users_only":true,
+                 "jetpack_support":true,
+                 "jetpack_module_required":"publicize"
                 },
             ...
      */

--- a/WordPress/src/main/java/org/wordpress/android/models/PublicizeServiceList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/PublicizeServiceList.java
@@ -40,22 +40,21 @@ public class PublicizeServiceList extends ArrayList<PublicizeService> {
     /*
      * passed JSON is the response from /meta/external-services?type=publicize
          "services": {
-                "facebook": {
-                    "ID": "facebook",
-                    "label": "Facebook",
-                    "type": "publicize",
-                    "description": "Publish your posts to your Facebook timeline or page.",
-                    "genericon": {
-                        "class": "facebook-alt",
-                        "unicode": "\\f203"
-                    },
-                    "icon": "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-fb-2x.png",
-                    "connect_URL": "https://public-api.wordpress.com/connect/?action=request
-                    &kr_nonce=b2c86a0cdb&nonce=94557d1529&for=connect&service=facebook&kr_blog_nonce=5e399375f1
-                    &magic=keyring&blog=52451191",
-                    "multiple_external_user_ID_support": true,
-                    "jetpack_support": true,
-                    "jetpack_module_required": "publicize"
+                "facebook":{
+                     "ID":"facebook",
+                     "label":"Facebook",
+                     "type":"publicize",
+                     "description":"Publish your posts to your Facebook timeline or page.",
+                     "genericon":{
+                        "class":"facebook-alt",
+                        "unicode":"\\f203"
+                     },
+                     "icon":"http:\/\/i.wordpress.com\/wp-content\/admin-plugins\/publicize\/assets\/publicize-fb-2x.png",
+                     "connect_URL":"https:\/\/public-api.wordpress.com\/connect\/?action=request&kr_nonce=a1e2ad2b80&nonce=c4b69a25c1&for=connect&service=facebook&kr_blog_nonce=0ae2027be9&magic=keyring&blog=90298630",
+                     "multiple_external_user_ID_support":true,
+                     "external_users_only":true,
+                     "jetpack_support":true,
+                     "jetpack_module_required":"publicize"
                 },
             ...
      */
@@ -81,6 +80,8 @@ public class PublicizeServiceList extends ArrayList<PublicizeService> {
             service.setDescription(jsonService.optString("description"));
             service.setIconUrl(jsonService.optString("icon"));
             service.setConnectUrl(jsonService.optString("connect_URL"));
+            service.setHasMultipleExternalUserIdSupport(jsonService.optBoolean("multiple_external_user_ID_support"));
+            service.setIsExternalUsersOnly(jsonService.optBoolean("external_users_only"));
 
             service.setIsJetpackSupported(jsonService.optBoolean("jetpack_support"));
             service.setIsMultiExternalUserIdSupported(jsonService.optBoolean("multiple_external_user_ID_support"));

--- a/WordPress/src/main/java/org/wordpress/android/models/PublicizeServiceList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/PublicizeServiceList.java
@@ -80,7 +80,7 @@ public class PublicizeServiceList extends ArrayList<PublicizeService> {
             service.setDescription(jsonService.optString("description"));
             service.setIconUrl(jsonService.optString("icon"));
             service.setConnectUrl(jsonService.optString("connect_URL"));
-            
+
             service.setIsJetpackSupported(jsonService.optBoolean("jetpack_support"));
             service.setIsMultiExternalUserIdSupported(jsonService.optBoolean("multiple_external_user_ID_support"));
             service.setIsExternalUsersOnly(jsonService.optBoolean("external_users_only"));

--- a/WordPress/src/main/java/org/wordpress/android/models/PublicizeServiceList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/PublicizeServiceList.java
@@ -80,11 +80,10 @@ public class PublicizeServiceList extends ArrayList<PublicizeService> {
             service.setDescription(jsonService.optString("description"));
             service.setIconUrl(jsonService.optString("icon"));
             service.setConnectUrl(jsonService.optString("connect_URL"));
-            service.setHasMultipleExternalUserIdSupport(jsonService.optBoolean("multiple_external_user_ID_support"));
-            service.setIsExternalUsersOnly(jsonService.optBoolean("external_users_only"));
-
+            
             service.setIsJetpackSupported(jsonService.optBoolean("jetpack_support"));
             service.setIsMultiExternalUserIdSupported(jsonService.optBoolean("multiple_external_user_ID_support"));
+            service.setIsExternalUsersOnly(jsonService.optBoolean("external_users_only"));
 
             JSONObject jsonGenericon = jsonService.optJSONObject("genericon");
             if (jsonGenericon != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserDialogFragment.java
@@ -19,8 +19,10 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.datasets.PublicizeTable;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.models.PublicizeConnection;
+import org.wordpress.android.models.PublicizeService;
 import org.wordpress.android.util.ToastUtils;
 
 import java.util.ArrayList;
@@ -148,10 +150,13 @@ public class PublicizeAccountChooserDialogFragment extends DialogFragment
                 JSONObject currentConnectionJson = jsonArray.getJSONObject(i);
                 PublicizeConnection connection = PublicizeConnection.fromJson(currentConnectionJson);
                 if (connection.getService().equals(mServiceId)) {
-                    if (connection.isInSite(mSite.getSiteId())) {
-                        mConnectedAccounts.add(connection);
-                    } else {
-                        mNotConnectedAccounts.add(connection);
+                    PublicizeService service = PublicizeTable.getService(mServiceId);
+                    if (service != null && !service.isExternalUsersOnly()) {
+                        if (connection.isInSite(mSite.getSiteId())) {
+                            mConnectedAccounts.add(connection);
+                        } else {
+                            mNotConnectedAccounts.add(connection);
+                        }
                     }
 
                     JSONArray externalJsonArray = currentConnectionJson.getJSONArray("additional_external_users");

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserDialogFragment.java
@@ -106,8 +106,9 @@ public class PublicizeAccountChooserDialogFragment extends DialogFragment
                 dialogInterface.dismiss();
                 int keychainId = mNotConnectedAccounts.get(mSelectedIndex).connectionId;
                 String service = mNotConnectedAccounts.get(mSelectedIndex).getService();
+                String externalUserId = mNotConnectedAccounts.get(mSelectedIndex).getExternalId();
                 EventBus.getDefault().post(new PublicizeEvents.ActionAccountChosen(mSite.getSiteId(), keychainId,
-                        service));
+                        service, externalUserId));
             }
         });
         builder.setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
@@ -162,11 +163,11 @@ public class PublicizeAccountChooserDialogFragment extends DialogFragment
                     JSONArray externalJsonArray = currentConnectionJson.getJSONArray("additional_external_users");
                     for (int j = 0; j < externalJsonArray.length(); j++) {
                         JSONObject currentExternalConnectionJson = externalJsonArray.getJSONObject(j);
-                        PublicizeConnection externalConnection = PublicizeConnection.fromJson(currentExternalConnectionJson);
+                        PublicizeConnection.updateConnectionfromExternalJson(connection, currentExternalConnectionJson);
                         if (connection.isInSite(mSite.getSiteId())) {
-                            mConnectedAccounts.add(externalConnection);
+                            mConnectedAccounts.add(connection);
                         } else {
-                            mNotConnectedAccounts.add(externalConnection);
+                            mNotConnectedAccounts.add(connection);
                         }
                     }
                 }
@@ -177,6 +178,10 @@ public class PublicizeAccountChooserDialogFragment extends DialogFragment
     }
 
     private void configureConnectionName() {
+        if (mNotConnectedAccounts.isEmpty()) {
+            return;
+        }
+
         PublicizeConnection connection = mNotConnectedAccounts.get(0);
         if (connection != null) {
             mConnectionName = connection.getLabel();

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserDialogFragment.java
@@ -145,12 +145,24 @@ public class PublicizeAccountChooserDialogFragment extends DialogFragment
             JSONObject jsonObject = new JSONObject(jsonString);
             JSONArray jsonArray = jsonObject.getJSONArray("connections");
             for (int i = 0; i < jsonArray.length(); i++) {
-                PublicizeConnection connection = PublicizeConnection.fromJson(jsonArray.getJSONObject(i));
+                JSONObject currentConnectionJson = jsonArray.getJSONObject(i);
+                PublicizeConnection connection = PublicizeConnection.fromJson(currentConnectionJson);
                 if (connection.getService().equals(mServiceId)) {
                     if (connection.isInSite(mSite.getSiteId())) {
                         mConnectedAccounts.add(connection);
                     } else {
                         mNotConnectedAccounts.add(connection);
+                    }
+
+                    JSONArray externalJsonArray = currentConnectionJson.getJSONArray("additional_external_users");
+                    for (int j = 0; j < externalJsonArray.length(); j++) {
+                        JSONObject currentExternalConnectionJson = externalJsonArray.getJSONObject(j);
+                        PublicizeConnection externalConnection = PublicizeConnection.fromJson(currentExternalConnectionJson);
+                        if (connection.isInSite(mSite.getSiteId())) {
+                            mConnectedAccounts.add(externalConnection);
+                        } else {
+                            mNotConnectedAccounts.add(externalConnection);
+                        }
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserListAdapter.java
@@ -84,10 +84,10 @@ public class PublicizeAccountChooserListAdapter
     }
 
     private String getName(PublicizeConnection connection) {
-        String name = connection.getExternalDisplayName();
+        String name = connection.getExternalName();
 
         if (name.isEmpty()) {
-            name = connection.getExternalName();
+            name = connection.getExternalDisplayName();
         }
 
         return name;

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserListAdapter.java
@@ -41,7 +41,7 @@ public class PublicizeAccountChooserListAdapter
         final PublicizeConnection connection = mConnectionItems.get(position);
         holder.mProfileImageView
                 .setImageUrl(connection.getExternalProfilePictureUrl(), WPNetworkImageView.ImageType.PHOTO);
-        holder.mNameTextView.setText(connection.getExternalDisplayName());
+        holder.mNameTextView.setText(getName(connection));
         holder.mRadioButton.setChecked(position == mSelectedPosition);
 
         if (!mAreAccountsConnected) {
@@ -81,5 +81,15 @@ public class PublicizeAccountChooserListAdapter
 
     public interface OnPublicizeAccountChooserListener {
         void onAccountSelected(int selectedIndex);
+    }
+
+    private String getName(PublicizeConnection connection) {
+        String name = connection.getExternalDisplayName();
+
+        if (name.isEmpty()) {
+            name = connection.getExternalName();
+        }
+
+        return name;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
@@ -113,7 +113,8 @@ public class PublicizeActions {
      * step two in creating a publicize connection: now that we have the keyring connection id,
      * create the actual connection
      */
-    public static void connectStepTwo(final long siteId, long keyringConnectionId, final String serviceId, final String externalUserId) {
+    public static void connectStepTwo(final long siteId, long keyringConnectionId,
+                                      final String serviceId, final String externalUserId) {
         RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
             public void onResponse(JSONObject jsonObject) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
@@ -139,21 +139,31 @@ public class PublicizeActions {
 
     private static boolean shouldShowChooserDialog(long siteId, String serviceId, JSONObject jsonObject) {
         JSONArray jsonConnectionList = jsonObject.optJSONArray("connections");
+
         if (jsonConnectionList == null || jsonConnectionList.length() <= 1) {
             return false;
         }
 
         int totalAccounts = 0;
+        int totalExternalAccounts = 0;
         try {
             for (int i = 0; i < jsonConnectionList.length(); i++) {
                 JSONObject connectionObject = jsonConnectionList.getJSONObject(i);
                 PublicizeConnection publicizeConnection = PublicizeConnection.fromJson(connectionObject);
                 if (publicizeConnection.getService().equals(serviceId) && !publicizeConnection.isInSite(siteId)) {
                     totalAccounts++;
+                    JSONArray externalJsonArray = connectionObject.getJSONArray("additional_external_users");
+                    for (int j = 0; j < externalJsonArray.length(); j++) {
+                        totalExternalAccounts++;
+                    }
                 }
             }
 
-            return totalAccounts > 0;
+            if (PublicizeTable.onlyExternalConnections(serviceId)) {
+                return totalAccounts > 0;
+            } else {
+                return totalAccounts > 0 || totalExternalAccounts > 0;
+            }
         } catch (JSONException e) {
             return false;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
@@ -93,7 +93,7 @@ public class PublicizeActions {
                             .post(new PublicizeEvents.ActionRequestChooseAccount(siteId, serviceId, jsonObject));
                 } else {
                     long keyringConnectionId = parseServiceKeyringId(serviceId, currentUserId, jsonObject);
-                    connectStepTwo(siteId, keyringConnectionId, serviceId);
+                    connectStepTwo(siteId, keyringConnectionId, serviceId, "");
                 }
             }
         };
@@ -113,7 +113,7 @@ public class PublicizeActions {
      * step two in creating a publicize connection: now that we have the keyring connection id,
      * create the actual connection
      */
-    public static void connectStepTwo(final long siteId, long keyringConnectionId, final String serviceId) {
+    public static void connectStepTwo(final long siteId, long keyringConnectionId, final String serviceId, final String externalUserId) {
         RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
             public void onResponse(JSONObject jsonObject) {
@@ -133,6 +133,7 @@ public class PublicizeActions {
 
         Map<String, String> params = new HashMap<>();
         params.put("keyring_connection_ID", Long.toString(keyringConnectionId));
+        params.put("external_user_ID", externalUserId);
         String path = String.format(Locale.ROOT, "/sites/%d/publicize-connections/new", siteId);
         WordPress.getRestClientUtilsV1_1().post(path, params, null, listener, errorListener);
     }
@@ -160,7 +161,7 @@ public class PublicizeActions {
             }
 
             if (PublicizeTable.onlyExternalConnections(serviceId)) {
-                return totalAccounts > 0;
+                return totalExternalAccounts > 0;
             } else {
                 return totalAccounts > 0 || totalExternalAccounts > 0;
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
@@ -134,7 +134,9 @@ public class PublicizeActions {
 
         Map<String, String> params = new HashMap<>();
         params.put("keyring_connection_ID", Long.toString(keyringConnectionId));
-        params.put("external_user_ID", externalUserId);
+        if (!externalUserId.isEmpty()) {
+            params.put("external_user_ID", externalUserId);
+        }
         String path = String.format(Locale.ROOT, "/sites/%d/publicize-connections/new", siteId);
         WordPress.getRestClientUtilsV1_1().post(path, params, null, listener, errorListener);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
@@ -6,6 +6,7 @@ public class PublicizeConstants {
     public static final String ARG_CONNECTION_ARRAY_JSON = "connection_array_json";
 
     public static final String GOOGLE_PLUS_ID = "google_plus";
+    public static final String FACEBOOK_ID = "facebook";
 
     public enum ConnectAction {
         CONNECT,

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -2,13 +2,11 @@ package org.wordpress.android.ui.publicize;
 
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v7.widget.AppCompatButton;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.TextView;
 
 import org.wordpress.android.R;

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -2,10 +2,13 @@ package org.wordpress.android.ui.publicize;
 
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v7.widget.AppCompatButton;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
@@ -14,6 +17,7 @@ import org.wordpress.android.datasets.PublicizeTable;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.models.PublicizeService;
+import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
 import org.wordpress.android.ui.publicize.adapters.PublicizeConnectionAdapter;
 import org.wordpress.android.util.ToastUtils;
@@ -122,6 +126,14 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
                 TextView txtNotice = (TextView) mServiceCardView.findViewById(R.id.text_description_notice);
                 txtNotice.setText(noticeText);
                 txtNotice.setVisibility(View.VISIBLE);
+
+                TextView learnMoreButton = (TextView) mServiceCardView.findViewById(R.id.learn_more_button);
+                learnMoreButton.setOnClickListener(new OnClickListener() {
+                    @Override public void onClick(View v) {
+                        WPWebViewActivity.openURL(getActivity(), "https://en.blog.wordpress.com/2018/07/23/sharing-options-from-wordpress-com-to-facebook-are-changing/");
+                    }
+                });
+                learnMoreButton.setVisibility(View.VISIBLE);
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -116,6 +116,13 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
             String description = String.format(getString(R.string.connection_service_description), mService.getLabel());
             TextView txtDescription = (TextView) mServiceCardView.findViewById(R.id.text_description);
             txtDescription.setText(description);
+
+            if (mService.getId().equals(PublicizeConstants.FACEBOOK_ID)) {
+                String noticeText = getString(R.string.connection_service_facebook_notice);
+                TextView txtNotice = (TextView) mServiceCardView.findViewById(R.id.text_description_notice);
+                txtNotice.setText(noticeText);
+                txtNotice.setVisibility(View.VISIBLE);
+            }
         }
 
         long currentUserId = mAccountStore.getAccount().getUserId();

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -26,6 +26,8 @@ import javax.inject.Inject;
 
 public class PublicizeDetailFragment extends PublicizeBaseFragment
         implements PublicizeConnectionAdapter.OnAdapterLoadedListener {
+    public static final String FACEBOOK_SHARING_CHANGE_BLOG_POST =
+            "https://en.blog.wordpress.com/2018/07/23/sharing-options-from-wordpress-com-to-facebook-are-changing/";
     private SiteModel mSite;
     private String mServiceId;
 
@@ -130,7 +132,8 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
                 TextView learnMoreButton = (TextView) mServiceCardView.findViewById(R.id.learn_more_button);
                 learnMoreButton.setOnClickListener(new OnClickListener() {
                     @Override public void onClick(View v) {
-                        WPWebViewActivity.openURL(getActivity(), "https://en.blog.wordpress.com/2018/07/23/sharing-options-from-wordpress-com-to-facebook-are-changing/");
+                        WPWebViewActivity.openURL(getActivity(),
+                                FACEBOOK_SHARING_CHANGE_BLOG_POST);
                     }
                 });
                 learnMoreButton.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeEvents.java
@@ -42,11 +42,13 @@ public class PublicizeEvents {
         private long mSiteId;
         private int mKeychainId;
         private String mService;
+        private String mExternalUserId;
 
-        public ActionAccountChosen(long siteId, int keychainId, String service) {
+        public ActionAccountChosen(long siteId, int keychainId, String service, String externalUserId) {
             mSiteId = siteId;
             mKeychainId = keychainId;
             mService = service;
+            mExternalUserId = externalUserId;
         }
 
         public long getSiteId() {
@@ -59,6 +61,10 @@ public class PublicizeEvents {
 
         public String getService() {
             return mService;
+        }
+
+        public String getExternalUserId() {
+            return mExternalUserId;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -323,7 +323,8 @@ public class PublicizeListActivity extends AppCompatActivity
             return;
         }
 
-        PublicizeActions.connectStepTwo(event.getSiteId(), event.getKeychainId(), event.getService(), event.getExternalUserId());
+        PublicizeActions.connectStepTwo(event.getSiteId(), event.getKeychainId(),
+                event.getService(), event.getExternalUserId());
         mProgressDialog = new ProgressDialog(this);
         mProgressDialog.setMessage(getString(R.string.connecting_account));
         mProgressDialog.show();

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -323,7 +323,7 @@ public class PublicizeListActivity extends AppCompatActivity
             return;
         }
 
-        PublicizeActions.connectStepTwo(event.getSiteId(), event.getKeychainId(), event.getService());
+        PublicizeActions.connectStepTwo(event.getSiteId(), event.getKeychainId(), event.getService(), event.getExternalUserId());
         mProgressDialog = new ProgressDialog(this);
         mProgressDialog.setMessage(getString(R.string.connecting_account));
         mProgressDialog.show();

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
@@ -136,7 +136,7 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
     }
 
     private boolean isHiddenService(PublicizeService service) {
-        boolean shouldHideGooglePlus = service.getId().equals(PublicizeConstants.GOOGLE_PLUS_ID) || mShouldHideGPlus;
+        boolean shouldHideGooglePlus = service.getId().equals(PublicizeConstants.GOOGLE_PLUS_ID) && mShouldHideGPlus;
         boolean isFacebook = service.getId().equals(PublicizeConstants.FACEBOOK_ID);
 
         return shouldHideGooglePlus || isFacebook;

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
@@ -25,26 +25,20 @@ import java.util.Collections;
 import java.util.Comparator;
 
 public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServiceAdapter.SharingViewHolder> {
-    public interface OnAdapterLoadedListener {
-        void onAdapterLoaded(boolean isEmpty);
-    }
-
-    public interface OnServiceClickListener {
-        void onServiceClicked(PublicizeService service);
-    }
-
     private final PublicizeServiceList mServices = new PublicizeServiceList();
     private final PublicizeConnectionList mConnections = new PublicizeConnectionList();
-
     private final long mSiteId;
     private final int mBlavatarSz;
     private final ColorFilter mGrayScaleFilter;
     private final long mCurrentUserId;
-
     private OnAdapterLoadedListener mAdapterLoadedListener;
     private OnServiceClickListener mServiceClickListener;
+    private boolean mShouldHideGPlus;
 
-    private boolean mShouldHideGPlus; // G+ no longers supports authentication via a WebView, so we hide it here unless the user already has a connection
+    /*
+     * AsyncTask to load services
+     */
+    private boolean mIsTaskRunning = false;
 
     public PublicizeServiceAdapter(Context context, long siteId, long currentUserId) {
         super();
@@ -141,6 +135,21 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
         });
     }
 
+    private boolean isHiddenService(PublicizeService service) {
+        boolean shouldHideGooglePlus = service.getId().equals(PublicizeConstants.GOOGLE_PLUS_ID) || mShouldHideGPlus;
+        boolean isFacebook = service.getId().equals(PublicizeConstants.FACEBOOK_ID);
+
+        return shouldHideGooglePlus || isFacebook;
+    }
+
+    public interface OnAdapterLoadedListener {
+        void onAdapterLoaded(boolean isEmpty);
+    }
+
+    public interface OnServiceClickListener {
+        void onServiceClicked(PublicizeService service);
+    }
+
     class SharingViewHolder extends RecyclerView.ViewHolder {
         private final TextView mTxtService;
         private final TextView mTxtUser;
@@ -155,11 +164,6 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
             mDivider = view.findViewById(R.id.divider);
         }
     }
-
-    /*
-     * AsyncTask to load services
-     */
-    private boolean mIsTaskRunning = false;
 
     private class LoadServicesTask extends AsyncTask<Void, Void, Boolean> {
         private final PublicizeServiceList mTmpServices = new PublicizeServiceList();
@@ -234,12 +238,5 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
                 }
             });
         }
-    }
-
-    private boolean isHiddenService(PublicizeService service) {
-        boolean shouldHideGooglePlus = service.getId().equals(PublicizeConstants.GOOGLE_PLUS_ID) || mShouldHideGPlus;
-        boolean isFacebook = service.getId().equals(PublicizeConstants.FACEBOOK_ID);
-
-        return shouldHideGooglePlus || isFacebook;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
@@ -137,9 +137,8 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
 
     private boolean isHiddenService(PublicizeService service) {
         boolean shouldHideGooglePlus = service.getId().equals(PublicizeConstants.GOOGLE_PLUS_ID) && mShouldHideGPlus;
-        boolean isFacebook = service.getId().equals(PublicizeConstants.FACEBOOK_ID);
 
-        return shouldHideGooglePlus || isFacebook;
+        return shouldHideGooglePlus;
     }
 
     public interface OnAdapterLoadedListener {

--- a/WordPress/src/main/res/layout/publicize_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_detail_fragment.xml
@@ -105,6 +105,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="@dimen/margin_extra_large"
                 android:layout_marginRight="@dimen/margin_extra_large"
+                android:paddingTop="@dimen/margin_large"
                 android:ellipsize="end"
                 android:textColor="@color/grey_darken_20"
                 android:textSize="@dimen/text_sz_medium"
@@ -112,6 +113,23 @@
                 tools:text="text_description_notice"
                 android:layout_marginEnd="@dimen/margin_extra_large"
                 android:layout_marginStart="@dimen/margin_extra_large"/>
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/learn_more_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_large"
+                android:layout_marginLeft="@dimen/margin_extra_large"
+                android:layout_marginRight="@dimen/margin_extra_large"
+                android:layout_marginTop="@dimen/margin_extra_large"
+                android:ellipsize="end"
+                android:text="@string/learn_more"
+                android:textColor="@color/blue_wordpress"
+                android:textSize="@dimen/text_sz_medium"
+                android:textStyle="bold"
+                tools:text="learn_more_button"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:layout_marginEnd="@dimen/margin_extra_large"/>
 
             <View
                 android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/publicize_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_detail_fragment.xml
@@ -98,6 +98,21 @@
                 android:layout_marginEnd="@dimen/margin_extra_large"
                 android:layout_marginStart="@dimen/margin_extra_large"/>
 
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/text_description_notice"
+                android:visibility="gone"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/margin_extra_large"
+                android:layout_marginRight="@dimen/margin_extra_large"
+                android:ellipsize="end"
+                android:textColor="@color/grey_darken_20"
+                android:textSize="@dimen/text_sz_medium"
+                android:textStyle="bold"
+                tools:text="text_description_notice"
+                android:layout_marginEnd="@dimen/margin_extra_large"
+                android:layout_marginStart="@dimen/margin_extra_large"/>
+
             <View
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/list_divider_height"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1631,7 +1631,7 @@
     <string name="connected_accounts_label">Connected accounts</string>
     <string name="connection_service_label">Publicize to %s</string>
     <string name="connection_service_description">Connect to automatically share your blog posts to %s.</string>
-    <string name="connection_service_facebook_notice">As of August 1, 2018, Facebook no longer allows direct sharing of posts to Facebook Profiles. Connections to Facebook Pages remain unchaged.</string>
+    <string name="connection_service_facebook_notice">As of August 1, 2018, Facebook no longer allows direct sharing of posts to Facebook Profiles. Connections to Facebook Pages remain unchanged.</string>
     <string name="share_btn_connect">Connect</string>
     <string name="share_btn_disconnect">Disconnect</string>
     <string name="share_btn_reconnect">Reconnect</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1631,6 +1631,7 @@
     <string name="connected_accounts_label">Connected accounts</string>
     <string name="connection_service_label">Publicize to %s</string>
     <string name="connection_service_description">Connect to automatically share your blog posts to %s.</string>
+    <string name="connection_service_facebook_notice">As of August 1, 2018, Facebook no longer allows direct sharing of posts to Facebook Profiles. Connections to Facebook Pages remain unchaged.</string>
     <string name="share_btn_connect">Connect</string>
     <string name="share_btn_disconnect">Disconnect</string>
     <string name="share_btn_reconnect">Reconnect</string>


### PR DESCRIPTION
Fixes #7591 & #8026 

We're no longer allowing users to add their profiles to publicize. Also, this adds pages to the selection list where people can connect to.

To test:

1. Add a facebook account with a page. Only the page will be shown in the selection dialog. No profiles.
2. Add a facebook account with no pages. It will error out.
3. See the facebook detail item and notice the new user message about the changes August 1st. 

![screenshot_20180729-195923](https://user-images.githubusercontent.com/1158819/43375451-fdead33e-9369-11e8-840e-9adf46776841.png)

@loremattei we're going to make a 10.5.1 to release this by August 1. Feel free to ship 10.5 without this tomorrow, thanks!
