### PR TITLE
Fix language switching for API 25+ by explicitly updating static context

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -443,6 +443,13 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         return mContext;
     }
 
+    /**
+     * Update locale of the static context when language is changed.
+     */
+    public static void updateContextLocale() {
+        mContext = LocaleManager.setLocale(mContext);
+    }
+
     public static RestClientUtils getRestClientUtils() {
         if (sRestClientUtils == null) {
             sRestClientUtils = new RestClientUtils(mContext, sRequestQueue, sOAuthAuthenticator, null);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -355,6 +355,7 @@ public class AppSettingsFragment extends PreferenceFragment
         }
 
         LocaleManager.setNewLocale(WordPress.getContext(), languageCode);
+        WordPress.updateContextLocale();
         updateLanguagePreference(languageCode);
 
         // Track language change on Analytics because we have both the device language and app selected language


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/8114

This is my proposal to fix the language switching bug I encountered last week. If there are concerns with the solution I have chosen, I will be happy to discuss them.

To test:
1. Open the app on an API version > 24 device/emulator.
2. Change language via Me -> App Settings.
3. Go to the stats screen (My Site -> Stats).
4. The screen will be displayed completely in the newly chosen language.