### PR TITLE
Issue/8234 use width height attributes for image size slider

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -898,9 +898,9 @@ public class MediaSettingsActivity extends AppCompatActivity
             boolean linkTargetBlank = mLinkTargetNewWindowView.isChecked();
             boolean hasSizeChanged = !StringUtils.equals(mEditorImageMetaData.getSize(), size);
 
-            boolean hasChanged = !StringUtils.equals(mEditorImageMetaData.getTitle(), thisTitle)
+            boolean hasChanged = hasSizeChanged
+                                 || !StringUtils.equals(mEditorImageMetaData.getTitle(), thisTitle)
                                  || !StringUtils.equals(mEditorImageMetaData.getAlt(), thisAltText)
-                                 || hasSizeChanged
                                  || !StringUtils.equals(mEditorImageMetaData.getCaption(), thisCaption)
                                  || !StringUtils.equals(mEditorImageMetaData.getAlign(), alignment)
                                  || !StringUtils.equals(mEditorImageMetaData.getLinkUrl(), linkUrl)
@@ -915,8 +915,7 @@ public class MediaSettingsActivity extends AppCompatActivity
                 mEditorImageMetaData.setLinkUrl(linkUrl);
                 mEditorImageMetaData.setLinkTargetBlank(linkTargetBlank);
 
-                // size affects multiple attributes, so we want to make sure we updated them it only if they
-                // were changed
+                // size affects multiple attributes, so we want to make sure we updated them only if they were changed
                 if (hasSizeChanged) {
                     updateImageSizeParameters();
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -20,6 +20,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.support.annotation.DrawableRes;
+import android.support.annotation.IntegerRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
@@ -1127,7 +1128,7 @@ public class MediaSettingsActivity extends AppCompatActivity
         private final int mCssClass;
         private final int mSize;
 
-        MediaSettingsImageSize(@StringRes int label, @StringRes int cssClass, int size) {
+        MediaSettingsImageSize(@StringRes int label, @StringRes int cssClass, @IntegerRes int size) {
             mLabel = label;
             mCssClass = cssClass;
             mSize = size;
@@ -1137,16 +1138,13 @@ public class MediaSettingsActivity extends AppCompatActivity
             return mSize;
         }
 
-        @StringRes
         public int getLabel() {
             return mLabel;
         }
 
-        @StringRes
         public int getCssClass() {
             return mCssClass;
         }
-
 
         public static MediaSettingsImageSize fromCssClass(Context context, String cssClass) {
             for (MediaSettingsImageSize mediaSettingsImageSize : values()) {

--- a/WordPress/src/main/res/values/integers.xml
+++ b/WordPress/src/main/res/values/integers.xml
@@ -28,4 +28,9 @@
     <!-- Support -->
     <integer name="max_length_support_name">50</integer>
 
+    <!-- Image Sizes -->
+    <integer name="image_size_thumbnail_px">150</integer>
+    <integer name="image_size_medium_px">300</integer>
+    <integer name="image_size_large_px">1024</integer>
+
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1255,15 +1255,15 @@
     <!-- Image Size -->
     <string name="image_size">Size</string>
 
-    <string name="size_thumbnail_label">Thumbnail</string>
-    <string name="size_medium_label">Medium</string>
-    <string name="size_large_label">Large</string>
-    <string name="size_full_label">Full Size</string>
+    <string name="image_size_thumbnail_label">Thumbnail</string>
+    <string name="image_size_medium_label">Medium</string>
+    <string name="image_size_large_label">Large</string>
+    <string name="image_size_full_label">Full Size</string>
 
-    <string name="size_thumbnail_class">size-thumbnail</string>
-    <string name="size_medium_class">size-medium</string>
-    <string name="size_large_class">size-large</string>
-    <string name="size_full_class">size-full</string>
+    <string name="image_size_thumbnail_class">size-thumbnail</string>
+    <string name="image_size_medium_class">size-medium</string>
+    <string name="image_size_large_class">size-large</string>
+    <string name="image_size_full_class">size-full</string>
 
     <!-- About View -->
     <string name="app_title">WordPress for Android</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1255,24 +1255,15 @@
     <!-- Image Size -->
     <string name="image_size">Size</string>
 
-    <string name="size_thumbnail">Thumbnail</string>
-    <string name="size_medium">Medium</string>
-    <string name="size_large">Large</string>
-    <string name="size_full">Full Size</string>
+    <string name="size_thumbnail_label">Thumbnail</string>
+    <string name="size_medium_label">Medium</string>
+    <string name="size_large_label">Large</string>
+    <string name="size_full_label">Full Size</string>
 
-    <string-array name="image_size_key_array" translatable="false">
-        <item>size-thumbnail</item>
-        <item>size-medium</item>
-        <item>size-large</item>
-        <item>size-full</item>
-    </string-array>
-
-    <string-array name="image_size_label_array" translatable="false">
-        <item>@string/size_thumbnail</item>
-        <item>@string/size_medium</item>
-        <item>@string/size_large</item>
-        <item>@string/size_full</item>
-    </string-array>
+    <string name="size_thumbnail_class">size-thumbnail</string>
+    <string name="size_medium_class">size-medium</string>
+    <string name="size_large_class">size-large</string>
+    <string name="size_full_class">size-full</string>
 
     <!-- About View -->
     <string name="app_title">WordPress for Android</string>

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1796,13 +1796,13 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
                     if (!TextUtils.isEmpty(metaData.getWidth())) {
                         attributes.setValue(ATTR_DIMEN_WIDTH, metaData.getWidth());
-                    } else{
+                    } else {
                         attributes.removeAttribute(ATTR_DIMEN_WIDTH);
                     }
 
                     if (!TextUtils.isEmpty(metaData.getHeight())) {
                         attributes.setValue(ATTR_DIMEN_HEIGHT, metaData.getHeight());
-                    } else{
+                    } else {
                         attributes.removeAttribute(ATTR_DIMEN_HEIGHT);
                     }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1794,8 +1794,17 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                         attributes.removeAttribute(ATTR_ALT);
                     }
 
-                    attributes.setValue(ATTR_DIMEN_WIDTH, metaData.getWidth());
-                    attributes.setValue(ATTR_DIMEN_HEIGHT, metaData.getHeight());
+                    if (!TextUtils.isEmpty(metaData.getWidth())) {
+                        attributes.setValue(ATTR_DIMEN_WIDTH, metaData.getWidth());
+                    } else{
+                        attributes.removeAttribute(ATTR_DIMEN_WIDTH);
+                    }
+
+                    if (!TextUtils.isEmpty(metaData.getHeight())) {
+                        attributes.setValue(ATTR_DIMEN_HEIGHT, metaData.getHeight());
+                    } else{
+                        attributes.removeAttribute(ATTR_DIMEN_HEIGHT);
+                    }
 
                     if (!TextUtils.isEmpty(metaData.getLinkUrl())) {
                         AztecAttributes linkAttributes =


### PR DESCRIPTION
Fixes #8234 

This PR changes the behavior of the image size slider in Media Settings. Now, changing the image size will not only change it's css size attribute but also change the `width` and `height` attributes.

New `width` and `height` are calculated based on aspect ratio.