### PR TITLE
Issue/8216-empty-site-picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -44,6 +44,7 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
+import org.wordpress.android.ui.ActionableEmptyView;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
@@ -80,6 +81,7 @@ public class SitePickerActivity extends AppCompatActivity
     private static final String KEY_LAST_SEARCH = "last_search";
     private static final String KEY_REFRESHING = "refreshing_sites";
 
+    private ActionableEmptyView mActionableEmptyView;
     private SitePickerAdapter mAdapter;
     private RecyclerView mRecycleView;
     private SwipeToRefreshHelper mSwipeToRefreshHelper;
@@ -110,6 +112,7 @@ public class SitePickerActivity extends AppCompatActivity
         restoreSavedInstanceState(savedInstanceState);
         setupActionBar();
         setupRecycleView();
+        setupEmptyView();
 
         initSwipeToRefreshHelper(findViewById(android.R.id.content));
         if (savedInstanceState != null) {
@@ -288,6 +291,11 @@ public class SitePickerActivity extends AppCompatActivity
         mRecycleView.setScrollBarStyle(View.SCROLLBARS_OUTSIDE_OVERLAY);
         mRecycleView.setItemAnimator(null);
         mRecycleView.setAdapter(getAdapter());
+    }
+
+    private void setupEmptyView() {
+        mActionableEmptyView = findViewById(R.id.actionable_empty_view);
+        mActionableEmptyView.updateLayoutForSearch(true, 0);
     }
 
     private void restoreSavedInstanceState(Bundle savedInstanceState) {
@@ -538,7 +546,12 @@ public class SitePickerActivity extends AppCompatActivity
     public boolean onQueryTextChange(String s) {
         getAdapter().setLastSearch(s);
         getAdapter().searchSites(s);
+        updateEmptyViewVisibility();
         return true;
+    }
+
+    private void updateEmptyViewVisibility() {
+        mActionableEmptyView.setVisibility(getAdapter().getItemCount() > 0 ? View.GONE : View.VISIBLE);
     }
 
     public void showProgress(boolean show) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -454,6 +454,7 @@ public class SitePickerActivity extends AppCompatActivity
 
             @Override
             public boolean onMenuItemActionCollapse(MenuItem item) {
+                mActionableEmptyView.setVisibility(View.GONE);
                 disableSearchMode();
                 return true;
             }

--- a/WordPress/src/main/res/layout/site_picker_activity.xml
+++ b/WordPress/src/main/res/layout/site_picker_activity.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<FrameLayout
+<RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <org.wordpress.android.ui.ActionableEmptyView
+        android:id="@+id/actionable_empty_view"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:visibility="gone"
+        app:aevTitle="@string/site_picker_remove_site_empty"
+        tools:visibility="visible" >
+    </org.wordpress.android.ui.ActionableEmptyView>
 
     <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
         android:id="@+id/ptr_layout"
@@ -30,4 +40,4 @@
         android:visibility="gone"
         tools:visibility="visible" />
 
-</FrameLayout>
+</RelativeLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1601,6 +1601,7 @@
     <string name="site_picker_add_self_hosted">Add self-hosted site</string>
     <string name="site_picker_create_wpcom">Create WordPress.com site</string>
     <string name="site_picker_cant_hide_current_site">\"%s\" wasn\'t hidden because it\'s the current site</string>
+    <string name="site_picker_remove_site_empty">No sites matching your search</string>
     <string name="site_picker_remove_site_error">Error removing site, try again later</string>
 
     <!-- Application logs view -->


### PR DESCRIPTION
### Fix
Add an actionable empty view shown when no sites match the query while searching in the site picker (i.e. ***My Site*** > ***Switch Site***) as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8216.  This was not included in the original project, but it's similar to the work in https://github.com/wordpress-mobile/WordPress-Android/issues/7996.  See the screenshots below for illustration.

![aes_site_picker](https://user-images.githubusercontent.com/3827611/44560025-2adace00-a713-11e8-8fb1-d9d32f50ff56.png)

#### Note
I'm not entirely happy with this solution.  I would prefer to use the [`EmptyViewRecyclerView`](https://github.com/wordpress-mobile/WordPress-Android/blob/19d8591335de160e89df8e6de61c0e380662140a/WordPress/src/main/java/org/wordpress/android/ui/prefs/EmptyViewRecyclerView.java) and [`ActionableEmptyView`](https://github.com/wordpress-mobile/WordPress-Android/blob/9db1372865d79967a8a6c1360ba89bba86521c68/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt) views in tandem to automate showing/hiding the empty view without extra code.  There is a lot happening with the site picker and [some bugs](https://github.com/wordpress-mobile/WordPress-Android/issues/8224) will need to be fixed before we can utilize [`EmptyViewRecyclerView`](https://github.com/wordpress-mobile/WordPress-Android/blob/19d8591335de160e89df8e6de61c0e380662140a/WordPress/src/main/java/org/wordpress/android/ui/prefs/EmptyViewRecyclerView.java) and [`ActionableEmptyView`](https://github.com/wordpress-mobile/WordPress-Android/blob/9db1372865d79967a8a6c1360ba89bba86521c68/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt).

### Test
0. Use account with multiple sites.
1. Go to ***My Site*** tab.
2. Tap ***Switch Site*** button in top card view.
3. Tap ***Search*** action in top toolbar.
4. Enter text matching no sites.
5. Notice actionable empty view is shown.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.