### PR TITLE
Fix new site flow and set the correct language ID

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
@@ -36,6 +36,7 @@ import org.wordpress.android.util.AutoForeground;
 import org.wordpress.android.util.AutoForegroundNotification;
 import org.wordpress.android.util.CrashlyticsUtils;
 import org.wordpress.android.util.LanguageUtils;
+import org.wordpress.android.util.LocaleManager;
 
 import java.util.Map;
 
@@ -379,12 +380,34 @@ public class SiteCreationService extends AutoForeground<SiteCreationState> {
     }
 
     private void createNewSite(String siteTitle, String siteSlug) {
-        final String language = LanguageUtils.getPatchedCurrentDeviceLanguage(this);
+        final String deviceLanguageCode = LanguageUtils.getPatchedCurrentDeviceLanguage(this);
+        /* Convert the device language code (codes defined by ISO 639-1) to a Language ID.
+         * Language IDs, used only by WordPress, are integer values that map to a language code.
+         * http://bit.ly/2H7gksN
+         */
+        Map<String, String> languageCodeToID = LocaleManager.generateLanguageMap(this);
+        String langID = null;
+        if (languageCodeToID.containsKey(deviceLanguageCode)) {
+            langID = languageCodeToID.get(deviceLanguageCode);
+        } else {
+            int pos = deviceLanguageCode.indexOf("_");
+            if (pos > -1) {
+                String newLang = deviceLanguageCode.substring(0, pos);
+                if (languageCodeToID.containsKey(newLang)){
+                    langID = languageCodeToID.get(newLang);
+                }
+            }
+        }
+
+        if (langID == null) {
+            // fallback to device language code if there is no match
+            langID = deviceLanguageCode;
+        }
 
         NewSitePayload newSitePayload = new NewSitePayload(
                 siteSlug,
                 siteTitle,
-                language,
+                langID,
                 SiteStore.SiteVisibility.PUBLIC,
                 false);
         mDispatcher.dispatch(SiteActionBuilder.newCreateNewSiteAction(newSitePayload));

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
@@ -393,7 +393,7 @@ public class SiteCreationService extends AutoForeground<SiteCreationState> {
             int pos = deviceLanguageCode.indexOf("_");
             if (pos > -1) {
                 String newLang = deviceLanguageCode.substring(0, pos);
-                if (languageCodeToID.containsKey(newLang)){
+                if (languageCodeToID.containsKey(newLang)) {
                     langID = languageCodeToID.get(newLang);
                 }
             }


### PR DESCRIPTION
Fixes #8379 by setting the correct wpcom langID to the REST API call that does create the new site.

Previously we were passing the ISO 639-1 language code to the REST Endpoint, but it was expecting an internal wpcom language ID.

To test:
1. Set your device to a non-English language.
2. Open the app (log out if needed, to start on the login/signup screen). Or just add a new blog on your current account.
3. [Signup if needed] Create a new site.
5. Check the site languages by opening it in a browser.