### PR TITLE
Feature/quick start activation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -473,9 +473,7 @@ public class MySiteFragment extends Fragment implements
             @Override
             public void onClick(View v) {
                 if (mQuickStartDot.getVisibility() == View.VISIBLE) {
-                    for (QuickStartTask quickStartTask : QuickStartTask.values()) {
-                        mQuickStartStore.setShownTask(AppPrefs.getSelectedSite(), quickStartTask, true);
-                    }
+                    QuickStartUtils.markAllTasksAsShown(mQuickStartStore);
                     updateQuickStartContainer();
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -556,12 +556,6 @@ public class WPMainActivity extends AppCompatActivity implements
                 if (trackAnalytics) {
                     AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.MY_SITE_ACCESSED, getSelectedSite());
                 }
-
-                MySiteFragment fragment = getMySiteFragment();
-                if (fragment != null) {
-                    fragment.checkQuickStart();
-                }
-
                 break;
             case PAGE_READER:
                 ActivityId.trackLastActivity(ActivityId.READER);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -522,7 +522,6 @@ public class WPMainActivity extends AppCompatActivity implements
                 // MySite fragment might not be attached to activity, so we need to remove focus point from here
                 QuickStartUtils.removeQuickStartFocusPoint((ViewGroup) findViewById(R.id.root_view_main));
             }
-            getMySiteFragment().completeQuickStarTask(getSelectedSite().getId(), QuickStartTask.PUBLISH_POST);
         }
 
         ActivityLauncher.addNewPostOrPageForResult(this, getSelectedSite(), false, false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -646,9 +646,9 @@ public class WPMainActivity extends AppCompatActivity implements
                     mySiteFragment.onActivityResult(requestCode, resultCode, data);
                 }
 
-                showQuickStartDialog();
                 setSite(data);
                 jumpNewPost(data);
+                showQuickStartDialog();
                 break;
             case RequestCodes.ADD_ACCOUNT:
                 if (resultCode == RESULT_OK) {
@@ -673,10 +673,9 @@ public class WPMainActivity extends AppCompatActivity implements
                     setSite(data);
                     jumpNewPost(data);
 
-                    // TODO for test purposes show Quick Start dialog when switching sites
-//                    if (data != null && data.getIntExtra(ARG_CREATE_SITE, 0) == RequestCodes.CREATE_SITE) {
-                    showQuickStartDialog();
-//                    }
+                    if (data != null && data.getIntExtra(ARG_CREATE_SITE, 0) == RequestCodes.CREATE_SITE) {
+                        showQuickStartDialog();
+                    }
                 }
                 break;
             case RequestCodes.SITE_SETTINGS:

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -97,6 +97,8 @@ import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged;
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
+import org.wordpress.android.fluxc.store.QuickStartStore;
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.UploadStore;
 import org.wordpress.android.fluxc.store.UploadStore.ClearMediaPayload;
@@ -282,6 +284,7 @@ public class EditPostActivity extends AppCompatActivity implements
     @Inject UploadStore mUploadStore;
     @Inject FluxCImageLoader mImageLoader;
     @Inject ShortcutUtils mShortcutUtils;
+    @Inject QuickStartStore mQuickStartStore;
 
     private SiteModel mSite;
 
@@ -408,6 +411,8 @@ public class EditPostActivity extends AppCompatActivity implements
             finish();
             return;
         }
+
+        mQuickStartStore.setDoneTask(AppPrefs.getSelectedSite(), QuickStartTask.PUBLISH_POST, true);
 
         if (mHasSetPostContent = mEditorFragment != null) {
             mEditorFragment.setImageLoader(mImageLoader);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -99,9 +99,6 @@ public class AppPrefs {
         // Used to flag the account created stat needs to be bumped after account information is synced.
         SHOULD_TRACK_MAGIC_LINK_SIGNUP,
 
-        // used to indicate that user is performing Quick Start tutorial
-        IS_QUICK_START_ACTIVE,
-
         // indicates how many times quick start dialog for a single task wash shown
         NUMBER_OF_TIMES_QUICK_START_DIALOG_SHOWN,
 
@@ -709,14 +706,6 @@ public class AppPrefs {
 
     public static void removeShouldTrackMagicLinkSignup() {
         remove(DeletablePrefKey.SHOULD_TRACK_MAGIC_LINK_SIGNUP);
-    }
-
-    public static void setQuickStartActive(Boolean isActive) {
-        setBoolean(DeletablePrefKey.IS_QUICK_START_ACTIVE, isActive);
-    }
-
-    public static boolean isQuickStartActive() {
-        return getBoolean(DeletablePrefKey.IS_QUICK_START_ACTIVE, false);
     }
 
     public static void setQuickStartDisabled(Boolean isDisabled) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartFragment.kt
@@ -139,7 +139,6 @@ class QuickStartFragment : Fragment() {
                 .setPositiveButton(getString(R.string.quick_start_button_skip_positive)) { _, _ ->
                     (view as ScrollView).smoothScrollTo(0, 0)
                     viewModel.skipAllTasks()
-                    AppPrefs.setQuickStartActive(false)
                 }
                 .setNegativeButton(getString(R.string.quick_start_button_skip_negative)) { _, _ ->
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartFragment.kt
@@ -55,7 +55,7 @@ class QuickStartFragment : Fragment() {
         viewModel.quickStartTaskStateStates.observe(this, Observer { quickStartModel ->
             var allTasksCompleted = true
             quickStartModel?.forEach {
-                if (it.isTaskCompleted) {
+                if (it.isTaskCompleted || it.isTaskShown) {
                     crossOutTask(it.task)
                 } else {
                     allTasksCompleted = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTaskState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTaskState.kt
@@ -5,5 +5,6 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 // represents completion state of Quick Start tasks
 data class QuickStartTaskState(
     val task: QuickStartTask,
-    val isTaskCompleted: Boolean
+    val isTaskCompleted: Boolean,
+    val isTaskShown: Boolean
 )

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -156,9 +156,9 @@ class QuickStartUtils {
 
         @JvmStatic
         fun isQuickStartInProgress(quickStartStore: QuickStartStore): Boolean {
-            return quickStartStore.hasDoneTask(AppPrefs.getSelectedSite().toLong(), QuickStartTask.CREATE_SITE)
-                    && quickStartStore.getDoneCount(AppPrefs.getSelectedSite().toLong()) > 0
-                    && quickStartStore.getShownCount(AppPrefs.getSelectedSite().toLong()) < QuickStartTask.values().size
+            return quickStartStore.hasDoneTask(AppPrefs.getSelectedSite().toLong(), QuickStartTask.CREATE_SITE) &&
+                    quickStartStore.getDoneCount(AppPrefs.getSelectedSite().toLong()) > 0 &&
+                    quickStartStore.getShownCount(AppPrefs.getSelectedSite().toLong()) < QuickStartTask.values().size
         }
 
         @JvmStatic

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -157,7 +157,8 @@ class QuickStartUtils {
         @JvmStatic
         fun isQuickStartInProgress(quickStartStore: QuickStartStore): Boolean {
             return quickStartStore.hasDoneTask(AppPrefs.getSelectedSite().toLong(), QuickStartTask.CREATE_SITE)
-                    && quickStartStore.getDoneCount(AppPrefs.getSelectedSite().toLong()) < QuickStartTask.values().size
+                    && quickStartStore.getDoneCount(AppPrefs.getSelectedSite().toLong()) > 0
+                    && quickStartStore.getShownCount(AppPrefs.getSelectedSite().toLong()) < QuickStartTask.values().size
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -16,6 +16,9 @@ import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.QuickStartStore
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
+import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.themes.ThemeBrowserActivity
 
 class QuickStartUtils {
@@ -149,6 +152,12 @@ class QuickStartUtils {
             return (siteModel.hasCapabilityManageOptions &&
                     ThemeBrowserActivity.isAccessible(siteModel) &&
                     SiteUtils.isAccessedViaWPComRest(siteModel))
+        }
+
+        @JvmStatic
+        fun isQuickStartInProgress(quickStartStore: QuickStartStore): Boolean {
+            return quickStartStore.hasDoneTask(AppPrefs.getSelectedSite().toLong(), QuickStartTask.CREATE_SITE)
+                    && quickStartStore.getDoneCount(AppPrefs.getSelectedSite().toLong()) < QuickStartTask.values().size
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -160,5 +160,12 @@ class QuickStartUtils {
                     && quickStartStore.getDoneCount(AppPrefs.getSelectedSite().toLong()) > 0
                     && quickStartStore.getShownCount(AppPrefs.getSelectedSite().toLong()) < QuickStartTask.values().size
         }
+
+        @JvmStatic
+        fun markAllTasksAsShown(quickStartStore: QuickStartStore) {
+            for (quickStartTask in QuickStartTask.values()) {
+                quickStartStore.setShownTask(AppPrefs.getSelectedSite().toLong(), quickStartTask, true)
+            }
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/quickstart/QuickStartViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/quickstart/QuickStartViewModel.kt
@@ -30,9 +30,7 @@ class QuickStartViewModel @Inject constructor(private val quickStartStore: Quick
     private fun refreshTaskStatus() {
         val list = ArrayList<QuickStartTaskState>()
         QuickStartTask.values().forEach {
-            // CREATE_SITE task is completed by default
-            list.add(QuickStartTaskState(it,
-                    if (it == QuickStartTask.CREATE_SITE) true else quickStartStore.hasDoneTask(siteId, it)))
+            list.add(QuickStartTaskState(it, quickStartStore.hasDoneTask(siteId, it)))
         }
         _quickStartTaskStateStates.postValue(list)
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/quickstart/QuickStartViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/quickstart/QuickStartViewModel.kt
@@ -30,7 +30,8 @@ class QuickStartViewModel @Inject constructor(private val quickStartStore: Quick
     private fun refreshTaskStatus() {
         val list = ArrayList<QuickStartTaskState>()
         QuickStartTask.values().forEach {
-            list.add(QuickStartTaskState(it, quickStartStore.hasDoneTask(siteId, it)))
+            list.add(QuickStartTaskState(it, quickStartStore.hasDoneTask(siteId, it),
+                    quickStartStore.hasShownTask(siteId, it)))
         }
         _quickStartTaskStateStates.postValue(list)
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/quickstart/QuickStartViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/quickstart/QuickStartViewModel.kt
@@ -42,6 +42,7 @@ class QuickStartViewModel @Inject constructor(private val quickStartStore: Quick
 
     fun skipAllTasks() {
         QuickStartTask.values().forEach { quickStartStore.setDoneTask(siteId, it, true) }
+        QuickStartTask.values().forEach { quickStartStore.setShownTask(siteId, it, true) }
         refreshTaskStatus()
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/quickstart/QuickStartViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/quickstart/QuickStartViewModelTest.kt
@@ -44,8 +44,7 @@ class QuickStartViewModelTest {
 
         Assert.assertNotNull(mQuickStartDetailStateList)
         assertEquals(QuickStartTask.values().size, mQuickStartDetailStateList?.size)
-        // CREATE_SITE task is always considered done, so there is allways 1 completed task in a list
-        assertEquals(1, mQuickStartDetailStateList?.filter { it.isTaskCompleted }?.size)
+        assertEquals(0, mQuickStartDetailStateList?.filter { it.isTaskCompleted }?.size)
     }
 
     @Test


### PR DESCRIPTION
Part of #7707

This PR adds a way to activate a Quick Start after site creation and updates the logic that keeps the status of a Quick Start on a per-site basis.

After discussion with @SylvesterWilmott we decided to show a quick start dialog every time you create a new site on Android.

There are a couple things to test.

**First:**

1. On account without any sites, create a site.
2. After navigating to MySite fragment you should see a Quick Start dialog and should be able to activate it.

_If you start Quick Start, after navigating to the Editor before going to MySite fragment, `PUBLISH_POST` task will be completed from start._

**Second:**

1. Create another site, and start a quick start. 
2. Complete a couple of tasks.
3. Switch between the site and make sure that the Quick Start progress or completion status is reflected on them correctly.

**Third:**

1. Complete a quick start on a site, and make sure that "orange dot" near the Quick Start counter on MySite fragment is visible.
2. Click on the Quick Start row, and make sure that the tasks in Quick Start list are completed.
3. Navigate back to MySite fragment and make sure that the Quick Start row is gone.

**Fourth:**

1. Switch between two site with active Quick Start
2. Make sure that quick start prompt for individual tasks in not apearing.