### PR TITLE
Support fragment migration: Publicize section

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeBaseFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeBaseFragment.java
@@ -1,8 +1,8 @@
 package org.wordpress.android.ui.publicize;
 
-import android.app.Fragment;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.StringRes;
+import android.support.v4.app.Fragment;
 import android.support.v7.widget.Toolbar;
 
 import org.wordpress.android.R;

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -1,12 +1,12 @@
 package org.wordpress.android.ui.publicize;
 
-import android.app.Fragment;
-import android.app.FragmentManager;
-import android.app.FragmentTransaction;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
@@ -107,7 +107,7 @@ public class PublicizeListActivity extends AppCompatActivity
 
         String tag = getString(R.string.fragment_tag_publicize_list);
         Fragment fragment = PublicizeListFragment.newInstance(mSite);
-        getFragmentManager()
+        getSupportFragmentManager()
                 .beginTransaction()
                 .replace(R.id.fragment_container, fragment, tag)
                 .commit();
@@ -115,7 +115,7 @@ public class PublicizeListActivity extends AppCompatActivity
 
     private PublicizeListFragment getListFragment() {
         String tag = getString(R.string.fragment_tag_publicize_list);
-        Fragment fragment = getFragmentManager().findFragmentByTag(tag);
+        Fragment fragment = getSupportFragmentManager().findFragmentByTag(tag);
         if (fragment != null) {
             return (PublicizeListFragment) fragment;
         } else {
@@ -134,12 +134,12 @@ public class PublicizeListActivity extends AppCompatActivity
      * close all but the first (list) fragment
      */
     private void returnToListFragment() {
-        if (getFragmentManager().getBackStackEntryCount() == 0) {
+        if (getSupportFragmentManager().getBackStackEntryCount() == 0) {
             return;
         }
 
         String tag = getString(R.string.fragment_tag_publicize_detail);
-        getFragmentManager().popBackStack(tag, FragmentManager.POP_BACK_STACK_INCLUSIVE);
+        getSupportFragmentManager().popBackStack(tag, FragmentManager.POP_BACK_STACK_INCLUSIVE);
     }
 
     private void showDetailFragment(PublicizeService service) {
@@ -149,7 +149,7 @@ public class PublicizeListActivity extends AppCompatActivity
 
         String tag = getString(R.string.fragment_tag_publicize_detail);
         Fragment detailFragment = PublicizeDetailFragment.newInstance(mSite, service);
-        getFragmentManager()
+        getSupportFragmentManager()
                 .beginTransaction()
                 .replace(R.id.fragment_container, detailFragment, tag)
                 .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
@@ -159,7 +159,7 @@ public class PublicizeListActivity extends AppCompatActivity
 
     private PublicizeDetailFragment getDetailFragment() {
         String tag = getString(R.string.fragment_tag_publicize_detail);
-        Fragment fragment = getFragmentManager().findFragmentByTag(tag);
+        Fragment fragment = getSupportFragmentManager().findFragmentByTag(tag);
         if (fragment != null) {
             return (PublicizeDetailFragment) fragment;
         } else {
@@ -182,7 +182,7 @@ public class PublicizeListActivity extends AppCompatActivity
 
         String tag = getString(R.string.fragment_tag_publicize_webview);
         Fragment webViewFragment = PublicizeWebViewFragment.newInstance(mSite, service, publicizeConnection);
-        getFragmentManager()
+        getSupportFragmentManager()
                 .beginTransaction()
                 .replace(R.id.fragment_container, webViewFragment, tag)
                 .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
@@ -192,7 +192,7 @@ public class PublicizeListActivity extends AppCompatActivity
 
     private PublicizeWebViewFragment getWebViewFragment() {
         String tag = getString(R.string.fragment_tag_publicize_webview);
-        Fragment fragment = getFragmentManager().findFragmentByTag(tag);
+        Fragment fragment = getSupportFragmentManager().findFragmentByTag(tag);
         if (fragment != null) {
             return (PublicizeWebViewFragment) fragment;
         } else {
@@ -202,7 +202,7 @@ public class PublicizeListActivity extends AppCompatActivity
 
     private void closeWebViewFragment() {
         String tag = getString(R.string.fragment_tag_publicize_webview);
-        getFragmentManager().popBackStack(tag, FragmentManager.POP_BACK_STACK_INCLUSIVE);
+        getSupportFragmentManager().popBackStack(tag, FragmentManager.POP_BACK_STACK_INCLUSIVE);
     }
 
     @Override
@@ -217,8 +217,8 @@ public class PublicizeListActivity extends AppCompatActivity
 
     @Override
     public void onBackPressed() {
-        if (getFragmentManager().getBackStackEntryCount() > 0) {
-            getFragmentManager().popBackStack();
+        if (getSupportFragmentManager().getBackStackEntryCount() > 0) {
+            getSupportFragmentManager().popBackStack();
         } else {
             super.onBackPressed();
         }
@@ -355,7 +355,7 @@ public class PublicizeListActivity extends AppCompatActivity
     @Override
     public void onButtonPrefsClicked() {
         Fragment fragment = PublicizeButtonPrefsFragment.newInstance(mSite);
-        getFragmentManager().beginTransaction()
+        getSupportFragmentManager().beginTransaction()
                             .replace(R.id.fragment_container, fragment)
                             .addToBackStack(null)
                             .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)


### PR DESCRIPTION
This PR moves usage of `Fragment` away, in favor of `android.app.v4.support.Fragment` in the Publicize (sharing) section of the app.

To test:

0. In the home tab of then app, Ggo to Configuration->Sharing
1. first screen you see is `PublicizeListFragment`. Make sure it shows correctly and rotation doesn't affect.
2. tap on an item in the list and you're shown `PublicizeDetailFragment` (for example, Facebook). Again verify it shows correctly and rotation doesn't affect it.
3. Tap on CONNECT, this will show the `PublicizeWebViewFragment`. Again verify it works (i.e. shows the facebook login page)  and rotation doesn't affect it.

