### PR TITLE
Reorder repositories in build.gradle to fix Gradle

### DIFF
--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'


### PR DESCRIPTION
The order of the repositories in `build.gradle` files matter and `google()` needs to come before `jcenter()` for some reason 🤷‍♂️ It's mentioned in several stackoverflow questions, [here](https://stackoverflow.com/a/48438866) is one.

To test:
Run `./gradlew --refresh-dependencies` and if it succeeds we're good. Travis will do that for us, so it'll mostly serve as a double check.