### PR TITLE
Issue/quick start strings

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2273,22 +2273,22 @@
     <string name="quick_start_dialog_view_site_message">Preview your new site to see what your visitors will see.</string>
     <string name="quick_start_dialog_view_site_message_short" tools:ignore="UnusedResources">Tap %1$s View Site %2$s to preview your site</string>
     <string name="quick_start_dialog_view_site_title">View your site</string>
-    <string name="quick_start_list_choose_theme_subtitle">@string/quick_start_dialog_choose_theme_message</string>
-    <string name="quick_start_list_choose_theme_title">@string/quick_start_dialog_choose_theme_title</string>
+    <string name="quick_start_list_choose_theme_subtitle" translatable="false">@string/quick_start_dialog_choose_theme_message</string>
+    <string name="quick_start_list_choose_theme_title" translatable="false">@string/quick_start_dialog_choose_theme_title</string>
     <string name="quick_start_list_complete_subtitle">doesn\'t it feel good to cross things off a list?</string>
     <string name="quick_start_list_complete_title">Congrats on finishing Quick Start</string>
     <string name="quick_start_list_create_site_subtitle">Get your site up and running</string>
     <string name="quick_start_list_create_site_title">Create your site</string>
-    <string name="quick_start_list_customize_site_subtitle">@string/quick_start_dialog_customize_site_message</string>
-    <string name="quick_start_list_customize_site_title">@string/quick_start_dialog_customize_site_title</string>
-    <string name="quick_start_list_follow_site_subtitle">@string/quick_start_dialog_follow_sites_message</string>
-    <string name="quick_start_list_follow_site_title">@string/quick_start_dialog_follow_sites_title</string>
-    <string name="quick_start_list_publish_post_subtitle">@string/quick_start_dialog_publish_post_message</string>
-    <string name="quick_start_list_publish_post_title">@string/quick_start_dialog_publish_post_title</string>
-    <string name="quick_start_list_share_site_subtitle">@string/quick_start_dialog_share_site_message</string>
-    <string name="quick_start_list_share_site_title">@string/quick_start_dialog_share_site_title</string>
-    <string name="quick_start_list_view_site_subtitle">@string/quick_start_dialog_view_site_message</string>
-    <string name="quick_start_list_view_site_title">@string/quick_start_dialog_view_site_title</string>
+    <string name="quick_start_list_customize_site_subtitle" translatable="false">@string/quick_start_dialog_customize_site_message</string>
+    <string name="quick_start_list_customize_site_title" translatable="false">@string/quick_start_dialog_customize_site_title</string>
+    <string name="quick_start_list_follow_site_subtitle" translatable="false">@string/quick_start_dialog_follow_sites_message</string>
+    <string name="quick_start_list_follow_site_title" translatable="false">@string/quick_start_dialog_follow_sites_title</string>
+    <string name="quick_start_list_publish_post_subtitle" translatable="false">@string/quick_start_dialog_publish_post_message</string>
+    <string name="quick_start_list_publish_post_title" translatable="false">@string/quick_start_dialog_publish_post_title</string>
+    <string name="quick_start_list_share_site_subtitle" translatable="false">@string/quick_start_dialog_share_site_message</string>
+    <string name="quick_start_list_share_site_title" translatable="false">@string/quick_start_dialog_share_site_title</string>
+    <string name="quick_start_list_view_site_subtitle" translatable="false">@string/quick_start_dialog_view_site_message</string>
+    <string name="quick_start_list_view_site_title" translatable="false">@string/quick_start_dialog_view_site_title</string>
     <string name="quick_start_sites">Quick Start</string>
     <string name="quick_start_sites_progress" translatable="false">%1$d/%2$d</string>
     <string name="quick_start_span_end" translatable="false">&lt;/span&gt;</string>


### PR DESCRIPTION
### Fix
Add the `translatable="false"` attribute to resources in the `strings.xml` file that reference other strings for the ***Quick Start*** project so they will be ignored by [GlotPress](https://translate.wordpress.org/).