### PR TITLE
Passwords should be invisible to the accessibility services

### DIFF
--- a/WordPress/src/main/res/layout/signup_epilogue.xml
+++ b/WordPress/src/main/res/layout/signup_epilogue.xml
@@ -151,6 +151,7 @@
                 android:id="@+id/signup_epilogue_input_password"
                 android:hint="@string/signup_epilogue_hint_password"
                 android:inputType="textPassword"
+                android:importantForAccessibility="no"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_extra_large"
                 android:layout_width="match_parent"

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -80,6 +80,7 @@
             android:id="@+id/pref_site_password"
             android:enabled="false"
             android:inputType="textPassword"
+            android:importantForAccessibility="no"
             android:key="@string/pref_key_site_password"
             android:maxLength="@integer/max_length_password"
             android:title="@string/site_settings_password_title"

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_alert_http_auth.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_alert_http_auth.xml
@@ -32,6 +32,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:inputType="textPassword"
+            android:importantForAccessibility="no"
             android:hint="@string/httppassword"/>
     </android.support.design.widget.TextInputLayout>
 </LinearLayout>

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_password_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_password_screen.xml
@@ -71,6 +71,7 @@
         android:hint="@string/password"
         android:importantForAutofill="noExcludeDescendants"
         android:inputType="textPassword"
+        android:importantForAccessibility="no"
         android:textAlignment="viewStart"
         android:gravity="start"
         app:passwordToggleEnabled="true"

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_username_password_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_username_password_screen.xml
@@ -105,6 +105,7 @@
         android:layout_marginBottom="@dimen/margin_extra_extra_large"
         android:hint="@string/password"
         android:inputType="textPassword"
+        android:importantForAccessibility="no"
         app:passwordToggleEnabled="true"
         app:passwordToggleTint="@color/grey"
         android:textAlignment="viewStart"


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.