### PR TITLE
Issue/updating bound revision in ViewHolder on change

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/history/RevisionItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/RevisionItemViewHolder.kt
@@ -24,28 +24,31 @@ class RevisionItemViewHolder(
     private val diffLayout: LinearLayout = itemView.findViewById(R.id.diff_layout)
     private val diffAdditions: TextView = itemView.findViewById(R.id.diff_additions)
     private val diffDeletions: TextView = itemView.findViewById(R.id.diff_deletions)
+    private lateinit var boundRevision: HistoryListItem.Revision
 
     fun bind(revision: HistoryListItem.Revision) {
-        container.setOnClickListener { itemClickListener(revision) }
-        title.text = revision.formattedTime
-        subtitle.text = revision.authorDisplayName
+        boundRevision = revision
 
-        if (!TextUtils.isEmpty(revision.authorAvatarURL)) {
-            imageManager.loadIntoCircle(avatar, ImageType.AVATAR, StringUtils.notNullStr(revision.authorAvatarURL))
+        container.setOnClickListener { itemClickListener(boundRevision) }
+        title.text = boundRevision.formattedTime
+        subtitle.text = boundRevision.authorDisplayName
+
+        if (!TextUtils.isEmpty(this.boundRevision.authorAvatarURL)) {
+            imageManager.loadIntoCircle(avatar, ImageType.AVATAR_WITH_BACKGROUND, StringUtils.notNullStr(boundRevision.authorAvatarURL))
         }
 
-        if (revision.totalAdditions == 0 && revision.totalDeletions == 0) {
+        if (boundRevision.totalAdditions == 0 && boundRevision.totalDeletions == 0) {
             diffLayout.visibility = View.GONE
         } else {
-            if (revision.totalAdditions > 0) {
-                diffAdditions.text = revision.totalAdditions.toString()
+            if (boundRevision.totalAdditions > 0) {
+                diffAdditions.text = boundRevision.totalAdditions.toString()
                 diffAdditions.visibility = View.VISIBLE
             } else {
                 diffAdditions.visibility = View.GONE
             }
 
-            if (revision.totalDeletions > 0) {
-                diffDeletions.text = revision.totalDeletions.toString()
+            if (boundRevision.totalDeletions > 0) {
+                diffDeletions.text = boundRevision.totalDeletions.toString()
                 diffDeletions.visibility = View.VISIBLE
             } else {
                 diffDeletions.visibility = View.GONE
@@ -57,12 +60,15 @@ class RevisionItemViewHolder(
         super.updateChanges(bundle)
         if (bundle.containsKey(HistoryDiffCallback.AVATAR_CHANGED_KEY)) {
             val avatarUrl = bundle.getString(HistoryDiffCallback.AVATAR_CHANGED_KEY)
+            boundRevision.authorAvatarURL = avatarUrl
             if (!TextUtils.isEmpty(avatarUrl)) {
                 imageManager.loadIntoCircle(avatar, ImageType.AVATAR, StringUtils.notNullStr(avatarUrl))
             }
         }
         if (bundle.containsKey(HistoryDiffCallback.DISPLAY_NAME_CHANGED_KEY)) {
-            subtitle.text = bundle.getString(HistoryDiffCallback.DISPLAY_NAME_CHANGED_KEY)
+            val authorDisplayName = bundle.getString(HistoryDiffCallback.DISPLAY_NAME_CHANGED_KEY)
+            boundRevision.authorDisplayName = authorDisplayName
+            subtitle.text = authorDisplayName
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/RevisionItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/RevisionItemViewHolder.kt
@@ -34,7 +34,8 @@ class RevisionItemViewHolder(
         subtitle.text = boundRevision.authorDisplayName
 
         if (!TextUtils.isEmpty(this.boundRevision.authorAvatarURL)) {
-            imageManager.loadIntoCircle(avatar, ImageType.AVATAR_WITH_BACKGROUND, StringUtils.notNullStr(boundRevision.authorAvatarURL))
+            imageManager.loadIntoCircle(avatar, ImageType.AVATAR_WITH_BACKGROUND,
+                    StringUtils.notNullStr(boundRevision.authorAvatarURL))
         }
 
         if (boundRevision.totalAdditions == 0 && boundRevision.totalDeletions == 0) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -123,6 +123,7 @@ class HistoryViewModel @Inject constructor(
             override fun onSuccess(peopleList: List<Person>, isEndOfList: Boolean) {
                 val existingRevisions = _revisions.value ?: return
                 val updatedRevisions = mutableListOf<HistoryListItem>()
+                revisionsList.clear()
 
                 existingRevisions.forEach { it ->
                     var mutableRevision = it
@@ -137,8 +138,8 @@ class HistoryViewModel @Inject constructor(
                             mutableRevision.authorAvatarURL = person.avatarUrl
                             mutableRevision.authorDisplayName = person.displayName
                         }
+                        revisionsList.add(mutableRevision)
                     }
-
                     updatedRevisions.add(mutableRevision)
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -123,7 +123,6 @@ class HistoryViewModel @Inject constructor(
             override fun onSuccess(peopleList: List<Person>, isEndOfList: Boolean) {
                 val existingRevisions = _revisions.value ?: return
                 val updatedRevisions = mutableListOf<HistoryListItem>()
-                revisionsList.clear()
 
                 existingRevisions.forEach { it ->
                     var mutableRevision = it
@@ -138,7 +137,6 @@ class HistoryViewModel @Inject constructor(
                             mutableRevision.authorAvatarURL = person.avatarUrl
                             mutableRevision.authorDisplayName = person.displayName
                         }
-                        revisionsList.add(mutableRevision)
                     }
                     updatedRevisions.add(mutableRevision)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -138,6 +138,7 @@ class HistoryViewModel @Inject constructor(
                             mutableRevision.authorDisplayName = person.displayName
                         }
                     }
+
                     updatedRevisions.add(mutableRevision)
                 }
 


### PR DESCRIPTION
I noticed an issue where we don't update Revision object used in click listener of `RevisionItemViewHolder`. This might cause issue when comparing Revision objects.

This PR addresses the issue by keeping the reverence to revision object and updating it with new values on change.