### PR TITLE
Fix crash when showing a dialog on Google signup/login error

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -756,13 +756,18 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
 
     @Override
     public void onGoogleSignupError(String msg) {
-        BasicFragmentDialog dialog = new BasicFragmentDialog();
-        dialog.initialize(GOOGLE_ERROR_DIALOG_TAG, getString(R.string.error),
-                msg,
-                getString(org.wordpress.android.login.R.string.login_error_button),
-                null,
-                null);
-        dialog.show(this.getSupportFragmentManager(), GOOGLE_ERROR_DIALOG_TAG);
+        // allow state loss
+        if (!getSupportFragmentManager().isStateSaved()) {
+            BasicFragmentDialog dialog = new BasicFragmentDialog();
+            dialog.initialize(GOOGLE_ERROR_DIALOG_TAG, getString(R.string.error),
+                    msg,
+                    getString(org.wordpress.android.login.R.string.login_error_button),
+                    null,
+                    null);
+            dialog.show(getSupportFragmentManager(), GOOGLE_ERROR_DIALOG_TAG);
+        } else {
+            AppLog.d(T.MAIN, "'Google sign up failed' dialog not shown, because the activity wasn't visible.");
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -756,7 +756,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
 
     @Override
     public void onGoogleSignupError(String msg) {
-        // allow state loss
+        // Only show the error dialog if the activity is still active
         if (!getSupportFragmentManager().isStateSaved()) {
             BasicFragmentDialog dialog = new BasicFragmentDialog();
             dialog.initialize(GOOGLE_ERROR_DIALOG_TAG, getString(R.string.error),


### PR DESCRIPTION
Fixes #8360 

This PR fixes an occasional crash when the `FragmentDialog.show()` method is invoked after the activity's state has already been saved.

Steps to reproduce the crash are unknown.

```

android.support.v4.app.FragmentManagerImpl.checkStateLoss (FragmentManager.java:2053)
--
  | android.support.v4.app.DialogFragment.show (DialogFragment.java:143)
  | org.wordpress.android.ui.accounts.LoginActivity.onGoogleSignupError (LoginActivity.java:765)
  | org.wordpress.android.login.GoogleFragment.showError (GoogleFragment.java:225)
  | org.wordpress.android.login.LoginGoogleFragment.onSocialChanged (LoginGoogleFragment.java:192)
  | java.lang.reflect.Method.invoke (Method.java)
  | java.lang.reflect.Method.invoke (Method.java:372)
  | org.greenrobot.eventbus.EventBus.invokeSubscriber (EventBus.java:485)
  | org.greenrobot.eventbus.EventBus.invokeSubscriber (EventBus.java:479)
  | org.greenrobot.eventbus.HandlerPoster.handleMessage (HandlerPoster.java:67)
```
