### PR TITLE
Issue/8199 memory leaks

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -935,7 +935,7 @@ public class ReaderPostDetailFragment extends Fragment
         mLikingUsersDivider.setVisibility(View.VISIBLE);
         mLikingUsersLabel.setVisibility(View.VISIBLE);
         mLikingUsersView.setVisibility(View.VISIBLE);
-        mLikingUsersView.showLikingUsers(mPost);
+        mLikingUsersView.showLikingUsers(mPost, mAccountStore.getAccount().getUserId());
     }
 
     private boolean showPhotoViewer(String imageUrl, View sourceView, int startX, int startY) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderLikingUsersView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderLikingUsersView.java
@@ -1,7 +1,7 @@
 package org.wordpress.android.ui.reader.views;
 
 import android.content.Context;
-import android.os.Handler;
+import android.os.AsyncTask;
 import android.util.AttributeSet;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -12,13 +12,13 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.ReaderLikeTable;
 import org.wordpress.android.datasets.ReaderUserTable;
-import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderUserIdList;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 
 import javax.inject.Inject;
@@ -27,10 +27,11 @@ import javax.inject.Inject;
  * LinearLayout which shows liking users - used by ReaderPostDetailFragment
  */
 public class ReaderLikingUsersView extends LinearLayout {
-    private final int mLikeAvatarSz;
-
-    @Inject AccountStore mAccountStore;
     @Inject ImageManager mImageManager;
+    private LoadAvatarsTask mLoadAvatarsTask;
+    private final int mLikeAvatarSz;
+    private final int mMarginAvatar;
+    private final int mMarginReader;
 
     public ReaderLikingUsersView(Context context) {
         this(context, null);
@@ -44,43 +45,36 @@ public class ReaderLikingUsersView extends LinearLayout {
         setGravity(Gravity.CENTER_VERTICAL);
 
         mLikeAvatarSz = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_small);
+        mMarginAvatar = context.getResources().getDimensionPixelSize(R.dimen.margin_extra_small);
+        mMarginReader = context.getResources().getDimensionPixelSize(R.dimen.reader_detail_margin);
     }
 
-    public void showLikingUsers(final ReaderPost post) {
+    public void showLikingUsers(final ReaderPost post, final long currentUserId) {
         if (post == null) {
             return;
         }
 
-        final Handler handler = new Handler();
-        new Thread() {
-            @Override
-            public void run() {
-                // get avatar URLs of liking users up to the max, sized to fit
-                int maxAvatars = getMaxAvatars();
-                ReaderUserIdList avatarIds = ReaderLikeTable.getLikesForPost(post);
-                // TODO: Probably a bad idea to have mAccountStore.getAccount().getUserId() here,
-                // a view should not read the account state
-                final ArrayList<String> avatars = ReaderUserTable.getAvatarUrls(avatarIds, maxAvatars, mLikeAvatarSz,
-                                                                                mAccountStore.getAccount().getUserId());
+        if (mLoadAvatarsTask != null) {
+            mLoadAvatarsTask.cancel(false);
+        }
+        mLoadAvatarsTask = new LoadAvatarsTask(this, currentUserId, mLikeAvatarSz, getMaxAvatars());
+        mLoadAvatarsTask.execute(post);
+    }
 
-                handler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        showLikingAvatars(avatars);
-                    }
-                });
-            }
-        }.start();
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        if (mLoadAvatarsTask != null) {
+            mLoadAvatarsTask.cancel(false);
+        }
     }
 
     /*
      * returns count of avatars that can fit the current space
      */
     private int getMaxAvatars() {
-        int marginAvatar = getResources().getDimensionPixelSize(R.dimen.margin_extra_small);
-        int marginReader = getResources().getDimensionPixelSize(R.dimen.reader_detail_margin);
-        int likeAvatarSizeWithMargin = mLikeAvatarSz + (marginAvatar * 2);
-        int spaceForAvatars = getWidth() - (marginReader * 2);
+        int likeAvatarSizeWithMargin = mLikeAvatarSz + (mMarginAvatar * 2);
+        int spaceForAvatars = getWidth() - (mMarginReader * 2);
         return spaceForAvatars / likeAvatarSizeWithMargin;
     }
 
@@ -114,6 +108,42 @@ public class ReaderLikingUsersView extends LinearLayout {
             }
             mImageManager.loadIntoCircle(imgAvatar, ImageType.AVATAR, StringUtils.notNullStr(url));
             index++;
+        }
+    }
+
+    private static class LoadAvatarsTask extends AsyncTask<ReaderPost, Void, ArrayList<String>> {
+        private final WeakReference<ReaderLikingUsersView> mViewReference;
+        private final long mCurrentUserId;
+        private final int mLikeAvatarSize;
+        private final int mMaxAvatars;
+
+        LoadAvatarsTask(ReaderLikingUsersView view, long currentUserId, int likeAvatarSz,
+                        int maxAvatars) {
+            mViewReference = new WeakReference<>(view);
+            mCurrentUserId = currentUserId;
+            mLikeAvatarSize = likeAvatarSz;
+            mMaxAvatars = maxAvatars;
+        }
+
+        @Override
+        protected ArrayList<String> doInBackground(ReaderPost... posts) {
+            if (posts.length != 1 || posts[0] == null) {
+                return null;
+            }
+            ReaderPost post = posts[0];
+            ReaderUserIdList avatarIds = ReaderLikeTable.getLikesForPost(post);
+            return ReaderUserTable.getAvatarUrls(avatarIds, mMaxAvatars, mLikeAvatarSize,
+                    mCurrentUserId);
+        }
+
+        @Override
+        protected void onPostExecute(ArrayList<String> avatars) {
+            super.onPostExecute(avatars);
+            ReaderLikingUsersView view = mViewReference.get();
+            if (view != null && avatars != null && !isCancelled()) {
+                view.mLoadAvatarsTask = null;
+                view.showLikingAvatars(avatars);
+            }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderLikingUsersView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderLikingUsersView.java
@@ -30,8 +30,6 @@ public class ReaderLikingUsersView extends LinearLayout {
     @Inject ImageManager mImageManager;
     private LoadAvatarsTask mLoadAvatarsTask;
     private final int mLikeAvatarSz;
-    private final int mMarginAvatar;
-    private final int mMarginReader;
 
     public ReaderLikingUsersView(Context context) {
         this(context, null);
@@ -45,8 +43,6 @@ public class ReaderLikingUsersView extends LinearLayout {
         setGravity(Gravity.CENTER_VERTICAL);
 
         mLikeAvatarSz = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_small);
-        mMarginAvatar = context.getResources().getDimensionPixelSize(R.dimen.margin_extra_small);
-        mMarginReader = context.getResources().getDimensionPixelSize(R.dimen.reader_detail_margin);
     }
 
     public void showLikingUsers(final ReaderPost post, final long currentUserId) {
@@ -73,8 +69,10 @@ public class ReaderLikingUsersView extends LinearLayout {
      * returns count of avatars that can fit the current space
      */
     private int getMaxAvatars() {
-        int likeAvatarSizeWithMargin = mLikeAvatarSz + (mMarginAvatar * 2);
-        int spaceForAvatars = getWidth() - (mMarginReader * 2);
+        final int marginAvatar = getResources().getDimensionPixelSize(R.dimen.margin_extra_small);
+        final int marginReader = getResources().getDimensionPixelSize(R.dimen.reader_detail_margin);
+        int likeAvatarSizeWithMargin = mLikeAvatarSz + (marginAvatar * 2);
+        int spaceForAvatars = getWidth() - (marginReader * 2);
         return spaceForAvatars / likeAvatarSizeWithMargin;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderLikingUsersView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderLikingUsersView.java
@@ -117,8 +117,7 @@ public class ReaderLikingUsersView extends LinearLayout {
         private final int mLikeAvatarSize;
         private final int mMaxAvatars;
 
-        LoadAvatarsTask(ReaderLikingUsersView view, long currentUserId, int likeAvatarSz,
-                        int maxAvatars) {
+        LoadAvatarsTask(ReaderLikingUsersView view, long currentUserId, int likeAvatarSz, int maxAvatars) {
             mViewReference = new WeakReference<>(view);
             mCurrentUserId = currentUserId;
             mLikeAvatarSize = likeAvatarSz;
@@ -132,8 +131,7 @@ public class ReaderLikingUsersView extends LinearLayout {
             }
             ReaderPost post = posts[0];
             ReaderUserIdList avatarIds = ReaderLikeTable.getLikesForPost(post);
-            return ReaderUserTable.getAvatarUrls(avatarIds, mMaxAvatars, mLikeAvatarSize,
-                    mCurrentUserId);
+            return ReaderUserTable.getAvatarUrls(avatarIds, mMaxAvatars, mLikeAvatarSize, mCurrentUserId);
         }
 
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -38,6 +38,7 @@ public class ReaderSiteHeaderView extends LinearLayout {
         void onBlogInfoLoaded(ReaderBlog blogInfo);
     }
 
+    private boolean mAttached;
     private long mBlogId;
     private long mFeedId;
     private ReaderFollowButton mFollowButton;
@@ -61,6 +62,16 @@ public class ReaderSiteHeaderView extends LinearLayout {
         ((WordPress) context.getApplicationContext()).component().inject(this);
         mBlavatarSz = getResources().getDimensionPixelSize(R.dimen.blavatar_sz_small);
         initView(context);
+    }
+
+    @Override protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        mAttached = true;
+    }
+
+    @Override protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        mAttached = false;
     }
 
     private void initView(Context context) {
@@ -99,7 +110,9 @@ public class ReaderSiteHeaderView extends LinearLayout {
             ReaderActions.UpdateBlogInfoListener listener = new ReaderActions.UpdateBlogInfoListener() {
                 @Override
                 public void onResult(ReaderBlog serverBlogInfo) {
-                    showBlogInfo(serverBlogInfo);
+                    if (mAttached) {
+                        showBlogInfo(serverBlogInfo);
+                    }
                 }
             };
             if (mFeedId != 0) {


### PR DESCRIPTION
Fixes #8199 

The app crashes when we try to load an image from a leaked context (after the activity has been destroyed).

This crash is quite rare, so it's almost impossible to reproduce it (usually occurs when the user has poor internet connection).
1. Go to reader
2. Open discovery
3. Press back button -> the app sometimes crashes
_________________________________________________________

You can reproduce this crash by removing the `ReaderLikingUsersView.java.onDetachedFromWindow` and adding `Thread.sleep(3000);` to `LoadAvatarsTask .doInBackground(..)`
1. Go to Reader
2. Open an article which has been liked by one user at least
3. Scroll to the "Liked by" section
4. Press back button -> the app sometimes crashes
