### PR TITLE
Issue/8341 add history load

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryListItem.kt
@@ -1,5 +1,9 @@
 package org.wordpress.android.ui.history
 
+import android.os.Parcelable
+import kotlinx.android.parcel.IgnoredOnParcel
+import kotlinx.android.parcel.Parcelize
+import kotlinx.android.parcel.RawValue
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.revisions.Diff
 import org.wordpress.android.fluxc.model.revisions.RevisionModel
@@ -9,7 +13,6 @@ import org.wordpress.android.ui.history.HistoryListItem.ViewType.REVISION
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.toFormattedDateString
 import org.wordpress.android.util.toFormattedTimeString
-import java.io.Serializable
 import java.util.ArrayList
 import java.util.Date
 
@@ -20,6 +23,7 @@ sealed class HistoryListItem(val type: ViewType) {
 
     data class Header(val text: String) : HistoryListItem(HEADER)
 
+    @Parcelize
     data class Revision(
         val revisionId: Long,
         val diffFromVersion: Long,
@@ -31,14 +35,14 @@ sealed class HistoryListItem(val type: ViewType) {
         val postDateGmt: String?,
         val postModifiedGmt: String?,
         val postAuthorId: String?,
-        val titleDiffs: ArrayList<Diff>,
-        val contentDiffs: ArrayList<Diff>
-    ) : HistoryListItem(REVISION), Serializable {
+        val titleDiffs: ArrayList<@RawValue Diff>,
+        val contentDiffs: ArrayList<@RawValue Diff>
+    ) : HistoryListItem(REVISION), Parcelable {
         // Replace space with T since API returns yyyy-MM-dd hh:mm:ssZ and ISO 8601 format is yyyy-MM-ddThh:mm:ssZ.
-        private val postDate: Date = DateTimeUtils.dateUTCFromIso8601(postDateGmt?.replace(" ", "T"))
-        val timeSpan: String = DateTimeUtils.javaDateToTimeSpan(postDate, WordPress.getContext())
-        val formattedDate: String = postDate.toFormattedDateString()
-        val formattedTime: String = postDate.toFormattedTimeString()
+        @IgnoredOnParcel private val postDate: Date = DateTimeUtils.dateUTCFromIso8601(postDateGmt?.replace(" ", "T"))
+        @IgnoredOnParcel val timeSpan: String = DateTimeUtils.javaDateToTimeSpan(postDate, WordPress.getContext())
+        @IgnoredOnParcel val formattedDate: String = postDate.toFormattedDateString()
+        @IgnoredOnParcel val formattedTime: String = postDate.toFormattedTimeString()
 
         constructor(model: RevisionModel) : this(
                 model.revisionId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryListItem.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.ui.history.HistoryListItem.ViewType.REVISION
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.toFormattedDateString
 import org.wordpress.android.util.toFormattedTimeString
+import java.io.Serializable
 import java.util.ArrayList
 import java.util.Date
 
@@ -32,7 +33,7 @@ sealed class HistoryListItem(val type: ViewType) {
         val postAuthorId: String?,
         val titleDiffs: ArrayList<Diff>,
         val contentDiffs: ArrayList<Diff>
-    ) : HistoryListItem(REVISION) {
+    ) : HistoryListItem(REVISION), Serializable {
         // Replace space with T since API returns yyyy-MM-dd hh:mm:ssZ and ISO 8601 format is yyyy-MM-ddThh:mm:ssZ.
         private val postDate: Date = DateTimeUtils.dateUTCFromIso8601(postDateGmt?.replace(" ", "T"))
         val timeSpan: String = DateTimeUtils.javaDateToTimeSpan(postDate, WordPress.getContext())

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryListItem.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.history
 
+import android.annotation.SuppressLint
 import android.os.Parcelable
 import kotlinx.android.parcel.IgnoredOnParcel
 import kotlinx.android.parcel.Parcelize
@@ -24,6 +25,7 @@ sealed class HistoryListItem(val type: ViewType) {
     data class Header(val text: String) : HistoryListItem(HEADER)
 
     @Parcelize
+    @SuppressLint("ParcelCreator")
     data class Revision(
         val revisionId: Long,
         val diffFromVersion: Long,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -270,7 +270,7 @@ public class EditPostActivity extends AppCompatActivity implements
     WPViewPager mViewPager;
 
     private PostModel mPost;
-    private PostModel mPostWithLocalChanges;
+    private PostModel mPostForUndo;
     private PostModel mOriginalPost;
     private boolean mOriginalPostHadLocalChangesOnOpen;
 
@@ -1206,7 +1206,7 @@ public class EditPostActivity extends AppCompatActivity implements
             } else if (itemId == R.id.menu_discard_changes) {
                 AnalyticsTracker.track(Stat.EDITOR_DISCARDED_CHANGES);
                 showDialogProgress(true);
-                mPostWithLocalChanges = mPost.clone();
+                mPostForUndo = mPost.clone();
                 mIsDiscardingChanges = true;
                 RemotePostPayload payload = new RemotePostPayload(mPost, mSite);
                 mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(payload));
@@ -1595,7 +1595,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
     private void loadRevision() {
         showDialogProgress(true);
-        mPostWithLocalChanges = mPost.clone();
+        mPostForUndo = mPost.clone();
         mPost.setTitle(mRevision.getPostTitle());
         mPost.setContent(mRevision.getPostContent());
         mPost.setStatus(PostStatus.DRAFT.toString());
@@ -1607,9 +1607,9 @@ public class EditPostActivity extends AppCompatActivity implements
                     @Override
                     public void onClick(View view) {
                         // TODO: Add analytics tracking for loaded revision undo.
-                        RemotePostPayload payload = new RemotePostPayload(mPostWithLocalChanges, mSite);
+                        RemotePostPayload payload = new RemotePostPayload(mPostForUndo, mSite);
                         mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(payload));
-                        mPost = mPostWithLocalChanges.clone();
+                        mPost = mPostForUndo.clone();
                         refreshEditorContent();
                     }
                 })
@@ -3493,9 +3493,9 @@ public class EditPostActivity extends AppCompatActivity implements
                                 .setAction(getString(R.string.undo), new OnClickListener() {
                                     @Override public void onClick(View view) {
                                         AnalyticsTracker.track(Stat.EDITOR_DISCARDED_CHANGES_UNDO);
-                                        RemotePostPayload payload = new RemotePostPayload(mPostWithLocalChanges, mSite);
+                                        RemotePostPayload payload = new RemotePostPayload(mPostForUndo, mSite);
                                         mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(payload));
-                                        mPost = mPostWithLocalChanges.clone();
+                                        mPost = mPostForUndo.clone();
                                         refreshEditorContent();
                                     }
                                 })

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1598,7 +1598,8 @@ public class EditPostActivity extends AppCompatActivity implements
         mPostForUndo = mPost.clone();
         mPost.setTitle(mRevision.getPostTitle());
         mPost.setContent(mRevision.getPostContent());
-        mPost.setStatus(PostStatus.DRAFT.toString());
+        mPost.setIsLocallyChanged(true);
+        mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
         refreshEditorContent();
 
         Snackbar.make(mViewPager, getString(R.string.history_loaded_revision),

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -219,6 +219,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private static final String STATE_KEY_IS_NEW_POST = "stateKeyIsNewPost";
     private static final String STATE_KEY_IS_PHOTO_PICKER_VISIBLE = "stateKeyPhotoPickerVisible";
     private static final String STATE_KEY_HTML_MODE_ON = "stateKeyHtmlModeOn";
+    private static final String STATE_KEY_REVISION_ID = "stateKeyRevisionId";
     private static final String TAG_DISCARDING_CHANGES_ERROR_DIALOG = "tag_discarding_changes_error_dialog";
     private static final String TAG_PUBLISH_CONFIRMATION_DIALOG = "tag_publish_confirmation_dialog";
     private static final String TAG_REMOVE_FAILED_UPLOADS_DIALOG = "tag_remove_failed_uploads_dialog";
@@ -286,6 +287,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private boolean mIsDialogProgressShown;
     private boolean mIsDiscardingChanges;
     private boolean mIsUpdatingPost;
+    private long mRevisionId;
 
     private View mPhotoPickerContainer;
     private PhotoPickerFragment mPhotoPickerFragment;
@@ -410,6 +412,7 @@ public class EditPostActivity extends AppCompatActivity implements
             mDroppedMediaUris = savedInstanceState.getParcelable(STATE_KEY_DROPPED_MEDIA_URIS);
             mIsNewPost = savedInstanceState.getBoolean(STATE_KEY_IS_NEW_POST, false);
             mIsDialogProgressShown = savedInstanceState.getBoolean(STATE_KEY_IS_DIALOG_PROGRESS_SHOWN, false);
+            mRevisionId = savedInstanceState.getLong(STATE_KEY_REVISION_ID);
 
             showDialogProgress(mIsDialogProgressShown);
 
@@ -700,6 +703,7 @@ public class EditPostActivity extends AppCompatActivity implements
         outState.putBoolean(STATE_KEY_IS_PHOTO_PICKER_VISIBLE, isPhotoPickerShowing());
         outState.putBoolean(STATE_KEY_HTML_MODE_ON, mHtmlModeMenuStateOn);
         outState.putSerializable(WordPress.SITE, mSite);
+        outState.putLong(STATE_KEY_REVISION_ID, mRevisionId);
 
         outState.putParcelableArrayList(STATE_KEY_DROPPED_MEDIA_URIS, mDroppedMediaUris);
 
@@ -1569,6 +1573,8 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onHistoryItemClicked(long revisionId, @NonNull String formattedDate, @NonNull String formattedTime) {
+        mRevisionId = revisionId;
+
         BasicFragmentDialog dialog = new BasicFragmentDialog();
         dialog.initialize(TAG_HISTORY_LOAD_DIALOG,
                 getString(R.string.history_load_dialog_title),

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -210,6 +210,7 @@ public class EditPostActivity extends AppCompatActivity implements
     public static final String EXTRA_HAS_CHANGES = "hasChanges";
     public static final String EXTRA_IS_DISCARDABLE = "isDiscardable";
     public static final String EXTRA_INSERT_MEDIA = "insertMedia";
+    public static final String TAG_HISTORY_LOAD_DIALOG = "history_load_dialog_tag";
     private static final String STATE_KEY_EDITOR_FRAGMENT = "editorFragment";
     private static final String STATE_KEY_DROPPED_MEDIA_URIS = "stateKeyDroppedMediaUri";
     private static final String STATE_KEY_POST_LOCAL_ID = "stateKeyPostModelLocalId";
@@ -1470,6 +1471,7 @@ public class EditPostActivity extends AppCompatActivity implements
             case TAG_DISCARDING_CHANGES_ERROR_DIALOG:
             case TAG_PUBLISH_CONFIRMATION_DIALOG:
             case TAG_REMOVE_FAILED_UPLOADS_DIALOG:
+            case TAG_HISTORY_LOAD_DIALOG:
                 // the dialog is automatically dismissed
                 break;
             default:
@@ -1488,6 +1490,9 @@ public class EditPostActivity extends AppCompatActivity implements
         switch (instanceTag) {
             case TAG_DISCARDING_CHANGES_ERROR_DIALOG:
                 mZendeskHelper.createNewTicket(this, Origin.DISCARD_CHANGES, mSite);
+                break;
+            case TAG_HISTORY_LOAD_DIALOG:
+                // TODO: Load revision.
                 break;
             case TAG_PUBLISH_CONFIRMATION_DIALOG:
                 mPost.setStatus(PostStatus.PUBLISHED.toString());
@@ -1564,6 +1569,14 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onHistoryItemClicked(long revisionId, @NonNull String formattedDate, @NonNull String formattedTime) {
+        BasicFragmentDialog dialog = new BasicFragmentDialog();
+        dialog.initialize(TAG_HISTORY_LOAD_DIALOG,
+                getString(R.string.history_load_dialog_title),
+                getString(R.string.history_load_dialog_message, formattedDate, formattedTime),
+                getString(R.string.history_load_dialog_button_positive),
+                getString(R.string.cancel),
+                null);
+        dialog.show(getSupportFragmentManager(), TAG_HISTORY_LOAD_DIALOG);
     }
 
     private boolean isNewPost() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -219,7 +219,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private static final String STATE_KEY_IS_NEW_POST = "stateKeyIsNewPost";
     private static final String STATE_KEY_IS_PHOTO_PICKER_VISIBLE = "stateKeyPhotoPickerVisible";
     private static final String STATE_KEY_HTML_MODE_ON = "stateKeyHtmlModeOn";
-    private static final String STATE_KEY_REVISION_ID = "stateKeyRevisionId";
+    private static final String STATE_KEY_REVISION = "stateKeyRevision";
     private static final String TAG_DISCARDING_CHANGES_ERROR_DIALOG = "tag_discarding_changes_error_dialog";
     private static final String TAG_PUBLISH_CONFIRMATION_DIALOG = "tag_publish_confirmation_dialog";
     private static final String TAG_REMOVE_FAILED_UPLOADS_DIALOG = "tag_remove_failed_uploads_dialog";
@@ -273,6 +273,8 @@ public class EditPostActivity extends AppCompatActivity implements
     private PostModel mOriginalPost;
     private boolean mOriginalPostHadLocalChangesOnOpen;
 
+    private Revision mRevision;
+
     private EditorFragmentAbstract mEditorFragment;
     private EditPostSettingsFragment mEditPostSettingsFragment;
     private EditPostPreviewFragment mEditPostPreviewFragment;
@@ -287,7 +289,6 @@ public class EditPostActivity extends AppCompatActivity implements
     private boolean mIsDialogProgressShown;
     private boolean mIsDiscardingChanges;
     private boolean mIsUpdatingPost;
-    private long mRevisionId;
 
     private View mPhotoPickerContainer;
     private PhotoPickerFragment mPhotoPickerFragment;
@@ -412,7 +413,7 @@ public class EditPostActivity extends AppCompatActivity implements
             mDroppedMediaUris = savedInstanceState.getParcelable(STATE_KEY_DROPPED_MEDIA_URIS);
             mIsNewPost = savedInstanceState.getBoolean(STATE_KEY_IS_NEW_POST, false);
             mIsDialogProgressShown = savedInstanceState.getBoolean(STATE_KEY_IS_DIALOG_PROGRESS_SHOWN, false);
-            mRevisionId = savedInstanceState.getLong(STATE_KEY_REVISION_ID);
+            mRevision = (Revision) savedInstanceState.getSerializable(STATE_KEY_REVISION);
 
             showDialogProgress(mIsDialogProgressShown);
 
@@ -703,7 +704,7 @@ public class EditPostActivity extends AppCompatActivity implements
         outState.putBoolean(STATE_KEY_IS_PHOTO_PICKER_VISIBLE, isPhotoPickerShowing());
         outState.putBoolean(STATE_KEY_HTML_MODE_ON, mHtmlModeMenuStateOn);
         outState.putSerializable(WordPress.SITE, mSite);
-        outState.putLong(STATE_KEY_REVISION_ID, mRevisionId);
+        outState.putSerializable(STATE_KEY_REVISION, mRevision);
 
         outState.putParcelableArrayList(STATE_KEY_DROPPED_MEDIA_URIS, mDroppedMediaUris);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -414,7 +414,7 @@ public class EditPostActivity extends AppCompatActivity implements
             mDroppedMediaUris = savedInstanceState.getParcelable(STATE_KEY_DROPPED_MEDIA_URIS);
             mIsNewPost = savedInstanceState.getBoolean(STATE_KEY_IS_NEW_POST, false);
             mIsDialogProgressShown = savedInstanceState.getBoolean(STATE_KEY_IS_DIALOG_PROGRESS_SHOWN, false);
-            mRevision = (Revision) savedInstanceState.getSerializable(STATE_KEY_REVISION);
+            mRevision = savedInstanceState.getParcelable(STATE_KEY_REVISION);
 
             showDialogProgress(mIsDialogProgressShown);
 
@@ -705,7 +705,7 @@ public class EditPostActivity extends AppCompatActivity implements
         outState.putBoolean(STATE_KEY_IS_PHOTO_PICKER_VISIBLE, isPhotoPickerShowing());
         outState.putBoolean(STATE_KEY_HTML_MODE_ON, mHtmlModeMenuStateOn);
         outState.putSerializable(WordPress.SITE, mSite);
-        outState.putSerializable(STATE_KEY_REVISION, mRevision);
+        outState.putParcelable(STATE_KEY_REVISION, mRevision);
 
         outState.putParcelableArrayList(STATE_KEY_DROPPED_MEDIA_URIS, mDroppedMediaUris);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1572,13 +1572,15 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void onHistoryItemClicked(long revisionId, @NonNull String formattedDate, @NonNull String formattedTime) {
-        mRevisionId = revisionId;
+    public void onHistoryItemClicked(@NonNull Revision revision) {
+        // TODO: Add analytics tracking for history list item.
+        mRevision = revision;
 
         BasicFragmentDialog dialog = new BasicFragmentDialog();
         dialog.initialize(TAG_HISTORY_LOAD_DIALOG,
                 getString(R.string.history_load_dialog_title),
-                getString(R.string.history_load_dialog_message, formattedDate, formattedTime),
+                getString(R.string.history_load_dialog_message, mRevision.getFormattedDate(),
+                        mRevision.getFormattedTime()),
                 getString(R.string.history_load_dialog_button_positive),
                 getString(R.string.cancel),
                 null);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -110,6 +110,7 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.Shortcut;
 import org.wordpress.android.ui.accounts.HelpActivity.Origin;
+import org.wordpress.android.ui.history.HistoryListItem.Revision;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaBrowserType;
 import org.wordpress.android.ui.media.MediaSettingsActivity;
@@ -1231,7 +1232,9 @@ public class EditPostActivity extends AppCompatActivity implements
             mProgressDialog = new ProgressDialog(this);
             mProgressDialog.setCancelable(false);
             mProgressDialog.setIndeterminate(true);
-            mProgressDialog.setMessage(getString(R.string.local_changes_discarding));
+            mProgressDialog.setMessage(mIsDiscardingChanges
+                    ? getString(R.string.local_changes_discarding)
+                    : getString(R.string.history_loading_revision));
             mProgressDialog.show();
         } else if (mProgressDialog != null) {
             mProgressDialog.dismiss();
@@ -1497,7 +1500,9 @@ public class EditPostActivity extends AppCompatActivity implements
                 mZendeskHelper.createNewTicket(this, Origin.DISCARD_CHANGES, mSite);
                 break;
             case TAG_HISTORY_LOAD_DIALOG:
-                // TODO: Load revision.
+                // TODO: Add analytics tracking for load button.
+                mViewPager.setCurrentItem(PAGE_CONTENT);
+                loadRevision();
                 break;
             case TAG_PUBLISH_CONFIRMATION_DIALOG:
                 mPost.setStatus(PostStatus.PUBLISHED.toString());
@@ -1586,6 +1591,16 @@ public class EditPostActivity extends AppCompatActivity implements
                 getString(R.string.cancel),
                 null);
         dialog.show(getSupportFragmentManager(), TAG_HISTORY_LOAD_DIALOG);
+    }
+
+    private void loadRevision() {
+        showDialogProgress(true);
+        mPostWithLocalChanges = mPost.clone();
+        mPost.setTitle(mRevision.getPostTitle());
+        mPost.setContent(mRevision.getPostContent());
+        mPost.setStatus(PostStatus.DRAFT.toString());
+        refreshEditorContent();
+        showDialogProgress(false);
     }
 
     private boolean isNewPost() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1600,6 +1600,21 @@ public class EditPostActivity extends AppCompatActivity implements
         mPost.setContent(mRevision.getPostContent());
         mPost.setStatus(PostStatus.DRAFT.toString());
         refreshEditorContent();
+
+        Snackbar.make(mViewPager, getString(R.string.history_loaded_revision),
+                AccessibilityUtils.getSnackbarDuration(EditPostActivity.this, Snackbar.LENGTH_LONG))
+                .setAction(getString(R.string.undo), new OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        // TODO: Add analytics tracking for loaded revision undo.
+                        RemotePostPayload payload = new RemotePostPayload(mPostWithLocalChanges, mSite);
+                        mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(payload));
+                        mPost = mPostWithLocalChanges.clone();
+                        refreshEditorContent();
+                    }
+                })
+                .show();
+
         showDialogProgress(false);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -197,7 +197,8 @@ public class EditPostActivity extends AppCompatActivity implements
         BasicFragmentDialog.BasicDialogNegativeClickInterface,
         PromoDialogClickInterface,
         PostSettingsListDialogFragment.OnPostSettingsDialogFragmentListener,
-        PostDatePickerDialogFragment.OnPostDatePickerDialogListener {
+        PostDatePickerDialogFragment.OnPostDatePickerDialogListener,
+        HistoryListFragment.HistoryItemClickInterface {
     public static final String EXTRA_POST_LOCAL_ID = "postModelLocalId";
     public static final String EXTRA_POST_REMOTE_ID = "postModelRemoteId";
     public static final String EXTRA_IS_PAGE = "isPage";
@@ -1559,6 +1560,10 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override
     public void onBackPressed() {
         handleBackPressed();
+    }
+
+    @Override
+    public void onHistoryItemClicked(long revisionId, @NonNull String formattedDate, @NonNull String formattedTime) {
     }
 
     private boolean isNewPost() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -45,6 +45,10 @@ class HistoryListFragment : Fragment() {
         }
     }
 
+    interface HistoryItemClickInterface {
+        fun onHistoryItemClicked(revisionId: Long, formattedDate: String, formattedTime: String)
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.history_list_fragment, container, false)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.history.HistoryAdapter
 import org.wordpress.android.ui.history.HistoryListItem
+import org.wordpress.android.ui.history.HistoryListItem.Revision
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
@@ -46,7 +47,7 @@ class HistoryListFragment : Fragment() {
     }
 
     interface HistoryItemClickInterface {
-        fun onHistoryItemClicked(revisionId: Long, formattedDate: String, formattedTime: String)
+        fun onHistoryItemClicked(revision: Revision)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -135,10 +136,9 @@ class HistoryListFragment : Fragment() {
         })
     }
 
-    private fun showLoadDialog(revision: HistoryListItem.Revision) {
+    private fun showLoadDialog(revision: Revision) {
         if (activity is HistoryItemClickInterface) {
-            (activity as HistoryItemClickInterface).onHistoryItemClicked(
-                    revision.revisionId, revision.formattedDate, revision.formattedTime)
+            (activity as HistoryItemClickInterface).onHistoryItemClicked(revision)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -136,7 +136,10 @@ class HistoryListFragment : Fragment() {
     }
 
     private fun showLoadDialog(revision: HistoryListItem.Revision) {
-        // TODO: Show load confirmation dialog.
+        if (activity is HistoryItemClickInterface) {
+            (activity as HistoryItemClickInterface).onHistoryItemClicked(
+                    revision.revisionId, revision.formattedDate, revision.formattedTime)
+        }
     }
 
     private fun updateRefreshing(listStatus: HistoryViewModel.HistoryListStatus?) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1212,7 +1212,6 @@
     <string name="history_load_dialog_message">Do you want to load the revision from %1$s at %2$s?</string>
     <string name="history_load_dialog_title">Load Revision</string>
     <string name="history_loaded_revision">Revision loaded</string>
-    <string name="history_loading_error">There was an error in loading the revision. Please contact support for more assistance.</string>
     <string name="history_loading_revision">Loading revision</string>
     <string name="history_title" translatable="false">@string/menu_history</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1211,6 +1211,8 @@
     <string name="history_load_dialog_button_positive">Load</string>
     <string name="history_load_dialog_message">Do you want to load the revision from %1$s at %2$s?</string>
     <string name="history_load_dialog_title">Load Revision</string>
+    <string name="history_loading_error">There was an error in loading the revision. Please contact support for more assistance.</string>
+    <string name="history_loading_revision">Loading revision</string>
     <string name="history_title" translatable="false">@string/menu_history</string>
 
     <!-- Post Formats -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1208,6 +1208,9 @@
     <string name="history_empty_title">No history yet</string>
     <string name="history_footer_page">Page Created on %1$s at %2$s</string>
     <string name="history_footer_post">Post Created on %1$s at %2$s</string>
+    <string name="history_load_dialog_button_positive">Load</string>
+    <string name="history_load_dialog_message">Do you want to load the revision from %1$s at %2$s?</string>
+    <string name="history_load_dialog_title">Load Revision</string>
     <string name="history_title" translatable="false">@string/menu_history</string>
 
     <!-- Post Formats -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1211,6 +1211,7 @@
     <string name="history_load_dialog_button_positive">Load</string>
     <string name="history_load_dialog_message">Do you want to load the revision from %1$s at %2$s?</string>
     <string name="history_load_dialog_title">Load Revision</string>
+    <string name="history_loaded_revision">Revision loaded</string>
     <string name="history_loading_error">There was an error in loading the revision. Please contact support for more assistance.</string>
     <string name="history_loading_revision">Loading revision</string>
     <string name="history_title" translatable="false">@string/menu_history</string>


### PR DESCRIPTION
### Fix
Add a [snackbar](https://material.io/design/components/snackbars.html) with "Revision loaded" message and an ***Undo*** action in the editor when a revision is loaded as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8341.  See the screenshots below for illustration.

![revisions_editor_loaded](https://user-images.githubusercontent.com/3827611/46926945-0d363080-d001-11e8-879a-76380dba2fa0.png)

#### Note
There are a couple differences between the ***Design*** and ***Develop*** screenshots.  The snackbar message was changed from "Version loaded" to "Revision loaded" for consistency with other revision references (e.g. ***Revision*** detail view) and to avoid confusion with multiple terms (i.e. history, revision, version).  The snackbar action was changed from [`blue_wordpress`](https://github.com/wordpress-mobile/WordPress-Android/blob/e329640898408ae7e48dd45299e1fdd4d52adfc5/WordPress/src/main/res/values/colors.xml#L38)(`#0087be`) to [`orange_jazzy`](https://github.com/wordpress-mobile/WordPress-Android/blob/e329640898408ae7e48dd45299e1fdd4d52adfc5/WordPress/src/main/res/values/colors.xml#L64)(`#f0821e`) for consistency with other snackbar actions (e.g. Quick Start) and use the default accent color from the app style.

This pull request includes two items that were not in the initial design; a confirmation dialog when tapping an item in the ***History*** list to load the revision and a loading progress dialog when the ***Load*** action is chosen from the confirmation dialog.  The confirmation dialog is a temporary solution and will be replaced by the ***Revision*** detail view as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8340.  See the screenshots below for illustration.

![revisions_history_load](https://user-images.githubusercontent.com/3827611/46926935-014a6e80-d001-11e8-9fe0-d3459f59cd57.png)

![revisions_editor_loading](https://user-images.githubusercontent.com/3827611/46926948-0f988a80-d001-11e8-8a38-ddacd56a1778.png)

### Test
#### Site Pages
1. Go to ***My Site*** tab.
2. Tap ***Site Pages*** item under ***Publish*** section.
3. Tap page in ***Site Pages*** list.
4. Tap overflow menu button in top toolbar.
5. Tap ***History*** item in menu.
6. Tap item in ***History*** list.
7. Notice confirmation dialog shown above.
8. Tap ***Cancel*** action.
9. Notice confirmation dialog is dismissed.
10. Tap item in ***History*** list.
11. Notice confirmation dialog shown above.
12. Tap ***Load*** action.
13. Notice loading progress dialog shown above.
14. Notice revision title and content loaded.
15. Notice snackbar with ***Undo*** action shown above.

#### Blog Posts
1. Go to ***My Site*** tab.
2. Tap ***Blog Posts*** item under ***Publish*** section.
3. Tap post in ***Blog Posts*** list.
4. Tap overflow menu button in top toolbar.
5. Tap ***History*** item in menu.
6. Tap item in ***History*** list.
7. Notice confirmation dialog shown above.
8. Tap ***Cancel*** action.
9. Notice confirmation dialog is dismissed.
10. Tap item in ***History*** list.
11. Notice confirmation dialog shown above.
12. Tap ***Load*** action.
13. Notice loading progress dialog shown above.
14. Notice revision title and content loaded.
15. Notice snackbar with ***Undo*** action shown above.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.  I requested @mzorz as an additional reviewer since he is a page/post expert and can confirm if [this](https://github.com/wordpress-mobile/WordPress-Android/blob/f5e41205dbaf14b00e05c6358951ba80f9e7e436/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L1599-L1603) is the proper way to handle page/post editing in regards to status/synchronizing/uploading.