### PR TITLE
Issue/missing fab string

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2166,6 +2166,7 @@
     <string name="stats_bar_date_value_type_desc">%s, %d %s</string>
     <string name="stats_bar_date_value_desc">%s, %d views</string>
     <string name="stats_bar_week_desc">Week of %s</string>
+    <string name="fab_add_tag_desc">Create Tag</string>
     <string name="fab_create_desc">create</string>
     <string name="stats_legend">stats graph legend</string>
     <string name="stats_tab_tap_content_description">showing %s</string>


### PR DESCRIPTION
### Fix
Add missing `fab_add_tag_desc` string to default `strings.xml` resource file, which was removed in https://github.com/wordpress-mobile/WordPress-Android/commit/b5287f47a04f756974a37322129a56b87e5cc5c9#diff-96c14faed2c61eacb909ae0349b44cef.