### PR TITLE
Issue/compat library vectors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,19 +96,24 @@ To help ease the translation process we ask that you mark alias string resources
 
 # Drawable Resources
 
-The Android support library [v23.2.1](http://android-developers.blogspot.com/2016/02/android-support-library-232.html) added support for drawable resources to be provided exclusively in vector format. Adding a vector drawable (to `WordPress/src/main/res/drawable/`) should be the first option when adding assets. Only if a vector drawable is not available should pngs be added to the project. Also make sure to use `app:srcCompat` in place of `android:src` in XML files.
+Adding a vector drawable (to `WordPress/src/main/res/drawable/`) should be the first option when adding assets. Only if a vector drawable is not available should PNG files be added to the project. Also make sure to use `android:src` in place of `app:srcCompat` in XML files.
 
-Since Vector Drawable are not the easiest file type to edit, they're chances the Vector Drawable you'll add comes from a SVG file. If the SVG file is specific to the WPAndroid project (like a banner image or unlike a gridicon), then add the SVG source in `WordPress/src/future/svg/`. The argument behind this: make sure we can find and edit the SVG file and then export it in Vector Drawable format.
+Some vector drawables may come from a SVG file and they are not the easiest file type to edit. If the SVG file is specific to the WPAndroid project (like a banner image or unlike a gridicon), then add the SVG source in `WordPress/src/future/svg/`. This will make sure we can find and edit the SVG file and then export it in vector drawable format.
 
-Please follow the following naming convention for our icon drawables:
+Please use the following naming convention for naming drawables:
 
-* If it's an icon, prefix it by `ic_`.
-* If it's a [gridicon](https://github.com/Automattic/gridicons/tree/master/svg) use the same name (examples: `ic_my_sites` or `ic_reply`).
-* If it's not white, add the color to the name (example: `ic_reply_grey`).
-* Postfix all icons by their size in dp (example: `ic_reply_grey_32dp`).
+* Use `ic_` for icons (i.e. simple, usually single color, usually square shape) and `img_` for images (i.e. complex, usually multiple colors).
+* Use the [gridicon](https://github.com/Automattic/gridicons/tree/master/svg) name if applicable (examples: `ic_my_sites` or `ic_reply`).
+* Use the color to icons (example: `ic_reply_grey`).
+* Use the width in dp (example: `ic_reply_grey_32dp`).
 
-Valid icon names: `ic_reply_grey_32dp` (grey reply icon 32dp), `ic_reply_24dp` (white reply icon 24dp).
-Invalid icon names: `reply_blue` (missing `ic_` prefix and size), `ic_checkmark_white_24dp` (we don't need to specify `white`).
+#### Valid
+`ic_reply_grey_32dp` (grey reply icon 32dp)
+`ic_reply_white_24dp` (white reply icon 24dp).
+#### Invalid
+`reply_blue` (missing `ic_` and width)
+`ic_confetti_284dp` (uses `ic_`, but should use `img_`)
+`img_confetti_98dp` (uses height, but should use width).
 
 # Subtree'd projects
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -47,7 +47,6 @@ android {
         targetSdkVersion 26
 
         multiDexEnabled true
-        vectorDrawables.useSupportLibrary = true
 
         buildConfigField "boolean", "REVISIONS_ENABLED", "false"
     }

--- a/WordPress/src/main/res/layout-sw600dp/theme_grid_cardview_header.xml
+++ b/WordPress/src/main/res/layout-sw600dp/theme_grid_cardview_header.xml
@@ -68,7 +68,7 @@
                         android:layout_margin="@dimen/margin_none"
                         android:adjustViewBounds="true"
                         android:contentDescription="@string/customize"
-                        card_view:srcCompat="@drawable/ic_customize_grey_dark_18dp" />
+                        android:src="@drawable/ic_customize_grey_dark_18dp" />
 
                     <org.wordpress.android.widgets.WPTextView
                         android:layout_width="wrap_content"
@@ -97,7 +97,7 @@
                         android:layout_margin="@dimen/margin_none"
                         android:adjustViewBounds="true"
                         android:contentDescription="@string/details"
-                        card_view:srcCompat="@drawable/ic_info_outline_grey_dark_18dp" />
+                        android:src="@drawable/ic_info_outline_grey_dark_18dp" />
 
                     <org.wordpress.android.widgets.WPTextView
                         android:layout_width="wrap_content"
@@ -126,7 +126,7 @@
                         android:layout_margin="@dimen/margin_none"
                         android:adjustViewBounds="true"
                         android:contentDescription="@string/support"
-                        card_view:srcCompat="@drawable/ic_help_outline_grey_dark_18dp" />
+                        android:src="@drawable/ic_help_outline_grey_dark_18dp" />
 
                     <org.wordpress.android.widgets.WPTextView
                         android:layout_width="wrap_content"

--- a/WordPress/src/main/res/layout-sw720dp/stats_insights_all_time_item.xml
+++ b/WordPress/src/main/res/layout-sw720dp/stats_insights_all_time_item.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:baselineAligned="false"
-    android:padding="@dimen/margin_extra_large"
-    android:orientation="horizontal">
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:baselineAligned="false"
+              android:padding="@dimen/margin_extra_large"
+              android:orientation="horizontal">
 
     <!-- Posts item -->
     <LinearLayout
@@ -29,7 +28,7 @@
                 android:layout_height="12dp"
                 android:layout_marginEnd="3dp"
                 android:contentDescription="@null"
-                app:srcCompat="@drawable/ic_posts_grey_dark_24dp" />
+                android:src="@drawable/ic_posts_grey_dark_24dp" />
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
                 style="@style/StatsInsightsLabel"
@@ -75,7 +74,7 @@
                 android:layout_height="12dp"
                 android:layout_marginEnd="3dp"
                 android:contentDescription="@null"
-                app:srcCompat="@drawable/ic_visible_on_grey_dark_12dp" />
+                android:src="@drawable/ic_visible_on_grey_dark_12dp" />
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
                 style="@style/StatsInsightsLabel"
@@ -121,7 +120,7 @@
                 android:layout_height="12dp"
                 android:layout_marginEnd="3dp"
                 android:contentDescription="@null"
-                app:srcCompat="@drawable/ic_user_grey_dark_12dp" />
+                android:src="@drawable/ic_user_grey_dark_12dp" />
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
                 style="@style/StatsInsightsLabel"
@@ -167,7 +166,7 @@
                 android:layout_height="12dp"
                 android:layout_marginEnd="3dp"
                 android:contentDescription="@null"
-                app:srcCompat="@drawable/ic_trophy_alert_yellow_32dp" />
+                android:src="@drawable/ic_trophy_alert_yellow_32dp" />
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
                 style="@style/StatsInsightsLabel"

--- a/WordPress/src/main/res/layout/about_activity.xml
+++ b/WordPress/src/main/res/layout/about_activity.xml
@@ -55,7 +55,7 @@
                     android:layout_height="50dp"
                     android:layout_marginTop="@dimen/margin_medium"
                     android:importantForAccessibility="no"
-                    app:srcCompat="@drawable/ic_my_sites_white_50dp"/>
+                    android:src="@drawable/ic_my_sites_white_50dp"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/about_first_line"

--- a/WordPress/src/main/res/layout/activity_log_item_detail.xml
+++ b/WordPress/src/main/res/layout/activity_log_item_detail.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -30,9 +29,8 @@
                     android:layout_width="36dp"
                     android:layout_height="36dp"
                     android:layout_marginEnd="12dp"
-                    app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
-                    android:contentDescription="@null"
-                    tools:src="@drawable/badge"/>
+                    android:src="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
+                    android:contentDescription="@null"/>
 
                 <ImageView
                     android:id="@+id/activityJetpackActorIcon"
@@ -40,9 +38,8 @@
                     android:layout_height="36dp"
                     android:layout_marginEnd="12dp"
                     android:visibility="gone"
-                    app:srcCompat="@drawable/ic_plans_grey_36dp"
-                    android:contentDescription="@string/activity_log_jetpack_icon"
-                    tools:src="@drawable/ic_plans_grey_36dp"/>
+                    android:src="@drawable/ic_plans_grey_36dp"
+                    android:contentDescription="@string/activity_log_jetpack_icon"/>
 
                 <LinearLayout
                     android:layout_width="0dp"
@@ -138,8 +135,7 @@
                     android:background="?attr/selectableItemBackgroundBorderless"
                     android:contentDescription="@null"
                     android:importantForAccessibility="no"
-                    app:srcCompat="@drawable/ic_history_blue_24dp"
-                    tools:src="@drawable/ic_history_blue_24dp"/>
+                    android:src="@drawable/ic_history_blue_24dp"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:layout_width="wrap_content"

--- a/WordPress/src/main/res/layout/activity_log_list_event_item.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_event_item.xml
@@ -3,7 +3,6 @@
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/activity_content_container"
     android:background="@color/white"
     android:clickable="true"
@@ -41,7 +40,7 @@
             android:layout_height="wrap_content"
             android:layout_width="wrap_content"
             android:padding="@dimen/activity_log_icon_margin"
-            app:srcCompat="@drawable/ic_history_white_24dp"
+            android:src="@drawable/ic_history_white_24dp"
             android:tint="@color/blue_wordpress" >
         </ImageButton>
 

--- a/WordPress/src/main/res/layout/activity_log_list_progress_item.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_progress_item.xml
@@ -3,7 +3,6 @@
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/activity_content_container"
     android:background="@color/white"
     android:clickable="true"
@@ -28,7 +27,7 @@
             android:layout_margin="@dimen/activity_log_icon_margin"
             android:layout_width="@dimen/activity_log_icon_size"
             android:padding="@dimen/margin_medium"
-            app:srcCompat="@drawable/ic_notice_outline_white_24dp" >
+            android:src="@drawable/ic_notice_outline_white_24dp" >
         </ImageView>
 
         <LinearLayout

--- a/WordPress/src/main/res/layout/comment_action_footer.xml
+++ b/WordPress/src/main/res/layout/comment_action_footer.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
               android:id="@+id/layout_buttons"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
@@ -37,7 +36,7 @@
                 android:paddingEnd="@dimen/margin_medium"
                 android:paddingStart="@dimen/margin_medium"
                 android:paddingTop="0dp"
-                app:srcCompat="@drawable/ic_checkmark_grey_min_24dp"/>
+                android:src="@drawable/ic_checkmark_grey_min_24dp"/>
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
                 android:id="@+id/btn_moderate_text"
@@ -71,7 +70,7 @@
                 android:paddingEnd="@dimen/margin_medium"
                 android:paddingStart="@dimen/margin_medium"
                 android:paddingTop="0dp"
-                app:srcCompat="@drawable/ic_spam_grey_min_24dp"/>
+                android:src="@drawable/ic_spam_grey_min_24dp"/>
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
                 android:id="@+id/btn_spam_text"
@@ -105,7 +104,7 @@
                 android:paddingEnd="@dimen/margin_medium"
                 android:paddingStart="@dimen/margin_medium"
                 android:paddingTop="0dp"
-                app:srcCompat="@drawable/ic_trash_grey_min_24dp"/>
+                android:src="@drawable/ic_trash_grey_min_24dp"/>
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
                 android:id="@+id/btn_trash_text"
@@ -139,7 +138,7 @@
                 android:paddingEnd="@dimen/margin_medium"
                 android:paddingStart="@dimen/margin_medium"
                 android:paddingTop="0dp"
-                app:srcCompat="@drawable/ic_star_outline_grey_min_24dp"/>
+                android:src="@drawable/ic_star_outline_grey_min_24dp"/>
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
                 android:id="@+id/btn_like_text"
@@ -173,7 +172,7 @@
                 android:paddingEnd="@dimen/margin_medium"
                 android:paddingStart="@dimen/margin_medium"
                 android:paddingTop="0dp"
-                app:srcCompat="@drawable/ic_pencil_grey_min_24dp"/>
+                android:src="@drawable/ic_pencil_grey_min_24dp"/>
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
                 android:id="@+id/btn_edit_text"

--- a/WordPress/src/main/res/layout/comment_listitem.xml
+++ b/WordPress/src/main/res/layout/comment_listitem.xml
@@ -1,6 +1,6 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:selectableItemBackground"
@@ -35,7 +35,7 @@
                 android:layout_height="@dimen/notifications_avatar_sz"
                 android:background="@drawable/shape_oval_blue"
                 android:padding="@dimen/margin_medium"
-                app:srcCompat="@drawable/ic_checkmark_white_24dp"
+                android:src="@drawable/ic_checkmark_white_24dp"
                 android:contentDescription="@string/comment_checkmark_desc"
                 android:visibility="gone" />
 

--- a/WordPress/src/main/res/layout/endlist_indicator.xml
+++ b/WordPress/src/main/res/layout/endlist_indicator.xml
@@ -3,9 +3,9 @@
 <!--
     appears below the last item in the page list
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/endlist_indicator"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -23,7 +23,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        app:srcCompat="@drawable/ic_wordpress_grey_20dp"
+        android:src="@drawable/ic_wordpress_grey_20dp"
         android:contentDescription="@null"
         android:layout_marginEnd="@dimen/margin_medium"
         android:layout_marginStart="@dimen/margin_medium"/>

--- a/WordPress/src/main/res/layout/home_row.xml
+++ b/WordPress/src/main/res/layout/home_row.xml
@@ -1,5 +1,5 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:background="?android:selectableItemBackground"
@@ -12,7 +12,7 @@
         android:layout_marginTop="12dip"
         android:gravity="center|center"
         android:scaleType="centerCrop"
-        app:srcCompat="@mipmap/app_icon"
+        android:src="@mipmap/app_icon"
         android:layout_marginStart="8dip"
         android:layout_marginEnd="8dp"/>
 

--- a/WordPress/src/main/res/layout/jetpack_remote_install_fragment.xml
+++ b/WordPress/src/main/res/layout/jetpack_remote_install_fragment.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
               xmlns:tools="http://schemas.android.com/tools"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
@@ -26,7 +25,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_extra_large"
                 android:contentDescription="@string/content_description_people_looking_charts"
-                app:srcCompat="@drawable/ic_plans_jetpack_green_88dp"/>
+                android:src="@drawable/ic_plans_jetpack_green_88dp"/>
 
             <TextView
                 android:id="@+id/jetpack_install_title"

--- a/WordPress/src/main/res/layout/list_editor.xml
+++ b/WordPress/src/main/res/layout/list_editor.xml
@@ -53,7 +53,7 @@
             android:layout_gravity="end|bottom"
             android:layout_marginBottom="@dimen/fab_margin"
             android:layout_marginEnd="@dimen/fab_margin"
-            app:srcCompat="@drawable/ic_plus_white_24dp"
+            android:src="@drawable/ic_plus_white_24dp"
             android:contentDescription="@string/add"
             app:borderWidth="0dp"
             app:rippleColor="@color/fab_pressed" />

--- a/WordPress/src/main/res/layout/login_epilogue_sites_listitem.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_sites_listitem.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/layout_container"
     android:layout_width="match_parent"
@@ -19,7 +19,7 @@
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:gravity="center_vertical"
         android:background="@drawable/blavatar_border"
-        app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
+        android:src="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
         android:contentDescription="@null"/>
 
     <LinearLayout

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -121,7 +121,7 @@
                 <ImageView
                     android:id="@+id/me_my_profile_icon"
                     style="@style/MeListRowIcon"
-                    app:srcCompat="@drawable/ic_user_grey_24dp"
+                    android:src="@drawable/ic_user_grey_24dp"
                     android:contentDescription="@null"/>
 
                 <org.wordpress.android.widgets.WPTextView
@@ -140,7 +140,7 @@
                 <ImageView
                     android:id="@+id/me_account_settings_icon"
                     style="@style/MeListRowIcon"
-                    app:srcCompat="@drawable/ic_cog_grey_24dp"
+                    android:src="@drawable/ic_cog_grey_24dp"
                     android:contentDescription="@null"/>
 
                 <org.wordpress.android.widgets.WPTextView
@@ -159,7 +159,7 @@
                 <ImageView
                     android:id="@+id/me_app_settings_icon"
                     style="@style/MeListRowIcon"
-                    app:srcCompat="@drawable/ic_phone_grey_darken_24dp"
+                    android:src="@drawable/ic_phone_grey_darken_24dp"
                     android:contentDescription="@null"/>
 
                 <org.wordpress.android.widgets.WPTextView
@@ -178,7 +178,7 @@
                 <ImageView
                     android:id="@+id/me_notifications_icon"
                     style="@style/MeListRowIcon"
-                    app:srcCompat="@drawable/ic_bell_grey_darken_24dp"
+                    android:src="@drawable/ic_bell_grey_darken_24dp"
                     android:contentDescription="@null"/>
 
                 <org.wordpress.android.widgets.WPTextView
@@ -198,7 +198,7 @@
                 <ImageView
                     android:id="@+id/me_support_icon"
                     style="@style/MeListRowIcon"
-                    app:srcCompat="@drawable/ic_help_grey_24dp"
+                    android:src="@drawable/ic_help_grey_24dp"
                     android:contentDescription="@null"/>
 
                 <org.wordpress.android.util.widgets.AutoResizeTextView
@@ -217,7 +217,7 @@
                 <ImageView
                     android:id="@+id/me_login_logout_icon"
                     style="@style/MeListRowIcon"
-                    app:srcCompat="@drawable/ic_sign_out_grey_24dp"
+                    android:src="@drawable/ic_sign_out_grey_24dp"
                     android:contentDescription="@null"/>
 
                 <org.wordpress.android.util.widgets.AutoResizeTextView

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -98,7 +98,7 @@
                     android:background="@drawable/media_icon_circle"
                     android:padding="10dp"
                     android:contentDescription="@string/media_grid_item_retry_desc"
-                    app:srcCompat="@drawable/media_retry_image"
+                    android:src="@drawable/media_retry_image"
                     android:layout_marginStart="@dimen/margin_medium"
                     android:layout_marginEnd="@dimen/margin_medium"/>
 
@@ -109,7 +109,7 @@
                     android:background="@drawable/media_icon_circle"
                     android:padding="10dp"
                     android:contentDescription="@string/media_grid_item_trash_desc"
-                    app:srcCompat="@drawable/ic_trash_white_24dp"
+                    android:src="@drawable/ic_trash_white_24dp"
                     android:layout_marginEnd="@dimen/margin_medium"
                     android:layout_marginStart="@dimen/margin_medium"/>
             </LinearLayout>
@@ -172,7 +172,7 @@
             android:layout_height="@dimen/photo_picker_preview_icon"
             android:padding="@dimen/margin_extra_small"
             android:contentDescription="@string/media_grid_item_play_video_desc"
-            app:srcCompat="@drawable/ic_play_video" />
+            android:src="@drawable/ic_play_video" />
 
     </FrameLayout>
 

--- a/WordPress/src/main/res/layout/media_preview_fragment.xml
+++ b/WordPress/src/main/res/layout/media_preview_fragment.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
                 xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
@@ -52,7 +51,7 @@
             android:layout_width="128dp"
             android:layout_height="128dp"
             android:layout_centerInParent="true"
-            app:srcCompat="@drawable/ic_gridicons_audio"
+            android:src="@drawable/ic_gridicons_audio"
             android:contentDescription="@string/media_preview_audio_desc"/>
 
     </RelativeLayout>

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -56,7 +56,7 @@
                     android:layout_height="60dp"
                     android:layout_gravity="center"
                     android:visibility="gone"
-                    app:srcCompat="@drawable/play_video_selector_large"
+                    android:src="@drawable/play_video_selector_large"
                     android:contentDescription="@string/media_settings_play"
                     tools:visibility="visible" />
             </FrameLayout>
@@ -542,7 +542,7 @@
         app:fabSize="normal"
         app:layout_anchor="@id/app_bar_layout"
         app:layout_anchorGravity="bottom|right|end"
-        app:srcCompat="@drawable/ic_fullscreen_white_24dp"
+        android:src="@drawable/ic_fullscreen_white_24dp"
         tools:visibility="visible" />
 
     <ProgressBar

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -68,7 +68,7 @@
                             android:contentDescription="@string/my_site_icon_content_description"
                             android:foreground="?attr/selectableItemBackgroundBorderless"
                             android:gravity="center_vertical"
-                            tools:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp" />
+                            tools:src="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp" />
 
                         <LinearLayout
                             android:layout_width="match_parent"
@@ -120,7 +120,7 @@
                             android:importantForAccessibility="no"
                             android:layout_height="wrap_content"
                             android:layout_gravity="center_vertical"
-                            app:srcCompat="@drawable/ic_arrow_left_grey"
+                            android:src="@drawable/ic_arrow_left_grey"
                             style="@style/MySiteListRowIcon" >
                         </ImageView>
 
@@ -151,7 +151,7 @@
                     android:id="@+id/my_site_quick_start_icon"
                     style="@style/MySiteListRowIcon"
                     android:importantForAccessibility="no"
-                    app:srcCompat="@drawable/ic_list_checkmark_grey_24dp"/>
+                    android:src="@drawable/ic_list_checkmark_grey_24dp"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/my_site_quick_start_text"
@@ -197,7 +197,7 @@
                     android:id="@+id/my_site_stats_icon"
                     style="@style/MySiteListRowIcon"
                     android:importantForAccessibility="no"
-                    app:srcCompat="@drawable/ic_stats_alt_grey_24dp"/>
+                    android:src="@drawable/ic_stats_alt_grey_24dp"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/my_site_stats_text_view"
@@ -214,7 +214,7 @@
                 <ImageView
                     android:id="@+id/my_site_activity_log_icon"
                     style="@style/MySiteListRowIcon"
-                    app:srcCompat="@drawable/ic_history_alt_grey_24dp"
+                    android:src="@drawable/ic_history_alt_grey_24dp"
                     android:importantForAccessibility="no"/>
 
                 <org.wordpress.android.widgets.WPTextView
@@ -233,7 +233,7 @@
                     android:id="@+id/my_site_plan_icon"
                     style="@style/MySiteListRowIcon"
                     android:importantForAccessibility="no"
-                    app:srcCompat="@drawable/ic_plans_grey_24dp"/>
+                    android:src="@drawable/ic_plans_grey_24dp"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/my_site_plan_text_view"
@@ -266,7 +266,7 @@
                     android:id="@+id/my_site_pages_icon"
                     style="@style/MySiteListRowIcon"
                     android:importantForAccessibility="no"
-                    app:srcCompat="@drawable/ic_pages_grey_24dp"/>
+                    android:src="@drawable/ic_pages_grey_24dp"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/my_site_pages_text_view"
@@ -288,7 +288,7 @@
                         android:id="@+id/my_site_blog_posts_icon"
                         style="@style/MySiteListRowIcon"
                         android:importantForAccessibility="no"
-                        app:srcCompat="@drawable/ic_posts_grey_24dp"/>
+                        android:src="@drawable/ic_posts_grey_24dp"/>
 
                     <org.wordpress.android.widgets.WPTextView
                         android:id="@+id/my_site_blog_posts_text_view"
@@ -308,7 +308,7 @@
                     android:id="@+id/my_site_media_icon"
                     style="@style/MySiteListRowIcon"
                     android:importantForAccessibility="no"
-                    app:srcCompat="@drawable/ic_media_grey_24dp"/>
+                    android:src="@drawable/ic_media_grey_24dp"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/my_site_media_text_view"
@@ -326,7 +326,7 @@
                     android:id="@+id/my_site_comments_icon"
                     style="@style/MySiteListRowIcon"
                     android:importantForAccessibility="no"
-                    app:srcCompat="@drawable/ic_comment_grey_24dp"/>
+                    android:src="@drawable/ic_comment_grey_24dp"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/my_site_comments_text_view"
@@ -351,7 +351,7 @@
                     android:id="@+id/my_site_themes_icon"
                     style="@style/MySiteListRowIcon"
                     android:importantForAccessibility="no"
-                    app:srcCompat="@drawable/ic_themes_grey_24dp"/>
+                    android:src="@drawable/ic_themes_grey_24dp"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/my_site_themes_text_view"
@@ -376,7 +376,7 @@
                     android:id="@+id/my_site_people_icon"
                     style="@style/MySiteListRowIcon"
                     android:importantForAccessibility="no"
-                    app:srcCompat="@drawable/ic_user_grey_24dp"/>
+                    android:src="@drawable/ic_user_grey_24dp"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/my_site_people_management_text_view"
@@ -394,7 +394,7 @@
                     android:id="@+id/my_site_plugins_icon"
                     style="@style/MySiteListRowIcon"
                     android:contentDescription="@string/plugins"
-                    app:srcCompat="@drawable/ic_plugins_white_24dp"/>
+                    android:src="@drawable/ic_plugins_white_24dp"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/my_site_plugins_text_view"
@@ -412,7 +412,7 @@
                     android:id="@+id/my_site_sharing_icon"
                     style="@style/MySiteListRowIcon"
                     android:importantForAccessibility="no"
-                    app:srcCompat="@drawable/ic_share_grey_dark_24dp"/>
+                    android:src="@drawable/ic_share_grey_dark_24dp"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/my_site_sharing_text_view"
@@ -430,7 +430,7 @@
                     android:id="@+id/my_site_settings_icon"
                     style="@style/MySiteListRowIcon"
                     android:importantForAccessibility="no"
-                    app:srcCompat="@drawable/ic_cog_grey_24dp"/>
+                    android:src="@drawable/ic_cog_grey_24dp"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/my_site_settings_text_view"
@@ -455,7 +455,7 @@
                     android:id="@+id/my_site_view_site_icon"
                     style="@style/MySiteListRowIcon"
                     android:importantForAccessibility="no"
-                    app:srcCompat="@drawable/ic_globe_grey_24dp"/>
+                    android:src="@drawable/ic_globe_grey_24dp"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/my_site_view_site_text_view"
@@ -466,7 +466,7 @@
                     android:id="@+id/my_site_view_site_icon_external"
                     style="@style/MySiteListRowSecondaryIcon"
                     android:importantForAccessibility="no"
-                    app:srcCompat="@drawable/ic_external_black_24dp"/>
+                    android:src="@drawable/ic_external_black_24dp"/>
 
             </LinearLayout>
 
@@ -480,7 +480,7 @@
                     android:id="@+id/my_site_view_admin_icon"
                     style="@style/MySiteListRowIcon"
                     android:importantForAccessibility="no"
-                    app:srcCompat="@drawable/ic_my_sites_grey_24dp"/>
+                    android:src="@drawable/ic_my_sites_grey_24dp"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/my_site_view_admin_text_view"
@@ -491,7 +491,7 @@
                     android:id="@+id/my_site_admin_icon_external"
                     style="@style/MySiteListRowSecondaryIcon"
                     android:importantForAccessibility="no"
-                    app:srcCompat="@drawable/ic_external_black_24dp"/>
+                    android:src="@drawable/ic_external_black_24dp"/>
 
             </LinearLayout>
 

--- a/WordPress/src/main/res/layout/navbar_item.xml
+++ b/WordPress/src/main/res/layout/navbar_item.xml
@@ -19,7 +19,7 @@
             android:layout_gravity="center"
             android:contentDescription="@string/tabbar_accessibility_label_my_site"
             android:tint="@drawable/nav_bar_button_selector"
-            tools:srcCompat="@drawable/ic_create_white_24dp"/>
+            tools:src="@drawable/ic_create_white_24dp"/>
 
         <View
             android:id="@+id/badge"

--- a/WordPress/src/main/res/layout/navbar_post_item.xml
+++ b/WordPress/src/main/res/layout/navbar_post_item.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center">
@@ -20,6 +19,6 @@
         android:layout_centerInParent="true"
         android:contentDescription="@string/tabbar_accessibility_label_write"
         android:tint="@color/white"
-        app:srcCompat="@drawable/ic_create_white_24dp"/>
+        android:src="@drawable/ic_create_white_24dp"/>
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/news_card.xml
+++ b/WordPress/src/main/res/layout/news_card.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -28,7 +27,7 @@
             android:focusable="true"
             android:padding="@dimen/margin_small"
             android:tint="@color/grey"
-            app:srcCompat="@drawable/ic_close_white_24dp"/>
+            android:src="@drawable/ic_close_white_24dp"/>
 
         <ImageView
             android:id="@+id/news_image"
@@ -38,7 +37,7 @@
             android:layout_marginEnd="@dimen/negative_margin_medium"
             android:layout_toStartOf="@+id/news_dismiss"
             android:contentDescription="@null"
-            app:srcCompat="@drawable/img_illustration_notifications_152dp"/>
+            android:src="@drawable/img_illustration_notifications_152dp"/>
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/news_title"

--- a/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
@@ -191,7 +191,7 @@
                             android:layout_height="wrap_content"
                             android:layout_marginTop="@dimen/margin_extra_large"
                             android:layout_width="wrap_content"
-                            app:srcCompat="@drawable/img_illustration_notifications_152dp"/>
+                            android:src="@drawable/img_illustration_notifications_152dp"/>
 
                         <org.wordpress.android.widgets.WPTextView
                             style="@style/JetpackConnectionText"

--- a/WordPress/src/main/res/layout/page_item.xml
+++ b/WordPress/src/main/res/layout/page_item.xml
@@ -1,5 +1,5 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -116,7 +116,7 @@
                 android:padding="@dimen/margin_medium"
                 android:contentDescription="@string/show_more_desc"
                 android:tint="@color/grey_text_min"
-                app:srcCompat="@drawable/ic_ellipsis_blue_wordpress_32dp"
+                android:src="@drawable/ic_ellipsis_blue_wordpress_32dp"
                 android:layout_alignParentEnd="true"
                 android:layout_marginStart="@dimen/margin_medium" />
 

--- a/WordPress/src/main/res/layout/page_list_item.xml
+++ b/WordPress/src/main/res/layout/page_list_item.xml
@@ -25,7 +25,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/ic_ellipsis_grey_darken_10_24dp"/>
+            android:src="@drawable/ic_ellipsis_grey_darken_10_24dp"/>
 
         <View
             android:id="@+id/large_stretcher"

--- a/WordPress/src/main/res/layout/pages_fragment.xml
+++ b/WordPress/src/main/res/layout/pages_fragment.xml
@@ -71,7 +71,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="end|bottom"
             android:layout_marginBottom="@dimen/fab_margin"
-            app:srcCompat="@drawable/ic_create_white_24dp"
+            android:src="@drawable/ic_create_white_24dp"
             android:contentDescription="@string/fab_create_desc"
             app:borderWidth="0dp"
             app:rippleColor="@color/fab_pressed"

--- a/WordPress/src/main/res/layout/people_invite_fragment.xml
+++ b/WordPress/src/main/res/layout/people_invite_fragment.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -117,7 +116,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:contentDescription="@string/people_invite_role_info_desc"
-                    app:srcCompat="@drawable/ic_info_black_24dp"
+                    android:src="@drawable/ic_info_black_24dp"
                     android:paddingEnd="@dimen/margin_small"
                     android:paddingStart="@dimen/margin_small"/>
             </LinearLayout>

--- a/WordPress/src/main/res/layout/photo_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/photo_picker_fragment.xml
@@ -62,7 +62,7 @@
                 android:layout_weight="1"
                 android:background="?android:selectableItemBackground"
                 android:contentDescription="@string/photo_picker_device_desc"
-                app:srcCompat="@drawable/media_bar_button_image_multiple"/>
+                android:src="@drawable/media_bar_button_image_multiple"/>
 
             <ImageView
                 android:id="@+id/icon_camera"
@@ -71,7 +71,7 @@
                 android:layout_weight="1"
                 android:background="?android:selectableItemBackground"
                 android:contentDescription="@string/photo_picker_camera_desc"
-                app:srcCompat="@drawable/media_bar_button_camera"/>
+                android:src="@drawable/media_bar_button_camera"/>
 
             <ImageView
                 android:id="@+id/icon_wpmedia"
@@ -80,7 +80,7 @@
                 android:layout_weight="1"
                 android:background="?android:selectableItemBackground"
                 android:contentDescription="@string/photo_picker_wpmedia_desc"
-                app:srcCompat="@drawable/media_bar_button_library"/>
+                android:src="@drawable/media_bar_button_library"/>
         </LinearLayout>
 
     </LinearLayout>

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -276,7 +276,7 @@
                         <ImageView
                             style="@style/PluginCardViewSecondaryElement.ExternalLinkImage"
                             android:contentDescription="@string/plugin_external_link_icon_content_description"
-                            app:srcCompat="@drawable/ic_external_black_24dp" />
+                            android:src="@drawable/ic_external_black_24dp" />
                     </RelativeLayout>
 
                     <View style="@style/PostSettingsDivider" />
@@ -293,7 +293,7 @@
                         <ImageView
                             style="@style/PluginCardViewSecondaryElement.ExternalLinkImage"
                             android:contentDescription="@string/plugin_external_link_icon_content_description"
-                            app:srcCompat="@drawable/ic_external_black_24dp" />
+                            android:src="@drawable/ic_external_black_24dp" />
                     </RelativeLayout>
 
                     <View style="@style/PostSettingsDivider" />
@@ -310,7 +310,7 @@
                         <ImageView
                             style="@style/PluginCardViewSecondaryElement.ExternalLinkImage"
                             android:contentDescription="@string/plugin_external_link_icon_content_description"
-                            app:srcCompat="@drawable/ic_external_black_24dp" />
+                            android:src="@drawable/ic_external_black_24dp" />
                     </RelativeLayout>
                 </LinearLayout>
             </android.support.v7.widget.CardView>
@@ -346,7 +346,7 @@
                             android:id="@+id/plugin_description_chevron"
                             style="@style/PluginCardViewSecondaryElement.ChevronImage"
                             android:contentDescription="@string/plugin_chevron_icon_content_description"
-                            app:srcCompat="@drawable/ic_chevron_down_grey_100_35dp" />
+                            android:src="@drawable/ic_chevron_down_grey_100_35dp" />
 
                     </RelativeLayout>
 
@@ -375,7 +375,7 @@
                             android:id="@+id/plugin_installation_chevron"
                             style="@style/PluginCardViewSecondaryElement.ChevronImage"
                             android:contentDescription="@string/plugin_chevron_icon_content_description"
-                            app:srcCompat="@drawable/ic_chevron_down_grey_100_35dp" />
+                            android:src="@drawable/ic_chevron_down_grey_100_35dp" />
 
                     </RelativeLayout>
 
@@ -404,7 +404,7 @@
                             android:id="@+id/plugin_whatsnew_chevron"
                             style="@style/PluginCardViewSecondaryElement.ChevronImage"
                             android:contentDescription="@string/plugin_chevron_icon_content_description"
-                            app:srcCompat="@drawable/ic_chevron_down_grey_100_35dp" />
+                            android:src="@drawable/ic_chevron_down_grey_100_35dp" />
 
                     </RelativeLayout>
 
@@ -433,7 +433,7 @@
                             android:id="@+id/plugin_faq_chevron"
                             style="@style/PluginCardViewSecondaryElement.ChevronImage"
                             android:contentDescription="@string/plugin_chevron_icon_content_description"
-                            app:srcCompat="@drawable/ic_chevron_down_grey_100_35dp" />
+                            android:src="@drawable/ic_chevron_down_grey_100_35dp" />
 
                     </RelativeLayout>
                 </LinearLayout>

--- a/WordPress/src/main/res/layout/plugin_ratings_cardview.xml
+++ b/WordPress/src/main/res/layout/plugin_ratings_cardview.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<android.support.v7.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/PluginCardView"
@@ -47,7 +47,7 @@
                 android:layout_gravity="center_vertical"
                 android:tint="@color/blue_medium"
                 android:contentDescription="@string/open_external_link_desc"
-                app:srcCompat="@drawable/ic_external_black_24dp" />
+                android:src="@drawable/ic_external_black_24dp" />
         </LinearLayout>
 
         <LinearLayout

--- a/WordPress/src/main/res/layout/post_list_fragment.xml
+++ b/WordPress/src/main/res/layout/post_list_fragment.xml
@@ -55,7 +55,7 @@
             android:contentDescription="@string/fab_create_desc"
             app:borderWidth="0dp"
             app:rippleColor="@color/fab_pressed"
-            app:srcCompat="@drawable/ic_create_white_24dp"/>
+            android:src="@drawable/ic_create_white_24dp"/>
 
     </android.support.design.widget.CoordinatorLayout>
 

--- a/WordPress/src/main/res/layout/promo_dialog.xml
+++ b/WordPress/src/main/res/layout/promo_dialog.xml
@@ -2,7 +2,6 @@
 
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:background="@color/white"
     android:layout_gravity="center"
@@ -25,7 +24,7 @@
             android:layout_gravity="center"
             android:background="@color/grey_light"
             android:contentDescription="@null"
-            app:srcCompat="@drawable/img_promo_editor" >
+            android:src="@drawable/img_promo_editor" >
         </ImageView>
 
     </LinearLayout>

--- a/WordPress/src/main/res/layout/publicize_list_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_list_fragment.xml
@@ -116,7 +116,7 @@
                             android:layout_height="24dp"
                             android:layout_gravity="center_vertical"
                             android:contentDescription="@null"
-                            app:srcCompat="@drawable/ic_cog_blue_wordpress_24dp"/>
+                            android:src="@drawable/ic_cog_blue_wordpress_24dp"/>
 
                         <org.wordpress.android.widgets.WPTextView
                             android:id="@+id/text_manage_button"

--- a/WordPress/src/main/res/layout/quick_start_fragment.xml
+++ b/WordPress/src/main/res/layout/quick_start_fragment.xml
@@ -59,14 +59,14 @@
                 android:id="@+id/icon_create_site"
                 style="@style/QuickStartIcon"
                 android:importantForAccessibility="no"
-                app:srcCompat="@drawable/ic_plus_white_24dp">
+                android:src="@drawable/ic_plus_white_24dp">
             </ImageView>
 
             <ImageView
                 android:id="@+id/done_create_site"
                 style="@style/QuickStartDone"
                 android:contentDescription="@string/content_description_done"
-                app:srcCompat="@drawable/ic_checkmark_white_24dp"
+                android:src="@drawable/ic_checkmark_white_24dp"
                 tools:visibility="visible">
             </ImageView>
 
@@ -105,14 +105,14 @@
                 android:id="@+id/icon_view_site"
                 style="@style/QuickStartIcon"
                 android:importantForAccessibility="no"
-                app:srcCompat="@drawable/ic_external_white_24dp">
+                android:src="@drawable/ic_external_white_24dp">
             </ImageView>
 
             <ImageView
                 android:id="@+id/done_view_site"
                 style="@style/QuickStartDone"
                 android:contentDescription="@string/content_description_done"
-                app:srcCompat="@drawable/ic_checkmark_white_24dp">
+                android:src="@drawable/ic_checkmark_white_24dp">
             </ImageView>
 
             <TextView
@@ -149,14 +149,14 @@
                 android:id="@+id/icon_browse_themes"
                 style="@style/QuickStartIcon"
                 android:importantForAccessibility="no"
-                app:srcCompat="@drawable/ic_themes_white_24dp">
+                android:src="@drawable/ic_themes_white_24dp">
             </ImageView>
 
             <ImageView
                 android:id="@+id/done_browse_themes"
                 style="@style/QuickStartDone"
                 android:contentDescription="@string/content_description_done"
-                app:srcCompat="@drawable/ic_checkmark_white_24dp">
+                android:src="@drawable/ic_checkmark_white_24dp">
             </ImageView>
 
             <TextView
@@ -193,14 +193,14 @@
                 android:id="@+id/icon_customize_site"
                 style="@style/QuickStartIcon"
                 android:importantForAccessibility="no"
-                app:srcCompat="@drawable/ic_customize_white_24dp">
+                android:src="@drawable/ic_customize_white_24dp">
             </ImageView>
 
             <ImageView
                 android:id="@+id/done_customize_site"
                 style="@style/QuickStartDone"
                 android:contentDescription="@string/content_description_done"
-                app:srcCompat="@drawable/ic_checkmark_white_24dp">
+                android:src="@drawable/ic_checkmark_white_24dp">
             </ImageView>
 
             <TextView
@@ -237,14 +237,14 @@
                 android:id="@+id/icon_share_site"
                 style="@style/QuickStartIcon"
                 android:importantForAccessibility="no"
-                app:srcCompat="@drawable/ic_share_white_24dp">
+                android:src="@drawable/ic_share_white_24dp">
             </ImageView>
 
             <ImageView
                 android:id="@+id/done_share_site"
                 style="@style/QuickStartDone"
                 android:contentDescription="@string/content_description_done"
-                app:srcCompat="@drawable/ic_checkmark_white_24dp">
+                android:src="@drawable/ic_checkmark_white_24dp">
             </ImageView>
 
             <TextView
@@ -281,14 +281,14 @@
                 android:id="@+id/icon_publish_post"
                 style="@style/QuickStartIcon"
                 android:importantForAccessibility="no"
-                app:srcCompat="@drawable/ic_create_white_24dp">
+                android:src="@drawable/ic_create_white_24dp">
             </ImageView>
 
             <ImageView
                 android:id="@+id/done_publish_post"
                 style="@style/QuickStartDone"
                 android:contentDescription="@string/content_description_done"
-                app:srcCompat="@drawable/ic_checkmark_white_24dp">
+                android:src="@drawable/ic_checkmark_white_24dp">
             </ImageView>
 
             <TextView
@@ -325,14 +325,14 @@
                 android:id="@+id/icon_follow_site"
                 style="@style/QuickStartIcon"
                 android:importantForAccessibility="no"
-                app:srcCompat="@drawable/ic_reader_follow_white_24dp">
+                android:src="@drawable/ic_reader_follow_white_24dp">
             </ImageView>
 
             <ImageView
                 android:id="@+id/done_follow_site"
                 style="@style/QuickStartDone"
                 android:contentDescription="@string/content_description_done"
-                app:srcCompat="@drawable/ic_checkmark_white_24dp">
+                android:src="@drawable/ic_checkmark_white_24dp">
             </ImageView>
 
             <TextView

--- a/WordPress/src/main/res/layout/reader_activity_subs.xml
+++ b/WordPress/src/main/res/layout/reader_activity_subs.xml
@@ -69,7 +69,7 @@
             android:background="?android:selectableItemBackground"
             android:padding="@dimen/margin_small"
             android:contentDescription="@string/add"
-            app:srcCompat="@drawable/ic_reader_follow_blue_medium_24dp" />
+            android:src="@drawable/ic_reader_follow_blue_medium_24dp" />
 
     </LinearLayout>
 

--- a/WordPress/src/main/res/layout/reader_bookmark_button.xml
+++ b/WordPress/src/main/res/layout/reader_bookmark_button.xml
@@ -2,7 +2,6 @@
 
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="?attr/selectableItemBackground"
     android:layout_height="wrap_content"
     android:layout_width="wrap_content"
@@ -17,7 +16,7 @@
         android:layout_gravity="center_vertical"
         android:layout_height="@dimen/reader_count_icon"
         android:layout_width="@dimen/reader_count_icon"
-        app:srcCompat="@drawable/ic_bookmark_selector_18dp" >
+        android:src="@drawable/ic_bookmark_selector_18dp" >
     </ImageView>
 
     <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -34,7 +34,7 @@
                 android:id="@+id/image_avatar_or_blavatar"
                 android:layout_centerVertical="true"
                 android:layout_marginEnd="@dimen/margin_large"
-                app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
+                android:src="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
                 android:contentDescription="@string/reader_blavatar_desc"
                 style="@style/ReaderImageView.Avatar" >
             </ImageView>
@@ -180,7 +180,7 @@
                 android:background="?android:selectableItemBackground"
                 android:layout_gravity="center_vertical"
                 android:layout_marginEnd="@dimen/margin_large"
-                app:srcCompat="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp"
+                android:src="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp"
                 android:contentDescription="@string/reader_blavatar_desc"
                 style="@style/ReaderImageView.Avatar.Small" >
             </ImageView>
@@ -226,7 +226,7 @@
                     android:layout_marginEnd="@dimen/margin_extra_small"
                     android:layout_marginStart="-2dp"
                     android:layout_width="@dimen/reader_count_icon"
-                    app:srcCompat="@drawable/ic_external_grey_min_24dp" >
+                    android:src="@drawable/ic_external_grey_min_24dp" >
                 </ImageView>
 
                 <org.wordpress.android.widgets.WPTextView
@@ -258,7 +258,7 @@
                 android:layout_toStartOf="@id/count_comments"
                 android:minWidth="@dimen/reader_button_minimum_height"
                 android:padding="@dimen/margin_medium"
-                app:srcCompat="@drawable/ic_bookmark_selector_18dp" >
+                android:src="@drawable/ic_bookmark_selector_18dp" >
             </ImageView>
 
             <org.wordpress.android.ui.reader.views.ReaderIconCountView
@@ -296,7 +296,7 @@
                 android:paddingBottom="@dimen/margin_medium"
                 android:paddingTop="@dimen/margin_medium"
                 android:tint="@color/grey_text_min"
-                app:srcCompat="@drawable/ic_ellipsis_grey_lighten_10_24dp" >
+                android:src="@drawable/ic_ellipsis_grey_lighten_10_24dp" >
             </ImageView>
 
         </RelativeLayout>

--- a/WordPress/src/main/res/layout/reader_cardview_xpost.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_xpost.xml
@@ -34,7 +34,7 @@
                 android:layout_height="@dimen/blavatar_sz"
                 android:layout_gravity="top|start"
                 android:contentDescription="@string/reader_blavatar_desc"
-                app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp" />
+                android:src="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp" />
 
             <ImageView
                 android:id="@+id/image_avatar"
@@ -42,7 +42,7 @@
                 android:layout_gravity="bottom|end"
                 android:layout_marginTop="14dp"
                 android:contentDescription="@string/reader_avatar_desc"
-                app:srcCompat="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp"
+                android:src="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp"
                 android:layout_marginStart="14dp"/>
         </FrameLayout>
 

--- a/WordPress/src/main/res/layout/reader_follow_button.xml
+++ b/WordPress/src/main/res/layout/reader_follow_button.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/frame_follow_button"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -13,7 +13,7 @@
         android:layout_height="@dimen/reader_follow_icon"
         android:layout_gravity="center_vertical"
         android:contentDescription="@null"
-        app:srcCompat="@drawable/ic_reader_follow_blue_medium_24dp" />
+        android:src="@drawable/ic_reader_follow_blue_medium_24dp" />
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/text_follow_button"

--- a/WordPress/src/main/res/layout/reader_include_comment_box.xml
+++ b/WordPress/src/main/res/layout/reader_include_comment_box.xml
@@ -4,9 +4,9 @@
     comment box at bottom of comment detail and reader comment list
 -->
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/white"
@@ -30,7 +30,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
             android:contentDescription="@null"
-            app:srcCompat="@drawable/ic_reply_grey_min_24dp"
+            android:src="@drawable/ic_reply_grey_min_24dp"
             android:layout_marginStart="@dimen/content_margin"/>
 
         <org.wordpress.android.widgets.SuggestionAutoCompleteText

--- a/WordPress/src/main/res/layout/reader_listitem_comment.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_comment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/layout_container"
     android:layout_width="match_parent"
@@ -103,7 +103,7 @@
                     android:layout_gravity="center_vertical"
                     android:padding="@dimen/margin_extra_small"
                     android:contentDescription="@null"
-                    app:srcCompat="@drawable/ic_reply_grey_min_24dp" />
+                    android:src="@drawable/ic_reply_grey_min_24dp" />
 
                 <org.wordpress.android.widgets.WPTextView
                     android:layout_width="wrap_content"

--- a/WordPress/src/main/res/layout/reader_listitem_tag.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_tag.xml
@@ -4,9 +4,9 @@
     list item which shows a followed tag - see ReaderTagAdapter
  -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:selectableItemBackground"
@@ -36,5 +36,5 @@
         android:background="?android:selectableItemBackground"
         android:padding="@dimen/margin_small"
         android:contentDescription="@string/remove"
-        app:srcCompat="@drawable/ic_cross_grey_600_24dp" />
+        android:src="@drawable/ic_cross_grey_600_24dp" />
 </LinearLayout>

--- a/WordPress/src/main/res/layout/reader_site_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_site_header_view.xml
@@ -2,7 +2,6 @@
 
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/layout_blog_info"
     android:layout_width="match_parent"
@@ -24,7 +23,7 @@
             android:id="@+id/image_blavatar"
             style="@style/ReaderImageView.Avatar"
             android:layout_centerVertical="true"
-            app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
+            android:src="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
             android:layout_marginEnd="@dimen/margin_large"
             android:contentDescription="@null"/>
 

--- a/WordPress/src/main/res/layout/related_posts_dialog.xml
+++ b/WordPress/src/main/res/layout/related_posts_dialog.xml
@@ -2,7 +2,6 @@
 
 <org.wordpress.android.widgets.WPScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:paddingTop="@dimen/site_settings_divider_height"
@@ -102,7 +101,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="96dp"
                 android:layout_marginTop="4dp"
-                app:srcCompat="@drawable/rppreview1" />
+                android:src="@drawable/rppreview1" />
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/related_post_title1"
@@ -130,7 +129,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="96dp"
                 android:layout_marginTop="8dp"
-                app:srcCompat="@drawable/rppreview2" />
+                android:src="@drawable/rppreview2" />
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/related_post_title2"
@@ -158,7 +157,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="96dp"
                 android:layout_marginTop="8dp"
-                app:srcCompat="@drawable/rppreview3" />
+                android:src="@drawable/rppreview3" />
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/related_post_title3"

--- a/WordPress/src/main/res/layout/signup_epilogue.xml
+++ b/WordPress/src/main/res/layout/signup_epilogue.xml
@@ -67,7 +67,7 @@
                             android:id="@+id/signup_epilogue_header_avatar"
                             android:layout_height="match_parent"
                             android:layout_width="match_parent"
-                            app:srcCompat="@drawable/ic_gridicons_user_circle_100dp"
+                            android:src="@drawable/ic_gridicons_user_circle_100dp"
                             android:importantForAccessibility="no"
                             app:wpDefaultImageDrawable="@drawable/ic_gridicons_user_circle_100dp"
                             app:wpErrorImageDrawable="@drawable/ic_gridicons_user_circle_100dp" >
@@ -83,7 +83,7 @@
                             android:tint="@color/grey_lighten_10"
                             android:importantForAccessibility="no"
                             android:visibility="gone"
-                            app:srcCompat="@drawable/ic_add_grey_24dp"
+                            android:src="@drawable/ic_add_grey_24dp"
                             tools:visibility="visible" >
                         </ImageButton>
 

--- a/WordPress/src/main/res/layout/site_creation_category_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_category_screen.xml
@@ -73,7 +73,7 @@
                         android:layout_centerVertical="true"
                         android:importantForAccessibility="no"
                         android:scaleType="centerInside"
-                        app:srcCompat="@drawable/img_type_blog_80dp"/>
+                        android:src="@drawable/img_type_blog_80dp"/>
 
                     <RelativeLayout
                         android:layout_width="match_parent"
@@ -127,7 +127,7 @@
                         android:layout_centerVertical="true"
                         android:importantForAccessibility="no"
                         android:scaleType="centerInside"
-                        app:srcCompat="@drawable/img_type_website_80dp"/>
+                        android:src="@drawable/img_type_website_80dp"/>
 
                     <RelativeLayout
                         android:layout_width="match_parent"
@@ -181,7 +181,7 @@
                         android:layout_centerVertical="true"
                         android:importantForAccessibility="no"
                         android:scaleType="centerInside"
-                        app:srcCompat="@drawable/img_type_portfolio_80dp"/>
+                        android:src="@drawable/img_type_portfolio_80dp"/>
 
                     <RelativeLayout
                         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/site_creation_creating_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_creating_screen.xml
@@ -2,7 +2,6 @@
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -25,7 +24,7 @@
                 android:layout_height="@dimen/site_creation_creating_illustration_height"
                 android:scaleType="centerInside"
                 android:importantForAccessibility="no"
-                app:srcCompat="@drawable/img_site_wordpress_camera_pencils_226dp"/>
+                android:src="@drawable/img_site_wordpress_camera_pencils_226dp"/>
 
             <LinearLayout
                 android:id="@+id/progress_container"
@@ -155,7 +154,7 @@
                 android:layout_above="@id/centerline"
                 android:contentDescription="@null"
                 android:scaleType="center"
-                app:srcCompat="@drawable/img_confetti_284dp"/>
+                android:src="@drawable/img_confetti_284dp"/>
 
             <TextView
                 style="@style/TextAppearance.AppCompat.Inverse"

--- a/WordPress/src/main/res/layout/site_picker_listitem.xml
+++ b/WordPress/src/main/res/layout/site_picker_listitem.xml
@@ -2,7 +2,6 @@
 
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -26,7 +25,7 @@
             android:background="@color/white"
             android:gravity="center_vertical"
             android:padding="1dp"
-            app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
+            android:src="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
             android:contentDescription="@string/blavatar_desc"/>
 
         <LinearLayout

--- a/WordPress/src/main/res/layout/site_settings_tag_list_activity.xml
+++ b/WordPress/src/main/res/layout/site_settings_tag_list_activity.xml
@@ -25,7 +25,7 @@
         android:visibility="invisible"
         app:borderWidth="0dp"
         app:rippleColor="@color/fab_pressed"
-        app:srcCompat="@drawable/ic_plus_white_24dp"
+        android:src="@drawable/ic_plus_white_24dp"
         tools:visibility="visible" >
     </android.support.design.widget.FloatingActionButton>
 

--- a/WordPress/src/main/res/layout/stats_insights_all_time_item.xml
+++ b/WordPress/src/main/res/layout/stats_insights_all_time_item.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools"
     android:baselineAligned="false"
     android:padding="@dimen/margin_extra_large"
     android:orientation="vertical">
@@ -35,7 +35,7 @@
                     android:layout_height="12dp"
                     android:layout_marginEnd="3dp"
                     android:contentDescription="@null"
-                    app:srcCompat="@drawable/ic_posts_grey_dark_24dp" />
+                    android:src="@drawable/ic_posts_grey_dark_24dp" />
 
                 <org.wordpress.android.util.widgets.AutoResizeTextView
                     style="@style/StatsInsightsLabel"
@@ -81,7 +81,7 @@
                     android:layout_height="12dp"
                     android:layout_marginEnd="3dp"
                     android:contentDescription="@null"
-                    app:srcCompat="@drawable/ic_visible_on_grey_dark_12dp" />
+                    android:src="@drawable/ic_visible_on_grey_dark_12dp" />
 
                 <org.wordpress.android.util.widgets.AutoResizeTextView
                     style="@style/StatsInsightsLabel"
@@ -134,7 +134,7 @@
                     android:layout_height="12dp"
                     android:layout_marginEnd="3dp"
                     android:contentDescription="@null"
-                    app:srcCompat="@drawable/ic_user_grey_dark_12dp" />
+                    android:src="@drawable/ic_user_grey_dark_12dp" />
 
                 <org.wordpress.android.util.widgets.AutoResizeTextView
                     style="@style/StatsInsightsLabel"
@@ -180,7 +180,7 @@
                     android:layout_height="12dp"
                     android:layout_marginEnd="3dp"
                     android:contentDescription="@null"
-                    app:srcCompat="@drawable/ic_trophy_alert_yellow_32dp" />
+                    android:src="@drawable/ic_trophy_alert_yellow_32dp" />
 
                 <org.wordpress.android.util.widgets.AutoResizeTextView
                     style="@style/StatsInsightsLabel"

--- a/WordPress/src/main/res/layout/stats_jetpack_connection_activity.xml
+++ b/WordPress/src/main/res/layout/stats_jetpack_connection_activity.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
@@ -32,7 +32,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/margin_extra_large"
                     android:layout_width="wrap_content"
-                    app:srcCompat="@drawable/img_illustration_stats_226dp" />
+                    android:src="@drawable/img_illustration_stats_226dp" />
 
                 <TextView
                     style="@style/JetpackConnectionText"

--- a/WordPress/src/main/res/layout/stats_list_cell.xml
+++ b/WordPress/src/main/res/layout/stats_list_cell.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -27,7 +27,7 @@
             android:layout_marginEnd="10dp"
             android:visibility="gone"
             android:contentDescription="@string/open_external_link_desc"
-            app:srcCompat="@drawable/ic_external_blue_wordpress_18dp" />
+            android:src="@drawable/ic_external_blue_wordpress_18dp" />
 
         <ImageView
             android:id="@+id/stats_list_cell_chevron"
@@ -37,7 +37,7 @@
             android:visibility="gone"
             android:importantForAccessibility="yes"
             android:contentDescription="@string/stats_list_cell_chevron_expand_desc"
-            app:srcCompat="@drawable/ic_chevron_right_blue_wordpress_24dp" />
+            android:src="@drawable/ic_chevron_right_blue_wordpress_24dp" />
 
         <ImageView
             android:id="@+id/stats_list_cell_image"
@@ -83,7 +83,7 @@
             android:layout_marginEnd="@dimen/margin_large"
             android:background="?android:selectableItemBackground"
             android:contentDescription="@string/show_more_desc"
-            app:srcCompat="@drawable/ic_ellipsis_blue_wordpress_32dp"
+            android:src="@drawable/ic_ellipsis_blue_wordpress_32dp"
             android:paddingEnd="@dimen/margin_small"
             android:paddingStart="@dimen/margin_small"/>
 

--- a/WordPress/src/main/res/layout/stats_visitors_and_views_fragment.xml
+++ b/WordPress/src/main/res/layout/stats_visitors_and_views_fragment.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
-    android:layout_gravity="center"
-    android:gravity="center">
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:orientation="vertical"
+              android:layout_gravity="center"
+              android:gravity="center">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -87,7 +86,7 @@
                 <ImageView
                     android:layout_width="24dp"
                     android:layout_height="24dp"
-                    app:srcCompat="@drawable/ic_info_grey_800_32dp"
+                    android:src="@drawable/ic_info_grey_800_32dp"
                     android:contentDescription="@null"
                     android:paddingEnd="@dimen/margin_medium"/>
                 <TextView

--- a/WordPress/src/main/res/layout/stats_visitors_and_views_tab.xml
+++ b/WordPress/src/main/res/layout/stats_visitors_and_views_tab.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
               xmlns:tools="http://schemas.android.com/tools"
               android:layout_height="match_parent"
               android:layout_width="0dp"
@@ -32,7 +31,7 @@
                 android:layout_height="12dp"
                 android:layout_marginEnd="3dp"
                 android:contentDescription="@null"
-                app:srcCompat="@drawable/ic_star_white_48dp" />
+                android:src="@drawable/ic_star_white_48dp" />
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
                 android:id="@+id/stats_visitors_and_views_tab_label"

--- a/WordPress/src/main/res/layout/theme_browser_fragment.xml
+++ b/WordPress/src/main/res/layout/theme_browser_fragment.xml
@@ -50,7 +50,7 @@
             android:layout_centerHorizontal="true"
             android:adjustViewBounds="true"
             android:contentDescription="@string/theme_no_search_result_found"
-            app:srcCompat="@drawable/drake_empty_results_400dp"/>
+            android:src="@drawable/drake_empty_results_400dp"/>
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/text_empty"

--- a/WordPress/src/main/res/layout/theme_grid_cardview_header.xml
+++ b/WordPress/src/main/res/layout/theme_grid_cardview_header.xml
@@ -70,7 +70,7 @@
                         android:layout_margin="@dimen/margin_none"
                         android:adjustViewBounds="true"
                         android:contentDescription="@null"
-                        card_view:srcCompat="@drawable/ic_customize_grey_dark_18dp" />
+                        android:src="@drawable/ic_customize_grey_dark_18dp" />
 
                     <org.wordpress.android.widgets.WPTextView
                         android:layout_width="wrap_content"
@@ -101,7 +101,7 @@
                         android:layout_margin="@dimen/margin_none"
                         android:adjustViewBounds="true"
                         android:contentDescription="@null"
-                        card_view:srcCompat="@drawable/ic_info_outline_grey_dark_18dp" />
+                        android:src="@drawable/ic_info_outline_grey_dark_18dp" />
 
                     <org.wordpress.android.widgets.WPTextView
                         android:layout_width="wrap_content"
@@ -132,7 +132,7 @@
                         android:layout_margin="@dimen/margin_none"
                         android:adjustViewBounds="true"
                         android:contentDescription="@null"
-                        card_view:srcCompat="@drawable/ic_help_outline_grey_dark_18dp" />
+                        android:src="@drawable/ic_help_outline_grey_dark_18dp" />
 
                     <org.wordpress.android.widgets.WPTextView
                         android:layout_width="wrap_content"

--- a/WordPress/src/main/res/layout/theme_grid_item.xml
+++ b/WordPress/src/main/res/layout/theme_grid_item.xml
@@ -98,7 +98,7 @@
                         android:background="?android:attr/selectableItemBackground"
                         android:contentDescription="@string/button_more"
                         android:padding="@dimen/theme_browser_more_button_padding"
-                        card_view:srcCompat="@drawable/ic_ellipsis_grey_lighten_10_24dp" />
+                        android:src="@drawable/ic_ellipsis_grey_lighten_10_24dp" />
 
                 </LinearLayout>
 

--- a/WordPress/src/main/res/layout/toolbar_login.xml
+++ b/WordPress/src/main/res/layout/toolbar_login.xml
@@ -18,5 +18,5 @@
         android:layout_height="24dp"
         android:layout_gravity="center"
         android:contentDescription="@null"
-        app:srcCompat="@drawable/ic_my_sites_white_32dp"/>
+        android:src="@drawable/ic_my_sites_white_32dp"/>
 </android.support.v7.widget.Toolbar>

--- a/WordPress/src/main/res/layout/username_changer_dialog_fragment.xml
+++ b/WordPress/src/main/res/layout/username_changer_dialog_fragment.xml
@@ -32,7 +32,7 @@
             android:paddingBottom="@dimen/margin_extra_large"
             android:paddingTop="@dimen/margin_extra_large"
             android:tint="@color/grey_lighten_10"
-            app:srcCompat="@drawable/ic_search_white_24dp" >
+            android:src="@drawable/ic_search_white_24dp" >
         </ImageView>
 
         <android.support.design.widget.TextInputEditText

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUtils.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUtils.java
@@ -9,7 +9,6 @@ import android.graphics.drawable.Drawable;
 import android.graphics.drawable.VectorDrawable;
 import android.os.Build;
 import android.support.annotation.DrawableRes;
-import android.support.graphics.drawable.VectorDrawableCompat;
 import android.support.v4.content.ContextCompat;
 import android.util.DisplayMetrics;
 
@@ -24,8 +23,7 @@ public class EditorMediaUtils {
         if (drawable instanceof BitmapDrawable) {
             bitmap = ((BitmapDrawable) drawable).getBitmap();
             bitmap = ImageUtils.getScaledBitmapAtLongestSide(bitmap, maxImageSizeForVisualEditor);
-        } else if (drawable instanceof VectorDrawableCompat
-                   || Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && drawable instanceof VectorDrawable) {
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && drawable instanceof VectorDrawable) {
             bitmap = Bitmap.createBitmap(maxImageSizeForVisualEditor, maxImageSizeForVisualEditor,
                                          Bitmap.Config.ARGB_8888);
             Canvas canvas = new Canvas(bitmap);


### PR DESCRIPTION
### Fix
Remove the support library flag for vector drawables and update the `app:srcCompat` references to `android:src` since the `minSdkVersion` is now `21`.  [`CONTRIBUTING.md`](https://github.com/wordpress-mobile/WordPress-Android/compare/issue/compat-library-vectors?expand=1#diff-6a3371457528722a734f3c51d9238c13) was also updated to reflect the preferred use and naming convention of vector drawables.

### Test
These changes touch every layout file using a vector drawable.  Launching the app and visiting multiple screens is the best way to test.

### Review
Only one developer is required to review these changes, but anyone can perform the review.