### PR TITLE
Properly placed pages - pagination

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -20,11 +20,9 @@ import org.wordpress.android.ui.pages.PageItem.Page
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState
-import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState.CAN_LOAD_MORE
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState.DONE
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState.ERROR
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState.FETCHING
-import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState.LOADING_MORE
 import javax.inject.Inject
 
 class PagesViewModel
@@ -62,20 +60,20 @@ class PagesViewModel
         refreshPages()
     }
 
-    private suspend fun refreshPages(isLoadingMore: Boolean = false) {
-        var newState = if (isLoadingMore) LOADING_MORE else FETCHING
+    private suspend fun refreshPages() {
+        var newState = FETCHING
         _listState.postValue(newState)
 
-        val result = pageStore.requestPagesFromServer(site, isLoadingMore)
+        val result = pageStore.requestPagesFromServer(site)
         if (result.isError) {
-            _listState.postValue(ERROR)
+            newState = ERROR
             AppLog.e(AppLog.T.ACTIVITY_LOG, "An error occurred while fetching the Pages")
         } else if (result.rowsAffected > 0) {
             _pages = pageStore.loadPagesFromDb(site)
             _refreshPages.asyncCall()
+            newState = DONE
         }
 
-        newState = if (result.canLoadMore) CAN_LOAD_MORE else DONE
         _listState.postValue(newState)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -41,7 +41,7 @@ class PagesViewModelTest {
     @Test
     fun clearsResultAndLoadsDataOnStart() = runBlocking<Unit> {
         whenever(pageStore.loadPagesFromDb(site)).thenReturn(listOf(PageModel(1, "title", DRAFT, -1)))
-        whenever(pageStore.requestPagesFromServer(any(), any())).thenReturn(OnPostChanged(1, false))
+        whenever(pageStore.requestPagesFromServer(any())).thenReturn(OnPostChanged(1, false))
         val listStateObserver = viewModel.listState.test()
         val refreshPagesObserver = viewModel.refreshPages.test()
         val searchResultObserver = viewModel.searchResult.test()
@@ -107,7 +107,7 @@ class PagesViewModelTest {
 
     private suspend fun initSearch() {
         whenever(pageStore.loadPagesFromDb(site)).thenReturn(listOf())
-        whenever(pageStore.requestPagesFromServer(any(), any())).thenReturn(OnPostChanged(0, false))
+        whenever(pageStore.requestPagesFromServer(any())).thenReturn(OnPostChanged(0, false))
         viewModel.start(site)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'd379bc018621e33ca1cfc912bf6eb88438d8f534'
+    fluxCVersion = '8bc70c0b8173983e989698c48f113fb2eef94795'
 }


### PR DESCRIPTION
In order to show all the pages in hierarchical order we need to load all the pages at once. In order to do this I've followed the way Calypso loads the sites. I'm loading all the pages one by one until I get to the end of the list. The operation itself takes a bit longer but at least it's consistent. In order to have a proper (clean) solution we'd need to create a different API endpoint. If we decide this approach is too slow, we can find some small improvements (like increasing the page size). However, I think this solution is good enough for most usecases.

This PR is showing the beauty of coroutines - in order to implement this we didn't need to change the PageStore contract, the operation just takes longer.