### PR TITLE
Changed logout confirmation to account for local changes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -345,7 +345,8 @@ public class MeFragment extends Fragment implements MainToolbarFragment {
         int numChanges = PostStore.getNumLocalChanges();
         String message;
         if (numChanges > 0) {
-            message = getResources().getQuantityString(R.plurals.sign_out_wpcom_confirm_with_changes, numChanges, numChanges);
+            message = getResources().getQuantityString(R.plurals.sign_out_wpcom_confirm_with_changes,
+                    numChanges, numChanges);
         } else {
             message = getString(R.string.sign_out_wpcom_confirm_with_no_changes);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -345,7 +345,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment {
         int numChanges = PostStore.getNumLocalChanges();
         String message;
         if (numChanges > 0) {
-            message = String.format(getString(R.string.sign_out_wpcom_confirm_with_changes), numChanges);
+            message = getResources().getQuantityString(R.plurals.sign_out_wpcom_confirm_with_changes, numChanges, numChanges);
         } else {
             message = getString(R.string.sign_out_wpcom_confirm_with_no_changes);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -36,6 +36,7 @@ import org.wordpress.android.fluxc.model.AccountModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
+import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.networking.GravatarApi;
 import org.wordpress.android.ui.ActivityLauncher;
@@ -339,8 +340,15 @@ public class MeFragment extends Fragment implements MainToolbarFragment {
     }
 
     private void signOutWordPressComWithConfirmation() {
-        String message = String.format(getString(R.string.sign_out_wpcom_confirm),
-                                       mAccountStore.getAccount().getUserName());
+        // if there are local changes we need to let the user know they'll be lost if they logout, otherwise
+        // we use a simpler (less scary!) confirmation
+        int numChanges = PostStore.getNumLocalChanges();
+        String message;
+        if (numChanges > 0) {
+            message = String.format(getString(R.string.sign_out_wpcom_confirm_with_changes), numChanges);
+        } else {
+            message = getString(R.string.sign_out_wpcom_confirm_with_no_changes);
+        }
 
         new AlertDialog.Builder(new ContextThemeWrapper(getActivity(), R.style.Calypso_Dialog_Alert))
                 .setMessage(message)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -12,7 +12,10 @@
         this problem.</string>
     <string name="no_network_title">No network available</string>
     <string name="no_network_message">There is no network available</string>
-    <string name="sign_out_wpcom_confirm_with_changes">You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes from your device. Log out anyway?</string>
+    <plurals name="sign_out_wpcom_confirm_with_changes">
+        <item quantity="one">You have changes to one post that haven’t been uploaded to your site. Logging out now will delete those changes from your device. Log out anyway?</item>
+        <item quantity="other">You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes from your device. Log out anyway?</item>
+    </plurals>
     <string name="sign_out_wpcom_confirm_with_no_changes">Log out of WordPress?</string>
 
     <!-- form labels -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -12,7 +12,8 @@
         this problem.</string>
     <string name="no_network_title">No network available</string>
     <string name="no_network_message">There is no network available</string>
-    <string name="sign_out_wpcom_confirm">Logging out from your account will remove all of @%s’s WordPress.com data from this device, including local drafts and local changes.</string>
+    <string name="sign_out_wpcom_confirm_with_changes">You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes from your device. Log out anyway?</string>
+    <string name="sign_out_wpcom_confirm_with_no_changes">Log out of WordPress?</string>
 
     <!-- form labels -->
     <string name="select_categories">Select categories</string>


### PR DESCRIPTION
Fixes #7655 - changes the logout confirmation message to only warn about losing local changes if there actually _are_ local changes.

No changes:

![nochanges](https://user-images.githubusercontent.com/3903757/43639649-ead51794-96ea-11e8-855e-4cb4c8b543a2.png)

Changes:

![changes](https://user-images.githubusercontent.com/3903757/43639656-f05783be-96ea-11e8-94d1-f18f9f23b9a3.png)

