### PR TITLE
Fix crash on device rotation while scrolling in the media library

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -189,6 +189,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             holder.mFileTypeView.setText(fileExtension.toUpperCase(Locale.ROOT));
             int placeholderResId = WPMediaUtils.getPlaceholder(fileName);
             holder.mFileTypeImageView.setImageResource(placeholderResId);
+            mImageManager.cancelRequestAndClearImageView(holder.mImageView);
         }
         holder.mImageView.setContentDescription(mContext.getString(R.string.media_grid_item_image_desc,
                 StringUtils.notNullStr(media.getFileName())));
@@ -252,7 +253,6 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
     public void onViewRecycled(GridViewHolder holder) {
         super.onViewRecycled(holder);
         holder.mImageView.setTag(R.id.media_grid_file_path_id, null);
-        mImageManager.cancelRequestAndClearImageView(holder.mImageView);
     }
 
     public ArrayList<Integer> getSelectedItems() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -433,7 +433,6 @@ public class PeopleListFragment extends Fragment {
         @Override public void onViewRecycled(@NonNull ViewHolder holder) {
             super.onViewRecycled(holder);
             PeopleViewHolder peopleViewHolder = (PeopleViewHolder) holder;
-            mImageManager.cancelRequestAndClearImageView(peopleViewHolder.mImgAvatar);
         }
 
         public class PeopleViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {


### PR DESCRIPTION
Fixes #8139 

Fixes crash when the app occasionally crashes when I "rotate device/add image to a post" while scrolling in the media library.
The onViewRecycled method is called after the parent activity is destroyed -> I've just removed optimization which tried to cancel any pending requests and clear any resources asap. However, it'll be automatically cleared when the view is detached from its parent or when another load in the `onBindViewHolder` method is started.

To test - this crash occurs just from time to time, so it's quite difficult to test it. However, since we just removed an optimization, I think manual test is not really necessary.

1. Create a new post
2.Add media -> WordPress media library
3. Scroll and rotate your device at the same time

