### PR TITLE
Issue/8485 mystery deletion span

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/DiffView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/DiffView.kt
@@ -22,7 +22,7 @@ class DiffView : AppCompatTextView {
         text = null
 
         diffs.forEachIndexed { index, diff ->
-            var diffValue = if (trimNewline && index == diffs.size - 1) {
+            val diffValue = if (trimNewline && index == diffs.size - 1) {
                 diff.value?.trimEnd('\n')
             } else {
                 diff.value

--- a/WordPress/src/main/java/org/wordpress/android/widgets/DiffView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/DiffView.kt
@@ -28,11 +28,6 @@ class DiffView : AppCompatTextView {
                 diff.value
             }
 
-            // add tiny spacing before and after DEL and ADD diffs (will be included in the span)
-            if (diff.operation == ADD || diff.operation == DELETE) {
-                diffValue = "\u200A" + diffValue + "\u200A"
-            }
-
             val diffContent = SpannableString(diffValue)
 
             if (diff.operation == ADD) {

--- a/WordPress/src/main/java/org/wordpress/android/widgets/DiffView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/DiffView.kt
@@ -67,12 +67,6 @@ class DiffView : AppCompatTextView {
                 )
             }
 
-            // if there is ADD or DEL diff before current ADD or DEL diff we add a little spacing between them
-            if (index > 0 && (diff.operation == ADD || diff.operation == DELETE) &&
-                    (diffs[index - 1].operation == ADD || diffs[index - 1].operation == DELETE)) {
-                append("\u200A")
-            }
-
             append(diffContent)
         }
     }


### PR DESCRIPTION
### Fix
Remove pseudo padding and margin from spans in the `DiffView` class.  This resolves the mystery deletion span as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8485 and makes diff views mimic Calypso.  See the screenshots below for illustration.

![diff_padding_spacing_title](https://user-images.githubusercontent.com/3827611/47574449-a02e6f00-d90d-11e8-9650-fc0cb214867f.png)

![diff_padding_spacing_content](https://user-images.githubusercontent.com/3827611/47574453-a1f83280-d90d-11e8-9f7e-4cefa53d6b67.png)

### Test
#### Site Pages
1. Go to ***My Site*** tab.
2. Tap ***Site Pages*** item under ***Publish*** section.
3. Tap page in ***Site Pages*** list.
4. Tap overflow menu button in top toolbar.
5. Tap ***History*** item in menu.
6. Tap item in ***History*** list.
7. Notice ***Revision*** full-screen dialog shown above.

#### Blog Posts
1. Go to ***My Site*** tab.
2. Tap ***Blog Posts*** item under ***Publish*** section.
3. Tap post in ***Blog Posts*** list.
4. Tap overflow menu button in top toolbar.
5. Tap ***History*** item in menu.
6. Tap item in ***History*** list.
7. Notice ***Revision*** full-screen dialog shown above.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.