### PR TITLE
Issue/add list progress

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogAdapter.kt
@@ -30,6 +30,7 @@ class ActivityLogAdapter(
             is ProgressItemViewHolder -> holder.bind(list[position] as Progress)
             is HeaderItemViewHolder -> holder.bind(list[position] as Header)
             is FooterItemViewHolder -> {}
+            is LoadingItemViewHolder -> {}
             else -> throw IllegalArgumentException("Unexpected view holder in ActivityLog")
         }
     }
@@ -60,6 +61,7 @@ class ActivityLogAdapter(
             ViewType.EVENT.id -> EventItemViewHolder(parent, itemClickListener, rewindClickListener)
             ViewType.HEADER.id -> HeaderItemViewHolder(parent)
             ViewType.FOOTER.id -> FooterItemViewHolder(parent)
+            ViewType.LOADING.id -> LoadingItemViewHolder(parent)
             else -> throw IllegalArgumentException("Unexpected view type in ActivityLog")
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -13,6 +13,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import kotlinx.android.synthetic.main.activity_log_list_fragment.*
+import kotlinx.android.synthetic.main.activity_log_list_loading_item.*
 import org.wordpress.android.R
 import org.wordpress.android.R.string
 import org.wordpress.android.WordPress
@@ -138,7 +139,7 @@ class ActivityLogListFragment : Fragment() {
         swipeToRefreshHelper.isRefreshing = eventListStatus == FETCHING
         // We want to show the progress bar at the bottom while loading more but not for initial fetch
         val showLoadMore = eventListStatus == LOADING_MORE
-        log_list_progress.visibility = if (showLoadMore) View.VISIBLE else View.GONE
+        progress?.visibility = if (showLoadMore) View.VISIBLE else View.GONE
     }
 
     private fun reloadEvents(data: List<ActivityLogListItem>) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Icon.HISTOR
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.EVENT
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.FOOTER
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.HEADER
+import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.LOADING
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.PROGRESS
 import java.text.DateFormat
 import java.util.Date
@@ -60,11 +61,14 @@ sealed class ActivityLogListItem(val type: ViewType) {
 
     object Footer : ActivityLogListItem(FOOTER)
 
+    object Loading : ActivityLogListItem(LOADING)
+
     enum class ViewType(val id: Int) {
         EVENT(0),
         PROGRESS(1),
         HEADER(2),
-        FOOTER(3)
+        FOOTER(3),
+        LOADING(4)
     }
 
     enum class Status(val value: String, @DrawableRes val color: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/LoadingItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/LoadingItemViewHolder.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.ui.activitylog.list
+
+import android.view.ViewGroup
+import org.wordpress.android.R
+
+class LoadingItemViewHolder(parent: ViewGroup) : ActivityLogViewHolder(parent, R.layout.activity_log_list_loading_item)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.activitylog.list.ActivityLogListItem
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Event
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Footer
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Header
+import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Loading
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -183,6 +184,9 @@ class ActivityLogViewModel @Inject constructor(
                 items.add(ActivityLogListItem.Header(currentItem.formattedDate))
             }
             items.add(currentItem)
+        }
+        if (eventList.isNotEmpty() && !done) {
+            items.add(Loading)
         }
         if (eventList.isNotEmpty() && site.hasFreePlan && done) {
             items.add(Footer)

--- a/WordPress/src/main/res/layout/activity_log_list_fragment.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_fragment.xml
@@ -30,15 +30,4 @@
 
     </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
-    <ProgressBar
-        android:id="@+id/log_list_progress"
-        android:layout_alignParentBottom="true"
-        android:layout_centerHorizontal="true"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_extra_large"
-        android:layout_width="wrap_content"
-        android:visibility="gone"
-        tools:visibility="visible"
-        style="?android:attr/progressBarStyle" />
-
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/activity_log_list_loading_item.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_loading_item.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
+    android:minHeight="?attr/listPreferredItemHeightLarge" >
+
+    <ProgressBar
+        android:id="@+id/progress"
+        android:layout_centerInParent="true"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/margin_extra_large"
+        android:layout_width="wrap_content"
+        android:visibility="invisible"
+        tools:visibility="visible"
+        style="?android:attr/progressBarStyle" >
+    </ProgressBar>
+
+</RelativeLayout>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.ui.activitylog.list.ActivityLogListItem
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Event
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Footer
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Header
+import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Loading
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus
 import java.util.Calendar
@@ -147,7 +148,7 @@ class ActivityLogViewModelTest {
 
         assertEquals(
                 viewModel.events.value,
-                expectedActivityList()
+                expectedActivityList(false, canLoadMore)
         )
 
         assertEquals(viewModel.eventListStatus.value, ActivityLogListStatus.CAN_LOAD_MORE)
@@ -198,7 +199,8 @@ class ActivityLogViewModelTest {
         assertEquals(viewModel.eventListStatus.value, ActivityLogListStatus.DONE)
     }
 
-    private fun expectedActivityList(isLastPageAndFreeSite: Boolean = false): List<ActivityLogListItem> {
+    private fun expectedActivityList(isLastPageAndFreeSite: Boolean = false, canLoadMore: Boolean = false):
+            List<ActivityLogListItem> {
         val activityLogListItems = mutableListOf<ActivityLogListItem>()
         val first = Event(activityLogList[0], true)
         val second = Event(activityLogList[1], true)
@@ -210,6 +212,9 @@ class ActivityLogViewModelTest {
         activityLogListItems.add(third)
         if (isLastPageAndFreeSite) {
             activityLogListItems.add(Footer)
+        }
+        if (canLoadMore) {
+            activityLogListItems.add(Loading)
         }
         return activityLogListItems
     }


### PR DESCRIPTION
### Fix
Add a loading view holder and type for the bottom progress spinner to the ***Activity Log***.  The current progress spinner overlaps the bottom list item view while loading more items.  Once the loading progress is finished, new list items are added to the bottom of the list off screen, which does not indicate the list can be scrolled to see the new items.  See the animation below for illustration.

![list_refresh_padding_without_small](https://user-images.githubusercontent.com/3827611/46049830-96430180-c0fe-11e8-856f-1a8b6b5ae4cb.gif)

These changes avoid the overlapping progress spinner and show new list items on screen making the scrolling more intuitive.  See the animation below for illustration.

![list_refresh_padding_with_view_small](https://user-images.githubusercontent.com/3827611/46049833-9b07b580-c0fe-11e8-8346-aaddfac9824e.gif)

### Test
#### No Activity
0. Use site with no activity.
1. Go to ***My Site*** tab.
2. Tap ***Activity*** item.
3. Notice refresh view is shown.
4. Notice empty view is shown.

#### Low Activity
0. Use site with low activity (i.e. all events fit on screen).
1. Go to ***My Site*** tab.
2. Tap ***Activity*** item.
3. Notice refresh view is shown.
4. Notice list is shown.

#### High Activity [Free Site]
0. Use free site with high activity (i.e. all events do not fit on screen).
1. Go to ***My Site*** tab.
2. Tap ***Activity*** item.
3. Notice refresh view is shown.
4. Notice list is shown.
5. Scroll to bottom of list.
6. Notice loading view is shown.
7. Notice new items are added on screen.
8. Repeat Steps 5 through 7 until all items are loaded.
9. Notice footer view is shown.

#### High Activity [Paid Site]
0. Use paid site with high activity (i.e. all events do not fit on screen).
1. Go to ***My Site*** tab.
2. Tap ***Activity*** item.
3. Notice refresh view is shown.
4. Notice list view is shown.
5. Scroll to bottom of list.
6. Notice loading view is shown.
7. Notice new items are added on screen.
8. Repeat Steps 5 through 7 until all items are loaded.
9. Notice footer view is not shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.