### PR TITLE
Issue/8337 editor menu history

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1012,7 +1012,8 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         if (historyMenuItem != null) {
-            historyMenuItem.setVisible(BuildConfig.REVISIONS_ENABLED);
+            boolean hasHistory = mSite.isWPCom() || mSite.isJetpackConnected();
+            historyMenuItem.setVisible(BuildConfig.REVISIONS_ENABLED && showMenuItems && hasHistory);
         }
 
         if (previewMenuItem != null) {


### PR DESCRIPTION
### Fix
Add a ***History*** item to the editor in the overflow menu when revisions exist for the opened page/post as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8338.  In order to have revisions, the site must be either WordPress.com or self-hosted with Jetpack connected.

#### Note
The same self-hosted site can be used while testing connected and disconnected states, but the site settings must be refreshed after connecting or disconnecting a WordPress.com account by going to ***My Site*** > ***Switch Site*** and refreshing the site list.

### Test
#### WordPress.com
1. Go to ***My Site*** tab.
2. Tap ***Site Pages*** or ***Blog Posts*** from ***Publish*** section.
3. Tap page or post from list.
4. Tap overflow menu action.
5. Notice ***History*** item in menu.

#### Self-Hosted [Disconnected]
1. Go to ***My Site*** tab.
2. Tap ***Site Pages*** or ***Blog Posts*** from ***Publish*** section.
3. Tap page or post from list.
4. Tap overflow menu action.
5. Notice ***History*** item is not in menu.

#### Self-Hosted [Connected]
1. Go to ***My Site*** tab.
2. Tap ***Site Pages*** or ***Blog Posts*** from ***Publish*** section.
3. Tap page or post from list.
4. Tap overflow menu action.
5. Notice ***History*** item in menu.

### Review
Only one developer is required to review these changes, but anyone can perform the review.