### PR TITLE
Using lowercase locale when building notification links.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateLogic.java
@@ -20,6 +20,7 @@ import org.wordpress.android.util.AppLog;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import de.greenrobot.event.EventBus;
@@ -51,7 +52,7 @@ public class NotificationsUpdateLogic {
         params.put("num_note_items", "20");
         params.put("fields", RestClientUtils.NOTIFICATION_FIELDS);
         if (!TextUtils.isEmpty(mLocale)) {
-            params.put("locale", mLocale.toLowerCase());
+            params.put("locale", mLocale.toLowerCase(Locale.ENGLISH));
         }
         RestListener listener = new RestListener();
         WordPress.getRestClientUtilsV1_1().getNotifications(params, listener, listener);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateLogic.java
@@ -51,7 +51,7 @@ public class NotificationsUpdateLogic {
         params.put("num_note_items", "20");
         params.put("fields", RestClientUtils.NOTIFICATION_FIELDS);
         if (!TextUtils.isEmpty(mLocale)) {
-            params.put("locale", mLocale);
+            params.put("locale", mLocale.toLowerCase());
         }
         RestListener listener = new RestListener();
         WordPress.getRestClientUtilsV1_1().getNotifications(params, listener, listener);


### PR DESCRIPTION
Fixes #8220 

When building notification links, we are using a locale with country code, like `en_US`
For some reason, the uppercase `US` screws up with the redirect URL, so by converting it to lower case we can fix the first part of the issue.

Disabling erroneously enabled mobile theme for some of the support sites (like french one) fixed second part of the issue.

To test 1:
With device set to English navigate to "Welcome notification" and press on "support documentation" link.
![02_welcome-notif](https://user-images.githubusercontent.com/9613966/44487229-becd6c80-a623-11e8-8eb5-5c78d772518a.png)

Confirm that support page is correctly opened.

To test 2:
With device set to French, perform same steps as in the first test, and make sure that correct french support page is opened.



