### PR TITLE
Move to My Sites screen when new post button is pressed on account with no sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -575,7 +575,7 @@ public class WPMainActivity extends AppCompatActivity implements
     // user tapped the new post button in the bottom navbar
     @Override
     public void onNewPostButtonClicked() {
-        if (mSiteStore.getSites().size() == 0) {
+        if (!mSiteStore.hasSite()) {
             // No site yet - Move to My Sites fragment that shows the create new site screen
             mBottomNav.setCurrentPosition(PAGE_MY_SITE);
             return;


### PR DESCRIPTION
I've noticed that on an account with no sites the new post button in bottom bar does nothing when pressed.

With this PR pressing the button moves to user to the My Sites tab. (My Sites screen, when no sites are available in the app, does show the "add site" UI and enable the user to create the first site).

![new-sites](https://user-images.githubusercontent.com/518232/46410025-bdf62300-c717-11e8-82bd-bb1aea76af05.gif)