### PR TITLE
Use a unique name for post remote ID extra key

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -200,7 +200,7 @@ public class EditPostActivity extends AppCompatActivity implements
         PostSettingsListDialogFragment.OnPostSettingsDialogFragmentListener,
         PostDatePickerDialogFragment.OnPostDatePickerDialogListener {
     public static final String EXTRA_POST_LOCAL_ID = "postModelLocalId";
-    public static final String EXTRA_POST_REMOTE_ID = "postModelLocalId";
+    public static final String EXTRA_POST_REMOTE_ID = "postModelRemoteId";
     public static final String EXTRA_IS_PAGE = "isPage";
     public static final String EXTRA_IS_PROMO = "isPromo";
     public static final String EXTRA_IS_QUICKPRESS = "isQuickPress";


### PR DESCRIPTION
Fixes #8300. There was a duplicate key used for remote/local post IDs, which resulted in a type mismatch (Int vs Long).

To test:

1. Open the Site Pages
2. Edit a page and upload a change
3. Go to the Post list screen
4. Open a post and upload a change
5. Notice no error message is displayed