### PR TITLE
Hide Jetpack security pref for self-hosted (non-jp) sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1677,6 +1677,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_discussion);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_advanced);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_quota);
+        WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_jetpack_settings);
     }
 
     private void removeNonJetpackPreferences() {


### PR DESCRIPTION
Fixes #7539 - prior to this fix, non-Jetpack self-hosted sites would still show "Jetpack Settings" in site preferences.

To test:
- Add a non-Jetpack self-hosted site to the app and ensure the "Jetpack Settings" section doesn't appear
- Switch to a Jetpack site and ensure the "Jetpack Settings" section **does** appear