### PR TITLE
Try/checkstyle avoid native fragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.prefs;
 
-import android.app.Fragment;
 import android.app.FragmentManager;
 import android.content.Context;
 import android.os.Bundle;
@@ -69,8 +68,11 @@ public class BlogPreferencesActivity extends AppCompatActivity {
             actionBar.setTitle(StringEscapeUtils.unescapeHtml4(SiteUtils.getSiteNameOrHomeURL(mSite)));
         }
 
+        // TODO: android.app.Fragment  is deprecated since Android P.
+        // Needs to be replaced with android.support.v4.app.Fragment
+        // See https://developer.android.com/reference/android/app/Fragment
         FragmentManager fragmentManager = getFragmentManager();
-        Fragment siteSettingsFragment = fragmentManager.findFragmentByTag(KEY_SETTINGS_FRAGMENT);
+        android.app.Fragment siteSettingsFragment = fragmentManager.findFragmentByTag(KEY_SETTINGS_FRAGMENT);
 
         if (siteSettingsFragment == null) {
             siteSettingsFragment = new SiteSettingsFragment();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DeleteSiteDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DeleteSiteDialogFragment.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
-import android.app.Fragment;
 import android.content.DialogInterface;
 import android.graphics.Typeface;
 import android.os.Bundle;
@@ -84,7 +83,10 @@ public class DeleteSiteDialogFragment extends DialogFragment implements TextWatc
         builder.setPositiveButton(R.string.delete, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                Fragment target = getTargetFragment();
+                // TODO: android.app.Fragment  is deprecated since Android P.
+                // Needs to be replaced with android.support.v4.app.Fragment
+                // See https://developer.android.com/reference/android/app/Fragment
+                android.app.Fragment target = getTargetFragment();
                 if (target != null) {
                     target.onActivityResult(getTargetRequestCode(), Activity.RESULT_OK, null);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/NumberPickerDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/NumberPickerDialog.java
@@ -5,7 +5,6 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
-import android.app.Fragment;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
@@ -135,7 +134,10 @@ public class NumberPickerDialog extends DialogFragment
 
     @Override
     public void onDismiss(DialogInterface dialog) {
-        Fragment target = getTargetFragment();
+        // TODO: android.app.Fragment  is deprecated since Android P.
+        // Needs to be replaced with android.support.v4.app.Fragment
+        // See https://developer.android.com/reference/android/app/Fragment
+        android.app.Fragment target = getTargetFragment();
         if (target != null) {
             target.onActivityResult(getTargetRequestCode(), Activity.RESULT_OK, getResultIntent());
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/RelatedPostsDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/RelatedPostsDialog.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
-import android.app.Fragment;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
@@ -143,7 +142,10 @@ public class RelatedPostsDialog extends DialogFragment
 
     @Override
     public void onDismiss(DialogInterface dialog) {
-        Fragment target = getTargetFragment();
+        // TODO: android.app.Fragment  is deprecated since Android P.
+        // Needs to be replaced with android.support.v4.app.Fragment
+        // See https://developer.android.com/reference/android/app/Fragment
+        android.app.Fragment target = getTargetFragment();
         if (target != null) {
             target.onActivityResult(getTargetRequestCode(), Activity.RESULT_OK, getResultIntent());
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFormatDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFormatDialog.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
-import android.app.Fragment;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -184,7 +183,10 @@ public class SiteSettingsFormatDialog extends DialogFragment implements DialogIn
     @Override
     public void onDismiss(DialogInterface dialog) {
         String formatValue = getSelectedFormatValue();
-        Fragment target = getTargetFragment();
+        // TODO: android.app.Fragment  is deprecated since Android P.
+        // Needs to be replaced with android.support.v4.app.Fragment
+        // See https://developer.android.com/reference/android/app/Fragment
+        android.app.Fragment target = getTargetFragment();
         if (mConfirmed && target != null && !TextUtils.isEmpty(formatValue)) {
             Intent intent = new Intent().putExtra(KEY_FORMAT_VALUE, formatValue);
             target.onActivityResult(getTargetRequestCode(), Activity.RESULT_OK, intent);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagDetailFragment.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.prefs;
 
-import android.app.Fragment;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -26,7 +25,10 @@ import static org.wordpress.android.ui.reader.utils.ReaderUtils.sanitizeWithDash
 /**
  * A fragment for editing a tag
  */
-public class SiteSettingsTagDetailFragment extends Fragment {
+// TODO: android.app.Fragment  is deprecated since Android P.
+// Needs to be replaced with android.support.v4.app.Fragment
+// See https://developer.android.com/reference/android/app/Fragment
+public class SiteSettingsTagDetailFragment extends android.app.Fragment {
     private static final String ARGS_TERM = "term";
     private static final String ARGS_IS_NEW_TERM = "is_new";
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTimezoneDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTimezoneDialog.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
-import android.app.Fragment;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
@@ -241,7 +240,10 @@ public class SiteSettingsTimezoneDialog extends DialogFragment implements Dialog
 
     @Override
     public void onDismiss(DialogInterface dialog) {
-        Fragment target = getTargetFragment();
+        // TODO: android.app.Fragment  is deprecated since Android P.
+        // Needs to be replaced with android.support.v4.app.Fragment
+        // See https://developer.android.com/reference/android/app/Fragment
+        android.app.Fragment target = getTargetFragment();
         if (mConfirmed && target != null && !TextUtils.isEmpty(mSelectedTimezone)) {
             Intent intent = new Intent().putExtra(KEY_TIMEZONE, mSelectedTimezone);
             target.onActivityResult(getTargetRequestCode(), Activity.RESULT_OK, intent);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationSettingsFollowedDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationSettingsFollowedDialog.java
@@ -5,7 +5,6 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
-import android.app.Fragment;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
@@ -141,7 +140,10 @@ public class NotificationSettingsFollowedDialog extends DialogFragment implement
 
     @Override
     public void onDismiss(DialogInterface dialog) {
-        Fragment target = getTargetFragment();
+        // TODO: android.app.Fragment  is deprecated since Android P.
+        // Needs to be replaced with android.support.v4.app.Fragment
+        // See https://developer.android.com/reference/android/app/Fragment
+        android.app.Fragment target = getTargetFragment();
 
         if (target != null) {
             target.onActivityResult(getTargetRequestCode(), Activity.RESULT_OK, getResultIntent());

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.util;
 
 import android.app.Dialog;
-import android.app.Fragment;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -26,7 +25,11 @@ import java.util.List;
 public class WPActivityUtils {
     // Hack! PreferenceScreens don't show the toolbar, so we'll manually add one
     // See: http://stackoverflow.com/a/27455363/309558
-    public static void addToolbarToDialog(final Fragment context, final Dialog dialog, String title) {
+
+    // TODO: android.app.Fragment  is deprecated since Android P.
+    // Needs to be replaced with android.support.v4.app.Fragment
+    // See https://developer.android.com/reference/android/app/Fragment
+    public static void addToolbarToDialog(final android.app.Fragment context, final Dialog dialog, String title) {
         if (!context.isAdded() || dialog == null) {
             return;
         }
@@ -70,10 +73,14 @@ public class WPActivityUtils {
      * removes it if it exists.
      * <p>
      * Originally added to prevent a crash that occurs with nested PreferenceScreens that added
-     * a toolbar via {@link WPActivityUtils#addToolbarToDialog(Fragment, Dialog, String)}. The
+     * a toolbar via {@link WPActivityUtils#addToolbarToDialog(android.app.Fragment, Dialog, String)}. The
      * crash can be reproduced by turning 'Don't keep activities' on from Developer options.
      */
-    public static void removeToolbarFromDialog(final Fragment context, final Dialog dialog) {
+
+    // TODO: android.app.Fragment  is deprecated since Android P.
+    // Needs to be replaced with android.support.v4.app.Fragment
+    // See https://developer.android.com/reference/android/app/Fragment
+    public static void removeToolbarFromDialog(final android.app.Fragment context, final Dialog dialog) {
         if (dialog == null || !context.isAdded()) {
             return;
         }

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -145,7 +145,9 @@
         <!-- Checks for imports                              -->
         <!-- See http://checkstyle.sf.net/config_import.html -->
         <module name="AvoidStarImport"/>
-        <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+        <module name="IllegalImport">
+            <property name="illegalClasses" value="android.app.Fragment"/>
+        </module>
         <module name="RedundantImport"/>
         <module name="UnusedImports">
             <property name="processJavadoc" value="true"/>


### PR DESCRIPTION
Closes #8238 

Follow up to the work done and tracked in https://github.com/wordpress-mobile/WordPress-Android/issues/8238

Added a check style rule in b90f834 to avoid using [`android.app.Fragment`](https://developer.android.com/reference/android/app/Fragment)  which is deprecated since Android P.

From now on, if you add a new `import android.app.Fragment` statement, running `./gradlew checkstyle` will throw an `IllegalImport` error:

```
> Task :WordPress:checkstyle 
[ant:checkstyle] [ERROR] /Users/<username>/WordPress-Android/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java:3:1: Illegal import - android.app.Fragment. [IllegalImport]
```

Also, commit 150811d adds fully qualified class names on the remaining classes until these are fully migrated to `import android.support.v4.app.Fragment;` or re-written as something else.

To test:
1. run `./gradlew checkstyle` and make sure all is green.
2. Then just add an `import android.app.Fragment;` statement in any class and run again. Observe the error is thrown.

