### PR TITLE
Update FluxC version in the release branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '835315abaebdca4334ca7b75dce827ffec7409bc'
+    fluxCVersion = 'f0e022e366e20a32d663031504202717a99862fd'
 }


### PR DESCRIPTION
This PR updates the FluxC version used by the app to match the one currently in `develop`.
This is required to solve an issue with self-signed SSL sites.

I cherry picked the relevant commit from `develop`.