### PR TITLE
Issue/8421 fix auth notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
@@ -2,10 +2,12 @@ package org.wordpress.android.push;
 
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 
 import org.wordpress.android.R;
+import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 
 import static org.wordpress.android.push.GCMMessageService.ACTIONS_PROGRESS_NOTIFICATION_ID;
 
@@ -55,5 +57,22 @@ public class NativeNotificationsUtils {
     public static void hideStatusBar(Context context) {
         Intent closeIntent = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
         context.sendBroadcast(closeIntent);
+    }
+
+    public static boolean extrasContainValid2FaToken(@NonNull Intent intent) {
+        if (!intent.hasExtra(NotificationsUtils.ARG_PUSH_AUTH_TOKEN)
+            || !intent.hasExtra(NotificationsUtils.ARG_PUSH_AUTH_EXPIRES)) {
+            throw new IllegalStateException("get2FATokenFromIntentExtras called without a valid intent.");
+        }
+        long expires = intent.getExtras().getLong(NotificationsUtils.ARG_PUSH_AUTH_EXPIRES, 0);
+
+        long now = System.currentTimeMillis() / 1000;
+        return expires == 0 || now <= expires;
+    }
+    public static String retrieve2FATokenFromIntentExtras(@NonNull Intent intent) {
+        if (!intent.hasExtra(NotificationsUtils.ARG_PUSH_AUTH_TOKEN)) {
+            throw new IllegalStateException("get2FATokenFromIntentExtras called without a valid intent.");
+        }
+        return intent.getExtras().getString(NotificationsUtils.ARG_PUSH_AUTH_TOKEN, "");
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtilsWrapper.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.push
+
+import android.content.Intent
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Injectable wrapper around NativeNotificationsUtilsWrapper.
+ *
+ * NativeNotificationsUtilsWrapper interface is consisted of static methods, which make the client code difficult to
+ * test/mock.
+ * Main purpose of this wrapper is to make testing easier.
+ *
+ */
+@Singleton
+class NativeNotificationsUtilsWrapper @Inject constructor(){
+    fun extrasContainValid2FaToken(intent: Intent) = NativeNotificationsUtils.extrasContainValid2FaToken(intent)
+
+    fun retrieve2FATokenFromIntentExtras(intent: Intent): String =
+            NativeNotificationsUtils.retrieve2FATokenFromIntentExtras(intent)
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;
@@ -33,7 +34,6 @@ import org.wordpress.android.ui.accounts.SiteCreationActivity;
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailActivity;
 import org.wordpress.android.ui.activitylog.list.ActivityLogListActivity;
 import org.wordpress.android.ui.comments.CommentsActivity;
-import org.wordpress.android.ui.quickstart.QuickStartActivity;
 import org.wordpress.android.ui.main.SitePickerActivity;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
@@ -57,6 +57,7 @@ import org.wordpress.android.ui.prefs.BlogPreferencesActivity;
 import org.wordpress.android.ui.prefs.MyProfileActivity;
 import org.wordpress.android.ui.prefs.notifications.NotificationsSettingsActivity;
 import org.wordpress.android.ui.publicize.PublicizeListActivity;
+import org.wordpress.android.ui.quickstart.QuickStartActivity;
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity;
 import org.wordpress.android.ui.stats.StatsActivity;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
@@ -65,11 +66,11 @@ import org.wordpress.android.ui.stats.StatsSingleItemDetailsActivity;
 import org.wordpress.android.ui.stats.models.StatsPostModel;
 import org.wordpress.android.ui.stockmedia.StockMediaPickerActivity;
 import org.wordpress.android.ui.themes.ThemeBrowserActivity;
-import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPActivityUtils;
+import org.wordpress.android.util.analytics.AnalyticsUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -175,6 +176,18 @@ public class ActivityLauncher {
         Intent intent = new Intent(context, WPMainActivity.class);
         intent.putExtra(WPMainActivity.ARG_OPEN_PAGE, WPMainActivity.ARG_NOTIFICATIONS);
         intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        context.startActivity(intent);
+    }
+
+    public static void startFrom2FaAuthPushNotification(Context context, Bundle extras) {
+        Intent intent = new Intent(context, WPMainActivity.class);
+        intent.putExtras(extras);
+
+        intent.putExtra(WPMainActivity.ARG_OPENED_FROM_PUSH, true);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK
+                        | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        intent.setAction("android.intent.action.MAIN");
+        intent.addCategory("android.intent.category.LAUNCHER");
         context.startActivity(intent);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -376,7 +376,7 @@ public class WPMainActivity extends AppCompatActivity implements
                 NotificationsUtils.showPushAuthAlert(WPMainActivity.this, token, title, message);
             } else if (NotificationsProcessingService.ARG_ACTION_AUTH_TOKEN_EXPIRED.equals(actionType)) {
                 // inform the user the token has expired
-                Snackbar.make(findViewById(R.id.fragment_container), R.string.push_auth_expired, Snackbar.LENGTH_LONG)
+                Snackbar.make(findViewById(R.id.coordinator), R.string.push_auth_expired, Snackbar.LENGTH_LONG)
                         .show();
             } else {
                 throw new IllegalStateException("Unknown ARG_ACTION_TYPE in 2fa push notification.");

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -4,7 +4,6 @@ import android.app.AlertDialog;
 import android.app.AppOpsManager;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.graphics.Typeface;
@@ -408,28 +407,6 @@ public class NotificationsUtils {
     public static boolean spannableHasCharacterAtIndex(Spannable spannable, char character, int index) {
         return spannable != null && index < spannable.length() && spannable.charAt(index) == character;
     }
-
-    public static boolean validate2FAuthorizationTokenFromIntentExtras(Intent intent, TwoFactorAuthCallback callback) {
-        // Check for push authorization request
-        if (intent != null && intent.hasExtra(NotificationsUtils.ARG_PUSH_AUTH_TOKEN)) {
-            Bundle extras = intent.getExtras();
-            String token = extras.getString(NotificationsUtils.ARG_PUSH_AUTH_TOKEN, "");
-            String title = extras.getString(NotificationsUtils.ARG_PUSH_AUTH_TITLE, "");
-            String message = extras.getString(NotificationsUtils.ARG_PUSH_AUTH_MESSAGE, "");
-            long expires = extras.getLong(NotificationsUtils.ARG_PUSH_AUTH_EXPIRES, 0);
-
-            long now = System.currentTimeMillis() / 1000;
-            if (expires > 0 && now > expires) {
-                callback.onTokenInvalid();
-                return false;
-            } else {
-                callback.onTokenValid(token, title, message);
-                return true;
-            }
-        }
-        return false;
-    }
-
 
     public static void showPushAuthAlert(Context context, final String token, String title, String message) {
         if (context == null


### PR DESCRIPTION
Fixes #8421 

When attempting to log in at WP.com using a browser the user receives a notification on their phone. After hitting "Approve" the app opens which doesn't feel intuitive because there's no further action required. 

This PR fixes following
- clicking on the `approve` button won't open the app.
- business logic is moved from WPMainActivity to NotificationsProcessingService
- push notification utility methods are moved from NotificationsUtils to NativeNotificationsUtils

To test:
1. Login to the app using an account with enabled 2fa
2. Move the app to background
3. Login in a browser to wordpress.com
4. Wait for the push notification
5. Repeat steps 1-4 for each variant

5a. Click on the approve button - make sure the app remains in background and you are now logged in 
in the browser

5b. Click on the dismiss button - make sure the app remains in background and you are not logged in in 
the browser

5c. Click on the notification body - the app comes to foreground and a dialog with 2 approve/dismiss buttons is displayed

5d. Change system date to tomorrow and click on approve - app comes to foreground and a snackbar with an error message is displayed



