### PR TITLE
Issue/7238 notifications filters analytics

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -56,6 +56,7 @@ import javax.inject.Inject;
 import de.greenrobot.event.EventBus;
 
 import static android.app.Activity.RESULT_OK;
+import static org.wordpress.android.analytics.AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER;
 import static org.wordpress.android.ui.JetpackConnectionSource.NOTIFICATIONS;
 import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
 
@@ -534,32 +535,39 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
             @Override
             public void run() {
                 // Filter the list according to the RadioGroup selection
-                int checkedId = mFilterRadioGroup.getCheckedRadioButtonId();
                 Map<String, String> properties = new HashMap<>(1);
-                if (checkedId == R.id.notifications_filter_all) {
-                    properties.put(AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_ALL.toString());
-                    AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
-                    mNotesAdapter.setFilter(NotesAdapter.FILTERS.FILTER_ALL);
-                } else if (checkedId == R.id.notifications_filter_unread) {
-                    properties.put(AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_UNREAD.toString());
-                    AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
-                    mNotesAdapter.setFilter(NotesAdapter.FILTERS.FILTER_UNREAD);
-                } else if (checkedId == R.id.notifications_filter_comments) {
-                    properties.put(AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_COMMENT.toString());
-                    AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
-                    mNotesAdapter.setFilter(NotesAdapter.FILTERS.FILTER_COMMENT);
-                } else if (checkedId == R.id.notifications_filter_follows) {
-                    properties.put(AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_FOLLOW.toString());
-                    AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
-                    mNotesAdapter.setFilter(NotesAdapter.FILTERS.FILTER_FOLLOW);
-                } else if (checkedId == R.id.notifications_filter_likes) {
-                    properties.put(AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_LIKE.toString());
-                    AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
-                    mNotesAdapter.setFilter(NotesAdapter.FILTERS.FILTER_LIKE);
-                } else {
-                    properties.put(AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_ALL.toString());
-                    AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
-                    mNotesAdapter.setFilter(NotesAdapter.FILTERS.FILTER_ALL);
+
+                switch (mFilterRadioGroup.getCheckedRadioButtonId()) {
+                    case R.id.notifications_filter_all:
+                        properties.put(NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_ALL.toString());
+                        AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
+                        mNotesAdapter.setFilter(FILTERS.FILTER_ALL);
+                        break;
+                    case R.id.notifications_filter_comments:
+                        properties.put(NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_COMMENT.toString());
+                        AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
+                        mNotesAdapter.setFilter(FILTERS.FILTER_COMMENT);
+                        break;
+                    case R.id.notifications_filter_follows:
+                        properties.put(NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_FOLLOW.toString());
+                        AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
+                        mNotesAdapter.setFilter(FILTERS.FILTER_FOLLOW);
+                        break;
+                    case R.id.notifications_filter_likes:
+                        properties.put(NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_LIKE.toString());
+                        AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
+                        mNotesAdapter.setFilter(FILTERS.FILTER_LIKE);
+                        break;
+                    case R.id.notifications_filter_unread:
+                        properties.put(NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_UNREAD.toString());
+                        AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
+                        mNotesAdapter.setFilter(FILTERS.FILTER_UNREAD);
+                        break;
+                    default:
+                        properties.put(NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_ALL.toString());
+                        AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
+                        mNotesAdapter.setFilter(FILTERS.FILTER_ALL);
+                        break;
                 }
 
                 restoreListScrollPosition();

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -25,6 +25,8 @@ import com.wordpress.rest.RestRequest;
 import org.json.JSONObject;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.datasets.NotificationsTable;
 import org.wordpress.android.fluxc.model.CommentStatus;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -38,12 +40,16 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.main.MainToolbarFragment;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter;
+import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS;
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter;
 import org.wordpress.android.ui.notifications.utils.NotificationsActions;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -529,17 +535,30 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
             public void run() {
                 // Filter the list according to the RadioGroup selection
                 int checkedId = mFilterRadioGroup.getCheckedRadioButtonId();
+                Map<String, String> properties = new HashMap<>(1);
                 if (checkedId == R.id.notifications_filter_all) {
+                    properties.put(AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_ALL.toString());
+                    AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
                     mNotesAdapter.setFilter(NotesAdapter.FILTERS.FILTER_ALL);
                 } else if (checkedId == R.id.notifications_filter_unread) {
+                    properties.put(AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_UNREAD.toString());
+                    AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
                     mNotesAdapter.setFilter(NotesAdapter.FILTERS.FILTER_UNREAD);
                 } else if (checkedId == R.id.notifications_filter_comments) {
+                    properties.put(AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_COMMENT.toString());
+                    AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
                     mNotesAdapter.setFilter(NotesAdapter.FILTERS.FILTER_COMMENT);
                 } else if (checkedId == R.id.notifications_filter_follows) {
+                    properties.put(AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_FOLLOW.toString());
+                    AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
                     mNotesAdapter.setFilter(NotesAdapter.FILTERS.FILTER_FOLLOW);
                 } else if (checkedId == R.id.notifications_filter_likes) {
+                    properties.put(AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_LIKE.toString());
+                    AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
                     mNotesAdapter.setFilter(NotesAdapter.FILTERS.FILTER_LIKE);
                 } else {
+                    properties.put(AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER, FILTERS.FILTER_ALL.toString());
+                    AnalyticsTracker.track(Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties);
                     mNotesAdapter.setFilter(NotesAdapter.FILTERS.FILTER_ALL);
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -47,8 +47,28 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
     @Inject protected NotificationsUtilsWrapper mNotificationsUtilsWrapper;
 
     public enum FILTERS {
-        FILTER_ALL, FILTER_LIKE, FILTER_COMMENT, FILTER_UNREAD,
-        FILTER_FOLLOW
+        FILTER_ALL,
+        FILTER_COMMENT,
+        FILTER_FOLLOW,
+        FILTER_LIKE,
+        FILTER_UNREAD;
+
+        public String toString() {
+            switch (this) {
+                case FILTER_ALL:
+                    return "all";
+                case FILTER_COMMENT:
+                    return "comment";
+                case FILTER_FOLLOW:
+                    return "follow";
+                case FILTER_LIKE:
+                    return "like";
+                case FILTER_UNREAD:
+                    return "unread";
+                default:
+                    return "all";
+            }
+        }
     }
 
     private FILTERS mCurrentFilter = FILTERS.FILTER_ALL;

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -17,6 +17,7 @@ public final class AnalyticsTracker {
     public static final String READER_DETAIL_TYPE_BLOG_PREVIEW = "preview-blog";
     public static final String READER_DETAIL_TYPE_TAG_PREVIEW = "preview-tag";
     public static final String ACTIVITY_LOG_ACTIVITY_ID_KEY = "activity_id";
+    public static final String NOTIFICATIONS_SELECTED_FILTER = "selected_filter";
 
     public enum Stat {
         APPLICATION_OPENED,
@@ -333,6 +334,7 @@ public final class AnalyticsTracker {
         NOTIFICATION_SETTINGS_DETAILS_OPENED,
         NOTIFICATION_SETTINGS_APP_NOTIFICATIONS_DISABLED,
         NOTIFICATION_SETTINGS_APP_NOTIFICATIONS_ENABLED,
+        NOTIFICATION_TAPPED_SEGMENTED_CONTROL,
         THEMES_ACCESSED_THEMES_BROWSER,
         THEMES_ACCESSED_SEARCH,
         THEMES_CHANGED_THEME,

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1009,6 +1009,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "notification_settings_app_notifications_disabled";
             case NOTIFICATION_SETTINGS_APP_NOTIFICATIONS_ENABLED:
                 return "notification_settings_app_notifications_enabled";
+            case NOTIFICATION_TAPPED_SEGMENTED_CONTROL:
+                return "notification_tapped_segmented_control";
             case ME_ACCESSED:
                 return "me_tab_accessed";
             case ME_GRAVATAR_TAPPED:


### PR DESCRIPTION
### Fix
Add analytics to track usage of segmented control filter for ***Notifications*** as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7238.

### Test
0. Add breakpoint [here](https://github.com/wordpress-mobile/WordPress-Android/commit/3639912de95e6c9988f3acddc1b49b365845749b#diff-c7cdd90d0d2e5e0c97c2358650a6e61fR540).
1. Go to ***Notifications*** tab.
2. Tap each segmented control filter.
3. Notice breakpoint is hit.
4. Notice associated case is hit.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.