### PR TITLE
Add/quick action completed track event with details

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -582,7 +582,6 @@ public class NotificationsProcessingService extends Service {
                 // Bump analytics
                 AnalyticsUtils.trackCommentReplyWithDetails(true, site, comment);
                 AnalyticsUtils.trackQuickActionTouched(QuickActionTrackPropertyValue.REPLY_TO, site, comment);
-
             } else {
                 // cancel the current notification
                 NativeNotificationsUtils.dismissNotification(mPushId, mContext);

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -42,6 +42,7 @@ import org.wordpress.android.ui.notifications.receivers.NotificationsPendingDraf
 import org.wordpress.android.ui.notifications.utils.NotificationsActions;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.notifications.utils.PendingDraftsNotificationsUtils;
+import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -525,7 +526,8 @@ public class NotificationsProcessingService extends Service {
             }
 
             // Bump analytics
-            AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATION_QUICK_ACTIONS_LIKED);
+            AnalyticsUtils.trackWithBlogPostDetails(
+                    AnalyticsTracker.Stat.NOTIFICATION_QUICK_ACTIONS_LIKED, mNote.getSiteId(), mNote.getPostId());
             trackQuickActionCompleted(QuickActionTrackPropertyValue.LIKE);
 
             SiteModel site = mSiteStore.getSiteBySiteId(mNote.getSiteId());
@@ -545,7 +547,8 @@ public class NotificationsProcessingService extends Service {
             }
 
             // Bump analytics
-            AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATION_QUICK_ACTIONS_APPROVED);
+            AnalyticsUtils.trackWithBlogPostDetails(
+                    AnalyticsTracker.Stat.NOTIFICATION_QUICK_ACTIONS_APPROVED, mNote.getSiteId(), mNote.getPostId());
             trackQuickActionCompleted(QuickActionTrackPropertyValue.APPROVE);
 
             // Update pseudo comment (built from the note)

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -171,6 +171,44 @@ public class AnalyticsUtils {
         }
     }
 
+    public enum QuickActionTrackPropertyValue {
+        LIKE {
+            public String toString() {
+                return "like";
+            }
+        },
+        APPROVE {
+            public String toString() {
+                return "approve";
+            }
+        },
+        REPLY_TO {
+            public String toString() {
+                return "reply-to";
+            }
+        }
+    }
+
+    public static void trackQuickActionTouched(QuickActionTrackPropertyValue type,
+                                               SiteModel site,
+                                               CommentModel comment) {
+        Map<String, Object> properties = new HashMap<>(1);
+        properties.put("quick_action", type.toString());
+
+        // add available information
+        if (site != null) {
+            properties.put(BLOG_ID_KEY, site.getSiteId());
+            properties.put(IS_JETPACK_KEY, site.isJetpackConnected());
+        }
+
+        if (comment != null) {
+            properties.put(POST_ID_KEY, comment.getRemotePostId());
+            properties.put(COMMENT_ID_KEY, comment.getRemoteCommentId());
+        }
+
+        AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATION_QUICK_ACTIONS_QUICKACTION_TOUCHED, properties);
+        AnalyticsTracker.flush();
+    }
 
     /**
      * Bump Analytics for comment reply, and add blog and comment details into properties.


### PR DESCRIPTION
This PR builds on top of the previously merged #8450, where `quick_action_touched`  event for comment-related notifications quick actions was introduced.

This PR adds more information to Tracks such as:
- Site's `blog_id` and `is_jetpack`
- Comment's `post_id` and `comment_id`.

For that, I've re-arranged the code, moving the `QuickActionTrackPropertyValue`  enum and `trackQuickActionTouched` method to `AnalyticsUtils.java`, and adding the needed parameters to the aforementioned method.

Also, took advantage of the opportunity and made the same information available for the pre-existing events in 2bf6d1a


**To test:**
Follow the steps indicated in #8450, and observe the properties now contain the information as in the examples below:

**Like**
<img width="437" alt="screen shot 2018-10-18 at 19 31 52" src="https://user-images.githubusercontent.com/6597771/47188207-87222e80-d30d-11e8-91c0-c6fab932b48c.png">

**Approve**
<img width="461" alt="screen shot 2018-10-18 at 19 30 53" src="https://user-images.githubusercontent.com/6597771/47188221-90ab9680-d30d-11e8-8d9c-93a214a78b27.png">

**Reply-to**
<img width="433" alt="screen shot 2018-10-18 at 19 32 42" src="https://user-images.githubusercontent.com/6597771/47188233-9ef9b280-d30d-11e8-90a6-d6d1b62436f7.png">

Note the images captured here are from inspecting the information being sent from Android Studio, you should see the same reflected on Tracks after a few minutes. The information shown on Tracks should contain data such as this:

``` 
blogid:	105693928
[...]
eventprops:
 - is_jetpack:	false
 - post_id:	1527
 - quick_action:	approve
 - comment_id:	561
``` 

cc @stevebaranski for matching changes on WordPress iOS
