### PR TITLE
Start pages vm when it was killed in background

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -186,11 +186,10 @@ class PagesFragment : Fragment() {
 
         setupObservers(activity)
 
-        if (isFirstStart) {
-            val site = activity.intent?.getSerializableExtra(WordPress.SITE) as SiteModel?
-            val nonNullSite = checkNotNull(site)
-            viewModel.start(nonNullSite)
-        } else {
+        val site = activity.intent?.getSerializableExtra(WordPress.SITE) as SiteModel?
+        val nonNullSite = checkNotNull(site)
+        viewModel.start(nonNullSite)
+        if (!isFirstStart) {
             restorePreviousSearch = true
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -109,7 +109,7 @@ class PagesViewModel
 
     private var _site: SiteModel? = null
     val site: SiteModel
-        get() = checkNotNull(_site) {"Trying to access unitialized site"}
+        get() = checkNotNull(_site) { "Trying to access unitialized site" }
 
     private var _arePageActionsEnabled = true
     val arePageActionsEnabled: Boolean
@@ -351,7 +351,8 @@ class PagesViewModel
 
                 delay(100)
                 _showSnackbarMessage.postValue(
-                        SnackbarMessageHolder(string.page_parent_changed, string.undo, action.undo))
+                        SnackbarMessageHolder(string.page_parent_changed, string.undo, action.undo)
+                )
             }
         }
         action.onError = {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -107,9 +107,9 @@ class PagesViewModel
     private val _showSnackbarMessage = SingleLiveEvent<SnackbarMessageHolder>()
     val showSnackbarMessage: LiveData<SnackbarMessageHolder> = _showSnackbarMessage
 
-    private lateinit var _site: SiteModel
+    private var _site: SiteModel? = null
     val site: SiteModel
-        get() = _site
+        get() = checkNotNull(_site) {"Trying to access unitialized site"}
 
     private var _arePageActionsEnabled = true
     val arePageActionsEnabled: Boolean
@@ -128,9 +128,12 @@ class PagesViewModel
     }
 
     fun start(site: SiteModel) {
-        _site = site
+        // Check if VM is not already initialized
+        if (_site == null) {
+            _site = site
 
-        loadPagesAsync()
+            loadPagesAsync()
+        }
     }
 
     init {


### PR DESCRIPTION
Fixes #8364

ViewModel and Fragment/Activity life-cycle are not the same. In this case when the Activity/Fragment is killed, the VM is cleared and is rebuild later. However, the Fragment has the `savedInstanceState` from the previous launch. We need to reinitialise the `ViewModel` in this case. 

To test:
* Turn "Don't keep activities" on in developer settings
* Go to "Site pages"
* Click on "Create a new page FAB"
* Go back