### PR TITLE
Feature/remove revisions flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -47,8 +47,6 @@ android {
         targetSdkVersion 26
 
         multiDexEnabled true
-
-        buildConfigField "boolean", "REVISIONS_ENABLED", "false"
     }
 
     flavorDimensions "buildType"
@@ -67,7 +65,6 @@ android {
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
             applicationId "org.wordpress.android.beta"
             dimension "buildType"
-            buildConfigField "boolean", "REVISIONS_ENABLED", "true"
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1038,7 +1038,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
         if (historyMenuItem != null) {
             boolean hasHistory = !mIsNewPost && (mSite.isWPCom() || mSite.isJetpackConnected());
-            historyMenuItem.setVisible(BuildConfig.REVISIONS_ENABLED && showMenuItems && hasHistory);
+            historyMenuItem.setVisible(showMenuItems && hasHistory);
         }
 
         if (previewMenuItem != null) {


### PR DESCRIPTION
Remove the feature flag from the `WordPress/build.gradle` file now that the Revisions/History project is complete and the feature is ready for release.