### PR TITLE
Automate taking screenshots across specified devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ google-services.json
 fastlane/.env*
 fastlane/report.xml
 fastlane/README.md
+fastlane/metadata/android/screenshots.html
+fastlane/metadata/android/*/images/

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -38,6 +38,7 @@ import tools.fastlane.screengrab.Screengrab;
 import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
 
 import static junit.framework.Assert.fail;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
 import static org.wordpress.android.BuildConfig.SCREENSHOT_LOGINPASSWORD;
@@ -46,7 +47,7 @@ import static org.wordpress.android.BuildConfig.SCREENSHOT_LOGINUSERNAME;
 @LargeTest
 @RunWith(AndroidJUnit4.class)
 public class WPScreenshotTest {
-    private static final int ATTEMPTS = 20;
+    private static final int ATTEMPTS = 50;
     private static final int WAITING_TIME = 300;
 
     @ClassRule
@@ -109,15 +110,14 @@ public class WPScreenshotTest {
 
         // Next Button
         nextButton = onView(
-                allOf(withId(R.id.primary_button), childAtPosition(
+                allOf(withId(R.id.primary_button), withText(R.string.next), childAtPosition(
                         allOf(withId(R.id.bottom_buttons), childAtPosition(
                                 withClassName(is("android.widget.RelativeLayout")), 2)), 1)));
         waitForElementUntilDisplayed(nextButton).perform(click());
 
-
         // Continue with this log button
         ViewInteraction continueButton = onView(
-                allOf(withId(R.id.primary_button), childAtPosition(
+                allOf(withId(R.id.primary_button), withText(R.string.login_continue), childAtPosition(
                         allOf(withId(R.id.bottom_buttons), childAtPosition(
                                 withClassName(is("android.widget.RelativeLayout")), 3)), 1)));
         waitForElementUntilDisplayed(continueButton).perform(click());

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,6 +13,31 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
+SUPPORTED_LOCALES = [
+  { glotpress: "ar", google_play: "ar" },
+  { glotpress: "de", google_play: "de-DE" },
+  { glotpress: "en-gb", google_play: "en-US" },
+  { glotpress: "es", google_play: "es-ES" },
+  { glotpress: "fr", google_play: "fr-CA" },
+  { glotpress: "fr", google_play: "fr-FR" },
+  { glotpress: "he", google_play: "iw-IL" },
+  { glotpress: "id", google_play: "id" },
+  { glotpress: "it", google_play: "it-IT" },
+  { glotpress: "ja", google_play: "ja-JP" },
+  { glotpress: "ko", google_play: "ko-KR" },
+  { glotpress: "nl", google_play: "nl-NL" },
+  { glotpress: "pl", google_play: "pl-PL" },
+  { glotpress: "pt-br", google_play: "pt-BR" },
+  { glotpress: "ru", google_play: "ru-RU" },
+  { glotpress: "sr", google_play:  "sr" },
+  { glotpress: "sv", google_play: "sv-SE" },
+  { glotpress: "th", google_play: "th" },
+  { glotpress: "tr", google_play: "tr-TR" },
+  { glotpress: "vi", google_play: "vi" },
+  { glotpress: "zh-cn", google_play: "zh-CN" },
+  { glotpress: "zh-tw", google_play: "zh-TW" },
+].freeze
+
 default_platform(:android)
 
 platform :android do
@@ -65,7 +90,7 @@ platform :android do
       use_tests_in_classes: "org.wordpress.android.ui.screenshots.WPScreenshotTest",
       reinstall_app: false,
       clear_previous_screenshots: true,
-      locales: ["ar", "de-DE", "en-US", "es-ES", "fr-CA", "fr-FR", "id", "it-IT", "iw-IL", "ja-JP", "ko-KR", "nl-NL", "pl-PL", "pt-BR", "ru-RU", "sr", "sv-SE", "th", "tr-TR", "vi", "zh-CN", "zh-TW"]
+      locales: SUPPORTED_LOCALES.map { |hsh| hsh[:google_play] }
     }
 
     take_android_emulator_screenshots(devices: screenshot_devices, screenshot_options: screenshot_options)
@@ -126,35 +151,10 @@ lane :download_metadata_strings do |options|
     play_store_app_title: "title.txt"
   }
 
-  metadata_locales = [
-    ["en-gb", "en-US"],
-    ["pl", "pl-PL"],
-    ["id", "id"],
-    ["ja", "ja-JP"],
-    ["fr", "fr-FR"],
-    ["fr", "fr-CA"],
-    ["ko", "ko-KR"],
-    ["zh-cn", "zh-CN"],
-    ["sv", "sv-SE"],
-    ["it", "it-IT"],
-    ["ru", "ru-RU"],
-    ["tr", "tr-TR"],
-    ["de", "de-DE"],
-    ["nl", "nl-NL"],
-    ["es", "es-ES"],
-    ["pt-br", "pt-BR"],
-    ["zh-tw", "zh-TW"],
-    ["he", "iw-IL"],
-    ["ar", "ar"],
-    ["sr",  "sr"],
-    ["th", "th"],
-    ["vi", "vi"]
-  ]
-
   delete_old_changelogs(build: options[:build_number])
   download_metadata(project_url: "https://translate.wordpress.org/projects/apps/android/release-notes/", 
     target_files: files, 
-    locales: metadata_locales)
+    locales: SUPPORTED_LOCALES)
 end 
 
 #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,55 +16,59 @@
 default_platform(:android)
 
 platform :android do
+
+  #####################################################################################
+  # screenshots
+  # -----------------------------------------------------------------------------------
+  # This lane takes screenshots for the WordPress app across the three device types:
+  # phone, sevenInch and tenInch. If device serials are not provided these avds will be
+  # used: fastlane_screenshots_phone, fastlane_screenshots_seven_inch,
+  # fastlane_screenshots_ten_inch
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # fastlane screenshots phone_serial:<serial> sevenInch_serial:<serial> tenInch_serial:<serial>
+  #
+  # Example:
+  # fastlane screenshots
+  # fastlane screenshots phone_serial:emulator-5444 sevenInch_serial:emulator-5446 tenInch_serial:emulator-5448
+  #####################################################################################
   desc "Build and capture screenshots"
-  lane :screenshots do
+  lane :screenshots do |options|
     gradle(task: "assembleVanillaDebug assembleVanillaDebugAndroidTest")
-    take_screenshots
+    take_screenshots(options)
   end
 
   desc "Capture screenshots"
   lane :take_screenshots do |options|
-    devs = adb_devices()
-    check_devices(devs: devs)
-    
-    device = devs[0]
-    demo_mode_enter(device_serial: device.serial)
+    screenshot_devices = [
+      {
+        screenshot_type: 'phone',
+        device_name: 'fastlane_screenshots_phone',
+        device_serial: options[:phone_serial],
+      },
+      {
+        screenshot_type: 'sevenInch',
+        device_name: 'fastlane_screenshots_seven_inch',
+        device_serial: options[:sevenInch_serial],
+      },
+      {
+        screenshot_type: 'tenInch',
+        device_name: 'fastlane_screenshots_ten_inch',
+        device_serial: options[:tenInch_serial],
+      }
+    ]
 
-    capture_android_screenshots(app_apk_path: "WordPress/build/outputs/apk/vanilla/debug/WordPress-vanilla-debug.apk",
-        tests_apk_path: "WordPress/build/outputs/apk/androidTest/vanilla/debug/WordPress-vanilla-debug-androidTest.apk", 
-        use_tests_in_classes: "org.wordpress.android.ui.screenshots.WPScreenshotTest", 
-        reinstall_app: true,
-        device_type: options[:device],
-        locales: ["ar", "de-DE", "en-US", "es-ES", "fr-CA", "fr-FR", "id", "it-IT", "iw-IL", "ja-JP", "ko-KR", "nl-NL", "pl-PL", "pt-BR", "ru-RU", "sr", "sv-SE", "th", "tr-TR", "vi", "zh-CN", "zh-TW"]
-        )
-        
-    demo_mode_exit(device_serial: device.serial)
-  end
+    screenshot_options = {
+      output_directory: "fastlane/metadata/android",
+      app_apk_path: "WordPress/build/outputs/apk/vanilla/debug/WordPress-vanilla-debug.apk",
+      tests_apk_path: "WordPress/build/outputs/apk/androidTest/vanilla/debug/WordPress-vanilla-debug-androidTest.apk",
+      use_tests_in_classes: "org.wordpress.android.ui.screenshots.WPScreenshotTest",
+      reinstall_app: false,
+      clear_previous_screenshots: true,
+      locales: ["ar", "de-DE", "en-US", "es-ES", "fr-CA", "fr-FR", "id", "it-IT", "iw-IL", "ja-JP", "ko-KR", "nl-NL", "pl-PL", "pt-BR", "ru-RU", "sr", "sv-SE", "th", "tr-TR", "vi", "zh-CN", "zh-TW"]
+    }
 
-  # Screenshot helpers
-  private_lane :check_devices do |options|
-    devs = options[:devs]
-    if devs.count == 0 then
-      UI.user_error!("No devices detected. Please, connect one device")
-    end
-    
-    if devs.count > 1 then
-      UI.user_error!("Too many devices detected. Please, connect one device")
-    end
-  end
-
-  private_lane :demo_mode_enter do |options|
-    # Setup device for demo
-    adb(command: "shell settings put global sysui_demo_allowed 1", serial: options[:device_serial])
-    # Disable system notifications
-    adb(command: "shell am broadcast -a com.android.systemui.demo -e command notifications -e visible false", serial: options[:device_serial])
-    # Enjoy lunch while browsing the Play Store
-    adb(command: "shell am broadcast -a com.android.systemui.demo -e command clock -e hhmm 1337", serial: options[:device_serial])
-  end
-
-  private_lane :demo_mode_exit do |options|
-    # Exit demo mode
-    adb(command: "shell am broadcast -a com.android.systemui.demo -e command exit", serial: options[:device_serial])
+    take_android_emulator_screenshots(devices: screenshot_devices, screenshot_options: screenshot_options)
   end
 end
 #####################################################################################

--- a/fastlane/actions/download_metadata.rb
+++ b/fastlane/actions/download_metadata.rb
@@ -17,9 +17,9 @@ module Fastlane
         downloader = Fastlane::Helpers::MetadataDownloader.new(Dir.pwd + "/fastlane/metadata/android", params[:target_files])
 
         params[:locales].each do | loc |
-          puts "Downloading language: #{loc[0]}"
-          complete_url = "#{params[:project_url]}#{loc[0]}/default/export-translations?filters[status]=current&format=json"
-          downloader.download(loc[1], complete_url)
+          puts "Downloading language: #{loc[:glotpress]}"
+          complete_url = "#{params[:project_url]}#{loc[:glotpress]}/default/export-translations?filters[status]=current&format=json"
+          downloader.download(loc[:google_play], complete_url)
         end
       end
 

--- a/fastlane/actions/take_android_emulator_screenshots.rb
+++ b/fastlane/actions/take_android_emulator_screenshots.rb
@@ -1,0 +1,133 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      TAKE_ANDROID_EMULATOR_SCREENSHOTS_CUSTOM_VALUE = :TAKE_ANDROID_EMULATOR_SCREENSHOTS_CUSTOM_VALUE
+    end
+
+    class TakeAndroidEmulatorScreenshotsAction < Action
+      def self.run(params)
+        UI.message "Taking Android emulator screenhots for #{params[:devices].count} devices"
+
+        require_relative '../helpers/android_virtual_device_helper.rb'
+
+        params[:devices].each do |device|
+          device_serial = device[:device_serial]
+          if device_serial.nil?
+            launcher = Fastlane::Helpers::AndroidVirtualDeviceLauncher.new
+            device_serial = launcher.trigger(device_name: device[:device_name])
+          end
+
+          enter_demo_mode(device_serial)
+          take_device_screenshots(device_serial, device[:screenshot_type], params[:screenshot_options])
+          exit_demo_mode(device_serial)
+        end
+      end
+
+      def self.enter_demo_mode(device_serial)
+        # Setup device for demo
+        other_action.adb(command: "shell settings put global sysui_demo_allowed 1",
+                         serial: device_serial)
+        # Disable system notifications
+        other_action.adb(command: "shell am broadcast -a com.android.systemui.demo -e command notifications -e visible false",
+                         serial: device_serial)
+        # Enjoy lunch while browsing the Play Store
+        other_action.adb(command: "shell am broadcast -a com.android.systemui.demo -e command clock -e hhmm 1337",
+                         serial: device_serial)
+      end
+
+      def self.exit_demo_mode(device_serial)
+        # Exit demo mode
+        other_action.adb(command: "shell am broadcast -a com.android.systemui.demo -e command exit", serial: device_serial)
+      end
+
+      def self.take_device_screenshots(device_serial, screenshot_type, screenshot_options)
+        merged_options = screenshot_options.merge({
+          device_type: screenshot_type,
+          specific_device: device_serial,
+        })
+
+        # Running an action from here using Dir.chdir unpredictably so relative paths are unreliable
+        # Use absolute paths so that Screengrab can find the paths
+        if merged_options.key?(:app_apk_path)
+          merged_options[:app_apk_path] = absolute_path(merged_options[:app_apk_path])
+        end
+        if merged_options.key?(:tests_apk_path)
+          merged_options[:tests_apk_path] = absolute_path(merged_options[:tests_apk_path])
+        end
+        output_directory = merged_options.fetch(:output_directory, File.join("fastlane", "metadata", "android"))
+        merged_options[:output_directory] = absolute_path(output_directory)
+
+        other_action.capture_android_screenshots(merged_options)
+      end
+
+      def self.absolute_path(relative_path)
+        Pathname.new(relative_path).expand_path.to_s
+      end
+
+      #####################################################
+      # @!group Validation
+      #####################################################
+
+      def self.verify_devices(devices)
+        UI.user_error! "Devices must not be empty" if devices.empty?
+        devices.each { |device| verify_device(device) }
+      end
+
+      def self.verify_device(device)
+        UI.user_error! "Each device must be a valid Hash" unless device.is_a?(Hash)
+
+        required_keys = [:screenshot_type]
+        required_keys.each do |key|
+          UI.user_error! "Device: '#{key}' is a required key" unless device.key?(key)
+        end
+
+        unless device.key?(:device_name) || device.key?(:device_serial)
+          UI.user_error! "Device: must have ':device_name' or ':device_serial'"
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+      def self.description
+        "Take screenhots in Android Emulators"
+      end
+
+      def self.details
+        "Take screenhots for all the specified Android Emulator configurations"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :devices,
+                                       env_name: "FL_TAKE_ANDROID_EMULATOR_SCREENSHOTS_DEVICES",
+                                       description: "Android emulator configurations to capture screenshots in",
+                                       type: Array,
+                                       verify_block: proc do |value|
+                                         verify_devices(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :screenshot_options,
+                                       env_name: "FL_TAKE_ANDROID_EMULATOR_SCREENSHOT_OPTIONS",
+                                       description: "The screenshot options to be provided to Fastlane Screengrab",
+                                       type: Hash)
+        ]
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.authors
+        ["jtreanor"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end

--- a/fastlane/helpers/android_virtual_device_helper.rb
+++ b/fastlane/helpers/android_virtual_device_helper.rb
@@ -1,0 +1,122 @@
+module Fastlane
+  module Helpers
+    module AndroidVirtualDevicePathHelper
+      def self.android_home
+        ENV['ANDROID_HOME'] || ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_SDK']
+      end
+
+      def self.emulator_path
+        Pathname.new(android_home).join("emulator/emulator").to_s
+      end
+    end
+
+    module AndroidVirtualDevicesAdbHelper
+      def self.adb(command: nil, serial: "")
+        Fastlane::Actions::AdbAction.run(command: command, serial: serial)
+      end
+
+      def self.adb_devices
+        Fastlane::Actions::AdbDevicesAction.run({})
+      end
+
+      def self.boot_completed?
+        adb(command: "shell getprop sys.boot_completed").to_i == 1
+      end
+
+      def self.wait_for_device
+        adb(command: "wait-for-device")
+      end
+
+      def self.shutdown_device(device_serial)
+        adb(command: "emu kill", serial: device_serial)
+      end
+    end
+
+    class AndroidVirtualDeviceLauncher
+      LAUNCH_TIMEOUT = 60
+      LAUNCH_WAIT = 2
+
+      def trigger(device_name: nil, wipe_data: true)
+        unless installed_avd?(device_name)
+          UI.user_error!("Android Virtual Device '#{device_name}' not found")
+        end
+
+        killer = AndroidVirtualDeviceKiller.new
+        killer.shutdown_all_devices
+
+        launch(device_name, wipe_data)
+        wait_for_device_boot
+
+        device_serial = AndroidVirtualDevicesAdbHelper.adb_devices.first.serial
+        device_serial
+      end
+
+      private
+
+      def installed_avd?(device_name)
+        avds = Action.sh("#{AndroidVirtualDevicePathHelper.emulator_path} -list-avds").split("\n")
+        avds.include? device_name
+      end
+
+      def launch(device_name, wipe_data)
+        UI.message("Launching emulator '#{device_name}'")
+
+        command = [
+          AndroidVirtualDevicePathHelper.emulator_path,
+          "-avd \"#{device_name}\"",
+          "-no-snapshot",
+          "-gpu auto",
+        ]
+        command << "-wipe-data" if wipe_data
+        command << "&" # Run in background
+        joined_command = command.join(" ")
+
+        UI.command(joined_command)
+        system(joined_command)
+      end
+
+      def wait_for_device_boot
+        AndroidVirtualDevicesAdbHelper.wait_for_device
+        begin
+          # Wait for complete boot
+          Timeout::timeout(LAUNCH_TIMEOUT) do
+            next if AndroidVirtualDevicesAdbHelper.boot_completed?
+            until AndroidVirtualDevicesAdbHelper.boot_completed?
+              sleep(LAUNCH_WAIT)
+            end
+          end
+        rescue Timeout::Error
+          UI.user_error!("Timed out waiting for the device to boot")
+        end
+      end
+    end
+
+    class AndroidVirtualDeviceKiller
+      SHUTDOWN_TIMEOUT = 60
+      SHUTDOWN_WAIT = 2
+
+      def shutdown_all_devices
+        UI.message("Shutting down all emulators")
+        AndroidVirtualDevicesAdbHelper.adb_devices.each do |device|
+          AndroidVirtualDevicesAdbHelper.shutdown_device(device.serial)
+        end
+        wait_for_no_devices
+      end
+
+      private
+
+      def wait_for_no_devices
+        begin
+          Timeout::timeout(SHUTDOWN_TIMEOUT) do
+            next if AndroidVirtualDevicesAdbHelper.adb_devices.empty?
+            until AndroidVirtualDevicesAdbHelper.adb_devices.empty?
+              sleep(SHUTDOWN_WAIT)
+            end
+          end
+        rescue Timeout::Error
+          UI.user_error!("Timed out waiting for devices to shutdown")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
These changes introduce a new Fastlane action which allows us to automate taking screenshots against the three device types: `phone`, `sevenInch` and `tenInch`.

By default `bundle exec fastlane screenshots` now runs on Android emulators with these names: `fastlane_screenshots_phone`, `fastlane_screenshots_seven_inch`, `fastlane_screenshots_ten_inch`.

This behavoiur can be overridden by providing serials as parameters. For example:

```
bundle exec fastlane screenshots phone_serial:emulator-5554 sevenInch_serial:emulator-5556 tenInch_serial:emulator-5558
```

This is another step towards fixing https://github.com/wordpress-mobile/WordPress-Android/issues/8006

To test:
- Create devices with the prefined names above. These commands should work:
```
avdmanager --verbose create avd --name "fastlane_screenshots_phone" -d "Nexus 5X" -k "system-images;android-27;google_apis;x86"
avdmanager --verbose create avd --name "fastlane_screenshots_ten_inch" -d "Nexus 10" -k "system-images;android-27;google_apis;x86"
avdmanager --verbose create avd --name "fastlane_screenshots_seven_inch" -d "Nexus 7" -k "system-images;android-27;google_apis;x86"
```
- Run `bundle exec fastlane screenshots`
- It should successfully take screenshots for all 3 defined devices.