### PR TITLE
Fix NPE uploading local media

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -661,6 +661,10 @@ public class MySiteFragment extends Fragment implements
         SiteModel site = getSelectedSite();
         if (site != null) {
             MediaModel media = buildMediaModel(file, site);
+            if (media == null) {
+                ToastUtils.showToast(getActivity(), R.string.file_not_found, ToastUtils.Duration.SHORT);
+                return;
+            }
             UploadService.uploadMedia(getActivity(), media);
         } else {
             ToastUtils.showToast(getActivity(), R.string.error_generic, ToastUtils.Duration.SHORT);

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -322,9 +322,14 @@ public class PhotoPickerActivity extends AppCompatActivity
             return;
         }
 
+        MediaModel media = FluxCUtils.mediaModelFromLocalUri(this, mediaUri, null, mMediaStore, mSite.getId());
+        if (media == null) {
+            ToastUtils.showToast(this, R.string.file_not_found, ToastUtils.Duration.SHORT);
+            return;
+        }
+
         showUploadProgressDialog();
 
-        MediaModel media = FluxCUtils.mediaModelFromLocalUri(this, mediaUri, null, mMediaStore, mSite.getId());
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
         ArrayList<MediaModel> mediaList = new ArrayList<>();
         mediaList.add(media);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2574,6 +2574,11 @@ public class EditPostActivity extends AppCompatActivity implements
     private void addMediaLegacyEditor(Uri mediaUri, boolean isVideo) {
         MediaModel mediaModel = buildMediaModel(mediaUri, getContentResolver().getType(mediaUri),
                                                 MediaUploadState.QUEUED);
+        if (mediaModel == null) {
+            ToastUtils.showToast(this, R.string.file_not_found, ToastUtils.Duration.SHORT);
+            return;
+        }
+
         if (isVideo) {
             mediaModel.setTitle(getResources().getString(R.string.video));
         } else {
@@ -2956,6 +2961,10 @@ public class EditPostActivity extends AppCompatActivity implements
 
         // we need to update media with the local post Id
         MediaModel media = buildMediaModel(uri, mimeType, startingState);
+        if (media == null) {
+            ToastUtils.showToast(this, R.string.file_not_found, ToastUtils.Duration.SHORT);
+            return null;
+        }
         media.setLocalPostId(mPost.getId());
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
 
@@ -2966,6 +2975,9 @@ public class EditPostActivity extends AppCompatActivity implements
 
     private MediaModel buildMediaModel(Uri uri, String mimeType, MediaUploadState startingState) {
         MediaModel media = FluxCUtils.mediaModelFromLocalUri(this, uri, mimeType, mMediaStore, mSite.getId());
+        if (media == null) {
+            return null;
+        }
         if (org.wordpress.android.fluxc.utils.MediaUtils.isVideoMimeType(media.getMimeType())) {
             String path = MediaUtils.getRealPathFromURI(this, uri);
             media.setThumbnailUrl(getVideoThumbnail(path));

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -10,6 +10,8 @@ import android.webkit.MimeTypeMap;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.MediaUtils.MediaUtilsLoggingException;
 import org.wordpress.android.util.helpers.MediaFile;
 
 import java.io.File;
@@ -85,11 +87,23 @@ public class FluxCUtils {
         String path = MediaUtils.getRealPathFromURI(context, uri);
 
         if (TextUtils.isEmpty(path)) {
+            // For now, we're wrapping up the actual log into a Crashlytics exception to reduce possibility
+            // of information not travelling to Crashlytics (Crashlytics rolls logs up to 8
+            // entries and 64kb max, and they only travel with the next crash happening, so logging an
+            // Exception assures us to have this information sent in the next batch).
+            // For more info: http://bit.ly/2oJHMG7 and http://bit.ly/2oPOtFX
+            CrashlyticsUtils.logException(
+                    new MediaUtilsLoggingException("The input URI " + uri.toString() + " can't be read."),
+                    T.UTILS);
             return null;
         }
 
         File file = new File(path);
         if (!file.exists()) {
+            CrashlyticsUtils.logException(
+                    new MediaUtilsLoggingException("The input URI " + uri.toString() + ", locally converted to " + path
+                                                   + " can't be read."),
+                    T.UTILS);
             return null;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -11,12 +11,20 @@ import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.util.AppLog.T;
-import org.wordpress.android.util.MediaUtils.MediaUtilsLoggingException;
 import org.wordpress.android.util.helpers.MediaFile;
 
 import java.io.File;
 
 public class FluxCUtils {
+    public static class FluxCUtilsLoggingException extends Exception {
+        public FluxCUtilsLoggingException(String message) {
+            super(message);
+        }
+        public FluxCUtilsLoggingException(Throwable originalException) {
+            super(originalException);
+        }
+    }
+
     /**
      * This method doesn't do much, but insure we're doing the same check in all parts of the app.
      *
@@ -93,7 +101,7 @@ public class FluxCUtils {
             // Exception assures us to have this information sent in the next batch).
             // For more info: http://bit.ly/2oJHMG7 and http://bit.ly/2oPOtFX
             CrashlyticsUtils.logException(
-                    new MediaUtilsLoggingException("The input URI " + uri.toString() + " can't be read."),
+                    new FluxCUtilsLoggingException("The input URI " + uri.toString() + " can't be read."),
                     T.UTILS);
             return null;
         }
@@ -101,7 +109,7 @@ public class FluxCUtils {
         File file = new File(path);
         if (!file.exists()) {
             CrashlyticsUtils.logException(
-                    new MediaUtilsLoggingException("The input URI " + uri.toString() + ", converted locally to " + path
+                    new FluxCUtilsLoggingException("The input URI " + uri.toString() + ", converted locally to " + path
                                                    + " doesn't exist."),
                     T.UTILS);
             return null;

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -72,8 +72,10 @@ public class FluxCUtils {
         return mediaFile;
     }
 
-    /*
-     * returns a MediaModel from a device media URI
+    /**
+     * This method returns a FluxC MediaModel from a device media URI
+     *
+     * @return MediaModel or null in case of problems reading the URI
      */
     public static MediaModel mediaModelFromLocalUri(@NonNull Context context,
                                                     @NonNull Uri uri,

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -101,8 +101,8 @@ public class FluxCUtils {
         File file = new File(path);
         if (!file.exists()) {
             CrashlyticsUtils.logException(
-                    new MediaUtilsLoggingException("The input URI " + uri.toString() + ", locally converted to " + path
-                                                   + " can't be read."),
+                    new MediaUtilsLoggingException("The input URI " + uri.toString() + ", converted locally to " + path
+                                                   + " doesn't exist."),
                     T.UTILS);
             return null;
         }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -41,16 +41,6 @@ public class MediaUtils {
     private static final int DEFAULT_MAX_IMAGE_WIDTH = 1024;
     private static final Pattern FILE_EXISTS_PATTERN = Pattern.compile("(.*?)(-([0-9]+))?(\\..*$)?");
 
-
-    public static class MediaUtilsLoggingException extends Exception {
-        public MediaUtilsLoggingException(String message) {
-            super(message);
-        }
-        public MediaUtilsLoggingException(Throwable originalException) {
-            super(originalException);
-        }
-    }
-
     public static boolean isValidImage(String url) {
         if (url == null) {
             return false;

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -41,6 +41,16 @@ public class MediaUtils {
     private static final int DEFAULT_MAX_IMAGE_WIDTH = 1024;
     private static final Pattern FILE_EXISTS_PATTERN = Pattern.compile("(.*?)(-([0-9]+))?(\\..*$)?");
 
+
+    public static class MediaUtilsLoggingException extends Exception {
+        public MediaUtilsLoggingException(String message) {
+            super(message);
+        }
+        public MediaUtilsLoggingException(Throwable originalException) {
+            super(originalException);
+        }
+    }
+
     public static boolean isValidImage(String url) {
         if (url == null) {
             return false;
@@ -404,6 +414,7 @@ public class MediaUtils {
         } else {
             path = uri.toString();
         }
+
         return path;
     }
 


### PR DESCRIPTION
Fixes #8210 by adding a check to `PhotoPickerActivity` that does ensure `MediaModel` is not null before dispatching a new `newUpdateMediaAction` action.

The NPE happens internal to FluxC, but is wp-android that does trigger an event with a null payload. I will probably add some more checks to FluxC to avoid the crashing in a separate PR.

This PR also adds few other checks to be sure MediaModel returned by `FluxcUtils` is not null (EX: when the file is not readable for some reason).