### PR TITLE
Feature/individual quick start prompts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -221,8 +221,7 @@ public class MySiteFragment extends Fragment implements
                 mQuickStartSnackBarHandler.removeCallbacksAndMessages(null);
                 mQuickStartSnackBarHandler.postDelayed(new Runnable() {
                     @Override public void run() {
-                        showQuickStartDialogTaskPrompt(AppPrefs.getNumberOfTimesQuickStartDialogShown()
-                                                       == MAX_NUMBER_OF_TIMES_TO_SHOW_QUICK_START_DIALOG);
+                        showQuickStartDialogTaskPrompt();
                     }
                 }, AUTO_QUICK_START_SNACKBAR_DELAY_MS);
             }
@@ -947,7 +946,7 @@ public class MySiteFragment extends Fragment implements
         AppPrefs.setQuickStartActive(true);
         AppPrefs.setNumberOfTimesQuickStartDialogShown(0);
         setPromptedQuickStartTask(QuickStartTask.VIEW_SITE);
-        showQuickStartDialogTaskPrompt(false);
+        showQuickStartDialogTaskPrompt();
         mQuickStartContainer.setVisibility(View.VISIBLE);
         updateQuickStartCounter();
     }
@@ -1122,18 +1121,22 @@ public class MySiteFragment extends Fragment implements
         ((WPMainActivity) getActivity()).showQuickStartSnackBar(shortQuickStartMessage);
     }
 
-    private void showQuickStartDialogTaskPrompt(final boolean showContinueQuickStartDialog) {
+    private void showQuickStartDialogTaskPrompt() {
         if (!isAdded() || getView() == null) {
             return;
         }
 
+        // if whe shown regular quick start task Snackbar maximum number of times we should show the final one
+        // with different content
+        final boolean shouldDirectUserToContinueQuickStart = AppPrefs.getNumberOfTimesQuickStartDialogShown()
+                                                                 == MAX_NUMBER_OF_TIMES_TO_SHOW_QUICK_START_DIALOG;
         final QuickStartMySitePrompts mySitePrompt =
                 QuickStartMySitePrompts.getPromptDetailsForTask(getPromptedQuickStartTask());
 
         String title;
         String message;
 
-        if (showContinueQuickStartDialog) {
+        if (shouldDirectUserToContinueQuickStart) {
             title = getString(R.string.quick_start_dialog_continue_setup_title);
             message = getString(R.string.quick_start_dialog_continue_setup_message);
         } else if (mySitePrompt != null) {
@@ -1154,7 +1157,7 @@ public class MySiteFragment extends Fragment implements
         mQuickStartTaskPromptSnackBar.setPositiveButton(
                 getString(R.string.quick_start_button_positive), new OnClickListener() {
                     @Override public void onClick(View v) {
-                        if (showContinueQuickStartDialog) {
+                        if (shouldDirectUserToContinueQuickStart) {
                             ActivityLauncher.viewQuickStartForResult(getActivity());
                         } else {
                             mActiveTutorialPrompt = mySitePrompt;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -225,8 +225,6 @@ public class MySiteFragment extends Fragment implements
                                                        == MAX_NUMBER_OF_TIMES_TO_SHOW_QUICK_START_DIALOG);
                     }
                 }, AUTO_QUICK_START_SNACKBAR_DELAY_MS);
-
-
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -104,7 +104,7 @@ public class MySiteFragment extends Fragment implements
     public static final String TAG_CHANGE_SITE_ICON_DIALOG = "TAG_CHANGE_SITE_ICON_DIALOG";
     public static final String TAG_EDIT_SITE_ICON_PERMISSIONS_DIALOG = "TAG_EDIT_SITE_ICON_PERMISSIONS_DIALOG";
     public static final String TAG_QUICK_START_DIALOG = "TAG_QUICK_START_DIALOG";
-    public static final String KEY_QUICK_START_SNACKBAR_WAS_SHOWN = "TAG_QUICK_START_DIALOG";
+    public static final String KEY_QUICK_START_SNACKBAR_WAS_SHOWN = "KEY_QUICK_START_SNACKBAR_WAS_SHOWN";
     public static final int MAX_NUMBER_OF_TIMES_TO_SHOW_QUICK_START_DIALOG = 1;
     public static final int AUTO_QUICK_START_SNACKBAR_DELAY_MS = 1000;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -194,7 +194,10 @@ public class MySiteFragment extends Fragment implements
         }
 
         updateQuickStartCounter();
+        showQuickStartTaskPromptIfNecessary();
+    }
 
+    private void showQuickStartTaskPromptIfNecessary() {
         if (AppPrefs.isQuickStartActive()) {
             QuickStartTask promptedTask = getPromptedQuickStartTask();
 
@@ -206,6 +209,7 @@ public class MySiteFragment extends Fragment implements
                 if (nextPrompt != null) {
                     setPromptedQuickStartTask(nextPrompt.getTask());
                 } else {
+                    // looks like we completed all the tasks!
                     setPromptedQuickStartTask(null);
                 }
             }
@@ -1130,8 +1134,8 @@ public class MySiteFragment extends Fragment implements
 
         mQuickStartTaskPromptSnackBar.setTitle(title);
 
-        mQuickStartTaskPromptSnackBar
-                .setPositiveButton(getString(R.string.quick_start_button_positive), new OnClickListener() {
+        mQuickStartTaskPromptSnackBar.setPositiveButton(
+                getString(R.string.quick_start_button_positive), new OnClickListener() {
                     @Override public void onClick(View v) {
                         if (showContinueQuickStartDialog) {
                             ActivityLauncher.viewQuickStartForResult(getActivity());
@@ -1159,7 +1163,7 @@ public class MySiteFragment extends Fragment implements
 
     private boolean shouldShowQuickStartTaskPrompt() {
         return AppPrefs.getNumberOfTimesQuickStartDialogShown() <= MAX_NUMBER_OF_TIMES_TO_SHOW_QUICK_START_DIALOG
-               && !mQuickStartSnackBarWasShown && getNextQuickStartPrompt() != null;
+               && !mQuickStartSnackBarWasShown && getPromptedQuickStartTask() != null;
     }
 
     private QuickStartMySitePrompts getNextQuickStartPrompt() {
@@ -1187,7 +1191,6 @@ public class MySiteFragment extends Fragment implements
         } else {
             AppPrefs.setPromptedQuickStartTask(task.toString());
         }
-
     }
 
     private void markQuickStartPromptAsShownOnce() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -211,7 +211,6 @@ public class MySiteFragment extends Fragment implements
                     showActiveQuickStartTaskPrompt();
                 }
             }
-
         }
     }
 
@@ -239,7 +238,6 @@ public class MySiteFragment extends Fragment implements
         if (mQuickStartTaskPromptSnackBar != null && mQuickStartTaskPromptSnackBar.isShowing()) {
             mQuickStartTaskPromptSnackBar.dismiss();
         }
-
     }
 
     @Override
@@ -1197,11 +1195,11 @@ public class MySiteFragment extends Fragment implements
         AppPrefs.setPromptedQuickStartTask(task.toString());
     }
 
-    private void markQuickStartPromptAsShownOnce(){
+    private void markQuickStartPromptAsShownOnce() {
         mQuickStartSnackBarWasShown = true;
     }
 
-    private void resetQuickStartPromptCounter(){
+    private void resetQuickStartPromptCounter() {
         AppPrefs.setNumberOfTimesQuickStartDialogShown(0);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -103,7 +103,7 @@ public class MySiteFragment extends Fragment implements
     public static final String TAG_CHANGE_SITE_ICON_DIALOG = "TAG_CHANGE_SITE_ICON_DIALOG";
     public static final String TAG_EDIT_SITE_ICON_PERMISSIONS_DIALOG = "TAG_EDIT_SITE_ICON_PERMISSIONS_DIALOG";
     public static final String TAG_QUICK_START_DIALOG = "TAG_QUICK_START_DIALOG";
-    public static final String ARG_QUICK_START_SNACKBAR_WAS_SHOWN = "TAG_QUICK_START_DIALOG";
+    public static final String KEY_QUICK_START_SNACKBAR_WAS_SHOWN = "TAG_QUICK_START_DIALOG";
     public static final int MAX_NUMBER_OF_TIMES_TO_SHOW_QUICK_START_DIALOG = 2;
 
     private WPNetworkImageView mBlavatarImageView;
@@ -165,7 +165,7 @@ public class MySiteFragment extends Fragment implements
         if (savedInstanceState != null) {
             mActiveTutorialPrompt =
                     (QuickStartMySitePrompts) savedInstanceState.getSerializable(QuickStartMySitePrompts.KEY);
-            mQuickStartSnackBarWasShown = savedInstanceState.getBoolean(ARG_QUICK_START_SNACKBAR_WAS_SHOWN, false);
+            mQuickStartSnackBarWasShown = savedInstanceState.getBoolean(KEY_QUICK_START_SNACKBAR_WAS_SHOWN, false);
         }
     }
 
@@ -224,7 +224,7 @@ public class MySiteFragment extends Fragment implements
     @Override public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putSerializable(QuickStartMySitePrompts.KEY, mActiveTutorialPrompt);
-        outState.putBoolean(ARG_QUICK_START_SNACKBAR_WAS_SHOWN, mQuickStartSnackBarWasShown);
+        outState.putBoolean(KEY_QUICK_START_SNACKBAR_WAS_SHOWN, mQuickStartSnackBarWasShown);
     }
 
     private void initSiteSettings() {
@@ -236,7 +236,7 @@ public class MySiteFragment extends Fragment implements
 
     @Override public void onPause() {
         super.onPause();
-        if (!getActivity().isChangingConfigurations()) {
+        if (getActivity() != null && !getActivity().isChangingConfigurations()) {
             mQuickStartSnackBarWasShown = false;
             clearActiveQuickStartTask();
             removeQuickStartFocusPoint();
@@ -919,6 +919,7 @@ public class MySiteFragment extends Fragment implements
                 // no-op
                 break;
             case TAG_QUICK_START_DIALOG:
+                // TODO we are resetting all quick start tasks for test purposes. Remove this in prod.
                 for (QuickStartTask quickStartTask : QuickStartTask.values()) {
                     mQuickStartStore.setDoneTask(AppPrefs.getSelectedSite(), quickStartTask, false);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -217,7 +217,7 @@ public class MySiteFragment extends Fragment implements
                 }
             }
 
-            if (shouldShowQuickStartTaskPrompt() && getView() != null) {
+            if (shouldShowQuickStartTaskPrompt()) {
                 mQuickStartSnackBarHandler.removeCallbacksAndMessages(null);
                 mQuickStartSnackBarHandler.postDelayed(new Runnable() {
                     @Override public void run() {
@@ -1126,10 +1126,10 @@ public class MySiteFragment extends Fragment implements
             return;
         }
 
-        // if whe shown regular quick start task Snackbar maximum number of times we should show the final one
-        // with different content
+        // if regular Quick Start Snackbar was displayed maximum number of times we should show the final one
+        // with a different content
         final boolean shouldDirectUserToContinueQuickStart = AppPrefs.getNumberOfTimesQuickStartDialogShown()
-                                                                 == MAX_NUMBER_OF_TIMES_TO_SHOW_QUICK_START_DIALOG;
+                                                             == MAX_NUMBER_OF_TIMES_TO_SHOW_QUICK_START_DIALOG;
         final QuickStartMySitePrompts mySitePrompt =
                 QuickStartMySitePrompts.getPromptDetailsForTask(getPromptedQuickStartTask());
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -647,7 +647,7 @@ public class MySiteFragment extends Fragment implements
 
                     resetQuickStartPromptCounter();
                     setPromptedQuickStartTask(mActiveTutorialPrompt.getTask());
-                    markQuickStartPromptAsShownOnce();
+                    mQuickStartSnackBarWasShown = true;
 
                     showActiveQuickStartTutorial();
                 }
@@ -1184,7 +1184,7 @@ public class MySiteFragment extends Fragment implements
     }
 
     /**
-     * Cycles through Quick Start tasks and picks returns a prompt information for the next unfinished one
+     * Cycles through Quick Start tasks and returns a prompt information for the next unfinished one
      */
     private QuickStartMySitePrompts getNextQuickStartPrompt() {
         for (QuickStartMySitePrompts quickStartMySitePrompt : QuickStartMySitePrompts.values()) {
@@ -1209,7 +1209,7 @@ public class MySiteFragment extends Fragment implements
     }
 
     /**
-     * Records Quick Start task that is currently being prompted to the use with a Snackbar
+     * Records Quick Start task that is currently being prompted to the user with a Snackbar
      */
     private void setPromptedQuickStartTask(QuickStartTask task) {
         if (task == null) {
@@ -1217,14 +1217,6 @@ public class MySiteFragment extends Fragment implements
         } else {
             AppPrefs.setPromptedQuickStartTask(task.toString());
         }
-    }
-
-    /**
-     * In order to show Quick Start snackbar in onResume but not during orientation change we maintain a flag that
-     * indicates that Snackbar was shown once.
-     */
-    private void markQuickStartPromptAsShownOnce() {
-        mQuickStartSnackBarWasShown = true;
     }
 
     private void resetQuickStartPromptCounter() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -668,9 +668,10 @@ public class WPMainActivity extends AppCompatActivity implements
                 if (getMySiteFragment() != null) {
                     getMySiteFragment().onActivityResult(requestCode, resultCode, data);
 
-                    if (data != null && data.getIntExtra(ARG_CREATE_SITE, 0) == RequestCodes.CREATE_SITE) {
+                    //TODO for test purposes show Quick Start dialog when switching sites
+//                    if (data != null && data.getIntExtra(ARG_CREATE_SITE, 0) == RequestCodes.CREATE_SITE) {
                         showQuickStartDialog();
-                    }
+//                    }
 
                     setSite(data);
                     jumpNewPost(data);
@@ -707,6 +708,10 @@ public class WPMainActivity extends AppCompatActivity implements
     }
 
     private void showQuickStartDialog() {
+        if (getSelectedSite() == null || !QuickStartUtils.isQuickStartAvailableForTheSite(getSelectedSite())) {
+            return;
+        }
+
         String tag = MySiteFragment.TAG_QUICK_START_DIALOG;
         PromoDialog promoDialog = new PromoDialog();
         promoDialog.initialize(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -506,7 +506,7 @@ public class WPMainActivity extends AppCompatActivity implements
         trackLastVisiblePage(position, true);
         if (getMySiteFragment() != null) {
             QuickStartUtils.removeQuickStartFocusPoint((ViewGroup) findViewById(R.id.root_view_main));
-
+            hideQuickStartSnackBar();
             if (position == PAGE_READER && getMySiteFragment().isQuickStartTaskActive(QuickStartTask.FOLLOW_SITE)) {
                 // MySite fragment might not be attached to activity, so we need to remove focus point from here
                 getMySiteFragment().requestNextStepOfActiveQuickStartTask();

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -710,7 +710,9 @@ public class WPMainActivity extends AppCompatActivity implements
     }
 
     private void showQuickStartDialog() {
-        if (getSelectedSite() == null || !QuickStartUtils.isQuickStartAvailableForTheSite(getSelectedSite())) {
+        if (AppPrefs.isQuickStartDisabled()
+            || getSelectedSite() == null
+            || !QuickStartUtils.isQuickStartAvailableForTheSite(getSelectedSite())) {
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -504,12 +504,15 @@ public class WPMainActivity extends AppCompatActivity implements
     public void onPageChanged(int position) {
         updateTitle(position);
         trackLastVisiblePage(position, true);
-        if (position == PAGE_READER && getMySiteFragment() != null
-            && getMySiteFragment().isQuickStartTaskActive(QuickStartTask.FOLLOW_SITE)) {
-            // MySite fragment might not be attached to activity, so we need to remove focus point from here
+        if (getMySiteFragment() != null) {
             QuickStartUtils.removeQuickStartFocusPoint((ViewGroup) findViewById(R.id.root_view_main));
-            getMySiteFragment().requestNextStepOfActiveQuickStartTask();
+
+            if (position == PAGE_READER && getMySiteFragment().isQuickStartTaskActive(QuickStartTask.FOLLOW_SITE)) {
+                // MySite fragment might not be attached to activity, so we need to remove focus point from here
+                getMySiteFragment().requestNextStepOfActiveQuickStartTask();
+            }
         }
+
     }
 
     // user tapped the new post button in the bottom navbar
@@ -670,7 +673,7 @@ public class WPMainActivity extends AppCompatActivity implements
 
                     //TODO for test purposes show Quick Start dialog when switching sites
 //                    if (data != null && data.getIntExtra(ARG_CREATE_SITE, 0) == RequestCodes.CREATE_SITE) {
-                        showQuickStartDialog();
+                    showQuickStartDialog();
 //                    }
 
                     setSite(data);
@@ -1046,5 +1049,6 @@ public class WPMainActivity extends AppCompatActivity implements
     @Override protected void onPause() {
         super.onPause();
         hideQuickStartSnackBar();
+        QuickStartUtils.removeQuickStartFocusPoint((ViewGroup) findViewById(R.id.root_view_main));
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -670,13 +670,13 @@ public class WPMainActivity extends AppCompatActivity implements
                 if (getMySiteFragment() != null) {
                     getMySiteFragment().onActivityResult(requestCode, resultCode, data);
 
+                    setSite(data);
+                    jumpNewPost(data);
+
                     // TODO for test purposes show Quick Start dialog when switching sites
 //                    if (data != null && data.getIntExtra(ARG_CREATE_SITE, 0) == RequestCodes.CREATE_SITE) {
                     showQuickStartDialog();
 //                    }
-
-                    setSite(data);
-                    jumpNewPost(data);
                 }
                 break;
             case RequestCodes.SITE_SETTINGS:

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -512,7 +512,6 @@ public class WPMainActivity extends AppCompatActivity implements
                 getMySiteFragment().requestNextStepOfActiveQuickStartTask();
             }
         }
-
     }
 
     // user tapped the new post button in the bottom navbar
@@ -671,7 +670,7 @@ public class WPMainActivity extends AppCompatActivity implements
                 if (getMySiteFragment() != null) {
                     getMySiteFragment().onActivityResult(requestCode, resultCode, data);
 
-                    //TODO for test purposes show Quick Start dialog when switching sites
+                    // TODO for test purposes show Quick Start dialog when switching sites
 //                    if (data != null && data.getIntExtra(ARG_CREATE_SITE, 0) == RequestCodes.CREATE_SITE) {
                     showQuickStartDialog();
 //                    }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -735,11 +735,11 @@ public class AppPrefs {
         setInt(DeletablePrefKey.NUMBER_OF_TIMES_QUICK_START_DIALOG_SHOWN, value);
     }
 
-    public static String getActiveQuickStartTask() {
+    public static String getPromptedQuickStartTask() {
         return getString(DeletablePrefKey.ACTIVE_QUICK_START_TASK);
     }
 
-    public static void setActiveQuickStartTask(String task) {
+    public static void setPromptedQuickStartTask(String task) {
         setString(DeletablePrefKey.ACTIVE_QUICK_START_TASK, task);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -100,6 +100,12 @@ public class AppPrefs {
 
         // used to indicate that user is performing Quick Start tutorial
         IS_QUICK_START_ACTIVE,
+
+        // indicates how many times quick start dialog for a single task wash shown
+        NUMBER_OF_TIMES_QUICK_START_DIALOG_SHOWN,
+
+        // keeps track of currently active quick start task
+        ACTIVE_QUICK_START_TASK
     }
 
     /**
@@ -160,7 +166,10 @@ public class AppPrefs {
         LAST_WP_COM_THEMES_SYNC,
 
         // user id last used to login with
-        LAST_USED_USER_ID
+        LAST_USED_USER_ID,
+
+        // used to indicate that user opted out of quick start
+        IS_QUICK_START_DISABLED
     }
 
     private static SharedPreferences prefs() {
@@ -458,7 +467,7 @@ public class AppPrefs {
 
     public static boolean isVisualEditorEnabled() {
         return isVisualEditorAvailable() && getBoolean(UndeletablePrefKey.VISUAL_EDITOR_ENABLED,
-                                                       !isAztecEditorEnabled());
+                !isAztecEditorEnabled());
     }
 
     public static boolean isAsyncPromoRequired() {
@@ -705,8 +714,32 @@ public class AppPrefs {
         setBoolean(DeletablePrefKey.IS_QUICK_START_ACTIVE, isActive);
     }
 
-    // TODO quick start is set to true by default for testing purposes. Remove in prod.
     public static boolean isQuickStartActive() {
-        return getBoolean(DeletablePrefKey.IS_QUICK_START_ACTIVE, true);
+        return getBoolean(DeletablePrefKey.IS_QUICK_START_ACTIVE, false);
+    }
+
+    public static void setQuickStartDisabled(Boolean isDisabled) {
+        setBoolean(UndeletablePrefKey.IS_QUICK_START_DISABLED, isDisabled);
+    }
+
+    public static boolean isQuickStartDisabled() {
+        return getBoolean(UndeletablePrefKey.IS_QUICK_START_DISABLED, true);
+    }
+
+
+    public static int getNumberOfTimesQuickStartDialogShown() {
+        return getInt(DeletablePrefKey.NUMBER_OF_TIMES_QUICK_START_DIALOG_SHOWN, 0);
+    }
+
+    public static void setNumberOfTimesQuickStartDialogShown(int value) {
+        setInt(DeletablePrefKey.NUMBER_OF_TIMES_QUICK_START_DIALOG_SHOWN, value);
+    }
+
+    public static String getActiveQuickStartTask() {
+        return getString(DeletablePrefKey.ACTIVE_QUICK_START_TASK);
+    }
+
+    public static void setActiveQuickStartTask(String task) {
+        setString(DeletablePrefKey.ACTIVE_QUICK_START_TASK, task);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -104,8 +104,8 @@ public class AppPrefs {
         // indicates how many times quick start dialog for a single task wash shown
         NUMBER_OF_TIMES_QUICK_START_DIALOG_SHOWN,
 
-        // keeps track of currently active quick start task
-        ACTIVE_QUICK_START_TASK
+        // keeps track of quick start tasks that is prompted to user
+        PROMPTED_QUICK_START_TASK
     }
 
     /**
@@ -726,7 +726,6 @@ public class AppPrefs {
         return getBoolean(UndeletablePrefKey.IS_QUICK_START_DISABLED, true);
     }
 
-
     public static int getNumberOfTimesQuickStartDialogShown() {
         return getInt(DeletablePrefKey.NUMBER_OF_TIMES_QUICK_START_DIALOG_SHOWN, 0);
     }
@@ -736,10 +735,10 @@ public class AppPrefs {
     }
 
     public static String getPromptedQuickStartTask() {
-        return getString(DeletablePrefKey.ACTIVE_QUICK_START_TASK);
+        return getString(DeletablePrefKey.PROMPTED_QUICK_START_TASK);
     }
 
     public static void setPromptedQuickStartTask(String task) {
-        setString(DeletablePrefKey.ACTIVE_QUICK_START_TASK, task);
+        setString(DeletablePrefKey.PROMPTED_QUICK_START_TASK, task);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.prefs;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import org.wordpress.android.WordPress;
@@ -734,11 +735,12 @@ public class AppPrefs {
         setInt(DeletablePrefKey.NUMBER_OF_TIMES_QUICK_START_DIALOG_SHOWN, value);
     }
 
+    @Nullable
     public static String getPromptedQuickStartTask() {
-        return getString(DeletablePrefKey.PROMPTED_QUICK_START_TASK);
+        return getString(DeletablePrefKey.PROMPTED_QUICK_START_TASK, null);
     }
 
-    public static void setPromptedQuickStartTask(String task) {
+    public static void setPromptedQuickStartTask(@Nullable String task) {
         setString(DeletablePrefKey.PROMPTED_QUICK_START_TASK, task);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -724,7 +724,7 @@ public class AppPrefs {
     }
 
     public static boolean isQuickStartDisabled() {
-        return getBoolean(UndeletablePrefKey.IS_QUICK_START_DISABLED, true);
+        return getBoolean(UndeletablePrefKey.IS_QUICK_START_DISABLED, false);
     }
 
     public static int getNumberOfTimesQuickStartDialogShown() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartMySitePrompts.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartMySitePrompts.kt
@@ -11,44 +11,58 @@ enum class QuickStartMySitePrompts constructor(
     val parentContainerId: Int,
     val focusedContainerId: Int,
     val shortMessagePrompt: Int,
-    val iconId: Int
+    val iconId: Int,
+    val promptDialogTitleId: Int,
+    val promptDialogMessageId: Int
 ) {
     VIEW_SITE_TUTORIAL(
             QuickStartTask.VIEW_SITE,
             R.id.my_site_scroll_view_root,
             R.id.row_view_site,
             R.string.quick_start_dialog_view_site_message_short,
-            R.drawable.ic_globe_grey_24dp),
+            R.drawable.ic_globe_grey_24dp,
+            R.string.quick_start_dialog_view_site_title,
+            R.string.quick_start_dialog_view_site_message),
     CHOSE_THEME_TUTORIAL(
             QuickStartTask.CHOOSE_THEME,
             R.id.my_site_scroll_view_root,
             R.id.row_themes,
             R.string.quick_start_dialog_choose_theme_message_short,
-            R.drawable.ic_themes_grey_24dp),
+            R.drawable.ic_themes_grey_24dp,
+            R.string.quick_start_dialog_choose_theme_title,
+            R.string.quick_start_dialog_choose_theme_message),
     CUSTOMIZE_SITE_TUTORIAL(
             QuickStartTask.CUSTOMIZE_SITE,
             R.id.my_site_scroll_view_root,
             R.id.row_themes,
             R.string.quick_start_dialog_customize_site_message_short_themes,
-            R.drawable.ic_themes_grey_24dp),
+            R.drawable.ic_themes_grey_24dp,
+            R.string.quick_start_dialog_customize_site_title,
+            R.string.quick_start_dialog_customize_site_message),
     SHARE_SITE_TUTORIAL(
             QuickStartTask.SHARE_SITE,
             R.id.my_site_scroll_view_root,
             R.id.row_sharing,
             R.string.quick_start_dialog_share_site_message_short_sharing,
-            R.drawable.ic_share_24dp),
+            R.drawable.ic_share_24dp,
+            R.string.quick_start_dialog_share_site_title,
+            R.string.quick_start_dialog_share_site_message),
     PUBLISH_POST_TUTORIAL(
             QuickStartTask.PUBLISH_POST,
             R.id.root_view_main,
             R.id.bottom_nav_new_post_button,
             R.string.quick_start_dialog_publish_post_message_short,
-            R.drawable.ic_create_white_24dp),
+            R.drawable.ic_create_white_24dp,
+            R.string.quick_start_dialog_publish_post_title,
+            R.string.quick_start_dialog_publish_post_message),
     FOLLOW_SITES_TUTORIAL(
             QuickStartTask.FOLLOW_SITE,
             R.id.root_view_main,
             R.id.bottom_nav_reader_button,
             R.string.quick_start_dialog_follow_sites_message_short_reader,
-            R.drawable.ic_reader_white_32dp);
+            R.drawable.ic_reader_white_32dp,
+            R.string.quick_start_dialog_follow_sites_title,
+            R.string.quick_start_dialog_follow_sites_message);
 
     companion object {
         const val KEY = "my_site_tutorial_prompts"

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -16,7 +16,6 @@ import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.themes.ThemeBrowserActivity
 
 class QuickStartUtils {
@@ -149,8 +148,7 @@ class QuickStartUtils {
         fun isQuickStartAvailableForTheSite(siteModel: SiteModel): Boolean {
             return (siteModel.hasCapabilityManageOptions
                     && ThemeBrowserActivity.isAccessible(siteModel)
-                    && SiteUtils.isAccessedViaWPComRest(siteModel)
-                    && AppPrefs.isQuickStartActive())
+                    && SiteUtils.isAccessedViaWPComRest(siteModel))
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -15,6 +15,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.prefs.AppPrefs
+import org.wordpress.android.ui.themes.ThemeBrowserActivity
 
 class QuickStartUtils {
     companion object {
@@ -140,6 +143,14 @@ class QuickStartUtils {
                     directParent.removeView(focusPointView)
                 }
             }
+        }
+
+        @JvmStatic
+        fun isQuickStartAvailableForTheSite(siteModel: SiteModel): Boolean {
+            return (siteModel.hasCapabilityManageOptions
+                    && ThemeBrowserActivity.isAccessible(siteModel)
+                    && SiteUtils.isAccessedViaWPComRest(siteModel)
+                    && AppPrefs.isQuickStartActive())
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -146,9 +146,9 @@ class QuickStartUtils {
 
         @JvmStatic
         fun isQuickStartAvailableForTheSite(siteModel: SiteModel): Boolean {
-            return (siteModel.hasCapabilityManageOptions
-                    && ThemeBrowserActivity.isAccessible(siteModel)
-                    && SiteUtils.isAccessedViaWPComRest(siteModel))
+            return (siteModel.hasCapabilityManageOptions &&
+                    ThemeBrowserActivity.isAccessible(siteModel) &&
+                    SiteUtils.isAccessedViaWPComRest(siteModel))
         }
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2208,16 +2208,15 @@
     <string name="quick_start_dialog_choose_theme_message">Browse all our themes to find your perfect fit.</string>
     <string name="quick_start_dialog_choose_theme_message_short" tools:ignore="UnusedResources">Tap %1$s Themes %2$s to discover new themes</string>
     <string name="quick_start_dialog_choose_theme_title">Choose a theme</string>
-    <string name="quick_start_dialog_continue_setup_message" tools:ignore="UnusedResources">Time to finish setting up your site!  Our checklist walks you through the next steps.</string>
-    <string name="quick_start_dialog_continue_setup_message_short" tools:ignore="UnusedResources">Tap %1$s Quick Start %2$s to see your checklist</string>
-    <string name="quick_start_dialog_continue_setup_title" tools:ignore="UnusedResources">Continue with site setup</string>
+    <string name="quick_start_dialog_continue_setup_message">Time to finish setting up your site!  Our checklist walks you through the next steps.</string>
+    <string name="quick_start_dialog_continue_setup_title">Continue with site setup</string>
     <string name="quick_start_dialog_customize_site_message">Change colors, fonts, and images for a perfectly personalized site.</string>
-    <string name="quick_start_dialog_customize_site_message_short_customize" tools:ignore="UnusedResources">Tap %1$s Customize %2$s to start personalizing your site</string>
+    <string name="quick_start_dialog_customize_site_message_short_customize">Tap %1$s Customize %2$s to start personalizing your site</string>
     <string name="quick_start_dialog_customize_site_message_short_themes" tools:ignore="UnusedResources">Tap %1$s Themes %2$s to continue</string>
     <string name="quick_start_dialog_customize_site_title">Customize your site</string>
     <string name="quick_start_dialog_follow_sites_message">Find sites that speak to you, and follow them to get updates when they publish.</string>
     <string name="quick_start_dialog_follow_sites_message_short_reader" tools:ignore="UnusedResources">Tap %1$s Reader %2$s to continue</string>
-    <string name="quick_start_dialog_follow_sites_message_short_search" tools:ignore="UnusedResources">Tap %1$s Search %2$s to look for sites with similar interests</string>
+    <string name="quick_start_dialog_follow_sites_message_short_search">Tap %1$s Search %2$s to look for sites with similar interests</string>
     <string name="quick_start_dialog_follow_sites_title">Follow other sites</string>
     <string name="quick_start_dialog_need_help_button_negative">No</string>
     <string name="quick_start_dialog_need_help_button_neutral">Never</string>
@@ -2228,7 +2227,7 @@
     <string name="quick_start_dialog_publish_post_message_short" tools:ignore="UnusedResources">Tap %1$s Create Post %2$s to create a new post</string>
     <string name="quick_start_dialog_publish_post_title">Publish a post</string>
     <string name="quick_start_dialog_share_site_message">Connect to your social media accounts &#8211; your site will automatically share new posts.</string>
-    <string name="quick_start_dialog_share_site_message_short_connections" tools:ignore="UnusedResources">Tap the %1$s Connections %2$s to add your social media accounts</string>
+    <string name="quick_start_dialog_share_site_message_short_connections">Tap the %1$s Connections %2$s to add your social media accounts</string>
     <string name="quick_start_dialog_share_site_message_short_sharing" tools:ignore="UnusedResources">Tap %1$s Sharing %2$s to continue</string>
     <string name="quick_start_dialog_share_site_title">Share your site</string>
     <string name="quick_start_dialog_skip_message">The quick tour will guide you through building a basic site.  Are you sure you want to skip?</string>
@@ -2253,9 +2252,9 @@
     <string name="quick_start_list_view_site_subtitle">@string/quick_start_dialog_view_site_message</string>
     <string name="quick_start_list_view_site_title">@string/quick_start_dialog_view_site_title</string>
     <string name="quick_start_sites">Quick Start</string>
-    <string name="quick_start_sites_progress" tools:ignore="UnusedResources" translatable="false">%1$d/%2$d</string>
+    <string name="quick_start_sites_progress" translatable="false">%1$d/%2$d</string>
     <string name="quick_start_span_end" translatable="false">&lt;/span&gt;</string>
     <string name="quick_start_span_start" translatable="false">&lt;span style=&quot;color:#0&quot;&gt;</string>
-    <string name="quick_start_focus_point_description" tools:ignore="UnusedResources">tap here</string>
+    <string name="quick_start_focus_point_description">tap here</string>
 
 </resources>


### PR DESCRIPTION
Part of #7707 

This PR adds all the quick start prompts with related logic
[![Image from Gyazo](https://i.gyazo.com/87f1c0f92155e53eb6ef0c7f14787939.png)](https://gyazo.com/87f1c0f92155e53eb6ef0c7f14787939)

and ability to start quick start process from the intial quick start dialog:
[![Image from Gyazo](https://i.gyazo.com/1844dc10037e9d4f1525bee3848d932d.png)](https://gyazo.com/1844dc10037e9d4f1525bee3848d932d)
For test purposes, you can trigger the dialog by selecting an eligible site from a site picker. Pressing OK in the dialog will reset the quick start state and will start it from begining.

Couple of notes about the logic:
Quick Start focus point (blue dot) will disappear from the MySite fragment or bottom nav the moment you navigate away from the MySite fragment. It will be retained on orientation change.

After you start the Quick Start process, the Snackbar that prompts you to complete the first task will appear twice, and on the third time, snackbar that will lead you to Quick Start tasks list will appear instead.

Triggering a task from Quick Start list when Quick Start snackbar will not appear (reached max count) will cause the counter to reset, and you will see dialogs appear again (after you complete the task or navigate away and back to MySite fragment).

@SylvesterWilmott please do confirm that it works as expected (or not) :)

Code and the logic are pretty complicated, so I probably messed up somethign at some point.