### PR TITLE
Don't rely on `sleep` to load images while generating screenshots

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -170,6 +170,12 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
+    androidTestImplementation('com.android.support.test.espresso:espresso-contrib:2.0') {
+        exclude group: 'com.android.support', module: 'appcompat'
+        exclude group: 'com.android.support', module: 'support-v4'
+        exclude module: 'recyclerview-v7'
+    }
+
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestCompile 'tools.fastlane:screengrab:1.2.0',  {

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -72,55 +72,32 @@ public class WPScreenshotTest {
     }
 
     private void wPLogin() {
-        // Login
-        ViewInteraction loginButton = onView(
-                allOf(withId(R.id.login_button),
-                        childAtPosition(allOf(withId(R.id.bottom_buttons),
-                                childAtPosition(withClassName(is("android.widget.RelativeLayout")), 3)),
-                        0)));
-        waitForElementUntilDisplayed(loginButton).perform(click());
+        // If we're already logged in, log out before starting
+        if (!hasElement(R.id.login_button)) {
+            wPLogout();
+        }
 
-        // User name
-        ViewInteraction userNameEditText = onView(
-                allOf(withId(R.id.input),
-                        childAtPosition(childAtPosition(withId(R.id.input_layout), 0), 0)));
-        waitForElementUntilDisplayed(userNameEditText).perform(replaceText(SCREENSHOT_LOGINUSERNAME),
-                closeSoftKeyboard());
+        // Login Prologue – We want to log in, not sign up
+        // See LoginPrologueFragment
+        clickOn(R.id.login_button);
 
-        // Next Button
-        ViewInteraction nextButton = onView(
-                allOf(withId(R.id.primary_button),
-                        childAtPosition(allOf(withId(R.id.bottom_buttons), childAtPosition(
-                                withClassName(is("android.widget.RelativeLayout")), 2)), 1)));
-        waitForElementUntilDisplayed(nextButton).perform(click());
+        // Email Address Screen – Fill it in and click "Next"
+        // See LoginEmailFragment
+        populateTextField(R.id.input, SCREENSHOT_LOGINUSERNAME);
+        clickOn(R.id.primary_button);
 
-        // Enter password button
-        ViewInteraction enterPasswordButton = onView(
-                allOf(withId(R.id.login_enter_password),
-                        childAtPosition(childAtPosition(
-                                withClassName(is("android.widget.ScrollView")), 0), 3)));
-        waitForElementUntilDisplayed(enterPasswordButton).perform(scrollTo(), click());
+        // Receive Magic Link or Enter Password Screen – Choose "Enter Password"
+        // See LoginMagicLinkRequestFragment
+        clickOn(R.id.login_enter_password);
 
-        // Password
-        ViewInteraction passwordEditText = onView(
-                allOf(withId(R.id.input), childAtPosition(
-                        childAtPosition(withId(R.id.input_layout), 0), 0)));
-        waitForElementUntilDisplayed(passwordEditText).perform(replaceText(SCREENSHOT_LOGINPASSWORD),
-                closeSoftKeyboard());
+        // Password Screen – Fill it in and click "Next"
+        // See LoginEmailPasswordFragment
+        populateTextField(R.id.input, SCREENSHOT_LOGINPASSWORD);
+        clickOn(R.id.primary_button);
 
-        // Next Button
-        nextButton = onView(
-                allOf(withId(R.id.primary_button), withText(R.string.next), childAtPosition(
-                        allOf(withId(R.id.bottom_buttons), childAtPosition(
-                                withClassName(is("android.widget.RelativeLayout")), 2)), 1)));
-        waitForElementUntilDisplayed(nextButton).perform(click());
-
-        // Continue with this log button
-        ViewInteraction continueButton = onView(
-                allOf(withId(R.id.primary_button), withText(R.string.login_continue), childAtPosition(
-                        allOf(withId(R.id.bottom_buttons), childAtPosition(
-                                withClassName(is("android.widget.RelativeLayout")), 3)), 1)));
-        waitForElementUntilDisplayed(continueButton).perform(click());
+        // Login Confirmation Screen – Click "Continue"
+        // See LoginEpilogueFragment
+        clickOn(R.id.primary_button);
     }
 
     private void wPLogout() {

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -1,15 +1,15 @@
 package org.wordpress.android.ui.screenshots;
 
+import android.test.suitebuilder.annotation.LargeTest;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.v7.widget.CardView;
-import android.test.suitebuilder.annotation.LargeTest;
 
 import org.junit.ClassRule;
-import org.wordpress.android.R;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wordpress.android.R;
 import org.wordpress.android.datasets.ReaderTagTable;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagList;
@@ -18,14 +18,29 @@ import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView;
 import org.wordpress.android.util.image.ImageType;
 
+import java.util.function.Supplier;
+
+import static org.wordpress.android.BuildConfig.SCREENSHOT_LOGINPASSWORD;
+import static org.wordpress.android.BuildConfig.SCREENSHOT_LOGINUSERNAME;
+import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.clickOn;
+import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.clickOnCellAtIndexIn;
+import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.getCurrentActivity;
+import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.hasElement;
+import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.populateTextField;
+import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.pressBackUntilElementIsVisible;
+import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.scrollToThenClickOn;
+import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.selectItemAtIndexInSpinner;
+import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.waitForAtLeastOneElementOfTypeToExist;
+import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.waitForAtLeastOneElementWithIdToExist;
+import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.waitForConditionToBeTrue;
+import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.waitForElementToBeDisplayed;
+import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.waitForElementToNotBeDisplayed;
+import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.waitForImagesOfTypeWithPlaceholder;
+import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.waitForRecyclerViewToStopReloading;
+
 import tools.fastlane.screengrab.Screengrab;
 import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
 
-import java.util.function.Supplier;
-import static org.wordpress.android.BuildConfig.SCREENSHOT_LOGINPASSWORD;
-import static org.wordpress.android.BuildConfig.SCREENSHOT_LOGINUSERNAME;
-
-import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.*;
 @LargeTest
 @RunWith(AndroidJUnit4.class)
 public class WPScreenshotTest {

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -101,23 +101,12 @@ public class WPScreenshotTest {
     }
 
     private void wPLogout() {
-        // Me button
-        ViewInteraction meButton = onView(
-                allOf(withId(R.id.nav_me),
-                        childAtPosition(childAtPosition(withId(R.id.bottom_navigation), 0), 3)));
-        waitForElementUntilDisplayed(meButton).perform(click());
+        // Click on the "Me" tab in the nav, then choose "Log Out"
+        clickOn(R.id.nav_me);
+        scrollToThenClickOn(R.id.row_logout);
 
-        // Log out button
-        ViewInteraction logoutButton = onView(
-                allOf(withId(R.id.row_logout),
-                        childAtPosition(childAtPosition(withId(R.id.scroll_view), 0), 11)));
-        waitForElementUntilDisplayed(logoutButton).perform(scrollTo(), click());
-
-        // Log out confirm button
-        ViewInteraction logoutConfirmButton = onView(
-                allOf(withId(android.R.id.button1), childAtPosition(
-                        childAtPosition(withClassName(is("android.widget.ScrollView")), 0), 3)));
-        waitForElementUntilDisplayed(logoutConfirmButton).perform(scrollTo(), click());
+        // Confirm that we want to log out
+        clickOn(android.R.id.button1);
     }
 
     private void navigateReader() {

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -25,6 +25,7 @@ import static org.wordpress.android.BuildConfig.SCREENSHOT_LOGINUSERNAME;
 import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.clickOn;
 import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.clickOnCellAtIndexIn;
 import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.getCurrentActivity;
+import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.moveCaretToEndAndDisplayIn;
 import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.hasElement;
 import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.populateTextField;
 import static org.wordpress.android.ui.screenshots.support.WPScreenshotSupport.pressBackUntilElementIsVisible;
@@ -58,8 +59,8 @@ public class WPScreenshotTest {
         Screengrab.setDefaultScreenshotStrategy(new UiAutomatorScreenshotStrategy());
 
         wPLogin();
-        navigateReader();
         editBlogPost();
+        navigateReader();
         navigateNotifications();
         navigateStats();
         wPLogout();
@@ -150,6 +151,7 @@ public class WPScreenshotTest {
 
         // Click in the post title editor and ensure the caret is at the end of the title editor
         scrollToThenClickOn(R.id.title);
+        moveCaretToEndAndDisplayIn(R.id.title);
 
         Screengrab.screenshot("screenshot_1");
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -295,24 +295,6 @@ public class WPScreenshotTest {
         waitForElementUntilDisplayed(navUpButton).perform(click());
     }
 
-    private static Matcher<View> childAtPosition(
-            final Matcher<View> parentMatcher, final int position) {
-        return new TypeSafeMatcher<View>() {
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("Child at position " + position + " in parent ");
-                parentMatcher.describeTo(description);
-            }
-
-            @Override
-            public boolean matchesSafely(View view) {
-                ViewParent parent = view.getParent();
-                return parent instanceof ViewGroup && parentMatcher.matches(parent)
-                        && view.equals(((ViewGroup) parent).getChildAt(position));
-            }
-        };
-    }
-
     private static ViewInteraction waitForElementUntilDisplayed(ViewInteraction element) {
         int i = 0;
         while (i++ < ATTEMPTS) {

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.screenshots;
 
 
+import android.support.test.espresso.Espresso;
 import android.support.test.espresso.ViewInteraction;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
@@ -194,50 +195,25 @@ public class WPScreenshotTest {
     }
 
     private void navigateStats() {
-        // Stats button
-        ViewInteraction statsButton = onView(
-                allOf(withId(R.id.nav_sites), childAtPosition(
-                        childAtPosition(withId(R.id.bottom_navigation), 0), 0)));
-        waitForElementUntilDisplayed(statsButton).perform(click());
+        // Click on the "Sites" tab in the nav, then choose "Stats"
+        clickOn(R.id.nav_sites);
+        scrollToThenClickOn(R.id.row_stats);
 
-        ViewInteraction linearLayout2 = onView(allOf(withId(R.id.row_stats), childAtPosition(
-                childAtPosition(withId(R.id.scroll_view), 0), 1)));
-        waitForElementUntilDisplayed(linearLayout2).perform(scrollTo(), click());
-
-        // Close the dialog
-        ViewInteraction dialogButton = onView(allOf(withId(R.id.promo_dialog_button_positive),
-                        childAtPosition(childAtPosition(
-                                withClassName(is("android.widget.RelativeLayout")), 3), 1)));
-        try {
-            // It may open or not, so catch the error if it's not up
-            waitForElementUntilDisplayed(dialogButton).perform(click());
-        } catch (Exception e) {
-            e.printStackTrace();
+        // If there's a pop-up message, dismiss it
+        if (hasElement(R.id.promo_dialog_button_positive)) {
+            clickOn(R.id.promo_dialog_button_positive);
         }
 
-        // Select Days view
-        ViewInteraction spinner = onView(
-                allOf(withId(R.id.filter_spinner), childAtPosition(
-                        withId(R.id.toolbar_filter), 0)));
-        waitForElementUntilDisplayed(spinner).perform(click());
+        // Select "Days" from the spinner
+        selectItemAtIndexInSpinner(1, R.id.filter_spinner);
 
-        ViewInteraction spinnerItem = onView(
-                allOf(withId(R.id.text), childAtPosition(
-                        withClassName(is("android.widget.DropDownListView")), 1)));
-        waitForElementUntilDisplayed(spinnerItem).perform(click());
+        // Wait for the stats to load
+        waitForElementToNotBeDisplayed(R.id.stats_empty_module_placeholder);
 
-        // Wait a bit
-        try {
-            Thread.sleep(3000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
         Screengrab.screenshot("screenshot_4");
 
-        // Navigate up
-        ViewInteraction navUpButton = onView(allOf(childAtPosition(allOf(withId(R.id.toolbar),
-                childAtPosition(withClassName(is("android.widget.LinearLayout")), 0)), 2)));
-        waitForElementUntilDisplayed(navUpButton).perform(click());
+        // Exit the Stats Activity
+        pressBackUntilElementIsVisible(R.id.nav_sites);
     }
 
     private static ViewInteraction waitForElementUntilDisplayed(ViewInteraction element) {

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -184,11 +184,12 @@ public class WPScreenshotTest {
     }
 
     private void navigateNotifications() {
-        // Notification button
-        ViewInteraction notificationButton = onView(
-                allOf(withId(R.id.nav_notifications), childAtPosition(
-                        childAtPosition(withId(R.id.bottom_navigation), 0), 4)));
-        waitForElementUntilDisplayed(notificationButton).perform(click());
+        // Click on the "Notifications" tab in the nav
+        clickOn(R.id.nav_notifications);
+
+        waitForAtLeastOneElementWithIdToExist(R.id.note_content_container);
+        waitForImagesOfTypeWithPlaceholder(R.id.note_avatar, ImageType.AVATAR);
+
         Screengrab.screenshot("screenshot_5");
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/EmptyImageMatcher.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/EmptyImageMatcher.java
@@ -1,0 +1,28 @@
+package org.wordpress.android.ui.screenshots.support;
+
+import android.view.View;
+import android.widget.ImageView;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+public class EmptyImageMatcher extends TypeSafeMatcher<View> {
+    public EmptyImageMatcher() {
+        super(View.class);
+    }
+
+    @Override
+    protected boolean matchesSafely(View item) {
+        if (item instanceof ImageView) {
+            ImageView imageView = (ImageView) item;
+            return imageView.getDrawable() == null;
+        }
+
+        return false;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("is an unloaded image");
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/FirstMatcher.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/FirstMatcher.java
@@ -1,0 +1,29 @@
+package org.wordpress.android.ui.screenshots.support;
+
+import android.view.View;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+public class FirstMatcher extends TypeSafeMatcher<View> {
+    private boolean mHasMatched = false;
+
+    public FirstMatcher() {
+        super(View.class);
+    }
+
+    @Override
+    protected boolean matchesSafely(View item) {
+        if (mHasMatched) {
+            return false;
+        }
+
+        mHasMatched = true;
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("first instance.");
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/FlashCaretViewAction.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/FlashCaretViewAction.java
@@ -1,0 +1,49 @@
+package org.wordpress.android.ui.screenshots.support;
+
+import android.support.test.espresso.UiController;
+import android.support.test.espresso.ViewAction;
+import android.view.View;
+import android.widget.EditText;
+import org.hamcrest.Matcher;
+
+import static android.text.InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.allOf;
+
+public class FlashCaretViewAction implements ViewAction {
+
+    @Override
+    public void perform(UiController uiController, View view) {
+
+        if (!(view instanceof EditText)) {
+            return;
+        }
+
+        EditText et = (EditText) view;
+
+        // disable the suggestions UI to prevent word underlining
+        et.setInputType(TYPE_TEXT_VARIATION_VISIBLE_PASSWORD);
+
+        // The best way to get the caret to show at a given time is to request focus – that resets the
+        // cursor loop (and as a bonus, moves the cursor to the end of the EditText).
+        // If, for some reason, this doesn't work consistently for us, an alternative approach would be to
+        // reverse-engineer how `TextView` draws the caret – in `getUpdatedHighlightPath`, the logic for how the
+        // whether to show the caret is defined:
+        //
+        // (SystemClock.uptimeMillis() - mEditor.mShowCursor) % (2 * Editor.BLINK) < Editor.BLINK
+        //
+        // Right now this is simpler though.
+        et.clearFocus();
+        et.requestFocus();
+    }
+
+    @Override
+    public Matcher<View> getConstraints() {
+        return allOf(instanceOf(EditText.class));
+    }
+
+    @Override
+    public String getDescription() {
+        return "Moving Text Edit Caret to the end of the text";
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/FlashCaretViewAction.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/FlashCaretViewAction.java
@@ -4,6 +4,7 @@ import android.support.test.espresso.UiController;
 import android.support.test.espresso.ViewAction;
 import android.view.View;
 import android.widget.EditText;
+
 import org.hamcrest.Matcher;
 
 import static android.text.InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
@@ -11,10 +12,8 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.allOf;
 
 public class FlashCaretViewAction implements ViewAction {
-
     @Override
     public void perform(UiController uiController, View view) {
-
         if (!(view instanceof EditText)) {
             return;
         }

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/PlaceholderComparison.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/PlaceholderComparison.java
@@ -1,0 +1,96 @@
+package org.wordpress.android.ui.screenshots.support;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.support.test.InstrumentationRegistry;
+import android.util.Size;
+import android.widget.ImageView;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
+import com.bumptech.glide.load.resource.bitmap.TransformationUtils;
+
+import org.wordpress.android.util.image.ImagePlaceholderManager;
+import org.wordpress.android.util.image.ImageType;
+
+import static junit.framework.Assert.fail;
+
+
+public class PlaceholderComparison {
+    private Context mContext;
+    private ImagePlaceholderManager mPlaceholderManager = new ImagePlaceholderManager();
+    private ImageType mImageType;
+
+    public PlaceholderComparison(ImageType imageType) {
+        mContext = InstrumentationRegistry.getTargetContext();
+        mImageType = imageType;
+    }
+
+    public boolean matches(ImageView view) {
+        Drawable drawable = view.getDrawable();
+        Size size = new Size(view.getWidth(), view.getHeight());
+
+        return matches(drawable, size);
+    }
+
+    private boolean matches(Drawable drawable, Size size) {
+        switch (mImageType) {
+            case PHOTO:
+            case VIDEO:
+                return colorComparePlaceholder(drawable);
+
+            case AVATAR: return bitmapComparePlaceholder(drawable, size);
+            case BLAVATAR: return bitmapComparePlaceholder(drawable, size);
+
+            default: fail();
+        }
+
+        return false;
+    }
+
+
+    private boolean colorComparePlaceholder(Drawable drawable) {
+        if (!(drawable instanceof ColorDrawable)) {
+            return false;
+        }
+
+        int placeholderResource = mPlaceholderManager.getPlaceholderResource(mImageType);
+        ColorDrawable template = new ColorDrawable(placeholderResource);
+        int templateColor = template.getColor();
+
+        return placeholderResource == templateColor;
+    }
+
+    private boolean bitmapComparePlaceholder(Drawable drawable, Size size) {
+        if (!(drawable instanceof BitmapDrawable)) {
+            return false;
+        }
+
+        int placeholderResource = mPlaceholderManager.getPlaceholderResource(mImageType);
+        Bitmap placeholder = ((BitmapDrawable) drawable).getBitmap();
+
+        Bitmap template = resourceToBitmap(placeholderResource, size);
+
+        if (mImageType == ImageType.AVATAR) {
+            BitmapPool pool = Glide.get(mContext).getBitmapPool();
+            template = TransformationUtils.circleCrop(pool, template, size.getWidth(), size.getHeight());
+        }
+
+        return placeholder.sameAs(template);
+    }
+
+    private Bitmap resourceToBitmap(int resourceId, Size size) {
+        Bitmap bitmap = Bitmap.createBitmap(size.getWidth(), size.getHeight(), Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+
+        Drawable d = mContext.getResources().getDrawable(resourceId);
+        d.setBounds(0, 0, size.getWidth(), size.getHeight());
+        d.draw(canvas);
+
+        return bitmap;
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/PlaceholderImageMatcher.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/PlaceholderImageMatcher.java
@@ -1,0 +1,34 @@
+package org.wordpress.android.ui.screenshots.support;
+
+import android.view.View;
+import android.widget.ImageView;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.wordpress.android.util.image.ImageType;
+
+public class PlaceholderImageMatcher extends TypeSafeMatcher<View> {
+    private ImageType mImageType;
+
+
+    public PlaceholderImageMatcher(ImageType imageType) {
+        super(View.class);
+        mImageType = imageType;
+    }
+
+    @Override
+    protected boolean matchesSafely(View item) {
+        if (item instanceof ImageView) {
+            ImageView view = (ImageView) item;
+            return new PlaceholderComparison(mImageType)
+                    .matches(view);
+        }
+
+        return false;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("is a placeholder for " + mImageType.name());
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/RefreshingRecyclerViewMatcher.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/RefreshingRecyclerViewMatcher.java
@@ -1,0 +1,28 @@
+package org.wordpress.android.ui.screenshots.support;
+
+import android.view.View;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.wordpress.android.ui.FilteredRecyclerView;
+
+public class RefreshingRecyclerViewMatcher extends TypeSafeMatcher<View> {
+    public RefreshingRecyclerViewMatcher() {
+        super(View.class);
+    }
+
+    @Override
+    protected boolean matchesSafely(View item) {
+        if (item instanceof FilteredRecyclerView) {
+            FilteredRecyclerView recyclerView = (FilteredRecyclerView) item;
+            return recyclerView.isRefreshing();
+        }
+
+        return false;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("is a refreshing recycler view");
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/SupplierIdler.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/SupplierIdler.java
@@ -1,0 +1,16 @@
+package org.wordpress.android.ui.screenshots.support;
+
+import java.util.function.Supplier;
+
+public class SupplierIdler extends WPScreenshotIdler {
+    private Supplier<Boolean> mSupplier;
+
+    public SupplierIdler(Supplier<Boolean> supplier) {
+        mSupplier = supplier;
+    }
+
+    @Override
+    public boolean checkCondition() {
+        return mSupplier.get();
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/WPScreenshotIdler.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/WPScreenshotIdler.java
@@ -1,0 +1,56 @@
+package org.wordpress.android.ui.screenshots.support;
+
+import android.support.test.espresso.IdlingResource;
+import static junit.framework.Assert.fail;
+
+public abstract class WPScreenshotIdler implements IdlingResource {
+    protected ResourceCallback mResourceCallback;
+    protected Boolean mConditionWasMet = false;
+
+    private Integer mNumberOfTries = 100;
+    private Integer mRetryInterval = 100;
+
+    @Override
+    public String getName() {
+        return this.getClass().getName();
+    }
+
+    @Override
+    public final boolean isIdleNow() {
+        if (mConditionWasMet) {
+            return true;
+        }
+
+        boolean isConditionMet = checkCondition();
+
+        if (isConditionMet) {
+            mConditionWasMet = true;
+            mResourceCallback.onTransitionToIdle();
+        }
+
+        return isConditionMet;
+    }
+
+    public abstract boolean checkCondition();
+
+    public void idleUntilReady() {
+        Integer tries = 0;
+
+        while (!checkCondition() && ++tries < mNumberOfTries) {
+            try {
+                Thread.sleep(mRetryInterval);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+        if (tries == mNumberOfTries) {
+            fail("Unable to continue – expectation wasn't satisfied quickly enough");
+        }
+    }
+
+    @Override
+    public void registerIdleTransitionCallback(ResourceCallback resourceCallback) {
+        mResourceCallback = resourceCallback;
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/WPScreenshotSupport.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/WPScreenshotSupport.java
@@ -162,7 +162,7 @@ public class WPScreenshotSupport {
 
     // Used by some methods that access the view layer directly. Because the screenshot generation code runs in
     // a different thread than the UI, the UI sometimes reports completion of an operation before repainting the
-    // screen to reflect the change. Delaying by one frame ensure's we're taking a screenshot of a stale UI.
+    // screen to reflect the change. Delaying by one frame ensures we're not taking a screenshot of a stale UI.
     public static void waitOneFrame() {
         try {
             Thread.sleep(17);

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/WPScreenshotSupport.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/WPScreenshotSupport.java
@@ -1,0 +1,291 @@
+package org.wordpress.android.ui.screenshots.support;
+
+import android.app.Activity;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.AmbiguousViewMatcherException;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.espresso.contrib.RecyclerViewActions;
+import android.support.test.espresso.matcher.ViewMatchers;
+import android.support.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeMatcher;
+import org.wordpress.android.R;
+import org.wordpress.android.util.image.ImageType;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static android.support.test.espresso.action.ViewActions.replaceText;
+import static android.support.test.espresso.action.ViewActions.scrollTo;
+import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
+import static android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.runner.lifecycle.Stage.RESUMED;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
+
+
+public class WPScreenshotSupport {
+    // HIGH-LEVEL METHODS
+
+    public static boolean hasElement(Integer elementID) {
+        return hasElement(onView(withId(elementID)));
+    }
+
+    public static boolean hasElement(ViewInteraction element) {
+        try {
+            element.check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
+            return true;
+        } catch (Throwable e) {
+            return false;
+        }
+    }
+
+    public static void scrollToThenClickOn(Integer elementID) {
+        waitForElementToBeDisplayed(elementID);
+        onView(withId(elementID))
+                .perform(scrollTo())
+                .perform(click());
+    }
+
+    public static void clickOn(Integer elementID) {
+        waitForElementToBeDisplayed(elementID);
+        onView(withId(elementID)).perform(click());
+    }
+
+    public static void clickOnCellAtIndexIn(int index, int elementID) {
+        waitForAtLeastOneElementWithIdToExist(elementID);
+        onView(withId(elementID))
+                .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
+    }
+
+    public static void populateTextField(Integer elementID, String text) {
+        waitForElementToBeDisplayed(elementID);
+        onView(withId(elementID))
+                .perform(replaceText(text))
+                .perform(closeSoftKeyboard());
+    }
+
+    public static void selectItemAtIndexInSpinner(Integer index, Integer elementID) {
+        waitForElementToBeDisplayed(elementID);
+        clickOn(elementID);
+
+        onView(
+                allOf(
+                        withId(R.id.text),
+                        childAtPosition(withClassName(is("android.widget.DropDownListView")), index)
+                )
+        ).perform(click());
+    }
+
+    // WAITERS
+    public static void waitForElementToBeDisplayed(final Integer elementID) {
+        waitForConditionToBeTrue(new Supplier<Boolean>() {
+            @Override
+            public Boolean get() {
+                return hasElement(elementID);
+            }
+        });
+    }
+
+    public static void waitForElementToNotBeDisplayed(final Integer elementID) {
+        waitForConditionToBeTrue(new Supplier<Boolean>() {
+            @Override
+            public Boolean get() {
+                return !hasElement(elementID);
+            }
+        });
+    }
+
+    public static void waitForConditionToBeTrue(Supplier<Boolean> supplier) {
+        new SupplierIdler(supplier).idleUntilReady();
+    }
+
+    public static void waitForImagesOfTypeWithPlaceholder(final Integer elementID, final ImageType imageType) {
+        waitForConditionToBeTrue(new Supplier<Boolean>() {
+            @Override
+            public Boolean get() {
+                return hasLoadedAllImagesOfTypeWithPlaceholder(elementID, imageType);
+            }
+        });
+
+        // sometimes the result of `getDrawable()` isn't the placeholder, but the placeholder is still displayed
+        waitOneFrame();
+    }
+
+    public static void waitForAtLeastOneElementOfTypeToExist(final Class c) {
+        waitForConditionToBeTrue(new Supplier<Boolean>() {
+            @Override
+            public Boolean get() {
+                return atLeastOneElementOfTypeExists(c);
+            }
+        });
+    }
+
+    public static void waitForAtLeastOneElementWithIdToExist(final int elementID) {
+        waitForConditionToBeTrue(new Supplier<Boolean>() {
+            @Override
+            public Boolean get() {
+                return atLeastOneElementWithIdExists(elementID);
+            }
+        });
+    }
+
+    public static void waitForRecyclerViewToStopReloading() {
+        waitForConditionToBeTrue(new Supplier<Boolean>() {
+            @Override
+            public Boolean get() {
+                return hasReloadingRecyclerView();
+            }
+        });
+    }
+
+    public static void pressBackUntilElementIsVisible(int elementID) {
+        while (!hasElement(elementID)) {
+            Espresso.pressBack();
+        }
+    }
+
+    // Used by some methods that access the view layer directly. Because the screenshot generation code runs in
+    // a different thread than the UI, the UI sometimes reports completion of an operation before repainting the
+    // screen to reflect the change. Delaying by one frame ensure's we're taking a screenshot of a stale UI.
+    public static void waitOneFrame() {
+        try{
+            Thread.sleep(17);
+        } catch(Exception ex){
+            //do nothing
+        }
+    }
+
+    // MATCHERS
+
+    /**
+     * Returns a matcher that ensures only a single match is returned. It is best combined with
+     * other matchers to prevent an {@link AmbiguousViewMatcherException}.
+     */
+    public static FirstMatcher first() {
+        return new FirstMatcher();
+    }
+
+    public static EmptyImageMatcher isEmptyImage() {
+        return new EmptyImageMatcher();
+    }
+
+    public static PlaceholderImageMatcher isPlaceholderImage(ImageType imageType) {
+        return new PlaceholderImageMatcher(imageType);
+    }
+
+    // HELPERS
+
+    public static Boolean atLeastOneElementOfTypeExists(Class c) {
+        try {
+            onView(
+                    allOf(
+                            Matchers.<View>instanceOf(c),
+                            first()
+                    )
+            ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
+
+            return true;
+        } catch (Throwable e) {
+            return false;
+        }
+    }
+
+    public static Boolean atLeastOneElementWithIdExists(int elementID) {
+        try {
+            onView(
+                    allOf(
+                            withId(elementID),
+                            first()
+                    )
+            ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
+
+            return true;
+        } catch (Throwable e) {
+            return false;
+        }
+    }
+
+    public static Boolean hasLoadedAllImagesOfTypeWithPlaceholder(Integer elementID, ImageType imageType) {
+        try {
+            onView(
+                    allOf(
+                            withId(elementID),
+                            isDisplayed(),
+                            anyOf(isEmptyImage(), isPlaceholderImage(imageType)),
+                            first()
+                    )
+            ).check(doesNotExist());
+
+            return true;
+        } catch (Throwable e) {
+            return false; // There are still unloaded images
+        }
+    }
+
+    public static boolean hasReloadingRecyclerView() {
+        try {
+            onView(
+                    allOf(
+                            new RefreshingRecyclerViewMatcher(),
+                            first()
+                    )
+            ).check(doesNotExist());
+
+            return true;
+        } catch (Throwable e) {
+            return false;
+        }
+    }
+
+    public static Matcher<View> childAtPosition(
+            final Matcher<View> parentMatcher, final int position) {
+        return new TypeSafeMatcher<View>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Child at position " + position + " in parent ");
+                parentMatcher.describeTo(description);
+            }
+
+            @Override
+            public boolean matchesSafely(View view) {
+                ViewParent parent = view.getParent();
+                return parent instanceof ViewGroup && parentMatcher.matches(parent)
+                        && view.equals(((ViewGroup) parent).getChildAt(position));
+            }
+        };
+    }
+
+    private static Activity mCurrentActivity;
+    public static Activity getCurrentActivity() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                Collection resumedActivities = ActivityLifecycleMonitorRegistry
+                        .getInstance()
+                        .getActivitiesInStage(RESUMED);
+
+                if (resumedActivities.iterator().hasNext()) {
+                    mCurrentActivity = (Activity) resumedActivities.iterator().next();
+                }
+            }
+        });
+
+        return mCurrentActivity;
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/WPScreenshotSupport.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/WPScreenshotSupport.java
@@ -79,6 +79,15 @@ public class WPScreenshotSupport {
                 .perform(replaceText(text))
                 .perform(closeSoftKeyboard());
     }
+    
+    public static void moveCaretToEndAndDisplayIn(int elementID) {
+        onView(withId(elementID))
+                .perform( new FlashCaretViewAction());
+
+        // To sync between the test target and the app target
+        waitOneFrame();
+        waitOneFrame();
+    }
 
     public static void selectItemAtIndexInSpinner(Integer index, Integer elementID) {
         waitForElementToBeDisplayed(elementID);

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/WPScreenshotSupport.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/WPScreenshotSupport.java
@@ -164,10 +164,10 @@ public class WPScreenshotSupport {
     // a different thread than the UI, the UI sometimes reports completion of an operation before repainting the
     // screen to reflect the change. Delaying by one frame ensure's we're taking a screenshot of a stale UI.
     public static void waitOneFrame() {
-        try{
+        try {
             Thread.sleep(17);
-        } catch(Exception ex){
-            //do nothing
+        } catch (Exception ex) {
+            // do nothing
         }
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/WPScreenshotSupport.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/support/WPScreenshotSupport.java
@@ -79,10 +79,10 @@ public class WPScreenshotSupport {
                 .perform(replaceText(text))
                 .perform(closeSoftKeyboard());
     }
-    
+
     public static void moveCaretToEndAndDisplayIn(int elementID) {
         onView(withId(elementID))
-                .perform( new FlashCaretViewAction());
+                .perform(new FlashCaretViewAction());
 
         // To sync between the test target and the app target
         waitOneFrame();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3534,4 +3534,10 @@ public class EditPostActivity extends AppCompatActivity implements
     public SiteModel getSite() {
         return mSite;
     }
+
+
+    // External Access to the Image Loader
+    public AztecImageLoader getAztecImageLoader() {
+        return mAztecImageLoader;
+    }
 }


### PR DESCRIPTION
First off, this is basically a rewrite of the screenshot generation code. The original tests used very verbose assertions that were a bit brittle in terms of how they looked up specific elements. While there may be a benefit to that I was unaware of, as I was working through the task, I realized I was repeating myself a lot and extracted the code I was writing to a new set of methods. Once I started working this way, it seemed a lot cleaner, so I applied it to the rest of the testing code.

One other benefit to extracting these methods from the screenshot generation suite is that it'll be possible for those methods to be used for other UI testing down the road, which will hopefully benefit other developers, too!

Let me know if this should be broken down into smaller pieces or adjusted in any way!

**A few issues this PR resolves:**

- If the device size is unusual, the tests don't crash while logging out.
- Notification avatars will always show up in screenshots.
- The test suite now waits until all images have loaded, rather than a specific amount of time.
- Screenshots won't sometimes show the RecyclerView loading indicator in the reader view.
- Navigating back to the main activity is now more reliable across different device sizes.
- If the device is already logged in when the test begins, the wPLogout method will be run before beginning the test so that it doesn't fail.

**To test:**

- Run the screenshot generation suite on a machine that's been used to generate the production screenshots before and ensure it works as intended.
- Ensure that the stats screenshot is generated correctly – my test blog has a pitiful amount of traffic, so I haven't been able to test this as thoroughly as I would've liked.

**To review:**

The implementation of how we track the number of images remaining for download in Aztec. There were many ways to accomplish this, including:

- Modifying Aztec directly to allow access to this information. (Rejected because that seemed like an if-all-else-fails solution).
- Creating a subclass of AztecImageLoader in the screenshot generation suite and injecting it into EditPostActivity. (Rejected because it would mean adding AztecImageLoader to the DI system, which can get complicated because of the separate testing application).
- Patching AztecImageLoader to track images being downloaded, and EditPostActivity to allow access to the image loader instance. (Went with this because it was the smallest set of changes and seemed like the safest option to ensure no breaking changes).

(replaces #8209 because it was auto-closed when I rebased)