### PR TITLE
Add additional tracking info to jetpack remote install

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallViewModel.kt
@@ -90,7 +90,12 @@ class JetpackRemoteInstallViewModel
     fun onEventsUpdated(event: OnJetpackInstalled) {
         val site = siteModel ?: return
         if (event.isError) {
-            AnalyticsTracker.track(AnalyticsTracker.Stat.INSTALL_JETPACK_REMOTE_FAILED)
+            AnalyticsTracker.track(
+                    AnalyticsTracker.Stat.INSTALL_JETPACK_REMOTE_FAILED,
+                    "JetpackRemoteInstall",
+                    event.error?.apiError ?: "EMPTY_TYPE",
+                    event.error?.message ?: "EMPTY_MESSAGE"
+            )
             mutableViewState.postValue(Error { startRemoteInstall(site) })
             return
         }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '6a044d69a86e7743189c873270dc531db16fd277'
+    fluxCVersion = 'f0e022e366e20a32d663031504202717a99862fd'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '835315abaebdca4334ca7b75dce827ffec7409bc'
+    fluxCVersion = '6a044d69a86e7743189c873270dc531db16fd277'
 }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -790,7 +790,7 @@ public class AnalyticsTrackerNosara extends Tracker {
             case INSTALL_JETPACK_REMOTE_COMPLETED:
                 return "install_jetpack_remote_completed";
             case INSTALL_JETPACK_REMOTE_FAILED:
-                return "connect_jetpack_remote_failed";
+                return "install_jetpack_remote_failed";
             case CONNECT_JETPACK_SELECTED:
                 return "connect_jetpack_selected";
             case CONNECT_JETPACK_FAILED:


### PR DESCRIPTION
Add additional api error type and message to the JRI failure tracking event in order to find out what kind of errors are causing the failure. 

To test:
There are not functionality changes
