### PR TITLE
Issue/7974 update oauth readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,26 +51,26 @@ In order to use WordPress.com functions you will need a client ID and
 a client secret key. These details will be used to authenticate your
 application and verify that the API calls being made are valid. You can
 create an application or view details for your existing applications with
-our [WordPress.com applications manager](https://developer.wordpress.com/apps/).
+our [WordPress.com applications manager][5].
 
 When creating your application, you should select "Native client" for the
 application type. The applications manager currently requires a "redirect URL",
 but this isn't used for mobile apps. Just use "https://localhost".
 
-Once you've created your application in the [applications manager](https://developer.wordpress.com/apps/), you'll
+Once you've created your application in the [applications manager][5], you'll
 need to edit the `./gradle.properties` file and change the
 `WP.OAUTH.APP_ID` and `WP.OAUTH.APP_SECRET` fields. Then you can compile and
 run the app on a device or an emulator and try to login with a WordPress.com
 account. Note that authenticating to WordPress.com via Google is not supported in development builds of the app, only in the official release.
 
-Note that credentials created with our [WordPress.com applications manager](https://developer.wordpress.com/apps/)
-allow login only and not signup. New accounts must be created using the [official app][1] or [on the web](https://wordpress.com/start).
-Login is restricted to the WordPress.com account with which the credentials were created. Also, you will be able to
-interact with sites of that same WordPress.com account only. In other words, if the credentials were created with
-foo@email.com, you will only be able to login with foo@email.com and access foo@email.com sites. Using another account
-like bar@email.com will cause the `Client cannot use "password" grant_type` error. 
+Note that credentials created with our [WordPress.com applications manager][5] allow login only and not signup. New
+accounts must be created using the [official app][1] or [on the web](https://wordpress.com/start). Login is restricted
+to the WordPress.com account with which the credentials were created. Also, you will be able to interact with sites of
+that same WordPress.com account only. In other words, if the credentials were created with foo@email.com, you will only
+be able to login with foo@email.com and access foo@email.com sites. Using another account like bar@email.com will cause
+the `Client cannot use "password" grant_type` error. 
 
-Read more about [OAuth2](https://developer.wordpress.com/docs/oauth2/) and the [WordPress.com REST endpoint](https://developer.wordpress.com/docs/api/).
+Read more about [OAuth2][6] and the [WordPress.com REST endpoint][7].
 
 ## Google Configuration ##
 
@@ -88,7 +88,7 @@ how we're organizing branches in our repository in the
 
 ## Need help to build or hack? ##
 
-Say hello on our [Slack](https://make.wordpress.org/chat/) channel: `#mobile`.
+Say hello on our [Slack][4] channel: `#mobile`.
 
 ## FAQ ##
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ need to edit the `./gradle.properties` file and change the
 run the app on a device or an emulator and try to login with a WordPress.com
 account. Note that authenticating to WordPress.com via Google is not supported in development builds of the app, only in the official release.
 
+Note that credentials created with our [WordPress.com applications manager](https://developer.wordpress.com/apps/)
+allow login only and not signup. New accounts must be created using the [official app][1] or [on the web](https://wordpress.com/start).
+Login is restricted to the WordPress.com account with which the credentials were created. Also, you will be able to
+interact with sites of that same WordPress.com account only. In other words, if the credentials were created with
+foo@email.com, you will only be able to login with foo@email.com and access foo@email.com sites. Using another account
+like bar@email.com will cause the `Client cannot use "password" grant_type` error. 
+
 Read more about [OAuth2](https://developer.wordpress.com/docs/oauth2/) and the [WordPress.com REST endpoint](https://developer.wordpress.com/docs/api/).
 
 ## Google Configuration ##


### PR DESCRIPTION
### Fix
Update the [README.md](https://github.com/wordpress-mobile/WordPress-Android/blob/ae78449892addfeba30f5e1d273d8b320ba0a8e1/README.md) with details about authentication credentials for developers as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7974.  Also, links in the file with existing numbered references were updated to use the reference-style for consistency.

### Review
Only one developer is required to review these changes, but anyone can perform the review.