### PR TITLE
Reference the FluxC version with the Pages fixes for 10.9.3 release

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -77,7 +77,7 @@ class PagesFragment : Fragment() {
         (nonNullActivity.application as? WordPress)?.component()?.inject(this)
 
         initializeViews(nonNullActivity)
-        initializeViewModels(nonNullActivity, savedInstanceState == null)
+        initializeViewModels(nonNullActivity, savedInstanceState)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -93,6 +93,11 @@ class PagesFragment : Fragment() {
                 onPageParentSet(pageId, parentId)
             }
         }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putSerializable(WordPress.SITE, viewModel.site)
+        super.onSaveInstanceState(outState)
     }
 
     fun onSpecificPageRequested(remotePageId: Long) {
@@ -181,17 +186,21 @@ class PagesFragment : Fragment() {
         })
     }
 
-    private fun initializeViewModels(activity: FragmentActivity, isFirstStart: Boolean) {
+    private fun initializeViewModels(activity: FragmentActivity, savedInstanceState: Bundle?) {
         viewModel = ViewModelProviders.of(activity, viewModelFactory).get(PagesViewModel::class.java)
 
         setupObservers(activity)
 
-        val site = activity.intent?.getSerializableExtra(WordPress.SITE) as SiteModel?
+        val site = if (savedInstanceState == null) {
+            val nonNullIntent = checkNotNull(activity.intent)
+            nonNullIntent.getSerializableExtra(WordPress.SITE) as SiteModel
+        } else {
+            restorePreviousSearch = true
+            savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+        }
+
         val nonNullSite = checkNotNull(site)
         viewModel.start(nonNullSite)
-        if (!isFirstStart) {
-            restorePreviousSearch = true
-        }
     }
 
     private fun setupObservers(activity: FragmentActivity) {

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '3ff1bbd9dec99d2dd032022b1d85141ed4b0c4c7'
+    fluxCVersion = 'd3a051b01f81b8442a9d8a1397ae424de0ab4212'
 }


### PR DESCRIPTION
This PR fixes a list of issues with Pages, which must be included in the last release for devices with API <21:
- Fix the broken page-parent on self-hosted sites without Jetpack (#8428)
- Fix the missing trashed pages on self-hosted sites (wordpress-mobile/WordPress-FluxC-Android/issues/940)
- Fix a rare crash (#8420)