### PR TITLE
Fixing Quick Start DB migration from 10.7 to 10.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '0bf53e06df9658ce9ba659e815d63ebac5aa1cf3'
+    fluxCVersion = '8ad769431e07f247aa36b8e9dc3e2cc3a4aff47c'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '8ad769431e07f247aa36b8e9dc3e2cc3a4aff47c'
+    fluxCVersion = '91f0f5972cc674a1b5a992235f9739f1b2d12a05'
 }


### PR DESCRIPTION
This PR updates a reference to a fix in Flux-C that addresses incorrect Quick Start DB migration issue.

Do not merge until [Fux-C part](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/885/) is finalized, merged and correct reference reflected in this PR.

To test: 
Install version 10.7 of the app and login into your account.
Install version 10.8-rc1 over the 10.7 and make sure it works.

