### PR TITLE
Release image resources on view detach

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -42,6 +42,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
                 .applyScaleType(scaleType)
                 .attachRequestListener(requestListener)
                 .into(imageView)
+                .clearOnDetach()
     }
 
     @JvmOverloads
@@ -50,6 +51,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
                 .load(bitmap)
                 .applyScaleType(scaleType)
                 .into(imageView)
+                .clearOnDetach()
     }
 
     @JvmOverloads
@@ -58,6 +60,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
                 .load(drawable)
                 .applyScaleType(scaleType)
                 .into(imageView)
+                .clearOnDetach()
     }
 
     @JvmOverloads
@@ -66,6 +69,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
                 .load(resourceId)
                 .applyScaleType(scaleType)
                 .into(imageView)
+                .clearOnDetach()
     }
 
     fun load(viewTarget: ViewTarget<TextView, Drawable>, imageType: ImageType, imgUrl: String) {
@@ -74,6 +78,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
                 .addFallback(imageType)
                 .addPlaceholder(imageType)
                 .into(viewTarget)
+                .clearOnDetach()
     }
 
     fun loadIntoCircle(imageView: ImageView, imageType: ImageType, imgUrl: String) {
@@ -83,6 +88,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
                 .addPlaceholder(imageType)
                 .circleCrop()
                 .into(imageView)
+                .clearOnDetach()
     }
 
     fun cancelRequestAndClearImageView(imageView: ImageView) {


### PR DESCRIPTION
Fixes #8044 

Calling GlideApp.with(context) instead of GlideApp.with(activity/fragment) in the ImageManager results in clear() not being automatically called when the activity/fragment is destroyed. 

This PR appends call to `clearOnDetach()` to all requests. `ClearOnDetach()` cancels ongoing requests + clears resources when an ImageView is detached from it's parent.

To test - this affects loading of all remote images in the app, however since we use single class `ImageManager` to load images, I believe it's enough to test just a couple of places. For example Reader + Media library.

