### PR TITLE
Fix missing number formatting in Stats Widget 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetProvider.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetProvider.java
@@ -33,6 +33,7 @@ import org.wordpress.android.ui.stats.service.StatsServiceStarter;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SiteUtils;
 
@@ -85,7 +86,13 @@ public class StatsWidgetProvider extends AppWidgetProvider {
     }
 
     private static void updateTabValue(Context context, RemoteViews remoteViews, int viewId, String text) {
-        remoteViews.setTextViewText(viewId, text);
+        int value = 0;
+        try {
+            value = Integer.parseInt(text);
+        } catch (NumberFormatException e) {
+            AppLog.e(T.STATS, e);
+        }
+        remoteViews.setTextViewText(viewId, FormatUtils.formatDecimal(value));
         if (text.equals("0")) {
             remoteViews.setTextColor(viewId, context.getResources().getColor(R.color.grey));
         }


### PR DESCRIPTION
This PR makes sure that numbers displayed in Stats widget are correctly formatted as per device settings.

**Testing**
To test this PR, add the widget to your home screen and select a site with lot of traffic. 
Numbers should be correctly formatted: 

<img width="450" alt="screen shot 2018-09-03 at 11 33 49" src="https://user-images.githubusercontent.com/518232/44979395-5bb9cf00-af6d-11e8-8f0b-e5de104c71c5.png">

(Screenshot above is with IT language settings - If you use US locale, there should be the comma and not the point).
