### PR TITLE
Support fragment migration: Stats section

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
@@ -1,8 +1,8 @@
 package org.wordpress.android.ui.stats;
 
 import android.app.Activity;
-import android.app.Fragment;
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
 
 import com.android.volley.NoConnectionError;
 import com.android.volley.VolleyError;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -1,10 +1,10 @@
 package org.wordpress.android.ui.stats;
 
-import android.app.FragmentManager;
-import android.app.FragmentTransaction;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -376,7 +376,7 @@ public class StatsActivity extends AppCompatActivity
         findViewById(R.id.stats_other_recent_stats_label_timeline).setVisibility(View.INVISIBLE);
         findViewById(R.id.stats_other_recent_stats_moved).setVisibility(View.INVISIBLE);
 
-        FragmentManager fm = getFragmentManager();
+        FragmentManager fm = getSupportFragmentManager();
         FragmentTransaction ft = fm.beginTransaction();
 
         StatsAbstractFragment fragment;
@@ -511,7 +511,7 @@ public class StatsActivity extends AppCompatActivity
         if (isFinishing()) {
             return;
         }
-        FragmentManager fm = getFragmentManager();
+        FragmentManager fm = getSupportFragmentManager();
 
         if (mCurrentTimeframe != StatsTimeframe.INSIGHTS) {
             mCallsToWaitFor = TOTAL_FRAGMENT_QUANTITY;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
@@ -1,9 +1,9 @@
 package org.wordpress.android.ui.stats;
 
-import android.app.FragmentManager;
-import android.app.FragmentTransaction;
 import android.content.Context;
 import android.os.Bundle;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
@@ -155,7 +155,7 @@ public class StatsViewAllActivity extends AppCompatActivity {
                 break;
         }
 
-        FragmentManager fm = getFragmentManager();
+        FragmentManager fm = getSupportFragmentManager();
         FragmentTransaction ft = fm.beginTransaction();
         mFragment = (StatsAbstractListFragment) fm.findFragmentByTag("ViewAll-Fragment");
         if (mFragment == null) {


### PR DESCRIPTION
This PR introduces use of`android.app.v4.support.Fragment` in the `Stats` section of the app.


To test:

1. go to home tab of the app and tap on Stats
2. make sure stats show correctly for yous site. Use different filters (Days, months, etc)
3. confirm rotating the device also works fine.
