### PR TITLE
Fix crash when loading video thumbnail

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -178,7 +178,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             }
         } else if (media.isVideo()) {
             holder.mFileContainer.setVisibility(View.GONE);
-            loadVideoThumbnail(media, holder.mImageView);
+            loadVideoThumbnail(position, media, holder.mImageView);
         } else {
             // not an image or video, so show file name and file type
             String fileName = media.getFileName();
@@ -429,7 +429,8 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
     /*
      * loads the thumbnail for the passed video media item - works with both local and network videos
      */
-    private void loadVideoThumbnail(final @NonNull MediaModel media, @NonNull final ImageView imageView) {
+    private void loadVideoThumbnail(final int position, final @NonNull MediaModel media,
+                                    @NonNull final ImageView imageView) {
         // if we have a thumbnail url, use it and be done
         if (!TextUtils.isEmpty(media.getThumbnailUrl())) {
             mImageManager.load(imageView, ImageType.VIDEO, media.getThumbnailUrl(), ScaleType.CENTER_CROP);
@@ -469,7 +470,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                             if (imageView.getTag(R.id.media_grid_file_path_id) instanceof String
                                 && (imageView.getTag(R.id.media_grid_file_path_id)).equals(filePath)) {
                                 imageView.setTag(R.id.media_grid_file_path_id, null);
-                                mImageManager.load(imageView, thumb, ScaleType.CENTER_CROP);
+                                notifyItemChanged(position);
                             }
                         }
                     });


### PR DESCRIPTION
Fixes #8183 

Fixes bug when the app sometimes crashes when the user presses back button while a video thumbnail is being loaded.

To test:
1. Go to Media library
2. Click on the Plus sign in the top right corner
3. Click on "Take video"
4. Press back button as soon as you are redirected back to media library and the video is still being uploaded
5. Observe the app sometimes crashes -> it happens just very occasionally, so I added `Thread.sleep(3000)` just before `mHandler.post` for testing purposes.
