### PR TITLE
Issue/8337 add revisions flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -48,6 +48,8 @@ android {
 
         multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
+
+        buildConfigField "boolean", "REVISIONS_ENABLED", "false"
     }
 
     flavorDimensions "buildType"
@@ -66,6 +68,7 @@ android {
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
             applicationId "org.wordpress.android.beta"
             dimension "buildType"
+            buildConfigField "boolean", "REVISIONS_ENABLED", "true"
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -997,12 +997,19 @@ public class EditPostActivity extends AppCompatActivity implements
             showMenuItems = false;
         }
 
+        MenuItem saveAsDraftMenuItem = menu.findItem(R.id.menu_save_as_draft_or_publish);
         MenuItem historyMenuItem = menu.findItem(R.id.menu_history);
         MenuItem previewMenuItem = menu.findItem(R.id.menu_preview_post);
-        MenuItem settingsMenuItem = menu.findItem(R.id.menu_post_settings);
-        MenuItem saveAsDraftMenuItem = menu.findItem(R.id.menu_save_as_draft_or_publish);
         MenuItem viewHtmlModeMenuItem = menu.findItem(R.id.menu_html_mode);
+        MenuItem settingsMenuItem = menu.findItem(R.id.menu_post_settings);
         MenuItem discardChanges = menu.findItem(R.id.menu_discard_changes);
+
+        if (saveAsDraftMenuItem != null) {
+            saveAsDraftMenuItem.setVisible(showMenuItems);
+            if (mPost != null) {
+                saveAsDraftMenuItem.setTitle(getSaveAsADraftButtonText());
+            }
+        }
 
         if (historyMenuItem != null) {
             historyMenuItem.setVisible(BuildConfig.REVISIONS_ENABLED);
@@ -1012,21 +1019,14 @@ public class EditPostActivity extends AppCompatActivity implements
             previewMenuItem.setVisible(showMenuItems);
         }
 
-        if (settingsMenuItem != null) {
-            settingsMenuItem.setTitle(mIsPage ? R.string.page_settings : R.string.post_settings);
-            settingsMenuItem.setVisible(showMenuItems);
-        }
-
-        if (saveAsDraftMenuItem != null) {
-            saveAsDraftMenuItem.setVisible(showMenuItems);
-            if (mPost != null) {
-                saveAsDraftMenuItem.setTitle(getSaveAsADraftButtonText());
-            }
-        }
-
         if (viewHtmlModeMenuItem != null) {
             viewHtmlModeMenuItem.setVisible(mEditorFragment instanceof AztecEditorFragment && showMenuItems);
             viewHtmlModeMenuItem.setTitle(mHtmlModeMenuStateOn ? R.string.menu_visual_mode : R.string.menu_html_mode);
+        }
+
+        if (settingsMenuItem != null) {
+            settingsMenuItem.setTitle(mIsPage ? R.string.page_settings : R.string.post_settings);
+            settingsMenuItem.setVisible(showMenuItems);
         }
 
         if (discardChanges != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -131,7 +131,6 @@ import org.wordpress.android.ui.uploads.UploadService;
 import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.ui.uploads.VideoOptimizer;
 import org.wordpress.android.util.AccessibilityUtils;
-import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -156,6 +155,7 @@ import org.wordpress.android.util.WPHtml;
 import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.util.WPPermissionUtils;
 import org.wordpress.android.util.WPUrlUtils;
+import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.android.util.helpers.MediaGalleryImageSpan;
@@ -997,11 +997,16 @@ public class EditPostActivity extends AppCompatActivity implements
             showMenuItems = false;
         }
 
+        MenuItem historyMenuItem = menu.findItem(R.id.menu_history);
         MenuItem previewMenuItem = menu.findItem(R.id.menu_preview_post);
         MenuItem settingsMenuItem = menu.findItem(R.id.menu_post_settings);
         MenuItem saveAsDraftMenuItem = menu.findItem(R.id.menu_save_as_draft_or_publish);
         MenuItem viewHtmlModeMenuItem = menu.findItem(R.id.menu_html_mode);
         MenuItem discardChanges = menu.findItem(R.id.menu_discard_changes);
+
+        if (historyMenuItem != null) {
+            historyMenuItem.setVisible(BuildConfig.REVISIONS_ENABLED);
+        }
 
         if (previewMenuItem != null) {
             previewMenuItem.setVisible(showMenuItems);

--- a/WordPress/src/main/res/menu/edit_post.xml
+++ b/WordPress/src/main/res/menu/edit_post.xml
@@ -1,32 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" >
+
     <item
         android:id="@+id/menu_save_post"
-        app:showAsAction="always"
-        android:title="@string/post_status_publish_post"/>
+        android:title="@string/post_status_publish_post"
+        app:showAsAction="always" >
+    </item>
 
     <group
         android:orderInCategory="1" >
+
         <item
             android:id="@+id/menu_save_as_draft_or_publish"
-            android:title="@string/menu_save_as_draft"/>
+            android:title="@string/menu_save_as_draft" >
+        </item>
+
+        <item
+            android:id="@+id/menu_history"
+            android:title="@string/menu_history" >
+        </item>
+
         <item
             android:id="@+id/menu_preview_post"
-            android:title="@string/menu_preview"/>
+            android:title="@string/menu_preview" >
+        </item>
+
         <item
             android:id="@+id/menu_html_mode"
-            android:title="@string/menu_html_mode"/>
+            android:title="@string/menu_html_mode" >
+        </item>
+
         <item
             android:id="@+id/menu_post_settings"
-            android:title="@string/post_settings"/>
+            android:title="@string/post_settings" >
+        </item>
+
     </group>
 
     <group
         android:orderInCategory="2" >
+
         <item
             android:id="@+id/menu_discard_changes"
-            android:title="@string/menu_discard_changes"/>
+            android:title="@string/menu_discard_changes" >
+        </item>
+
     </group>
 
 </menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1186,6 +1186,7 @@
     <string name="menu_save_as_draft">Save as Draft</string>
     <string name="menu_publish_now">Publish Now</string>
     <string name="menu_preview">Preview</string>
+    <string name="menu_history">History</string>
     <string name="menu_html_mode">HTML Mode</string>
     <string name="menu_html_mode_done_snackbar">Switched to HTML mode</string>
     <string name="menu_visual_mode">Visual Mode</string>


### PR DESCRIPTION
### Fix
Add a feature flag as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8337 and add a ***History*** item to the editor in the overflow menu as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8338.  This addresses https://github.com/wordpress-mobile/WordPress-Android/issues/8338 *partially*.  The second part will display the ***History*** item only when revisions exist for the opened page/post.

### Test
#### Enabled
1. Build project with `wasabi` variant.
2. Go to ***My Site*** tab.
3. Tap ***Site Pages*** or ***Blog Posts*** item under ***Publish*** section.
4. Tap overflow menu action.
5. Notice ***History*** item is in list.
#### Disabled
1. Build project with `vanilla` or `zalpha` variant.
2. Go to ***My Site*** tab.
3. Tap ***Site Pages*** or ***Blog Posts*** item under ***Publish*** section.
4. Tap overflow menu action.
5. Notice ***History*** item is not in list.
