### PR TITLE
Introduced testcases to validate DomainSuggestionsViewModel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domainregister/suggestionslist/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domainregister/suggestionslist/DomainSuggestionsFragment.kt
@@ -52,7 +52,6 @@ class DomainSuggestionsFragment : Fragment() {
             ToastUtils.showToast(activity, "Still under development.")
         }
         domainSearchEditText.addTextChangedListener(object : TextWatcher {
-
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domainregister/suggestionslist/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domainregister/suggestionslist/DomainSuggestionsFragment.kt
@@ -25,6 +25,7 @@ import javax.inject.Inject
 class DomainSuggestionsFragment : Fragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: DomainSuggestionsViewModel
+    private val debouncer = Debouncer()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.domain_suggestions_fragment, container, false)
@@ -51,7 +52,6 @@ class DomainSuggestionsFragment : Fragment() {
             ToastUtils.showToast(activity, "Still under development.")
         }
         domainSearchEditText.addTextChangedListener(object : TextWatcher {
-            private val debouncer = Debouncer()
 
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
@@ -89,6 +89,11 @@ class DomainSuggestionsFragment : Fragment() {
 
     private fun onDomainSuggestionSelected(domainSuggestion: DomainSuggestionResponse?, selectedPosition: Int) {
         viewModel.onDomainSuggestionsSelected(domainSuggestion, selectedPosition)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        debouncer.shutdown()
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domainregister/suggestionslist/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domainregister/suggestionslist/DomainSuggestionsFragment.kt
@@ -17,15 +17,12 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse
 import org.wordpress.android.util.ToastUtils
-import org.wordpress.android.util.helpers.Debouncer
 import org.wordpress.android.viewmodel.domainregister.DomainSuggestionsViewModel
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 class DomainSuggestionsFragment : Fragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: DomainSuggestionsViewModel
-    private val debouncer = Debouncer()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.domain_suggestions_fragment, container, false)
@@ -56,9 +53,7 @@ class DomainSuggestionsFragment : Fragment() {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
 
             override fun afterTextChanged(view: Editable?) {
-                debouncer.debounce(Void::class.java, {
-                    viewModel.updateSearchQuery(view.toString())
-                }, GET_SUGGESTIONS_INTERVAL_MS, TimeUnit.MILLISECONDS)
+                viewModel.updateSearchQuery(view.toString())
             }
         })
         val adapter = DomainSuggestionsAdapter(this::onDomainSuggestionSelected)
@@ -88,14 +83,5 @@ class DomainSuggestionsFragment : Fragment() {
 
     private fun onDomainSuggestionSelected(domainSuggestion: DomainSuggestionResponse?, selectedPosition: Int) {
         viewModel.onDomainSuggestionsSelected(domainSuggestion, selectedPosition)
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        debouncer.shutdown()
-    }
-
-    companion object {
-        private const val GET_SUGGESTIONS_INTERVAL_MS = 250L
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/domainregister/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/domainregister/DomainSuggestionsViewModel.kt
@@ -4,7 +4,6 @@ import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.Transformations
 import android.arch.lifecycle.ViewModel
-import android.os.Handler
 import android.text.TextUtils
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -17,7 +16,6 @@ import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
 import org.wordpress.android.models.networkresource.ListState
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import java.util.ArrayList
 import javax.inject.Inject
 import kotlin.properties.Delegates
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/domainregister/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/domainregister/DomainSuggestionsViewModel.kt
@@ -28,7 +28,6 @@ class DomainSuggestionsViewModel @Inject constructor(
 ) : ViewModel() {
     lateinit var site: SiteModel
     private var isStarted = false
-    private val handler = Handler()
 
     private val _suggestions = MutableLiveData<DomainSuggestionsListState>()
     val suggestionsLiveData: LiveData<List<DomainSuggestionResponse>>
@@ -54,7 +53,7 @@ class DomainSuggestionsViewModel @Inject constructor(
 
     private var searchQuery: String by Delegates.observable("") { _, oldValue, newValue ->
         if (newValue != oldValue) {
-            submitSearch(newValue, true)
+            fetchSuggestions()
         }
     }
 
@@ -80,19 +79,6 @@ class DomainSuggestionsViewModel @Inject constructor(
 
     private fun initializeDefaultSuggestions() {
         searchQuery = site.name
-    }
-
-    private fun submitSearch(query: String, delayed: Boolean) {
-        if (delayed) {
-            handler.postDelayed({
-                if (query == searchQuery) {
-                    submitSearch(query, false)
-                }
-            }, 250)
-        } else {
-            suggestions = ListState.Ready(ArrayList())
-            fetchSuggestions()
-        }
     }
 
     // Network Request

--- a/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
+++ b/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
@@ -43,7 +43,7 @@
             android:background="@android:color/transparent"
             android:clickable="false"
             android:hint="@string/suggestions_search_hint"
-            android:imeOptions="actionSearch"
+            android:imeOptions="actionDone"
             android:inputType="text"
             android:maxLines="1"
             android:textColorHint="@color/grey_darken_10"

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/domainregister/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/domainregister/DomainSuggestionsViewModelTest.kt
@@ -106,11 +106,11 @@ class DomainSuggestionsViewModelTest {
         val action = actionCaptor.firstValue
         Assert.assertEquals(action.type, SiteAction.SUGGEST_DOMAINS)
         Assert.assertTrue(action.payload is SuggestDomainsPayload)
-        (action.payload as SuggestDomainsPayload).apply {
-            Assert.assertEquals(this.includeWordpressCom, false)
-            Assert.assertEquals(this.onlyWordpressCom, false)
-            Assert.assertEquals(this.includeDotBlogSubdomain, true)
-            Assert.assertEquals(this.query, query)
+        (action.payload as SuggestDomainsPayload).let {
+            Assert.assertEquals(it.includeWordpressCom, false)
+            Assert.assertEquals(it.onlyWordpressCom, false)
+            Assert.assertEquals(it.includeDotBlogSubdomain, true)
+            Assert.assertEquals(it.query, query)
         }
         verify(isLoadingObserver, atLeast(1)).onChanged(any())
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/domainregister/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/domainregister/DomainSuggestionsViewModelTest.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockito_kotlin.argumentCaptor
 import com.nhaarman.mockito_kotlin.atLeast
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
@@ -21,6 +22,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse
 import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
+import org.wordpress.android.util.helpers.Debouncer
 
 @RunWith(MockitoJUnitRunner::class)
 class DomainSuggestionsViewModelTest {
@@ -29,6 +31,8 @@ class DomainSuggestionsViewModelTest {
     val rule = InstantTaskExecutorRule()
     @Mock
     private lateinit var dispatcher: Dispatcher
+    @Mock
+    private lateinit var debouncer: Debouncer
     private var site: SiteModel = SiteModel()
     private val actionCaptor = argumentCaptor<Action<Any>>()
 
@@ -40,8 +44,12 @@ class DomainSuggestionsViewModelTest {
 
     @Before
     fun setUp() {
-        viewModel = DomainSuggestionsViewModel(dispatcher)
+        viewModel = DomainSuggestionsViewModel(dispatcher, debouncer)
         viewModel.site = site
+        whenever(debouncer.debounce(any(), any(), any(), any())).thenAnswer { invocation ->
+            val delayedRunnable = invocation.arguments[1] as Runnable
+            delayedRunnable.run()
+        }
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/domainregister/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/domainregister/DomainSuggestionsViewModelTest.kt
@@ -1,0 +1,123 @@
+package org.wordpress.android.viewmodel.domainregister
+
+import android.arch.core.executor.testing.InstantTaskExecutorRule
+import android.arch.lifecycle.Observer
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.atLeast
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.SiteAction
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse
+import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains
+import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
+
+@RunWith(MockitoJUnitRunner::class)
+class DomainSuggestionsViewModelTest {
+    @Rule
+    @JvmField
+    val rule = InstantTaskExecutorRule()
+    @Mock
+    private lateinit var dispatcher: Dispatcher
+    private var site: SiteModel = SiteModel()
+    private val actionCaptor = argumentCaptor<Action<Any>>()
+
+    private lateinit var viewModel: DomainSuggestionsViewModel
+
+    init {
+        site.name = "Wordpress"
+    }
+
+    @Before
+    fun setUp() {
+        viewModel = DomainSuggestionsViewModel(dispatcher)
+        viewModel.site = site
+    }
+
+    @Test
+    fun onStartFetchingSuggestions() {
+        Assert.assertNull(viewModel.selectedSuggestion.value)
+        Assert.assertNull(viewModel.selectedPosition.value)
+
+        viewModel.start(site)
+        assertFetchSuggestions(site.name)
+    }
+
+    @Test
+    fun onSuggestionsSearchQueryChanged() {
+        val query = "sample site name"
+        viewModel.updateSearchQuery(query)
+        assertFetchSuggestions(query)
+    }
+
+    @Test
+    fun onSuggestionSelectionUpdated() {
+        val suggestions = getMockDomainSuggestions()
+
+        viewModel.onDomainSuggestionsFetched(OnSuggestedDomains("", suggestions))
+
+        val enableChooseDomainObserver = mock<Observer<Boolean>>()
+        viewModel.shouldEnableChooseDomain.observeForever(enableChooseDomainObserver)
+
+        validateSuggestion(suggestions, 1)
+        validateSuggestion(suggestions, 0)
+        // Check Deselection
+        validateSuggestion(suggestions, -1)
+        verify(enableChooseDomainObserver, atLeast(3)).onChanged(any())
+    }
+
+    private fun validateSuggestion(suggestions: List<DomainSuggestionResponse>, selectedPosition: Int) {
+        val selectedSuggestion = suggestions.getOrNull(selectedPosition)
+        viewModel.onDomainSuggestionsSelected(selectedSuggestion, selectedPosition)
+
+        Assert.assertEquals(viewModel.selectedSuggestion.value, selectedSuggestion)
+        Assert.assertEquals(viewModel.selectedPosition.value, selectedPosition)
+    }
+
+    private fun assertFetchSuggestions(query: String) {
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val isLoadingObserver = mock<Observer<Boolean>>()
+        viewModel.isLoadingInProgress.observeForever(isLoadingObserver)
+
+        val action = actionCaptor.firstValue
+        Assert.assertEquals(action.type, SiteAction.SUGGEST_DOMAINS)
+        Assert.assertTrue(action.payload is SuggestDomainsPayload)
+        (action.payload as? SuggestDomainsPayload)?.apply {
+            Assert.assertEquals(this.includeWordpressCom, false)
+            Assert.assertEquals(this.onlyWordpressCom, false)
+            Assert.assertEquals(this.includeDotBlogSubdomain, true)
+            Assert.assertEquals(this.query, query)
+        }
+        verify(isLoadingObserver, atLeast(1)).onChanged(any())
+    }
+
+    private fun getMockDomainSuggestions(): List<DomainSuggestionResponse> {
+        val suggestions = mutableListOf<DomainSuggestionResponse>()
+        suggestions.add(getMockDomainSuggestion("samplesite1"))
+        suggestions.add(getMockDomainSuggestion("samplesite2"))
+        suggestions.add(getMockDomainSuggestion("samplesite3"))
+        return suggestions
+    }
+
+    private fun getMockDomainSuggestion(siteName: String): DomainSuggestionResponse {
+        val domainSuggestionResponse = DomainSuggestionResponse()
+        domainSuggestionResponse.domain_name = "$siteName.com"
+        domainSuggestionResponse.is_free = false
+        domainSuggestionResponse.cost = "50 $"
+        domainSuggestionResponse.product_id = "0"
+        domainSuggestionResponse.product_slug = "sample_slug"
+        domainSuggestionResponse.relevance = 1.0F
+        return domainSuggestionResponse
+    }
+}


### PR DESCRIPTION
This PR introduces a few Mockito testcases to validate `DomainSuggestionsViewModel`. This is one of the `ViewModel` utilized for [custom domain association](https://github.com/wordpress-mobile/WordPress-Android/issues/7923)

Additionally this PR also refactors the logic for debouncing the search input into the `Fragment` rather than keeping it in the `ViewModel` as it will cause issues with the test cases. 