### PR TITLE
Feature/activity log coroutines

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -101,6 +101,8 @@ android {
 androidExtensions {
     experimental = true
 }
+// enable kotlin coroutines
+kotlin { experimental { coroutines "enable" } }
 
 dependencies {
     implementation('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {

--- a/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
+++ b/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
@@ -31,7 +31,8 @@ import dagger.android.support.AndroidSupportInjectionModule;
         LoginAnalyticsModule.class,
         LoginFragmentModule.class,
         LoginServiceModule.class,
-        SupportModule.class
+        SupportModule.class,
+        ThreadModule.class
 })
 public interface AppComponentDebug extends AppComponent {
     @Component.Builder

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -158,7 +158,8 @@ import dagger.android.support.AndroidSupportInjectionModule;
         LoginAnalyticsModule.class,
         LoginFragmentModule.class,
         LoginServiceModule.class,
-        SupportModule.class
+        SupportModule.class,
+        ThreadModule.class
 })
 public interface AppComponent extends AndroidInjector<WordPress> {
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/modules/ThreadModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ThreadModule.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.modules
+
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.experimental.CommonPool
+import kotlinx.coroutines.experimental.CoroutineDispatcher
+import kotlinx.coroutines.experimental.android.UI
+import javax.inject.Named
+
+const val UI_CONTEXT = "UI_CONTEXT"
+const val COMMON_POOL_CONTEXT = "COMMON_POOL_CONTEXT"
+
+@Module
+class ThreadModule {
+    @Provides
+    @Named(UI_CONTEXT)
+    fun provideUiContext(): CoroutineDispatcher {
+        return UI
+    }
+
+    @Provides
+    @Named(COMMON_POOL_CONTEXT)
+    fun provideBackgroundContext(): CoroutineDispatcher {
+        return CommonPool
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/RewindProgressChecker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/RewindProgressChecker.kt
@@ -28,7 +28,7 @@ class RewindProgressChecker
             delay(CHECK_DELAY_MILLIS)
         }
         var result: OnRewindStatusFetched? = null
-        while(isActive) {
+        while (isActive) {
             val rewindStatusForSite = activityLogStore.getRewindStatusForSite(site)
             val rewind = rewindStatusForSite?.rewind
             if (rewind != null && rewind.status == FINISHED && rewind.restoreId == restoreId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/RewindProgressChecker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/RewindProgressChecker.kt
@@ -23,9 +23,14 @@ class RewindProgressChecker
         return start(site, restoreId, true)
     }
 
-    suspend fun start(site: SiteModel, restoreId: Long, now: Boolean = false) = runBlocking(coroutineContext) {
+    suspend fun start(
+        site: SiteModel,
+        restoreId: Long,
+        now: Boolean = false,
+        checkDelay: Long = CHECK_DELAY_MILLIS
+    ) = runBlocking(coroutineContext) {
         if (!now) {
-            delay(CHECK_DELAY_MILLIS)
+            delay(checkDelay)
         }
         var result: OnRewindStatusFetched? = null
         while (isActive) {
@@ -39,7 +44,7 @@ class RewindProgressChecker
             if (result.isError) {
                 break
             }
-            delay(CHECK_DELAY_MILLIS)
+            delay(checkDelay)
         }
         result
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/RewindProgressChecker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/RewindProgressChecker.kt
@@ -1,63 +1,46 @@
 package org.wordpress.android.ui.activitylog
 
-import android.os.Handler
-import android.os.Looper
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.ActivityLogActionBuilder
+import kotlinx.coroutines.experimental.delay
+import kotlinx.coroutines.experimental.runBlocking
+import org.wordpress.android.fluxc.action.ActivityLogAction.FETCH_REWIND_STATE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind.Status.FINISHED
 import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchRewindStatePayload
-import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.ActivityLogStore.OnRewindStatusFetched
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.experimental.coroutineContext
 
 @Singleton
 class RewindProgressChecker
-@Inject
-constructor(val activityLogStore: ActivityLogStore, val siteStore: SiteStore, val dispatcher: Dispatcher) {
-    private var handler: Handler = Handler(Looper.getMainLooper())
-    private var checkState: Runnable? = null
-    var isRunning: Boolean = false
-
+@Inject constructor(private val activityLogStore: ActivityLogStore) {
     companion object {
         const val CHECK_DELAY_MILLIS = 10000L
     }
 
-    fun startNow(site: SiteModel, restoreId: Long) {
-        start(site, restoreId, true)
+    suspend fun startNow(site: SiteModel, restoreId: Long): OnRewindStatusFetched? {
+        return start(site, restoreId, true)
     }
 
-    fun start(site: SiteModel, restoreId: Long, now: Boolean = false) {
-        isRunning = true
-        checkState = object : Runnable {
-            override fun run() {
-                val rewindStatusForSite = activityLogStore.getRewindStatusForSite(site)
-                val rewind = rewindStatusForSite?.rewind
-                rewind?.let {
-                    if (rewind.status == FINISHED && rewind.restoreId == restoreId) {
-                        isRunning = false
-                        return
-                    }
-                }
-
-                val action = ActivityLogActionBuilder.newFetchRewindStateAction(FetchRewindStatePayload(site))
-                dispatcher.dispatch(action)
-
-                handler.postDelayed(this, CHECK_DELAY_MILLIS)
+    suspend fun start(site: SiteModel, restoreId: Long, now: Boolean = false) = runBlocking(coroutineContext) {
+        if (!now) {
+            delay(CHECK_DELAY_MILLIS)
+        }
+        var result: OnRewindStatusFetched? = null
+        while(isActive) {
+            val rewindStatusForSite = activityLogStore.getRewindStatusForSite(site)
+            val rewind = rewindStatusForSite?.rewind
+            if (rewind != null && rewind.status == FINISHED && rewind.restoreId == restoreId) {
+                result = OnRewindStatusFetched(FETCH_REWIND_STATE)
+                break
             }
+            result = activityLogStore.fetchActivitiesRewind(FetchRewindStatePayload(site))
+            if (result.isError) {
+                break
+            }
+            delay(CHECK_DELAY_MILLIS)
         }
-        if (now) {
-            handler.post(checkState)
-        } else {
-            handler.postDelayed(checkState, CHECK_DELAY_MILLIS)
-        }
-    }
-
-    fun cancel() {
-        checkState?.let {
-            handler.removeCallbacks(checkState)
-            isRunning = false
-        }
+        result
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/RewindStatusService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/RewindStatusService.kt
@@ -79,6 +79,8 @@ class RewindStatusService
     }
 
     fun stop() {
+        rewindProgressCheckerJob?.cancel()
+        fetchRewindJob?.cancel()
         if (site != null) {
             site = null
         }
@@ -113,7 +115,7 @@ class RewindStatusService
             val restoreId = rewindStatus.rewind?.restoreId
             if (rewindProgressCheckerJob?.isActive != true && restoreId != null) {
                 site?.let {
-                    rewindProgressCheckerJob = launch {
+                    rewindProgressCheckerJob = launch(coroutineContext) {
                         val rewindStatusFetched = rewindProgressChecker.startNow(it, restoreId)
                         onRewindStatusFetched(rewindStatusFetched?.error, rewindStatusFetched?.isError == true)
                     }
@@ -146,7 +148,7 @@ class RewindStatusService
         }
         site?.let {
             event.restoreId?.let { restoreId ->
-                rewindProgressCheckerJob = launch {
+                rewindProgressCheckerJob = launch(coroutineContext) {
                     val rewindStatusFetched = rewindProgressChecker.start(it, restoreId)
                     onRewindStatusFetched(rewindStatusFetched?.error, rewindStatusFetched?.isError == true)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -212,7 +212,7 @@ class ActivityLogViewModel @Inject constructor(
             val payload = ActivityLogStore.FetchActivityLogPayload(site, isLoadingMore)
             launch(coroutineContext) {
                 val result = activityLogStore.fetchActivities(payload)
-                onEventsUpdated(result)
+                onActivityLogFetched(result)
             }
         }
     }
@@ -249,7 +249,7 @@ class ActivityLogViewModel @Inject constructor(
         }
     }
 
-    fun onEventsUpdated(event: OnActivityLogFetched) {
+    private fun onActivityLogFetched(event: OnActivityLogFetched) {
         if (event.isError) {
             _eventListStatus.postValue(ActivityLogListStatus.ERROR)
             AppLog.e(AppLog.T.ACTIVITY_LOG, "An error occurred while fetching the Activity log events")

--- a/WordPress/src/test/java/org/wordpress/android/CoroutineTestUtils.kt
+++ b/WordPress/src/test/java/org/wordpress/android/CoroutineTestUtils.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android
+
+import kotlinx.coroutines.experimental.delay
+import org.mockito.stubbing.OngoingStubbing
+
+suspend fun <T> OngoingStubbing<T>.thenReturnSuspended(value: T) {
+    delay(1000)
+    thenReturn(value)
+}

--- a/WordPress/src/test/java/org/wordpress/android/CoroutineTestUtils.kt
+++ b/WordPress/src/test/java/org/wordpress/android/CoroutineTestUtils.kt
@@ -1,9 +1,0 @@
-package org.wordpress.android
-
-import kotlinx.coroutines.experimental.delay
-import org.mockito.stubbing.OngoingStubbing
-
-suspend fun <T> OngoingStubbing<T>.thenReturnSuspended(value: T) {
-    delay(1000)
-    thenReturn(value)
-}

--- a/WordPress/src/test/java/org/wordpress/android/ui/activitylog/RewindProgressCheckerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/activitylog/RewindProgressCheckerTest.kt
@@ -1,0 +1,95 @@
+package org.wordpress.android.ui.activitylog
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.inOrder
+import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.whenever
+import junit.framework.Assert.assertEquals
+import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.experimental.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.action.ActivityLogAction.FETCH_REWIND_STATE
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind.Status.FINISHED
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.State.ACTIVE
+import org.wordpress.android.fluxc.store.ActivityLogStore
+import org.wordpress.android.fluxc.store.ActivityLogStore.OnRewindStatusFetched
+import org.wordpress.android.fluxc.store.ActivityLogStore.RewindStatusError
+import org.wordpress.android.fluxc.store.ActivityLogStore.RewindStatusErrorType.GENERIC_ERROR
+import java.util.Date
+
+@RunWith(MockitoJUnitRunner::class)
+class RewindProgressCheckerTest {
+    @Mock lateinit var activityLogStore: ActivityLogStore
+    @Mock lateinit var site: SiteModel
+    private val restoreId = 1L
+    private lateinit var rewindProgressChecker: RewindProgressChecker
+    @Before
+    fun setUp() {
+        rewindProgressChecker = RewindProgressChecker(activityLogStore)
+    }
+
+    private val finishedRewind = Rewind("rewindId", restoreId, FINISHED, 100, "finished")
+
+    private val rewindStatusModel = RewindStatusModel(ACTIVE, "reason", Date(), true, null, null)
+    private val finishedRewindStatus = rewindStatusModel.copy(rewind = finishedRewind)
+
+    @Test
+    fun `on start checks current value and finishes if rewind is done`() = runBlocking {
+        whenever(activityLogStore.getRewindStatusForSite(site)).thenReturn(finishedRewindStatus)
+
+        val onRewindStatusFetched = rewindProgressChecker.start(site, restoreId, checkDelay = -1)
+
+        assertEquals(OnRewindStatusFetched(FETCH_REWIND_STATE), onRewindStatusFetched)
+    }
+
+    @Test
+    fun `on start triggers fetch if rewind not in progress`() = runBlocking {
+        whenever(activityLogStore.getRewindStatusForSite(site)).thenReturn(rewindStatusModel, finishedRewindStatus)
+        whenever(activityLogStore.fetchActivitiesRewind(any())).thenReturn(OnRewindStatusFetched(FETCH_REWIND_STATE))
+
+        val onRewindStatusFetched = rewindProgressChecker.start(site, restoreId, checkDelay = -1)
+
+        with(inOrder(activityLogStore)) {
+            verify(activityLogStore).getRewindStatusForSite(site)
+            verify(activityLogStore).fetchActivitiesRewind(any())
+            verify(activityLogStore).getRewindStatusForSite(site)
+        }
+
+        assertEquals(OnRewindStatusFetched(FETCH_REWIND_STATE), onRewindStatusFetched)
+    }
+
+    @Test
+    fun `on fetch fail return error`() = runBlocking {
+        whenever(activityLogStore.getRewindStatusForSite(site)).thenReturn(rewindStatusModel)
+        val errorStatus = OnRewindStatusFetched(RewindStatusError(GENERIC_ERROR, "generic error"), FETCH_REWIND_STATE)
+        whenever(activityLogStore.fetchActivitiesRewind(any())).thenReturn(errorStatus)
+
+        val onRewindStatusFetched = rewindProgressChecker.start(site, restoreId, checkDelay = -1)
+
+        with(inOrder(activityLogStore)) {
+            verify(activityLogStore).getRewindStatusForSite(site)
+            verify(activityLogStore).fetchActivitiesRewind(any())
+            verifyNoMoreInteractions()
+        }
+
+        assertEquals(errorStatus, onRewindStatusFetched)
+    }
+
+    @Test
+    fun `on cancel stops a job`() = runBlocking {
+        val onRewindStatusFetched = launch {
+            rewindProgressChecker.start(site, restoreId)
+        }
+
+        onRewindStatusFetched.cancel()
+
+        verifyZeroInteractions(activityLogStore)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/activitylog/RewindProgressCheckerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/activitylog/RewindProgressCheckerTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockito_kotlin.inOrder
 import com.nhaarman.mockito_kotlin.verifyZeroInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import junit.framework.Assert.assertEquals
+import kotlinx.coroutines.experimental.Unconfined
 import kotlinx.coroutines.experimental.launch
 import kotlinx.coroutines.experimental.runBlocking
 import org.junit.Before
@@ -32,7 +33,7 @@ class RewindProgressCheckerTest {
     private lateinit var rewindProgressChecker: RewindProgressChecker
     @Before
     fun setUp() {
-        rewindProgressChecker = RewindProgressChecker(activityLogStore)
+        rewindProgressChecker = RewindProgressChecker(activityLogStore, Unconfined)
     }
 
     private val finishedRewind = Rewind("rewindId", restoreId, FINISHED, 100, "finished")

--- a/WordPress/src/test/java/org/wordpress/android/ui/activitylog/RewindStatusServiceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/activitylog/RewindStatusServiceTest.kt
@@ -143,19 +143,6 @@ class RewindStatusServiceTest {
     }
 
     @Test
-    fun updatesRewindStatusAndRestartsCheckerWhenRewindNotAlreadyRunning() = runBlocking<Unit> {
-        rewindStatusService.start(site)
-        val rewindStatusInProgress = activeRewindStatusModel.copy(rewind = rewindInProgress)
-        whenever(activityLogStore.getRewindStatusForSite(site)).thenReturn(rewindStatusInProgress)
-        whenever(activityLogStore.fetchActivitiesRewind(any())).thenReturn(OnRewindStatusFetched(FETCH_REWIND_STATE))
-        reset(rewindProgressChecker)
-
-        rewindStatusService.requestStatusUpdate()
-
-        verify(rewindProgressChecker).startNow(site, rewindInProgress.restoreId)
-    }
-
-    @Test
     fun triggersRewindAndMakesActionUnavailable() = runBlocking {
         val rewindId = "10"
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/activitylog/RewindStatusServiceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/activitylog/RewindStatusServiceTest.kt
@@ -188,7 +188,7 @@ class RewindStatusServiceTest {
     }
 
     @Test
-    fun onRewindStateFinishedUpdateState() = runBlocking{
+    fun onRewindStateFinishedUpdateState() = runBlocking {
         rewindStatusService.start(site)
 
         val rewindFinished = rewindInProgress.copy(status = FINISHED, progress = 100)
@@ -223,7 +223,7 @@ class RewindStatusServiceTest {
     }
 
     @Test
-    fun onRewindFetchStatusAndStartWorker() = runBlocking<Unit>{
+    fun onRewindFetchStatusAndStartWorker() = runBlocking<Unit> {
         rewindStatusService.start(site)
 
         whenever(activityLogStore.rewind(any())).thenReturn(OnRewind("5", 10, REWIND))

--- a/WordPress/src/test/java/org/wordpress/android/ui/activitylog/RewindStatusServiceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/activitylog/RewindStatusServiceTest.kt
@@ -1,19 +1,19 @@
 package org.wordpress.android.ui.activitylog
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.argumentCaptor
-import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
+import kotlinx.coroutines.experimental.Unconfined
+import kotlinx.coroutines.experimental.runBlocking
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.ActivityLogAction.FETCH_REWIND_STATE
 import org.wordpress.android.fluxc.action.ActivityLogAction.REWIND
 import org.wordpress.android.fluxc.annotations.action.Action
@@ -44,10 +44,11 @@ class RewindStatusServiceTest {
     @Rule @JvmField val rule = InstantTaskExecutorRule()
 
     private val actionCaptor = argumentCaptor<Action<Any>>()
+    private val rewindStatusCaptor = argumentCaptor<FetchRewindStatePayload>()
+    private val rewindCaptor = argumentCaptor<RewindPayload>()
 
     @Mock private lateinit var activityLogStore: ActivityLogStore
     @Mock private lateinit var rewindProgressChecker: RewindProgressChecker
-    @Mock private lateinit var dispatcher: Dispatcher
     @Mock private lateinit var site: SiteModel
 
     private lateinit var rewindStatusService: RewindStatusService
@@ -92,7 +93,7 @@ class RewindStatusServiceTest {
 
     @Before
     fun setUp() {
-        rewindStatusService = RewindStatusService(activityLogStore, rewindProgressChecker, dispatcher)
+        rewindStatusService = RewindStatusService(activityLogStore, rewindProgressChecker, Unconfined)
         rewindAvailable = null
         rewindStatusService.rewindAvailable.observeForever { rewindAvailable = it }
         rewindStatusService.rewindProgress.observeForever { rewindProgress = it }
@@ -134,10 +135,9 @@ class RewindStatusServiceTest {
     }
 
     @Test
-    fun triggersFetchWhenRewindStatusNotAvailable() {
+    fun triggersFetchWhenRewindStatusNotAvailable() = runBlocking {
         rewindStatusService.start(site)
 
-        verify(dispatcher).register(rewindStatusService)
         assertFetchRewindStatusAction()
     }
 
@@ -153,16 +153,7 @@ class RewindStatusServiceTest {
     }
 
     @Test
-    fun unregistersOnStop() {
-        rewindStatusService.start(site)
-
-        rewindStatusService.stop()
-
-        verify(dispatcher).unregister(rewindStatusService)
-    }
-
-    @Test
-    fun triggersRewindAndMakesActionUnavailable() {
+    fun triggersRewindAndMakesActionUnavailable() = runBlocking {
         val rewindId = "10"
 
         rewindStatusService.rewind(rewindId, site)
@@ -173,22 +164,27 @@ class RewindStatusServiceTest {
     }
 
     @Test
-    fun cancelsWorkerOnFetchErrorRewindStateAndEmitsError() {
+    fun cancelsWorkerOnFetchErrorRewindStateAndEmitsError() = runBlocking {
+        rewindStatusService.start(site)
         val error = RewindStatusError(INVALID_RESPONSE, null)
-        rewindStatusService.onRewindStatusFetched(OnRewindStatusFetched(error, REWIND))
+        whenever(activityLogStore.fetchActivitiesRewind(any())).thenReturn(OnRewindStatusFetched(error, REWIND))
+
+        rewindStatusService.requestStatusUpdate()
 
         verify(rewindProgressChecker).cancel()
         assertEquals(error, rewindStatusFetchError)
     }
 
     @Test
-    fun onRewindStateInProgressUpdateState() {
+    fun onRewindStateInProgressUpdateState() = runBlocking {
         rewindStatusService.start(site)
 
         val rewindStatusInProgress = activeRewindStatusModel.copy(rewind = rewindInProgress)
         whenever(activityLogStore.getRewindStatusForSite(site)).thenReturn(rewindStatusInProgress)
 
-        rewindStatusService.onRewindStatusFetched(OnRewindStatusFetched(FETCH_REWIND_STATE))
+        whenever(activityLogStore.fetchActivitiesRewind(any())).thenReturn(OnRewindStatusFetched(FETCH_REWIND_STATE))
+
+        rewindStatusService.requestStatusUpdate()
 
         assertEquals(rewindAvailable, false)
         assertEquals(rewindProgress?.status, Status.RUNNING)
@@ -196,14 +192,16 @@ class RewindStatusServiceTest {
     }
 
     @Test
-    fun onRewindStateFinishedUpdateStateAndCancelWorker() {
+    fun onRewindStateFinishedUpdateStateAndCancelWorker() = runBlocking{
         rewindStatusService.start(site)
 
         val rewindFinished = rewindInProgress.copy(status = FINISHED, progress = 100)
         val rewindStatusInProgress = activeRewindStatusModel.copy(rewind = rewindFinished)
         whenever(activityLogStore.getRewindStatusForSite(site)).thenReturn(rewindStatusInProgress)
 
-        rewindStatusService.onRewindStatusFetched(OnRewindStatusFetched(FETCH_REWIND_STATE))
+        whenever(activityLogStore.fetchActivitiesRewind(any())).thenReturn(OnRewindStatusFetched(FETCH_REWIND_STATE))
+
+        rewindStatusService.requestStatusUpdate()
 
         assertEquals(rewindAvailable, true)
         assertEquals(rewindProgress?.status, Status.FINISHED)
@@ -211,14 +209,17 @@ class RewindStatusServiceTest {
     }
 
     @Test
-    fun onRewindErrorCancelWorkerAndReenableRewindStatus() {
+    fun onRewindErrorCancelWorkerAndReenableRewindStatus() = runBlocking {
         rewindStatusService.start(site)
-        reset(dispatcher)
 
         whenever(activityLogStore.getRewindStatusForSite(site)).thenReturn(activeRewindStatusModel)
 
         val error = RewindError(RewindErrorType.INVALID_RESPONSE, null)
-        rewindStatusService.onRewind(OnRewind(rewindId, error, REWIND))
+        whenever(activityLogStore.rewind(any())).thenReturn(OnRewind(rewindId, error, REWIND))
+
+        rewindAvailable = null
+
+        rewindStatusService.rewind(rewindId, site)
 
         assertEquals(rewindAvailable, true)
         assertEquals(error, rewindError)
@@ -227,35 +228,28 @@ class RewindStatusServiceTest {
     }
 
     @Test
-    fun onRewindFetchStatusAndStartWorker() {
+    fun onRewindFetchStatusAndStartWorker() = runBlocking{
         rewindStatusService.start(site)
-        reset(dispatcher)
 
-        rewindStatusService.onRewind(OnRewind("5", 10, REWIND))
+        whenever(activityLogStore.rewind(any())).thenReturn(OnRewind("5", 10, REWIND))
+
+        rewindStatusService.rewind(rewindId, site)
 
         verify(rewindProgressChecker).start(site, 10)
     }
 
-    private fun assertFetchRewindStatusAction() {
-        verify(dispatcher).dispatch(actionCaptor.capture())
-        actionCaptor.firstValue.apply {
-            assertEquals(FETCH_REWIND_STATE, this.type)
-            assertTrue(this.payload is FetchRewindStatePayload)
-            (this.payload as FetchRewindStatePayload).apply {
-                assertEquals(this.site, site)
-            }
+    private suspend fun assertFetchRewindStatusAction() {
+        verify(activityLogStore).fetchActivitiesRewind(rewindStatusCaptor.capture())
+        rewindStatusCaptor.firstValue.apply {
+            assertEquals(this.site, site)
         }
     }
 
-    private fun assertRewindAction(rewindId: String) {
-        verify(dispatcher).dispatch(actionCaptor.capture())
-        actionCaptor.firstValue.apply {
-            assertEquals(REWIND, this.type)
-            assertTrue(this.payload is RewindPayload)
-            (this.payload as RewindPayload).apply {
-                assertEquals(this.site, site)
-                assertEquals(this.rewindId, rewindId)
-            }
+    private suspend fun assertRewindAction(rewindId: String) {
+        verify(activityLogStore).rewind(rewindCaptor.capture())
+        rewindCaptor.firstValue.apply {
+            assertEquals(this.site, site)
+            assertEquals(this.rewindId, rewindId)
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'c5b0b19b0924d5f61a6dfca245280248290fc4d3'
+    fluxCVersion = '298f6adc5d8d773817c546f3cf08f17c88415384'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '1e81a3adba68e1e78134700aefae9dfc8f7c5440'
+    fluxCVersion = 'c5b0b19b0924d5f61a6dfca245280248290fc4d3'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '91f0f5972cc674a1b5a992235f9739f1b2d12a05'
+    fluxCVersion = '1e81a3adba68e1e78134700aefae9dfc8f7c5440'
 }


### PR DESCRIPTION
This PR adds coroutines to Activity log. Most of the changes to the production code are relatively simple. The main change is going from 
```
dispatcher.dispatch(FetchAction(FetchPayload()))
@Subscribe
fun onFetched(event: OnFetch){}
```
to the coroutine simplification
```
launch {
val onFetch = store.fetchAction(FetchPayload())
onFetched(onFetch)
}
```
This inlines the async call and makes the code more readable.
To test:
- go to activity log
- load next page
- go to a detail
- go back
- click on rewind on an activity
- you see a rewind item on the first position
- rewind ends successfuly
