### PR TITLE
Checkstyle rules updates

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -34,15 +34,6 @@
 
     <!-- Miscellaneous other checks.                   -->
     <!-- See http://checkstyle.sf.net/config_misc.html -->
-    <!--<module name="RegexpSingleline">-->
-       <!--<property name="format" value="\s+$"/>-->
-       <!--<property name="minimum" value="0"/>-->
-       <!--<property name="maximum" value="0"/>-->
-       <!--<property name="message" value="Line has trailing spaces."/>-->
-       <!--<property name="severity" value="error"/>-->
-    <!--</module>-->
-
-
     <module name="RegexpMultiline">
       <property name="format"
                 value="(\n|\r\n)[\t ]*(\n|\r\n)[\t ]*\}"/>

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -34,13 +34,13 @@
 
     <!-- Miscellaneous other checks.                   -->
     <!-- See http://checkstyle.sf.net/config_misc.html -->
-    <module name="RegexpSingleline">
-       <property name="format" value="\s+$"/>
-       <property name="minimum" value="0"/>
-       <property name="maximum" value="0"/>
-       <property name="message" value="Line has trailing spaces."/>
-       <property name="severity" value="error"/>
-    </module>
+    <!--<module name="RegexpSingleline">-->
+       <!--<property name="format" value="\s+$"/>-->
+       <!--<property name="minimum" value="0"/>-->
+       <!--<property name="maximum" value="0"/>-->
+       <!--<property name="message" value="Line has trailing spaces."/>-->
+       <!--<property name="severity" value="error"/>-->
+    <!--</module>-->
 
 
     <module name="RegexpMultiline">


### PR DESCRIPTION
This has been annoying me since we started strictly enforcing the checkstyle rules. I've talked to a couple of people and I'm not the only one. I'd like to remove the empty line restriction because it prevents me from adding a space between the default constructor and instance variables or methods, making the code look cramped and harder to read.

Example:
```
class ActivityLogViewModel @Inject constructor(
    private val dispatcher: Dispatcher,
    private val activityLogStore: ActivityLogStore,
    private val rewindStatusService: RewindStatusService,
    private val resourceProvider: ResourceProvider
) : ViewModel() {
    enum class ActivityLogListStatus {
        CAN_LOAD_MORE,
        DONE,
        ERROR,
        FETCHING,
        LOADING_MORE
    }
...
```
vs
```
class ActivityLogViewModel @Inject constructor(
    private val dispatcher: Dispatcher,
    private val activityLogStore: ActivityLogStore,
    private val rewindStatusService: RewindStatusService,
    private val resourceProvider: ResourceProvider
) : ViewModel() {

    enum class ActivityLogListStatus {
        CAN_LOAD_MORE,
        DONE,
        ERROR,
        FETCHING,
        LOADING_MORE
    }
...
```

What do you think? Is there any other rule that we should amend?