### PR TITLE
Favor the feedId when previewing a site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -96,7 +96,7 @@ public class ReaderActivityLauncher {
         AnalyticsTracker.track(AnalyticsTracker.Stat.READER_BLOG_PREVIEWED);
         Intent intent = new Intent(context, ReaderPostListActivity.class);
 
-        if (siteId == 0) {
+        if (feedId != 0) {
             intent.putExtra(ReaderConstants.ARG_FEED_ID, feedId);
             intent.putExtra(ReaderConstants.ARG_IS_FEED, true);
         } else {


### PR DESCRIPTION
Fixes #7972 - previously tapping the title of a non-wp site in the reader would show either the wrong posts or no posts at all. This simple PR corrects this by favoring the feedId when previewing a site (which works with both wp and non-wp sites).

To test:
- Follow a feed such as https://www.nasa.gov/rss/dyn/breaking_news.rss
- Locate a post from that feed and tap its title (or find that feed in the reader settings and tap it's title)
- Notice that the correct posts are shown