### PR TITLE
Help the developer out if $ANDROID_HOME isn’t set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ fastlane/report.xml
 fastlane/README.md
 fastlane/metadata/android/screenshots.html
 fastlane/metadata/android/*/images/
+
+# Ruby Bundler Output
+/.bundle
+/vendor

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,7 @@ source "https://rubygems.org" do
   gem 'danger'
 
   gem "fastlane"
+  gem "java-properties"
+
   # frozen_string_literal: true
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
+    java-properties (0.2.0)
     json (2.1.0)
     jwt (2.1.0)
     kramdown (1.17.0)
@@ -178,6 +179,7 @@ PLATFORMS
 DEPENDENCIES
   danger!
   fastlane!
+  java-properties!
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/fastlane/helpers/android_virtual_device_helper.rb
+++ b/fastlane/helpers/android_virtual_device_helper.rb
@@ -27,7 +27,7 @@ module Fastlane
         if android_sdk_root.nil? && local.nil?
             UI.user_error! "There is no Android SDK root set. Unable to continue."
         elsif android_sdk_root.nil? && local
-        UI.user_error! "There is no Android SDK root set. Unable to continue.\nTo solve this, add:\n\nexport ANDROID_HOME=#{local}\nexport ANDROID_SDK_ROOT=$ANDROID_HOME\n\nto ~/.profile"
+            UI.user_error! "There is no Android SDK root set. Unable to continue.\nTo solve this, add:\n\nexport ANDROID_HOME=#{local}\nexport ANDROID_SDK_ROOT=$ANDROID_HOME\n\nto ~/.profile"
 
         end
 

--- a/fastlane/helpers/android_virtual_device_helper.rb
+++ b/fastlane/helpers/android_virtual_device_helper.rb
@@ -28,7 +28,6 @@ module Fastlane
             UI.user_error! "There is no Android SDK root set. Unable to continue."
         elsif android_sdk_root.nil? && local
             UI.user_error! "There is no Android SDK root set. Unable to continue.\nTo solve this, add:\n\nexport ANDROID_HOME=#{local}\nexport ANDROID_SDK_ROOT=$ANDROID_HOME\n\nto ~/.profile"
-
         end
 
         return android_sdk_root

--- a/fastlane/helpers/android_virtual_device_helper.rb
+++ b/fastlane/helpers/android_virtual_device_helper.rb
@@ -2,11 +2,44 @@ module Fastlane
   module Helpers
     module AndroidVirtualDevicePathHelper
       def self.android_home
-        ENV['ANDROID_HOME'] || ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_SDK']
+
+        android_sdk_root = ENV['ANDROID_HOME'] || ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_SDK']
+
+        if android_sdk_root
+            return android_sdk_root
+        end
+
+        begin
+            require 'java-properties'
+        rescue LoadError
+            UI.user_error! "Unable to load dependencies. Did you run `bundle` and `bundle exec fastlane`?"
+        end
+
+        propertiesFile = "#{project_root_path}/local.properties"
+
+        local = nil
+
+        if File.exist? propertiesFile
+            properties = JavaProperties.load(propertiesFile)
+            local = properties[:"sdk.dir"]
+        end
+
+        if android_sdk_root.nil? && local.nil?
+            UI.user_error! "There is no Android SDK root set. Unable to continue."
+        elsif android_sdk_root.nil? && local
+        UI.user_error! "There is no Android SDK root set. Unable to continue.\nTo solve this, add:\n\nexport ANDROID_HOME=#{local}\nexport ANDROID_SDK_ROOT=$ANDROID_HOME\n\nto ~/.profile"
+
+        end
+
+        return android_sdk_root
       end
 
       def self.emulator_path
         Pathname.new(android_home).join("emulator/emulator").to_s
+      end
+
+      def self.project_root_path
+        Pathname.new(File.dirname(__FILE__)).parent().parent()
       end
     end
 


### PR DESCRIPTION
Instead of showing an error saying “no implicit conversion of nil into String”, explain to the developer that they need to set up the environment variable and how. If they're using the bundled fastlane, it'll even read their local.properties file (if it exists) and tell them where the SDK is located.