### PR TITLE
Add wordpress.com prefix after encoding the URL

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionWebViewClient.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionWebViewClient.java
@@ -88,10 +88,11 @@ class JetpackConnectionWebViewClient extends WebViewClient {
         } else {
             redirectUrl = stringUrl.substring(from);
         }
-        if (redirectUrl.startsWith(JETPACK_PATH)) {
-            redirectUrl = WORDPRESS_COM_PREFIX + redirectUrl;
+        String decodedUrl = URLDecoder.decode(redirectUrl, WPWebViewActivity.ENCODING_UTF8);
+        if (decodedUrl.startsWith(JETPACK_PATH)) {
+            decodedUrl = WORDPRESS_COM_PREFIX + decodedUrl;
         }
-        mRedirectPage = URLDecoder.decode(redirectUrl, WPWebViewActivity.ENCODING_UTF8);
+        mRedirectPage = decodedUrl;
     }
 
     String getRedirectPage() {


### PR DESCRIPTION
Fixes #8289 

This check `redirectUrl.startsWith(JETPACK_PATH)` never passed because we were comparing the string `/jetpack` with the string before encoding (which never contains `/`). The bug was caused by a check that is checking the URL in `WPWebViewActivity`. The url was relative - it didn't contain the `http://wordpress.com` prefix. 

To test:
- Create a site with `jurassic.ninja`
- Add an admin account with a google email (not connected to another wp.com account)
- Login with your self-hosted site
- Setup Jetpack
- Select `Sign-up with Google` when asked to login to wp.com
- Approve connection
- Finish the flow without crashes
