### PR TITLE
Fix missing site crash in ActivityLogListActivity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -297,6 +297,10 @@ public class ActivityLauncher {
     }
 
     public static void viewActivityLogList(Activity activity, SiteModel site) {
+        if (site == null) {
+            ToastUtils.showToast(activity, R.string.blog_not_found, ToastUtils.Duration.SHORT);
+            return;
+        }
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.ACTIVITY_LOG_LIST_OPENED, site);
         Intent intent = new Intent(activity, ActivityLogListActivity.class);
         intent.putExtra(WordPress.SITE, site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -39,22 +39,25 @@ class ActivityLogListFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        log_list_view.layoutManager = LinearLayoutManager(activity, LinearLayoutManager.VERTICAL, false)
+        val nonNullActivity = checkNotNull(activity)
+
+        log_list_view.layoutManager = LinearLayoutManager(nonNullActivity, LinearLayoutManager.VERTICAL, false)
 
         swipeToRefreshHelper = buildSwipeToRefreshHelper(swipe_refresh_layout) {
-            if (NetworkUtils.checkConnection(activity)) {
+            if (NetworkUtils.checkConnection(nonNullActivity)) {
                 viewModel.onPullToRefresh()
             } else {
                 swipeToRefreshHelper.isRefreshing = false
             }
         }
 
-        (activity?.application as WordPress).component()?.inject(this)
+        (nonNullActivity.application as WordPress).component()?.inject(this)
 
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(ActivityLogViewModel::class.java)
 
         val site = if (savedInstanceState == null) {
-            activity?.intent?.getSerializableExtra(WordPress.SITE) as SiteModel
+            val nonNullIntent = checkNotNull(nonNullActivity.intent)
+            nonNullIntent.getSerializableExtra(WordPress.SITE) as SiteModel
         } else {
             savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
         }


### PR DESCRIPTION
Issue: #8363

I couldn't reproduce the crash but it was caused by either activity, intent or an extra `SiteModel` in the intent missing. I'm adding a check and logging to the point where we're creating the Intent, and splitting the checks in the `ActivityLogListFragment` to see what's actually missing. The crash is minor and happening only on emulators. 