### PR TITLE
Issue/8311 crash resume reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -398,6 +398,8 @@ public class ReaderPostListFragment extends Fragment
             if (discoverTag != null && discoverTag.equals(readerTag)) {
                 setCurrentTag(readerTag);
                 updateCurrentTag();
+            } else if (discoverTag == null) {
+                AppLog.w(T.READER, "Discover tag not found; ReaderTagTable returned null");
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -17,8 +17,8 @@ import android.support.design.widget.Snackbar;
 import android.support.design.widget.TabLayout;
 import android.support.design.widget.TabLayout.OnTabSelectedListener;
 import android.support.design.widget.TabLayout.Tab;
-import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.ListPopupWindow;
@@ -102,7 +102,6 @@ import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel;
 import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView;
 import org.wordpress.android.util.AccessibilityUtils;
-import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -113,6 +112,7 @@ import org.wordpress.android.util.QuickStartUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
+import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.widgets.RecyclerItemDecoration;
 
@@ -392,10 +392,11 @@ public class ReaderPostListFragment extends Fragment
                 mLastTappedSiteSearchResult = null;
             }
 
-            ReaderTag tag = AppPrefs.getReaderTag();
+            ReaderTag discoverTag = ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH);
+            ReaderTag readerTag = AppPrefs.getReaderTag();
 
-            if (ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH).equals(tag)) {
-                setCurrentTag(tag);
+            if (discoverTag != null && discoverTag.equals(readerTag)) {
+                setCurrentTag(readerTag);
                 updateCurrentTag();
             }
         }


### PR DESCRIPTION
#### Note
This pull request targets the `release/10.9` branch.  The `release/10.9` branch should be merged into `develop` after merging these changes and a new release candidate package should be built.

### Fix
Add a null check for the `ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH)` statement to resolve the crash described in https://github.com/wordpress-mobile/WordPress-Android/issues/8311.

While all users should have the ***Discover*** tag, the `ReaderTagTable` is returning `null` in some unknown cases, which implies the ***Discover*** tag is not in the database.  I wasn't able to reproduce the crash and I'm unsure how the database could not have the ***Discover*** tag.  Therefore, the null check solution was used.  I added the application logging message in 03fbb6c to help troubleshoot the errant scenario in the future.

### Review
Only one developer is required to review these changes, but anyone can perform the review.