### PR TITLE
Issue/deprecate avatar type

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginHeaderViewHolder.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginHeaderViewHolder.java
@@ -46,7 +46,8 @@ public class LoginHeaderViewHolder extends RecyclerView.ViewHolder {
         if (isAfterLogin) {
             mLoggedInAsHeading.setVisibility(View.VISIBLE);
             mUserDetailsCard.setVisibility(View.VISIBLE);
-            imageManager.loadIntoCircle(mAvatarImageView, ImageType.AVATAR, StringUtils.notNullStr(avatarUrl));
+            imageManager.loadIntoCircle(mAvatarImageView, ImageType.AVATAR_WITHOUT_BACKGROUND,
+                    StringUtils.notNullStr(avatarUrl));
             mUsernameTextView.setText(context.getString(R.string.login_username_at, username));
 
             if (!TextUtils.isEmpty(displayName)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -273,7 +273,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
             } else {
                 AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_SOCIAL_EPILOGUE_VIEWED);
                 new DownloadAvatarAndUploadGravatarThread(mPhotoUrl, mEmailAddress, mAccount.getAccessToken()).start();
-                mImageManager.loadIntoCircle(mHeaderAvatar, ImageType.AVATAR, mPhotoUrl);
+                mImageManager.loadIntoCircle(mHeaderAvatar, ImageType.AVATAR_WITHOUT_BACKGROUND, mPhotoUrl);
             }
         } else {
             mDialog = (FullScreenDialogFragment) getFragmentManager().findFragmentByTag(FullScreenDialogFragment.TAG);
@@ -293,7 +293,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                 mHeaderEmailAddress.setText(mEmailAddress);
                 mHeaderAvatarAdd.setVisibility(mIsAvatarAdded ? View.GONE : View.VISIBLE);
             }
-            mImageManager.loadIntoCircle(mHeaderAvatar, ImageType.AVATAR, mPhotoUrl);
+            mImageManager.loadIntoCircle(mHeaderAvatar, ImageType.AVATAR_WITHOUT_BACKGROUND, mPhotoUrl);
         }
     }
 
@@ -545,7 +545,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
         if (bitmap != null) {
             mImageManager.load(mHeaderAvatar, bitmap);
         } else {
-            mImageManager.loadIntoCircle(mHeaderAvatar, ImageType.AVATAR,
+            mImageManager.loadIntoCircle(mHeaderAvatar, ImageType.AVATAR_WITHOUT_BACKGROUND,
                     newAvatarUploaded ? injectFilePath : avatarUrl, new RequestListener<Drawable>() {
                         @Override
                         public void onLoadFailed(@Nullable Exception e) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -20,7 +20,7 @@ import org.wordpress.android.ui.notifications.utils.FormattableContentClickHandl
 import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
 import org.wordpress.android.ui.posts.BasicFragmentDialog
 import org.wordpress.android.util.image.ImageManager
-import org.wordpress.android.util.image.ImageType.AVATAR
+import org.wordpress.android.util.image.ImageType.AVATAR_WITH_BACKGROUND
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_ID_KEY
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWIND_ID_KEY
 import org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModel
@@ -127,7 +127,7 @@ class ActivityLogDetailFragment : Fragment() {
     private fun setActorIcon(actorIcon: String?, showJetpackIcon: Boolean?) {
         when {
             actorIcon != null && actorIcon != "" -> {
-                imageManager.loadIntoCircle(activityActorIcon, AVATAR, actorIcon)
+                imageManager.loadIntoCircle(activityActorIcon, AVATAR_WITH_BACKGROUND, actorIcon)
                 activityActorIcon.visibility = View.VISIBLE
                 activityJetpackActorIcon.visibility = View.GONE
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
@@ -247,7 +247,8 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             holder.mContainerView.setBackgroundColor(mSelectedColor);
         } else {
             checkmarkVisibility = View.GONE;
-            mImageManager.loadIntoCircle(holder.mImgAvatar, ImageType.AVATAR, getAvatarForDisplay(comment, mAvatarSz));
+            mImageManager.loadIntoCircle(holder.mImgAvatar, ImageType.AVATAR_WITH_BACKGROUND,
+                    getAvatarForDisplay(comment, mAvatarSz));
             holder.mContainerView.setBackgroundColor(mUnselectedColor);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -65,7 +65,6 @@ import org.wordpress.android.ui.suggestion.adapters.SuggestionAdapter;
 import org.wordpress.android.ui.suggestion.service.SuggestionEvents;
 import org.wordpress.android.ui.suggestion.util.SuggestionServiceConnectionManager;
 import org.wordpress.android.ui.suggestion.util.SuggestionUtils;
-import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -77,6 +76,7 @@ import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPLinkMovementMethod;
+import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
 import org.wordpress.android.widgets.SuggestionAutoCompleteText;
@@ -661,7 +661,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         } else if (mComment.getAuthorEmail() != null) {
             avatarUrl = GravatarUtils.gravatarFromEmail(mComment.getAuthorEmail(), avatarSz);
         }
-        mImageManager.loadIntoCircle(imgAvatar, ImageType.AVATAR, avatarUrl);
+        mImageManager.loadIntoCircle(imgAvatar, ImageType.AVATAR_WITH_BACKGROUND, avatarUrl);
 
         updateStatusViews();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -324,7 +324,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment {
         if (bitmap != null) {
             mImageManager.load(mAvatarImageView, bitmap);
         } else {
-            mImageManager.loadIntoCircle(mAvatarImageView, ImageType.AVATAR,
+            mImageManager.loadIntoCircle(mAvatarImageView, ImageType.AVATAR_WITHOUT_BACKGROUND,
                     newAvatarUploaded ? injectFilePath : avatarUrl, new RequestListener<Drawable>() {
                         @Override
                         public void onLoadFailed(@Nullable Exception e) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -334,7 +334,7 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
 
             // Add the note header if one was provided
             if (mNote.getHeader() != null) {
-                ImageType imageType = mNote.isFollowType() ? ImageType.BLAVATAR : ImageType.AVATAR;
+                ImageType imageType = mNote.isFollowType() ? ImageType.BLAVATAR : ImageType.AVATAR_WITH_BACKGROUND;
                 HeaderNoteBlock headerNoteBlock = new HeaderNoteBlock(
                         getActivity(),
                         transformToFormattableContentList(mNote.getHeader()),

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -284,7 +284,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         }
 
         String avatarUrl = GravatarUtils.fixGravatarUrl(note.getIconURL(), mAvatarSz);
-        mImageManager.loadIntoCircle(noteViewHolder.mImgAvatar, ImageType.AVATAR, avatarUrl);
+        mImageManager.loadIntoCircle(noteViewHolder.mImgAvatar, ImageType.AVATAR_WITH_BACKGROUND, avatarUrl);
 
         boolean isUnread = note.isUnread();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
@@ -118,7 +118,7 @@ public class CommentUserNoteBlock extends UserNoteBlock {
             noteBlockHolder.mAvatarImageView.setOnTouchListener(null);
             noteBlockHolder.mAvatarImageView.setContentDescription(null);
         }
-        mImageManager.loadIntoCircle(noteBlockHolder.mAvatarImageView, ImageType.AVATAR, imageUrl);
+        mImageManager.loadIntoCircle(noteBlockHolder.mAvatarImageView, ImageType.AVATAR_WITH_BACKGROUND, imageUrl);
 
         noteBlockHolder.mCommentTextView
                 .setText(getCommentTextOfNotification(noteBlockHolder));

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/HeaderNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/HeaderNoteBlock.java
@@ -60,7 +60,7 @@ public class HeaderNoteBlock extends NoteBlock {
 
         Spannable spannable = mNotificationsUtilsWrapper.getSpannableContentForRanges(mHeadersList.get(0));
         noteBlockHolder.mNameTextView.setText(spannable);
-        if (mImageType == ImageType.AVATAR) {
+        if (mImageType == ImageType.AVATAR_WITH_BACKGROUND) {
             mImageManager.loadIntoCircle(noteBlockHolder.mAvatarImageView, mImageType, getAvatarUrl());
         } else {
             mImageManager.load(noteBlockHolder.mAvatarImageView, mImageType, getAvatarUrl());

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/UserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/UserNoteBlock.java
@@ -111,7 +111,7 @@ public class UserNoteBlock extends NoteBlock {
             //noinspection AndroidLintClickableViewAccessibility
             noteBlockHolder.mAvatarImageView.setOnTouchListener(null);
         }
-        mImageManager.loadIntoCircle(noteBlockHolder.mAvatarImageView, ImageType.AVATAR, imageUrl);
+        mImageManager.loadIntoCircle(noteBlockHolder.mAvatarImageView, ImageType.AVATAR_WITH_BACKGROUND, imageUrl);
 
         return view;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -400,7 +400,7 @@ public class PeopleListFragment extends Fragment {
 
             if (person != null) {
                 String avatarUrl = GravatarUtils.fixGravatarUrl(person.getAvatarUrl(), mAvatarSz);
-                mImageManager.loadIntoCircle(peopleViewHolder.mImgAvatar, ImageType.AVATAR, avatarUrl);
+                mImageManager.loadIntoCircle(peopleViewHolder.mImgAvatar, ImageType.AVATAR_WITH_BACKGROUND, avatarUrl);
                 peopleViewHolder.mTxtDisplayName.setText(StringEscapeUtils.unescapeHtml4(person.getDisplayName()));
                 if (person.getRole() != null) {
                     peopleViewHolder.mTxtRole.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PersonDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PersonDetailFragment.java
@@ -143,7 +143,7 @@ public class PersonDetailFragment extends Fragment {
             int avatarSz = getResources().getDimensionPixelSize(R.dimen.people_avatar_sz);
             String avatarUrl = GravatarUtils.fixGravatarUrl(person.getAvatarUrl(), avatarSz);
 
-            mImageManager.loadIntoCircle(mAvatarImageView, ImageType.AVATAR, avatarUrl);
+            mImageManager.loadIntoCircle(mAvatarImageView, ImageType.AVATAR_WITH_BACKGROUND, avatarUrl);
             mDisplayNameTextView.setText(StringEscapeUtils.unescapeHtml4(person.getDisplayName()));
             if (person.getRole() != null) {
                 mRoleTextView.setText(RoleUtils.getDisplayName(person.getRole(), mUserRoles));

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeConnectionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeConnectionAdapter.java
@@ -99,7 +99,8 @@ public class PublicizeConnectionAdapter extends RecyclerView.Adapter<PublicizeCo
         holder.mTxtUser.setText(connection.getExternalDisplayName());
         holder.mDivider.setVisibility(position == 0 ? View.GONE : View.VISIBLE);
 
-        mImageManager.loadIntoCircle(holder.mImgAvatar, ImageType.AVATAR, connection.getExternalProfilePictureUrl());
+        mImageManager.loadIntoCircle(holder.mImgAvatar, ImageType.AVATAR_WITH_BACKGROUND,
+                connection.getExternalProfilePictureUrl());
 
         holder.mBtnConnect.setAction(PublicizeConstants.ConnectAction.DISCONNECT);
         holder.mBtnConnect.setOnClickListener(new View.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAuthorsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAuthorsFragment.java
@@ -254,7 +254,7 @@ public class StatsAuthorsFragment extends StatsAbstractListFragment {
 
             // icon
             // holder.showNetworkImage(icon);
-            mImageManager.loadIntoCircle(holder.networkImageView, ImageType.AVATAR,
+            mImageManager.loadIntoCircle(holder.networkImageView, ImageType.AVATAR_WITH_BACKGROUND,
                     GravatarUtils.fixGravatarUrl(icon, mResourceVars.mHeaderAvatarSizePx));
 
             holder.networkImageView.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
@@ -233,7 +233,7 @@ public class StatsCommentsFragment extends StatsAbstractListFragment {
                             currentRowData.getViews()));
 
             // avatar
-            mImageManager.loadIntoCircle(holder.networkImageView, ImageType.AVATAR,
+            mImageManager.loadIntoCircle(holder.networkImageView, ImageType.AVATAR_WITH_BACKGROUND,
                     GravatarUtils.fixGravatarUrl(currentRowData.getAvatar(), mResourceVars.mHeaderAvatarSizePx));
             holder.networkImageView.setVisibility(View.VISIBLE);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
@@ -381,7 +381,7 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
                             holder.totalsTextView.getText()));
 
             // Avatar
-            mImageManager.loadIntoCircle(holder.networkImageView, ImageType.AVATAR,
+            mImageManager.loadIntoCircle(holder.networkImageView, ImageType.AVATAR_WITH_BACKGROUND,
                     GravatarUtils.fixGravatarUrl(currentRowData.getAvatar(), mResourceVars.mHeaderAvatarSizePx));
             holder.networkImageView.setVisibility(View.VISIBLE);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/adapters/SuggestionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/adapters/SuggestionAdapter.java
@@ -79,7 +79,7 @@ public class SuggestionAdapter extends BaseAdapter implements Filterable {
 
         if (suggestion != null) {
             String avatarUrl = GravatarUtils.fixGravatarUrl(suggestion.getImageUrl(), mAvatarSz);
-            mImageManager.loadIntoCircle(holder.mImgAvatar, ImageType.AVATAR, avatarUrl);
+            mImageManager.loadIntoCircle(holder.mImgAvatar, ImageType.AVATAR_WITH_BACKGROUND, avatarUrl);
             holder.mTxtUserLogin
                     .setText(convertView.getResources().getString(R.string.at_username, suggestion.getUserLogin()));
             holder.mTxtDisplayName.setText(suggestion.getDisplayName());

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
@@ -12,6 +12,8 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.PHOTO -> R.color.grey_lighten_30
             ImageType.VIDEO -> R.color.grey_lighten_30
             ImageType.AVATAR -> R.drawable.ic_placeholder_gravatar_grey_lighten_20_100dp
+            ImageType.AVATAR_WITH_BACKGROUND -> R.drawable.bg_oval_grey_user_32dp
+            ImageType.AVATAR_WITHOUT_BACKGROUND -> R.drawable.ic_user_circle_grey_24dp
             ImageType.BLAVATAR -> R.drawable.ic_placeholder_blavatar_grey_lighten_20_40dp
             ImageType.PLAN -> R.drawable.ic_reader_blue_wordpress_18dp
             ImageType.THEME -> R.color.grey_lighten_30
@@ -26,6 +28,8 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.PHOTO -> R.color.grey_light
             ImageType.VIDEO -> R.color.grey_light
             ImageType.AVATAR -> R.drawable.shape_oval_grey_light
+            ImageType.AVATAR_WITH_BACKGROUND -> R.drawable.bg_oval_grey_user_32dp
+            ImageType.AVATAR_WITHOUT_BACKGROUND -> R.drawable.ic_user_circle_grey_24dp
             ImageType.BLAVATAR -> R.color.grey_light
             ImageType.PLAN -> R.drawable.ic_reader_blue_wordpress_18dp
             ImageType.THEME -> R.drawable.theme_loading

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
@@ -8,33 +8,33 @@ import javax.inject.Singleton
 class ImagePlaceholderManager @Inject constructor() {
     fun getErrorResource(imgType: ImageType): Int? {
         return when (imgType) {
-            ImageType.IMAGE -> null // don't display any error drawable
-            ImageType.PHOTO -> R.color.grey_lighten_30
-            ImageType.VIDEO -> R.color.grey_lighten_30
             ImageType.AVATAR -> R.drawable.ic_placeholder_gravatar_grey_lighten_20_100dp
             ImageType.AVATAR_WITH_BACKGROUND -> R.drawable.bg_oval_grey_user_32dp
             ImageType.AVATAR_WITHOUT_BACKGROUND -> R.drawable.ic_user_circle_grey_24dp
             ImageType.BLAVATAR -> R.drawable.ic_placeholder_blavatar_grey_lighten_20_40dp
+            ImageType.IMAGE -> null // don't display any error drawable
+            ImageType.PHOTO -> R.color.grey_lighten_30
             ImageType.PLAN -> R.drawable.ic_reader_blue_wordpress_18dp
+            ImageType.PLUGIN -> R.drawable.plugin_placeholder
             ImageType.THEME -> R.color.grey_lighten_30
             ImageType.UNKNOWN -> R.drawable.ic_notice_grey_500_48dp
-            ImageType.PLUGIN -> R.drawable.plugin_placeholder
+            ImageType.VIDEO -> R.color.grey_lighten_30
         }
     }
 
     fun getPlaceholderResource(imgType: ImageType): Int? {
         return when (imgType) {
-            ImageType.IMAGE -> null // don't display any placeholder
-            ImageType.PHOTO -> R.color.grey_light
-            ImageType.VIDEO -> R.color.grey_light
             ImageType.AVATAR -> R.drawable.shape_oval_grey_light
             ImageType.AVATAR_WITH_BACKGROUND -> R.drawable.bg_oval_grey_user_32dp
             ImageType.AVATAR_WITHOUT_BACKGROUND -> R.drawable.ic_user_circle_grey_24dp
             ImageType.BLAVATAR -> R.color.grey_light
+            ImageType.IMAGE -> null // don't display any placeholder
+            ImageType.PHOTO -> R.color.grey_light
             ImageType.PLAN -> R.drawable.ic_reader_blue_wordpress_18dp
+            ImageType.PLUGIN -> R.drawable.plugin_placeholder
             ImageType.THEME -> R.drawable.theme_loading
             ImageType.UNKNOWN -> R.drawable.legacy_dashicon_format_image_big_grey
-            ImageType.PLUGIN -> R.drawable.plugin_placeholder
+            ImageType.VIDEO -> R.color.grey_light
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
@@ -1,6 +1,11 @@
 package org.wordpress.android.util.image
 
 enum class ImageType {
+    @Deprecated(
+            message = "Use AVATAR_WITH_BACKGROUND or AVATAR_WITHOUT_BACKGROUND instead.",
+            replaceWith = ReplaceWith(
+                    expression = "AVATAR_WITH_BACKGROUND",
+                    imports = ["org.wordpress.android.util.image.ImageType"]))
     AVATAR,
     AVATAR_WITH_BACKGROUND,
     AVATAR_WITHOUT_BACKGROUND,

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
@@ -1,15 +1,15 @@
 package org.wordpress.android.util.image
 
 enum class ImageType {
-    IMAGE,
-    PHOTO,
-    VIDEO,
     AVATAR,
     AVATAR_WITH_BACKGROUND,
     AVATAR_WITHOUT_BACKGROUND,
     BLAVATAR,
+    IMAGE,
+    PHOTO,
     PLAN,
+    PLUGIN,
     THEME,
     UNKNOWN,
-    PLUGIN
+    VIDEO
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
@@ -5,6 +5,8 @@ enum class ImageType {
     PHOTO,
     VIDEO,
     AVATAR,
+    AVATAR_WITH_BACKGROUND,
+    AVATAR_WITHOUT_BACKGROUND,
     BLAVATAR,
     PLAN,
     THEME,


### PR DESCRIPTION
### Fix
Deprecate the [`AVATAR`]() image type and update instances of it with either [`AVATAR_WITH_BACKGROUND`]() or [`AVATAR_WITHOUT_BACKGROUND`]() based on the usage.  The `AVATAR` image type uses an old resource, [`ic_placeholder_gravatar_grey_lighten_20_100dp`](https://github.com/wordpress-mobile/WordPress-Android/blob/41e8f6d232746306b08bb330aea82cbd2b3bbd18/WordPress/src/main/res/drawable/ic_placeholder_gravatar_grey_lighten_20_100dp.xml), as the error and placeholder image.  The `AVATAR_WITH_BACKGROUND` image type uses [`bg_oval_grey_user_32dp`](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/res/drawable/bg_oval_grey_user_32dp.xml), which is the avatar design for the ***Revisions***.  The `AVATAR_WITHOUT_BACKGROUND` image type uses [`ic_user_circle_grey_24dp`](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/libs/login/WordPressLoginFlow/src/main/res/drawable/ic_user_circle_grey_24dp.xml), which is the avatar design for the ***Me*** tab and ***Login*** epilogue.

Instances of `AVATAR` in the ***Reader*** were left as is since it uses a square image for blavatars (e.g. [`ic_placeholder_blavatar_grey_lighten_20_40dp`](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/res/drawable/ic_placeholder_blavatar_grey_lighten_20_40dp.xml)), which is similar to the old [`ic_placeholder_gravatar_grey_lighten_20_100dp`](https://github.com/wordpress-mobile/WordPress-Android/blob/41e8f6d232746306b08bb330aea82cbd2b3bbd18/WordPress/src/main/res/drawable/ic_placeholder_gravatar_grey_lighten_20_100dp.xml) resource.

### Test
0. Use slow internet connection.
1. Go to screens with avatar images.
2. Notice placeholder avatar image while loading.
3. Notice user avatar image once loaded.
4. Notice error avatar image if failed.