### PR TITLE
News card notification in the bottom nav bar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.main;
 
 import android.app.Activity;
 import android.app.Fragment;
+import android.arch.lifecycle.Observer;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -39,6 +40,7 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
 import org.wordpress.android.login.LoginAnalyticsListener;
+import org.wordpress.android.models.news.NewsItem;
 import org.wordpress.android.networking.ConnectionChangeReceiver;
 import org.wordpress.android.push.GCMMessageService;
 import org.wordpress.android.push.GCMRegistrationIntentService;
@@ -54,6 +56,7 @@ import org.wordpress.android.ui.accounts.LoginActivity;
 import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
 import org.wordpress.android.ui.accounts.SiteCreationActivity;
 import org.wordpress.android.ui.main.WPMainNavigationView.OnPageListener;
+import org.wordpress.android.ui.news.NewsManager;
 import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter;
@@ -134,6 +137,7 @@ public class WPMainActivity extends AppCompatActivity
     @Inject protected LoginAnalyticsListener mLoginAnalyticsListener;
     @Inject ShortcutsNavigator mShortcutsNavigator;
     @Inject ShortcutUtils mShortcutUtils;
+    @Inject NewsManager mNewsManager;
 
     /*
      * fragments implement this if their contents can be scrolled, called when user
@@ -188,6 +192,7 @@ public class WPMainActivity extends AppCompatActivity
         mIsMagicLinkSignup = getIntent().getBooleanExtra(ARG_IS_MAGIC_LINK_SIGNUP, false);
         mJetpackConnectSource = (JetpackConnectionSource) getIntent().getSerializableExtra(ARG_JETPACK_CONNECT_SOURCE);
         String authTokenToSet = null;
+        registeNewsItemObserver();
 
         if (savedInstanceState == null) {
             if (FluxCUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore)) {
@@ -303,6 +308,16 @@ public class WPMainActivity extends AppCompatActivity
         } else {
             AppLog.e(T.MAIN, "WPMainActivity.handleOpenIntent called with an invalid argument.");
         }
+    }
+
+    private void registeNewsItemObserver() {
+        mNewsManager.newsItemSource().observe(this, new Observer<NewsItem>() {
+            @Override
+            public void onChanged(@Nullable NewsItem item) {
+                mBottomNav.showReaderBadge(item != null);
+            }
+        });
+        mNewsManager.pull(false);
     }
 
     private void launchZendeskMyTickets() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -40,7 +40,6 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
 import org.wordpress.android.login.LoginAnalyticsListener;
-import org.wordpress.android.models.news.NewsItem;
 import org.wordpress.android.networking.ConnectionChangeReceiver;
 import org.wordpress.android.push.GCMMessageService;
 import org.wordpress.android.push.GCMRegistrationIntentService;
@@ -311,10 +310,10 @@ public class WPMainActivity extends AppCompatActivity
     }
 
     private void registeNewsItemObserver() {
-        mNewsManager.newsItemSource().observe(this, new Observer<NewsItem>() {
+        mNewsManager.notificationBadgeVisibility().observe(this, new Observer<Boolean>() {
             @Override
-            public void onChanged(@Nullable NewsItem item) {
-                mBottomNav.showReaderBadge(item != null);
+            public void onChanged(@Nullable Boolean showBadge) {
+                mBottomNav.showReaderBadge(showBadge != null ? showBadge : false);
             }
         });
         mNewsManager.pull(false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -299,11 +299,19 @@ class WPMainNavigationView @JvmOverloads constructor(
         return null
     }
 
-    /*
-     * show or hide the badge on the notification page
-     */
+    fun showReaderBadge(showBadge: Boolean) {
+        showBadge(PAGE_READER, showBadge)
+    }
+
     fun showNoteBadge(showBadge: Boolean) {
-        val badgeView = getItemView(PAGE_NOTIFS)?.findViewById<View>(R.id.badge)
+        showBadge(PAGE_NOTIFS, showBadge)
+    }
+
+    /*
+     * show or hide the badge on the 'pageId' icon in the bottom bar
+     */
+    private fun showBadge(pageId: Int, showBadge: Boolean) {
+        val badgeView = getItemView(pageId)?.findViewById<View>(R.id.badge)
 
         val currentVisibility = badgeView?.visibility
         val newVisibility = if (showBadge) View.VISIBLE else View.GONE

--- a/WordPress/src/main/java/org/wordpress/android/ui/news/NewsManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/news/NewsManager.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
  * Business logic related to fetching/showing the News Card (a card used for announcing new features/updates).
  */
 @Singleton
-class NewsManager @Inject constructor(val newsService: NewsService, val appPrefs: AppPrefsWrapper) {
+class NewsManager @Inject constructor(private val newsService: NewsService, private val appPrefs: AppPrefsWrapper) {
     private val dataSourceMediator: MediatorLiveData<NewsItem> = MediatorLiveData()
     private var dataSource: LiveData<NewsItem> = newsService.newsItemSource()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/news/NewsManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/news/NewsManager.kt
@@ -34,7 +34,7 @@ class NewsManager @Inject constructor(private val newsService: NewsService, priv
         return dataSourceMediator
     }
 
-    fun notificationBadgeVisibility() : LiveData<Boolean> {
+    fun notificationBadgeVisibility(): LiveData<Boolean> {
         return notificationBadgeVisibility
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -103,7 +103,9 @@ public class AppPrefs {
         SUPPORT_NAME,
 
         // Store a version of the last dismissed News Card
-        NEWS_CARD_DISMISSED_VERSION
+        NEWS_CARD_DISMISSED_VERSION,
+        // Store a version of the last shown News Card
+        NEWS_CARD_SHOWN_VERSION
     }
 
     /**
@@ -735,5 +737,13 @@ public class AppPrefs {
 
     public static int getNewsCardDismissedVersion() {
         return getInt(DeletablePrefKey.NEWS_CARD_DISMISSED_VERSION, -1);
+    }
+
+    public static void setNewsCardShownVersion(int version) {
+        setInt(DeletablePrefKey.NEWS_CARD_SHOWN_VERSION, version);
+    }
+
+    public static int getNewsCardShownVersion() {
+        return getInt(DeletablePrefKey.NEWS_CARD_SHOWN_VERSION, -1);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -15,4 +15,8 @@ class AppPrefsWrapper @Inject constructor() {
     var newsCardDismissedVersion: Int
         get() = AppPrefs.getNewsCardDismissedVersion()
         set(version) = AppPrefs.setNewsCardDismissedVersion(version)
+
+    var newsCardShownVersion: Int
+        get() = AppPrefs.getNewsCardShownVersion()
+        set(version) = AppPrefs.setNewsCardShownVersion(version)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -43,7 +43,7 @@ class ReaderPostListViewModel @Inject constructor(
 
     fun onTagChanged(tag: ReaderTag?) {
         newsTrackerHelper.reset()
-        initialTag?.let {
+        initialTag?.let { initialTag ->
             // show the card only when the initial tag is selected in the filter
             if (tag == initialTag) {
                 _newsItemSourceMediator.addSource(newsItemSource) { _newsItemSourceMediator.value = it }
@@ -64,6 +64,7 @@ class ReaderPostListViewModel @Inject constructor(
             newsTracker.trackNewsCardShown(READER, item.version)
             newsTrackerHelper.itemTracked(item.version)
         }
+        newsManager.cardShown(item)
     }
 
     fun onNewsCardExtendedInfoRequested(item: NewsItem) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/news/NewsManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/news/NewsManagerTest.kt
@@ -20,12 +20,19 @@ import org.wordpress.android.ui.prefs.AppPrefsWrapper
 @RunWith(MockitoJUnitRunner::class)
 class NewsManagerTest {
     @Rule
-    @JvmField val rule = InstantTaskExecutorRule()
+    @JvmField
+    val rule = InstantTaskExecutorRule()
 
-    @Mock private lateinit var newsService: NewsService
-    @Mock private lateinit var observer: Observer<NewsItem>
-    @Mock private lateinit var item: NewsItem
-    @Mock private lateinit var appPrefs: AppPrefsWrapper
+    @Mock
+    private lateinit var newsService: NewsService
+    @Mock
+    private lateinit var observeNewsItems: Observer<NewsItem>
+    @Mock
+    private lateinit var observeBadgeVisibility: Observer<Boolean>
+    @Mock
+    private lateinit var item: NewsItem
+    @Mock
+    private lateinit var appPrefs: AppPrefsWrapper
 
     private lateinit var newsManager: NewsManager
     private val liveData = MutableLiveData<NewsItem>()
@@ -35,8 +42,11 @@ class NewsManagerTest {
         whenever(newsService.newsItemSource()).thenReturn(liveData)
         newsManager = NewsManager(newsService, appPrefs)
 
-        val observable = newsManager.newsItemSource()
-        observable.observeForever(observer)
+        val itemsObservable = newsManager.newsItemSource()
+        itemsObservable.observeForever(observeNewsItems)
+
+        val notificationBadgeObservable = newsManager.notificationBadgeVisibility()
+        notificationBadgeObservable.observeForever(observeBadgeVisibility)
     }
 
     @Test
@@ -48,10 +58,10 @@ class NewsManagerTest {
         liveData.postValue(null)
         liveData.postValue(item)
 
-        val inOrder = inOrder(observer)
-        inOrder.verify(observer).onChanged(item)
-        inOrder.verify(observer).onChanged(null)
-        inOrder.verify(observer).onChanged(item)
+        val inOrder = inOrder(observeNewsItems)
+        inOrder.verify(observeNewsItems).onChanged(item)
+        inOrder.verify(observeNewsItems).onChanged(null)
+        inOrder.verify(observeNewsItems).onChanged(item)
     }
 
     @Test
@@ -60,7 +70,7 @@ class NewsManagerTest {
         whenever(item.version).thenReturn(1)
 
         liveData.postValue(item)
-        verify(observer, never()).onChanged(any())
+        verify(observeNewsItems, never()).onChanged(any())
     }
 
     @Test
@@ -76,7 +86,7 @@ class NewsManagerTest {
     @Test
     fun emitNullWhenDismissInvoked() {
         newsManager.dismiss(item)
-        verify(observer).onChanged(null)
+        verify(observeNewsItems).onChanged(null)
     }
 
     @Test
@@ -89,5 +99,48 @@ class NewsManagerTest {
     fun propagateStopToNewsServiceWhenStopInvoked() {
         newsManager.stop()
         verify(newsService).stop()
+    }
+
+    @Test
+    fun showNotificationBadgeWhenCardAvailable() {
+        whenever(appPrefs.newsCardDismissedVersion).thenReturn(-1)
+        whenever(appPrefs.newsCardShownVersion).thenReturn(-1)
+        whenever(item.version).thenReturn(1)
+        liveData.postValue(item)
+
+        verify(observeBadgeVisibility).onChanged(true)
+    }
+
+    @Test
+    fun doNotShowNotificationBadgeWhenCardNotAvailable() {
+        liveData.postValue(null)
+
+        verify(observeBadgeVisibility).onChanged(false)
+    }
+
+    @Test
+    fun doNotShowNotificationBadgeWhenCardAlreadyShown() {
+        whenever(appPrefs.newsCardDismissedVersion).thenReturn(-1)
+        whenever(appPrefs.newsCardShownVersion).thenReturn(1)
+        whenever(item.version).thenReturn(1)
+        liveData.postValue(item)
+
+        verify(observeBadgeVisibility).onChanged(false)
+    }
+
+    @Test
+    fun verifyVersionOfShownItemIsStored() {
+        whenever(item.version).thenReturn(123)
+
+        liveData.postValue(item)
+        newsManager.cardShown(item)
+
+        verify(appPrefs).newsCardShownVersion = 123
+    }
+
+    @Test
+    fun hideBadgeWhenCardShown() {
+        newsManager.cardShown(item)
+        verify(observeBadgeVisibility).onChanged(false)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/news/NewsManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/news/NewsManagerTest.kt
@@ -20,19 +20,13 @@ import org.wordpress.android.ui.prefs.AppPrefsWrapper
 @RunWith(MockitoJUnitRunner::class)
 class NewsManagerTest {
     @Rule
-    @JvmField
-    val rule = InstantTaskExecutorRule()
+    @JvmField val rule = InstantTaskExecutorRule()
 
-    @Mock
-    private lateinit var newsService: NewsService
-    @Mock
-    private lateinit var observeNewsItems: Observer<NewsItem>
-    @Mock
-    private lateinit var observeBadgeVisibility: Observer<Boolean>
-    @Mock
-    private lateinit var item: NewsItem
-    @Mock
-    private lateinit var appPrefs: AppPrefsWrapper
+    @Mock private lateinit var newsService: NewsService
+    @Mock private lateinit var observeNewsItems: Observer<NewsItem>
+    @Mock private lateinit var observeBadgeVisibility: Observer<Boolean>
+    @Mock private lateinit var item: NewsItem
+    @Mock private lateinit var appPrefs: AppPrefsWrapper
 
     private lateinit var newsManager: NewsManager
     private val liveData = MutableLiveData<NewsItem>()


### PR DESCRIPTION
Fixes #8150 

Adds notification badge (orange dot) to the Reader icon in the bottom navigation bar, if a new announcement is available and hasn't been shown yet. Hides the notifications when the new announcement is shown

To test:
- increment LocalNewsItem.kt in order to show the card
1. Open the app
2. Notice there is an orange dot on the Reader icon in the bottom navigation bar
3. Open Reader
4. Notice the orange dot disappears as soon as the NewsCard is shown
5. Restart the app and make sure the orange dot isn't shown
6. Dismiss the card and make sure the orange dot isn't shown
7. Restart the app and make sure the orange dot isn't shown
