### PR TITLE
Support fragment migration: Themes browser

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -1,13 +1,13 @@
 package org.wordpress.android.ui.themes;
 
-import android.app.AlertDialog;
-import android.app.FragmentManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.FragmentManager;
 import android.support.v7.app.ActionBar;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
@@ -96,7 +96,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
             fetchWpComThemesIfSyncTimedOut(false);
         } else {
             mThemeBrowserFragment =
-                    (ThemeBrowserFragment) getFragmentManager().findFragmentByTag(ThemeBrowserFragment.TAG);
+                    (ThemeBrowserFragment) getSupportFragmentManager().findFragmentByTag(ThemeBrowserFragment.TAG);
         }
 
         Toolbar toolbar = findViewById(R.id.toolbar);
@@ -135,7 +135,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
 
     @Override
     public void onBackPressed() {
-        FragmentManager fm = getFragmentManager();
+        FragmentManager fm = getSupportFragmentManager();
         if (fm.getBackStackEntryCount() > 0) {
             fm.popBackStack();
         } else {
@@ -345,7 +345,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
 
     private void addBrowserFragment() {
         mThemeBrowserFragment = ThemeBrowserFragment.newInstance(mSite);
-        getFragmentManager().beginTransaction()
+        getSupportFragmentManager().beginTransaction()
                             .add(R.id.theme_browser_container, mThemeBrowserFragment, ThemeBrowserFragment.TAG)
                             .commit();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -2,9 +2,9 @@ package org.wordpress.android.ui.themes;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.app.Fragment;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
 import android.support.v7.widget.SearchView;
 import android.text.Spannable;
 import android.text.TextUtils;


### PR DESCRIPTION
This PR takes `Fragment` away, in favor of `android.app.v4.support.Fragment` in the `Themes` browser section of the app.

To test:

1. go to home tab of the app and tap on Themes
2. make sure the list of available themes is shown properly.
3. confirm rotating the device also works fine.

