### PR TITLE
Issue/add tags empty

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -23,6 +23,7 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.View.OnLongClickListener;
 import android.view.ViewGroup;
 import android.widget.TextView;
@@ -123,7 +124,7 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
                     view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
                 }
 
-                Toast.makeText(SiteSettingsTagListActivity.this, R.string.fab_add_tag_desc, Toast.LENGTH_SHORT).show();
+                Toast.makeText(view.getContext(), R.string.site_settings_tags_empty_button, Toast.LENGTH_SHORT).show();
                 return true;
             }
         });
@@ -134,6 +135,11 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
         }
 
         mActionableEmptyView = findViewById(R.id.actionable_empty_view);
+        mActionableEmptyView.button.setOnClickListener(new OnClickListener() {
+            @Override public void onClick(View view) {
+                showDetailFragment(null);
+            }
+        });
 
         mRecycler = findViewById(R.id.recycler);
         mRecycler.setHasFixedSize(true);
@@ -336,6 +342,22 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
         }
     }
 
+    private void showActionableEmptyViewForSearch(boolean isSearch) {
+        mActionableEmptyView.updateLayoutForSearch(isSearch, 0);
+
+        if (isSearch) {
+            mActionableEmptyView.button.setVisibility(View.GONE);
+            mActionableEmptyView.image.setVisibility(View.GONE);
+            mActionableEmptyView.subtitle.setVisibility(View.GONE);
+            mActionableEmptyView.title.setText(R.string.site_settings_tags_empty_title_search);
+        } else {
+            mActionableEmptyView.button.setVisibility(View.VISIBLE);
+            mActionableEmptyView.image.setVisibility(View.VISIBLE);
+            mActionableEmptyView.subtitle.setVisibility(View.VISIBLE);
+            mActionableEmptyView.title.setText(R.string.site_settings_tags_empty_title);
+        }
+    }
+
     @Override
     public boolean onQueryTextSubmit(String query) {
         mAdapter.filter(query);
@@ -351,18 +373,14 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
 
     @Override
     public boolean onMenuItemActionExpand(MenuItem item) {
-        mActionableEmptyView.updateLayoutForSearch(true, 0);
-        mActionableEmptyView.image.setVisibility(View.GONE);
-        mActionableEmptyView.title.setText(R.string.site_settings_tags_empty_title_search);
+        showActionableEmptyViewForSearch(true);
         hideFabIfShowing();
         return true;
     }
 
     @Override
     public boolean onMenuItemActionCollapse(MenuItem item) {
-        mActionableEmptyView.updateLayoutForSearch(false, 0);
-        mActionableEmptyView.image.setVisibility(View.VISIBLE);
-        mActionableEmptyView.title.setText(R.string.site_settings_tags_empty_title);
+        showActionableEmptyViewForSearch(false);
         showFabIfHidden();
         return true;
     }
@@ -477,6 +495,8 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
                 }
             }
             notifyDataSetChanged();
+
+            showActionableEmptyViewForSearch(mFilteredTags.isEmpty());
         }
 
         class TagViewHolder extends RecyclerView.ViewHolder {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -394,16 +394,17 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(
                 new ContextThemeWrapper(this, R.style.Calypso_Dialog_Alert));
         dialogBuilder.setMessage(message);
-        dialogBuilder.setPositiveButton(getResources().getText(R.string.delete_yes),
-                                        new DialogInterface.OnClickListener() {
-                                            public void onClick(DialogInterface dialog, int whichButton) {
-                                                showProgressDialog(R.string.dlg_deleting_tag);
-                                                Action action = TaxonomyActionBuilder.newDeleteTermAction(
-                                                        new TaxonomyStore.RemoteTermPayload(term, mSite));
-                                                mDispatcher.dispatch(action);
-                                            }
-                                        });
-        dialogBuilder.setNegativeButton(getResources().getText(R.string.delete_no), null);
+        dialogBuilder.setPositiveButton(
+                getResources().getText(R.string.delete_yes),
+                new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int whichButton) {
+                        showProgressDialog(R.string.dlg_deleting_tag);
+                        Action action = TaxonomyActionBuilder.newDeleteTermAction(
+                                new TaxonomyStore.RemoteTermPayload(term, mSite));
+                        mDispatcher.dispatch(action);
+                    }
+                });
+        dialogBuilder.setNegativeButton(R.string.cancel, null);
         dialogBuilder.setCancelable(true);
         dialogBuilder.create().show();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -18,12 +18,15 @@ import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.SearchView;
 import android.text.TextUtils;
 import android.view.ContextThemeWrapper;
+import android.view.HapticFeedbackConstants;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.View.OnLongClickListener;
 import android.view.ViewGroup;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.greenrobot.eventbus.Subscribe;
@@ -110,8 +113,18 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
         mFabView = findViewById(R.id.fab_button);
         mFabView.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View v) {
+            public void onClick(View view) {
                 showDetailFragment(null);
+            }
+        });
+        mFabView.setOnLongClickListener(new OnLongClickListener() {
+            @Override public boolean onLongClick(View view) {
+                if (view.isHapticFeedbackEnabled()) {
+                    view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
+                }
+
+                Toast.makeText(SiteSettingsTagListActivity.this, R.string.fab_add_tag_desc, Toast.LENGTH_SHORT).show();
+                return true;
             }
         });
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -146,7 +146,10 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
     @Override
     public void onResume() {
         super.onResume();
-        showFabIfHidden();
+
+        if (!isDetailFragmentShowing()) {
+            showFabIfHidden();
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -165,10 +165,7 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
     @Override
     public void onResume() {
         super.onResume();
-
-        if (!isDetailFragmentShowing()) {
-            showFabIfHidden();
-        }
+        showFabIfNotShowingDetailAndNotEmpty();
     }
 
     @Override
@@ -265,6 +262,21 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
         }, delayMs);
     }
 
+    private void showFabIfNotShowingDetailAndNotEmpty() {
+        // scale in the fab after a brief delay if it's not already showing
+        if (mFabView.getVisibility() != View.VISIBLE) {
+            long delayMs = getResources().getInteger(R.integer.fab_animation_delay);
+            new Handler().postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    if (!isDetailFragmentShowing() && mActionableEmptyView.getVisibility() != View.VISIBLE) {
+                        showFabIfHidden();
+                    }
+                }
+            }, delayMs);
+        }
+    }
+
     private void hideFabIfShowing() {
         if (!isFinishing() && mFabView.getVisibility() == View.VISIBLE) {
             AniUtils.showFab(mFabView, false);
@@ -336,7 +348,7 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
         if (fragment != null) {
             getFragmentManager().popBackStack();
             ActivityUtils.hideKeyboard(this);
-            showFabIfHidden();
+            showFabIfNotShowingDetailAndNotEmpty();
             setTitle(R.string.site_settings_tags_title);
             invalidateOptionsMenu();
         }
@@ -381,7 +393,7 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
     @Override
     public boolean onMenuItemActionCollapse(MenuItem item) {
         showActionableEmptyViewForSearch(false);
-        showFabIfHidden();
+        showFabIfNotShowingDetailAndNotEmpty();
         return true;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -65,7 +65,6 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
     @Inject SiteStore mSiteStore;
     @Inject TaxonomyStore mTaxonomyStore;
 
-    private static final String KEY_SAVED_QUERY = "SAVED_QUERY";
     private static final String KEY_PROGRESS_RES_ID = "PROGRESS_RESOURCE_ID";
 
     private SiteModel mSite;
@@ -74,7 +73,6 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
     private ActionableEmptyView mActionableEmptyView;
 
     private TagListAdapter mAdapter;
-    private String mSavedQuery;
     private int mLastProgressResId;
 
     private MenuItem mSearchMenuItem;
@@ -103,7 +101,6 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
             mSite = (SiteModel) getIntent().getSerializableExtra(WordPress.SITE);
         } else {
             mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
-            mSavedQuery = savedInstanceState.getString(KEY_SAVED_QUERY);
         }
         if (mSite == null) {
             ToastUtils.showToast(this, R.string.blog_not_found, ToastUtils.Duration.SHORT);
@@ -184,9 +181,7 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putSerializable(WordPress.SITE, mSite);
-        if (mSearchMenuItem.isActionViewExpanded()) {
-            outState.putString(KEY_SAVED_QUERY, mSearchView.getQuery().toString());
-        }
+
         if (mProgressDialog != null && mProgressDialog.isShowing()) {
             outState.putInt(KEY_PROGRESS_RES_ID, mLastProgressResId);
         }
@@ -197,15 +192,9 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
         getMenuInflater().inflate(R.menu.tag_list, menu);
 
         mSearchMenuItem = menu.findItem(R.id.menu_search);
+        mSearchMenuItem.setOnActionExpandListener(this);
         mSearchView = (SearchView) mSearchMenuItem.getActionView();
         mSearchView.setOnQueryTextListener(this);
-
-        // open search bar if we were searching for something before
-        if (!TextUtils.isEmpty(mSavedQuery)) {
-            mSearchMenuItem.expandActionView();
-            onQueryTextSubmit(mSavedQuery);
-            mSearchView.setQuery(mSavedQuery, true);
-        }
 
         return super.onCreateOptionsMenu(menu);
     }
@@ -215,23 +204,9 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
         if (item.getItemId() == android.R.id.home) {
             onBackPressed();
             return true;
-        } else if (item.getItemId() == R.id.menu_search) {
-            mSearchMenuItem = item;
-            mSearchMenuItem.setOnActionExpandListener(this);
-
-            mSearchView = (SearchView) item.getActionView();
-            mSearchView.setOnQueryTextListener(this);
-
-            if (!TextUtils.isEmpty(mSavedQuery)) {
-                onQueryTextSubmit(mSavedQuery);
-                mSearchView.setQuery(mSavedQuery, true);
-            }
-
-            mSearchMenuItem.expandActionView();
-
-            return true;
+        } else {
+            return super.onOptionsItemSelected(item);
         }
-        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -438,15 +438,16 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
             mFilteredTags.addAll(allTags);
         }
 
+        @NonNull
         @Override
-        public TagViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        public TagViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
             View view = LayoutInflater.from(parent.getContext())
                                       .inflate(R.layout.site_settings_tag_list_row, parent, false);
             return new TagListAdapter.TagViewHolder(view);
         }
 
         @Override
-        public void onBindViewHolder(final TagListAdapter.TagViewHolder holder, int position) {
+        public void onBindViewHolder(@NonNull final TagListAdapter.TagViewHolder holder, int position) {
             TermModel term = mFilteredTags.get(position);
             holder.mTxtTag.setText(StringEscapeUtils.unescapeHtml4(term.getName()));
             if (term.getPostCount() > 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -231,7 +231,7 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
             @Override
             public void run() {
                 if (!isFinishing() && mFabView.getVisibility() != View.VISIBLE) {
-                    AniUtils.showFab(mFabView, true);
+                    AniUtils.scaleIn(mFabView, AniUtils.Duration.MEDIUM);
                 }
             }
         }, delayMs);
@@ -254,7 +254,7 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
 
     private void hideFabIfShowing() {
         if (!isFinishing() && mFabView.getVisibility() == View.VISIBLE) {
-            AniUtils.showFab(mFabView, false);
+            AniUtils.scaleOut(mFabView, AniUtils.Duration.SHORT);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -64,7 +64,7 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
     private static final String KEY_PROGRESS_RES_ID = "PROGRESS_RESOURCE_ID";
 
     private SiteModel mSite;
-    private RecyclerView mRecycler;
+    private EmptyViewRecyclerView mRecycler;
     private View mFabView;
     private View mEmptyView;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -483,7 +483,7 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
             }
             notifyDataSetChanged();
 
-            showActionableEmptyViewForSearch(mFilteredTags.isEmpty());
+            showActionableEmptyViewForSearch(mSearchMenuItem.isActionViewExpanded() && mFilteredTags.isEmpty());
         }
 
         class TagViewHolder extends RecyclerView.ViewHolder {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -38,6 +38,7 @@ import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
+import org.wordpress.android.ui.ActionableEmptyView;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
@@ -66,7 +67,7 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
     private SiteModel mSite;
     private EmptyViewRecyclerView mRecycler;
     private View mFabView;
-    private View mEmptyView;
+    private ActionableEmptyView mActionableEmptyView;
 
     private TagListAdapter mAdapter;
     private String mSavedQuery;
@@ -119,11 +120,12 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
             mFabView.setVisibility(View.INVISIBLE);
         }
 
+        mActionableEmptyView = findViewById(R.id.actionable_empty_view);
+
         mRecycler = findViewById(R.id.recycler);
         mRecycler.setHasFixedSize(true);
         mRecycler.setLayoutManager(new LinearLayoutManager(this));
-
-        mEmptyView = findViewById(R.id.empty_view);
+        mRecycler.setEmptyView(mActionableEmptyView);
 
         loadTags();
 
@@ -331,18 +333,20 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
         return true;
     }
 
-    private void showEmptyView(boolean show) {
-        mEmptyView.setVisibility(show ? View.VISIBLE : View.GONE);
-    }
-
     @Override
     public boolean onMenuItemActionExpand(MenuItem item) {
+        mActionableEmptyView.updateLayoutForSearch(true, 0);
+        mActionableEmptyView.image.setVisibility(View.GONE);
+        mActionableEmptyView.title.setText(R.string.site_settings_tags_empty_title_search);
         hideFabIfShowing();
         return true;
     }
 
     @Override
     public boolean onMenuItemActionCollapse(MenuItem item) {
+        mActionableEmptyView.updateLayoutForSearch(false, 0);
+        mActionableEmptyView.image.setVisibility(View.VISIBLE);
+        mActionableEmptyView.title.setText(R.string.site_settings_tags_empty_title);
         showFabIfHidden();
         return true;
     }
@@ -455,7 +459,6 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
                 }
             }
             notifyDataSetChanged();
-            showEmptyView(mFilteredTags.isEmpty());
         }
 
         class TagViewHolder extends RecyclerView.ViewHolder {

--- a/WordPress/src/main/res/layout/site_settings_tag_list_activity.xml
+++ b/WordPress/src/main/res/layout/site_settings_tag_list_activity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<FrameLayout
+<RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -9,37 +9,40 @@
 
     <org.wordpress.android.ui.prefs.EmptyViewRecyclerView
         android:id="@+id/recycler"
-        android:background="@color/white"
         android:layout_height="match_parent"
         android:layout_width="match_parent" >
     </org.wordpress.android.ui.prefs.EmptyViewRecyclerView>
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/fab_button"
-        android:layout_width="wrap_content"
+        android:contentDescription="@string/fab_add_tag_desc"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
         android:layout_height="wrap_content"
-        android:layout_gravity="end|bottom"
         android:layout_marginBottom="@dimen/fab_margin"
         android:layout_marginEnd="@dimen/fab_margin"
         android:layout_marginRight="@dimen/fab_margin"
-        android:contentDescription="@string/fab_add_tag_desc"
+        android:layout_width="wrap_content"
         app:borderWidth="0dp"
         app:rippleColor="@color/fab_pressed"
-        app:srcCompat="@drawable/ic_plus_white_24dp" />
+        app:srcCompat="@drawable/ic_plus_white_24dp" >
+    </android.support.design.widget.FloatingActionButton>
 
-    <TextView
-        android:id="@+id/empty_view"
-        style="@style/EmptyListText"
+    <org.wordpress.android.ui.ActionableEmptyView
+        android:id="@+id/actionable_empty_view"
+        android:layout_height="match_parent"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:text="@string/empty_list_default"
         android:visibility="gone"
-        tools:visibility="visible" />
+        app:aevImage="@drawable/img_illustration_empty_results_216dp"
+        app:aevTitle="@string/site_settings_tags_empty_title"
+        tools:visibility="visible" >
+    </org.wordpress.android.ui.ActionableEmptyView>
 
     <FrameLayout
         android:id="@+id/container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_width="match_parent" >
+    </FrameLayout>
 
-</FrameLayout>
+</RelativeLayout>

--- a/WordPress/src/main/res/layout/site_settings_tag_list_activity.xml
+++ b/WordPress/src/main/res/layout/site_settings_tag_list_activity.xml
@@ -24,9 +24,11 @@
         android:layout_marginEnd="@dimen/fab_margin"
         android:layout_marginRight="@dimen/fab_margin"
         android:layout_width="wrap_content"
+        android:visibility="invisible"
         app:borderWidth="0dp"
         app:rippleColor="@color/fab_pressed"
-        app:srcCompat="@drawable/ic_plus_white_24dp" >
+        app:srcCompat="@drawable/ic_plus_white_24dp"
+        tools:visibility="visible" >
     </android.support.design.widget.FloatingActionButton>
 
     <org.wordpress.android.ui.ActionableEmptyView

--- a/WordPress/src/main/res/layout/site_settings_tag_list_activity.xml
+++ b/WordPress/src/main/res/layout/site_settings_tag_list_activity.xml
@@ -36,7 +36,9 @@
         android:layout_height="match_parent"
         android:layout_width="match_parent"
         android:visibility="gone"
+        app:aevButton="@string/site_settings_tags_empty_button"
         app:aevImage="@drawable/img_illustration_empty_results_216dp"
+        app:aevSubtitle="@string/site_settings_tags_empty_subtitle"
         app:aevTitle="@string/site_settings_tags_empty_title"
         tools:visibility="visible" >
     </org.wordpress.android.ui.ActionableEmptyView>

--- a/WordPress/src/main/res/layout/site_settings_tag_list_activity.xml
+++ b/WordPress/src/main/res/layout/site_settings_tag_list_activity.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:layout_width="match_parent" >
 
-    <android.support.v7.widget.RecyclerView
+    <org.wordpress.android.ui.prefs.EmptyViewRecyclerView
         android:id="@+id/recycler"
-        android:layout_width="match_parent"
+        android:background="@color/white"
         android:layout_height="match_parent"
-        android:background="@color/white" />
+        android:layout_width="match_parent" >
+    </org.wordpress.android.ui.prefs.EmptyViewRecyclerView>
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/fab_button"

--- a/WordPress/src/main/res/menu/tag_list.xml
+++ b/WordPress/src/main/res/menu/tag_list.xml
@@ -7,6 +7,6 @@
         android:icon="@drawable/ic_search_white_24dp"
         android:title="@string/search"
         app:actionViewClass="android.support.v7.widget.SearchView"
-        app:showAsAction="ifRoom|collapseActionView" />
+        app:showAsAction="always|collapseActionView" />
 
 </menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -503,6 +503,8 @@
     <string name="site_settings_username_title" translatable="false">@string/username</string>
     <string name="site_settings_password_title" translatable="false">@string/password</string>
     <string name="site_settings_default_category_title">Default Category</string>
+    <string name="site_settings_tags_empty_button">Create a tag</string>
+    <string name="site_settings_tags_empty_subtitle">Tags created here can be quickly added to new posts</string>
     <string name="site_settings_tags_empty_title">You don\'t have any tags</string>
     <string name="site_settings_tags_empty_title_search">No tags matching your search</string>
     <string name="site_settings_tags_title">Tags</string>
@@ -2164,7 +2166,6 @@
     <string name="stats_bar_date_value_type_desc">%s, %d %s</string>
     <string name="stats_bar_date_value_desc">%s, %d views</string>
     <string name="stats_bar_week_desc">Week of %s</string>
-    <string name="fab_add_tag_desc">Create Tag</string>
     <string name="fab_create_desc">create</string>
     <string name="stats_legend">stats graph legend</string>
     <string name="stats_tab_tap_content_description">showing %s</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -103,7 +103,6 @@
     <string name="copy">Copy</string>
     <string name="error_please_choose_browser">Error opening the default web browser. Please choose another app:</string>
     <string name="delete_yes">Delete</string>
-    <string name="delete_no">Don\'t Delete</string>
     <string name="add_count">Add %d</string>
     <string name="preview_count">Preview %d</string>
     <string name="write_post">Write Post</string>
@@ -570,7 +569,7 @@
     <string name="tag_description_hint">Description</string>
     <string name="add_new_tag">Add New Tag</string>
     <string name="error_tag_exists">A tag with this name already exists</string>
-    <string name="dlg_confirm_delete_tag">Permanently delete \'%s\'?</string>
+    <string name="dlg_confirm_delete_tag">Permanently delete \'%s\' tag?</string>
     <string name="dlg_deleting_tag">Deleting</string>
     <string name="dlg_saving_tag">Saving</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -504,7 +504,7 @@
     <string name="site_settings_password_title" translatable="false">@string/password</string>
     <string name="site_settings_default_category_title">Default Category</string>
     <string name="site_settings_tags_empty_button">Create a tag</string>
-    <string name="site_settings_tags_empty_subtitle">Tags created here can be quickly added to new posts</string>
+    <string name="site_settings_tags_empty_subtitle">Add your frequently used tags here so they can be quickly selected when tagging your posts</string>
     <string name="site_settings_tags_empty_title">You don\'t have any tags</string>
     <string name="site_settings_tags_empty_title_search">No tags matching your search</string>
     <string name="site_settings_tags_title">Tags</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -504,6 +504,8 @@
     <string name="site_settings_username_title" translatable="false">@string/username</string>
     <string name="site_settings_password_title" translatable="false">@string/password</string>
     <string name="site_settings_default_category_title">Default Category</string>
+    <string name="site_settings_tags_empty_title">You don\'t have any tags</string>
+    <string name="site_settings_tags_empty_title_search">No tags matching your search</string>
     <string name="site_settings_tags_title">Tags</string>
     <string name="site_settings_default_format_title">Default Format</string>
     <string name="site_settings_week_start_title">Week starts on</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2165,7 +2165,7 @@
     <string name="stats_bar_date_value_type_desc">%s, %d %s</string>
     <string name="stats_bar_date_value_desc">%s, %d views</string>
     <string name="stats_bar_week_desc">Week of %s</string>
-    <string name="fab_add_tag_desc">create tag</string>
+    <string name="fab_add_tag_desc">Create Tag</string>
     <string name="fab_create_desc">create</string>
     <string name="stats_legend">stats graph legend</string>
     <string name="stats_tab_tap_content_description">showing %s</string>


### PR DESCRIPTION
### Fix
Add an actionable empty state similar to those in https://github.com/wordpress-mobile/WordPress-Android/issues/7996 to the ***Tags*** screen under ***Site Settings***.  There are also fixes for buggy behavior with search device rotation, tags detail fragment, and floating action button.  See the screenshots below for illustration.

![aes_tags](https://user-images.githubusercontent.com/3827611/43930613-4e7cc6f8-9bef-11e8-863c-1cef7aee92a7.png)

### Test
0. Select site without tags.
1. Go to ***My Site*** tab.
2. Tap ***Settings*** item under ***Configuration*** section.
3. Tap ***Tags*** items under ***Writing*** section.
4. Notice default actionable empty state is shown.
5. Tap ***Search*** action.
6. Notice search actionable empty state is shown.
7. Tap back arrow.
8. Tap ***Create a Tag*** button.
9. Enter tag name.
10. Tap back arrow.
11. Notice default actionable empty state is not shown.
12. Notice floating action button is shown.
13. Tap ***Search*** action.
14. Notice floating action button is not shown.
15. Notice search actionable empty state is not shown.
16. Enter search not matching tag name from Step 9.
17. Notice search actionable empty state is shown.
18. Tap back arrow.
19. Notice default actionable empty state is not shown.
20. Notice floating action button is shown.

### Review
Only one develop and one designer are required to review these changes, but anyone can perform the review.