### PR TITLE
Fix missing icons in Stats widget

### DIFF
--- a/WordPress/src/main/res/layout/stats_widget_layout.xml
+++ b/WordPress/src/main/res/layout/stats_widget_layout.xml
@@ -74,7 +74,7 @@
                     android:layout_marginRight="@dimen/stats_widget_image_layout_margin"
                     android:layout_marginEnd="@dimen/stats_widget_image_layout_margin"
                     android:contentDescription="@null"
-                    app:srcCompat="@drawable/ic_visible_on_grey_dark_12dp" />
+                    android:background="@drawable/ic_visible_on_grey_dark_12dp" />
 
                 <TextView
                     android:textColor="@color/grey_dark"
@@ -121,7 +121,7 @@
                     android:layout_marginRight="@dimen/stats_widget_image_layout_margin"
                     android:layout_marginEnd="@dimen/stats_widget_image_layout_margin"
                     android:contentDescription="@null"
-                    app:srcCompat="@drawable/ic_user_grey_dark_12dp" />
+                    android:background="@drawable/ic_user_grey_dark_12dp" />
 
                 <TextView
                     android:textColor="@color/grey_dark"
@@ -168,7 +168,7 @@
                     android:layout_marginRight="@dimen/stats_widget_image_layout_margin"
                     android:layout_marginEnd="@dimen/stats_widget_image_layout_margin"
                     android:contentDescription="@null"
-                    app:srcCompat="@drawable/ic_star_grey_dark_12dp" />
+                    android:background="@drawable/ic_star_grey_dark_12dp" />
 
                 <TextView
                     android:textColor="@color/grey_dark"
@@ -215,7 +215,7 @@
                     android:layout_marginRight="@dimen/stats_widget_image_layout_margin"
                     android:layout_marginEnd="@dimen/stats_widget_image_layout_margin"
                     android:contentDescription="@null"
-                    app:srcCompat="@drawable/ic_comment_grey_dark_12dp" />
+                    android:background="@drawable/ic_comment_grey_dark_12dp" />
 
                 <TextView
                     android:textColor="@color/grey_dark"

--- a/WordPress/src/main/res/layout/stats_widget_layout.xml
+++ b/WordPress/src/main/res/layout/stats_widget_layout.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/stats_widget_outer_container"
     android:background="@drawable/stats_widget_background"
     android:layout_width="match_parent"
@@ -20,7 +19,7 @@
         <ImageView
             android:layout_width="@dimen/stats_widget_icon_size"
             android:layout_height="@dimen/stats_widget_icon_size"
-            app:srcCompat="@drawable/ic_my_sites_white_32dp"
+            android:background="@drawable/ic_my_sites_white_32dp"
             android:contentDescription="@null"/>
 
         <TextView


### PR DESCRIPTION
Fixes #8261 by setting  attribute `background` instead of `srcCompat` on `ImageView`(s). srcCompat was giving problems in the widget since compat-thingy is not loaded there. (Tried to use `AppCompatImageView` but it seems cannot be used in a Widget).

To test:
- Add a Stats Widget to your home screen, and verify the icons are all there.

Tested on API 21, 26, 27.