### PR TITLE
News Card - integration

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/news/NewsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/news/NewsViewHolder.kt
@@ -1,0 +1,34 @@
+package org.wordpress.android.ui.news
+
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.RelativeLayout
+import android.widget.TextView
+import org.wordpress.android.R
+import org.wordpress.android.models.news.NewsItem
+
+class NewsViewHolder(parent: ViewGroup, private val listener: NewsCardListener) :
+        RecyclerView.ViewHolder(
+                LayoutInflater.from(parent.context).inflate(R.layout.news_card, parent, false)
+        ) {
+    interface NewsCardListener {
+        fun onItemClicked(url: String)
+        fun onDismissClicked(item: NewsItem)
+    }
+
+    private val container: RelativeLayout = itemView.findViewById(R.id.news_container)
+    private val title: TextView = itemView.findViewById(R.id.news_title)
+    private val content: TextView = itemView.findViewById(R.id.news_content)
+    private val action: TextView = itemView.findViewById(R.id.news_action)
+    private val dismissView: ImageView = itemView.findViewById(R.id.news_dismiss)
+
+    fun bind(item: NewsItem) {
+        title.text = item.title
+        content.text = item.content
+        action.text = item.actionText
+        container.setOnClickListener { listener.onItemClicked(item.actionUrl) }
+        dismissView.setOnClickListener { listener.onDismissClicked(item) }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1484,28 +1484,31 @@ public class ReaderPostListFragment extends Fragment
                 }
             };
 
+    private final NewsCardListener mNewsCardListener = new NewsCardListener() {
+        @Override public void onItemClicked(@NotNull String url) {
+            Activity activity = getActivity();
+            if (activity != null) {
+                WPWebViewActivity.openURL(activity, url);
+            }
+        }
+
+        @Override public void onDismissClicked(NewsItem item) {
+            mViewModel.onDismissClicked(item);
+        }
+    };
+
     private ReaderPostAdapter getPostAdapter() {
         if (mPostAdapter == null) {
             AppLog.d(T.READER, "reader post list > creating post adapter");
             Context context = WPActivityUtils.getThemedContext(getActivity());
-            mPostAdapter = new ReaderPostAdapter(context, getPostListType(), mImageManager, new NewsCardListener() {
-                @Override public void onItemClicked(@NotNull String url) {
-                    Activity activity = getActivity();
-                    if (activity != null) {
-                        WPWebViewActivity.openURL(activity, url);
-                    }
-                }
-
-                @Override public void onDismissClicked(NewsItem item) {
-                    mViewModel.onDismissClicked(item);
-                }
-            });
+            mPostAdapter = new ReaderPostAdapter(context, getPostListType(), mImageManager);
             mPostAdapter.setOnFollowListener(this);
             mPostAdapter.setOnPostSelectedListener(this);
             mPostAdapter.setOnPostPopupListener(this);
             mPostAdapter.setOnDataLoadedListener(mDataLoadedListener);
             mPostAdapter.setOnDataRequestedListener(mDataRequestedListener);
             mPostAdapter.setOnPostBookmarkedListener(mOnPostBookmarkedListener);
+            mPostAdapter.setOnNewsCardListener(mNewsCardListener);
             if (getActivity() instanceof ReaderSiteHeaderView.OnBlogInfoLoadedListener) {
                 mPostAdapter.setOnBlogInfoLoadedListener((ReaderSiteHeaderView.OnBlogInfoLoadedListener) getActivity());
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -181,6 +181,12 @@ public class ReaderPostListFragment extends Fragment
 
     private ReaderPostListViewModel mViewModel;
 
+    private Observer<NewsItem> mNewsItemObserver = new Observer<NewsItem>() {
+        @Override public void onChanged(@Nullable NewsItem newsItem) {
+            getPostAdapter().updateNewsCardItem(newsItem);
+        }
+    };
+
     @Inject ViewModelProvider.Factory mViewModelFactory;
     @Inject AccountStore mAccountStore;
     @Inject ReaderStore mReaderStore;
@@ -337,15 +343,6 @@ public class ReaderPostListFragment extends Fragment
         mViewModel = ViewModelProviders.of((FragmentActivity) getActivity(), mViewModelFactory)
                                        .get(ReaderPostListViewModel.class);
         mViewModel.start(mCurrentTag);
-        setupObservables();
-    }
-
-    private void setupObservables() {
-        mViewModel.getNewsDataSource().observe((FragmentActivity) getActivity(), new Observer<NewsItem>() {
-            @Override public void onChanged(@Nullable NewsItem newsItem) {
-                getPostAdapter().updateNewsCardItem(newsItem);
-            }
-        });
     }
 
     @Override
@@ -1512,8 +1509,10 @@ public class ReaderPostListFragment extends Fragment
             if (getActivity() instanceof ReaderSiteHeaderView.OnBlogInfoLoadedListener) {
                 mPostAdapter.setOnBlogInfoLoadedListener((ReaderSiteHeaderView.OnBlogInfoLoadedListener) getActivity());
             }
+            mViewModel.getNewsDataSource().removeObserver(mNewsItemObserver);
             if (getPostListType().isTagType()) {
                 mPostAdapter.setCurrentTag(getCurrentTag());
+                mViewModel.getNewsDataSource().observe((FragmentActivity) getActivity(), mNewsItemObserver);
             } else if (getPostListType() == ReaderPostListType.BLOG_PREVIEW) {
                 mPostAdapter.setCurrentBlogAndFeed(mCurrentBlogId, mCurrentFeedId);
             } else if (getPostListType() == ReaderPostListType.SEARCH_RESULTS) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -678,7 +678,7 @@ public class ReaderPostListFragment extends Fragment
     }
 
     private void setupObservables() {
-        mViewModel.getNewsItem().observe((FragmentActivity) getActivity(), new Observer<NewsItem>() {
+        mViewModel.getNewsDataSource().observe((FragmentActivity) getActivity(), new Observer<NewsItem>() {
             @Override public void onChanged(@Nullable NewsItem newsItem) {
                 getPostAdapter().updateNewsCardItem(newsItem);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -77,7 +77,7 @@ import javax.inject.Inject;
 
 public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     private final ImageManager mImageManager;
-    private final NewsCardListener mNewsCardListener;
+    private NewsCardListener mNewsCardListener;
     private ReaderTag mCurrentTag;
     private long mCurrentBlogId;
     private long mCurrentFeedId;
@@ -684,11 +684,9 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     // ********************************************************************************************
 
-    public ReaderPostAdapter(Context context, ReaderPostListType postListType, ImageManager imageManager,
-                             NewsCardListener newsCardListener) {
+    public ReaderPostAdapter(Context context, ReaderPostListType postListType, ImageManager imageManager) {
         super();
         ((WordPress) context.getApplicationContext()).component().inject(this);
-        this.mNewsCardListener = newsCardListener;
         this.mImageManager = imageManager;
         mPostListType = postListType;
         mAvatarSzMedium = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_medium);
@@ -746,6 +744,10 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     public void setOnBlogInfoLoadedListener(ReaderSiteHeaderView.OnBlogInfoLoadedListener listener) {
         mBlogInfoLoadedListener = listener;
+    }
+
+    public void setOnNewsCardListener(NewsCardListener newsCardListener) {
+        this.mNewsCardListener = newsCardListener;
     }
 
     private ReaderTypes.ReaderPostListType getPostListType() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -37,6 +37,9 @@ import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderPostDiscoverData;
 import org.wordpress.android.models.ReaderPostList;
 import org.wordpress.android.models.ReaderTag;
+import org.wordpress.android.models.news.NewsItem;
+import org.wordpress.android.ui.news.NewsViewHolder;
+import org.wordpress.android.ui.news.NewsViewHolder.NewsCardListener;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderAnim;
@@ -74,6 +77,7 @@ import javax.inject.Inject;
 
 public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     private final ImageManager mImageManager;
+    private final NewsCardListener mNewsCardListener;
     private ReaderTag mCurrentTag;
     private long mCurrentBlogId;
     private long mCurrentFeedId;
@@ -91,6 +95,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private final ReaderTypes.ReaderPostListType mPostListType;
     private final ReaderPostList mPosts = new ReaderPostList();
     private final HashSet<String> mRenderedIds = new HashSet<>();
+    private NewsItem mNewsItem;
 
     private ReaderInterfaces.OnFollowListener mFollowListener;
     private ReaderInterfaces.OnPostSelectedListener mPostSelectedListener;
@@ -110,9 +115,13 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private static final int VIEW_TYPE_TAG_HEADER = 3;
     private static final int VIEW_TYPE_GAP_MARKER = 4;
     private static final int VIEW_TYPE_REMOVED_POST = 5;
+    private static final int VIEW_TYPE_NEWS_CARD = 6;
 
     private static final long ITEM_ID_HEADER = -1L;
     private static final long ITEM_ID_GAP_MARKER = -2L;
+    private static final long ITEM_ID_NEWS_CARD = -3L;
+
+    private static final int NEWS_CARD_POSITION = 0;
 
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
@@ -309,10 +318,13 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     @Override
     public int getItemViewType(int position) {
-        if (position == 0 && hasSiteHeader()) {
+        int headerPosition = hasNewsCard() ? 1 : 0;
+        if (position == NEWS_CARD_POSITION && hasNewsCard()) {
+            return VIEW_TYPE_NEWS_CARD;
+        } else if (position == headerPosition && hasSiteHeader()) {
             // first item is a ReaderSiteHeaderView
             return VIEW_TYPE_SITE_HEADER;
-        } else if (position == 0 && hasTagHeader()) {
+        } else if (position == headerPosition && hasTagHeader()) {
             // first item is a ReaderTagHeaderView
             return VIEW_TYPE_TAG_HEADER;
         } else if (position == mGapMarkerPosition) {
@@ -334,6 +346,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         Context context = parent.getContext();
         View postView;
         switch (viewType) {
+            case VIEW_TYPE_NEWS_CARD:
+                return new NewsViewHolder(parent, mNewsCardListener);
             case VIEW_TYPE_SITE_HEADER:
                 ReaderSiteHeaderView readerSiteHeaderView = new ReaderSiteHeaderView(context);
                 readerSiteHeaderView.setOnFollowListener(mFollowListener);
@@ -379,6 +393,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         } else if (holder instanceof GapMarkerViewHolder) {
             GapMarkerViewHolder gapHolder = (GapMarkerViewHolder) holder;
             gapHolder.mGapMarkerView.setCurrentTag(mCurrentTag);
+        } else if (holder instanceof NewsViewHolder) {
+            ((NewsViewHolder) holder).bind(mNewsItem);
         }
     }
 
@@ -668,9 +684,11 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     // ********************************************************************************************
 
-    public ReaderPostAdapter(Context context, ReaderPostListType postListType, ImageManager imageManager) {
+    public ReaderPostAdapter(Context context, ReaderPostListType postListType, ImageManager imageManager,
+                             NewsCardListener newsCardListener) {
         super();
         ((WordPress) context.getApplicationContext()).component().inject(this);
+        this.mNewsCardListener = newsCardListener;
         this.mImageManager = imageManager;
         mPostListType = postListType;
         mAvatarSzMedium = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_medium);
@@ -686,7 +704,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         setHasStableIds(true);
     }
 
-    private boolean hasCustomFirstItem() {
+    private boolean hasHeader() {
         return hasSiteHeader() || hasTagHeader();
     }
 
@@ -801,14 +819,17 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     private ReaderPost getItem(int position) {
-        if (position == 0 && hasCustomFirstItem()) {
+        if (position == NEWS_CARD_POSITION && hasNewsCard()) {
+            return null;
+        }
+        if (position == getHeaderPosition() && hasHeader()) {
             return null;
         }
         if (position == mGapMarkerPosition) {
             return null;
         }
 
-        int arrayPos = hasCustomFirstItem() ? position - 1 : position;
+        int arrayPos = position - getItemPositionOffset();
 
         if (mGapMarkerPosition > -1 && position > mGapMarkerPosition) {
             arrayPos--;
@@ -817,12 +838,30 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         return mPosts.get(arrayPos);
     }
 
+    private int getItemPositionOffset() {
+        int newsCardOffset = hasNewsCard() ? 1 : 0;
+        int headersOffset = hasHeader() ? 1 : 0;
+        return newsCardOffset + headersOffset;
+    }
+
+    private int getHeaderPosition() {
+        int headerPosition = hasNewsCard() ? 1 : 0;
+        return hasHeader() ? headerPosition : -1;
+    }
+
     @Override
     public int getItemCount() {
-        if (hasCustomFirstItem() || mGapMarkerPosition != -1) {
-            return mPosts.size() + 1;
+        int size = mPosts.size();
+        if (mGapMarkerPosition != -1) {
+            size++;
         }
-        return mPosts.size();
+        if (hasHeader()) {
+            size++;
+        }
+        if (hasNewsCard()) {
+            size++;
+        }
+        return size;
     }
 
     public boolean isEmpty() {
@@ -842,6 +881,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 return ITEM_ID_HEADER;
             case VIEW_TYPE_GAP_MARKER:
                 return ITEM_ID_GAP_MARKER;
+            case VIEW_TYPE_NEWS_CARD:
+                return ITEM_ID_NEWS_CARD;
             default:
                 ReaderPost post = getItem(position);
                 return post != null ? post.getStableId() : 0;
@@ -1086,6 +1127,24 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
     }
 
+    public void updateNewsCardItem(NewsItem newsItem) {
+        NewsItem prevState = mNewsItem;
+        mNewsItem = newsItem;
+        if (prevState == null && newsItem != null) {
+            notifyItemInserted(NEWS_CARD_POSITION);
+        } else if (prevState != null) {
+            if (newsItem == null) {
+                notifyItemRemoved(NEWS_CARD_POSITION);
+            } else {
+                notifyItemChanged(NEWS_CARD_POSITION);
+            }
+        }
+    }
+
+    private boolean hasNewsCard() {
+        return mNewsItem != null && !isEmpty();
+    }
+
     /*
      * AsyncTask to load posts in the current tag
      */
@@ -1165,10 +1224,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 } else {
                     // we want the gap marker to appear *below* this post
                     gapMarkerPosition = gapMarkerPostPosition + 1;
-                    // increment it if there's a custom first item
-                    if (hasCustomFirstItem()) {
-                        gapMarkerPosition++;
-                    }
+                    // increment it if there are custom items at the top of the list (header or newsCard)
+                    gapMarkerPosition += getItemPositionOffset();
                     AppLog.d(AppLog.T.READER, "gap marker at position " + gapMarkerPostPosition);
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -1142,7 +1142,11 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     private boolean hasNewsCard() {
-        return mNewsItem != null && !isEmpty();
+        // We don't want to display the card when we are displaying just a loading screen. However, on Discover a header
+        // is shown, even when we are loading data, so the card should be displayed. [moreover displaying the card only
+        // after we fetch the data results in weird animation after configuration change, since it plays insertion
+        // animation for all the data (including the card) except of the header which hasn't changed].
+        return mNewsItem != null && (!isEmpty() || isDiscover());
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -14,16 +14,21 @@ class ReaderPostListViewModel @Inject constructor(
     private val newsItemSource = newsManager.newsItemSource()
     private val _newsItemSourceMediator = MediatorLiveData<NewsItem>()
 
-    private lateinit var initialTag: ReaderTag
+    /**
+     * News Card shouldn't be shown when the initialTag is null. InitialTag may be null for Blog previews for instance.
+     */
+    private var initialTag: ReaderTag? = null
     private var isStarted = false
 
-    fun start(tag: ReaderTag) {
+    fun start(tag: ReaderTag?) {
         if (isStarted) {
             return
         }
-        initialTag = tag
-        onTagChanged(tag)
-        newsManager.pull()
+        initialTag?.let {
+            initialTag = tag
+            onTagChanged(tag)
+            newsManager.pull()
+        }
         isStarted = true
     }
 
@@ -31,13 +36,15 @@ class ReaderPostListViewModel @Inject constructor(
         return _newsItemSourceMediator
     }
 
-    fun onTagChanged(tag: ReaderTag) {
-        // show the card only when the initial tag is selected in the filter
-        if (tag == initialTag) {
-            _newsItemSourceMediator.addSource(newsItemSource) { _newsItemSourceMediator.value = it }
-        } else {
-            _newsItemSourceMediator.removeSource(newsItemSource)
-            _newsItemSourceMediator.value = null
+    fun onTagChanged(tag: ReaderTag?) {
+        initialTag?.let {
+            // show the card only when the initial tag is selected in the filter
+            if (tag == initialTag) {
+                _newsItemSourceMediator.addSource(newsItemSource) { _newsItemSourceMediator.value = it }
+            } else {
+                _newsItemSourceMediator.removeSource(newsItemSource)
+                _newsItemSourceMediator.value = null
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -24,7 +24,7 @@ class ReaderPostListViewModel @Inject constructor(
         if (isStarted) {
             return
         }
-        initialTag?.let {
+        tag?.let {
             initialTag = tag
             onTagChanged(tag)
             newsManager.pull()

--- a/WordPress/src/main/res/layout/news_card.xml
+++ b/WordPress/src/main/res/layout/news_card.xml
@@ -12,7 +12,6 @@
         android:id="@+id/news_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-
         android:background="?android:selectableItemBackground"
         android:clickable="true"
         android:focusable="true"

--- a/WordPress/src/main/res/layout/news_card.xml
+++ b/WordPress/src/main/res/layout/news_card.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/margin_large"
+    android:background="@color/white">
+
+    <RelativeLayout
+        android:id="@+id/news_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+
+        android:background="?android:selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:padding="@dimen/margin_large">
+
+        <ImageView
+            android:id="@+id/news_dismiss"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            android:background="?android:selectableItemBackground"
+            android:clickable="true"
+            android:contentDescription="@string/dismiss"
+            android:focusable="true"
+            android:padding="@dimen/margin_small"
+            android:tint="@color/grey"
+            app:srcCompat="@drawable/ic_close_white_24dp"/>
+
+        <ImageView
+            android:id="@+id/news_image"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="@dimen/negative_margin_medium"
+            android:layout_marginRight="@dimen/negative_margin_medium"
+            android:layout_toLeftOf="@+id/news_dismiss"
+            android:layout_toStartOf="@+id/news_dismiss"
+            android:contentDescription="@null"
+            app:srcCompat="@drawable/img_illustration_notifications_152dp"/>
+
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/news_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_toLeftOf="@+id/news_image"
+            android:layout_toStartOf="@+id/news_image"
+            android:ellipsize="end"
+            android:gravity="start"
+            android:maxLines="2"
+            android:textStyle="bold"
+            tools:text="New version available"/>
+
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/news_content"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/news_title"
+            android:layout_marginTop="@dimen/margin_medium"
+            android:layout_toLeftOf="@+id/news_image"
+            android:layout_toStartOf="@+id/news_image"
+            android:ellipsize="end"
+            android:gravity="start"
+            android:maxLines="4"
+            tools:text="There is a newer version of this app available"/>
+
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/news_action"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/news_content"
+            android:layout_marginTop="@dimen/margin_medium"
+            android:layout_toLeftOf="@id/news_image"
+            android:layout_toStartOf="@+id/news_image"
+            android:maxLines="1"
+            android:textColor="@color/reader_hyperlink"
+            tools:text="Read more"/>
+
+    </RelativeLayout>
+</FrameLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -67,6 +67,7 @@
     <dimen name="margin_extra_extra_large">48dp</dimen>
     <dimen name="margin_filter_spinner">64dp</dimen>
     <dimen name="margin_theme_browser_top">160dp</dimen>
+    <dimen name="negative_margin_medium">-8dp</dimen>
 
     <!-- left/right margin for reader cards -->
     <dimen name="reader_card_margin_normal">0dp</dimen>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
     <string name="add_count">Add %d</string>
     <string name="preview_count">Preview %d</string>
     <string name="write_post">Write Post</string>
+    <string name="dismiss">dismiss</string>
 
     <string name="button_not_now">Not now</string>
 


### PR DESCRIPTION
Fixes #8149 

Note: Branch is based on a branch from #8187 .

Few notes about the News Card feature
We want to create a card, which we'll use to announce new features and updates at different places in the app. First place where we want to display the card is Reader. However, there are few rules when the card should be displayed.

To Test: 
- you'll need to manually set the version to 1 in `LocalNewsItem.kt` otherwise the card will never be shown.

1. The card is displayed only when there are data for the News Card available.
2. The card is displayed only on the first filter of the reader (when the user starts the app and first filter is Followed Sites for instance, the card should not be visible on other filters. However, if the user changes the filter to Discovery for instance and restarts the app, the card should be displayed on Discovery and should not be displayed on Followed Sites.)
3. When the card is dismissed, it should not be visible until a new card with an incremented version is published -> The card is displayed only when the card with the same announcement (same version) hasn't been dismissed by the user.


Note: 
`Fun with indices` in the ReaderPostAdapter. Changing the adapter is error prone, so please try to review it as carefully as possible :).


![news-card](https://user-images.githubusercontent.com/2261188/44038239-a6276eba-9f16-11e8-87c2-d89ddea88d3b.png)

Dismiss animation
![f0158eea2d3fbd2c2b76781a780fbcf1 1](https://user-images.githubusercontent.com/2261188/44260340-5ee65880-a214-11e8-9769-114fc94b27aa.gif)


cc @nozomimimi