### PR TITLE
Remove the plurals version of the logout message

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -342,11 +342,9 @@ public class MeFragment extends Fragment implements MainToolbarFragment {
     private void signOutWordPressComWithConfirmation() {
         // if there are local changes we need to let the user know they'll be lost if they logout, otherwise
         // we use a simpler (less scary!) confirmation
-        int numChanges = PostStore.getNumLocalChanges();
         String message;
-        if (numChanges > 0) {
-            message = getResources().getQuantityString(R.plurals.sign_out_wpcom_confirm_with_changes,
-                    numChanges, numChanges);
+        if (PostStore.getNumLocalChanges() > 0) {
+            message = getString(R.string.sign_out_wpcom_confirm_with_changes);
         } else {
             message = getString(R.string.sign_out_wpcom_confirm_with_no_changes);
         }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -12,10 +12,7 @@
         this problem.</string>
     <string name="no_network_title">No network available</string>
     <string name="no_network_message">There is no network available</string>
-    <plurals name="sign_out_wpcom_confirm_with_changes">
-        <item quantity="one">You have changes to one post that haven’t been uploaded to your site. Logging out now will delete those changes from your device. Log out anyway?</item>
-        <item quantity="other">You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes from your device. Log out anyway?</item>
-    </plurals>
+    <string name="sign_out_wpcom_confirm_with_changes">You have changes to posts that haven’t been uploaded to your site. Logging out now will delete those changes from your device. Log out anyway?</string>
     <string name="sign_out_wpcom_confirm_with_no_changes">Log out of WordPress?</string>
 
     <!-- form labels -->


### PR DESCRIPTION
Replaces the `plurals` version of the logout confirmation message with one that works for any changes. This was necessary since Glotpress doesn't support `plurals`.

![screenshot_1533320124](https://user-images.githubusercontent.com/3903757/43659038-c250f02a-9728-11e8-817a-a3af6adcae03.png)
