### PR TITLE
Use the ImageType to set the placeholder in the reader post list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -500,9 +500,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     }
 
                     @Override public void showPlaceholder() {
-                        mImageManager.load(holder.mImgFeatured, new ColorDrawable(
-                                        ContextCompat.getColor(holder.mImgFeatured.getContext(),
-                                                R.color.grey_lighten_30)));
+                        mImageManager.load(holder.mImgFeatured, ImageType.VIDEO);
                     }
 
                     @Override public void cacheThumbnailUrl(String thumbnailUrl) {

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -103,6 +103,20 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
     }
 
     /**
+     * Loads the ImageType placeholder into the ImageView.
+     */
+    @JvmOverloads
+    fun load(imageView: ImageView, imageType: ImageType, scaleType: ImageView.ScaleType = CENTER) {
+
+        val resourceId = placeholderManager.getPlaceholderResource(imageType) ?: return
+
+        GlideApp.with(imageView.context)
+                .load(loadDrawable(imageView.context, resourceId))
+                .applyScaleType(scaleType)
+                .into(imageView)
+    }
+
+    /**
      * Loads the Drawable into the ImageView.
      */
     @JvmOverloads


### PR DESCRIPTION
This change improves consistency for the placeholder image – now the default video placeholder resource will be used, and if it's changed in the [ImagePlaceHolderManager](https://github.com/jkmassel/WordPress-Android/blob/6cbd09c5c9599ccc87439c8fca250ec737df7d04/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt), it won't be inconsistent. This, in turn, makes it possible to check via the UI testing framework that there are no video placeholders visible.

**To test:**
Commenting out [line 499](https://github.com/jkmassel/WordPress-Android/blob/6cbd09c5c9599ccc87439c8fca250ec737df7d04/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java#L499) will show the video placeholder image without loading the thumbnail.