### PR TITLE
Issue/deep indented parentheses

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/plans/RemoteTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/plans/RemoteTests.java
@@ -158,10 +158,12 @@ public class RemoteTests extends DefaultMocksInstrumentationTestCase {
             }
         };
 
-        mRestClientV1p2.makeRequest(Request.Method.POST, "https://public-api.wordpress.com/rest/v1.2/plans/features",
-                                    null,
-                                    listener,
-                                    mErrListener
-                                   );
+        mRestClientV1p2.makeRequest(
+                Request.Method.POST,
+                "https://public-api.wordpress.com/rest/v1.2/plans/features",
+                null,
+                listener,
+                mErrListener
+        );
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
@@ -148,8 +148,7 @@ public final class SiteSettingsTable {
             AppPrefs.setImageOptimizeQuality(
                     cursor.getInt(cursor.getColumnIndex("imageEncoderQuality")));
             AppPrefs.setVideoOptimize(
-                    cursor.getInt(cursor.getColumnIndex("optimizedVideo")) == 1
-                                     );
+                    cursor.getInt(cursor.getColumnIndex("optimizedVideo")) == 1);
             AppPrefs.setVideoOptimizeWidth(
                     cursor.getInt(cursor.getColumnIndex("maxVideoWidth")));
             AppPrefs.setVideoOptimizeQuality(

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -225,7 +225,7 @@ public class NotificationsProcessingService extends Service {
                         NativeNotificationsUtils.dismissNotification(
                                 PendingDraftsNotificationsUtils.makePendingDraftNotificationId(postId),
                                 mContext
-                                                                    );
+                        );
                     }
                     AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATION_PENDING_DRAFTS_IGNORED);
                     return;

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -495,9 +495,7 @@ public class NotificationsProcessingService extends Service {
 
             HashMap<String, String> params = new HashMap<>();
             params.put("locale", LocaleManager.getLanguage(mContext));
-            WordPress.getRestClientUtils().getNotification(params,
-                                                           noteId, listener, errorListener
-                                                          );
+            WordPress.getRestClientUtils().getNotification(params, noteId, listener, errorListener);
         }
 
         // Like or unlike a comment via the REST API

--- a/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
@@ -235,7 +235,7 @@ public class FullScreenDialogFragment extends DialogFragment {
                         }
                     }
                 }
-                                         );
+        );
     }
 
     public void onBackPressed() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -344,11 +344,12 @@ public class WPWebViewActivity extends WebViewActivity {
         }
 
         try {
-            String postData = String.format("log=%s&pwd=%s&redirect_to=%s",
-                                            URLEncoder.encode(StringUtils.notNullStr(username), ENCODING_UTF8),
-                                            URLEncoder.encode(StringUtils.notNullStr(password), ENCODING_UTF8),
-                                            URLEncoder.encode(StringUtils.notNullStr(urlToLoad), ENCODING_UTF8)
-                                           );
+            String postData = String.format(
+                    "log=%s&pwd=%s&redirect_to=%s",
+                    URLEncoder.encode(StringUtils.notNullStr(username), ENCODING_UTF8),
+                    URLEncoder.encode(StringUtils.notNullStr(password), ENCODING_UTF8),
+                    URLEncoder.encode(StringUtils.notNullStr(urlToLoad), ENCODING_UTF8)
+            );
 
             // Add token authorization when signing in to WP.com
             if (WPUrlUtils.safeToAddWordPressComAuthToken(authenticationUrl)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -279,7 +279,7 @@ public class SitePickerActivity extends AppCompatActivity
                         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
                     }
                 }
-                                                         );
+        );
     }
 
     private void setupRecycleView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -268,7 +268,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
                         fetchMediaList(false);
                     }
                 }
-                                                         );
+        );
 
         if (savedInstanceState != null) {
             restoreState(savedInstanceState);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -397,7 +397,7 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
                             ((FooterNoteBlock) noteBlock).setClickableSpan(
                                     JSONUtils.queryJSON(noteObject, "ranges[last]", new JSONObject()),
                                     mNote.getType()
-                                                                          );
+                             );
                         } else {
                             noteBlock = new NoteBlock(noteObject, mImageManager, mOnNoteBlockTextClickListener);
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -390,7 +390,7 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
                 params.setScrollFlags(
                         AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
                         | AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS
-                                     );
+                );
             } else {
                 params.setScrollFlags(0);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateLogic.java
@@ -65,10 +65,7 @@ public class NotificationsUpdateLogic {
                 // Not sure this could ever happen, but make sure we're catching all response types
                 AppLog.w(AppLog.T.NOTIFS, "Success, but did not receive any notes");
                 EventBus.getDefault().post(
-                        new NotificationEvents.NotificationsRefreshCompleted(
-                                new ArrayList<Note>(0)
-                        )
-                                          );
+                        new NotificationEvents.NotificationsRefreshCompleted(new ArrayList<Note>(0)));
             } else {
                 try {
                     notes = NotificationsActions.parseNotes(response);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateLogic.java
@@ -78,14 +78,10 @@ public class NotificationsUpdateLogic {
                         setNoteRead(mNoteId, notes);
                     }
                     NotificationsTable.saveNotes(notes, true);
-                    EventBus.getDefault().post(
-                            new NotificationEvents.NotificationsRefreshCompleted(notes)
-                                              );
+                    EventBus.getDefault().post(new NotificationEvents.NotificationsRefreshCompleted(notes));
                 } catch (JSONException e) {
                     AppLog.e(AppLog.T.NOTIFS, "Success, but can't parse the response", e);
-                    EventBus.getDefault().post(
-                            new NotificationEvents.NotificationsRefreshError()
-                                              );
+                    EventBus.getDefault().post(new NotificationEvents.NotificationsRefreshError());
                 }
             }
             completed();
@@ -94,9 +90,7 @@ public class NotificationsUpdateLogic {
         @Override
         public void onErrorResponse(final VolleyError volleyError) {
             logVolleyErrorDetails(volleyError);
-            EventBus.getDefault().post(
-                    new NotificationEvents.NotificationsRefreshError(volleyError)
-                                      );
+            EventBus.getDefault().post(new NotificationEvents.NotificationsRefreshError(volleyError));
             completed();
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsActions.java
@@ -45,7 +45,7 @@ public class NotificationsActions {
                         AppLog.e(AppLog.T.NOTIFS, "Could not mark notifications/seen' value via API.", error);
                     }
                 }
-                                                                );
+        );
     }
 
     public static List<Note> parseNotes(JSONObject response) throws JSONException {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -322,7 +322,7 @@ public class NotificationsUtils {
                         spanIndex,
                         spanIndex + 1,
                         Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-                                              );
+                );
 
                 // Add an AlignmentSpan to center the image
                 spannableStringBuilder.setSpan(
@@ -330,7 +330,7 @@ public class NotificationsUtils {
                         spanIndex,
                         spanIndex + 1,
                         Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-                                              );
+                );
 
                 indexAdjustment += imagePlaceholder.length();
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/models/Plan.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/models/Plan.java
@@ -114,8 +114,7 @@ public class Plan implements Serializable {
             JSONArray featuresHighlightSections = planJSONObject.getJSONArray("features_highlight");
             for (int i = 0; i < featuresHighlightSections.length(); i++) {
                 mFeaturesHighlightSections.add(
-                        new PlanFeaturesHighlightSection(featuresHighlightSections.getJSONObject(i))
-                                              );
+                        new PlanFeaturesHighlightSection(featuresHighlightSections.getJSONObject(i)));
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1330,7 +1330,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 AnalyticsTracker.Stat.EDITOR_CREATED_POST,
                 mSiteStore.getSiteByLocalId(mPost.getLocalSiteId()),
                 properties
-                                           );
+        );
     }
 
     private synchronized void updatePostObject(boolean isAutosave) throws EditorFragmentNotAddedException {
@@ -1391,7 +1391,7 @@ public class EditPostActivity extends AppCompatActivity implements
                     this,
                     org.wordpress.android.editor.R.drawable.ic_gridicons_image,
                     aztecEditorFragment.getMaxMediaSize()
-                                                                                                    );
+            );
             mAztecImageLoader = new AztecImageLoader(getBaseContext(), mImageManager, loadingImagePlaceholder);
             aztecEditorFragment.setAztecImageLoader(mAztecImageLoader);
             aztecEditorFragment.setLoadingImagePlaceholder(loadingImagePlaceholder);
@@ -1400,7 +1400,7 @@ public class EditPostActivity extends AppCompatActivity implements
                     this,
                     org.wordpress.android.editor.R.drawable.ic_gridicons_video_camera,
                     aztecEditorFragment.getMaxMediaSize()
-                                                                                                    );
+            );
             aztecEditorFragment.setAztecVideoLoader(new AztecVideoLoader(getBaseContext(), loadingVideoPlaceholder));
             aztecEditorFragment.setLoadingVideoPlaceholder(loadingVideoPlaceholder);
 
@@ -1415,7 +1415,7 @@ public class EditPostActivity extends AppCompatActivity implements
                                        && !PostStatus.PRIVATE.toString().equals(getPost().getStatus());
                             }
                         }
-                                                             );
+                );
             }
             aztecEditorFragment.setExternalLogger(new AztecLog.ExternalLogger() {
                 @Override
@@ -2706,9 +2706,10 @@ public class EditPostActivity extends AppCompatActivity implements
                     scanIntent.setData(capturedImageUri);
                     sendBroadcast(scanIntent);
                 } else {
-                    this.sendBroadcast(new Intent(Intent.ACTION_MEDIA_MOUNTED,
-                                                  Uri.parse("file://" + Environment.getExternalStorageDirectory()))
-                                      );
+                    this.sendBroadcast(new Intent(
+                            Intent.ACTION_MEDIA_MOUNTED,
+                            Uri.parse("file://" + Environment.getExternalStorageDirectory()))
+                    );
                 }
             } else {
                 ToastUtils.showToast(this, R.string.gallery_error, Duration.SHORT);
@@ -2913,7 +2914,7 @@ public class EditPostActivity extends AppCompatActivity implements
             Bitmap thumb = ImageUtils.getVideoFrameFromVideo(
                     videoPath,
                     EditorMediaUtils.getMaximumThumbnailSizeForEditor(this)
-                                                            );
+            );
             if (thumb != null) {
                 thumb.compress(Bitmap.CompressFormat.PNG, 75, outputStream);
                 thumbnailPath = outputFile.getAbsolutePath();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPreviewFragment.java
@@ -126,7 +126,7 @@ public class EditPostPreviewFragment extends Fragment {
                         getActivity(),
                         mPost,
                         Math.min(mTextView.getWidth(), mTextView.getHeight())
-                                                  );
+                );
             } else {
                 String htmlText = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><html><head><link rel=\"stylesheet\" "
                                   + "type=\"text/css\" href=\"webview.css\" /></head><body><div "

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -268,7 +268,7 @@ public class PostsListFragment extends Fragment
                         requestPosts(false);
                     }
                 }
-                                                         );
+        );
     }
 
     private @Nullable PostsListAdapter getPostListAdapter() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -132,7 +132,7 @@ public class SelectCategoriesActivity extends AppCompatActivity {
                         refreshCategories();
                     }
                 }
-                                                         );
+        );
 
         populateCategoryList();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ReleaseNotesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ReleaseNotesActivity.java
@@ -69,7 +69,7 @@ public class ReleaseNotesActivity extends WebViewActivity {
                         ReleaseNotesActivity.this.setTitle(view.getTitle());
                     }
                 }
-                                 );
+        );
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1507,7 +1507,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                             }
                         }
                 )
-                                   );
+        );
         view.findViewById(R.id.fab_button).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -1537,7 +1537,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                                             list.smoothScrollToPosition(getAdapter().getItemCount() - 1);
                                         }
                                     }
-                                     );
+                            );
                             mSiteSettings.saveSettings();
                             AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.SITE_SETTINGS_ADDED_LIST_ITEM,
                                                                 mSite);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
@@ -174,7 +174,7 @@ public class NotificationsSettingsDialogPreference extends DialogPreference {
                 mSettings.updateSettingForChannelAndType(
                         mChannel, mType, settingName,
                         mUpdatedJson.optBoolean(settingName), mBlogId
-                                                        );
+                );
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -145,7 +145,7 @@ public class ReaderCommentListActivity extends AppCompatActivity {
                         updatePostAndComments();
                     }
                 }
-                                                         );
+        );
 
         mRecyclerView = (ReaderRecyclerView) findViewById(R.id.recycler_view);
         int spacingHorizontal = 0;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -246,7 +246,7 @@ public class ReaderPostDetailFragment extends Fragment
                         updatePost();
                     }
                 }
-                                                         );
+        );
 
         mScrollView = view.findViewById(R.id.scroll_view_reader);
         mScrollView.setScrollDirectionListener(this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -727,24 +727,24 @@ public class ReaderPostListFragment extends Fragment
         });
 
         mSearchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
-                                               @Override
-                                               public boolean onQueryTextSubmit(String query) {
-                                                   submitSearchQuery(query);
-                                                   return true;
-                                               }
+                @Override
+                public boolean onQueryTextSubmit(String query) {
+                    submitSearchQuery(query);
+                    return true;
+                }
 
-                                               @Override
-                                               public boolean onQueryTextChange(String newText) {
-                                                   if (TextUtils.isEmpty(newText)) {
-                                                       showSearchMessage();
-                                                       hideSearchTabs();
-                                                   } else {
-                                                       populateSearchSuggestionAdapter(newText);
-                                                   }
-                                                   return true;
-                                               }
-                                           }
-                                          );
+                @Override
+                public boolean onQueryTextChange(String newText) {
+                    if (TextUtils.isEmpty(newText)) {
+                        showSearchMessage();
+                        hideSearchTabs();
+                    } else {
+                        populateSearchSuggestionAdapter(newText);
+                    }
+                    return true;
+                    }
+                }
+        );
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/ReferrerSpamHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/ReferrerSpamHelper.java
@@ -55,13 +55,13 @@ class ReferrerSpamHelper {
                     referrerGroup.isMarkedAsSpam
                             ? mActivityRef.get().getString(R.string.stats_referrers_marking_not_spam)
                             : mActivityRef.get().getString(R.string.stats_referrers_marking_spam)
-                                          );
+            );
         } else {
             menuItem = popup.getMenu().add(
                     referrerGroup.isMarkedAsSpam
                             ? mActivityRef.get().getString(R.string.stats_referrers_unspam)
                             : mActivityRef.get().getString(R.string.stats_referrers_spam)
-                                          );
+            );
         }
 
         menuItem.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -163,7 +163,7 @@ public class StatsActivity extends AppCompatActivity
                         refreshStatsFromCurrentDate();
                     }
                 }
-                                                         );
+        );
 
         setTitle(R.string.stats);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
@@ -130,8 +130,7 @@ public class StatsCommentsFragment extends StatsAbstractListFragment {
             int totalNumberOfFollowers = mCommentFollowersModel.getTotal();
             String totalCommentsFollowers = getString(R.string.stats_comments_total_comments_followers);
             mTotalsLabel.setText(
-                    String.format(totalCommentsFollowers, FormatUtils.formatDecimal(totalNumberOfFollowers))
-                                );
+                    String.format(totalCommentsFollowers, FormatUtils.formatDecimal(totalNumberOfFollowers)));
         }
 
         ArrayAdapter adapter = null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
@@ -360,10 +360,7 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
                             new View.OnClickListener() {
                                 @Override
                                 public void onClick(View view) {
-                                    ReaderActivityLauncher.showReaderBlogPreview(
-                                            mContext,
-                                            blogID
-                                                                                );
+                                    ReaderActivityLauncher.showReaderBlogPreview(mContext, blogID);
                                 }
                             });
                 } else {
@@ -377,12 +374,7 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
             }
 
             // since date
-            holder.totalsTextView.setText(
-                    StatsUtils.getSinceLabel(
-                            mContext,
-                            currentRowData.getDateSubscribed()
-                                            )
-                                         );
+            holder.totalsTextView.setText(StatsUtils.getSinceLabel(mContext, currentRowData.getDateSubscribed()));
             holder.totalsTextView.setContentDescription(
                     holder.totalsTextView.getContext().getString(
                             R.string.stats_follower_since_desc,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
@@ -177,7 +177,7 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
                             getString(R.string.stats_pagination_label),
                             FormatUtils.formatDecimal(followersModel.getPage()),
                             FormatUtils.formatDecimal(followersModel.getPages())
-                                                          );
+                    );
                     mBottomPaginationText.setText(paginationLabel);
                     mTopPaginationText.setText(paginationLabel);
                     setNavigationButtonsEnabled(true);
@@ -196,7 +196,7 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
                                         followersModel.getPage() - 1,
                                         new StatsServiceLogic.StatsEndpointsEnum[]{
                                                 sectionsToUpdate()[mTopPagerSelectedButtonIndex]}
-                                            );
+                                );
                             }
                         };
                         mBottomPaginationGoBackButton.setOnClickListener(clickListener);
@@ -217,7 +217,7 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
                                         followersModel.getPage() + 1,
                                         new StatsServiceLogic.StatsEndpointsEnum[]{
                                                 sectionsToUpdate()[mTopPagerSelectedButtonIndex]}
-                                            );
+                                );
                             }
                         };
                         mBottomPaginationGoForwardButton.setOnClickListener(clickListener);
@@ -236,7 +236,7 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
                             FormatUtils.formatDecimal(
                                     mTopPagerSelectedButtonIndex == 0 ? followersModel.getTotalWPCom()
                                             : followersModel.getTotalEmail())
-                                                 );
+                            );
                     mTotalsLabel.setText(pagedLabel);
                 } else {
                     // No paging required. Hide the controls.

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsInsightsMostPopularFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsInsightsMostPopularFragment.java
@@ -107,8 +107,8 @@ public class StatsInsightsMostPopularFragment extends StatsAbstractInsightsFragm
                 String.format(
                         getString(R.string.stats_insights_most_popular_percent_views),
                         roundToInteger(mInsightsPopularModel.getHighestDayPercent())
-                             )
-                                             );
+                )
+        );
 
         TextView mostPopularHourTextView = (TextView) ll.findViewById(R.id.stats_most_popular_hour);
         DateFormat timeFormat = android.text.format.DateFormat.getTimeFormat(getActivity());
@@ -121,8 +121,8 @@ public class StatsInsightsMostPopularFragment extends StatsAbstractInsightsFragm
                 String.format(
                         getString(R.string.stats_insights_most_popular_percent_views),
                         roundToInteger(mInsightsPopularModel.getHighestHourPercent())
-                             )
-                                              );
+                )
+        );
 
         mResultContainer.addView(ll);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -133,7 +133,7 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
                         refreshStats();
                     }
                 }
-                                                         );
+        );
 
         TextView mStatsForLabel = (TextView) findViewById(R.id.stats_summary_title);
         mGraphContainer = (LinearLayout) findViewById(R.id.stats_bar_chart_fragment_container);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
@@ -394,19 +394,19 @@ public class StatsUtils {
                 ReaderActivityLauncher.showReaderBlogPreview(
                         ctx,
                         blogID
-                                                            );
+                );
             } else {
                 ReaderActivityLauncher.showReaderPostDetail(
                         ctx,
                         blogID,
                         itemID
-                                                           );
+                );
             }
         } else if (itemType.equals(StatsConstants.ITEM_TYPE_HOME_PAGE)) {
             ReaderActivityLauncher.showReaderBlogPreview(
                     ctx,
                     blogID
-                                                        );
+            );
         } else {
             AppLog.d(AppLog.T.UTILS, "Opening the in-app browser: " + itemURL);
             WPWebViewActivity.openURL(ctx, itemURL);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
@@ -454,9 +454,7 @@ public class StatsUtils {
             Date date = from.parse(dataSubscribed);
 
             // See http://momentjs.com/docs/#/displaying/fromnow/
-            long currentDifference = Math.abs(
-                    StatsUtils.getDateDiff(date, currentDateTime, TimeUnit.SECONDS)
-                                             );
+            long currentDifference = Math.abs(StatsUtils.getDateDiff(date, currentDateTime, TimeUnit.SECONDS));
 
             if (currentDifference <= 45) {
                 return ctx.getString(R.string.stats_followers_seconds_ago);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
@@ -94,7 +94,7 @@ public class StatsViewAllActivity extends AppCompatActivity {
                         refreshStats();
                     }
                 }
-                                                         );
+        );
 
         if (savedInstanceState != null) {
             mLocalBlogID = savedInstanceState.getInt(StatsActivity.ARG_LOCAL_TABLE_SITE_ID, -1);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewHolder.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewHolder.java
@@ -83,7 +83,7 @@ public class StatsViewHolder {
                         }
                     }
                 }
-                                     );
+        );
 
         entryTextView.setTextColor(entryTextView.getContext().getResources().getColor(R.color.stats_link_text_color));
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/datasets/StatsTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/datasets/StatsTable.java
@@ -201,9 +201,11 @@ public class StatsTable {
         SQLiteDatabase db = StatsDatabaseHelper.getWritableDb(ctx);
         try {
             db.beginTransaction();
-            int rowDeleted = db.delete(TABLE_NAME, "blogID=? AND type=?",
-                                       new String[]{Long.toString(blogId), Integer.toString(sectionToUpdate.ordinal())}
-                                      );
+            int rowDeleted = db.delete(
+                    TABLE_NAME,
+                    "blogID=? AND type=?",
+                    new String[]{Long.toString(blogId), Integer.toString(sectionToUpdate.ordinal())}
+            );
             db.setTransactionSuccessful();
             AppLog.d(AppLog.T.STATS,
                      "Stats deleted for localBlogID " + blogId + " and type " + sectionToUpdate.getRestEndpointPath());

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsServiceLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsServiceLogic.java
@@ -338,10 +338,8 @@ public class StatsServiceLogic {
                 JSONObject response = new JSONObject(cachedStats);
                 mResponseObjectModel = StatsUtils.parseResponse(sectionToUpdate, blogId, response);
 
-                EventBus.getDefault().post(
-                        sectionToUpdate.getEndpointUpdateEvent(blogId, timeframe, date,
-                                                               maxResultsRequested, pageRequested, mResponseObjectModel)
-                                          );
+                EventBus.getDefault().post(sectionToUpdate.getEndpointUpdateEvent(blogId, timeframe, date,
+                        maxResultsRequested, pageRequested, mResponseObjectModel));
 
                 updateWidgetsUI(blogId, sectionToUpdate, timeframe, date, pageRequested, mResponseObjectModel);
                 checkAllRequestsFinished(null);
@@ -558,11 +556,8 @@ public class StatsServiceLogic {
                         }
                     }
 
-                    EventBus.getDefault().post(
-                            mEndpointName.getEndpointUpdateEvent(mRequestBlogId, mTimeframe, mDate,
-                                                                 mMaxResultsRequested, mPageRequested,
-                                                                 mResponseObjectModel)
-                                              );
+                    EventBus.getDefault().post(mEndpointName.getEndpointUpdateEvent(mRequestBlogId, mTimeframe, mDate,
+                            mMaxResultsRequested, mPageRequested, mResponseObjectModel));
 
                     updateWidgetsUI(mRequestBlogId, mEndpointName, mTimeframe, mDate, mPageRequested,
                                     mResponseObjectModel);

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -243,7 +243,7 @@ public class ThemeBrowserFragment extends Fragment
                         mCallback.onSwipeToRefresh();
                     }
                 }
-                                                         );
+        );
         mSwipeToRefreshHelper.setRefreshing(mShouldRefreshOnStart);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -847,7 +847,7 @@ class PostUploadNotifier {
                     mContext.getString(R.string.uploading_subtitle_media_only),
                     sNotificationData.mTotalMediaItems - getCurrentMediaItem(),
                     sNotificationData.mTotalMediaItems
-                                            );
+            );
         }
         return uploadingMessage;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/VideoOptimizer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/VideoOptimizer.java
@@ -94,9 +94,8 @@ public class VideoOptimizer implements org.m4m.IProgressListener {
 
         if (mediaComposer == null) {
             AppLog.w(AppLog.T.MEDIA, "VideoOptimizer > null composer");
-            AnalyticsTracker.track(MEDIA_VIDEO_CANT_OPTIMIZE,
-                                   AnalyticsUtils.getMediaProperties(getContext(), true, null, mInputPath)
-                                  );
+            AnalyticsTracker.track(MEDIA_VIDEO_CANT_OPTIMIZE, AnalyticsUtils.getMediaProperties(getContext(), true,
+                    null, mInputPath));
             mListener.onVideoOptimizationCompleted(mMedia);
             return;
         }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -274,7 +274,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                         mFormattingToolbar.enableFormatButtons(!hasFocus);
                     }
                 }
-                                       );
+        );
 
         mContent.setOnDragListener(mOnDragListener);
         mSource.setOnDragListener(mOnDragListener);


### PR DESCRIPTION
### Fix
Remove unnecessary indention for parentheses for better code readability.  This formatting was most likely an unfortunate consequence of the code styling automation.  These changes modify deep indented parentheses from multiple-line code in three cases; single-line method calls, multi-parameter method calls, and multi-line method calls.   See the pseudocode below for examples.

#### Before
```
methodCall(
        firstParameter,
        secondParameter,
        thirdParameter
          );
```

#### After [Single-Line Method Calls]
```
methodCall(firstParameter, secondParameter, thirdParameter);
```

#### After [Multi-Parameter Method Calls]
```
methodCall(
        firstParameter, secondParameter, thirdParameter);
```

#### After [Multi-Line Method Calls]
```
methodCall(
        firstParameter,
        secondParameter,
        thirdParameter
);
```

### Test
There are no functional changes with this pull request.

### Review
Only one developer is required to review these changes, but anyone can perform the review.