### PR TITLE
Issue/update site empty

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -3,12 +3,12 @@
   <component name="CheckStyle-IDEA">
     <option name="configuration">
       <map>
-        <entry key="active-configuration" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
+        <entry key="active-configuration" value="LOCAL_FILE:$PROJECT_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="checkstyle-version" value="8.2" />
         <entry key="copy-libs" value="false" />
         <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
-        <entry key="location-2" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
+        <entry key="location-2" value="LOCAL_FILE:$PROJECT_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="scan-before-checkin" value="false" />
         <entry key="scanscope" value="AllSourcesWithTests" />
         <entry key="suppress-errors" value="false" />

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -36,6 +36,7 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.login.LoginMode;
+import org.wordpress.android.ui.ActionableEmptyView;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.accounts.LoginActivity;
@@ -105,9 +106,8 @@ public class MySiteFragment extends Fragment implements SiteSettingsListener,
     private WPTextView mConfigurationHeader;
     private View mSettingsView;
     private LinearLayout mAdminView;
-    private LinearLayout mNoSiteView;
+    private ActionableEmptyView mActionableEmptyView;
     private ScrollView mScrollView;
-    private ImageView mNoSiteDrakeImageView;
     private WPTextView mCurrentPlanNameTextView;
     private View mSharingView;
     private SiteSettingsInterface mSiteSettings;
@@ -198,8 +198,7 @@ public class MySiteFragment extends Fragment implements SiteSettingsListener,
         mSharingView = rootView.findViewById(R.id.row_sharing);
         mAdminView = rootView.findViewById(R.id.row_admin);
         mScrollView = rootView.findViewById(R.id.scroll_view);
-        mNoSiteView = rootView.findViewById(R.id.no_site_view);
-        mNoSiteDrakeImageView = rootView.findViewById(R.id.my_site_no_site_view_drake);
+        mActionableEmptyView = rootView.findViewById(R.id.actionable_empty_view);
         mCurrentPlanNameTextView = rootView.findViewById(R.id.my_site_current_plan_text_view);
         mPageView = rootView.findViewById(R.id.row_pages);
 
@@ -349,11 +348,11 @@ public class MySiteFragment extends Fragment implements SiteSettingsListener,
             }
         });
 
-        rootView.findViewById(R.id.my_site_add_site_btn).setOnClickListener(new View.OnClickListener() {
+        mActionableEmptyView.button.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 SitePickerActivity.addSite(getActivity(), mAccountStore.hasAccessToken(),
-                                           mAccountStore.getAccount().getUserName());
+                        mAccountStore.getAccount().getUserName());
             }
         });
 
@@ -556,22 +555,22 @@ public class MySiteFragment extends Fragment implements SiteSettingsListener,
 
         if (site == null) {
             mScrollView.setVisibility(View.GONE);
-            mNoSiteView.setVisibility(View.VISIBLE);
+            mActionableEmptyView.setVisibility(View.VISIBLE);
 
             // if the screen height is too short, we can just hide the drake illustration
             Activity activity = getActivity();
             boolean drakeVisibility = DisplayUtils.getDisplayPixelHeight(activity) >= 500;
             if (drakeVisibility) {
-                mNoSiteDrakeImageView.setVisibility(View.VISIBLE);
+                mActionableEmptyView.image.setVisibility(View.VISIBLE);
             } else {
-                mNoSiteDrakeImageView.setVisibility(View.GONE);
+                mActionableEmptyView.image.setVisibility(View.GONE);
             }
 
             return;
         }
 
         mScrollView.setVisibility(View.VISIBLE);
-        mNoSiteView.setVisibility(View.GONE);
+        mActionableEmptyView.setVisibility(View.GONE);
 
         toggleAdminVisibility(site);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -557,10 +557,8 @@ public class MySiteFragment extends Fragment implements SiteSettingsListener,
             mScrollView.setVisibility(View.GONE);
             mActionableEmptyView.setVisibility(View.VISIBLE);
 
-            // if the screen height is too short, we can just hide the drake illustration
-            Activity activity = getActivity();
-            boolean drakeVisibility = DisplayUtils.getDisplayPixelHeight(activity) >= 500;
-            if (drakeVisibility) {
+            // Hide actionable empty view image when screen height is under 600 pixels.
+            if (DisplayUtils.getDisplayPixelHeight(getActivity()) >= 600) {
                 mActionableEmptyView.image.setVisibility(View.VISIBLE);
             } else {
                 mActionableEmptyView.image.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -665,7 +665,7 @@ public class MySiteFragment extends Fragment implements SiteSettingsListener,
     }
 
     @Override
-    public void setTitle(final String title) {
+    public void setTitle(@NonNull final String title) {
         mToolbarTitle = title;
         if (mToolbar != null) {
             mToolbar.setTitle(title);

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -1,17 +1,17 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-             xmlns:app="http://schemas.android.com/apk/res-auto"
-             xmlns:card_view="http://schemas.android.com/apk/res-auto"
-             xmlns:tools="http://schemas.android.com/tools"
-             android:layout_width="match_parent"
-             android:layout_height="match_parent"
-             android:orientation="vertical">
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent" >
 
     <include layout="@layout/toolbar_main"/>
 
     <ScrollView
         android:id="@+id/scroll_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/toolbar_height"
+        android:layout_width="match_parent">
 
         <LinearLayout
             android:clipToPadding="false"
@@ -29,9 +29,9 @@
                 android:layout_marginRight="@dimen/content_margin"
                 android:layout_marginStart="@dimen/content_margin"
                 android:layout_marginTop="@dimen/margin_medium"
-                card_view:cardBackgroundColor="@color/white"
-                card_view:cardCornerRadius="@dimen/cardview_default_radius"
-                card_view:cardElevation="@dimen/card_elevation">
+                app:cardBackgroundColor="@color/white"
+                app:cardCornerRadius="@dimen/cardview_default_radius"
+                app:cardElevation="@dimen/card_elevation">
 
                 <RelativeLayout
                     android:layout_width="match_parent"
@@ -454,47 +454,16 @@
 
     </ScrollView>
 
-    <LinearLayout
-        android:id="@+id/no_site_view"
-        android:layout_width="match_parent"
+    <org.wordpress.android.ui.ActionableEmptyView
+        android:id="@+id/actionable_empty_view"
         android:layout_height="match_parent"
-        android:layout_marginBottom="@dimen/margin_large"
-        android:layout_marginEnd="@dimen/my_site_no_site_view_margin"
-        android:layout_marginLeft="@dimen/my_site_no_site_view_margin"
-        android:layout_marginRight="@dimen/my_site_no_site_view_margin"
-        android:layout_marginStart="@dimen/my_site_no_site_view_margin"
-        android:layout_marginTop="@dimen/margin_large"
-        android:gravity="center"
-        android:orientation="vertical"
-        android:visibility="gone">
+        android:layout_marginTop="@dimen/toolbar_height"
+        android:layout_width="match_parent"
+        android:visibility="gone"
+        app:aevButton="@string/my_site_add_new_site"
+        app:aevImage="@drawable/img_site_wordpress_camera_pencils_226dp"
+        app:aevSubtitle="@string/my_site_create_new_site"
+        app:aevTitle="@string/my_site_create_new_site_title" >
+    </org.wordpress.android.ui.ActionableEmptyView>
 
-        <ImageView
-            android:id="@+id/my_site_no_site_view_drake"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:importantForAccessibility="no"
-            app:srcCompat="@drawable/img_site_wordpress_camera_pencils_226dp"/>
-
-        <org.wordpress.android.widgets.WPTextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_extra_medium_large"
-            android:gravity="center"
-            android:text="@string/my_site_create_new_site"
-            android:textColor="@color/grey"
-            android:textSize="@dimen/text_sz_medium"
-            app:fixWidowWords="true"/>
-
-        <android.support.v7.widget.AppCompatButton
-            android:id="@+id/my_site_add_site_btn"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/empty_list_button_top_margin"
-            android:contentDescription="@string/my_site_add_new_site"
-            android:text="@string/my_site_add_new_site"
-            android:theme="@style/WordPress.Button.Primary"/>
-
-    </LinearLayout>
-
-</LinearLayout>
+</RelativeLayout>

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -198,7 +198,8 @@
                     android:paddingLeft="0dp"
                     android:paddingStart="0dp"
                     android:text="@string/plan"
-                    android:textAlignment="viewEnd"/>
+                    android:textAlignment="viewEnd"
+                    tools:ignore="RtlSymmetry" />
 
             </LinearLayout>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1582,6 +1582,7 @@
     <string name="my_site_btn_view_site">View Site</string>
     <string name="my_site_btn_plugins">Plugins</string>
     <string name="my_site_create_new_site">Create a new site for your business, magazine, or personal blog; or connect an existing WordPress installation.</string>
+    <string name="my_site_create_new_site_title">You don\'t have any sites</string>
     <string name="my_site_add_new_site">Add new site</string>
     <string name="my_site_icon_dialog_title">Site Icon</string>
     <string name="my_site_icon_dialog_add_message">Would you like to add a site icon?</string>


### PR DESCRIPTION
### Fix
Update actionable empty state on the ***My Site*** screen to match those in https://github.com/wordpress-mobile/WordPress-Android/issues/7996.  It was not specifically included in the original issue, but the ***My Site*** screen contained an empty view with a custom layout.  I updated the layout to use the new `ActionableEmptyView` for consistency and style.  See the screenshots below for illustration.

![aes_site_portrait](https://user-images.githubusercontent.com/3827611/44063427-4001b420-9f15-11e8-81f8-9e99d66f7097.png)

![aes_site_landscape](https://user-images.githubusercontent.com/3827611/44063363-fd095a60-9f14-11e8-99e7-87ddd5688cdd.png)

### Test
0. Use account without sites.
1. Go to ***My Site*** tab.
2. Notice actionable empty state.

### Review
Only one develop and one designer are required to review these changes, but anyone can perform the review.