### PR TITLE
Issue/8035 fabric optout

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -230,7 +230,9 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         sImageLoader = mImageLoader;
         sOAuthAuthenticator = mOAuthAuthenticator;
 
-        if (!PackageUtils.isDebugBuild()) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        boolean hasUserOptedOut = !prefs.getBoolean(getString(R.string.pref_key_send_usage), true);
+        if (!PackageUtils.isDebugBuild() && !hasUserOptedOut) {
             Fabric.with(this, new Crashlytics());
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -230,9 +230,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         sImageLoader = mImageLoader;
         sOAuthAuthenticator = mOAuthAuthenticator;
 
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-        boolean hasUserOptedOut = !prefs.getBoolean(getString(R.string.pref_key_send_usage), true);
-        if (!PackageUtils.isDebugBuild() && !hasUserOptedOut) {
+        if (CrashlyticsUtils.shouldEnableCrashlytics(this)) {
             Fabric.with(this, new Crashlytics());
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -136,7 +136,6 @@ class WPMainNavigationView @JvmOverloads constructor(
     }
 
     private fun handlePostButtonClicked() {
-        throw IllegalArgumentException("fabric test") // TODO: remove this
         val postView = getItemView(PAGE_NEW_POST)
 
         // animate the button icon before telling the listener the post button was clicked - this way

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -136,6 +136,7 @@ class WPMainNavigationView @JvmOverloads constructor(
     }
 
     private fun handlePostButtonClicked() {
+        throw IllegalArgumentException("fabric test") // TODO: remove this
         val postView = getItemView(PAGE_NEW_POST)
 
         // animate the button icon before telling the listener the post button was clicked - this way

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -15,6 +15,8 @@ import android.text.TextUtils;
 import android.util.Pair;
 import android.view.MenuItem;
 
+import com.crashlytics.android.Crashlytics;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.R;
@@ -31,8 +33,10 @@ import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.CrashlyticsUtils;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.PackageUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPMediaUtils;
@@ -44,6 +48,8 @@ import java.util.Locale;
 import java.util.Map;
 
 import javax.inject.Inject;
+
+import io.fabric.sdk.android.Fabric;
 
 public class AppSettingsFragment extends PreferenceFragment
         implements OnPreferenceClickListener, Preference.OnPreferenceChangeListener {
@@ -83,15 +89,23 @@ public class AppSettingsFragment extends PreferenceFragment
                         if (newValue == null) {
                             return false;
                         }
+                        boolean hasUserOptedOut = !(boolean) newValue;
                         AnalyticsUtils.updateAnalyticsPreference(
                                 getActivity(),
                                 mDispatcher,
                                 mAccountStore,
-                                !(boolean) newValue);
+                                hasUserOptedOut);
+                        //if (!PackageUtils.isDebugBuild()) {
+                            if (hasUserOptedOut) {
+                                CrashlyticsUtils.disableCrashlytics();
+                            } else {
+                                Fabric.with(WordPress.getContext(), new Crashlytics());
+                            }
+                        //}
                         return true;
                     }
                 }
-                                                                                             );
+        );
         updateAnalyticsSyncUI();
 
         mLanguagePreference = (DetailListPreference) findPreference(getString(R.string.pref_key_language));

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -36,7 +36,6 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.CrashlyticsUtils;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.NetworkUtils;
-import org.wordpress.android.util.PackageUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPMediaUtils;
@@ -95,13 +94,11 @@ public class AppSettingsFragment extends PreferenceFragment
                                 mDispatcher,
                                 mAccountStore,
                                 hasUserOptedOut);
-                        //if (!PackageUtils.isDebugBuild()) {
-                            if (hasUserOptedOut) {
-                                CrashlyticsUtils.disableCrashlytics();
-                            } else {
-                                Fabric.with(WordPress.getContext(), new Crashlytics());
-                            }
-                        //}
+                        if (CrashlyticsUtils.shouldEnableCrashlytics(getActivity())) {
+                            Fabric.with(WordPress.getContext(), new Crashlytics());
+                        } else {
+                            CrashlyticsUtils.disableCrashlytics();
+                        }
                         return true;
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -94,10 +94,14 @@ public class AppSettingsFragment extends PreferenceFragment
                                 mDispatcher,
                                 mAccountStore,
                                 hasUserOptedOut);
+                        /*
+                         * Note that if tracking was just disabled, the only way to get Crashlytics to stop sending
+                         * crash reports is to alert the user that the app needs to be restarted and then we either
+                         * restart the app or expect the user to do it. This seemed user-unfriendly, especially
+                         * since the app would need to restart after the very next crash.
+                         */
                         if (CrashlyticsUtils.shouldEnableCrashlytics(getActivity())) {
                             Fabric.with(WordPress.getContext(), new Crashlytics());
-                        } else {
-                            CrashlyticsUtils.disableCrashlytics();
                         }
                         return true;
                     }

--- a/WordPress/src/main/java/org/wordpress/android/util/CrashlyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashlyticsUtils.java
@@ -13,15 +13,21 @@ public class CrashlyticsUtils {
     private static final String TAG_KEY = "tag";
     private static final String MESSAGE_KEY = "message";
 
+    /**
+     * Disables Crashlytics if it's already enabled
+     */
     public static void disableCrashlytics() {
         if (!Fabric.isInitialized()) {
             return;
         }
 
-        Field field = null;
+        /*
+         * first we use reflection to set the Fabric singleton to null because otherwise the call
+         * to Fabric.with() below will do nothing)
+         */
         try {
             Class<?> clazz = Class.forName(Fabric.class.getName());
-            field = clazz.getDeclaredField("singleton");
+            Field field = clazz.getDeclaredField("singleton");
             field.setAccessible(true);
             field.set(null, null);
         } catch (Exception e) {
@@ -29,6 +35,11 @@ public class CrashlyticsUtils {
             return;
         }
 
+        /*
+         * then we create a new instance that disables logging - ideally this wouldn't be necessary
+         * since we just nulled the existing instance above, but it seems more future-proof to
+         * explicitly disable Crashlytics
+         */
         CrashlyticsCore crashlytics = new CrashlyticsCore.Builder().disabled(true).build();
         Fabric.with(WordPress.getContext(), crashlytics);
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/CrashlyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashlyticsUtils.java
@@ -1,12 +1,37 @@
 package org.wordpress.android.util;
 
 import com.crashlytics.android.Crashlytics;
+import com.crashlytics.android.core.CrashlyticsCore;
+
+import org.wordpress.android.WordPress;
+
+import java.lang.reflect.Field;
 
 import io.fabric.sdk.android.Fabric;
 
 public class CrashlyticsUtils {
     private static final String TAG_KEY = "tag";
     private static final String MESSAGE_KEY = "message";
+
+    public static void disableCrashlytics() {
+        if (!Fabric.isInitialized()) {
+            return;
+        }
+
+        Field field = null;
+        try {
+            Class<?> clazz = Class.forName(Fabric.class.getName());
+            field = clazz.getDeclaredField("singleton");
+            field.setAccessible(true);
+            field.set(null, null);
+        } catch (Exception e) {
+            AppLog.e(AppLog.T.MAIN, e.getMessage());
+            return;
+        }
+
+        CrashlyticsCore crashlytics = new CrashlyticsCore.Builder().disabled(true).build();
+        Fabric.with(WordPress.getContext(), crashlytics);
+    }
 
     public static void logException(Throwable tr, AppLog.T tag, String message) {
         if (!Fabric.isInitialized()) {

--- a/WordPress/src/main/java/org/wordpress/android/util/CrashlyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashlyticsUtils.java
@@ -21,7 +21,7 @@ public class CrashlyticsUtils {
 
     public static boolean shouldEnableCrashlytics(@NonNull Context context) {
         if (PackageUtils.isDebugBuild()) {
-            //return false; // TODO: uncomment
+            return false;
         }
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);

--- a/WordPress/src/main/java/org/wordpress/android/util/CrashlyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashlyticsUtils.java
@@ -1,8 +1,14 @@
 package org.wordpress.android.util;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
+
 import com.crashlytics.android.Crashlytics;
 import com.crashlytics.android.core.CrashlyticsCore;
 
+import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 
 import java.lang.reflect.Field;
@@ -12,6 +18,16 @@ import io.fabric.sdk.android.Fabric;
 public class CrashlyticsUtils {
     private static final String TAG_KEY = "tag";
     private static final String MESSAGE_KEY = "message";
+
+    public static boolean shouldEnableCrashlytics(@NonNull Context context) {
+        if (PackageUtils.isDebugBuild()) {
+            //return false; // TODO: uncomment
+        }
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        boolean hasUserOptedOut = !prefs.getBoolean(context.getString(R.string.pref_key_send_usage), true);
+        return !hasUserOptedOut;
+    }
 
     /**
      * Disables Crashlytics if it's already enabled

--- a/WordPress/src/main/java/org/wordpress/android/util/CrashlyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashlyticsUtils.java
@@ -6,12 +6,8 @@ import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 
 import com.crashlytics.android.Crashlytics;
-import com.crashlytics.android.core.CrashlyticsCore;
 
 import org.wordpress.android.R;
-import org.wordpress.android.WordPress;
-
-import java.lang.reflect.Field;
 
 import io.fabric.sdk.android.Fabric;
 
@@ -27,37 +23,6 @@ public class CrashlyticsUtils {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         boolean hasUserOptedOut = !prefs.getBoolean(context.getString(R.string.pref_key_send_usage), true);
         return !hasUserOptedOut;
-    }
-
-    /**
-     * Disables Crashlytics if it's already enabled
-     */
-    public static void disableCrashlytics() {
-        if (!Fabric.isInitialized()) {
-            return;
-        }
-
-        /*
-         * first we use reflection to set the Fabric singleton to null because otherwise the call
-         * to Fabric.with() below will do nothing)
-         */
-        try {
-            Class<?> clazz = Class.forName(Fabric.class.getName());
-            Field field = clazz.getDeclaredField("singleton");
-            field.setAccessible(true);
-            field.set(null, null);
-        } catch (Exception e) {
-            AppLog.e(AppLog.T.MAIN, e.getMessage());
-            return;
-        }
-
-        /*
-         * then we create a new instance that disables logging - ideally this wouldn't be necessary
-         * since we just nulled the existing instance above, but it seems more future-proof to
-         * explicitly disable Crashlytics
-         */
-        CrashlyticsCore crashlytics = new CrashlyticsCore.Builder().disabled(true).build();
-        Fabric.with(WordPress.getContext(), crashlytics);
     }
 
     public static void logException(Throwable tr, AppLog.T tag, String message) {


### PR DESCRIPTION
Fixes #8035 - disables Crashlytics reporting when the user opts-out of tracking. Note the Fabric [docs](https://docs.fabric.io/android/crashlytics/advanced-setup.html#enable-opt-in-reporting) state that the app must be restarted for Crashlytics to honor the opt out, but I wanted to avoid that user-unfriendly option which is why I resorted to reflection in this PR.

To test:
- Set the build variant to `vanillaRelease` (since Crashlytics is disabled for debug builds)
- Add a deliberate exception to the app so you can make it crash (I found it easiest to throw an exception [here](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/8035-fabric-optout/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt#L139) so the app crashes when you click the Post button)
- Configure the emulator so you can sniff traffic with Charles Proxy
- Ensure "Collect Inforrmation" is enabled in App Settings > Privacy
- Make the app crash and note that Charles shows the crash info was sent to Crashlytics (see screenshot below)
- Do the same thing with "Collect Information" disabled and note that crash info is *not* sent

<img width="716" alt="screen shot 2018-07-30 at 3 22 15 pm" src="https://user-images.githubusercontent.com/3903757/43418929-79b6eb12-940d-11e8-8985-03b505f3963f.png">

Note to self: work on the related [Woo issue](https://github.com/woocommerce/woocommerce-android/issues/280) once this is merged.