### PR TITLE
Search in Properly Placed Pages

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -157,8 +157,8 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.6.1'
     testImplementation 'org.robolectric:shadows-multidex:3.6.1'
-    testImplementation 'org.mockito:mockito-core:2.8.9'
-    testImplementation 'com.nhaarman:mockito-kotlin:1.5.0'
+    testImplementation 'org.mockito:mockito-core:2.20.1'
+    testImplementation 'com.nhaarman:mockito-kotlin:1.6.0'
 
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.0'
     androidTestImplementation 'org.objenesis:objenesis:2.1'

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -159,6 +159,7 @@ dependencies {
     testImplementation 'org.robolectric:shadows-multidex:3.6.1'
     testImplementation 'org.mockito:mockito-core:2.20.1'
     testImplementation 'com.nhaarman:mockito-kotlin:1.6.0'
+    testImplementation 'org.assertj:assertj-core:2.9.1'
 
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.0'
     androidTestImplementation 'org.objenesis:objenesis:2.1'

--- a/WordPress/src/main/java/org/wordpress/android/networking/PageStore.kt
+++ b/WordPress/src/main/java/org/wordpress/android/networking/PageStore.kt
@@ -4,14 +4,14 @@ import kotlinx.coroutines.experimental.CommonPool
 import kotlinx.coroutines.experimental.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import org.wordpress.android.fluxc.store.PostStore
-import org.wordpress.android.models.pages.PageModel
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.PostAction
 import org.wordpress.android.fluxc.generated.PostActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
+import org.wordpress.android.models.pages.PageModel
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.experimental.Continuation
@@ -23,6 +23,12 @@ class PageStore @Inject constructor(private val postStore: PostStore, private va
 
     init {
         dispatcher.register(this)
+    }
+
+    suspend fun search(site: SiteModel, searchQuery: String): List<PageModel> = withContext(CommonPool) {
+        postStore.getPagesForSite(site)
+                .filter { it != null && it.title.toLowerCase().contains(searchQuery.toLowerCase()) }
+                .map { PageModel(it) }
     }
 
     suspend fun loadPagesFromDb(site: SiteModel): List<PageModel> = withContext(CommonPool) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
@@ -14,7 +14,7 @@ sealed class PageItem(val type: Type) {
         val enabledActions: Set<Action> = setOf()
     ) : PageItem(PAGE)
 
-    data class Divider(val id: Long, val title: String) : PageItem(DIVIDER)
+    data class Divider(val id: Long, val title: Int) : PageItem(DIVIDER)
 
     data class Empty(val textResource: Int? = null) : PageItem(EMPTY)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
@@ -14,7 +14,7 @@ sealed class PageItem(val type: Type) {
         val enabledActions: Set<Action> = setOf()
     ) : PageItem(PAGE)
 
-    data class Divider(val id: Long, val title: Int) : PageItem(DIVIDER)
+    data class Divider(val title: Int) : PageItem(DIVIDER)
 
     data class Empty(val textResource: Int? = null) : PageItem(EMPTY)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
@@ -66,7 +66,7 @@ sealed class PageItemViewHolder(internal val parent: ViewGroup, @LayoutRes layou
         private val dividerTitle = itemView.findViewById<TextView>(id.divider_text)
         override fun onBind(pageItem: PageItem) {
             (pageItem as Divider).apply {
-                dividerTitle.text = pageItem.title
+                dividerTitle.text = dividerTitle.resources.getText(pageItem.title)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesAdapter.kt
@@ -44,7 +44,7 @@ class PagesAdapter(private val onAction: (PageItem.Action, PageItem) -> Boolean)
             val newItem = result[newItemPosition]
             return oldItem.type == newItem.type && when (oldItem) {
                 is Page -> oldItem.id == (newItem as Page).id
-                is Divider -> oldItem.id == (newItem as Divider).id
+                is Divider -> oldItem == (newItem as Divider)
                 else -> false
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -103,12 +103,14 @@ class PagesFragment : Fragment() {
 
         val searchView = actionMenuItem.actionView as SearchView
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
-            override fun onQueryTextSubmit(query: String?): Boolean {
-                return viewModel.onSearchTextSubmit(query)
+            override fun onQueryTextSubmit(query: String): Boolean {
+                viewModel.onSearch(query)
+                return true
             }
 
-            override fun onQueryTextChange(newText: String?): Boolean {
-                return viewModel.onSearchTextChange(newText)
+            override fun onQueryTextChange(newText: String): Boolean {
+                viewModel.onSearch(newText)
+                return true
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -82,9 +82,15 @@ class PagesViewModel
     }
 
     fun onSearchTextChange(query: String?): Boolean {
-        if (!query.isNullOrEmpty()) {
-            val listOf = mockResult(query)
-            _searchResult.postValue(listOf)
+        if (query != null && query.isNotEmpty()) {
+            launch {
+                val result = pageStore.search(site, query).map { Page(it.pageId.toLong(), it.title, null) }
+                if (result.isNotEmpty()) {
+                    _searchResult.postValue(result)
+                } else {
+                    _searchResult.postValue(listOf(Empty(string.pages_empty_search_result)))
+                }
+            }
         } else {
             clearSearch()
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -88,7 +88,7 @@ class PagesViewModel
                 if (isActive) {
                     val result = pageStore.groupedSearch(site, searchQuery)
                             .map { (status, results) ->
-                                listOf(Divider(1, status.toResource())) +
+                                listOf(Divider(status.toResource())) +
                                         results.map { Page(it.pageId.toLong(), it.title, null) }
                             }
                             .fold(mutableListOf()) { acc: MutableList<PageItem>, list: List<PageItem> ->

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -69,7 +69,8 @@ class PagesViewModel
                     query = searchQuery
                     delay(200)
                     if (query == searchQuery) {
-                        val result = pageStore.search(site, searchQuery).map { Page(it.pageId.toLong(), it.title, null) }
+                        val result = pageStore.search(site, searchQuery)
+                                .map { Page(it.pageId.toLong(), it.title, null) }
                         if (result.isNotEmpty()) {
                             _searchResult.postValue(result)
                         } else {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2231,4 +2231,5 @@
     <string name="pages_publish_now">Publish Now</string>
     <string name="pages_move_to_draft">Move to Draft</string>
     <string name="pages_move_to_trash">Move to Trash</string>
+    <string name="pages_empty_search_result">No pages matching search query</string>
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/networking/PageStoreTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/networking/PageStoreTest.kt
@@ -1,0 +1,56 @@
+package org.wordpress.android.networking
+
+import com.nhaarman.mockito_kotlin.whenever
+import junit.framework.Assert.assertEquals
+import kotlinx.coroutines.experimental.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.PostStore
+
+@RunWith(MockitoJUnitRunner::class)
+class PageStoreTest {
+    @Mock lateinit var postStore: PostStore
+    @Mock lateinit var dispatcher: Dispatcher
+    @Mock lateinit var site: SiteModel
+    private val pageWithoutQuery = PostModel()
+    private val pageWithQuery = PostModel()
+    private val pageWithoutTitle = PostModel()
+    private lateinit var store: PageStore
+
+    private val query = "que"
+
+    @Before
+    fun setUp() {
+        pageWithoutQuery.title = "page 1"
+        pageWithQuery.title = "page2 start $query end "
+        val pages = listOf(pageWithoutQuery, pageWithQuery, pageWithoutTitle)
+        whenever(postStore.getPagesForSite(site)).thenReturn(pages)
+        store = PageStore(postStore, dispatcher)
+    }
+
+    @Test
+    fun searchFindsAllResultsContainingText() {
+        val result = runBlocking {
+            store.search(site, query)
+        }
+
+        assertEquals(result.size, 1)
+        assertEquals(result[0].title, pageWithQuery.title)
+    }
+
+
+    @Test
+    fun emptySearchResultWhenNothingContainsQuery() {
+        val result = runBlocking {
+            store.search(site, "foo")
+        }
+
+        assertEquals(result.size, 0)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/networking/PageStoreTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/networking/PageStoreTest.kt
@@ -1,7 +1,10 @@
 package org.wordpress.android.networking
 
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import junit.framework.Assert.assertEquals
+import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.runBlocking
 import org.junit.Before
 import org.junit.Test
@@ -9,26 +12,41 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.PostAction.FETCH_PAGES
+import org.wordpress.android.fluxc.generated.PostActionBuilder
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload
+import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
 
 @RunWith(MockitoJUnitRunner::class)
 class PageStoreTest {
     @Mock lateinit var postStore: PostStore
     @Mock lateinit var dispatcher: Dispatcher
     @Mock lateinit var site: SiteModel
-    private val pageWithoutQuery = PostModel()
-    private val pageWithQuery = PostModel()
-    private val pageWithoutTitle = PostModel()
-    private lateinit var store: PageStore
 
     private val query = "que"
+    private val pageWithoutQuery = initPage(1, 10, "page 1")
+    private val pageWithQuery = initPage(2, title = "page2 start $query end ")
+    private val pageWithoutTitle = initPage(3, 10)
+
+    private fun initPage(id: Int, parentId: Long? = null, title: String? = null): PostModel {
+        val page = PostModel()
+        page.id = id
+        parentId?.let {
+            page.parentId = parentId
+        }
+        title?.let {
+            page.title = it
+        }
+        page.status = "DRAFT"
+        return page
+    }
+    private lateinit var store: PageStore
 
     @Before
     fun setUp() {
-        pageWithoutQuery.title = "page 1"
-        pageWithQuery.title = "page2 start $query end "
         val pages = listOf(pageWithoutQuery, pageWithQuery, pageWithoutTitle)
         whenever(postStore.getPagesForSite(site)).thenReturn(pages)
         store = PageStore(postStore, dispatcher)
@@ -36,9 +54,7 @@ class PageStoreTest {
 
     @Test
     fun searchFindsAllResultsContainingText() {
-        val result = runBlocking {
-            store.search(site, query)
-        }
+        val result = runBlocking { store.search(site, query) }
 
         assertEquals(result.size, 1)
         assertEquals(result[0].title, pageWithQuery.title)
@@ -47,10 +63,36 @@ class PageStoreTest {
 
     @Test
     fun emptySearchResultWhenNothingContainsQuery() {
-        val result = runBlocking {
-            store.search(site, "foo")
-        }
+        val result = runBlocking { store.search(site, "foo") }
 
         assertEquals(result.size, 0)
+    }
+
+    @Test
+    fun loadsPagesFromDb() {
+        val pages = runBlocking { store.loadPagesFromDb(site) }
+
+        assertEquals(pages.size, 3)
+        assertEquals(pages[0].pageId, pageWithoutQuery.id)
+        assertEquals(pages[0].parentId, pageWithoutQuery.parentId)
+        assertEquals(pages[1].pageId, pageWithQuery.id)
+        assertEquals(pages[1].parentId, pageWithQuery.parentId)
+        assertEquals(pages[2].pageId, pageWithoutTitle.id)
+        assertEquals(pages[2].parentId, pageWithoutTitle.parentId)
+    }
+
+    @Test
+    fun requestPagesFetchesFromServerAndReturnsEvent() {
+        val expected = OnPostChanged(5, true)
+        expected.causeOfChange = FETCH_PAGES
+        val async = async { store.requestPagesFromServer(site, true) }
+
+        val result = runBlocking {
+            store.onPostChanged(expected)
+            async.await()
+        }
+
+        assertEquals(expected, result)
+        verify(dispatcher).dispatch(eq(PostActionBuilder.newFetchPagesAction(FetchPostsPayload(site, true))))
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/networking/PageStoreTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/networking/PageStoreTest.kt
@@ -60,7 +60,6 @@ class PageStoreTest {
         assertEquals(result[0].title, pageWithQuery.title)
     }
 
-
     @Test
     fun emptySearchResultWhenNothingContainsQuery() {
         val result = runBlocking { store.search(site, "foo") }

--- a/WordPress/src/test/java/org/wordpress/android/networking/PageStoreTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/networking/PageStoreTest.kt
@@ -1,11 +1,12 @@
 package org.wordpress.android.networking
 
-import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
-import junit.framework.Assert.assertEquals
-import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.experimental.delay
+import kotlinx.coroutines.experimental.launch
 import kotlinx.coroutines.experimental.runBlocking
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,12 +14,16 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.PostAction.FETCH_PAGES
-import org.wordpress.android.fluxc.generated.PostActionBuilder
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PostStore
-import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
+import org.wordpress.android.models.pages.PageModel
+import org.wordpress.android.models.pages.PageStatus
+import org.wordpress.android.models.pages.PageStatus.DRAFT
+import org.wordpress.android.models.pages.PageStatus.PUBLISHED
+import org.wordpress.android.models.pages.PageStatus.SCHEDULED
+import org.wordpress.android.models.pages.PageStatus.TRASHED
 
 @RunWith(MockitoJUnitRunner::class)
 class PageStoreTest {
@@ -31,18 +36,6 @@ class PageStoreTest {
     private val pageWithQuery = initPage(2, title = "page2 start $query end ")
     private val pageWithoutTitle = initPage(3, 10)
 
-    private fun initPage(id: Int, parentId: Long? = null, title: String? = null): PostModel {
-        val page = PostModel()
-        page.id = id
-        parentId?.let {
-            page.parentId = parentId
-        }
-        title?.let {
-            page.title = it
-        }
-        page.status = "DRAFT"
-        return page
-    }
     private lateinit var store: PageStore
 
     @Before
@@ -56,42 +49,119 @@ class PageStoreTest {
     fun searchFindsAllResultsContainingText() {
         val result = runBlocking { store.search(site, query) }
 
-        assertEquals(result.size, 1)
-        assertEquals(result[0].title, pageWithQuery.title)
+        assertThat(result).hasSize(1)
+        assertThat(result[0].title).isEqualTo(pageWithQuery.title)
+    }
+
+    @Test
+    fun searchFilitersOutUnknownStatus() {
+        whenever(postStore.getPagesForSite(site)).thenReturn(listOf(initPage(1, title = query, status = "foo")))
+
+        val result = runBlocking { store.search(site, query) }
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun searchOrdersResultsByStatus() {
+        val trashStatus = "trash"
+        val draftStatus = "draft"
+        val publishStatus = "publish"
+        val futureStatus = "future"
+        val title = "title"
+        val trashedSite1 = initPage(1, title = title, status = trashStatus)
+        val draftSite1 = initPage(2, title = title, status = draftStatus)
+        val publishedSite1 = initPage(3, title = title, status = publishStatus)
+        val scheduledSite1 = initPage(4, title = title, status = futureStatus)
+        val scheduledSite2 = initPage(5, title = title, status = futureStatus)
+        val publishedSite2 = initPage(6, title = title, status = publishStatus)
+        val draftSite2 = initPage(7, title = title, status = draftStatus)
+        val trashedSite2 = initPage(8, title = title, status = trashStatus)
+        val pages = listOf(
+                trashedSite1,
+                draftSite1,
+                publishedSite1,
+                scheduledSite1,
+                scheduledSite2,
+                publishedSite2,
+                draftSite2,
+                trashedSite2
+        )
+        whenever(postStore.getPagesForSite(site)).thenReturn(pages)
+
+        val result = runBlocking { store.groupedSearch(site, title) }
+
+        assertThat(result.keys).contains(PUBLISHED, DRAFT, SCHEDULED, TRASHED)
+        assertPage(result, 0, 3, PageStatus.PUBLISHED)
+        assertPage(result, 1, 6, PageStatus.PUBLISHED)
+        assertPage(result, 0, 2, PageStatus.DRAFT)
+        assertPage(result, 1, 7, PageStatus.DRAFT)
+        assertPage(result, 0, 4, PageStatus.SCHEDULED)
+        assertPage(result, 1, 5, PageStatus.SCHEDULED)
+        assertPage(result, 0, 1, PageStatus.TRASHED)
+        assertPage(result, 1, 8, PageStatus.TRASHED)
+    }
+
+    private fun assertPage(map: Map<PageStatus, List<PageModel>>, position: Int, id: Int, status: PageStatus) {
+        val page = map[status]?.get(position)
+        assertThat(page).isNotNull()
+        assertThat(page!!.pageId).isEqualTo(id)
+        assertThat(page.status).isEqualTo(status)
     }
 
     @Test
     fun emptySearchResultWhenNothingContainsQuery() {
         val result = runBlocking { store.search(site, "foo") }
 
-        assertEquals(result.size, 0)
+        assertThat(result).isEmpty()
     }
 
     @Test
     fun loadsPagesFromDb() {
         val pages = runBlocking { store.loadPagesFromDb(site) }
 
-        assertEquals(pages.size, 3)
-        assertEquals(pages[0].pageId, pageWithoutQuery.id)
-        assertEquals(pages[0].parentId, pageWithoutQuery.parentId)
-        assertEquals(pages[1].pageId, pageWithQuery.id)
-        assertEquals(pages[1].parentId, pageWithQuery.parentId)
-        assertEquals(pages[2].pageId, pageWithoutTitle.id)
-        assertEquals(pages[2].parentId, pageWithoutTitle.parentId)
+        assertThat(pages).hasSize(3)
+        assertThat(pages[0].pageId).isEqualTo(pageWithoutQuery.id)
+        assertThat(pages[0].parentId).isEqualTo(pageWithoutQuery.parentId)
+        assertThat(pages[1].pageId).isEqualTo(pageWithQuery.id)
+        assertThat(pages[1].parentId).isEqualTo(pageWithQuery.parentId)
+        assertThat(pages[2].pageId).isEqualTo(pageWithoutTitle.id)
+        assertThat(pages[2].parentId).isEqualTo(pageWithoutTitle.parentId)
     }
 
     @Test
-    fun requestPagesFetchesFromServerAndReturnsEvent() {
+    fun requestPagesFetchesFromServerAndReturnsEvent() = runBlocking {
         val expected = OnPostChanged(5, true)
         expected.causeOfChange = FETCH_PAGES
-        val async = async { store.requestPagesFromServer(site, true) }
-
-        val result = runBlocking {
-            store.onPostChanged(expected)
-            async.await()
+        var event: OnPostChanged? = null
+        val job = launch(kotlin.coroutines.experimental.coroutineContext) {
+            event = store.requestPagesFromServer(site, true)
         }
+        delay(10)
+        store.onPostChanged(expected)
+        job.join()
 
-        assertEquals(expected, result)
-        verify(dispatcher).dispatch(eq(PostActionBuilder.newFetchPagesAction(FetchPostsPayload(site, true))))
+        assertThat(expected).isEqualTo(event)
+        verify(dispatcher).dispatch(any())
+    }
+
+    private fun initPage(
+        id: Int,
+        parentId: Long? = null,
+        title: String? = null,
+        status: String? = "draft"
+    ): PostModel {
+        val page = PostModel()
+        page.id = id
+        parentId?.let {
+            page.parentId = parentId
+        }
+        title?.let {
+            page.title = it
+        }
+        status?.let {
+            page.status = status
+        }
+        return page
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/LiveDataUtils.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/LiveDataUtils.kt
@@ -1,0 +1,78 @@
+package org.wordpress.android.viewmodel
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.Observer
+import kotlinx.coroutines.experimental.CommonPool
+import kotlinx.coroutines.experimental.delay
+import kotlinx.coroutines.experimental.launch
+import java.util.concurrent.TimeoutException
+import kotlin.coroutines.experimental.Continuation
+import kotlin.coroutines.experimental.suspendCoroutine
+
+fun <T> LiveData<T>.test(): TestObserver<T> {
+    val mutableLiveData = MutableLiveData<T>()
+    this.observeForever { mutableLiveData.postValue(it) }
+    mutableLiveData.value = null
+    val observer = TestObserver<T>()
+    mutableLiveData.observeForever(observer)
+    return observer
+}
+
+class TestObserver<T> : Observer<T> {
+    private val values = mutableListOf<T?>()
+    private var requiredItemCount: Int = -1
+    private var continuation: Continuation<List<T>>? = null
+    private var nullableContinuation: Continuation<List<T?>>? = null
+    override fun onChanged(t: T?) {
+        values.add(t)
+        if (values.size >= requiredItemCount) {
+            nullableContinuation?.resume(values.toList())
+            nullableContinuation = null
+        }
+        if (t != null) {
+            val nonNullValues = nonNullValues()
+            if (nonNullValues.size >= requiredItemCount) {
+                continuation?.resume(nonNullValues)
+                continuation = null
+            }
+        }
+    }
+
+    suspend fun await(timeout: Int = 1000): T {
+        return awaitValues(1, timeout)[0]
+    }
+
+    suspend fun awaitValues(count: Int, timeout: Int = 1000) = suspendCoroutine<List<T>> {
+        requiredItemCount = count
+        continuation = it
+        launch(CommonPool) {
+            delay(timeout)
+            continuation?.resumeWithException(TimeoutException())
+            continuation = null
+        }
+        val nonNullValues = nonNullValues()
+        if (nonNullValues.size >= count) {
+            it.resume(nonNullValues)
+            continuation = null
+        }
+    }
+
+    suspend fun awaitNullableValues(count: Int, timeout: Int = 1000) = suspendCoroutine<List<T?>> {
+        requiredItemCount = count
+        continuation = it
+        launch(CommonPool) {
+            delay(timeout)
+            nullableContinuation?.resumeWithException(TimeoutException())
+            nullableContinuation = null
+        }
+        if (values.size >= count) {
+            it.resume(values)
+            continuation = null
+        }
+    }
+
+    private fun nonNullValues(): List<T> {
+        return values.filter { it != null }.map { it!! }
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/LiveDataUtils.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/LiveDataUtils.kt
@@ -19,6 +19,13 @@ fun <T> LiveData<T>.test(): TestObserver<T> {
     return observer
 }
 
+fun <T> LiveData<T>.start(): LiveData<T> {
+    val mutableLiveData = MutableLiveData<T>()
+    this.observeForever { mutableLiveData.postValue(it) }
+    mutableLiveData.value = null
+    return mutableLiveData
+}
+
 class TestObserver<T> : Observer<T> {
     private val values = mutableListOf<T?>()
     private var requiredItemCount: Int = -1

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -1,0 +1,108 @@
+package org.wordpress.android.viewmodel.pages
+
+import android.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.whenever
+import junit.framework.Assert.assertEquals
+import kotlinx.coroutines.experimental.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.R.string
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
+import org.wordpress.android.models.pages.PageModel
+import org.wordpress.android.models.pages.PageStatus.DRAFT
+import org.wordpress.android.networking.PageStore
+import org.wordpress.android.ui.pages.PageItem
+import org.wordpress.android.ui.pages.PageItem.Empty
+import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState.DONE
+import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState.FETCHING
+import org.wordpress.android.viewmodel.test
+
+@RunWith(MockitoJUnitRunner::class)
+class PagesViewModelTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    @Mock lateinit var pageStore: PageStore
+    @Mock lateinit var site: SiteModel
+    private lateinit var viewModel: PagesViewModel
+    @Before
+    fun setUp() {
+        viewModel = PagesViewModel(pageStore)
+    }
+
+    @Test
+    fun loadsDataOnStart() = runBlocking<Unit> {
+        whenever(pageStore.loadPagesFromDb(site)).thenReturn(listOf(PageModel(1, "title", DRAFT, -1)))
+        whenever(pageStore.requestPagesFromServer(any(), any())).thenReturn(OnPostChanged(1, false))
+        val listStateObserver = viewModel.listState.test()
+        val refreshPagesObserver = viewModel.refreshPages.test()
+
+        viewModel.start(site)
+
+        val listStates = listStateObserver.awaitValues(2)
+
+        assertEquals(FETCHING, listStates[0])
+        assertEquals(DONE, listStates[1])
+        refreshPagesObserver.awaitNullableValues(2)
+    }
+
+    @Test
+    fun onSearchReturnsResultsFromStore() = runBlocking {
+        initSearch()
+        val query = "query"
+        val expectedResult = listOf(PageModel(1, "title", DRAFT, -1))
+        val pageItems = expectedResult.map { PageItem.Page(it.pageId.toLong(),  it.title, null) }
+        whenever(pageStore.search(site, query)).thenReturn(expectedResult)
+
+        val observer = viewModel.searchResult.test()
+
+        viewModel.onSearch(query)
+
+        val searchResult = observer.await()
+
+        assertEquals(pageItems, searchResult)
+    }
+
+    @Test
+    fun onEmptySearchResultEmitsEmptyItem() = runBlocking {
+        initSearch()
+        val query = "query"
+        val pageItems = listOf(Empty(string.pages_empty_search_result))
+        whenever(pageStore.search(site, query)).thenReturn(listOf())
+
+        val data = viewModel.searchResult.test()
+
+        viewModel.onSearch(query)
+
+        val result = data.await()
+
+        assertEquals(pageItems, result)
+    }
+
+    @Test
+    fun onEmptyQueryClearsSearch() = runBlocking {
+        initSearch()
+        val query = ""
+        val pageItems = listOf(Empty(string.empty_list_default))
+
+        val data = viewModel.searchResult.test()
+
+        viewModel.onSearch(query)
+
+        val result = data.await()
+
+        assertEquals(pageItems, result)
+    }
+
+    private suspend fun initSearch() {
+        whenever(pageStore.loadPagesFromDb(site)).thenReturn(listOf())
+        whenever(pageStore.requestPagesFromServer(any(), any())).thenReturn(OnPostChanged(0, false))
+        viewModel.start(site)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.models.pages.PageModel
 import org.wordpress.android.models.pages.PageStatus.DRAFT
 import org.wordpress.android.networking.PageStore
 import org.wordpress.android.ui.pages.PageItem
+import org.wordpress.android.ui.pages.PageItem.Divider
 import org.wordpress.android.ui.pages.PageItem.Empty
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState.DONE
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState.FETCHING
@@ -59,9 +60,10 @@ class PagesViewModelTest {
     fun onSearchReturnsResultsFromStore() = runBlocking<Unit> {
         initSearch()
         val query = "query"
-        val expectedResult = listOf(PageModel(1, "title", DRAFT, -1))
-        val pageItems = expectedResult.map { PageItem.Page(it.pageId.toLong(), it.title, null) }
-        whenever(pageStore.search(site, query)).thenReturn(expectedResult)
+        val title = "title"
+        val drafts = listOf(PageModel(1, title, DRAFT, -1))
+        val expectedResult = listOf(Divider(string.pages_drafts), PageItem.Page(1, title, null))
+        whenever(pageStore.groupedSearch(site, query)).thenReturn(sortedMapOf(DRAFT to drafts))
 
         val observer = viewModel.searchResult.test()
 
@@ -69,7 +71,7 @@ class PagesViewModelTest {
 
         val result = observer.await()
 
-        assertThat(result).isEqualTo(pageItems)
+        assertThat(result).isEqualTo(expectedResult)
     }
 
     @Test
@@ -77,7 +79,7 @@ class PagesViewModelTest {
         initSearch()
         val query = "query"
         val pageItems = listOf(Empty(string.pages_empty_search_result))
-        whenever(pageStore.search(site, query)).thenReturn(listOf())
+        whenever(pageStore.groupedSearch(site, query)).thenReturn(sortedMapOf())
 
         val data = viewModel.searchResult.test()
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.whenever
 import junit.framework.Assert.assertEquals
 import kotlinx.coroutines.experimental.runBlocking
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -50,13 +51,12 @@ class PagesViewModelTest {
 
         val listStates = listStateObserver.awaitValues(2)
 
-        assertEquals(FETCHING, listStates[0])
-        assertEquals(DONE, listStates[1])
+        assertThat(listStates).containsExactly(FETCHING, DONE)
         refreshPagesObserver.awaitNullableValues(2)
     }
 
     @Test
-    fun onSearchReturnsResultsFromStore() = runBlocking {
+    fun onSearchReturnsResultsFromStore() = runBlocking<Unit> {
         initSearch()
         val query = "query"
         val expectedResult = listOf(PageModel(1, "title", DRAFT, -1))
@@ -67,13 +67,13 @@ class PagesViewModelTest {
 
         viewModel.onSearch(query)
 
-        val searchResult = observer.await()
+        val result = observer.await()
 
-        assertEquals(pageItems, searchResult)
+        assertThat(result).isEqualTo(pageItems)
     }
 
     @Test
-    fun onEmptySearchResultEmitsEmptyItem() = runBlocking {
+    fun onEmptySearchResultEmitsEmptyItem() = runBlocking<Unit> {
         initSearch()
         val query = "query"
         val pageItems = listOf(Empty(string.pages_empty_search_result))
@@ -85,11 +85,11 @@ class PagesViewModelTest {
 
         val result = data.await()
 
-        assertEquals(pageItems, result)
+        assertThat(result).isEqualTo(pageItems)
     }
 
     @Test
-    fun onEmptyQueryClearsSearch() = runBlocking {
+    fun onEmptyQueryClearsSearch() = runBlocking<Unit> {
         initSearch()
         val query = ""
         val pageItems = listOf(Empty(string.empty_list_default))
@@ -100,7 +100,7 @@ class PagesViewModelTest {
 
         val result = data.await()
 
-        assertEquals(pageItems, result)
+        assertThat(result).isEqualTo(pageItems)
     }
 
     private suspend fun initSearch() {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -60,7 +60,7 @@ class PagesViewModelTest {
         initSearch()
         val query = "query"
         val expectedResult = listOf(PageModel(1, "title", DRAFT, -1))
-        val pageItems = expectedResult.map { PageItem.Page(it.pageId.toLong(),  it.title, null) }
+        val pageItems = expectedResult.map { PageItem.Page(it.pageId.toLong(), it.title, null) }
         whenever(pageStore.search(site, query)).thenReturn(expectedResult)
 
         val observer = viewModel.searchResult.test()

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -37,13 +37,16 @@ class PagesViewModelTest {
     }
 
     @Test
-    fun loadsDataOnStart() = runBlocking<Unit> {
+    fun clearsResultAndLoadsDataOnStart() = runBlocking<Unit> {
         whenever(pageStore.loadPagesFromDb(site)).thenReturn(listOf(PageModel(1, "title", DRAFT, -1)))
         whenever(pageStore.requestPagesFromServer(any(), any())).thenReturn(OnPostChanged(1, false))
         val listStateObserver = viewModel.listState.test()
         val refreshPagesObserver = viewModel.refreshPages.test()
+        val searchResultObserver = viewModel.searchResult.test()
 
         viewModel.start(site)
+
+        assertEquals(searchResultObserver.await(), listOf(Empty(string.empty_list_default)))
 
         val listStates = listStateObserver.awaitValues(2)
 


### PR DESCRIPTION
Add search functionality to Properly Placed Pages. Search is implemented in code in PageStore. I assume we might have an endpoint in future that hits directly API. 

I've added some tests for Search (PagesViewModel, PageStore). Testing coroutines has been non-trivial, I'm planning to write a post about it. 

I had to bump mockito version in order to test coroutines.
