### PR TITLE
Issue/8283 signup snackbar truncated

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -13,6 +13,7 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
+import android.widget.TextView;
 
 import com.google.android.gms.auth.api.credentials.Credential;
 import com.google.android.gms.common.ConnectionResult;
@@ -728,7 +729,11 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
 
     @Override
     public void showSignupToLoginMessage() {
-        Snackbar.make(findViewById(R.id.main_view), R.string.signup_user_exists, Snackbar.LENGTH_LONG).show();
+        Snackbar snackbar =
+                Snackbar.make(findViewById(R.id.main_view), R.string.signup_user_exists, Snackbar.LENGTH_LONG);
+        TextView snackbarText = snackbar.getView().findViewById(android.support.design.R.id.snackbar_text);
+        snackbarText.setMaxLines(2);
+        snackbar.show();
     }
 
     // GoogleListener

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -11,6 +11,7 @@ import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import kotlinx.android.synthetic.main.activity_log_list_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.R.string
@@ -105,7 +106,10 @@ class ActivityLogListFragment : Fragment() {
         viewModel.showSnackbarMessage.observe(this, Observer { message ->
             val parent: View? = activity?.findViewById(android.R.id.content)
             if (message != null && parent != null) {
-                Snackbar.make(parent, message, Snackbar.LENGTH_LONG).show()
+                val snackbar = Snackbar.make(parent, message, Snackbar.LENGTH_LONG)
+                val snackbarText = snackbar.view.findViewById<TextView>(android.support.design.R.id.snackbar_text)
+                snackbarText.maxLines = 2
+                snackbar.show()
             }
         })
 


### PR DESCRIPTION
### Fix
Add setting the maximum number of lines to two for the snackbar view so that the text will not be truncated as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8283.  This only occurs on devices that have a large screen density for which the snackbar width does not fill the display such as tablets *and* snackbars with text containing `\n`.  All instances of snackbar text containing `\n` were updated (i.e. signup and rewind).  See the screenshots below for illustration.

![8283](https://user-images.githubusercontent.com/3827611/45194031-42d84480-b21f-11e8-8a64-fad12c62fc00.png)

### Test
#### Signup
0. Use existing WordPress.com account with Google account disconnected and two-factor authentication disabled.
1. Tap ***Sign Up*** button.
2. Tap ***Sign Up with Google*** button.
3. Choose Google account with existing WordPress.com account.
4. Notice snackbar with message below.
> Email already exists on WordPress.com.
> Proceeding with login.

#### Rewind
0. Use existing WordPress.com account with Activity Log and rewind enabled.
1. Go to ***My Site*** tab.
2. Tap ***Activity*** item.
3. Tap ***Rewind*** button on activity event.
4. Notice snackbar with message format below whlie rewinding.
> Your site is being restored
> Rewinding to DATE TIME
5. Notice snackbar with message format below once rewound.
> Your site has been successfully restored
> Rewound to DATE TIME

### Review
Only one developer is required to review these changes, but anyone can perform the review.