### PR TITLE
Try to fix NPE in PostUploadHandler 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -311,6 +311,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
                 if (!mPost.getTagNameList().isEmpty()) {
                     sCurrentUploadingPostAnalyticsProperties.put("with_tags", true);
                 }
+                sCurrentUploadingPostAnalyticsProperties.put("via_new_editor", AppPrefs.isVisualEditorEnabled());
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -271,7 +271,8 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
         private void prepareUploadAnalytics(String postContent) {
             // Other methods (like 'uploadNextPost') synchronize over `sQueuedPostsList` before setting
             // `sCurrentUploadingPostAnalyticsProperties` to null. Make sure racing conditions are avoid here
-            // by synchronizing over sQueuedPostsList. See https://github.com/wordpress-mobile/WordPress-Android/issues/7990
+            // by synchronizing over sQueuedPostsList.
+            // See https://github.com/wordpress-mobile/WordPress-Android/issues/7990
             synchronized (sQueuedPostsList) {
                 // Calculate the words count
                 sCurrentUploadingPostAnalyticsProperties = new HashMap<>();

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -269,40 +269,47 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
         }
 
         private void prepareUploadAnalytics(String postContent) {
-            // Calculate the words count
-            sCurrentUploadingPostAnalyticsProperties = new HashMap<>();
-            sCurrentUploadingPostAnalyticsProperties.put("word_count", AnalyticsUtils.getWordCount(mPost.getContent()));
-            sCurrentUploadingPostAnalyticsProperties.put("editor_source", AppPrefs.isAztecEditorEnabled() ? "aztec"
-                    : AppPrefs.isVisualEditorEnabled() ? "hybrid" : "legacy");
+            // Other methods (like 'uploadNextPost') synchronize over `sQueuedPostsList` before setting
+            // `sCurrentUploadingPostAnalyticsProperties` to null. Make sure racing conditions are avoid here
+            // by synchronizing over sQueuedPostsList. See https://github.com/wordpress-mobile/WordPress-Android/issues/7990
+            synchronized (sQueuedPostsList) {
+                // Calculate the words count
+                sCurrentUploadingPostAnalyticsProperties = new HashMap<>();
+                sCurrentUploadingPostAnalyticsProperties
+                        .put("word_count", AnalyticsUtils.getWordCount(mPost.getContent()));
+                sCurrentUploadingPostAnalyticsProperties.put("editor_source", AppPrefs.isAztecEditorEnabled() ? "aztec"
+                        : AppPrefs.isVisualEditorEnabled() ? "hybrid" : "legacy");
 
-            if (hasGallery()) {
-                sCurrentUploadingPostAnalyticsProperties.put("with_galleries", true);
-            }
-            if (!mHasImage) {
-                // Check if there is a img tag in the post. Media added in any editor other than legacy.
-                String imageTagsPattern = "<img[^>]+src\\s*=\\s*[\"]([^\"]+)[\"][^>]*>";
-                Pattern pattern = Pattern.compile(imageTagsPattern);
-                Matcher matcher = pattern.matcher(postContent);
-                mHasImage = matcher.find();
-            }
-            if (mHasImage) {
-                sCurrentUploadingPostAnalyticsProperties.put("with_photos", true);
-            }
-            if (!mHasVideo) {
-                // Check if there is a video tag in the post. Media added in any editor other than legacy.
-                String videoTagsPattern = "<video[^>]+src\\s*=\\s*[\"]([^\"]+)[\"][^>]*>|\\[wpvideo\\s+([^\\]]+)\\]";
-                Pattern pattern = Pattern.compile(videoTagsPattern);
-                Matcher matcher = pattern.matcher(postContent);
-                mHasVideo = matcher.find();
-            }
-            if (mHasVideo) {
-                sCurrentUploadingPostAnalyticsProperties.put("with_videos", true);
-            }
-            if (mHasCategory) {
-                sCurrentUploadingPostAnalyticsProperties.put("with_categories", true);
-            }
-            if (!mPost.getTagNameList().isEmpty()) {
-                sCurrentUploadingPostAnalyticsProperties.put("with_tags", true);
+                if (hasGallery()) {
+                    sCurrentUploadingPostAnalyticsProperties.put("with_galleries", true);
+                }
+                if (!mHasImage) {
+                    // Check if there is a img tag in the post. Media added in any editor other than legacy.
+                    String imageTagsPattern = "<img[^>]+src\\s*=\\s*[\"]([^\"]+)[\"][^>]*>";
+                    Pattern pattern = Pattern.compile(imageTagsPattern);
+                    Matcher matcher = pattern.matcher(postContent);
+                    mHasImage = matcher.find();
+                }
+                if (mHasImage) {
+                    sCurrentUploadingPostAnalyticsProperties.put("with_photos", true);
+                }
+                if (!mHasVideo) {
+                    // Check if there is a video tag in the post. Media added in any editor other than legacy.
+                    String videoTagsPattern =
+                            "<video[^>]+src\\s*=\\s*[\"]([^\"]+)[\"][^>]*>|\\[wpvideo\\s+([^\\]]+)\\]";
+                    Pattern pattern = Pattern.compile(videoTagsPattern);
+                    Matcher matcher = pattern.matcher(postContent);
+                    mHasVideo = matcher.find();
+                }
+                if (mHasVideo) {
+                    sCurrentUploadingPostAnalyticsProperties.put("with_videos", true);
+                }
+                if (mHasCategory) {
+                    sCurrentUploadingPostAnalyticsProperties.put("with_categories", true);
+                }
+                if (!mPost.getTagNameList().isEmpty()) {
+                    sCurrentUploadingPostAnalyticsProperties.put("with_tags", true);
+                }
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -304,7 +304,6 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
             if (!mPost.getTagNameList().isEmpty()) {
                 sCurrentUploadingPostAnalyticsProperties.put("with_tags", true);
             }
-            sCurrentUploadingPostAnalyticsProperties.put("via_new_editor", AppPrefs.isVisualEditorEnabled());
         }
 
         /**


### PR DESCRIPTION
Fixes #7990 by synchronizing over `sQueuedPostsList` before setting/preparing `sCurrentUploadingPostAnalyticsProperties` map with properties about the post.

I noticed that in other parts of the code we're synchronizing over `sQueuedPostsList` before making changes to the 3 static variables `sQueuedPostsList, sCurrentUploadingPost, sCurrentUploadingPostAnalyticsProperties`. Instead in `prepareUploadAnalytics`, where does the crash happen, we're not sync over `sQueuedPostsList`.
In theory the code added in this PR isn't necessary, but for some reason the NPE is happening so I decided to add this synch guard, and prevent other NPE. Also tried to reproduce the problem, and checked for potential racing conditions, but had no luck with both of them.

cc @mzorz 
