### PR TITLE
Fix News Card not shown when initial list is empty

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1539,7 +1539,7 @@ public class ReaderPostListFragment extends Fragment
 
     private final NewsCardListener mNewsCardListener = new NewsCardListener() {
         @Override public void onItemShown(@NotNull NewsItem item) {
-            mViewModel.onNewsCardShown(item);
+            mViewModel.onNewsCardShown(item, getCurrentTag());
         }
 
         @Override public void onItemClicked(@NotNull NewsItem item) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -50,7 +50,7 @@ class ReaderPostListViewModel @Inject constructor(
         newsTrackerHelper.reset()
         tag?.let { newTag ->
             // show the card only when the initial tag is selected in the filter
-            if (initialTag== null || newTag == initialTag) {
+            if (initialTag == null || newTag == initialTag) {
                 _newsItemSourceMediator.addSource(newsItemSource, onTagChanged)
             } else {
                 _newsItemSourceMediator.removeSource(newsItemSource)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -23,17 +23,19 @@ class ReaderPostListViewModel @Inject constructor(
     private val onTagChanged: Observer<NewsItem?> = Observer { it: NewsItem? -> _newsItemSourceMediator.value = it }
 
     /**
-     * News Card shouldn't be shown when the initialTag is null. InitialTag may be null for Blog previews for instance.
+     * First tag for which the card was shown.
      */
     private var initialTag: ReaderTag? = null
     private var isStarted = false
 
+    /**
+     * Tag may be null for Blog previews for instance.
+     */
     fun start(tag: ReaderTag?) {
         if (isStarted) {
             return
         }
         tag?.let {
-            initialTag = tag
             onTagChanged(tag)
             newsManager.pull()
         }
@@ -46,9 +48,9 @@ class ReaderPostListViewModel @Inject constructor(
 
     fun onTagChanged(tag: ReaderTag?) {
         newsTrackerHelper.reset()
-        initialTag?.let { initialTag ->
+        tag?.let { newTag ->
             // show the card only when the initial tag is selected in the filter
-            if (tag == initialTag) {
+            if (initialTag== null || newTag == initialTag) {
                 _newsItemSourceMediator.addSource(newsItemSource, onTagChanged)
             } else {
                 _newsItemSourceMediator.removeSource(newsItemSource)
@@ -62,7 +64,11 @@ class ReaderPostListViewModel @Inject constructor(
         newsManager.dismiss(item)
     }
 
-    fun onNewsCardShown(item: NewsItem) {
+    fun onNewsCardShown(
+        item: NewsItem,
+        currentTag: ReaderTag
+    ) {
+        initialTag = currentTag
         if (newsTrackerHelper.shouldTrackNewsCardShown(item.version)) {
             newsTracker.trackNewsCardShown(READER, item.version)
             newsTrackerHelper.itemTracked(item.version)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -105,7 +105,6 @@ class PagesViewModel
             }
         }
 
-
     private val _showSnackbarMessage = SingleLiveEvent<SnackbarMessageHolder>()
     val showSnackbarMessage: LiveData<SnackbarMessageHolder> = _showSnackbarMessage
 


### PR DESCRIPTION
Fixes #8219 

This PR fixes a bug -> the News Card is not shown when the first selected filter in the Reader doesn't contain any items. After the fix, the News Card is shown in first non-empty list of the reader.

To test:
- you'll need to manually set the version to 1 in LocalNewsItem.kt otherwise the card will never be shown.

- The card is displayed only on the first filter of the reader (when the user starts the app and first filter is Followed Sites for instance, the card should not be visible on other filters. However, if the user changes the filter to Discovery for instance and restarts the app, the card should be displayed on Discovery and should not be displayed on Followed Sites.)
+ when the first filter doesn't contain any items, the card is shown on the first filter which contains items

1. Follow a site
2. Click on My Site section in the bottom navigation bar
4. Restart the app
5. Notice an orange dot on the Reader icon
6. Open Reader
7. Notice the News Card is shown and the orange dot disappears

------------------
1. Change filter to Saved Posts
2. Make sure you don't have any saved posts
3. Restart the app
4. Notice the News Card is not shown in the empty list
5. Change filter to Discovery
6. Notice the News Card is shown
7. Change filter to Followed Sites
8. Notice the News Card is not shown
9. Change filter back to Discovery and notice the card is shown there