### PR TITLE
Fix crash when onTagChanged invoked multiple times with a same tag

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.reader.viewmodels
 
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MediatorLiveData
+import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModel
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.news.NewsItem
@@ -18,6 +19,8 @@ class ReaderPostListViewModel @Inject constructor(
 ) : ViewModel() {
     private val newsItemSource = newsManager.newsItemSource()
     private val _newsItemSourceMediator = MediatorLiveData<NewsItem>()
+
+    private val onTagChanged: Observer<NewsItem?> = Observer { it: NewsItem? -> _newsItemSourceMediator.value = it }
 
     /**
      * News Card shouldn't be shown when the initialTag is null. InitialTag may be null for Blog previews for instance.
@@ -46,7 +49,7 @@ class ReaderPostListViewModel @Inject constructor(
         initialTag?.let { initialTag ->
             // show the card only when the initial tag is selected in the filter
             if (tag == initialTag) {
-                _newsItemSourceMediator.addSource(newsItemSource) { _newsItemSourceMediator.value = it }
+                _newsItemSourceMediator.addSource(newsItemSource, onTagChanged)
             } else {
                 _newsItemSourceMediator.removeSource(newsItemSource)
                 _newsItemSourceMediator.value = null


### PR DESCRIPTION
Fixes #8314 

The app crashes when `ReaderPostListViewModel.onTagChanged(searchTag)` is invoked multiple times with a same tag.

To test:
I don't know how to reproduce the crash. I manually added multiple calls to `ReaderPostListViewModel.onTagChanged(searchTag)` with a same tag to verify it doesn't crash the app.


Anyone can review this PR. 

