### PR TITLE
Feature/news card tracks

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/news/NewsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/news/NewsTracker.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.ui.news
+
+import org.wordpress.android.util.AnalyticsUtils
+import javax.inject.Inject
+
+import javax.inject.Singleton
+
+@Singleton
+class NewsTracker @Inject constructor() {
+    enum class NewsCardOrigin {
+        READER
+    }
+
+    fun trackNewsCardShown(origin: NewsCardOrigin, version: Int) {
+        AnalyticsUtils.trackNewsCardShown(origin.name.toLowerCase(), version)
+    }
+
+    fun trackNewsCardDismissed(origin: NewsCardOrigin, version: Int) {
+        AnalyticsUtils.trackNewsCardDismissed(origin.name.toLowerCase(), version)
+    }
+
+    fun trackNewsCardExtendedInfoRequested(origin: NewsCardOrigin, version: Int) {
+        AnalyticsUtils.trackNewsCardExtendedInfoRequested(origin.name.toLowerCase(), version)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/news/NewsTrackerHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/news/NewsTrackerHelper.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.ui.news
+
+import org.wordpress.android.models.news.NewsItem
+import javax.inject.Inject
+
+/**
+ * Helper to prevent tracking duplicate events when the view has been just recycled or after a config change.
+ */
+class NewsTrackerHelper @Inject constructor() {
+    private val trackedItems: ArrayList<Int> = ArrayList()
+
+    fun shouldTrackNewsCardShown(itemVersion: Int): Boolean = !trackedItems.contains(itemVersion)
+
+    fun itemTracked(itemVersion: Int) {
+        trackedItems.add(itemVersion)
+    }
+
+    fun reset() {
+        trackedItems.clear()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/news/NewsTrackerHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/news/NewsTrackerHelper.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.news
 
-import org.wordpress.android.models.news.NewsItem
 import javax.inject.Inject
 
 /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/news/NewsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/news/NewsViewHolder.kt
@@ -14,7 +14,8 @@ class NewsViewHolder(parent: ViewGroup, private val listener: NewsCardListener) 
                 LayoutInflater.from(parent.context).inflate(R.layout.news_card, parent, false)
         ) {
     interface NewsCardListener {
-        fun onItemClicked(url: String)
+        fun onItemShown(item: NewsItem)
+        fun onItemClicked(item: NewsItem)
         fun onDismissClicked(item: NewsItem)
     }
 
@@ -25,10 +26,11 @@ class NewsViewHolder(parent: ViewGroup, private val listener: NewsCardListener) 
     private val dismissView: ImageView = itemView.findViewById(R.id.news_dismiss)
 
     fun bind(item: NewsItem) {
+        listener.onItemShown(item)
         title.text = item.title
         content.text = item.content
         action.text = item.actionText
-        container.setOnClickListener { listener.onItemClicked(item.actionUrl) }
+        container.setOnClickListener { listener.onItemClicked(item) }
         dismissView.setOnClickListener { listener.onDismissClicked(item) }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1489,15 +1489,20 @@ public class ReaderPostListFragment extends Fragment
             AppLog.d(T.READER, "reader post list > creating post adapter");
             Context context = WPActivityUtils.getThemedContext(getActivity());
             mPostAdapter = new ReaderPostAdapter(context, getPostListType(), mImageManager, new NewsCardListener() {
-                @Override public void onItemClicked(@NotNull String url) {
+                @Override public void onItemShown(@NotNull NewsItem item) {
+                    mViewModel.onNewsCardShown(item);
+                }
+
+                @Override public void onItemClicked(@NotNull NewsItem item) {
+                    mViewModel.onNewsCardExtendedInfoRequested(item);
                     Activity activity = getActivity();
                     if (activity != null) {
-                        WPWebViewActivity.openURL(activity, url);
+                        WPWebViewActivity.openURL(activity, item.getActionUrl());
                     }
                 }
 
                 @Override public void onDismissClicked(NewsItem item) {
-                    mViewModel.onDismissClicked(item);
+                    mViewModel.onNewsCardDismissed(item);
                 }
             });
             mPostAdapter.setOnFollowListener(this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -38,7 +38,6 @@ import org.wordpress.android.models.ReaderPostDiscoverData;
 import org.wordpress.android.models.ReaderPostList;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.news.NewsItem;
-import org.wordpress.android.ui.news.NewsTracker;
 import org.wordpress.android.ui.news.NewsViewHolder;
 import org.wordpress.android.ui.news.NewsViewHolder.NewsCardListener;
 import org.wordpress.android.util.image.ImageManager;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -38,6 +38,7 @@ import org.wordpress.android.models.ReaderPostDiscoverData;
 import org.wordpress.android.models.ReaderPostList;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.news.NewsItem;
+import org.wordpress.android.ui.news.NewsTracker;
 import org.wordpress.android.ui.news.NewsViewHolder;
 import org.wordpress.android.ui.news.NewsViewHolder.NewsCardListener;
 import org.wordpress.android.util.image.ImageManager;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -6,10 +6,15 @@ import android.arch.lifecycle.ViewModel
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.news.NewsItem
 import org.wordpress.android.ui.news.NewsManager
+import org.wordpress.android.ui.news.NewsTracker
+import org.wordpress.android.ui.news.NewsTracker.NewsCardOrigin.READER
+import org.wordpress.android.ui.news.NewsTrackerHelper
 import javax.inject.Inject
 
 class ReaderPostListViewModel @Inject constructor(
-    private val newsManager: NewsManager
+    private val newsManager: NewsManager,
+    private val newsTracker: NewsTracker,
+    private val newsTrackerHelper: NewsTrackerHelper
 ) : ViewModel() {
     private val newsItemSource = newsManager.newsItemSource()
     private val _newsItemSourceMediator = MediatorLiveData<NewsItem>()
@@ -32,6 +37,7 @@ class ReaderPostListViewModel @Inject constructor(
     }
 
     fun onTagChanged(tag: ReaderTag) {
+        newsTrackerHelper.reset()
         // show the card only when the initial tag is selected in the filter
         if (tag == initialTag) {
             _newsItemSourceMediator.addSource(newsItemSource) { _newsItemSourceMediator.value = it }
@@ -41,8 +47,20 @@ class ReaderPostListViewModel @Inject constructor(
         }
     }
 
-    fun onDismissClicked(item: NewsItem) {
+    fun onNewsCardDismissed(item: NewsItem) {
+        newsTracker.trackNewsCardDismissed(READER, item.version)
         newsManager.dismiss(item)
+    }
+
+    fun onNewsCardShown(item: NewsItem) {
+        if (newsTrackerHelper.shouldTrackNewsCardShown(item.version)) {
+            newsTracker.trackNewsCardShown(READER, item.version)
+            newsTrackerHelper.itemTracked(item.version)
+        }
+    }
+
+    fun onNewsCardExtendedInfoRequested(item: NewsItem) {
+        newsTracker.trackNewsCardExtendedInfoRequested(READER, item.version)
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
@@ -32,6 +32,9 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.wordpress.android.analytics.AnalyticsTracker.Stat.NEWS_CARD_DIMISSED;
+import static org.wordpress.android.analytics.AnalyticsTracker.Stat.NEWS_CARD_EXTENDED_INFO_REQUESTED;
+import static org.wordpress.android.analytics.AnalyticsTracker.Stat.NEWS_CARD_SHOWN;
 import static org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_ARTICLE_COMMENTED_ON;
 import static org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_ARTICLE_LIKED;
 import static org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_ARTICLE_OPENED;
@@ -52,6 +55,8 @@ public class AnalyticsUtils {
     private static final String INTENT_DATA = "intent_data";
     private static final String INTERCEPTED_URI = "intercepted_uri";
     private static final String INTERCEPTOR_CLASSNAME = "interceptor_classname";
+    private static final String NEWS_CARD_ORIGIN = "origin";
+    private static final String NEWS_CARD_VERSION = "version";
 
     public static final String HAS_GUTENBERG_BLOCKS_KEY = "has_gutenberg_blocks";
 
@@ -446,5 +451,33 @@ public class AnalyticsUtils {
     public static void trackAnalyticsAccountCreated(String username, String email) {
         AnalyticsUtils.refreshMetadataNewUser(username, email);
         AnalyticsTracker.track(Stat.CREATED_ACCOUNT);
+    }
+
+    /**
+     * Don't use this method directly, use injectable NewsTracker instead.
+     */
+    public static void trackNewsCardShown(String origin, int version) {
+        AnalyticsTracker.track(NEWS_CARD_SHOWN, createNewsCardProperties(origin, version));
+    }
+
+    /**
+     * Don't use this method directly, use injectable NewsTracker instead.
+     */
+    public static void trackNewsCardDismissed(String origin, int version) {
+        AnalyticsTracker.track(NEWS_CARD_DIMISSED, createNewsCardProperties(origin, version));
+    }
+
+    /**
+     * Don't use this method directly, use injectable NewsTracker instead.
+     */
+    public static void trackNewsCardExtendedInfoRequested(String origin, int version) {
+        AnalyticsTracker.track(NEWS_CARD_EXTENDED_INFO_REQUESTED, createNewsCardProperties(origin, version));
+    }
+
+    private static Map<String, String> createNewsCardProperties(String origin, int version) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(NEWS_CARD_ORIGIN, origin);
+        properties.put(NEWS_CARD_VERSION, String.valueOf(version));
+        return properties;
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -101,13 +101,13 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun verifyViewModelPropagatesDismissToNewsTracker(){
+    fun verifyViewModelPropagatesDismissToNewsTracker() {
         viewModel.onNewsCardDismissed(item)
         verify(newsTracker).trackNewsCardDismissed(argThat { this == READER }, any())
     }
 
     @Test
-    fun verifyViewModelPropagatesCardShownToNewsTracker(){
+    fun verifyViewModelPropagatesCardShownToNewsTracker() {
         whenever(newsTrackerHelper.shouldTrackNewsCardShown(any())).thenReturn(true)
         viewModel.onNewsCardShown(item)
         verify(newsTracker).trackNewsCardShown(argThat { this == READER }, any())
@@ -115,7 +115,7 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun verifyViewModelDoesNotPropagatesCardShownToNewsTracker(){
+    fun verifyViewModelDoesNotPropagatesCardShownToNewsTracker() {
         whenever(newsTrackerHelper.shouldTrackNewsCardShown(any())).thenReturn(false)
         viewModel.onNewsCardShown(item)
         verify(newsTracker, times(0)).trackNewsCardShown(argThat { this == READER }, any())
@@ -123,7 +123,7 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun verifyViewModelPropagatesExtendedInfoRequestedToNewsTracker(){
+    fun verifyViewModelPropagatesExtendedInfoRequestedToNewsTracker() {
         viewModel.onNewsCardExtendedInfoRequested(item)
         verify(newsTracker).trackNewsCardExtendedInfoRequested(argThat { this == READER }, any())
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -3,7 +3,10 @@ package org.wordpress.android.viewmodel.reader
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.Observer
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.argThat
 import com.nhaarman.mockito_kotlin.inOrder
+import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Before
@@ -15,6 +18,9 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.news.NewsItem
 import org.wordpress.android.ui.news.NewsManager
+import org.wordpress.android.ui.news.NewsTracker
+import org.wordpress.android.ui.news.NewsTracker.NewsCardOrigin.READER
+import org.wordpress.android.ui.news.NewsTrackerHelper
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel
 
 @RunWith(MockitoJUnitRunner::class)
@@ -28,6 +34,8 @@ class ReaderPostListViewModelTest {
     @Mock private lateinit var item: NewsItem
     @Mock private lateinit var initialTag: ReaderTag
     @Mock private lateinit var otherTag: ReaderTag
+    @Mock private lateinit var newsTracker: NewsTracker
+    @Mock private lateinit var newsTrackerHelper: NewsTrackerHelper
 
     private lateinit var viewModel: ReaderPostListViewModel
     private val liveData = MutableLiveData<NewsItem>()
@@ -35,7 +43,7 @@ class ReaderPostListViewModelTest {
     @Before
     fun setUp() {
         whenever(newsManager.newsItemSource()).thenReturn(liveData)
-        viewModel = ReaderPostListViewModel(newsManager)
+        viewModel = ReaderPostListViewModel(newsManager, newsTracker, newsTrackerHelper)
         val observable = viewModel.getNewsDataSource()
         observable.observeForever(observer)
     }
@@ -61,7 +69,7 @@ class ReaderPostListViewModelTest {
 
     @Test
     fun verifyViewModelPropagatesDismissToNewsManager() {
-        viewModel.onDismissClicked(item)
+        viewModel.onNewsCardDismissed(item)
         verify(newsManager).dismiss(item)
     }
 
@@ -90,5 +98,33 @@ class ReaderPostListViewModelTest {
         inOrder.verify(observer).onChanged(item)
         inOrder.verify(observer).onChanged(null)
         inOrder.verify(observer).onChanged(item)
+    }
+
+    @Test
+    fun verifyViewModelPropagatesDismissToNewsTracker(){
+        viewModel.onNewsCardDismissed(item)
+        verify(newsTracker).trackNewsCardDismissed(argThat { this == READER }, any())
+    }
+
+    @Test
+    fun verifyViewModelPropagatesCardShownToNewsTracker(){
+        whenever(newsTrackerHelper.shouldTrackNewsCardShown(any())).thenReturn(true)
+        viewModel.onNewsCardShown(item)
+        verify(newsTracker).trackNewsCardShown(argThat { this == READER }, any())
+        verify(newsTrackerHelper).itemTracked(any())
+    }
+
+    @Test
+    fun verifyViewModelDoesNotPropagatesCardShownToNewsTracker(){
+        whenever(newsTrackerHelper.shouldTrackNewsCardShown(any())).thenReturn(false)
+        viewModel.onNewsCardShown(item)
+        verify(newsTracker, times(0)).trackNewsCardShown(argThat { this == READER }, any())
+        verify(newsTrackerHelper, times(0)).itemTracked(any())
+    }
+
+    @Test
+    fun verifyViewModelPropagatesExtendedInfoRequestedToNewsTracker(){
+        viewModel.onNewsCardExtendedInfoRequested(item)
+        verify(newsTracker).trackNewsCardExtendedInfoRequested(argThat { this == READER }, any())
     }
 }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -404,6 +404,9 @@ public final class AnalyticsTracker {
         SUPPORT_HELP_CENTER_VIEWED,
         SUPPORT_IDENTITY_FORM_VIEWED,
         SUPPORT_IDENTITY_SET,
+        NEWS_CARD_SHOWN,
+        NEWS_CARD_DIMISSED,
+        NEWS_CARD_EXTENDED_INFO_REQUESTED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1144,11 +1144,11 @@ public class AnalyticsTrackerNosara extends Tracker {
             case SUPPORT_IDENTITY_SET:
                 return "support_identity_set";
             case NEWS_CARD_SHOWN:
-                return "newscard_shown";
+                return "news_card_shown";
             case NEWS_CARD_DIMISSED:
-                return "newscard_dismissed";
+                return "news_card_dismissed";
             case NEWS_CARD_EXTENDED_INFO_REQUESTED:
-                return "newscard_extendedinfo_requested";
+                return "news_card_extended_info_requested";
             default:
                 return null;
         }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1143,6 +1143,12 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "support_identity_form_viewed";
             case SUPPORT_IDENTITY_SET:
                 return "support_identity_set";
+            case NEWS_CARD_SHOWN:
+                return "newscard_shown";
+            case NEWS_CARD_DIMISSED:
+                return "newscard_dismissed";
+            case NEWS_CARD_EXTENDED_INFO_REQUESTED:
+                return "newscard_extendedinfo_requested";
             default:
                 return null;
         }


### PR DESCRIPTION
Fixes #8193 

Note: Branch is based on a branch from #8188 -> 8188 needs to be merged first, so this PR doesn't contain changes from both branches.

This PR adds tracking for the NewsCard feature.

Few notes about the News Card feature
We want to create a card, which we'll use to announce new features and updates at different places in the app. First place where we want to display the card is Reader.

To test - you'll need to manually increment LocalNewsItem version, otherwise the card won't be shown.
1. Go to reader 
2. Make sure 'newscard_shown' event is tracked
3. Make sure the event is **not** tracked when scrolling or after you rotate your device
4. Change filter to Saved Posts and back to your initial filter
5. Make sure 'newscard_shown' event is tracked
6. Click on the News Card
7. Make sure 'newscard_extendedinfo_requested' is tracked
8. Go back to Reader and click on the dismiss icon
9. Make sure 'newscard_dismissed' is tracked

All events should contain card version and location of the card ('reader').

