### PR TITLE
Update the FluxC reference that includes the missing trashed pages fix.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'e8a0101063eb02d33365921a75cb21746e308ca6'
+    fluxCVersion = '52841f47748080793911dc3945cb202d79853daa'
 }


### PR DESCRIPTION
Fixes a bug where self-hosted sites without Jetpack don't load the TRASHED pages.

To test:
1. Open a self-hosted site without Jetpack
2. Go to Site pages
3. Move a page to trash
4. Go to the Trashed tab
5. Notice the trashed page is there