### PR TITLE
Update FluxC version to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'f0e022e366e20a32d663031504202717a99862fd'
+    fluxCVersion = 'e8a0101063eb02d33365921a75cb21746e308ca6'
 }


### PR DESCRIPTION
This brings FluxC up to the latest. Here are the changes since last update: https://github.com/wordpress-mobile/WordPress-FluxC-Android/compare/f0e022e366e20a32d663031504202717a99862fd...e8a0101063eb02d33365921a75cb21746e308ca6

It includes my recent change to improve how SSL certs are trusted (https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/925)