### PR TITLE
Fix typo in error message

### DIFF
--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -819,7 +819,7 @@ Language: cs_CZ
     <string name="media_upload_error">Došlo k chybě nahrávání médií</string>
     <string name="retry">Znovu</string>
     <string name="confirm">Potvrdit</string>
-    <string name="xmlrpc_endpoint_forbidden_error">Nelze se připojit. Došlo k chybě 403 při pokusu o přístup k vašemu XMLRPC mEndpoint. Aplikace potřebuje tuto aplikaci, aby mohla komunikovat s vaším webem. Obraťte se na svojí hostingovou společnost, abyste vyřešili tento problém.</string>
+    <string name="xmlrpc_endpoint_forbidden_error">Nelze se připojit. Došlo k chybě 403 při pokusu o přístup k vašemu XMLRPC endpoint. Aplikace potřebuje tuto aplikaci, aby mohla komunikovat s vaším webem. Obraťte se na svojí hostingovou společnost, abyste vyřešili tento problém.</string>
     <string name="xmlrpc_post_blocked_error">Nepodařilo se připojit. Váš hostitel blokuje požadavky POST, které jsou potřeba ke komunikaci s webovou stránkou. Pro vyřešení toho problému kontaktujte svého hostitele.</string>
     <string name="reader_empty_followed_blogs_search_title">Neodpovídají žádné weby</string>
     <string name="reader_hint_search_followed_sites">Prohledat sledované stránky</string>

--- a/WordPress/src/main/res/values-en-rAU/strings.xml
+++ b/WordPress/src/main/res/values-en-rAU/strings.xml
@@ -849,7 +849,7 @@ Language: en_AU
     <string name="media_upload_error">Media upload error occurred</string>
     <string name="retry">Retry</string>
     <string name="confirm">Confirm</string>
-    <string name="xmlrpc_endpoint_forbidden_error">Couldn\'t connect. We received a 403 error when trying to access your\n        site XMLRPC mEndpoint. The app needs that in order to communicate with your site. Contact your host to solve\n        this problem.</string>
+    <string name="xmlrpc_endpoint_forbidden_error">Couldn\'t connect. We received a 403 error when trying to access your\n        site XMLRPC endpoint. The app needs that in order to communicate with your site. Contact your host to solve\n        this problem.</string>
     <string name="xmlrpc_post_blocked_error">Couldn\'t connect. Your host is blocking POST requests, and the app needs\n        that in order to communicate with your site. Contact your host to solve this problem.</string>
     <string name="reader_empty_followed_blogs_search_title">No matching sites</string>
     <string name="reader_hint_search_followed_sites">Search followed sites</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -849,7 +849,7 @@ Language: en_CA
     <string name="media_upload_error">Media upload error occurred</string>
     <string name="retry">Retry</string>
     <string name="confirm">Confirm</string>
-    <string name="xmlrpc_endpoint_forbidden_error">Couldn\'t connect. We received a 403 error when trying to access your\n        site XMLRPC mEndpoint. The app needs that in order to communicate with your site. Contact your host to solve\n        this problem.</string>
+    <string name="xmlrpc_endpoint_forbidden_error">Couldn\'t connect. We received a 403 error when trying to access your\n        site XMLRPC endpoint. The app needs that in order to communicate with your site. Contact your host to solve\n        this problem.</string>
     <string name="xmlrpc_post_blocked_error">Couldn\'t connect. Your host is blocking POST requests, and the app needs\n        that in order to communicate with your site. Contact your host to solve this problem.</string>
     <string name="reader_empty_followed_blogs_search_title">No matching sites</string>
     <string name="reader_hint_search_followed_sites">Search followed sites</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -849,7 +849,7 @@ Language: en_GB
     <string name="media_upload_error">Media upload error occurred</string>
     <string name="retry">Retry</string>
     <string name="confirm">Confirm</string>
-    <string name="xmlrpc_endpoint_forbidden_error">Couldn\'t connect. We received a 403 error when trying to access your\n        site XMLRPC mEndpoint. The app needs that in order to communicate with your site. Contact your host to solve\n        this problem.</string>
+    <string name="xmlrpc_endpoint_forbidden_error">Couldn\'t connect. We received a 403 error when trying to access your\n        site XMLRPC endpoint. The app needs that in order to communicate with your site. Contact your host to solve\n        this problem.</string>
     <string name="xmlrpc_post_blocked_error">Couldn\'t connect. Your host is blocking POST requests, and the app needs\n        that in order to communicate with your site. Contact your host to solve this problem.</string>
     <string name="reader_empty_followed_blogs_search_title">No matching sites</string>
     <string name="reader_hint_search_followed_sites">Search followed sites</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -848,7 +848,7 @@ Language: es
     <string name="media_upload_error">Hubo un error al cargar el archivo multimedia</string>
     <string name="retry">Reintentar</string>
     <string name="confirm">Confirmar</string>
-    <string name="xmlrpc_endpoint_forbidden_error">No se pudo conectar. Se ha recibido un error 403 cuando se intenta acceder a \n        tu mEndpoint del XMLRPC de sitio. La aplicación lo necesita para comunicarse con su sitio. Póngase en contacto con su anfitrión para solucionar este problema.</string>
+    <string name="xmlrpc_endpoint_forbidden_error">No se pudo conectar. Se ha recibido un error 403 cuando se intenta acceder a \n        tu endpoint del XMLRPC de sitio. La aplicación lo necesita para comunicarse con su sitio. Póngase en contacto con su anfitrión para solucionar este problema.</string>
     <string name="xmlrpc_post_blocked_error">No se pudo conectar. Su alojamiento está bloqueando las peticiones POST, y la aplicación las necesita \n        para comunicarse con su sitio. Póngase en contacto con su alojamiento para solucionar este problema.</string>
     <string name="reader_empty_followed_blogs_search_title">Ningún sitio coincide con tu búsqueda</string>
     <string name="reader_hint_search_followed_sites">Busca en los sitios que sigues</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -836,7 +836,7 @@ Language: sq_AL
     <string name="media_upload_error">Ndodhi një gabim ngarkimi mediash</string>
     <string name="retry">Riprovoni</string>
     <string name="confirm">Ripohojeni</string>
-    <string name="xmlrpc_endpoint_forbidden_error">S’u bë dot lidhja. Morëm një gabim 403, kur provuat të hyjmë\n        te mEndpoint XMLRPC e sajtit tuaj. Kjo i duhet aplikacionit, që të mund të komunikojë me sajtin tuaj.\n        Lidhuni me strehuesin tuaj që ta zgjidhni këtë problem.</string>
+    <string name="xmlrpc_endpoint_forbidden_error">S’u bë dot lidhja. Morëm një gabim 403, kur provuat të hyjmë\n        te endpoint XMLRPC e sajtit tuaj. Kjo i duhet aplikacionit, që të mund të komunikojë me sajtin tuaj.\n        Lidhuni me strehuesin tuaj që ta zgjidhni këtë problem.</string>
     <string name="xmlrpc_post_blocked_error">S’u bë dot lidhja. Strehuesi juaj i bllokon kërkesat POST, dhe aplikacionit\n        i duhen që të mund të komunikojë me sajtin tuaj. Lidhuni me strehuesin tuaj që ta zgjidhni këtë problem.</string>
     <string name="reader_empty_followed_blogs_search_title">S’ka sajte me përputhje</string>
     <string name="reader_hint_search_followed_sites">Kërkoni te sajtet vijues</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="xmlrpc_post_blocked_error">Couldn\'t connect. Your host is blocking POST requests, and the app needs
         that in order to communicate with your site. Contact your host to solve this problem.</string>
     <string name="xmlrpc_endpoint_forbidden_error">Couldn\'t connect. We received a 403 error when trying to access your
-        site XMLRPC mEndpoint. The app needs that in order to communicate with your site. Contact your host to solve
+        site XMLRPC endpoint. The app needs that in order to communicate with your site. Contact your host to solve
         this problem.</string>
     <string name="no_network_title">No network available</string>
     <string name="no_network_message">There is no network available</string>


### PR DESCRIPTION
Fixes #8170 - Typo in error message

Fix a typo introduced [here](https://github.com/wordpress-mobile/WordPress-Android/commit/e1b3087d6ace04000c083a40944f51b6922ee420#diff-96c14faed2c61eacb909ae0349b44cefR12)

This PR change again from **mEndpoint** to **endpoint**