### PR TITLE
Issue/8224 switch site search

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -147,20 +147,17 @@ public class SitePickerActivity extends AppCompatActivity
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
         getMenuInflater().inflate(R.menu.site_picker, menu);
+        mMenuSearch = menu.findItem(R.id.menu_search);
+        mMenuEdit = menu.findItem(R.id.menu_edit);
+        mMenuAdd = menu.findItem(R.id.menu_add);
         return true;
     }
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
-
-        mMenuEdit = menu.findItem(R.id.menu_edit);
-        mMenuAdd = menu.findItem(R.id.menu_add);
-        mMenuSearch = menu.findItem(R.id.menu_search);
-
         updateMenuItemVisibility();
         setupSearchView();
-
         return true;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -480,7 +480,7 @@ public class SitePickerActivity extends AppCompatActivity
     private void enableSearchMode() {
         setIsInSearchModeAndSetNewAdapter(true);
         mRecycleView.swapAdapter(getAdapter(), true);
-        updateMenuItemVisibility();
+        invalidateOptionsMenu();
     }
 
     private void disableSearchMode() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -290,7 +290,7 @@ public class SitePickerActivity extends AppCompatActivity
     }
 
     private void setupRecycleView() {
-        mRecycleView = (RecyclerView) findViewById(R.id.recycler_view);
+        mRecycleView = findViewById(R.id.recycler_view);
         mRecycleView.setLayoutManager(new LinearLayoutManager(this));
         mRecycleView.setScrollBarStyle(View.SCROLLBARS_OUTSIDE_OVERLAY);
         mRecycleView.setItemAnimator(null);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -242,9 +242,9 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         if ((site.mLocalId == mCurrentLocalId && !mIsMultiSelectEnabled)
             || (mIsMultiSelectEnabled && isItemSelected(position))) {
-            holder.mLayoutContainer.setBackgroundDrawable(mSelectedItemBackground);
+            holder.mLayoutContainer.setBackground(mSelectedItemBackground);
         } else {
-            holder.mLayoutContainer.setBackgroundDrawable(null);
+            holder.mLayoutContainer.setBackground(null);
         }
 
         // different styling for visible/hidden sites

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -289,8 +289,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                             toggleSelection(clickedPosition);
                             return true;
                         } else if (mSiteSelectedListener != null) {
-                            boolean result = mSiteSelectedListener.onSiteLongClick(getItem(clickedPosition));
-                            return result;
+                            return mSiteSelectedListener.onSiteLongClick(getItem(clickedPosition));
                         }
                     } else {
                         AppLog.w(AppLog.T.MAIN, "site picker > invalid clicked position " + clickedPosition);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -673,7 +673,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         private final long mSiteId;
         private final String mBlogName;
         private final String mHomeURL;
-        private final String mUrl;
         private final String mBlavatarUrl;
         private boolean mIsHidden;
         private boolean mIsRecentPick;
@@ -683,7 +682,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             mSiteId = siteModel.getSiteId();
             mBlogName = SiteUtils.getSiteNameOrHomeURL(siteModel);
             mHomeURL = SiteUtils.getHomeURLOrHostName(siteModel);
-            mUrl = siteModel.getUrl();
             mBlavatarUrl = SiteUtils.getSiteIconUrl(siteModel, mBlavatarSz);
             mIsHidden = !siteModel.isVisible();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -6,6 +6,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.support.annotation.LayoutRes;
+import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -212,8 +213,9 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         notifyDataSetChanged();
     }
 
+    @NonNull
     @Override
-    public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         if (viewType == VIEW_TYPE_HEADER) {
             return mHeaderHandler.onCreateViewHolder(mInflater, parent, false);
         } else {
@@ -223,7 +225,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     @Override
-    public void onBindViewHolder(final RecyclerView.ViewHolder viewHolder, int position) {
+    public void onBindViewHolder(@NonNull final RecyclerView.ViewHolder viewHolder, int position) {
         int viewType = getItemViewType(position);
 
         if (viewType == VIEW_TYPE_HEADER) {


### PR DESCRIPTION
### Fix
Add a few enhancements to the classes associated with the ***Switch Site*** screen as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8224 and https://github.com/wordpress-mobile/WordPress-Android/pull/8322.  The changes include:
 - update `enableSearchMode()` to use `invalidateOptionsMenu()` for consistency
 - move member variable initializations from `onPrepareOptionsMenu` to `onCreateOptionsMenu` to minimize `menu.findItem(int id)` calls
 - remove redundant variables for optimization
 - remove redundant view casts for simplicity
 - add method and parameter annotation for completeness
 - update deprecated methods for future compatibility
 - remove unused variable for simplicity

### Test
No functional changes are included in this pull request.  The steps below are listed to confirm the current behavior is maintained.
#### Search
0. Use account with multiple sites.
1. Go to ***My Site*** tab.
2. Tap ***Switch Site*** button in top card view.
3. Notice ***Search***, ***Add new site***, and ***Show/hide sites*** actions are shown.
4. Tap ***Search*** action in top toolbar.
5. Notice ***Search***, ***Add new site***, and ***Show/hide sites*** actions are hidden.
6. Tap back arrow in top toolbar.
7. Notice ***Search***, ***Add new site***, and ***Show/hide sites*** actions are shown.

#### Selection
0. Use account with multiple sites and first alphabetical site hidden.
1. Go to ***My Site*** tab.
2. Tap ***Switch Site*** button in top card view.
3. Notice active site is selected.
4. Long-press next site in list (below divider if present).
5. Notice no sites are selected.
6. Notice top toolbar title shows ***0 selected***.
7. Tap any site.
8. Notice top toolbar title shows ***1 selected***.

### Review
Only one developer is required to review these changes, but anyone can perform the review.