### PR TITLE
Issue/date time extensions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
@@ -10,9 +10,8 @@ import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.HE
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.LOADING
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.PROGRESS
 import org.wordpress.android.util.toFormattedDateString
-import java.text.DateFormat
+import org.wordpress.android.util.toFormattedTimeString
 import java.util.Date
-import java.util.Locale
 
 sealed class ActivityLogListItem(val type: ViewType) {
     interface IActionableItem {
@@ -35,7 +34,7 @@ sealed class ActivityLogListItem(val type: ViewType) {
         val isProgressBarVisible: Boolean = false
     ) : ActivityLogListItem(EVENT), IActionableItem {
         val formattedDate: String = date.toFormattedDateString()
-        val formattedTime: String = DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault()).format(date)
+        val formattedTime: String = date.toFormattedTimeString()
         val icon = Icon.fromValue(gridIcon)
         val status = Status.fromValue(eventStatus)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.FO
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.HEADER
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.LOADING
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.ViewType.PROGRESS
+import org.wordpress.android.util.toFormattedDateString
 import java.text.DateFormat
 import java.util.Date
 import java.util.Locale
@@ -33,7 +34,7 @@ sealed class ActivityLogListItem(val type: ViewType) {
         val buttonIcon: Icon = HISTORY,
         val isProgressBarVisible: Boolean = false
     ) : ActivityLogListItem(EVENT), IActionableItem {
-        val formattedDate: String = DateFormat.getDateInstance(DateFormat.LONG, Locale.getDefault()).format(date)
+        val formattedDate: String = date.toFormattedDateString()
         val formattedTime: String = DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault()).format(date)
         val icon = Icon.fromValue(gridIcon)
         val status = Status.fromValue(eventStatus)


### PR DESCRIPTION
### Fix
Update the formatted date and time values used in the [`ActivityLogListItem`](https://github.com/wordpress-mobile/WordPress-Android/compare/issue/date-time-extensions?expand=1#diff-615e7f1ea170a64ba30f05b3e5bd256a) class to use the extension functions.

### Test
1. Go to ***My Site*** tab.
2. Tap ***Activity*** item.
3. Notice ***Activity Log*** list is displayed similar to the screenshot below.

<img src="https://user-images.githubusercontent.com/3827611/46816393-e353e400-cd4a-11e8-8d2b-e7c589207b9b.png" width="360">