### PR TITLE
Add glide to ReaderPhotoView

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -13,7 +13,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
-import android.widget.ImageView.ScaleType;
 import android.widget.MediaController;
 import android.widget.TextView;
 import android.widget.VideoView;
@@ -283,7 +282,7 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
             mediaUri = PhotonUtils.getPhotonImageUrl(mediaUri, maxWidth, 0);
         }
         showProgress(true);
-        mImageManager.load(mImageView, ImageType.FULLSCREEN_PHOTO, mediaUri, ScaleType.CENTER,
+        mImageManager.loadWithResultListener(mImageView, ImageType.IMAGE, mediaUri, null,
                 new RequestListener<Drawable>() {
                     @Override
                     public void onResourceReady(@NotNull Drawable resource) {
@@ -306,7 +305,9 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
                     @Override
                     public void onLoadFailed(@Nullable Exception e) {
                         if (isAdded()) {
-                            AppLog.e(T.MEDIA, e);
+                            if (e != null) {
+                                AppLog.e(T.MEDIA, e);
+                            }
                             showProgress(false);
                             showLoadingError();
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -751,7 +751,7 @@ public class MediaSettingsActivity extends AppCompatActivity
             imageUrl = PhotonUtils.getPhotonImageUrl(mediaUri, size, 0);
         }
         showProgress(true);
-        mImageManager.load(mImageView, ImageType.FULLSCREEN_PHOTO, imageUrl, ScaleType.CENTER,
+        mImageManager.loadWithResultListener(mImageView, ImageType.IMAGE, imageUrl, null,
                 new RequestListener<Drawable>() {
                     @Override
                     public void onResourceReady(@NotNull Drawable resource) {
@@ -766,7 +766,9 @@ public class MediaSettingsActivity extends AppCompatActivity
                     @Override
                     public void onLoadFailed(@Nullable Exception e) {
                         if (!isFinishing()) {
-                            AppLog.e(T.MEDIA, e);
+                            if (e != null) {
+                                AppLog.e(T.MEDIA, e);
+                            }
                             showProgress(false);
                             delayedFinishWithError();
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
@@ -14,7 +14,6 @@ import android.view.animation.AnimationUtils;
 import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
-import android.widget.ImageView.ScaleType;
 import android.widget.LinearLayout;
 import android.widget.MediaController;
 import android.widget.VideoView;
@@ -26,6 +25,8 @@ import org.json.JSONObject;
 import org.wordpress.android.R;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.util.AccessibilityUtils;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.JSONUtils;
 import org.wordpress.android.util.image.ImageManager;
@@ -163,10 +164,14 @@ public class NoteBlock {
             noteBlockHolder.getImageView().setVisibility(View.VISIBLE);
             // Request image, and animate it when loaded
             mImageManager
-                    .load(noteBlockHolder.getImageView(), ImageType.IMAGE, getNoteMediaItem().optString("url", ""),
-                            ScaleType.CENTER, new ImageManager.RequestListener<Drawable>() {
+                    .loadWithResultListener(noteBlockHolder.getImageView(), ImageType.IMAGE,
+                            getNoteMediaItem().optString("url", ""), null,
+                            new ImageManager.RequestListener<Drawable>() {
                                 @Override
                                 public void onLoadFailed(@Nullable Exception e) {
+                                    if (e != null) {
+                                        AppLog.e(T.NOTIFS, e);
+                                    }
                                     noteBlockHolder.hideImageView();
                                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -79,7 +79,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
                 .load(imgUrl)
                 .addFallback(imageType)
                 .addPlaceholder(imageType)
-                .addThumbnail(imageView.context, thumbnailUrl)
+                .addThumbnail(imageView.context, thumbnailUrl, requestListener)
                 .attachRequestListener(requestListener)
                 .into(imageView)
                 .clearOnDetach()
@@ -200,13 +200,18 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
         return if (errorImageRes == null) this else this.error(errorImageRes)
     }
 
-    private fun GlideRequest<Drawable>.addThumbnail(context: Context, thumbnailUrl: String?): GlideRequest<Drawable> {
+    private fun GlideRequest<Drawable>.addThumbnail(
+        context: Context,
+        thumbnailUrl: String?,
+        listener: RequestListener<Drawable>
+    ): GlideRequest<Drawable> {
         return if (TextUtils.isEmpty(thumbnailUrl)) {
             this
         } else {
             val thumbnailRequest = GlideApp
                     .with(context)
                     .load(thumbnailUrl)
+                    .attachRequestListener(listener)
             return this.thumbnail(thumbnailRequest)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
@@ -15,7 +15,6 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.BLAVATAR -> R.drawable.ic_placeholder_blavatar_grey_lighten_20_40dp
             ImageType.PLAN -> R.drawable.ic_reader_blue_wordpress_18dp
             ImageType.THEME -> R.color.grey_lighten_30
-            ImageType.FULLSCREEN_PHOTO -> null // manually handled in the view
             ImageType.UNKNOWN -> R.drawable.ic_notice_grey_500_48dp
             ImageType.PLUGIN -> R.drawable.plugin_placeholder
         }
@@ -30,7 +29,6 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.BLAVATAR -> R.color.grey_light
             ImageType.PLAN -> R.drawable.ic_reader_blue_wordpress_18dp
             ImageType.THEME -> R.drawable.theme_loading
-            ImageType.FULLSCREEN_PHOTO -> null // manually handled in the view
             ImageType.UNKNOWN -> R.drawable.legacy_dashicon_format_image_big_grey
             ImageType.PLUGIN -> R.drawable.plugin_placeholder
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
@@ -8,7 +8,6 @@ enum class ImageType {
     BLAVATAR,
     PLAN,
     THEME,
-    FULLSCREEN_PHOTO,
     UNKNOWN,
     PLUGIN
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/getters/WPCustomImageGetter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/getters/WPCustomImageGetter.kt
@@ -76,7 +76,7 @@ class WPCustomImageGetter(
 
         return textView.get()?.let {
             val target = WPRemoteResourceViewTarget(it, maxWidth)
-            imageManager.load(target, ImageType.UNKNOWN, source)
+            imageManager.loadIntoCustomTarget(target, ImageType.UNKNOWN, source)
             targets.add(target)
 
             target.drawable


### PR DESCRIPTION
Fixes #8137 

Replaces Volley with Glide in the ReaderPhotoView -> adds support for animated gif images.

I've also done some refactoring of the ImageManager class as part of this PR (it's in a separate commit), however if you prefer to do the refactoring in another PR, just let me know;). Thanks!

To test:
1. Go to Reader
2. Open a post with an image
3. Click on the image
4. Make sure the images is correctly loaded
_____________________________________________________
1. Do steps 1-4 for a gif image and make sure it's being animated

Note: You might want to test this on an emulator and set network type to Edge. So you can see both lowResolution image and the highResolution image.