### PR TITLE
Remove Pin lock from the app

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -162,9 +162,6 @@ dependencies {
     androidTestImplementation 'com.squareup.okhttp:mockwebserver:2.7.5'
     androidTestImplementation 'com.squareup.okio:okio:1.13.0'
 
-    // Provided by the WordPress-Android Repository
-    implementation 'org.wordpress:passcodelock:1.5.1'
-
     // Dagger
     implementation 'com.google.dagger:dagger:2.11'
     kapt 'com.google.dagger:dagger-compiler:2.11'

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -486,19 +486,6 @@
             android:name=".ui.notifications.NotificationsDetailActivity"
             android:theme="@style/CalypsoTheme" />
 
-        <!-- Passcode lock activities -->
-        <activity
-            android:name="org.wordpress.passcodelock.PasscodeUnlockActivity"
-            android:theme="@style/CalypsoTheme"
-            android:launchMode="singleInstance"
-            android:label="@string/passcode_screen_title"
-            android:windowSoftInputMode="stateHidden" />
-        <activity
-            android:name="org.wordpress.passcodelock.PasscodeManagePasswordActivity"
-            android:theme="@style/CalypsoTheme"
-            android:label="@string/passcode_screen_title"
-            android:windowSoftInputMode="stateHidden" />
-
         <!--People Management-->
         <activity
             android:name=".ui.people.PeopleManagementActivity"

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -88,8 +88,6 @@ import org.wordpress.android.util.PackageUtils;
 import org.wordpress.android.util.ProfilingUtils;
 import org.wordpress.android.util.RateLimitedTask;
 import org.wordpress.android.util.VolleyUtils;
-import org.wordpress.passcodelock.AbstractAppLock;
-import org.wordpress.passcodelock.AppLockManager;
 
 import java.io.File;
 import java.io.IOException;
@@ -262,17 +260,6 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
 
 
         RestClientUtils.setUserAgent(getUserAgent());
-
-        // PasscodeLock setup
-        if (!AppLockManager.getInstance().isAppLockFeatureEnabled()) {
-            // Make sure that PasscodeLock isn't already in place.
-            // Notifications services can enable it before the app is started.
-            AppLockManager.getInstance().enableDefaultAppLockIfAvailable(this);
-        }
-        if (AppLockManager.getInstance().isAppLockFeatureEnabled()) {
-            AppLockManager.getInstance().getAppLock().setExemptActivities(
-                    new String[]{"org.wordpress.android.ui.ShareIntentReceiverActivity"});
-        }
 
         mZendeskHelper.setupZendesk(this, BuildConfig.ZENDESK_DOMAIN, BuildConfig.ZENDESK_APP_ID,
                 BuildConfig.ZENDESK_OAUTH_CLIENT_ID);
@@ -538,11 +525,6 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
             AnalyticsTracker.endSession(false);
             AnalyticsTracker.clearAllData();
 
-            // disable passcode lock
-            AbstractAppLock appLock = AppLockManager.getInstance().getAppLock();
-            if (appLock != null) {
-                appLock.setPassword(null);
-            }
         }
 
         if (!event.isError() && mAccountStore.hasAccessToken()) {
@@ -910,10 +892,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
             }
             AnalyticsUtils.refreshMetadata(mAccountStore, mSiteStore);
             mApplicationOpenedDate = new Date();
-            Map<String, Boolean> properties = new HashMap<>(1);
-            properties.put("pin_lock_enabled", AppLockManager.getInstance().getAppLock() != null
-                                               && AppLockManager.getInstance().getAppLock().isPasswordLocked());
-            AnalyticsTracker.track(Stat.APPLICATION_OPENED, properties);
+            AnalyticsTracker.track(Stat.APPLICATION_OPENED);
             if (NetworkUtils.isNetworkAvailable(mContext)) {
                 // Refresh account informations and Notifications
                 if (mAccountStore.hasAccessToken()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -64,7 +64,6 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPActivityUtils;
-import org.wordpress.passcodelock.AppLockManager;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -563,7 +562,6 @@ public class ActivityLauncher {
             WPActivityUtils.disableComponent(context, ReaderPostPagerActivity.class);
 
             context.startActivity(intent);
-            AppLockManager.getInstance().setExtendedTimeout();
         } catch (ActivityNotFoundException e) {
             ToastUtils.showToast(context, context.getString(R.string.cant_open_url), ToastUtils.Duration.LONG);
             AppLog.e(AppLog.T.UTILS, "No default app available on the device to open the link: " + url, e);
@@ -578,7 +576,6 @@ public class ActivityLauncher {
             } else {
                 Intent chooser = Intent.createChooser(intent, context.getString(R.string.error_please_choose_browser));
                 context.startActivity(chooser);
-                AppLockManager.getInstance().setExtendedTimeout();
             }
         } finally {
             // re-enable deeplinking

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -39,7 +39,6 @@ import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPMediaUtils;
-import org.wordpress.passcodelock.AppLockManager;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -238,14 +237,12 @@ public class PhotoPickerActivity extends AppCompatActivity
                                       @Override
                                       public void onMediaCapturePathReady(String mediaCapturePath) {
                                           mMediaCapturePath = mediaCapturePath;
-                                          AppLockManager.getInstance().setExtendedTimeout();
                                       }
                                   });
     }
 
     private void launchPictureLibrary() {
         WPMediaUtils.launchPictureLibrary(this, false);
-        AppLockManager.getInstance().setExtendedTimeout();
     }
 
     private void launchWPMediaLibrary() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -162,7 +162,6 @@ import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.widgets.WPViewPager;
 import org.wordpress.aztec.AztecExceptionHandler;
 import org.wordpress.aztec.util.AztecLog;
-import org.wordpress.passcodelock.AppLockManager;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -1290,17 +1289,14 @@ public class EditPostActivity extends AppCompatActivity implements
 
     private void launchPictureLibrary() {
         WPMediaUtils.launchPictureLibrary(this, true);
-        AppLockManager.getInstance().setExtendedTimeout();
     }
 
     private void launchVideoLibrary() {
         WPMediaUtils.launchVideoLibrary(this, true);
-        AppLockManager.getInstance().setExtendedTimeout();
     }
 
     private void launchVideoCamera() {
         WPMediaUtils.launchVideoCamera(this);
-        AppLockManager.getInstance().setExtendedTimeout();
     }
 
     private void showErrorAndFinish(int errorMessageId) {
@@ -2122,7 +2118,6 @@ public class EditPostActivity extends AppCompatActivity implements
                                       @Override
                                       public void onMediaCapturePathReady(String mediaCapturePath) {
                                           mMediaCapturePath = mediaCapturePath;
-                                          AppLockManager.getInstance().setExtendedTimeout();
                                       }
                                   });
     }
@@ -3190,8 +3185,6 @@ public class EditPostActivity extends AppCompatActivity implements
                         refreshBlogMedia();
                     }
                 });
-            } else {
-                AppLockManager.getInstance().setExtendedTimeout();
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsActivity.java
@@ -3,24 +3,17 @@ package org.wordpress.android.ui.prefs;
 import android.app.FragmentManager;
 import android.content.Context;
 import android.os.Bundle;
-import android.preference.Preference;
-import android.preference.SwitchPreference;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
 import org.wordpress.android.R;
-import org.wordpress.android.push.GCMMessageService;
 import org.wordpress.android.util.LocaleManager;
-import org.wordpress.passcodelock.AppLockManager;
-import org.wordpress.passcodelock.PasscodePreferenceFragment;
 
 public class AppSettingsActivity extends AppCompatActivity {
     private static final String KEY_APP_SETTINGS_FRAGMENT = "app-settings-fragment";
-    private static final String KEY_PASSCODE_FRAGMENT = "passcode-fragment";
 
     private AppSettingsFragment mAppSettingsFragment;
-    private PasscodePreferenceFragment mPasscodePreferenceFragment;
 
     @Override
     protected void attachBaseContext(Context newBase) {
@@ -39,41 +32,12 @@ public class AppSettingsActivity extends AppCompatActivity {
 
         FragmentManager fragmentManager = getFragmentManager();
         mAppSettingsFragment = (AppSettingsFragment) fragmentManager.findFragmentByTag(KEY_APP_SETTINGS_FRAGMENT);
-        mPasscodePreferenceFragment =
-                (PasscodePreferenceFragment) fragmentManager.findFragmentByTag(KEY_PASSCODE_FRAGMENT);
-        if (mAppSettingsFragment == null || mPasscodePreferenceFragment == null) {
-            Bundle passcodeArgs = new Bundle();
-            passcodeArgs.putBoolean(PasscodePreferenceFragment.KEY_SHOULD_INFLATE, false);
+        if (mAppSettingsFragment == null) {
             mAppSettingsFragment = new AppSettingsFragment();
-            mPasscodePreferenceFragment = new PasscodePreferenceFragment();
-            mPasscodePreferenceFragment.setArguments(passcodeArgs);
 
             fragmentManager.beginTransaction()
-                           .replace(android.R.id.content, mPasscodePreferenceFragment, KEY_PASSCODE_FRAGMENT)
                            .add(android.R.id.content, mAppSettingsFragment, KEY_APP_SETTINGS_FRAGMENT)
                            .commit();
-        }
-    }
-
-    @Override
-    public void onStart() {
-        super.onStart();
-
-        Preference togglePref =
-                mAppSettingsFragment.findPreference(getString(org.wordpress.passcodelock.R.string
-                                                                      .pref_key_passcode_toggle));
-        Preference changePref =
-                mAppSettingsFragment.findPreference(getString(org.wordpress.passcodelock.R.string
-                                                                      .pref_key_change_passcode));
-
-        if (togglePref != null && changePref != null) {
-            mPasscodePreferenceFragment.setPreferences(togglePref, changePref);
-            ((SwitchPreference) togglePref).setChecked(
-                    AppLockManager.getInstance().getAppLock().isPasswordLocked());
-
-            // here they've changed the PIN lock settings, so let's rebuild notifications if they have
-            // quick actions
-            GCMMessageService.rebuildAndUpdateNotifsOnSystemBarForRemainingNote(this);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTimezoneDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTimezoneDialog.java
@@ -324,7 +324,7 @@ public class SiteSettingsTimezoneDialog extends DialogFragment implements Dialog
 
             boolean isSelected = mSelectedTimezone != null
                                  && mSelectedTimezone.equals(mFilteredTimezones.get(position).mValue);
-            int colorRes = isSelected ? R.color.list_row_selected : R.color.transparent;
+            int colorRes = isSelected ? R.color.color_control_activated : R.color.transparent;
             holder.mTxtLabel.setBackgroundColor(getResources().getColor(colorRes));
             holder.mTxtLabel.setText(mFilteredTimezones.get(position).mLabel);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -85,7 +85,6 @@ import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 import org.wordpress.android.widgets.WPScrollView;
 import org.wordpress.android.widgets.WPScrollView.ScrollDirectionListener;
 import org.wordpress.android.widgets.WPTextView;
-import org.wordpress.passcodelock.AppLockManager;
 
 import java.util.EnumSet;
 
@@ -1168,12 +1167,6 @@ public class ReaderPostDetailFragment extends Fragment
                     case COMMENT_JUMP:
                     case COMMENT_REPLY:
                     case COMMENT_LIKE:
-                        if (AppLockManager.getInstance().isAppLockFeatureEnabled()) {
-                            // passcode screen was launched already (when ReaderPostPagerActivity got resumed) so reset
-                            // the timeout to let the passcode screen come up for the ReaderCommentListActivity.
-                            // See https://github.com/wordpress-mobile/WordPress-Android/issues/4887
-                            AppLockManager.getInstance().getAppLock().forcePasswordLock();
-                        }
                         ReaderActivityLauncher.showReaderComments(getActivity(), mPost.blogId, mPost.postId,
                                 mDirectOperation, mCommentId, mInterceptedUri);
                         getActivity().finish();

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -26,7 +26,6 @@ import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog.T;
-import org.wordpress.passcodelock.AppLockManager;
 
 import java.io.File;
 import java.io.IOException;
@@ -221,7 +220,6 @@ public class WPMediaUtils {
     }
 
     public static void launchVideoLibrary(Activity activity, boolean multiSelect) {
-        AppLockManager.getInstance().setExtendedTimeout();
         activity.startActivityForResult(prepareVideoLibraryIntent(activity, multiSelect),
                                         RequestCodes.VIDEO_LIBRARY);
     }
@@ -238,7 +236,6 @@ public class WPMediaUtils {
     }
 
     public static void launchVideoCamera(Activity activity) {
-        AppLockManager.getInstance().setExtendedTimeout();
         activity.startActivityForResult(prepareVideoCameraIntent(), RequestCodes.TAKE_VIDEO);
     }
 
@@ -247,7 +244,6 @@ public class WPMediaUtils {
     }
 
     public static void launchPictureLibrary(Activity activity, boolean multiSelect) {
-        AppLockManager.getInstance().setExtendedTimeout();
         activity.startActivityForResult(
                 preparePictureLibraryIntent(activity.getString(R.string.pick_photo), multiSelect),
                 RequestCodes.PICTURE_LIBRARY);
@@ -273,7 +269,6 @@ public class WPMediaUtils {
     public static void launchCamera(Activity activity, String applicationId, LaunchCameraCallback callback) {
         Intent intent = prepareLaunchCamera(activity, applicationId, callback);
         if (intent != null) {
-            AppLockManager.getInstance().setExtendedTimeout();
             activity.startActivityForResult(intent, RequestCodes.TAKE_PHOTO);
         }
     }

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -121,27 +121,6 @@
 
     </PreferenceCategory>
 
-
-    <PreferenceCategory
-        android:key="@string/pref_key_passlock_section"
-        android:layout="@layout/wp_preference_category"
-        android:persistent="false"
-        android:title="@string/passcode_preference_title">
-
-        <org.wordpress.android.ui.prefs.WPSwitchPreference
-            android:key="@string/pref_key_passcode_toggle"
-            android:layout="@layout/wp_preference_layout"
-            android:persistent="false"
-            android:title="@string/passcode_turn_on"/>
-
-        <Preference
-            android:key="@string/pref_key_change_passcode"
-            android:layout="@layout/wp_preference_layout"
-            android:persistent="false"
-            android:title="@string/passcode_change_passcode"/>
-
-    </PreferenceCategory>
-
     <PreferenceCategory
         android:key="@string/pref_key_about_section"
         android:layout="@layout/wp_preference_category"


### PR DESCRIPTION
Fixes [#29](https://github.com/wordpress-mobile/PasscodeLock-Android/pull/29)
- in order to fix a security issue in PasscodeLock library we have decided to remove the library completely from the app. The Pin lock feature has very low usage and presents a security issue. The project is no longer maintained. 

To test:
- go to App settings
- Pin lock category is gone
