### PR TITLE
Issue/8217 empty followed sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
@@ -10,14 +10,19 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 
 import org.wordpress.android.R;
+import org.wordpress.android.datasets.ReaderTagTable;
 import org.wordpress.android.models.ReaderBlog;
 import org.wordpress.android.models.ReaderRecommendedBlog;
+import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.ui.ActionableEmptyView;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.adapters.ReaderBlogAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderBlogAdapter.ReaderBlogType;
+import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.ui.reader.views.ReaderRecyclerView;
 import org.wordpress.android.util.AppLog;
 
@@ -84,6 +89,24 @@ public class ReaderBlogFragment extends Fragment
 
         if (hasBlogAdapter() && getBlogAdapter().isEmpty()) {
             actionableEmptyView.setVisibility(View.VISIBLE);
+            actionableEmptyView.image.setImageResource(R.drawable.img_illustration_empty_results_216dp);
+            actionableEmptyView.subtitle.setText(R.string.reader_empty_followed_blogs_description);
+            actionableEmptyView.button.setText(R.string.reader_empty_followed_blogs_button_discover);
+            actionableEmptyView.button.setOnClickListener(new OnClickListener() {
+                @Override public void onClick(View view) {
+                    ReaderTag tag = ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH);
+
+                    if (!ReaderTagTable.tagExists(tag)) {
+                        tag = ReaderTagTable.getFirstTag();
+                    }
+
+                    AppPrefs.setReaderTag(tag);
+
+                    if (getActivity() != null) {
+                        getActivity().finish();
+                    }
+                }
+            });
 
             switch (getBlogType()) {
                 case RECOMMENDED:
@@ -91,9 +114,17 @@ public class ReaderBlogFragment extends Fragment
                     break;
                 case FOLLOWED:
                     if (getBlogAdapter().hasSearchFilter()) {
+                        actionableEmptyView.updateLayoutForSearch(true, 0);
                         actionableEmptyView.title.setText(R.string.reader_empty_followed_blogs_search_title);
+                        actionableEmptyView.subtitle.setVisibility(View.GONE);
+                        actionableEmptyView.button.setVisibility(View.GONE);
+                        actionableEmptyView.image.setVisibility(View.GONE);
                     } else {
+                        actionableEmptyView.updateLayoutForSearch(false, 0);
                         actionableEmptyView.title.setText(R.string.reader_empty_followed_blogs_title);
+                        actionableEmptyView.subtitle.setVisibility(View.VISIBLE);
+                        actionableEmptyView.button.setVisibility(View.VISIBLE);
+                        actionableEmptyView.image.setVisibility(View.VISIBLE);
                     }
                     break;
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -346,6 +346,13 @@ public class ReaderPostListFragment extends Fragment
                 getSiteSearchAdapter().checkFollowStatusForSite(mLastTappedSiteSearchResult);
                 mLastTappedSiteSearchResult = null;
             }
+
+            ReaderTag tag = AppPrefs.getReaderTag();
+
+            if (ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH).equals(tag)) {
+                setCurrentTag(tag);
+                updateCurrentTag();
+            }
         }
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1505,7 +1505,7 @@
     <string name="reader_empty_followed_tags_title">No followed tags</string>
     <string name="reader_empty_recommended_blogs">No recommended sites</string>
     <string name="reader_empty_followed_blogs_title">No followed sites</string>
-    <string name="reader_empty_followed_blogs_search_title">No matching sites</string>
+    <string name="reader_empty_followed_blogs_search_title">No sites matching your search</string>
     <string name="reader_empty_followed_blogs_description">You are not following any sites yet. Why not follow one now?</string>
     <string name="reader_empty_followed_blogs_no_recent_posts_title">No recent posts</string>
     <string name="reader_empty_followed_blogs_no_recent_posts_description">The sites you follow haven\'t posted anything recently</string>


### PR DESCRIPTION
### Fix
Update the actionable empty view to show an image, title, subtitle, and button when no sites are followed (similar to selecting ***Followed Sites*** on the ***Reader*** tab as shown in the screenshot below) and only `No sites matching your search` text when searching on the ***Followed Sites*** tab of the ***Reader*** settings as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8217.  This was not included in the original project, but it's similar to the work in https://github.com/wordpress-mobile/WordPress-Android/issues/7996.  See the screenshots below for illustration.

![aes_reader_settings_sites](https://user-images.githubusercontent.com/3827611/44585896-6dcc8e00-a773-11e8-9697-9804a4697d89.png)

### Test
0. Use account with no followed sites.
1. Go to ***Reader*** tab.
2. Tap ***Edit Tags and Sites*** action in top toolbar.
3. Go to ***Followed Sites*** tab.
4. Notice updated ***No followed sites*** empty view is shown.
5. Tap ***Discover Sites*** button.
6. Notice ***Reader*** is shown.
7. Notice ***Discover*** is selected from toolbar menu.
8. Tap ***Edit Tags and Sites*** action in top toolbar.
9. Tap ***Search*** action in top toolbar.
10. Enter text matching no sites.
11. Notice updated ***No sites matching your search*** empty view is shown.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.