### PR TITLE
Reference the FluxC version with the Pages fixes for 11.0 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'f0e022e366e20a32d663031504202717a99862fd'
+    fluxCVersion = '26abbd22acffa9488f1b56bfe07ea529177edd04'
 }


### PR DESCRIPTION
This PR references the FluxC branch that includes hot-fixes for 2 issues:
- Fix the broken page-parent on self-hosted sites without Jetpack (#8428)
- Fix the missing trashed pages on self-hosted sites (#WordPress-FluxC-Android/issues/940)