### PR TITLE
Support fragment migration: People section

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/RoleUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/RoleUtils.java
@@ -1,6 +1,6 @@
 package org.wordpress.android.models;
 
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 
 import org.wordpress.android.R;
 import org.wordpress.android.fluxc.model.RoleModel;

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -1,9 +1,9 @@
 package org.wordpress.android.ui.people;
 
 
-import android.app.Fragment;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.text.Editable;
 import android.text.TextUtils;

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.people;
 
-import android.app.Fragment;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
@@ -8,6 +7,7 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.AppBarLayout;
+import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewCompat;
 import android.support.v7.widget.RecyclerView;

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -1,13 +1,13 @@
 package org.wordpress.android.ui.people;
 
-import android.app.AlertDialog;
-import android.app.Fragment;
-import android.app.FragmentManager;
-import android.app.FragmentTransaction;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.ActionBar;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
@@ -128,7 +128,7 @@ public class PeopleManagementActivity extends AppCompatActivity
         }
 
 
-        FragmentManager fragmentManager = getFragmentManager();
+        FragmentManager fragmentManager = getSupportFragmentManager();
 
         if (savedInstanceState == null) {
             // only delete cached people if there is a connection
@@ -255,20 +255,20 @@ public class PeopleManagementActivity extends AppCompatActivity
             confirmRemovePerson();
             return true;
         } else if (item.getItemId() == R.id.invite) {
-            FragmentManager fragmentManager = getFragmentManager();
+            FragmentManager fragmentManager = getSupportFragmentManager();
             Fragment peopleInviteFragment = fragmentManager.findFragmentByTag(KEY_PERSON_DETAIL_FRAGMENT);
 
             if (peopleInviteFragment == null) {
                 peopleInviteFragment = PeopleInviteFragment.newInstance(mSite);
             }
             if (peopleInviteFragment != null && !peopleInviteFragment.isAdded()) {
-                FragmentTransaction fragmentTransaction = getFragmentManager().beginTransaction();
+                FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
                 fragmentTransaction.replace(R.id.fragment_container, peopleInviteFragment, KEY_PEOPLE_INVITE_FRAGMENT);
                 fragmentTransaction.addToBackStack(null);
                 fragmentTransaction.commit();
             }
         } else if (item.getItemId() == R.id.send_invitation) {
-            FragmentManager fragmentManager = getFragmentManager();
+            FragmentManager fragmentManager = getSupportFragmentManager();
             Fragment peopleInviteFragment = fragmentManager.findFragmentByTag(KEY_PEOPLE_INVITE_FRAGMENT);
             if (peopleInviteFragment != null) {
                 ((InvitationSender) peopleInviteFragment).send();
@@ -459,7 +459,7 @@ public class PeopleManagementActivity extends AppCompatActivity
         }
         if (!personDetailFragment.isAdded()) {
             AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_PERSON, mSite);
-            FragmentTransaction fragmentTransaction = getFragmentManager().beginTransaction();
+            FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
             fragmentTransaction.replace(R.id.fragment_container, personDetailFragment, KEY_PERSON_DETAIL_FRAGMENT);
             fragmentTransaction.addToBackStack(null);
 
@@ -617,7 +617,7 @@ public class PeopleManagementActivity extends AppCompatActivity
     }
 
     private boolean navigateBackToPeopleListFragment() {
-        FragmentManager fragmentManager = getFragmentManager();
+        FragmentManager fragmentManager = getSupportFragmentManager();
         if (fragmentManager.getBackStackEntryCount() > 0) {
             fragmentManager.popBackStack();
 
@@ -673,11 +673,11 @@ public class PeopleManagementActivity extends AppCompatActivity
     }
 
     private PeopleListFragment getListFragment() {
-        return (PeopleListFragment) getFragmentManager().findFragmentByTag(KEY_PEOPLE_LIST_FRAGMENT);
+        return (PeopleListFragment) getSupportFragmentManager().findFragmentByTag(KEY_PEOPLE_LIST_FRAGMENT);
     }
 
     private PersonDetailFragment getDetailFragment() {
-        return (PersonDetailFragment) getFragmentManager().findFragmentByTag(KEY_PERSON_DETAIL_FRAGMENT);
+        return (PersonDetailFragment) getSupportFragmentManager().findFragmentByTag(KEY_PERSON_DETAIL_FRAGMENT);
     }
 
     public interface InvitationSender {

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PersonDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PersonDetailFragment.java
@@ -1,7 +1,7 @@
 package org.wordpress.android.ui.people;
 
-import android.app.Fragment;
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/RoleChangeDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/RoleChangeDialogFragment.java
@@ -1,12 +1,12 @@
 package org.wordpress.android.ui.people;
 
-import android.app.AlertDialog;
 import android.app.Dialog;
-import android.app.DialogFragment;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
 import android.view.ContextThemeWrapper;
 import android.view.View;
 import android.view.ViewGroup;

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/RoleSelectDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/RoleSelectDialogFragment.java
@@ -1,13 +1,13 @@
 package org.wordpress.android.ui.people;
 
-import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.Dialog;
-import android.app.DialogFragment;
-import android.app.Fragment;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.Fragment;
+import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatActivity;
 import android.view.ContextThemeWrapper;
 
 import org.wordpress.android.R;
@@ -70,9 +70,9 @@ public class RoleSelectDialogFragment extends DialogFragment {
         roleChangeDialogFragment.show(parentFragment.getFragmentManager(), null);
     }
 
-    public static <T extends Activity & OnRoleSelectListener> void show(T parentActivity) {
+    public static <T extends AppCompatActivity & OnRoleSelectListener> void show(T parentActivity) {
         RoleSelectDialogFragment roleChangeDialogFragment = new RoleSelectDialogFragment();
-        roleChangeDialogFragment.show(parentActivity.getFragmentManager(), null);
+        roleChangeDialogFragment.show(parentActivity.getSupportFragmentManager(), null);
     }
 
     // Container Activity must implement this interface


### PR DESCRIPTION
This PR moves usage of `Fragment` away, in favor of `android.app.v4.support.Fragment` in the People (invite) section of the app.


To test:

1. go to home tab of the app and tap on Configuration -> People
2. see the first fragment to be shown is `PeopleListFragment`. Verify the list of site admins/roles is shown there, and rotate the screen to make sure it all works okay.
3. tap on one of the persons. `PersonDetailFragment` is shown. Verify it shows the details about the person. Rotate the device, verify it works.
4. tap on the role. The `RoleChangeDialog` should be shown, that allows you to change this person's role. Verify it shows okay and doesn't  break on rotation.
5. tap on the `+` sign on the top right corner of the screen. It takes you to `PeopleInviteFragment`. Verify it shows okay and rotation doesn't break anything.
6. tap on the Role section in this screen so to make `RoleSelectDialog`run. Verify again it shows okay and doesn't break on rotation.

