### PR TITLE
Hide get started bar with javascript.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
@@ -8,6 +8,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.ValueCallback;
 import android.webkit.WebView;
 import android.widget.Button;
 import android.widget.ImageView;
@@ -239,12 +240,16 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
     // Hacky solution to https://github.com/wordpress-mobile/WordPress-Android/issues/8233
     // Ideally we would hide "get started" bar on server side
     @SuppressLint("SetJavaScriptEnabled")
-    private static void hideGetStartedBar(@NonNull WebView webView) {
+    private static void hideGetStartedBar(@NonNull final WebView webView) {
         webView.getSettings().setJavaScriptEnabled(true);
         String javascript = "document.querySelector('html').style.cssText += '; margin-top: 0 !important;';\n"
                             + "document.getElementById('wpadminbar').style.display = 'none';\n";
 
-        webView.evaluateJavascript(javascript, null);
+        webView.evaluateJavascript(javascript, new ValueCallback<String>() {
+            @Override public void onReceiveValue(String value) {
+                webView.getSettings().setJavaScriptEnabled(false);
+            }
+        });
     }
 
     private void disableUntil(@IdRes int textViewId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
@@ -1,8 +1,10 @@
 package org.wordpress.android.ui.accounts.signup;
 
+import android.annotation.SuppressLint;
 import android.os.Bundle;
 import android.support.annotation.IdRes;
 import android.support.annotation.LayoutRes;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.View;
 import android.view.ViewGroup;
@@ -228,9 +230,21 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
         @Override
         public void onPageFinished(WebView view, String url) {
             super.onPageFinished(view, url);
-
+            hideGetStartedBar(view);
+            
             mIsPageFinished = true;
         }
+    }
+
+    // Hacky solution to https://github.com/wordpress-mobile/WordPress-Android/issues/8233
+    // Ideally we would hide "get started" bar on server side
+    @SuppressLint("SetJavaScriptEnabled")
+    private static void hideGetStartedBar(@NonNull WebView webView) {
+        webView.getSettings().setJavaScriptEnabled(true);
+        String javascript = "document.querySelector('html').style.cssText += '; margin-top: 0 !important;';\n"
+                            + "document.getElementById('wpadminbar').style.display = 'none';\n";
+
+        webView.evaluateJavascript(javascript, null);
     }
 
     private void disableUntil(@IdRes int textViewId) {


### PR DESCRIPTION
Fixes #8233 



Hide "Get started" bar using javascript. At least until we implement a proper server-side solution.
This PR uses same approach as [iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/10040).

[![Image from Gyazo](https://i.gyazo.com/e3d454b40d3f683d6151560dbb8a5198.png)](https://gyazo.com/e3d454b40d3f683d6151560dbb8a5198)

To test:

1. Create an account
2. Go through the site creation flow
3. Finish the process
4. The Site preview opens.
5. Make sure the "Get started" bar is not visible at the top of the preview screen.