### PR TITLE
Hide autoupdated toggle on AT sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -503,6 +503,8 @@ public class PluginDetailActivity extends AppCompatActivity {
                 .setVisibility(mPlugin.isInstalled() && isNotAutoManaged() ? View.VISIBLE : View.GONE);
         findViewById(R.id.plugin_state_active_container)
                 .setVisibility(canPluginBeDisabledOrRemoved() ? View.VISIBLE : View.GONE);
+        findViewById(R.id.plugin_state_autoupdates_container)
+                .setVisibility(mSite.isAutomatedTransfer() ? View.GONE : View.VISIBLE);
         mSwitchActive.setChecked(mIsActive);
         mSwitchAutoupdates.setChecked(mIsAutoUpdateEnabled);
 

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -251,7 +251,9 @@
 
                     <View style="@style/PostSettingsDivider" />
 
-                    <RelativeLayout style="@style/PluginCardViewHorizontalContainer">
+                    <RelativeLayout
+                        android:id="@+id/plugin_state_autoupdates_container"
+                        style="@style/PluginCardViewHorizontalContainer">
 
                         <TextView
                             style="@style/PluginCardViewPrimaryText"


### PR DESCRIPTION
- AT sites now autoupdate all plugins. This PR hides the autoupdate toggle since it no longer does anything on AT sites.

To test:
- go to AT site
- go to on Plugins
- go to any installed plugin
- Autoupdate toggle is **not visible**

To test 2:
- go to self-hosted Jetpack site
- go to on Plugins
- go to any installed plugin
- Autoupdate toggle is **visible**

