### PR TITLE
Fix bottom navigation button that does not tint icon when selected on API 21

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -12,7 +12,6 @@ import android.support.design.widget.BottomNavigationView.OnNavigationItemResele
 import android.support.design.widget.BottomNavigationView.OnNavigationItemSelectedListener
 import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentManager
-import android.support.v4.content.ContextCompat
 import android.util.AttributeSet
 import android.util.SparseArray
 import android.view.LayoutInflater
@@ -224,14 +223,8 @@ class WPMainNavigationView @JvmOverloads constructor(
         }
     }
 
-    /*
-     * ideally we'd use a color selector to tint the icon based on its selected state, but prior to
-     * API 21 setting a color selector via XML will crash the app, and setting it programmatically
-     * will have no effect
-     */
     private fun setImageViewSelected(position: Int, isSelected: Boolean) {
-        val color = ContextCompat.getColor(context, if (isSelected) R.color.blue_medium else R.color.grey_lighten_10)
-        getImageViewForPosition(position)?.setColorFilter(color, android.graphics.PorterDuff.Mode.MULTIPLY)
+        getImageViewForPosition(position)?.isSelected = isSelected
     }
 
     @DrawableRes

--- a/WordPress/src/main/res/drawable/nav_bar_button_selector.xml
+++ b/WordPress/src/main/res/drawable/nav_bar_button_selector.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:color="@color/blue_medium" android:state_selected="true"/>
+    <item android:color="@color/grey_lighten_10"/>
+
+</selector>

--- a/WordPress/src/main/res/layout/navbar_item.xml
+++ b/WordPress/src/main/res/layout/navbar_item.xml
@@ -18,7 +18,7 @@
             android:layout_height="24dp"
             android:layout_gravity="center"
             android:contentDescription="@string/tabbar_accessibility_label_my_site"
-            android:tint="@color/grey_lighten_10"
+            android:tint="@drawable/nav_bar_button_selector"
             tools:srcCompat="@drawable/ic_create_white_24dp"/>
 
         <View


### PR DESCRIPTION
Fixes #8370 by using a `selector` when setting the button tint property.
The fix was easy thanks to the recent `minSDK=21` upgrade  - prior to API 21 setting a color selector via XML will crash the app, and setting it programmatically will have no effect.

**To test:**
- Use device running API 21.
- Go to My Site tab.
- Notice icon is *tinted*.
- Go to Reader tab.
- Notice icon is tinted.
- Go to Me tab.
- Notice icon is tinted.
- Go to Notifications tab.
- Notice icon is tinted.


**Tested on**
- API 21 (Emulator)
- API 22 (Emulator)
- API 23 (Emulator)
- API 25 (Emulator)
- API 26 (Samsung S9)
- API 27 (Nexus 5X)

Huge thanks to @nbradbury for the code 🥇 
