### PR TITLE
Added translatable="false" flag to css image size classes

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1269,10 +1269,10 @@
     <string name="image_size_large_label">Large</string>
     <string name="image_size_full_label">Full Size</string>
 
-    <string name="image_size_thumbnail_class">size-thumbnail</string>
-    <string name="image_size_medium_class">size-medium</string>
-    <string name="image_size_large_class">size-large</string>
-    <string name="image_size_full_class">size-full</string>
+    <string name="image_size_thumbnail_class" translatable="false">size-thumbnail</string>
+    <string name="image_size_medium_class" translatable="false">size-medium</string>
+    <string name="image_size_large_class" translatable="false">size-large</string>
+    <string name="image_size_full_class" translatable="false">size-full</string>
 
     <!-- About View -->
     <string name="app_title">WordPress for Android</string>
@@ -2336,7 +2336,7 @@
     which would result in showing an out-of-date announcement. Moreover since the url has translatable set to false,
     the out-of-date announcement might redirect the user to the new feature. -->
     <!--suppress UnusedResources -->
-    <string name="news_card_announcement_title_sample_announcement" >[New feature available]</string>
+    <string name="news_card_announcement_title_sample_announcement">[New feature available]</string>
     <!--suppress UnusedResources -->
     <string name="news_card_announcement_content_sample_announcement">[No time to read right now? No problem: save posts for when you do.]</string>
     <!--suppress UnusedResources -->


### PR DESCRIPTION
Makes sure the CSS classes used for image size slider in the editor are not translatable.