### PR TITLE
Fix ContextImpl cannot be cast to WordPress

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -87,7 +87,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
 
     public MediaGridAdapter(@NonNull Context context, @NonNull SiteModel site, @NonNull MediaBrowserType browserType) {
         super();
-        ((WordPress) WordPress.getContext()).component().inject(this);
+        ((WordPress) WordPress.getContext().getApplicationContext()).component().inject(this);
         setHasStableIds(true);
 
         mContext = context;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -41,7 +41,7 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
     @Inject SiteStore mSiteStore;
 
     MediaUploadHandler() {
-        ((WordPress) WordPress.getContext()).component().inject(this);
+        ((WordPress) WordPress.getContext().getApplicationContext()).component().inject(this);
         AppLog.i(T.MEDIA, "MediaUploadHandler > Created");
         mDispatcher.register(this);
         EventBus.getDefault().register(this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -74,7 +74,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
     @Inject MediaStore mMediaStore;
 
     PostUploadHandler(PostUploadNotifier postUploadNotifier) {
-        ((WordPress) WordPress.getContext()).component().inject(this);
+        ((WordPress) WordPress.getContext().getApplicationContext()).component().inject(this);
         AppLog.i(T.POSTS, "PostUploadHandler > Created");
         mDispatcher.register(this);
         mPostUploadNotifier = postUploadNotifier;

--- a/WordPress/src/main/java/org/wordpress/android/util/WPWebViewClient.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPWebViewClient.java
@@ -42,7 +42,7 @@ public class WPWebViewClient extends URLFilteredWebViewClient {
 
     public WPWebViewClient(SiteModel site, String token, List<String> urls) {
         super(urls);
-        ((WordPress) WordPress.getContext()).component().inject(this);
+        ((WordPress) WordPress.getContext().getApplicationContext()).component().inject(this);
         mSite = site;
         mToken = token;
     }


### PR DESCRIPTION
Fixes #8309 

We cast `WordPress.getContext()` to `WordPress`, however when the user changes a locale within the app, the `WordPress.getContext()` doesn't contain `WordPress` but `ContextImpl`.

To test:
1. Change a locale in the app settings
2. Go to My Site
3. Click on the Media Library
4. Notice the app doesn't crash
-----------------------
1. Change a locale in the app settings
2. Create a new Post
3. Upload a new Image
4. Notice the app doesn't crash

