### PR TITLE
Fix Post content lost when content fed from share and unedited

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2147,7 +2147,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 mEditorFragment.setContent(text);
             }
 
-            //update PostModel
+            // update PostModel
             mPost.setContent(text);
             PostUtils.updatePublishDateIfShouldBePublishedImmediately(mPost);
             mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2136,6 +2136,7 @@ public class EditPostActivity extends AppCompatActivity implements
         if (text != null) {
             if (title != null) {
                 mEditorFragment.setTitle(title);
+                mPost.setTitle(title);
             }
             // Create an <a href> element around links
             text = AutolinkUtils.autoCreateLinks(text);
@@ -2145,6 +2146,11 @@ public class EditPostActivity extends AppCompatActivity implements
             } else {
                 mEditorFragment.setContent(text);
             }
+
+            //update PostModel
+            mPost.setContent(text);
+            PostUtils.updatePublishDateIfShouldBePublishedImmediately(mPost);
+            mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
         }
 
         // Check for shared media


### PR DESCRIPTION
Fixes #8201

This PR makes sure to update the `mPost` PostModel when content comes from a share intent (that is specifically handled within the [`setPostContentFromShareAction`  method](https://github.com/wordpress-mobile/WordPress-Android/compare/issue/8201-post-content-lost-share?expand=1#diff-38b6aea9cfff5f3e0e4b7389b44de602R2130), were the changes in this PR were made). Otherwise, the Aztec editor would be initialized with the content, but then if the user didn't perform any edits then the original content had no difference with the actual content, hence the `EditPostActivity` logic would not end up saving the post's content.

#### BEFORE
![share-before](https://user-images.githubusercontent.com/6597771/44226410-67805580-a166-11e8-96a9-4ecc672bb8f5.gif)
See the problem? The editor was populated with the content shared by the user from the Chrome app, but then the internal logic would not find any difference as the `mPost` model did not have any changes.

#### AFTER
![share](https://user-images.githubusercontent.com/6597771/44226422-6fd89080-a166-11e8-96bd-9b5cbeb2ec7a.gif)
Now the logic understands there's been a change (from _nothing_ to _something_) and takes care of saving the Post correctly.

To test:
1. go to any app where you can select and share text, such as Gmail
2. select a piece of text and wait for the contextual menu to appear
3. in the contextual menu, tap on `SHARE`
4. pick WordPress app to share to
5. if you have multiple sites configured in your WordPress app, you'll be shown a site picker where to create the new blog Post in. Pick a site. Otherwise, you'll be shown step 6.
6. The Editor screen appears, with the pasted text in the content area.
7. Hit `Publish` on the upper right corner of the screen
8. When asked to confirm, confirm
9. Observe the Post is uploaded
10. Now go to the  posts list, and look for your Post. Select the Post you just created
11. Observe there's no empty content anymore - your content is displayed in the Editor, just as it was pasted.