### PR TITLE
Fix for issue #7874: empty appbar when no title is set

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -830,9 +830,11 @@ public class MySiteFragment extends Fragment implements
 
     @Override
     public void setTitle(@NonNull final String title) {
-        mToolbarTitle = title.isEmpty() ? getString(R.string.wordpress_as_site_title_when_no_title) : title;
-        if (mToolbar != null) {
-            mToolbar.setTitle(mToolbarTitle);
+        if(isAdded()){
+            mToolbarTitle = title.isEmpty() ? getString(R.string.wordpress) : title;
+            if (mToolbar != null) {
+                mToolbar.setTitle(mToolbarTitle);
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -830,7 +830,7 @@ public class MySiteFragment extends Fragment implements
 
     @Override
     public void setTitle(@NonNull final String title) {
-        if(isAdded()){
+        if (isAdded()) {
             mToolbarTitle = title.isEmpty() ? getString(R.string.wordpress) : title;
             if (mToolbar != null) {
                 mToolbar.setTitle(mToolbarTitle);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -831,9 +831,8 @@ public class MySiteFragment extends Fragment implements
     @Override
     public void setTitle(@NonNull final String title) {
         if (isAdded()) {
-            if (title != null) {
-                mToolbarTitle = title.isEmpty() ? getString(R.string.wordpress) : title;
-            }
+            mToolbarTitle = (title == null || title.isEmpty()) ? getString(R.string.wordpress) : title;
+
             if (mToolbar != null) {
                 mToolbar.setTitle(mToolbarTitle);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -831,7 +831,9 @@ public class MySiteFragment extends Fragment implements
     @Override
     public void setTitle(@NonNull final String title) {
         if (isAdded()) {
-            mToolbarTitle = title.isEmpty() ? getString(R.string.wordpress) : title;
+            if (title != null) {
+                mToolbarTitle = title.isEmpty() ? getString(R.string.wordpress) : title;
+            }
             if (mToolbar != null) {
                 mToolbar.setTitle(mToolbarTitle);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -830,9 +830,9 @@ public class MySiteFragment extends Fragment implements
 
     @Override
     public void setTitle(@NonNull final String title) {
-        mToolbarTitle = title;
+        mToolbarTitle = title.isEmpty() ? getString(R.string.wordpress_as_site_title_when_no_title) : title;
         if (mToolbar != null) {
-            mToolbar.setTitle(title);
+            mToolbar.setTitle(mToolbarTitle);
         }
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -47,6 +47,9 @@
     <string name="edit_photo_screen_title">Edit Photo</string>
     <string name="notif_detail_screen_title">Notification detail %s</string>
 
+    <!-- default strings -->
+    <string name="wordpress_as_site_title_when_no_title">WordPress</string>
+
     <!-- general strings -->
     <string name="posts">Posts</string>
     <string name="sites">Sites</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -48,7 +48,7 @@
     <string name="notif_detail_screen_title">Notification detail %s</string>
 
     <!-- default strings -->
-    <string name="wordpress_as_site_title_when_no_title">WordPress</string>
+    <string name="wordpress" translatable="false">WordPress</string>
 
     <!-- general strings -->
     <string name="posts">Posts</string>


### PR DESCRIPTION
Fixes #7874 

To test: Changed `mToolbarTitle` in `setTitle` method in file `MySiteFragment.java`

Below is a screenshot after fix.
<img width="409" alt="android fix" src="https://user-images.githubusercontent.com/1898545/46837887-c9e48380-cdae-11e8-8f43-2fe53e4903bd.png">

