### PR TITLE
Adds remove list actions to logout and application's onCreate

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -45,6 +45,7 @@ import org.wordpress.android.datasets.ReaderDatabase;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
+import org.wordpress.android.fluxc.generated.ListActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.generated.ThemeActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -52,6 +53,7 @@ import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
+import org.wordpress.android.fluxc.store.ListStore.RemoveExpiredListsPayload;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
@@ -278,6 +280,9 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
 
         // verify media is sanitized
         sanitizeMediaUploadStateForSite();
+
+        // remove expired lists
+        mDispatcher.dispatch(ListActionBuilder.newRemoveExpiredListsAction(new RemoveExpiredListsPayload()));
 
         // setup the Credentials Client so we can clean it up on wpcom logout
         mCredentialsClient = new GoogleApiClient.Builder(this)
@@ -577,6 +582,8 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         }
         // delete wpcom and jetpack sites
         mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());
+        // remove all lists
+        mDispatcher.dispatch(ListActionBuilder.newRemoveAllListsAction());
 
         // reset all user prefs
         AppPrefs.reset();

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '0e458b70a9bb942b1e2ab2e3d6302f69d2c12ac4'
+    fluxCVersion = '457ea50fcb4f8791cb10a7c2ac8e0726a9b95f7d'
 }


### PR DESCRIPTION
This PR adds two remove list actions. First, when the user logs out, we clear all the lists. For now, this is the behavior we want, however if we ever add lists that needs to be preserved after a logout (which I doubt), we'll change this logic. Second, we clear the lists that has not been modified in the last week every time the app is launched. This is so that when we start using lists with filters (especially search) we don't end up with a bunch of unused lists clogging up the DB. Both of these actions are added to FluxC in this PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/948

This PR also contains a minor fix to the conflict resolution for the unique constraint in `ListItemModel` which is used by FluxC internally to manage lists.

**To test:**
Unfortunately there is no easy way to test either of these 3 changes without downloading and examining the DB. However, all of these changes should be fairly straightforward.