### PR TITLE
Bump Ktlint library to version 0.28.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ subprojects {
     }
 
     dependencies {
-        ktlint 'com.github.shyiko:ktlint:0.21.0'
+        ktlint 'com.github.shyiko:ktlint:0.28.0'
     }
 
     task ktlint(type: JavaExec) {


### PR DESCRIPTION
Bumping old ktlint version. Shouldn't change much for the devs. It enables better formatting of Kotlin files.