### PR TITLE
Make AztecText.fromHtml() isInit=true only when initializing

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -52,9 +52,9 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'org.wordpress:utils:1.22'
 
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:fix~paste-hash-calculation-SNAPSHOT')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:fix~paste-hash-calculation-SNAPSHOT')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:fix~paste-hash-calculation-SNAPSHOT')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:fbfe28cbfc7f7c63545215977a4db803b59eb362')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:fbfe28cbfc7f7c63545215977a4db803b59eb362')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:fbfe28cbfc7f7c63545215977a4db803b59eb362')
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.1.4"

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -52,9 +52,9 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'org.wordpress:utils:1.22'
 
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.8')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.3.8')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.3.8')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:fix~paste-hash-calculation-SNAPSHOT')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:fix~paste-hash-calculation-SNAPSHOT')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:fix~paste-hash-calculation-SNAPSHOT')
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.1.4"

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -552,7 +552,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         // Initialize both editors (visual, source) with the same content. Need to do that so the starting point used in
         //  their content diffing algorithm is the same. That's assumed by the Toolbar's mode-switching logic too.
         mSource.displayStyledAndFormattedHtml(postContent);
-        mContent.fromHtml(postContent);
+        mContent.fromHtml(postContent, true);
 
         updateFailedAndUploadingMedia();
 
@@ -1847,7 +1847,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                                                             captionAttributes);
 
                         // setting caption causes rendering issue in some cases, reset content to avoid them
-                        mContent.fromHtml(mContent.toHtml(false));
+                        mContent.fromHtml(mContent.toHtml(false), false);
                     } else {
                         // if no caption present apply align attribute directly to image
                         if (!TextUtils.isEmpty(metaData.getAlign())) {


### PR DESCRIPTION
Fixes #8275 

**WARNING**: the corresponding Aztec PR https://github.com/wordpress-mobile/AztecEditor-Android/pull/745 needs to be reviewed jointly and merged first before merging this one.

Changes in logic are in that other PR, this PR only updates the call to Aztec's functionality as explained there.

To test:
1. Go to any app where you can select and copy text, such as Chrome or a note-taking app.
2. Select a piece of text and wait for the contextual menu to appear
3. In the contextual menu, tap on `COPY`.
4. In the WordPress app, start a new post.
5. Tap on the Title area and enter a title.
6. Long tap in the Content area and paste the content you copied.
7. Hit Publish on the upper right corner of the screen.
8. When asked to confirm, confirm.
9 Now go to the posts list, and select the post you just created.
10. Observe the post now contains the content as you pasted it 🎉 

Also if you exit the editor instead of publishing the Post, you'll see the draft gets updated/uploaded and tapping on it again in the Posts list will open the editor, showing the content you pasted as well.

cc @loremattei I'm asking to merge to `release/10.8` as it fixes a content-loss type of bug
