### PR TITLE
Support fragment migration: AuthenticationDialogUtils

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/AuthenticationDialogUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AuthenticationDialogUtils.java
@@ -1,8 +1,8 @@
 package org.wordpress.android.util;
 
-import android.app.Activity;
-import android.app.FragmentTransaction;
 import android.content.Intent;
+import android.support.v4.app.FragmentTransaction;
+import android.support.v7.app.AppCompatActivity;
 
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
@@ -13,12 +13,12 @@ import org.wordpress.android.ui.accounts.LoginActivity;
 import org.wordpress.android.widgets.AuthErrorDialogFragment;
 
 public class AuthenticationDialogUtils {
-    public static void showAuthErrorView(Activity activity, SiteStore siteStore, SiteModel site) {
+    public static void showAuthErrorView(AppCompatActivity activity, SiteStore siteStore, SiteModel site) {
         showAuthErrorView(activity, siteStore, AuthErrorDialogFragment.DEFAULT_RESOURCE_ID,
                           AuthErrorDialogFragment.DEFAULT_RESOURCE_ID, site);
     }
 
-    public static void showAuthErrorView(Activity activity, SiteStore siteStore, int titleResId, int messageResId,
+    public static void showAuthErrorView(AppCompatActivity activity, SiteStore siteStore, int titleResId, int messageResId,
                                          SiteModel site) {
         final String alertTag = "alert_ask_credentials";
         if (activity.isFinishing()) {
@@ -49,7 +49,7 @@ public class AuthenticationDialogUtils {
             return;
         }
 
-        FragmentTransaction ft = activity.getFragmentManager().beginTransaction();
+        FragmentTransaction ft = activity.getSupportFragmentManager().beginTransaction();
         AuthErrorDialogFragment authAlert = new AuthErrorDialogFragment();
         authAlert.setArgs(titleResId, messageResId, site);
         ft.add(authAlert, alertTag);

--- a/WordPress/src/main/java/org/wordpress/android/util/AuthenticationDialogUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AuthenticationDialogUtils.java
@@ -18,8 +18,8 @@ public class AuthenticationDialogUtils {
                           AuthErrorDialogFragment.DEFAULT_RESOURCE_ID, site);
     }
 
-    public static void showAuthErrorView(AppCompatActivity activity, SiteStore siteStore, int titleResId, int messageResId,
-                                         SiteModel site) {
+    public static void showAuthErrorView(AppCompatActivity activity, SiteStore siteStore, int titleResId,
+                                         int messageResId, SiteModel site) {
         final String alertTag = "alert_ask_credentials";
         if (activity.isFinishing()) {
             return;

--- a/WordPress/src/main/java/org/wordpress/android/widgets/AuthErrorDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/AuthErrorDialogFragment.java
@@ -1,10 +1,10 @@
 package org.wordpress.android.widgets;
 
-import android.app.AlertDialog;
 import android.app.Dialog;
-import android.app.DialogFragment;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
 import android.view.ContextThemeWrapper;
 
 import org.wordpress.android.R;


### PR DESCRIPTION
This PR uses support fragment classes in `AuthenticationDialogUtils`. It'd be important to merge given #8254 has been merged.

To test:
I couldn't find a way to test this easily, so in order to test the specific change (moving to support fragment) I artificially inserted the call in `onAuthenticationChanged` in `WPMainActivity` to see if it worked.
```
                AuthenticationDialogUtils.showAuthErrorView(this, mSiteStore, mSelectedSite);
```
1. logout of wpcom
2. log back in
3. you should see the error dialog briefly

You can also put the call anywhere else (as long it's WPMainActivity) to make sure it works as intended.

