### PR TITLE
Issue/8215 empty followed tags

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
@@ -30,7 +30,7 @@ public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagD
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.reader_fragment_list, container, false);
-        mRecyclerView = (ReaderRecyclerView) view.findViewById(R.id.recycler_view);
+        mRecyclerView = view.findViewById(R.id.recycler_view);
         return view;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.reader;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -28,7 +29,7 @@ public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagD
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.reader_fragment_list, container, false);
         mRecyclerView = view.findViewById(R.id.recycler_view);
         return view;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
@@ -6,10 +6,10 @@ import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.models.ReaderTag;
+import org.wordpress.android.ui.ActionableEmptyView;
 import org.wordpress.android.ui.reader.adapters.ReaderTagAdapter;
 import org.wordpress.android.ui.reader.views.ReaderRecyclerView;
 import org.wordpress.android.util.AppLog;
@@ -35,18 +35,22 @@ public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagD
     }
 
     private void checkEmptyView() {
-        if (!isAdded()) {
+        if (!isAdded() || getView() == null) {
             return;
         }
 
-        TextView emptyView = (TextView) getView().findViewById(R.id.text_empty);
-        if (emptyView != null) {
-            boolean isEmpty = hasTagAdapter() && getTagAdapter().isEmpty();
-            emptyView.setVisibility(isEmpty ? View.VISIBLE : View.GONE);
-            if (isEmpty) {
-                emptyView.setText(R.string.reader_empty_followed_tags);
-            }
+        ActionableEmptyView actionableEmptyView = getView().findViewById(R.id.actionable_empty_view);
+
+        if (actionableEmptyView == null) {
+            return;
         }
+
+        actionableEmptyView.image.setImageResource(R.drawable.img_illustration_empty_results_216dp);
+        actionableEmptyView.image.setVisibility(View.VISIBLE);
+        actionableEmptyView.title.setText(R.string.reader_empty_followed_tags_title);
+        actionableEmptyView.subtitle.setText(R.string.reader_empty_followed_tags_subtitle);
+        actionableEmptyView.subtitle.setVisibility(View.VISIBLE);
+        actionableEmptyView.setVisibility(hasTagAdapter() && getTagAdapter().isEmpty() ? View.VISIBLE : View.GONE);
     }
 
     @Override

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1501,7 +1501,8 @@
     <string name="reader_empty_posts_in_tag">No posts with this tag</string>
     <string name="reader_empty_posts_in_tag_updating">Fetching posts…</string>
     <string name="reader_empty_posts_in_custom_list">The sites in this list haven\'t posted anything recently</string>
-    <string name="reader_empty_followed_tags">You don\'t follow any tags</string>
+    <string name="reader_empty_followed_tags_subtitle">Add tags here to find posts about your favorite topics</string>
+    <string name="reader_empty_followed_tags_title">No followed tags</string>
     <string name="reader_empty_recommended_blogs">No recommended sites</string>
     <string name="reader_empty_followed_blogs_title">No followed sites</string>
     <string name="reader_empty_followed_blogs_search_title">No matching sites</string>


### PR DESCRIPTION
### Fix
Add an actionable empty view shown on the ***Followed Tags*** tab of the ***Reader*** settings when no tags are followed as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8215.  See the screenshots below for illustration.

![aes_reader_settings_tags](https://user-images.githubusercontent.com/3827611/44439026-87a97d80-a587-11e8-8613-c5f5442b6e03.png)

#### Note
Since both the `ReaderTagFragment` and `ReaderBlogFragment` classes use the `reader_fragment_list` layout, I had to handle setting the image and subtitle visibility programmatically in Java rather than statically in XML.  I'll optimize that in a subsequent pull request addressing https://github.com/wordpress-mobile/WordPress-Android/issues/8217, which updates the ***Followed Sites*** tab of the ***Reader*** settings affecting the `ReaderBlogFragment` class.

Some code cleanup was included with these changes as well by removing redundant view casts and adding parameter annotation for overridden methods.

### Test
0. Use account with no followed tags.
1. Go to ***Reader*** tab.
2. Tap ***Edit Tags and Sites*** action in top toolbar.
3. Go to ***Followed Tags*** tab.
4. Notice empty view is shown.
5. Enter text in ***Enter a URL or tag to follow*** field.
6. Tap ***Add*** button next to ***Enter a URL or tag to follow*** field.
7. Notice actionable empty view is not shown.
8. Tap ***Remove*** button next to tag added in Steps 5 and 6.
9. Notice actionable empty view is shown

### Review
Only one develop and one designer are required to review these changes, but anyone can perform the review.