### PR TITLE
Zendesk: Adds new custom fields.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -35,6 +35,7 @@ import zendesk.support.UiConfig
 import zendesk.support.guide.HelpCenterActivity
 import zendesk.support.request.RequestActivity
 import zendesk.support.requestlist.RequestListActivity
+import java.util.Locale
 import java.util.Timer
 import kotlin.concurrent.schedule
 
@@ -367,7 +368,9 @@ private fun buildZendeskCustomFields(
             CustomField(TicketFieldIds.currentSite, currentSiteInformation),
             CustomField(TicketFieldIds.deviceFreeSpace, DeviceUtils.getTotalAvailableMemorySize()),
             CustomField(TicketFieldIds.logs, AppLog.toPlainText(context)),
-            CustomField(TicketFieldIds.networkInformation, getNetworkInformation(context))
+            CustomField(TicketFieldIds.networkInformation, getNetworkInformation(context)),
+            CustomField(TicketFieldIds.appLanguage, Locale.getDefault().getLanguage()),
+            CustomField(TicketFieldIds.sourcePlatform, ZendeskConstants.sourcePlatform)
     )
 }
 
@@ -475,6 +478,7 @@ private object ZendeskConstants {
     const val noneValue = "none"
     // We rely on this platform tag to filter tickets in Zendesk, so should be kept separate from the `articleLabel`
     const val platformTag = "Android"
+    const val sourcePlatform = "Mobile - Android"
     const val ticketSubject = "WordPress for Android Support"
     const val wpComTag = "wpcom"
     const val unknownValue = "unknown"
@@ -488,6 +492,8 @@ private object TicketFieldIds {
     const val logs = 22871957L
     const val networkInformation = 360000086966L
     const val currentSite = 360000103103L
+    const val appLanguage = 360008583691L
+    const val sourcePlatform = 25176023L
 }
 
 object ZendeskExtraTags {

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -37,6 +37,7 @@ import zendesk.support.request.RequestActivity
 import zendesk.support.requestlist.RequestListActivity
 import java.util.Locale
 import java.util.Timer
+import kotlin.collections.ArrayList
 import kotlin.concurrent.schedule
 
 private const val zendeskNeedsToBeEnabledError = "Zendesk needs to be setup before this method can be called"
@@ -478,7 +479,7 @@ private object ZendeskConstants {
     const val noneValue = "none"
     // We rely on this platform tag to filter tickets in Zendesk, so should be kept separate from the `articleLabel`
     const val platformTag = "Android"
-    const val sourcePlatform = "Mobile - Android"
+    const val sourcePlatform = "mobile_-_android"
     const val ticketSubject = "WordPress for Android Support"
     const val wpComTag = "wpcom"
     const val unknownValue = "unknown"
@@ -493,7 +494,7 @@ private object TicketFieldIds {
     const val networkInformation = 360000086966L
     const val currentSite = 360000103103L
     const val appLanguage = 360008583691L
-    const val sourcePlatform = 25176023L
+    const val sourcePlatform = 360009311651L
 }
 
 object ZendeskExtraTags {

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -370,7 +370,7 @@ private fun buildZendeskCustomFields(
             CustomField(TicketFieldIds.deviceFreeSpace, DeviceUtils.getTotalAvailableMemorySize()),
             CustomField(TicketFieldIds.logs, AppLog.toPlainText(context)),
             CustomField(TicketFieldIds.networkInformation, getNetworkInformation(context)),
-            CustomField(TicketFieldIds.appLanguage, Locale.getDefault().getLanguage()),
+            CustomField(TicketFieldIds.appLanguage, Locale.getDefault().language),
             CustomField(TicketFieldIds.sourcePlatform, ZendeskConstants.sourcePlatform)
     )
 }


### PR DESCRIPTION
Fixes #8129

Adds new fields to Zendesk tickets identifying the platform the ticket originated from and the language currently in use.

To test:
Create a new Zendesk issue.
Confirm in the Zendesk tool that the new fields show up and are populated with the correct data.

cc @charliescheer