### PR TITLE
Fix crash - recycled bitmap is being reused in Aztec

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -650,7 +650,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override protected void onStop() {
         super.onStop();
-        if (mAztecImageLoader != null) {
+        if (mAztecImageLoader != null && isFinishing()) {
             mAztecImageLoader.clearTargets();
             mAztecImageLoader = null;
         }


### PR DESCRIPTION
Fixes #8387

It seems that the new AztecImageLoader based on Glide has introduced a spike of RuntimeExceptions in AztecMediaSpan.draw - Internal ref: 5a2735cd61b02d480df3abcc.

The issue is we recycle all bitmaps in the editor as soon as the onStop method is called. However, when the app goes to background and back to foreground the app crashes as the View haven't been destroyed and the app tries to reuse the recycled bitmaps. I've added a check to the onStop method to make sure we recycle the bitmaps only when the Activity/View is about to be destroyed.

To test:

1. Start the app and go to posts list
2. Tap on Edit for a post that contains lot of pictures
3. Once the editor is on the screen and the placeholders visible
4. Rotate the device landscape
5. (Wait a bit)
6. Rotate the device portrait
7. Tap home screen
8. Wait a couple of secs
9. Re-open the app - notice it doesn't
