### PR TITLE
Issue/8133 storage permision for camera

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -221,7 +221,7 @@ public class PhotoPickerFragment extends Fragment {
 
         if (icon == PhotoPickerIcon.ANDROID_CAPTURE_PHOTO || icon == PhotoPickerIcon.ANDROID_CAPTURE_VIDEO) {
             if (ContextCompat.checkSelfPermission(
-                    getActivity(), permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+                    getActivity(), permission.CAMERA) != PackageManager.PERMISSION_GRANTED || !hasStoragePermission()) {
                 requestCameraPermission();
                 return;
             }
@@ -506,9 +506,9 @@ public class PhotoPickerFragment extends Fragment {
     }
 
     private void requestCameraPermission() {
-        String[] permissions = new String[]{permission.CAMERA};
-        requestPermissions(
-                permissions, WPPermissionUtils.PHOTO_PICKER_CAMERA_PERMISSION_REQUEST_CODE);
+        // in addition to CAMERA permission we also need a storage permission, to store media from the camera
+        String[] permissions = new String[]{permission.CAMERA, permission.WRITE_EXTERNAL_STORAGE};
+        requestPermissions(permissions, WPPermissionUtils.PHOTO_PICKER_CAMERA_PERMISSION_REQUEST_CODE);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1062,6 +1062,7 @@ public class EditPostActivity extends AppCompatActivity implements
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         boolean allGranted = WPPermissionUtils.setPermissionListAsked(
                 this, requestCode, permissions, grantResults, true);
 


### PR DESCRIPTION
Hopefully Fixes #8133

We cant use media from the camera without `WRITE_EXTERNAL_STORAGE` permission. This PR addresses this by asking for the storage permission when the user tries to use a camera without it.

This PR also addresses a crash when you try to add a video from the camera to the post, without having external storage permissions first.

To test:

1. Do a fresh install of the app, or make sure the app has no Storage and Camera permissions.
2. Open Editor and Media Toolbar.
3. Tap on the Camera icon.
4. Select "Take video" option.
5. Grant requested permissions.
6. Record a video and press OK (or whatever in the camera app).
7. Notice the video is added to the post, and the app is not crashing.
