### PR TITLE
Support fragment migration: MyProfile screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileActivity.java
@@ -1,8 +1,8 @@
 package org.wordpress.android.ui.prefs;
 
-import android.app.FragmentManager;
 import android.content.Context;
 import android.os.Bundle;
+import android.support.v4.app.FragmentManager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
@@ -43,7 +43,7 @@ public class MyProfileActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
 
-        FragmentManager fragmentManager = getFragmentManager();
+        FragmentManager fragmentManager = getSupportFragmentManager();
         MyProfileFragment myProfileFragment =
                 (MyProfileFragment) fragmentManager.findFragmentByTag(KEY_MY_PROFILE_FRAGMENT);
         if (myProfileFragment == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileFragment.java
@@ -1,7 +1,7 @@
 package org.wordpress.android.ui.prefs;
 
-import android.app.Fragment;
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ProfileInputDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ProfileInputDialogFragment.java
@@ -1,10 +1,10 @@
 package org.wordpress.android.ui.prefs;
 
-import android.app.AlertDialog;
 import android.app.Dialog;
-import android.app.DialogFragment;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
 import android.text.TextUtils;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;


### PR DESCRIPTION
This PR makes use of support fragment variants in the `MyProfile` screen.

To test:
1. go to the Me tab
2. tap on "My Profile"
3. verify it shows the data correctly. Rotate the device and verify it works.
4. tap on any of the fields and verify the ProfileInputDialogFragment gets shown
5. enter data, rotate the device, verify the entered data is still in place, etc.
6. tap OK and verify the new data is reflected on the my Profile screen when the dialog is dismissed
