### PR TITLE
News Card - ViewModel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -3,6 +3,7 @@ package org.wordpress.android.modules;
 import android.arch.lifecycle.ViewModel;
 import android.arch.lifecycle.ViewModelProvider;
 
+import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel;
 import org.wordpress.android.viewmodel.PluginBrowserViewModel;
 import org.wordpress.android.viewmodel.ViewModelFactory;
 import org.wordpress.android.viewmodel.ViewModelKey;
@@ -29,6 +30,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(ActivityLogDetailViewModel.class)
     abstract ViewModel activityLogDetailViewModel(ActivityLogDetailViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(ReaderPostListViewModel.class)
+    abstract ViewModel readerPostListViewModel(ReaderPostListViewModel viewModel);
 
     @Binds
     abstract ViewModelProvider.Factory provideViewModelFactory(ViewModelFactory viewModelFactory);

--- a/WordPress/src/main/java/org/wordpress/android/ui/news/LocalNewsService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/news/LocalNewsService.kt
@@ -13,9 +13,9 @@ import javax.inject.Inject
  * This is just a temporary solution until News Cards are supported on the server.
  */
 class LocalNewsService @Inject constructor(private val context: Context) : NewsService {
-    val data: MutableLiveData<NewsItem?> = MutableLiveData()
+    val data: MutableLiveData<NewsItem> = MutableLiveData()
 
-    override fun newsItemSource(): LiveData<NewsItem?> {
+    override fun newsItemSource(): LiveData<NewsItem> {
         return data
     }
 
@@ -27,7 +27,7 @@ class LocalNewsService @Inject constructor(private val context: Context) : NewsS
         // clean not required
     }
 
-    private fun loadCardFromResources(): NewsItem? {
+    private fun loadCardFromResources(): NewsItem {
         return NewsItem(
                 context.getString(LocalNewsItem.titleResId),
                 context.getString(LocalNewsItem.contentResId),

--- a/WordPress/src/main/java/org/wordpress/android/ui/news/NewsManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/news/NewsManager.kt
@@ -12,8 +12,8 @@ import javax.inject.Singleton
  */
 @Singleton
 class NewsManager @Inject constructor(val newsService: NewsService, val appPrefs: AppPrefsWrapper) {
-    private val dataSourceMediator: MediatorLiveData<NewsItem?> = MediatorLiveData()
-    private var dataSource: LiveData<NewsItem?> = newsService.newsItemSource()
+    private val dataSourceMediator: MediatorLiveData<NewsItem> = MediatorLiveData()
+    private var dataSource: LiveData<NewsItem> = newsService.newsItemSource()
 
     init {
         dataSourceMediator.addSource(dataSource) {
@@ -23,7 +23,7 @@ class NewsManager @Inject constructor(val newsService: NewsService, val appPrefs
         }
     }
 
-    fun newsItemSource(): LiveData<NewsItem?> {
+    fun newsItemSource(): LiveData<NewsItem> {
         return dataSourceMediator
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/news/NewsService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/news/NewsService.kt
@@ -4,7 +4,7 @@ import android.arch.lifecycle.LiveData
 import org.wordpress.android.models.news.NewsItem
 
 interface NewsService {
-    fun newsItemSource(): LiveData<NewsItem?>
+    fun newsItemSource(): LiveData<NewsItem>
 
     fun pull(skipCache: Boolean)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -1,0 +1,50 @@
+package org.wordpress.android.ui.reader.viewmodels
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MediatorLiveData
+import android.arch.lifecycle.ViewModel
+import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.models.news.NewsItem
+import org.wordpress.android.ui.news.NewsManager
+import javax.inject.Inject
+
+class ReaderPostListViewModel @Inject constructor(
+    private val newsManager: NewsManager
+) : ViewModel() {
+    private val newsItemSource = newsManager.newsItemSource()
+    private val _newsItemSourceMediator = MediatorLiveData<NewsItem?>()
+    val newsItem: LiveData<NewsItem?>
+        get() = _newsItemSourceMediator
+
+    private lateinit var initialTag: ReaderTag
+    private var isStarted = false
+
+    fun start(tag: ReaderTag) {
+        if (isStarted) {
+            return
+        }
+        initialTag = tag
+        onTagChanged(tag)
+        newsManager.pull()
+        isStarted = true
+    }
+
+    fun onTagChanged(tag: ReaderTag) {
+        // show the card only when the initial tag is selected in the filter
+        if (tag == initialTag) {
+            _newsItemSourceMediator.addSource(newsItemSource) { _newsItemSourceMediator.value = it }
+        } else {
+            _newsItemSourceMediator.removeSource(newsItemSource)
+            _newsItemSourceMediator.value = null
+        }
+    }
+
+    fun onDismissClicked(item: NewsItem) {
+        newsManager.dismiss(item)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        newsManager.stop()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -13,8 +13,6 @@ class ReaderPostListViewModel @Inject constructor(
 ) : ViewModel() {
     private val newsItemSource = newsManager.newsItemSource()
     private val _newsItemSourceMediator = MediatorLiveData<NewsItem>()
-    val newsItem: LiveData<NewsItem>
-        get() = _newsItemSourceMediator
 
     private lateinit var initialTag: ReaderTag
     private var isStarted = false
@@ -27,6 +25,10 @@ class ReaderPostListViewModel @Inject constructor(
         onTagChanged(tag)
         newsManager.pull()
         isStarted = true
+    }
+
+    fun getNewsDataSource(): LiveData<NewsItem> {
+        return _newsItemSourceMediator
     }
 
     fun onTagChanged(tag: ReaderTag) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -12,8 +12,8 @@ class ReaderPostListViewModel @Inject constructor(
     private val newsManager: NewsManager
 ) : ViewModel() {
     private val newsItemSource = newsManager.newsItemSource()
-    private val _newsItemSourceMediator = MediatorLiveData<NewsItem?>()
-    val newsItem: LiveData<NewsItem?>
+    private val _newsItemSourceMediator = MediatorLiveData<NewsItem>()
+    val newsItem: LiveData<NewsItem>
         get() = _newsItemSourceMediator
 
     private lateinit var initialTag: ReaderTag

--- a/WordPress/src/test/java/org/wordpress/android/ui/news/LocalNewsServiceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/news/LocalNewsServiceTest.kt
@@ -4,7 +4,7 @@ import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.Observer
 import android.content.Context
 import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.times
+import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Before
@@ -41,7 +41,7 @@ class LocalNewsServiceTest {
     fun verifyItemEmittedOnPullInvoked() {
         val observable = localNewsService.newsItemSource()
         observable.observeForever(observer)
-        verify(observer, times(0)).onChanged(any())
+        verify(observer, never()).onChanged(any())
         localNewsService.pull(false)
         verify(observer).onChanged(newsItem)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/news/LocalNewsServiceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/news/LocalNewsServiceTest.kt
@@ -22,7 +22,7 @@ class LocalNewsServiceTest {
     @JvmField
     val rule = InstantTaskExecutorRule()
 
-    @Mock private lateinit var observer: Observer<NewsItem?>
+    @Mock private lateinit var observer: Observer<NewsItem>
     @Mock private lateinit var context: Context
 
     private lateinit var newsItem: NewsItem

--- a/WordPress/src/test/java/org/wordpress/android/ui/news/NewsManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/news/NewsManagerTest.kt
@@ -22,12 +22,12 @@ class NewsManagerTest {
     @JvmField val rule = InstantTaskExecutorRule()
 
     @Mock private lateinit var newsService: NewsService
-    @Mock private lateinit var observer: Observer<NewsItem?>
+    @Mock private lateinit var observer: Observer<NewsItem>
     @Mock private lateinit var item: NewsItem
     @Mock private lateinit var appPrefs: AppPrefsWrapper
 
     private lateinit var newsManager: NewsManager
-    private val liveData = MutableLiveData<NewsItem?>()
+    private val liveData = MutableLiveData<NewsItem>()
 
     @Before
     fun setUp() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/news/NewsManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/news/NewsManagerTest.kt
@@ -4,7 +4,8 @@ import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.Observer
 import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.times
+import com.nhaarman.mockito_kotlin.inOrder
+import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Before
 import org.junit.Rule
@@ -47,8 +48,10 @@ class NewsManagerTest {
         liveData.postValue(null)
         liveData.postValue(item)
 
-        verify(observer, times(2)).onChanged(item)
-        verify(observer, times(1)).onChanged(null)
+        val inOrder = inOrder(observer)
+        inOrder.verify(observer).onChanged(item)
+        inOrder.verify(observer).onChanged(null)
+        inOrder.verify(observer).onChanged(item)
     }
 
     @Test
@@ -57,7 +60,7 @@ class NewsManagerTest {
         whenever(item.version).thenReturn(1)
 
         liveData.postValue(item)
-        verify(observer, times(0)).onChanged(any())
+        verify(observer, never()).onChanged(any())
     }
 
     @Test
@@ -67,7 +70,7 @@ class NewsManagerTest {
         liveData.postValue(item)
         newsManager.dismiss(item)
 
-        verify(appPrefs, times(1)).newsCardDismissedVersion = 123
+        verify(appPrefs).newsCardDismissedVersion = 123
     }
 
     @Test
@@ -79,12 +82,12 @@ class NewsManagerTest {
     @Test
     fun propagatePullToNewsServiceWhenPullInvoked() {
         newsManager.pull(true)
-        verify(newsService, times(1)).pull(true)
+        verify(newsService).pull(true)
     }
 
     @Test
     fun propagateStopToNewsServiceWhenStopInvoked() {
         newsManager.stop()
-        verify(newsService, times(1)).stop()
+        verify(newsService).stop()
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.viewmodel.reader
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.Observer
-import com.nhaarman.mockito_kotlin.times
+import com.nhaarman.mockito_kotlin.inOrder
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Before
@@ -36,14 +36,14 @@ class ReaderPostListViewModelTest {
     fun setUp() {
         whenever(newsManager.newsItemSource()).thenReturn(liveData)
         viewModel = ReaderPostListViewModel(newsManager)
-        val observable = viewModel.newsItem
+        val observable = viewModel.getNewsDataSource()
         observable.observeForever(observer)
     }
 
     @Test
     fun verifyPullInvokedInOnStart() {
         viewModel.start(initialTag)
-        verify(newsManager, times(1)).pull(false)
+        verify(newsManager).pull(false)
     }
 
     @Test
@@ -53,14 +53,16 @@ class ReaderPostListViewModelTest {
         liveData.postValue(null)
         liveData.postValue(item)
 
-        verify(observer, times(2)).onChanged(item)
-        verify(observer, times(1)).onChanged(null)
+        val inOrder = inOrder(observer)
+        inOrder.verify(observer).onChanged(item)
+        inOrder.verify(observer).onChanged(null)
+        inOrder.verify(observer).onChanged(item)
     }
 
     @Test
     fun verifyViewModelPropagatesDismissToNewsManager() {
         viewModel.onDismissClicked(item)
-        verify(newsManager, times(1)).dismiss(item)
+        verify(newsManager).dismiss(item)
     }
 
     @Test
@@ -68,8 +70,9 @@ class ReaderPostListViewModelTest {
         viewModel.start(initialTag)
         liveData.postValue(item)
         viewModel.onTagChanged(otherTag)
-        verify(observer, times(1)).onChanged(item)
-        verify(observer, times(1)).onChanged(null)
+        val inOrder = inOrder(observer)
+        inOrder.verify(observer).onChanged(item)
+        inOrder.verify(observer).onChanged(null)
     }
 
     @Test
@@ -83,7 +86,9 @@ class ReaderPostListViewModelTest {
         liveData.postValue(item) // should not be propagated to the UI
         viewModel.onTagChanged(initialTag)
 
-        verify(observer, times(2)).onChanged(item)
-        verify(observer, times(1)).onChanged(null)
+        val inOrder = inOrder(observer)
+        inOrder.verify(observer).onChanged(item)
+        inOrder.verify(observer).onChanged(null)
+        inOrder.verify(observer).onChanged(item)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -24,13 +24,13 @@ class ReaderPostListViewModelTest {
     val rule = InstantTaskExecutorRule()
 
     @Mock private lateinit var newsManager: NewsManager
-    @Mock private lateinit var observer: Observer<NewsItem?>
+    @Mock private lateinit var observer: Observer<NewsItem>
     @Mock private lateinit var item: NewsItem
     @Mock private lateinit var initialTag: ReaderTag
     @Mock private lateinit var otherTag: ReaderTag
 
     private lateinit var viewModel: ReaderPostListViewModel
-    private val liveData = MutableLiveData<NewsItem?>()
+    private val liveData = MutableLiveData<NewsItem>()
 
     @Before
     fun setUp() {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -1,0 +1,89 @@
+package org.wordpress.android.viewmodel.reader
+
+import android.arch.core.executor.testing.InstantTaskExecutorRule
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.Observer
+import com.nhaarman.mockito_kotlin.times
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.models.news.NewsItem
+import org.wordpress.android.ui.news.NewsManager
+import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel
+
+@RunWith(MockitoJUnitRunner::class)
+class ReaderPostListViewModelTest {
+    @Rule
+    @JvmField
+    val rule = InstantTaskExecutorRule()
+
+    @Mock private lateinit var newsManager: NewsManager
+    @Mock private lateinit var observer: Observer<NewsItem?>
+    @Mock private lateinit var item: NewsItem
+    @Mock private lateinit var initialTag: ReaderTag
+    @Mock private lateinit var otherTag: ReaderTag
+
+    private lateinit var viewModel: ReaderPostListViewModel
+    private val liveData = MutableLiveData<NewsItem?>()
+
+    @Before
+    fun setUp() {
+        whenever(newsManager.newsItemSource()).thenReturn(liveData)
+        viewModel = ReaderPostListViewModel(newsManager)
+        val observable = viewModel.newsItem
+        observable.observeForever(observer)
+    }
+
+    @Test
+    fun verifyPullInvokedInOnStart() {
+        viewModel.start(initialTag)
+        verify(newsManager, times(1)).pull(false)
+    }
+
+    @Test
+    fun verifyViewModelPropagatesNewsItems() {
+        viewModel.start(initialTag)
+        liveData.postValue(item)
+        liveData.postValue(null)
+        liveData.postValue(item)
+
+        verify(observer, times(2)).onChanged(item)
+        verify(observer, times(1)).onChanged(null)
+    }
+
+    @Test
+    fun verifyViewModelPropagatesDismissToNewsManager() {
+        viewModel.onDismissClicked(item)
+        verify(newsManager, times(1)).dismiss(item)
+    }
+
+    @Test
+    fun emitNullOnInitialTagChanged() {
+        viewModel.start(initialTag)
+        liveData.postValue(item)
+        viewModel.onTagChanged(otherTag)
+        verify(observer, times(1)).onChanged(item)
+        verify(observer, times(1)).onChanged(null)
+    }
+
+    @Test
+    fun verifyNewsItemAvailableOnlyForInitialReaderTag() {
+        viewModel.start(initialTag)
+        liveData.postValue(item)
+        viewModel.onTagChanged(otherTag)
+        liveData.postValue(item) // should not be propagated to the UI
+        liveData.postValue(item) // should not be propagated to the UI
+        liveData.postValue(item) // should not be propagated to the UI
+        liveData.postValue(item) // should not be propagated to the UI
+        viewModel.onTagChanged(initialTag)
+
+        verify(observer, times(2)).onChanged(item)
+        verify(observer, times(1)).onChanged(null)
+    }
+}


### PR DESCRIPTION
Fixes #8186 

Note: Branch is based on a branch from #8172.

This PR introduces ReaderPostListViewModel.

Few notes about the News Card feature
We want to create a card, which we'll use to announce new features and updates at different places in the app. First place where we want to display the card is Reader. However, there are few rules when the card should be displayed.
1. The card is displayed only when there are data for the News Card available.
2. The card is displayed only when the card with the same announcement hasn't been dismissed by the user.
3. The card is displayed only on the first filter of the reader (when the user starts the app and first filter is Followed Sites, the card should not be visible on other filters. However, if the user changes the filter for instance to Discovery and restarts the app, the card should be displayed on Discovery and should not be displayed on Followed Sites.)
4. When the card is dismissed, it should not be visible until a new card with an incremented version is published.

To test - nothing to test, since this is just a view model layer.
