### PR TITLE
Issue/8235 editor image dimensions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -705,6 +705,12 @@ public class MediaSettingsActivity extends AppCompatActivity
         }
     }
 
+    private void hideImageDimensions() {
+        findViewById(R.id.text_image_dimensions).setVisibility(View.GONE);
+        findViewById(R.id.text_image_dimensions_label).setVisibility(View.GONE);
+        findViewById(R.id.divider_dimensions).setVisibility(View.GONE);
+    }
+
     /**
      * Initialize the image alignment spinner
      */
@@ -756,6 +762,10 @@ public class MediaSettingsActivity extends AppCompatActivity
                     public void onResourceReady(@NotNull Drawable resource) {
                         if (!isFinishing()) {
                             showProgress(false);
+
+                            if (isMediaFromEditor()) {
+                                hideImageDimensions();
+                            }
                         }
                     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -709,6 +709,11 @@ public class MediaSettingsActivity extends AppCompatActivity
         findViewById(R.id.text_image_dimensions).setVisibility(View.GONE);
         findViewById(R.id.text_image_dimensions_label).setVisibility(View.GONE);
         findViewById(R.id.divider_dimensions).setVisibility(View.GONE);
+
+        // Hide file type divider too if duration is hidden (i.e. media length is zero) to remove bottom divider.
+        if (mMedia.getLength() == 0) {
+            findViewById(R.id.divider_filetype).setVisibility(View.GONE);
+        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -757,9 +757,6 @@ public class MediaSettingsActivity extends AppCompatActivity
                     public void onResourceReady(@NotNull Drawable resource) {
                         if (!isFinishing()) {
                             showProgress(false);
-                            if (isMediaFromEditor()) {
-                                showImageDimensions(resource.getIntrinsicWidth(), resource.getIntrinsicHeight());
-                            }
                         }
                     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -750,7 +750,6 @@ public class MediaSettingsActivity extends AppCompatActivity
         if (SiteUtils.isPhotonCapable(mSite)) {
             imageUrl = PhotonUtils.getPhotonImageUrl(mediaUri, size, 0);
         }
-        showProgress(true);
         mImageManager.loadWithResultListener(mImageView, ImageType.IMAGE, imageUrl, null,
                 new RequestListener<Drawable>() {
                     @Override

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -466,6 +466,7 @@
                                 tools:text="text_filetype" />
                     </LinearLayout>
                     <View
+                        android:id="@+id/divider_filetype"
                         style="@style/MediaSettings.Divider"
                         android:layout_width="match_parent"
                         android:layout_height="1dp" />


### PR DESCRIPTION
### Fix
Display the correct values in the ***Image Dimensions*** field of an image uploaded from the editor as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8235.

The [`MediaSettingsActivity.showImageDimensions()`](https://github.com/wordpress-mobile/WordPress-Android/blob/df0c6af1cb1189edb730430142e258ee58a29869/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java#L691-L706) method updates the ***Image Dimensions*** field values.  It was first being called during `onCreate` with the `MediaModel.getHeight()` and `MediaModel.getWidth()` values.  Then it was called a second time in the [Volley image loader response with the bitmap height and width](https://github.com/wordpress-mobile/WordPress-Android/commit/d2dcd424f3894bca6e394971ee5b9cc20f6db589#diff-5174e65460ee5a6d300de6ff37d22ea9L761).  When we migrated from Volley to Glide, the second call was updated to use the drawable intrinsic height and width.  The `Drawable.getIntrinsicHeight()` and `Drawable.getIntrinsicWidth()` methods return incorrect values so the second call has been removed.  If the `MediaModel` has a `0` value for height or width, [the ***Image Dimensions*** field is hidden in the `showImageDimensions()` method](https://github.com/wordpress-mobile/WordPress-Android/blob/df0c6af1cb1189edb730430142e258ee58a29869/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java#L702-L704).

A redundant `showProgress(true);` statement was removed also.

### Test
1. Go to ***My Site*** tab.
2. Tap ***Blog Posts*** item under ***Publish*** section.
3. Tap ***Create*** floating action button.
4. Tap content area of editor.
5. Tap ***Show Media Options*** button.
6. Select image from device or take new photo with camera.
7. Wait for image to upload.
8. Tap image to view details.
9. Notice correct values are displayed in ***Image Dimensions*** field.

### Review
Only one developer is required to review these changes, but anyone can perform the review.