### PR TITLE
Fix the new post list diff calculation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '5a2623ead82bf502b1bde1d9616aee668b4ffddd'
+    fluxCVersion = '0e458b70a9bb942b1e2ab2e3d6302f69d2c12ac4'
 }


### PR DESCRIPTION
Previously, we were returning `true` from both `ListManagerDiffCallback.areItemsTheSame` and `ListManagerDiffCallback.areContentsTheSame` if both items are `null`. Since the items are `null` only if they are both remote items and in that case their contents are the same as far as we are concerned. However, they are actually not the same item since they have different `remoteItemId`s. When we treat them as if they are the same items, we get this weird animation and rare hangs especially when the user visits a post list for the first time (loading a lot of posts): https://cloudup.com/cMczJcqe_T4. This PR fixes the issue and here is how it looks now: https://cloudup.com/cv-yO_iNyxA

To test:
* Logout and login to clear out your posts (just for better testing)
* Visit the "Blog posts" page and verify that the posts are loading correctly
* Add a new post and verify that it shows up at the top of the list
* Update an existing post and verify that its changes are reflected in the post list