### PR TITLE
Issue/8224 switch site screen search and selection

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -180,7 +180,6 @@ public class SitePickerActivity extends AppCompatActivity
 
         // no point showing search if there aren't multiple blogs
         mMenuSearch.setVisible(mSiteStore.getSitesCount() > 1);
-        invalidateOptionsMenu();
     }
 
     @Override
@@ -488,7 +487,7 @@ public class SitePickerActivity extends AppCompatActivity
         hideSoftKeyboard();
         setIsInSearchModeAndSetNewAdapter(false);
         mRecycleView.swapAdapter(getAdapter(), true);
-        updateMenuItemVisibility();
+        invalidateOptionsMenu();
     }
 
     private void hideSoftKeyboard() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -180,6 +180,7 @@ public class SitePickerActivity extends AppCompatActivity
 
         // no point showing search if there aren't multiple blogs
         mMenuSearch.setVisible(mSiteStore.getSitesCount() > 1);
+        invalidateOptionsMenu();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -238,7 +238,8 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         holder.mTxtDomain.setText(site.mHomeURL);
         mImageManager.load(holder.mImgBlavatar, ImageType.BLAVATAR, site.mBlavatarUrl);
 
-        if (site.mLocalId == mCurrentLocalId || (mIsMultiSelectEnabled && isItemSelected(position))) {
+        if ((site.mLocalId == mCurrentLocalId && !mIsMultiSelectEnabled)
+            || (mIsMultiSelectEnabled && isItemSelected(position))) {
             holder.mLayoutContainer.setBackgroundDrawable(mSelectedItemBackground);
         } else {
             holder.mLayoutContainer.setBackgroundDrawable(null);
@@ -387,6 +388,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         mIsMultiSelectEnabled = enable;
         mSelectedPositions.clear();
+        notifyDataSetChanged();
 
         loadSites();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -290,7 +290,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                             return true;
                         } else if (mSiteSelectedListener != null) {
                             boolean result = mSiteSelectedListener.onSiteLongClick(getItem(clickedPosition));
-                            setItemSelected(clickedPosition, true);
                             return result;
                         }
                     } else {
@@ -388,7 +387,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         mIsMultiSelectEnabled = enable;
         mSelectedPositions.clear();
-        notifyDataSetChanged();
 
         loadSites();
     }


### PR DESCRIPTION
Fixes #8224 Switch Site Screen Search and Selection

To test:

**Search**
1. Use account with multiple sites.
2. Go to **My Site** tab.
3. Tap **Switch Site** button in top card view.
4. Notice **Search**, **Add new site**, and **Show/hide** sites actions are shown.
5. Tap **Search** action in top toolbar.
6. Notice **Search, Add new site**, and **Show/hide** sites actions are hidden.
7. Tap back arrow in top toolbar.
8. Notice **Search**, **Add new site**, and **Show/hide** sites actions are shown.

**Selection**

1. Use account with multiple sites and first alphabetical site hidden.
2. Go to **My Site** tab.
3. Tap **Switch Site** button in top card view.
4. Notice active site is selected.
5. Long-press next site in list.
6. Notice site long-pressed in Step 5 is now selected.
7. Notice active site is unselected.
8. Notice top toolbar title shows **1 selected**.
9. Tap active site.
10. Notice top toolbar title shows **2 selected**.

cc: @theck13 