### PR TITLE
Feature/use formattable content in activity log

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -41,7 +41,7 @@ class ActivityLogDetailFragment : Fragment() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        activity?.let {
+        activity?.let { it ->
             viewModel = ViewModelProviders.of(it, viewModelFactory)
                     .get<ActivityLogDetailViewModel>(ActivityLogDetailViewModel::class.java)
 
@@ -71,7 +71,9 @@ class ActivityLogDetailFragment : Fragment() {
                 activityCreatedDate.text = activityLogModel?.createdDate
                 activityCreatedTime.text = activityLogModel?.createdTime
 
-                activityRewindButton.setOnClickListener(activityLogModel?.rewindAction)
+                activityRewindButton.setOnClickListener{
+                    activityLogModel?.onClick()
+                }
             })
 
             viewModel.rewindAvailable.observe(this, Observer { available ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -67,7 +67,9 @@ class ActivityLogDetailFragment : Fragment() {
                 activityActorName.setTextOrHide(activityLogModel?.actorName)
                 activityActorRole.setTextOrHide(activityLogModel?.actorRole)
 
-                val spannable = activityLogModel?.content?.let { activityLogModel.spannableBuilder(it, activityMessage) }
+                val spannable = activityLogModel?.content?.let {
+                    activityLogModel.spannableBuilder(it, activityMessage)
+                }
 
                 activityMessage.setTextOrHide(spannable)
                 activityType.setTextOrHide(activityLogModel?.summary)
@@ -75,7 +77,7 @@ class ActivityLogDetailFragment : Fragment() {
                 activityCreatedDate.text = activityLogModel?.createdDate
                 activityCreatedTime.text = activityLogModel?.createdTime
 
-                activityRewindButton.setOnClickListener{
+                activityRewindButton.setOnClickListener {
                     activityLogModel?.onClick()
                 }
             })

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -15,6 +15,8 @@ import kotlinx.android.synthetic.main.activity_log_item_detail.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.tools.FormattableRange
+import org.wordpress.android.ui.notifications.utils.FormattableContentClickHandler
 import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
 import org.wordpress.android.ui.posts.BasicFragmentDialog
 import org.wordpress.android.util.image.ImageManager
@@ -28,6 +30,7 @@ class ActivityLogDetailFragment : Fragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var notificationsUtilsWrapper: NotificationsUtilsWrapper
+    @Inject lateinit var formattableContentClickHandler: FormattableContentClickHandler
 
     private lateinit var viewModel: ActivityLogDetailViewModel
 
@@ -70,7 +73,7 @@ class ActivityLogDetailFragment : Fragment() {
 
                 val spannable = activityLogModel?.content?.let {
                     notificationsUtilsWrapper.getSpannableContentForRanges(it, activityMessage, { range ->
-                        viewModel.onRangeClicked(activity, range)
+                        viewModel.onRangeClicked(range)
                     }, false)
                 }
 
@@ -93,6 +96,12 @@ class ActivityLogDetailFragment : Fragment() {
 
             viewModel.showRewindDialog.observe(this, Observer<ActivityLogDetailModel> { detailModel ->
                 detailModel?.let { onRewindButtonClicked(it) }
+            })
+
+            viewModel.handleFormattableRangeClick.observe(this, Observer<FormattableRange> { range ->
+                if (range != null) {
+                    formattableContentClickHandler.onClick(activity, range)
+                }
             })
 
             viewModel.start(site, activityLogId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailModel.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.ui.activitylog.detail
 
 import android.text.Spannable
+import android.widget.TextView
+import org.wordpress.android.fluxc.tools.FormattableContent
 
 data class ActivityLogDetailModel(
     val activityID: String,
@@ -10,7 +12,8 @@ data class ActivityLogDetailModel(
     val isRewindButtonVisible: Boolean,
     val actorName: String? = null,
     val actorRole: String? = null,
-    val content: Spannable? = null,
+    val content: FormattableContent? = null,
+    val spannableBuilder: (FormattableContent, TextView) -> Spannable,
     val summary: String? = null,
     val createdDate: String = "",
     val createdTime: String = "",

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailModel.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.activitylog.detail
 
+import android.text.Spannable
+
 data class ActivityLogDetailModel(
     val activityID: String,
     val rewindId: String?,
@@ -8,9 +10,13 @@ data class ActivityLogDetailModel(
     val isRewindButtonVisible: Boolean,
     val actorName: String? = null,
     val actorRole: String? = null,
-    val text: String? = null,
+    val content: Spannable? = null,
     val summary: String? = null,
     val createdDate: String = "",
     val createdTime: String = "",
-    val rewindAction: (() -> Unit)
-)
+    private val rewindAction: ((ActivityLogDetailModel) -> Unit)
+) {
+    fun onClick() {
+        rewindAction(this)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailModel.kt
@@ -1,7 +1,5 @@
 package org.wordpress.android.ui.activitylog.detail
 
-import android.text.Spannable
-import android.widget.TextView
 import org.wordpress.android.fluxc.tools.FormattableContent
 
 data class ActivityLogDetailModel(
@@ -13,13 +11,7 @@ data class ActivityLogDetailModel(
     val actorName: String? = null,
     val actorRole: String? = null,
     val content: FormattableContent? = null,
-    val spannableBuilder: (FormattableContent, TextView) -> Spannable,
     val summary: String? = null,
     val createdDate: String = "",
-    val createdTime: String = "",
-    private val rewindAction: ((ActivityLogDetailModel) -> Unit)
-) {
-    fun onClick() {
-        rewindAction(this)
-    }
-}
+    val createdTime: String = ""
+)

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlockClickableSpan.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlockClickableSpan.java
@@ -24,6 +24,7 @@ public class NoteBlockClickableSpan extends ClickableSpan {
     private long mSiteId;
     private long mPostId;
     private FormattableRangeType mRangeType;
+    private FormattableRange mFormattableRange;
     private String mUrl;
     private List<Integer> mIndices;
     private boolean mPressed;
@@ -52,6 +53,7 @@ public class NoteBlockClickableSpan extends ClickableSpan {
 
     private void processRangeData(FormattableRange range) {
         if (range != null) {
+            mFormattableRange = range;
             mId = range.getId() == null ? 0 : range.getId();
             mSiteId = range.getSiteId() == null ? 0 : range.getSiteId();
             mPostId = range.getPostId() == null ? 0 : range.getPostId();
@@ -123,6 +125,10 @@ public class NoteBlockClickableSpan extends ClickableSpan {
 
     public FormattableRangeType getRangeType() {
         return mRangeType;
+    }
+
+    public FormattableRange getFormattableRange() {
+        return mFormattableRange;
     }
 
     public List<Integer> getIndices() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlockLinkMovementMethod.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlockLinkMovementMethod.java
@@ -12,7 +12,7 @@ import android.widget.TextView;
  * Allows links to be highlighted when tapped on note blocks.
  * See: http://stackoverflow.com/a/20905824/309558
  */
-class NoteBlockLinkMovementMethod extends LinkMovementMethod {
+public class NoteBlockLinkMovementMethod extends LinkMovementMethod {
     private NoteBlockClickableSpan mPressedSpan;
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
@@ -88,7 +88,11 @@ class FormattableContentClickHandler
         showStatsActivityForSite(activity, site, rangeType)
     }
 
-    private fun showStatsActivityForSite(activity: FragmentActivity, site: SiteModel, rangeType: FormattableRangeType) {
+    private fun showStatsActivityForSite(
+        activity: FragmentActivity,
+        site: SiteModel,
+        rangeType: FormattableRangeType
+    ) {
         if (rangeType == FormattableRangeType.FOLLOW) {
             val intent = Intent(activity, StatsViewAllActivity::class.java)
             intent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, StatsViewType.FOLLOWERS)
@@ -97,7 +101,10 @@ class FormattableContentClickHandler
             intent.putExtra(StatsAbstractFragment.ARGS_IS_SINGLE_VIEW, true)
             intent.putExtra(StatsActivity.ARG_LOCAL_TABLE_SITE_ID, site.id)
 
-            intent.putExtra(StatsViewAllActivity.ARG_STATS_VIEW_ALL_TITLE, activity.getString(R.string.stats_view_followers))
+            intent.putExtra(
+                    StatsViewAllActivity.ARG_STATS_VIEW_ALL_TITLE,
+                    activity.getString(R.string.stats_view_followers)
+            )
             activity.startActivity(intent)
         } else {
             ActivityLauncher.viewBlogStats(activity, site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.notifications.utils
 
 import android.content.Intent
 import android.support.v4.app.FragmentActivity
-import android.text.TextUtils
 import org.wordpress.android.R
 import org.wordpress.android.datasets.ReaderPostTable
 import org.wordpress.android.fluxc.model.SiteModel
@@ -51,7 +50,7 @@ class FormattableContentClickHandler
                 if (ReaderUtils.postAndCommentExists(siteId, postId, id)) {
                     showReaderCommentsList(activity, siteId, postId, id)
                 } else {
-                    showWebViewActivityForUrl(activity, clickedSpan.url)
+                    showWebViewActivityForUrl(activity, clickedSpan.url, rangeType)
                 }
             }
             FormattableRangeType.STAT, FormattableRangeType.FOLLOW ->
@@ -62,13 +61,12 @@ class FormattableContentClickHandler
             } else {
                 showPostActivity(activity, siteId, id)
             }
-            else ->
-                // We don't know what type of id this is, let's see if it has a URL and push a webview
-                if (!TextUtils.isEmpty(clickedSpan.url)) {
-                    showWebViewActivityForUrl(activity, clickedSpan.url)
-                } else {
-                    AppLog.e(API, "Unexpected range type $rangeType without an url")
-                }
+            FormattableRangeType.BLOCKQUOTE,
+            FormattableRangeType.NOTICON,
+            FormattableRangeType.MATCH,
+            FormattableRangeType.UNKNOWN -> {
+                showWebViewActivityForUrl(activity, clickedSpan.url, rangeType)
+            }
         }
     }
 
@@ -114,8 +112,9 @@ class FormattableContentClickHandler
         }
     }
 
-    private fun showWebViewActivityForUrl(activity: FragmentActivity, url: String?) {
-        if (url == null) {
+    private fun showWebViewActivityForUrl(activity: FragmentActivity, url: String?, rangeType: FormattableRangeType) {
+        if (url == null || url.isEmpty()) {
+            AppLog.e(API, "Trying to open web view activity but the URL is missing for range type $rangeType")
             return
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
@@ -18,6 +18,8 @@ import org.wordpress.android.ui.stats.StatsActivity
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.StatsViewAllActivity
 import org.wordpress.android.ui.stats.StatsViewType
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.API
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
@@ -46,10 +48,8 @@ class FormattableContentClickHandler
                 // Load the comment in the reader list if it exists, otherwise show a webview
             {
                 val postId = clickedSpan.postId ?: 0
-                if (ReaderUtils.postAndCommentExists(siteId, postId,
-                                id)) {
-                    showReaderCommentsList(activity, siteId, postId,
-                            id)
+                if (ReaderUtils.postAndCommentExists(siteId, postId, id)) {
+                    showReaderCommentsList(activity, siteId, postId, id)
                 } else {
                     showWebViewActivityForUrl(activity, clickedSpan.url)
                 }
@@ -66,6 +66,8 @@ class FormattableContentClickHandler
                 // We don't know what type of id this is, let's see if it has a URL and push a webview
                 if (!TextUtils.isEmpty(clickedSpan.url)) {
                     showWebViewActivityForUrl(activity, clickedSpan.url)
+                } else {
+                    AppLog.e(API, "Unexpected range type $rangeType without an url")
                 }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
@@ -21,9 +21,10 @@ import org.wordpress.android.ui.stats.StatsViewType
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
+private const val DOMAIN_WP_COM = "wordpress.com"
+
 class FormattableContentClickHandler
 @Inject constructor(val siteStore: SiteStore) {
-    private val domainWpCom = "wordpress.com"
     fun onClick(activity: FragmentActivity, clickedSpan: FormattableRange) {
         if (activity.isFinishing) {
             return
@@ -116,7 +117,7 @@ class FormattableContentClickHandler
             return
         }
 
-        if (url.contains(domainWpCom)) {
+        if (url.contains(DOMAIN_WP_COM)) {
             WPWebViewActivity.openUrlByUsingGlobalWPCOMCredentials(activity, url)
         } else {
             WPWebViewActivity.openURL(activity, url)

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.ui.notifications.utils
 
 import android.content.Intent
-import android.support.v7.app.AppCompatActivity
+import android.support.v4.app.FragmentActivity
 import android.text.TextUtils
 import org.wordpress.android.R
 import org.wordpress.android.datasets.ReaderPostTable
@@ -24,13 +24,14 @@ import javax.inject.Inject
 class FormattableContentClickHandler
 @Inject constructor(val siteStore: SiteStore) {
     private val domainWpCom = "wordpress.com"
-    fun onClick(activity: AppCompatActivity, clickedSpan: FormattableRange) {
+    fun onClick(activity: FragmentActivity, clickedSpan: FormattableRange) {
         if (activity.isFinishing) {
             return
         }
         val id = clickedSpan.id ?: 0
         val siteId = clickedSpan.siteId ?: 0
-        when (clickedSpan.rangeType()) {
+        val rangeType = clickedSpan.rangeType()
+        when (rangeType) {
             FormattableRangeType.SITE ->
                 // Show blog preview
                 showBlogPreviewActivity(activity, id)
@@ -54,7 +55,7 @@ class FormattableContentClickHandler
             }
             FormattableRangeType.STAT, FormattableRangeType.FOLLOW ->
                 // We can open native stats if the site is a wpcom or Jetpack sites
-                showStatsActivityForSite(activity, siteId, clickedSpan.rangeType())
+                showStatsActivityForSite(activity, siteId, rangeType)
             FormattableRangeType.LIKE -> if (ReaderPostTable.postExists(siteId, id)) {
                 showReaderPostLikeUsers(activity, siteId, id)
             } else {
@@ -68,15 +69,15 @@ class FormattableContentClickHandler
         }
     }
 
-    private fun showBlogPreviewActivity(activity: AppCompatActivity, siteId: Long) {
+    private fun showBlogPreviewActivity(activity: FragmentActivity, siteId: Long) {
         ReaderActivityLauncher.showReaderBlogPreview(activity, siteId)
     }
 
-    private fun showPostActivity(activity: AppCompatActivity, siteId: Long, postId: Long) {
+    private fun showPostActivity(activity: FragmentActivity, siteId: Long, postId: Long) {
         ReaderActivityLauncher.showReaderPostDetail(activity, siteId, postId)
     }
 
-    private fun showStatsActivityForSite(activity: AppCompatActivity, siteId: Long, rangeType: FormattableRangeType) {
+    private fun showStatsActivityForSite(activity: FragmentActivity, siteId: Long, rangeType: FormattableRangeType) {
         val site = siteStore.getSiteBySiteId(siteId)
         if (site == null) {
             // One way the site can be null: new site created, receive a notification from this site,
@@ -87,7 +88,7 @@ class FormattableContentClickHandler
         showStatsActivityForSite(activity, site, rangeType)
     }
 
-    private fun showStatsActivityForSite(activity: AppCompatActivity, site: SiteModel, rangeType: FormattableRangeType) {
+    private fun showStatsActivityForSite(activity: FragmentActivity, site: SiteModel, rangeType: FormattableRangeType) {
         if (rangeType == FormattableRangeType.FOLLOW) {
             val intent = Intent(activity, StatsViewAllActivity::class.java)
             intent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, StatsViewType.FOLLOWERS)
@@ -103,7 +104,7 @@ class FormattableContentClickHandler
         }
     }
 
-    private fun showWebViewActivityForUrl(activity: AppCompatActivity, url: String?) {
+    private fun showWebViewActivityForUrl(activity: FragmentActivity, url: String?) {
         if (url == null) {
             return
         }
@@ -115,11 +116,11 @@ class FormattableContentClickHandler
         }
     }
 
-    private fun showReaderPostLikeUsers(activity: AppCompatActivity, blogId: Long, postId: Long) {
+    private fun showReaderPostLikeUsers(activity: FragmentActivity, blogId: Long, postId: Long) {
         ReaderActivityLauncher.showReaderLikingUsers(activity, blogId, postId)
     }
 
-    private fun showReaderCommentsList(activity: AppCompatActivity, siteId: Long, postId: Long, commentId: Long) {
+    private fun showReaderCommentsList(activity: FragmentActivity, siteId: Long, postId: Long, commentId: Long) {
         ReaderActivityLauncher.showReaderComments(activity, siteId, postId, commentId)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
@@ -8,6 +8,18 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.tools.FormattableRange
 import org.wordpress.android.fluxc.tools.FormattableRangeType
+import org.wordpress.android.fluxc.tools.FormattableRangeType.BLOCKQUOTE
+import org.wordpress.android.fluxc.tools.FormattableRangeType.COMMENT
+import org.wordpress.android.fluxc.tools.FormattableRangeType.FOLLOW
+import org.wordpress.android.fluxc.tools.FormattableRangeType.LIKE
+import org.wordpress.android.fluxc.tools.FormattableRangeType.MATCH
+import org.wordpress.android.fluxc.tools.FormattableRangeType.NOTICON
+import org.wordpress.android.fluxc.tools.FormattableRangeType.PAGE
+import org.wordpress.android.fluxc.tools.FormattableRangeType.POST
+import org.wordpress.android.fluxc.tools.FormattableRangeType.SITE
+import org.wordpress.android.fluxc.tools.FormattableRangeType.STAT
+import org.wordpress.android.fluxc.tools.FormattableRangeType.UNKNOWN
+import org.wordpress.android.fluxc.tools.FormattableRangeType.USER
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.reader.ReaderActivityLauncher
@@ -34,37 +46,37 @@ class FormattableContentClickHandler
         val siteId = clickedSpan.siteId ?: 0
         val rangeType = clickedSpan.rangeType()
         when (rangeType) {
-            FormattableRangeType.SITE ->
+            SITE ->
                 // Show blog preview
                 showBlogPreviewActivity(activity, id)
-            FormattableRangeType.USER ->
+            USER ->
                 // Show blog preview
                 showBlogPreviewActivity(activity, siteId)
-            FormattableRangeType.POST ->
+            PAGE, POST ->
                 // Show post detail
                 showPostActivity(activity, siteId, id)
-            FormattableRangeType.COMMENT ->
-                // Load the comment in the reader list if it exists, otherwise show a webview
+            COMMENT ->
             {
-                val postId = clickedSpan.postId ?: 0
+                // Load the comment in the reader list if it exists, otherwise show a webview
+                val postId = clickedSpan.postId ?: clickedSpan.rootId ?: 0
                 if (ReaderUtils.postAndCommentExists(siteId, postId, id)) {
                     showReaderCommentsList(activity, siteId, postId, id)
                 } else {
                     showWebViewActivityForUrl(activity, clickedSpan.url, rangeType)
                 }
             }
-            FormattableRangeType.STAT, FormattableRangeType.FOLLOW ->
+            STAT, FOLLOW ->
                 // We can open native stats if the site is a wpcom or Jetpack sites
                 showStatsActivityForSite(activity, siteId, rangeType)
-            FormattableRangeType.LIKE -> if (ReaderPostTable.postExists(siteId, id)) {
+            LIKE -> if (ReaderPostTable.postExists(siteId, id)) {
                 showReaderPostLikeUsers(activity, siteId, id)
             } else {
                 showPostActivity(activity, siteId, id)
             }
-            FormattableRangeType.BLOCKQUOTE,
-            FormattableRangeType.NOTICON,
-            FormattableRangeType.MATCH,
-            FormattableRangeType.UNKNOWN -> {
+            BLOCKQUOTE,
+            NOTICON,
+            MATCH,
+            UNKNOWN -> {
                 showWebViewActivityForUrl(activity, clickedSpan.url, rangeType)
             }
         }
@@ -94,7 +106,7 @@ class FormattableContentClickHandler
         site: SiteModel,
         rangeType: FormattableRangeType
     ) {
-        if (rangeType == FormattableRangeType.FOLLOW) {
+        if (rangeType == FOLLOW) {
             val intent = Intent(activity, StatsViewAllActivity::class.java)
             intent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, StatsViewType.FOLLOWERS)
             intent.putExtra(StatsAbstractFragment.ARGS_TIMEFRAME, StatsTimeframe.DAY)

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
@@ -1,0 +1,125 @@
+package org.wordpress.android.ui.notifications.utils
+
+import android.content.Intent
+import android.support.v7.app.AppCompatActivity
+import android.text.TextUtils
+import org.wordpress.android.R
+import org.wordpress.android.datasets.ReaderPostTable
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.tools.FormattableRange
+import org.wordpress.android.fluxc.tools.FormattableRangeType
+import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.WPWebViewActivity
+import org.wordpress.android.ui.reader.ReaderActivityLauncher
+import org.wordpress.android.ui.reader.utils.ReaderUtils
+import org.wordpress.android.ui.stats.StatsAbstractFragment
+import org.wordpress.android.ui.stats.StatsActivity
+import org.wordpress.android.ui.stats.StatsTimeframe
+import org.wordpress.android.ui.stats.StatsViewAllActivity
+import org.wordpress.android.ui.stats.StatsViewType
+import org.wordpress.android.util.ToastUtils
+import javax.inject.Inject
+
+class FormattableContentClickHandler
+@Inject constructor(val siteStore: SiteStore) {
+    private val domainWpCom = "wordpress.com"
+    fun onClick(activity: AppCompatActivity, clickedSpan: FormattableRange) {
+        if (activity.isFinishing) {
+            return
+        }
+        val id = clickedSpan.id ?: 0
+        val siteId = clickedSpan.siteId ?: 0
+        when (clickedSpan.rangeType()) {
+            FormattableRangeType.SITE ->
+                // Show blog preview
+                showBlogPreviewActivity(activity, id)
+            FormattableRangeType.USER ->
+                // Show blog preview
+                showBlogPreviewActivity(activity, siteId)
+            FormattableRangeType.POST ->
+                // Show post detail
+                showPostActivity(activity, siteId, id)
+            FormattableRangeType.COMMENT ->
+                // Load the comment in the reader list if it exists, otherwise show a webview
+            {
+                val postId = clickedSpan.postId ?: 0
+                if (ReaderUtils.postAndCommentExists(siteId, postId,
+                                id)) {
+                    showReaderCommentsList(activity, siteId, postId,
+                            id)
+                } else {
+                    showWebViewActivityForUrl(activity, clickedSpan.url)
+                }
+            }
+            FormattableRangeType.STAT, FormattableRangeType.FOLLOW ->
+                // We can open native stats if the site is a wpcom or Jetpack sites
+                showStatsActivityForSite(activity, siteId, clickedSpan.rangeType())
+            FormattableRangeType.LIKE -> if (ReaderPostTable.postExists(siteId, id)) {
+                showReaderPostLikeUsers(activity, siteId, id)
+            } else {
+                showPostActivity(activity, siteId, id)
+            }
+            else ->
+                // We don't know what type of id this is, let's see if it has a URL and push a webview
+                if (!TextUtils.isEmpty(clickedSpan.url)) {
+                    showWebViewActivityForUrl(activity, clickedSpan.url)
+                }
+        }
+    }
+
+    private fun showBlogPreviewActivity(activity: AppCompatActivity, siteId: Long) {
+        ReaderActivityLauncher.showReaderBlogPreview(activity, siteId)
+    }
+
+    private fun showPostActivity(activity: AppCompatActivity, siteId: Long, postId: Long) {
+        ReaderActivityLauncher.showReaderPostDetail(activity, siteId, postId)
+    }
+
+    private fun showStatsActivityForSite(activity: AppCompatActivity, siteId: Long, rangeType: FormattableRangeType) {
+        val site = siteStore.getSiteBySiteId(siteId)
+        if (site == null) {
+            // One way the site can be null: new site created, receive a notification from this site,
+            // but the site list is not yet updated in the app.
+            ToastUtils.showToast(activity, R.string.blog_not_found)
+            return
+        }
+        showStatsActivityForSite(activity, site, rangeType)
+    }
+
+    private fun showStatsActivityForSite(activity: AppCompatActivity, site: SiteModel, rangeType: FormattableRangeType) {
+        if (rangeType == FormattableRangeType.FOLLOW) {
+            val intent = Intent(activity, StatsViewAllActivity::class.java)
+            intent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, StatsViewType.FOLLOWERS)
+            intent.putExtra(StatsAbstractFragment.ARGS_TIMEFRAME, StatsTimeframe.DAY)
+            intent.putExtra(StatsAbstractFragment.ARGS_SELECTED_DATE, "")
+            intent.putExtra(StatsAbstractFragment.ARGS_IS_SINGLE_VIEW, true)
+            intent.putExtra(StatsActivity.ARG_LOCAL_TABLE_SITE_ID, site.id)
+
+            intent.putExtra(StatsViewAllActivity.ARG_STATS_VIEW_ALL_TITLE, activity.getString(R.string.stats_view_followers))
+            activity.startActivity(intent)
+        } else {
+            ActivityLauncher.viewBlogStats(activity, site)
+        }
+    }
+
+    private fun showWebViewActivityForUrl(activity: AppCompatActivity, url: String?) {
+        if (url == null) {
+            return
+        }
+
+        if (url.contains(domainWpCom)) {
+            WPWebViewActivity.openUrlByUsingGlobalWPCOMCredentials(activity, url)
+        } else {
+            WPWebViewActivity.openURL(activity, url)
+        }
+    }
+
+    private fun showReaderPostLikeUsers(activity: AppCompatActivity, blogId: Long, postId: Long) {
+        ReaderActivityLauncher.showReaderLikingUsers(activity, blogId, postId)
+    }
+
+    private fun showReaderCommentsList(activity: AppCompatActivity, siteId: Long, postId: Long, commentId: Long) {
+        ReaderActivityLauncher.showReaderComments(activity, siteId, postId, commentId)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -57,6 +57,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import kotlin.Unit;
+import kotlin.jvm.functions.Function1;
+
 public class NotificationsUtils {
     public static final String ARG_PUSH_AUTH_TOKEN = "arg_push_auth_token";
     public static final String ARG_PUSH_AUTH_TITLE = "arg_push_auth_title";
@@ -185,9 +188,58 @@ public class NotificationsUtils {
      * @return Spannable string with formatted content
      */
     static Spannable getSpannableContentForRanges(FormattableContent formattableContent, TextView textView,
-                                                         final NoteBlock.OnNoteBlockTextClickListener
-                                                                 onNoteBlockTextClickListener,
-                                                         boolean isFooter) {
+                                                  final NoteBlock.OnNoteBlockTextClickListener
+                                                          onNoteBlockTextClickListener,
+                                                  boolean isFooter) {
+        return getSpannableContentForRanges(formattableContent,
+                textView,
+                isFooter,
+                new Function1<NoteBlockClickableSpan, Unit>() {
+                    @Override public Unit invoke(NoteBlockClickableSpan noteBlockClickableSpan) {
+                        onNoteBlockTextClickListener.onNoteBlockTextClicked(noteBlockClickableSpan);
+                        return null;
+                    }
+                });
+    }
+
+    /**
+     * Returns a spannable with formatted content based on WP.com note content 'range' data
+     *
+     * @param formattableContent the data
+     * @param textView the TextView that will display the spannnable
+     * @param clickHandler - click listener for ClickableSpans in the spannable
+     * @param isFooter - Set if spannable should apply special formatting
+     * @return Spannable string with formatted content
+     */
+    static Spannable getSpannableContentForRanges(FormattableContent formattableContent,
+                                                  TextView textView,
+                                                  final Function1<FormattableRange, Unit> clickHandler,
+                                                  boolean isFooter) {
+        return getSpannableContentForRanges(formattableContent,
+                textView,
+                isFooter,
+                new Function1<NoteBlockClickableSpan, Unit>() {
+                    @Override public Unit invoke(NoteBlockClickableSpan noteBlockClickableSpan) {
+                        clickHandler.invoke(noteBlockClickableSpan.getFormattableRange());
+                        return null;
+                    }
+                });
+    }
+
+    /**
+     * Returns a spannable with formatted content based on WP.com note content 'range' data
+     *
+     * @param formattableContent the data
+     * @param textView the TextView that will display the spannnable
+     * @param onNoteBlockTextClickListener - click listener for ClickableSpans in the spannable
+     * @param isFooter - Set if spannable should apply special formatting
+     * @return Spannable string with formatted content
+     */
+    private static Spannable getSpannableContentForRanges(FormattableContent formattableContent,
+                                                          TextView textView,
+                                                          boolean isFooter,
+                                                          final Function1<NoteBlockClickableSpan, Unit>
+                                                                  onNoteBlockTextClickListener) {
         if (formattableContent == null) {
             return new SpannableStringBuilder();
         }
@@ -209,7 +261,7 @@ public class NotificationsUtils {
                     @Override
                     public void onClick(View widget) {
                         if (onNoteBlockTextClickListener != null) {
-                            onNoteBlockTextClickListener.onNoteBlockTextClicked(this);
+                            onNoteBlockTextClickListener.invoke(this);
                         }
                     }
                 };

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -192,15 +192,17 @@ public class NotificationsUtils {
                                                   final NoteBlock.OnNoteBlockTextClickListener
                                                           onNoteBlockTextClickListener,
                                                   boolean isFooter) {
-        return getSpannableContentForRanges(formattableContent,
-                textView,
-                isFooter,
-                new Function1<NoteBlockClickableSpan, Unit>() {
+        Function1<NoteBlockClickableSpan, Unit> clickListener =
+                onNoteBlockTextClickListener != null ? new Function1<NoteBlockClickableSpan, Unit>() {
                     @Override public Unit invoke(NoteBlockClickableSpan noteBlockClickableSpan) {
                         onNoteBlockTextClickListener.onNoteBlockTextClicked(noteBlockClickableSpan);
                         return null;
                     }
-                });
+                } : null;
+        return getSpannableContentForRanges(formattableContent,
+                textView,
+                isFooter,
+                clickListener);
     }
 
     /**
@@ -216,15 +218,17 @@ public class NotificationsUtils {
                                                   TextView textView,
                                                   final Function1<FormattableRange, Unit> clickHandler,
                                                   boolean isFooter) {
-        return getSpannableContentForRanges(formattableContent,
-                textView,
-                isFooter,
-                new Function1<NoteBlockClickableSpan, Unit>() {
+        Function1<NoteBlockClickableSpan, Unit> clickListener =
+                clickHandler != null ? new Function1<NoteBlockClickableSpan, Unit>() {
                     @Override public Unit invoke(NoteBlockClickableSpan noteBlockClickableSpan) {
                         clickHandler.invoke(noteBlockClickableSpan.getFormattableRange());
                         return null;
                     }
-                });
+                } : null;
+        return getSpannableContentForRanges(formattableContent,
+                textView,
+                isFooter,
+                clickListener);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -280,7 +280,7 @@ public class NotificationsUtils {
                                 .setSpan(styleSpan, indices.get(0), indices.get(1), Spanned.SPAN_INCLUSIVE_INCLUSIVE);
                     }
 
-                    if (onNoteBlockTextClickListener != null) {
+                    if (onNoteBlockTextClickListener != null && textView != null) {
                         textView.setLinksClickable(true);
                         textView.setMovementMethod(new NoteBlockLinkMovementMethod());
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -43,6 +43,7 @@ import org.wordpress.android.models.Note;
 import org.wordpress.android.push.GCMMessageService;
 import org.wordpress.android.ui.notifications.blocks.NoteBlock;
 import org.wordpress.android.ui.notifications.blocks.NoteBlockClickableSpan;
+import org.wordpress.android.ui.notifications.blocks.NoteBlockLinkMovementMethod;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DeviceUtils;
@@ -277,6 +278,11 @@ public class NotificationsUtils {
                         StyleSpan styleSpan = new StyleSpan(clickableSpan.getSpanStyle());
                         spannableStringBuilder
                                 .setSpan(styleSpan, indices.get(0), indices.get(1), Spanned.SPAN_INCLUSIVE_INCLUSIVE);
+                    }
+
+                    if (onNoteBlockTextClickListener != null) {
+                        textView.setLinksClickable(true);
+                        textView.setMovementMethod(new NoteBlockLinkMovementMethod());
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtilsWrapper.kt
@@ -5,6 +5,7 @@ import android.widget.TextView
 import org.json.JSONObject
 import org.wordpress.android.fluxc.tools.FormattableContent
 import org.wordpress.android.fluxc.tools.FormattableContentMapper
+import org.wordpress.android.fluxc.tools.FormattableRange
 import org.wordpress.android.ui.notifications.blocks.NoteBlock
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -45,4 +46,12 @@ class NotificationsUtilsWrapper @Inject constructor(val formattableContentMapper
         isFooter: Boolean
     ): Spannable = NotificationsUtils.getSpannableContentForRanges(formattableContent,
             textView, onNoteBlockTextClickListener, isFooter)
+
+    fun getSpannableContentForRanges(
+        formattableContent: FormattableContent?,
+        textView: TextView,
+        clickHandler: (FormattableRange) -> Unit,
+        isFooter: Boolean
+    ): Spannable = NotificationsUtils.getSpannableContentForRanges(formattableContent,
+            textView, clickHandler, isFooter)
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -5,7 +5,6 @@ import android.arch.lifecycle.MediatorLiveData
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.Transformations
 import android.arch.lifecycle.ViewModel
-import android.support.v4.app.FragmentActivity
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel.ActivityActor
@@ -13,7 +12,6 @@ import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.tools.FormattableRange
 import org.wordpress.android.ui.activitylog.RewindStatusService
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailModel
-import org.wordpress.android.ui.notifications.utils.FormattableContentClickHandler
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.ACTIVITY_LOG
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -29,8 +27,7 @@ class ActivityLogDetailViewModel
 @Inject constructor(
     val dispatcher: Dispatcher,
     private val activityLogStore: ActivityLogStore,
-    private val rewindStatusService: RewindStatusService,
-    private val formattableContentClickHandler: FormattableContentClickHandler
+    private val rewindStatusService: RewindStatusService
 ) : ViewModel() {
     lateinit var site: SiteModel
     lateinit var activityLogId: String
@@ -38,6 +35,10 @@ class ActivityLogDetailViewModel
     private val _showRewindDialog = SingleLiveEvent<ActivityLogDetailModel>()
     val showRewindDialog: LiveData<ActivityLogDetailModel>
         get() = _showRewindDialog
+
+    private val _handleFormattableRangeClick = SingleLiveEvent<FormattableRange>()
+    val handleFormattableRangeClick: LiveData<FormattableRange>
+        get() = _handleFormattableRangeClick
 
     private val _item = MutableLiveData<ActivityLogDetailModel>()
     val activityLogItem: LiveData<ActivityLogDetailModel>
@@ -89,8 +90,8 @@ class ActivityLogDetailViewModel
         rewindStatusService.stop()
     }
 
-    fun onRangeClicked(activity: FragmentActivity, range: FormattableRange) {
-        formattableContentClickHandler.onClick(activity, range)
+    fun onRangeClicked(range: FormattableRange) {
+        _handleFormattableRangeClick.value = range
     }
 
     fun onRewindClicked(model: ActivityLogDetailModel) {

--- a/WordPress/src/main/res/layout/activity_log_item_detail.xml
+++ b/WordPress/src/main/res/layout/activity_log_item_detail.xml
@@ -111,7 +111,9 @@
                 android:layout_marginTop="24dp"
                 android:textAppearance="@style/Base.TextAppearance.AppCompat.Subhead"
                 android:textColor="@color/grey_dark"
-                tools:text="Jetpack by WordPress.com autoupdated to 5.6"/>
+                android:linksClickable="true"
+                tools:text="Jetpack by WordPress.com autoupdated to 5.6"
+                android:focusable="true"/>
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/activityType"

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -1,9 +1,7 @@
 package org.wordpress.android.viewmodel.activitylog
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
-import android.support.v4.app.FragmentActivity
 import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -23,7 +21,6 @@ import org.wordpress.android.fluxc.tools.FormattableContent
 import org.wordpress.android.fluxc.tools.FormattableRange
 import org.wordpress.android.ui.activitylog.RewindStatusService
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailModel
-import org.wordpress.android.ui.notifications.utils.FormattableContentClickHandler
 import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
@@ -34,7 +31,6 @@ class ActivityLogDetailViewModelTest {
     @Mock private lateinit var activityLogStore: ActivityLogStore
     @Mock private lateinit var site: SiteModel
     @Mock private lateinit var rewindStatusService: RewindStatusService
-    @Mock private lateinit var formattableContentClickHandler: FormattableContentClickHandler
     private lateinit var viewModel: ActivityLogDetailViewModel
 
     private val activityID = "id1"
@@ -71,8 +67,7 @@ class ActivityLogDetailViewModelTest {
         viewModel = ActivityLogDetailViewModel(
                 dispatcher,
                 activityLogStore,
-                rewindStatusService,
-                formattableContentClickHandler
+                rewindStatusService
         )
         viewModel.activityLogItem.observeForever { lastEmittedItem = it }
     }
@@ -178,11 +173,10 @@ class ActivityLogDetailViewModelTest {
     @Test
     fun onRangeClickPassesClickToCLickHandler() {
         val range = mock<FormattableRange>()
-        val activity = mock<FragmentActivity>()
 
-        viewModel.onRangeClicked(activity, range)
+        viewModel.onRangeClicked(range)
 
-        verify(formattableContentClickHandler).onClick(activity, range)
+        assertEquals(range, viewModel.handleFormattableRangeClick.value)
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '692c67ef36658e2b862ec4b98a152593958b5a02'
+    fluxCVersion = 'e77856300f925d6d99e614c5968e0874ab336ec3'
 }


### PR DESCRIPTION
Fixes #8276
I'm adding a new Click listener that extract click handling on formattable content. This listener is being passed into NotificationUtilsWrapper. NotificationsUtilsWrapper is called to create a Spannable from Formattable content in Activity Log. As a result we can now see formattable content with links in Activity Log.  

![formattable_content_in_activity_log](https://user-images.githubusercontent.com/1079756/45162428-4a332a00-b1ee-11e8-81ed-9b6eedf6ff4b.gif)

To test:
- Go to activity log
- Click on items that link to content (for example mentioning a Site, a Link or a Comment)
- You see that the text of the Content is now blue and clickable
- Clicking on the content opens it in a new window

