### PR TITLE
Issue/8340 add history detail (Part 2)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
@@ -381,11 +381,11 @@ public class FullScreenDialogFragment extends DialogFragment {
         Context mContext;
         OnConfirmListener mOnConfirmListener;
         OnDismissListener mOnDismissListener;
-        String mAction;
-        String mSubtitle;
-        String mTitle;
-        boolean mHideActivityBar;
-        int mToolbarColor;
+        String mAction = "";
+        String mSubtitle = "";
+        String mTitle = "";
+        boolean mHideActivityBar = false;
+        int mToolbarColor = R.color.color_primary;
 
         /**
          * Builder to construct {@link FullScreenDialogFragment}.

--- a/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
@@ -44,6 +44,7 @@ public class FullScreenDialogFragment extends DialogFragment {
     private String mAction;
     private String mSubtitle;
     private String mTitle;
+    private Toolbar mToolbar;
     private boolean mHideActivityBar;
     private int mToolbarColor;
 
@@ -250,20 +251,20 @@ public class FullScreenDialogFragment extends DialogFragment {
      * @param view {@link View}
      */
     private void initToolbar(View view) {
-        Toolbar toolbar = view.findViewById(R.id.full_screen_dialog_fragment_toolbar);
-        toolbar.setTitle(mTitle);
-        toolbar.setSubtitle(mSubtitle);
-        toolbar.setSubtitleTextAppearance(view.getContext(), R.style.Toolbar_Subtitle);
-        toolbar.setBackgroundColor(getResources().getColor(mToolbarColor != 0 ? mToolbarColor : R.color.color_primary));
-        toolbar.setNavigationIcon(ContextCompat.getDrawable(view.getContext(), R.drawable.ic_close_white_24dp));
-        toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+        mToolbar = view.findViewById(R.id.full_screen_dialog_fragment_toolbar);
+        mToolbar.setTitle(mTitle);
+        mToolbar.setSubtitle(mSubtitle);
+        mToolbar.setSubtitleTextAppearance(view.getContext(), R.style.Toolbar_Subtitle);
+        mToolbar.setBackgroundColor(getResources().getColor(mToolbarColor));
+        mToolbar.setNavigationIcon(ContextCompat.getDrawable(view.getContext(), R.drawable.ic_close_white_24dp));
+        mToolbar.setNavigationOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 onDismissClicked();
             }
         });
 
-        Menu menu = toolbar.getMenu();
+        Menu menu = mToolbar.getMenu();
         MenuItem action = menu.add(0, ID_ACTION, 0, this.mAction);
         action.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
         action.setOnMenuItemClickListener(
@@ -337,6 +338,28 @@ public class FullScreenDialogFragment extends DialogFragment {
      */
     public void setOnDismissListener(@Nullable OnDismissListener listener) {
         this.mOnDismissListener = listener;
+    }
+
+    /**
+     * Set {@link FullScreenDialogFragment} subtitle text.
+     *
+     * @param text {@link String} to set as subtitle text
+     */
+    public void setSubtitle(@NonNull String text) {
+        mSubtitle = text;
+        mToolbar.setSubtitle(mSubtitle);
+    }
+
+    /**
+     * Set {@link FullScreenDialogFragment} subtitle text.
+     *
+     * @param textId resource ID to set as subtitle text
+     */
+    public void setSubtitle(@StringRes int textId) {
+        if (getContext() != null) {
+            mSubtitle = getContext().getString(textId);
+            mToolbar.setSubtitle(mSubtitle);
+        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailFragment.kt
@@ -1,0 +1,49 @@
+package org.wordpress.android.ui.history
+
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import org.wordpress.android.R
+import org.wordpress.android.ui.history.HistoryListItem.Revision
+import org.wordpress.android.widgets.DiffView
+
+class HistoryDetailFragment : Fragment() {
+    private var mRevision: Revision? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        mRevision = if (savedInstanceState != null) {
+            savedInstanceState.getParcelable(KEY_REVISION)
+        } else {
+            arguments?.getParcelable(EXTRA_REVISION)
+        }
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val rootView = inflater.inflate(R.layout.history_detail_fragment, container, false) as ViewGroup
+        (rootView.findViewById<View>(R.id.title) as DiffView).showDiffs(mRevision!!.titleDiffs, true)
+        (rootView.findViewById<View>(R.id.content) as DiffView).showDiffs(mRevision!!.contentDiffs, false)
+        return rootView
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putParcelable(KEY_REVISION, mRevision)
+    }
+
+    companion object {
+        const val EXTRA_REVISION = "EXTRA_REVISION"
+        const val KEY_REVISION = "KEY_REVISION"
+
+        fun newInstance(revision: Revision): HistoryDetailFragment {
+            val fragment = HistoryDetailFragment()
+            val bundle = Bundle()
+            bundle.putParcelable(EXTRA_REVISION, revision)
+            fragment.arguments = bundle
+            return fragment
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailFullScreenDialogFragment.java
@@ -1,42 +1,66 @@
 package org.wordpress.android.ui.history;
 
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentStatePagerAdapter;
+import android.support.v4.view.ViewPager;
+import android.support.v4.view.ViewPager.OnPageChangeListener;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
+import org.wordpress.android.ui.FullScreenDialogFragment;
 import org.wordpress.android.ui.FullScreenDialogFragment.FullScreenDialogContent;
 import org.wordpress.android.ui.FullScreenDialogFragment.FullScreenDialogController;
 import org.wordpress.android.ui.history.HistoryListItem.Revision;
-import org.wordpress.android.widgets.DiffView;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.widgets.WPViewPager;
+import org.wordpress.android.widgets.WPViewPagerTransformer;
+import org.wordpress.android.widgets.WPViewPagerTransformer.TransformType;
+
+import java.util.ArrayList;
 
 public class HistoryDetailFullScreenDialogFragment extends Fragment implements FullScreenDialogContent {
     protected FullScreenDialogController mDialogController;
 
+    private ArrayList<Revision> mRevisions;
+    private HistoryDetailFragmentAdapter mAdapter;
+    private ImageView mNextButton;
+    private ImageView mPreviousButton;
+    private OnPageChangeListener mOnPageChangeListener;
     private Revision mRevision;
+    private TextView mTotalAdditions;
+    private TextView mTotalDeletions;
+    private WPViewPager mViewPager;
+    private int mPosition;
 
     public static final String EXTRA_REVISION = "EXTRA_REVISION";
+    public static final String EXTRA_REVISIONS = "EXTRA_REVISIONS";
     public static final String KEY_REVISION = "KEY_REVISION";
 
-    public static Bundle newBundle(Revision revision) {
+    public static Bundle newBundle(Revision revision, ArrayList<Revision> revisions) {
         Bundle bundle = new Bundle();
         bundle.putParcelable(EXTRA_REVISION, revision);
+        bundle.putParcelableArrayList(EXTRA_REVISIONS, revisions);
         return bundle;
     }
 
-    @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
-                             @Nullable Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.history_detail_dialog_fragment, container, false);
 
         if (getArguments() != null) {
             mRevision = getArguments().getParcelable(EXTRA_REVISION);
+            mRevisions = getArguments().getParcelableArrayList(EXTRA_REVISIONS);
         }
 
         return rootView;
@@ -52,27 +76,42 @@ public class HistoryDetailFullScreenDialogFragment extends Fragment implements F
         super.onActivityCreated(savedInstanceState);
 
         if (getView() != null) {
-            ((DiffView) getView().findViewById(R.id.title)).showDiffs(mRevision.getTitleDiffs(), true);
-            ((DiffView) getView().findViewById(R.id.content)).showDiffs(mRevision.getContentDiffs(), false);
+            mPosition = mRevisions.indexOf(mRevision);
 
-            if (mRevision.getTotalAdditions() > 0) {
-                TextView totalAdditionsView = getView().findViewById(R.id.diff_additions);
-                totalAdditionsView.setText(String.valueOf(mRevision.getTotalAdditions()));
-                totalAdditionsView.setVisibility(View.VISIBLE);
-            }
+            mViewPager = getView().findViewById(R.id.diff_pager);
+            mViewPager.setPageTransformer(false, new WPViewPagerTransformer(TransformType.SLIDE_OVER));
 
-            if (mRevision.getTotalDeletions() > 0) {
-                TextView totalDeletionsView = getView().findViewById(R.id.diff_deletions);
-                totalDeletionsView.setText(String.valueOf(mRevision.getTotalDeletions()));
-                totalDeletionsView.setVisibility(View.VISIBLE);
-            }
+            mAdapter = new HistoryDetailFragmentAdapter(getChildFragmentManager(), mRevisions);
+
+            mViewPager.setAdapter(mAdapter);
+            mViewPager.setCurrentItem(mPosition);
+
+            mTotalAdditions = getView().findViewById(R.id.diff_additions);
+            mTotalDeletions = getView().findViewById(R.id.diff_deletions);
+
+            mNextButton = getView().findViewById(R.id.next);
+            mNextButton.setOnClickListener(new OnClickListener() {
+                @Override public void onClick(View view) {
+                    mViewPager.setCurrentItem(mPosition + 1, true);
+                }
+            });
+
+            mPreviousButton = getView().findViewById(R.id.previous);
+            mPreviousButton.setOnClickListener(new OnClickListener() {
+                @Override public void onClick(View view) {
+                    mViewPager.setCurrentItem(mPosition - 1, true);
+                }
+            });
+
+            refreshRevisionDetails();
+            resetOnPageChangeListener();
         }
     }
 
     @Override
     public boolean onConfirmClicked(FullScreenDialogController controller) {
         Bundle result = new Bundle();
-        result.putParcelable(KEY_REVISION, mRevision);
+        result.putParcelable(KEY_REVISION, mRevisions.get(mPosition));
         controller.confirm(result);
         return true;
     }
@@ -81,5 +120,106 @@ public class HistoryDetailFullScreenDialogFragment extends Fragment implements F
     public boolean onDismissClicked(FullScreenDialogController controller) {
         controller.dismiss();
         return true;
+    }
+
+    private void refreshRevisionDetails() {
+        if (getParentFragment() instanceof FullScreenDialogFragment) {
+            ((FullScreenDialogFragment) getParentFragment()).setSubtitle(mRevision.getTimeSpan());
+        }
+
+        if (mRevision.getTotalAdditions() > 0) {
+            mTotalAdditions.setText(String.valueOf(mRevision.getTotalAdditions()));
+            mTotalAdditions.setVisibility(View.VISIBLE);
+        } else {
+            mTotalAdditions.setVisibility(View.GONE);
+        }
+
+        if (mRevision.getTotalDeletions() > 0) {
+            mTotalDeletions.setText(String.valueOf(mRevision.getTotalDeletions()));
+            mTotalDeletions.setVisibility(View.VISIBLE);
+        } else {
+            mTotalDeletions.setVisibility(View.GONE);
+        }
+
+        mNextButton.setEnabled(mPosition != mAdapter.getCount() - 1);
+        mPreviousButton.setEnabled(mPosition != 0);
+    }
+
+    private void resetOnPageChangeListener() {
+        if (mOnPageChangeListener != null) {
+            mViewPager.removeOnPageChangeListener(mOnPageChangeListener);
+        } else {
+            mOnPageChangeListener = new ViewPager.OnPageChangeListener() {
+                @Override
+                public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+                }
+
+                @Override
+                public void onPageScrollStateChanged(int state) {
+                }
+
+                @Override
+                public void onPageSelected(int position) {
+                    mPosition = position;
+                    mRevision = mAdapter.getRevisionAtPosition(mPosition);
+                    refreshRevisionDetails();
+                }
+            };
+        }
+
+        mViewPager.addOnPageChangeListener(mOnPageChangeListener);
+    }
+
+    private class HistoryDetailFragmentAdapter extends FragmentStatePagerAdapter {
+        private final ArrayList<Revision> mRevisions;
+
+        @SuppressWarnings("unchecked")
+        HistoryDetailFragmentAdapter(FragmentManager fragmentManager, ArrayList<Revision> revisions) {
+            super(fragmentManager);
+             mRevisions = (ArrayList<Revision>) revisions.clone();
+        }
+
+        @Override
+        public Fragment getItem(int position) {
+            return HistoryDetailFragment.Companion.newInstance(mRevisions.get(position));
+        }
+
+        @Override
+        public int getCount() {
+            return mRevisions.size();
+        }
+
+        @Override
+        public void restoreState(Parcelable state, ClassLoader loader) {
+            try {
+                super.restoreState(state, loader);
+            } catch (IllegalStateException exception) {
+                AppLog.e(T.EDITOR, exception);
+            }
+        }
+
+        @Override
+        public Parcelable saveState() {
+            Bundle bundle = (Bundle) super.saveState();
+
+            if (bundle == null) {
+                bundle = new Bundle();
+            }
+
+            bundle.putParcelableArray("states", null);
+            return bundle;
+        }
+
+        private Revision getRevisionAtPosition(int position) {
+            if (isValidPosition(position)) {
+                return mRevisions.get(position);
+            } else {
+                return null;
+            }
+        }
+
+        private boolean isValidPosition(int position) {
+            return (position >= 0 && position < getCount());
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailFullScreenDialogFragment.java
@@ -110,6 +110,7 @@ public class HistoryDetailFullScreenDialogFragment extends Fragment implements F
 
     @Override
     public boolean onConfirmClicked(FullScreenDialogController controller) {
+        // TODO: Add analytics tracking for confirm button.
         Bundle result = new Bundle();
         result.putParcelable(KEY_REVISION, mRevisions.get(mPosition));
         controller.confirm(result);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1587,11 +1587,11 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void onHistoryItemClicked(@NonNull Revision revision) {
+    public void onHistoryItemClicked(@NonNull Revision revision, @NonNull ArrayList<Revision> revisions) {
         // TODO: Add analytics tracking for history list item.
         mRevision = revision;
 
-        Bundle bundle = HistoryDetailFullScreenDialogFragment.newBundle(revision);
+        Bundle bundle = HistoryDetailFullScreenDialogFragment.newBundle(mRevision, revisions);
 
         mFullScreenDialogFragment = new FullScreenDialogFragment.Builder(EditPostActivity.this)
                 .setTitle(R.string.history_detail_title)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1645,7 +1645,7 @@ public class EditPostActivity extends AppCompatActivity implements
         refreshEditorContent();
 
         Snackbar.make(mViewPager, getString(R.string.history_loaded_revision),
-                AccessibilityUtils.getSnackbarDuration(EditPostActivity.this, Snackbar.LENGTH_LONG))
+                AccessibilityUtils.getSnackbarDuration(EditPostActivity.this, 4000))
                 .setAction(getString(R.string.undo), new OnClickListener() {
                     @Override
                     public void onClick(View view) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1622,7 +1622,12 @@ public class EditPostActivity extends AppCompatActivity implements
 
         if (result != null && result.getParcelable(KEY_REVISION) != null) {
             mRevision = result.getParcelable(KEY_REVISION);
-            loadRevision();
+
+            new Handler().postDelayed(new Runnable() {
+                @Override public void run() {
+                    loadRevision();
+                }
+            }, getResources().getInteger(R.integer.full_screen_dialog_animation_duration));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1609,7 +1609,6 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onConfirm(@Nullable Bundle result) {
-        // TODO: Add analytics tracking for revision detail confirmed.
         mViewPager.setCurrentItem(PAGE_CONTENT);
 
         if (result != null && result.getParcelable(KEY_REVISION) != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1109,6 +1109,11 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private boolean handleBackPressed() {
+        if (mFullScreenDialogFragment != null && mFullScreenDialogFragment.isVisible()) {
+            mFullScreenDialogFragment.dismiss();
+            return false;
+        }
+
         Fragment fragment = getSupportFragmentManager().findFragmentByTag(
                 ImageSettingsDialogFragment.IMAGE_SETTINGS_DIALOG_TAG);
         if (fragment != null && fragment.isVisible()) {
@@ -1116,12 +1121,15 @@ public class EditPostActivity extends AppCompatActivity implements
                 ImageSettingsDialogFragment imFragment = (ImageSettingsDialogFragment) fragment;
                 imFragment.dismissFragment();
             }
+
             return false;
         }
+
         if (mViewPager.getCurrentItem() > PAGE_CONTENT) {
             if (mViewPager.getCurrentItem() == PAGE_SETTINGS) {
                 mEditorFragment.setFeaturedImageId(mPost.getFeaturedImageId());
             }
+
             mViewPager.setCurrentItem(PAGE_CONTENT);
             invalidateOptionsMenu();
         } else if (isPhotoPickerShowing()) {
@@ -1129,6 +1137,7 @@ public class EditPostActivity extends AppCompatActivity implements
         } else {
             savePostAndOptionallyFinish(true);
         }
+
         return true;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -127,7 +127,7 @@ class HistoryListFragment : Fragment() {
             }
         })
 
-        viewModel.showSnackbarMessage.observe(this, Observer { message ->
+        viewModel.showSnackbar.observe(this, Observer { message ->
             val parent: View? = activity?.findViewById(android.R.id.content)
             if (message != null && parent != null) {
                 val snackbar = Snackbar.make(parent, message, Snackbar.LENGTH_LONG)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -5,13 +5,11 @@ import android.arch.lifecycle.ViewModelProvider
 import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.support.annotation.NonNull
-import android.support.design.widget.Snackbar
 import android.support.v4.app.Fragment
 import android.support.v7.widget.LinearLayoutManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import kotlinx.android.synthetic.main.history_list_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -124,16 +122,6 @@ class HistoryListFragment : Fragment() {
         viewModel.showDialog.observe(this, Observer {
             if (it is HistoryListItem.Revision && activity is HistoryItemClickInterface) {
                 (activity as HistoryItemClickInterface).onHistoryItemClicked(it, viewModel.revisionsList)
-            }
-        })
-
-        viewModel.showSnackbar.observe(this, Observer { message ->
-            val parent: View? = activity?.findViewById(android.R.id.content)
-            if (message != null && parent != null) {
-                val snackbar = Snackbar.make(parent, message, Snackbar.LENGTH_LONG)
-                val snackbarText = snackbar.view.findViewById<TextView>(android.support.design.R.id.snackbar_text)
-                snackbarText.maxLines = 2
-                snackbar.show()
             }
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -115,8 +115,10 @@ class HistoryListFragment : Fragment() {
             reloadList(it ?: emptyList())
         })
 
-        viewModel.eventListStatus.observe(this, Observer { listStatus ->
-            updateRefreshing(listStatus)
+        viewModel.listStatus.observe(this, Observer { listStatus ->
+            if (isAdded && view != null) {
+                swipeToRefreshHelper.isRefreshing = listStatus == FETCHING
+            }
         })
 
         viewModel.showDialog.observe(this, Observer {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -119,7 +119,7 @@ class HistoryListFragment : Fragment() {
             updateRefreshing(listStatus)
         })
 
-        viewModel.showLoadDialog.observe(this, Observer {
+        viewModel.showDialog.observe(this, Observer {
             if (it is HistoryListItem.Revision && activity is HistoryItemClickInterface) {
                 (activity as HistoryItemClickInterface).onHistoryItemClicked(it, viewModel.revisionsList)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -47,7 +47,7 @@ class HistoryListFragment : Fragment() {
     }
 
     interface HistoryItemClickInterface {
-        fun onHistoryItemClicked(revision: Revision)
+        fun onHistoryItemClicked(revision: Revision, revisions: ArrayList<Revision>)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -120,8 +120,8 @@ class HistoryListFragment : Fragment() {
         })
 
         viewModel.showLoadDialog.observe(this, Observer {
-            if (it is HistoryListItem.Revision) {
-                showLoadDialog(it)
+            if (it is HistoryListItem.Revision && activity is HistoryItemClickInterface) {
+                (activity as HistoryItemClickInterface).onHistoryItemClicked(it, viewModel.revisionsList)
             }
         })
 
@@ -134,19 +134,5 @@ class HistoryListFragment : Fragment() {
                 snackbar.show()
             }
         })
-    }
-
-    private fun showLoadDialog(revision: Revision) {
-        if (activity is HistoryItemClickInterface) {
-            (activity as HistoryItemClickInterface).onHistoryItemClicked(revision)
-        }
-    }
-
-    private fun updateRefreshing(listStatus: HistoryViewModel.HistoryListStatus?) {
-        if (!isAdded || view == null) {
-            return
-        }
-
-        swipeToRefreshHelper.isRefreshing = listStatus == FETCHING
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -85,36 +85,8 @@ class HistoryViewModel @Inject constructor(
         }
 
         revisionAuthorsId = ArrayList(revisionAuthorsId.distinct())
-        _revisions.value = revisionsToHistoryListItems(revisions)
+        _revisions.value = getHistoryListItemsFromRevisionModels(revisions)
         fetchRevisionAuthorDetails(revisionAuthorsId)
-    }
-
-    private fun revisionsToHistoryListItems(revisions: List<RevisionModel>): List<HistoryListItem> {
-        val items = mutableListOf<HistoryListItem>()
-
-        revisions.forEach {
-            val item = HistoryListItem.Revision(it)
-            val last = items.lastOrNull() as? Revision
-
-            if (item.formattedDate != last?.formattedDate) {
-                items.add(HistoryListItem.Header(item.formattedDate))
-            }
-
-            items.add(item)
-            revisionsList.add(item)
-        }
-
-        if (revisions.isNotEmpty()) {
-            val last = items.last() as Revision
-            val footer = if (post.isPage) {
-                resourceProvider.getString(R.string.history_footer_page, last.formattedDate, last.formattedTime)
-            } else {
-                resourceProvider.getString(R.string.history_footer_post, last.formattedDate, last.formattedTime)
-            }
-            items.add(HistoryListItem.Footer(footer))
-        }
-
-        return items
     }
 
     private fun fetchRevisionAuthorDetails(authorsId: List<String>) {
@@ -159,6 +131,34 @@ class HistoryViewModel @Inject constructor(
         uiScope.launch {
             dispatcher.dispatch(PostActionBuilder.newFetchRevisionsAction(payload))
         }
+    }
+
+    private fun getHistoryListItemsFromRevisionModels(revisions: List<RevisionModel>): List<HistoryListItem> {
+        val items = mutableListOf<HistoryListItem>()
+
+        revisions.forEach {
+            val item = HistoryListItem.Revision(it)
+            val last = items.lastOrNull() as? Revision
+
+            if (item.formattedDate != last?.formattedDate) {
+                items.add(HistoryListItem.Header(item.formattedDate))
+            }
+
+            items.add(item)
+            revisionsList.add(item)
+        }
+
+        if (revisions.isNotEmpty()) {
+            val last = items.last() as Revision
+            val footer = if (post.isPage) {
+                resourceProvider.getString(R.string.history_footer_page, last.formattedDate, last.formattedTime)
+            } else {
+                resourceProvider.getString(R.string.history_footer_post, last.formattedDate, last.formattedTime)
+            }
+            items.add(HistoryListItem.Footer(footer))
+        }
+
+        return items
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -44,9 +44,9 @@ class HistoryViewModel @Inject constructor(
     val showDialog: LiveData<HistoryListItem>
         get() = _showDialog
 
-    private val _showSnackbarMessage = SingleLiveEvent<String>()
-    val showSnackbarMessage: LiveData<String>
-        get() = _showSnackbarMessage
+    private val _showSnackbar = SingleLiveEvent<String>()
+    val showSnackbar: LiveData<String>
+        get() = _showSnackbar
 
     private val _revisions = MutableLiveData<List<HistoryListItem>>()
     val revisions: LiveData<List<HistoryListItem>>

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -37,7 +37,7 @@ class HistoryViewModel @Inject constructor(
     }
 
     private val _listStatus = MutableLiveData<HistoryListStatus>()
-    val eventListStatus: LiveData<HistoryListStatus>
+    val listStatus: LiveData<HistoryListStatus>
         get() = _listStatus
 
     private val _showDialog = SingleLiveEvent<HistoryListItem>()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -54,6 +54,7 @@ class HistoryViewModel @Inject constructor(
 
     private var isStarted = false
 
+    lateinit var revisionsList: ArrayList<Revision>
     lateinit var post: PostModel
     lateinit var site: SiteModel
 
@@ -66,6 +67,7 @@ class HistoryViewModel @Inject constructor(
             return
         }
 
+        this.revisionsList = ArrayList()
         this.post = post
         this.site = site
 
@@ -86,6 +88,7 @@ class HistoryViewModel @Inject constructor(
             }
 
             items.add(item)
+            revisionsList.add(item)
         }
 
         if (revisions.isNotEmpty()) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -40,9 +40,9 @@ class HistoryViewModel @Inject constructor(
     val eventListStatus: LiveData<HistoryListStatus>
         get() = _listStatus
 
-    private val _showLoadDialog = SingleLiveEvent<HistoryListItem>()
-    val showLoadDialog: LiveData<HistoryListItem>
-        get() = _showLoadDialog
+    private val _showDialog = SingleLiveEvent<HistoryListItem>()
+    val showDialog: LiveData<HistoryListItem>
+        get() = _showDialog
 
     private val _showSnackbarMessage = SingleLiveEvent<String>()
     val showSnackbarMessage: LiveData<String>
@@ -119,7 +119,7 @@ class HistoryViewModel @Inject constructor(
 
     fun onItemClicked(item: HistoryListItem) {
         if (item is HistoryListItem.Revision) {
-            _showLoadDialog.value = item
+            _showDialog.value = item
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -122,6 +122,7 @@ class HistoryViewModel @Inject constructor(
             override fun onSuccess(peopleList: List<Person>, isEndOfList: Boolean) {
                 val existingRevisions = _revisions.value ?: return
                 val updatedRevisions = mutableListOf<HistoryListItem>()
+                revisionsList.clear()
 
                 existingRevisions.forEach { it ->
                     var mutableRevision = it
@@ -136,6 +137,8 @@ class HistoryViewModel @Inject constructor(
                             mutableRevision.authorAvatarURL = person.avatarUrl
                             mutableRevision.authorDisplayName = person.displayName
                         }
+
+                        revisionsList.add(mutableRevision)
                     }
 
                     updatedRevisions.add(mutableRevision)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -44,17 +44,13 @@ class HistoryViewModel @Inject constructor(
     val listStatus: LiveData<HistoryListStatus>
         get() = _listStatus
 
-    private val _showDialog = SingleLiveEvent<HistoryListItem>()
-    val showDialog: LiveData<HistoryListItem>
-        get() = _showDialog
-
-    private val _showSnackbar = SingleLiveEvent<String>()
-    val showSnackbar: LiveData<String>
-        get() = _showSnackbar
-
     private val _revisions = MutableLiveData<List<HistoryListItem>>()
     val revisions: LiveData<List<HistoryListItem>>
         get() = _revisions
+
+    private val _showDialog = SingleLiveEvent<HistoryListItem>()
+    val showDialog: LiveData<HistoryListItem>
+        get() = _showDialog
 
     private var isStarted = false
 

--- a/WordPress/src/main/res/anim/full_screen_dialog_fragment_none.xml
+++ b/WordPress/src/main/res/anim/full_screen_dialog_fragment_none.xml
@@ -4,7 +4,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <translate
-        android:duration="@android:integer/config_mediumAnimTime"
+        android:duration="@integer/full_screen_dialog_animation_duration"
         android:fromXDelta="0"
         android:toXDelta="0" >
     </translate>

--- a/WordPress/src/main/res/anim/full_screen_dialog_fragment_slide_down.xml
+++ b/WordPress/src/main/res/anim/full_screen_dialog_fragment_slide_down.xml
@@ -4,7 +4,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <translate
-        android:duration="@android:integer/config_mediumAnimTime"
+        android:duration="@integer/full_screen_dialog_animation_duration"
         android:fromYDelta="0%"
         android:interpolator="@android:anim/accelerate_interpolator"
         android:toYDelta="100%" >

--- a/WordPress/src/main/res/anim/full_screen_dialog_fragment_slide_up.xml
+++ b/WordPress/src/main/res/anim/full_screen_dialog_fragment_slide_up.xml
@@ -4,7 +4,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <translate
-        android:duration="@android:integer/config_mediumAnimTime"
+        android:duration="@integer/full_screen_dialog_animation_duration"
         android:fromYDelta="100%"
         android:interpolator="@android:anim/decelerate_interpolator"
         android:toYDelta="0%" >

--- a/WordPress/src/main/res/drawable-ldrtl/ic_chevron_left_grey_dark_24dp.xml
+++ b/WordPress/src/main/res/drawable-ldrtl/ic_chevron_left_grey_dark_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="@color/grey_dark"
+        android:pathData="M10,20l8,-8l-8,-8L8.6,5.4l6.6,6.6l-6.6,6.6" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/drawable-ldrtl/ic_chevron_left_grey_lighten_10_24dp.xml
+++ b/WordPress/src/main/res/drawable-ldrtl/ic_chevron_left_grey_lighten_10_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="@color/grey_lighten_10"
+        android:pathData="M10,20l8,-8l-8,-8L8.6,5.4l6.6,6.6l-6.6,6.6" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/drawable-ldrtl/ic_chevron_right_grey_dark_24dp.xml
+++ b/WordPress/src/main/res/drawable-ldrtl/ic_chevron_right_grey_dark_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="@color/grey_dark"
+        android:pathData="M14 20l-8-8 8-8 1.414 1.414L8.828 12l6.586 6.586" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/drawable-ldrtl/ic_chevron_right_grey_lighten_10_24dp.xml
+++ b/WordPress/src/main/res/drawable-ldrtl/ic_chevron_right_grey_lighten_10_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="@color/grey_lighten_10"
+        android:pathData="M14 20l-8-8 8-8 1.414 1.414L8.828 12l6.586 6.586" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/drawable/ic_chevron_left_grey_dark_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_chevron_left_grey_dark_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="@color/grey_dark"
+        android:pathData="M14 20l-8-8 8-8 1.414 1.414L8.828 12l6.586 6.586" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/drawable/ic_chevron_left_grey_dark_24dp_selector.xml
+++ b/WordPress/src/main/res/drawable/ic_chevron_left_grey_dark_24dp_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/ic_chevron_left_grey_dark_24dp" android:state_enabled="true" />
+    <item android:drawable="@drawable/ic_chevron_left_grey_lighten_10_24dp" />
+
+</selector>

--- a/WordPress/src/main/res/drawable/ic_chevron_left_grey_lighten_10_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_chevron_left_grey_lighten_10_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="@color/grey_lighten_10"
+        android:pathData="M14 20l-8-8 8-8 1.414 1.414L8.828 12l6.586 6.586" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/drawable/ic_chevron_right_grey_dark_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_chevron_right_grey_dark_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="@color/grey_dark"
+        android:pathData="M10,20l8,-8l-8,-8L8.6,5.4l6.6,6.6l-6.6,6.6" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/drawable/ic_chevron_right_grey_dark_24dp_selector.xml
+++ b/WordPress/src/main/res/drawable/ic_chevron_right_grey_dark_24dp_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/ic_chevron_right_grey_dark_24dp" android:state_enabled="true" />
+    <item android:drawable="@drawable/ic_chevron_right_grey_lighten_10_24dp" />
+
+</selector>

--- a/WordPress/src/main/res/drawable/ic_chevron_right_grey_lighten_10_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_chevron_right_grey_lighten_10_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="@color/grey_lighten_10"
+        android:pathData="M10,20l8,-8l-8,-8L8.6,5.4l6.6,6.6l-6.6,6.6" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/layout/history_detail_dialog_fragment.xml
+++ b/WordPress/src/main/res/layout/history_detail_dialog_fragment.xml
@@ -3,131 +3,101 @@
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:background="@color/white"
     android:layout_height="match_parent"
     android:layout_width="match_parent" >
 
-    <LinearLayout
-        android:id="@+id/diff_layout"
+    <RelativeLayout
+        android:id="@+id/bottom_bar"
         android:background="@color/white"
-        android:gravity="center"
         android:layout_alignParentBottom="true"
-        android:layout_centerInParent="true"
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        android:orientation="horizontal"
-        android:padding="@dimen/margin_extra_large" >
-
-        <TextView
-            android:id="@+id/diff_additions"
-            android:drawablePadding="@dimen/margin_small"
-            android:drawableStart="@drawable/bg_oval_blue_wordpress_plus_white_16dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/margin_small_medium"
-            android:layout_marginStart="@dimen/margin_small_medium"
-            android:layout_width="wrap_content"
-            android:textAppearance="@style/Base.TextAppearance.AppCompat.Body1"
-            android:textColor="@color/grey_darken_10"
-            android:visibility="gone"
-            tools:text="3"
-            tools:visibility="visible" >
-        </TextView>
-
-        <TextView
-            android:id="@+id/diff_deletions"
-            android:drawablePadding="@dimen/margin_small"
-            android:drawableStart="@drawable/bg_oval_alert_red_minus_white_16dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/margin_small_medium"
-            android:layout_marginStart="@dimen/margin_small_medium"
-            android:layout_width="wrap_content"
-            android:textAppearance="@style/Base.TextAppearance.AppCompat.Body1"
-            android:textColor="@color/grey_darken_10"
-            android:visibility="gone"
-            tools:text="1"
-            tools:visibility="visible" >
-        </TextView>
-
-    </LinearLayout>
-
-    <ScrollView
-        android:fillViewport="true"
-        android:layout_above="@+id/diff_layout"
-        android:layout_alignParentTop="true"
         android:layout_height="wrap_content"
         android:layout_width="match_parent" >
 
-        <LinearLayout
-            android:layout_width="match_parent"
+        <ImageView
+            android:id="@+id/previous"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:contentDescription="@string/history_detail_button_previous"
+            android:focusable="true"
+            android:layout_alignParentStart="true"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:layout_width="wrap_content"
+            android:minHeight="@dimen/min_touch_target_sz"
+            android:minWidth="@dimen/min_touch_target_sz"
+            android:padding="@dimen/margin_extra_large"
+            android:src="@drawable/ic_chevron_left_grey_dark_24dp_selector" >
+        </ImageView>
 
-            <RelativeLayout
+        <LinearLayout
+            android:id="@+id/diff_layout"
+            android:gravity="center"
+            android:layout_centerInParent="true"
+            android:layout_toEndOf="@+id/previous"
+            android:layout_toStartOf="@+id/next"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:orientation="horizontal"
+            android:padding="@dimen/margin_extra_large" >
+
+            <TextView
+                android:id="@+id/diff_additions"
+                android:drawablePadding="@dimen/margin_small"
+                android:drawableStart="@drawable/bg_oval_blue_wordpress_plus_white_16dp"
                 android:layout_height="wrap_content"
-                android:layout_width="match_parent" >
+                android:layout_marginEnd="@dimen/margin_small_medium"
+                android:layout_marginStart="@dimen/margin_small_medium"
+                android:layout_width="wrap_content"
+                android:textAppearance="@style/Base.TextAppearance.AppCompat.Body1"
+                android:textColor="@color/grey_darken_10"
+                android:visibility="gone"
+                tools:text="3"
+                tools:visibility="visible" >
+            </TextView>
 
-                <org.wordpress.android.widgets.DiffView
-                    android:id="@+id/title"
-                    android:background="@null"
-                    android:clickable="false"
-                    android:fontFamily="serif"
-                    android:hint="@string/post_title"
-                    android:imeOptions="flagNoExtractUi"
-                    android:inputType="none"
-                    android:layout_height="wrap_content"
-                    android:layout_width="match_parent"
-                    android:lineSpacingExtra="@dimen/spacing_extra_title"
-                    android:padding="@dimen/margin_extra_large"
-                    android:textColor="@color/grey_dark"
-                    android:textColorHint="@color/hint_text"
-                    android:textIsSelectable="true"
-                    android:textSize="@dimen/aztec_title_size"
-                    android:textStyle="bold" >
-                </org.wordpress.android.widgets.DiffView>
-
-            </RelativeLayout>
-
-            <View
-                android:layout_height="@dimen/format_bar_horizontal_divider_height"
-                android:layout_marginEnd="@dimen/sourceview_side_margin"
-                android:layout_marginStart="@dimen/sourceview_side_margin"
-                android:layout_width="fill_parent"
-                style="@style/DividerSourceView" >
-            </View>
-
-            <FrameLayout
-                android:layout_height="match_parent"
-                android:layout_width="match_parent" >
-
-                <org.wordpress.android.widgets.DiffView
-                    android:id="@+id/content"
-                    android:clickable="false"
-                    android:fontFamily="serif"
-                    android:gravity="top|start"
-                    android:hint="@string/editor_content_hint"
-                    android:imeOptions="flagNoExtractUi"
-                    android:inputType="none"
-                    android:layout_height="match_parent"
-                    android:layout_width="match_parent"
-                    android:paddingEnd="@dimen/margin_large"
-                    android:paddingStart="@dimen/margin_large"
-                    android:paddingTop="@dimen/margin_large"
-                    android:scrollbars="vertical"
-                    android:textColor="@color/grey_dark"
-                    android:textColorHint="@color/hint_text"
-                    android:textIsSelectable="true"
-                    android:textSize="@dimen/text_sz_post_content" >
-                </org.wordpress.android.widgets.DiffView>
-
-            </FrameLayout>
+            <TextView
+                android:id="@+id/diff_deletions"
+                android:drawablePadding="@dimen/margin_small"
+                android:drawableStart="@drawable/bg_oval_alert_red_minus_white_16dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/margin_small_medium"
+                android:layout_marginStart="@dimen/margin_small_medium"
+                android:layout_width="wrap_content"
+                android:textAppearance="@style/Base.TextAppearance.AppCompat.Body1"
+                android:textColor="@color/grey_darken_10"
+                android:visibility="gone"
+                tools:text="1"
+                tools:visibility="visible" >
+            </TextView>
 
         </LinearLayout>
 
-    </ScrollView>
+        <ImageView
+            android:id="@+id/next"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:contentDescription="@string/history_detail_button_next"
+            android:focusable="true"
+            android:layout_alignParentEnd="true"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:minHeight="@dimen/min_touch_target_sz"
+            android:minWidth="@dimen/min_touch_target_sz"
+            android:padding="@dimen/margin_extra_large"
+            android:src="@drawable/ic_chevron_right_grey_dark_24dp_selector" >
+        </ImageView>
+
+    </RelativeLayout>
+
+    <org.wordpress.android.widgets.WPViewPager
+        android:id="@+id/diff_pager"
+        android:layout_above="@+id/bottom_bar"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent" >
+    </org.wordpress.android.widgets.WPViewPager>
 
     <View
         android:background="@color/grey_lighten_30"
-        android:layout_above="@+id/diff_layout"
+        android:layout_above="@+id/bottom_bar"
         android:layout_height="@dimen/list_divider_height"
         android:layout_width="match_parent" >
     </View>

--- a/WordPress/src/main/res/layout/history_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/history_detail_fragment.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:background="@color/white"
+    android:fillViewport="true"
+    android:layout_alignParentTop="true"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent" >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" >
+
+        <RelativeLayout
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent" >
+
+            <org.wordpress.android.widgets.DiffView
+                android:id="@+id/title"
+                android:background="@null"
+                android:clickable="false"
+                android:fontFamily="serif"
+                android:hint="@string/post_title"
+                android:imeOptions="flagNoExtractUi"
+                android:inputType="none"
+                android:layout_height="wrap_content"
+                android:layout_width="match_parent"
+                android:lineSpacingExtra="@dimen/spacing_extra_title"
+                android:padding="@dimen/margin_extra_large"
+                android:textColor="@color/grey_dark"
+                android:textColorHint="@color/hint_text"
+                android:textIsSelectable="true"
+                android:textSize="@dimen/aztec_title_size"
+                android:textStyle="bold" >
+            </org.wordpress.android.widgets.DiffView>
+
+        </RelativeLayout>
+
+        <View
+            android:layout_height="@dimen/format_bar_horizontal_divider_height"
+            android:layout_marginEnd="@dimen/sourceview_side_margin"
+            android:layout_marginStart="@dimen/sourceview_side_margin"
+            android:layout_width="fill_parent"
+            style="@style/DividerSourceView" >
+        </View>
+
+        <FrameLayout
+            android:layout_height="match_parent"
+            android:layout_width="match_parent" >
+
+            <org.wordpress.android.widgets.DiffView
+                android:id="@+id/content"
+                android:clickable="false"
+                android:fontFamily="serif"
+                android:gravity="top|start"
+                android:hint="@string/editor_content_hint"
+                android:imeOptions="flagNoExtractUi"
+                android:inputType="none"
+                android:layout_height="match_parent"
+                android:layout_width="match_parent"
+                android:paddingEnd="@dimen/margin_extra_large"
+                android:paddingStart="@dimen/margin_extra_large"
+                android:paddingTop="@dimen/margin_extra_large"
+                android:scrollbars="vertical"
+                android:textColor="@color/grey_dark"
+                android:textColorHint="@color/hint_text"
+                android:textIsSelectable="true"
+                android:textSize="@dimen/text_sz_post_content" >
+            </org.wordpress.android.widgets.DiffView>
+
+        </FrameLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/WordPress/src/main/res/values/integers.xml
+++ b/WordPress/src/main/res/values/integers.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <resources>
+
+    <integer name="full_screen_dialog_animation_duration">@android:integer/config_mediumAnimTime</integer>
+
     <integer name="smallest_width_dp">320</integer>
 
     <!-- max #chars user can type when adding a new topic to the reader -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1193,6 +1193,8 @@
 
     <!-- History -->
     <string name="description_user">User avatar</string>
+    <string name="history_detail_button_next">Next</string>
+    <string name="history_detail_button_previous">Previous</string>
     <string name="history_detail_title">Revision</string>
     <string name="history_empty_subtitle_page">When you make changes to your page you\'ll be able to see the history here</string>
     <string name="history_empty_subtitle_post">When you make changes to your post you\'ll be able to see the history here</string>


### PR DESCRIPTION
### Fix
Add paging through revisions by swiping and tapping chevrons in the bottom toolbar as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8340.  See the screenshots below for illustration.

![revisions_history_detail_paging](https://user-images.githubusercontent.com/3827611/47475470-7e3bcc00-d7e9-11e8-810f-732632c6165c.png)

#### Note
The visual differences (e.g. toolbar color, subtitle format, image display) have been discussed and passed design review in https://github.com/wordpress-mobile/WordPress-Android/pull/8457.  These changes focus on the paging interaction and chevron buttons.  See the animation below for illustration.

<img src="https://user-images.githubusercontent.com/3827611/47514997-b249d800-d84f-11e8-9771-b3995b85a7f7.gif" width="360">

### Test
#### Site Pages
1. Go to ***My Site*** tab.
2. Tap ***Site Pages*** item under ***Publish*** section.
3. Tap page in ***Site Pages*** list.
4. Tap overflow menu button in top toolbar.
5. Tap ***History*** item in menu.
6. Tap item in ***History*** list.
7. Notice ***Revision*** full-screen dialog shown above.
8. Swipe left/right over revision content.
9. Notice next/previous revision is shown.
10. Tap left/right chevron button in bottom toolbar.
11. Notice next/previous revision is shown.

#### Blog Posts
1. Go to ***My Site*** tab.
2. Tap ***Blog Posts*** item under ***Publish*** section.
3. Tap post in ***Blog Posts*** list.
4. Tap overflow menu button in top toolbar.
5. Tap ***History*** item in menu.
6. Tap item in ***History*** list.
7. Notice ***Revision*** full-screen dialog shown above.
8. Swipe left/right over revision content.
9. Notice next/previous revision is shown.
10. Tap left/right chevron button in bottom toolbar.
11. Notice next/previous revision is shown.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.