### PR TITLE
Issue/8497 copy site creation flow

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -49,6 +49,7 @@ android {
         multiDexEnabled true
 
         buildConfigField "boolean", "REVISIONS_ENABLED", "false"
+        buildConfigField "boolean", "NEW_SITE_CREATION_ENABLED", "false"
     }
 
     flavorDimensions "buildType"

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -133,6 +133,11 @@
             android:windowSoftInputMode="adjustResize" />
 
         <activity
+            android:name=".ui.sitecreation.NewSiteCreationActivity"
+            android:theme="@style/LoginTheme"
+            android:windowSoftInputMode="adjustResize" />
+
+        <activity
             android:name=".ui.accounts.HelpActivity"
             android:label="@string/help_screen_title"
             android:theme="@style/CalypsoTheme.NoActionBarShadow" />
@@ -646,6 +651,11 @@
             android:label="Login to WPCOM Service" />
         <service
             android:name=".ui.accounts.signup.SiteCreationService"
+            android:exported="false"
+            android:label="Site Creation Service" />
+
+        <service
+            android:name=".ui.sitecreation.NewSiteCreationService"
             android:exported="false"
             android:label="Site Creation Service" />
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -124,6 +124,16 @@ import org.wordpress.android.ui.reader.views.ReaderLikingUsersView;
 import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView;
 import org.wordpress.android.ui.reader.views.ReaderTagHeaderView;
 import org.wordpress.android.ui.reader.views.ReaderWebView;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationActivity;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationCategoryFragment;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationDomainAdapter;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationDomainFragment;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationDomainLoaderFragment;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationService;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationSiteDetailsFragment;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationThemeAdapter;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationThemeFragment;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationThemeLoaderFragment;
 import org.wordpress.android.ui.stats.StatsAbstractFragment;
 import org.wordpress.android.ui.stats.StatsActivity;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
@@ -175,6 +185,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
 
     void inject(SiteCreationService object);
 
+    void inject(NewSiteCreationService object);
+
     void inject(UploadService object);
 
     void inject(MediaUploadHandler object);
@@ -210,6 +222,24 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(SiteCreationDomainLoaderFragment object);
 
     void inject(SiteCreationDomainAdapter object);
+
+    void inject(NewSiteCreationActivity object);
+
+    void inject(NewSiteCreationCategoryFragment object);
+
+    void inject(NewSiteCreationThemeFragment object);
+
+    void inject(NewSiteCreationThemeLoaderFragment object);
+
+    void inject(NewSiteCreationThemeAdapter object);
+
+    void inject(NewSiteCreationSiteDetailsFragment object);
+
+    void inject(NewSiteCreationDomainFragment object);
+
+    void inject(NewSiteCreationDomainLoaderFragment object);
+
+    void inject(NewSiteCreationDomainAdapter object);
 
     void inject(StatsWidgetConfigureActivity object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -13,6 +13,7 @@ import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v4.app.Fragment;
 import android.text.TextUtils;
 
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -33,7 +34,6 @@ import org.wordpress.android.ui.accounts.SiteCreationActivity;
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailActivity;
 import org.wordpress.android.ui.activitylog.list.ActivityLogListActivity;
 import org.wordpress.android.ui.comments.CommentsActivity;
-import org.wordpress.android.ui.quickstart.QuickStartActivity;
 import org.wordpress.android.ui.main.SitePickerActivity;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
@@ -57,7 +57,9 @@ import org.wordpress.android.ui.prefs.BlogPreferencesActivity;
 import org.wordpress.android.ui.prefs.MyProfileActivity;
 import org.wordpress.android.ui.prefs.notifications.NotificationsSettingsActivity;
 import org.wordpress.android.ui.publicize.PublicizeListActivity;
+import org.wordpress.android.ui.quickstart.QuickStartActivity;
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationActivity;
 import org.wordpress.android.ui.stats.StatsActivity;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
 import org.wordpress.android.ui.stats.StatsConstants;
@@ -65,11 +67,11 @@ import org.wordpress.android.ui.stats.StatsSingleItemDetailsActivity;
 import org.wordpress.android.ui.stats.models.StatsPostModel;
 import org.wordpress.android.ui.stockmedia.StockMediaPickerActivity;
 import org.wordpress.android.ui.themes.ThemeBrowserActivity;
-import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPActivityUtils;
+import org.wordpress.android.util.analytics.AnalyticsUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -481,7 +483,8 @@ public class ActivityLauncher {
     }
 
     public static void newBlogForResult(Activity activity) {
-        Intent intent = new Intent(activity, SiteCreationActivity.class);
+        Intent intent = new Intent(activity,
+                BuildConfig.NEW_SITE_CREATION_ENABLED ? NewSiteCreationActivity.class : SiteCreationActivity.class);
         activity.startActivityForResult(intent, RequestCodes.CREATE_SITE);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.java
@@ -1,0 +1,221 @@
+package org.wordpress.android.ui.sitecreation;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentTransaction;
+import android.support.v7.app.AppCompatActivity;
+import android.view.MenuItem;
+
+import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.ui.ActivityLauncher;
+import org.wordpress.android.ui.accounts.HelpActivity;
+import org.wordpress.android.ui.main.SitePickerActivity;
+import org.wordpress.android.util.LocaleManager;
+import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.UrlUtils;
+
+public class NewSiteCreationActivity extends AppCompatActivity implements NewSiteCreationListener {
+    public static final String KEY_DO_NEW_POST = "KEY_DO_NEW_POST";
+
+    private static final String KEY_CATERGORY = "KEY_CATERGORY";
+    private static final String KEY_THEME_ID = "KEY_THEME_ID";
+    private static final String KEY_SITE_TITLE = "KEY_SITE_TITLE";
+    private static final String KEY_SITE_TAGLINE = "KEY_SITE_TAGLINE";
+
+    private String mCategory;
+    private String mThemeId;
+    private String mSiteTitle;
+    private String mSiteTagline;
+
+    @Override
+    protected void attachBaseContext(Context newBase) {
+        super.attachBaseContext(LocaleManager.setLocale(newBase));
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ((WordPress) getApplication()).component().inject(this);
+
+        setContentView(R.layout.site_creation_activity);
+
+        if (savedInstanceState == null) {
+            AnalyticsTracker.track(AnalyticsTracker.Stat.SITE_CREATION_ACCESSED);
+
+            earlyLoadThemeLoaderFragment();
+            showFragment(new NewSiteCreationCategoryFragment(), NewSiteCreationCategoryFragment.TAG);
+        } else {
+            mCategory = savedInstanceState.getString(KEY_CATERGORY);
+            mThemeId = savedInstanceState.getString(KEY_THEME_ID);
+            mSiteTitle = savedInstanceState.getString(KEY_SITE_TITLE);
+            mSiteTagline = savedInstanceState.getString(KEY_SITE_TAGLINE);
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        outState.putString(KEY_CATERGORY, mCategory);
+        outState.putString(KEY_THEME_ID, mThemeId);
+        outState.putString(KEY_SITE_TITLE, mSiteTitle);
+        outState.putString(KEY_SITE_TAGLINE, mSiteTagline);
+    }
+
+    private void showFragment(Fragment fragment, String tag) {
+        FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
+        fragmentTransaction.replace(R.id.fragment_container, fragment, tag);
+        fragmentTransaction.commit();
+    }
+
+    private void slideInFragment(Fragment fragment, String tag) {
+        FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
+        fragmentTransaction.setCustomAnimations(R.anim.activity_slide_in_from_right, R.anim.activity_slide_out_to_left,
+                R.anim.activity_slide_in_from_left, R.anim.activity_slide_out_to_right);
+        fragmentTransaction.replace(R.id.fragment_container, fragment, tag);
+        fragmentTransaction.addToBackStack(null);
+        fragmentTransaction.commitAllowingStateLoss();
+    }
+
+    private void earlyLoadThemeLoaderFragment() {
+        FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
+        NewSiteCreationThemeLoaderFragment themeLoaderFragment = new NewSiteCreationThemeLoaderFragment();
+        themeLoaderFragment.setRetainInstance(true);
+        fragmentTransaction.add(themeLoaderFragment, NewSiteCreationThemeLoaderFragment.TAG);
+        fragmentTransaction.commit();
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            onBackPressed();
+            return true;
+        }
+
+        return false;
+    }
+
+    private void launchZendesk(HelpActivity.Origin origin) {
+        ActivityLauncher.viewHelpAndSupport(this, origin, null, null);
+    }
+
+    private enum SiteCreationBackStackMode {
+        NORMAL,
+        MODAL,
+        FINISH_OK,
+        FINISH_DISMISS
+    }
+
+    private SiteCreationBackStackMode getSiteCreationBackStackMode() {
+        NewSiteCreationCreatingFragment siteCreationCreatingFragment =
+                (NewSiteCreationCreatingFragment) getSupportFragmentManager()
+                        .findFragmentByTag(NewSiteCreationCreatingFragment.TAG);
+
+        if (siteCreationCreatingFragment == null || siteCreationCreatingFragment.canGoBack()) {
+            return SiteCreationBackStackMode.NORMAL;
+        } else if (siteCreationCreatingFragment.isInModalMode()) {
+            return SiteCreationBackStackMode.MODAL;
+        } else if (siteCreationCreatingFragment.isCreationSucceeded()) {
+            return SiteCreationBackStackMode.FINISH_OK;
+        } else {
+            return SiteCreationBackStackMode.FINISH_DISMISS;
+        }
+    }
+
+    @Override
+    public void onBackPressed() {
+        switch (getSiteCreationBackStackMode()) {
+            case NORMAL:
+                super.onBackPressed();
+                break;
+            case MODAL:
+                ToastUtils.showToast(this, R.string.site_creation_creating_modal);
+                break;
+            case FINISH_OK:
+                setResult(RESULT_OK);
+                finish();
+                break;
+            case FINISH_DISMISS:
+                finish();
+                break;
+        }
+    }
+
+    // SiteCreationListener implementation methods
+
+    @Override
+    public void withCategory(String category) {
+        mCategory = category;
+        slideInFragment(NewSiteCreationThemeFragment.newInstance(category), NewSiteCreationThemeFragment.TAG);
+    }
+
+    @Override
+    public void helpCategoryScreen() {
+        launchZendesk(HelpActivity.Origin.SITE_CREATION_CATEGORY);
+    }
+
+    @Override
+    public void withTheme(String themeId) {
+        mThemeId = themeId;
+        slideInFragment(new NewSiteCreationSiteDetailsFragment(), NewSiteCreationSiteDetailsFragment.TAG);
+    }
+
+    @Override
+    public void helpThemeScreen() {
+        launchZendesk(HelpActivity.Origin.SITE_CREATION_THEME);
+    }
+
+    @Override
+    public void withSiteDetails(String siteTitle, String siteTagline) {
+        mSiteTitle = siteTitle;
+        mSiteTagline = siteTagline;
+
+        NewSiteCreationDomainFragment fragment = NewSiteCreationDomainFragment.newInstance(mSiteTitle);
+        slideInFragment(fragment, NewSiteCreationDomainFragment.TAG);
+    }
+
+    @Override
+    public void helpSiteDetailsScreen() {
+        launchZendesk(HelpActivity.Origin.SITE_CREATION_DETAILS);
+    }
+
+    @Override
+    public void withDomain(String domain) {
+        String siteSlug = UrlUtils.extractSubDomain(domain);
+
+        NewSiteCreationCreatingFragment siteCreationCreatingFragment =
+                NewSiteCreationCreatingFragment.newInstance(mSiteTitle, mSiteTagline, siteSlug, mThemeId);
+        slideInFragment(siteCreationCreatingFragment, NewSiteCreationCreatingFragment.TAG);
+    }
+
+    @Override
+    public void helpDomainScreen() {
+        launchZendesk(HelpActivity.Origin.SITE_CREATION_DOMAIN);
+    }
+
+    @Override
+    public void doConfigureSite(int siteLocalId) {
+        Intent intent = new Intent();
+        intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, siteLocalId);
+        setResult(RESULT_OK, intent);
+        finish();
+    }
+
+    @Override
+    public void doWriteFirstPost(int siteLocalId) {
+        Intent intent = new Intent();
+        intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, siteLocalId);
+        intent.putExtra(KEY_DO_NEW_POST, true);
+        setResult(RESULT_OK, intent);
+        finish();
+    }
+
+    @Override
+    public void helpSiteCreatingScreen() {
+        launchZendesk(HelpActivity.Origin.SITE_CREATION_CREATING);
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationBaseFormFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationBaseFormFragment.java
@@ -1,0 +1,130 @@
+package org.wordpress.android.ui.sitecreation;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewStub;
+import android.widget.Button;
+
+import org.wordpress.android.R;
+
+public abstract class NewSiteCreationBaseFormFragment<SiteCreationListenerType> extends Fragment {
+    private Button mPrimaryButton;
+    private Button mSecondaryButton;
+
+    protected SiteCreationListenerType mSiteCreationListener;
+
+    protected abstract @LayoutRes
+    int getContentLayout();
+
+    protected abstract void setupContent(ViewGroup rootView);
+
+    protected void setupBottomButtons(Button secondaryButton, Button primaryButton) {
+    }
+
+    protected Button getPrimaryButton() {
+        return mPrimaryButton;
+    }
+
+    protected abstract void onHelp();
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setHasOptionsMenu(true);
+    }
+
+    protected ViewGroup createMainView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.site_creation_form_screen, container, false);
+        ViewStub formContainer = ((ViewStub) rootView.findViewById(R.id.site_creation_form_content_stub));
+        formContainer.setLayoutResource(getContentLayout());
+        formContainer.inflate();
+        return rootView;
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        ViewGroup rootView = createMainView(inflater, container, savedInstanceState);
+
+        setupContent(rootView);
+
+        mPrimaryButton = (Button) rootView.findViewById(R.id.primary_button);
+        mSecondaryButton = (Button) rootView.findViewById(R.id.secondary_button);
+        setupBottomButtons(mSecondaryButton, mPrimaryButton);
+
+        return rootView;
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        Toolbar toolbar = (Toolbar) view.findViewById(R.id.toolbar);
+        ((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
+
+        ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setTitle(R.string.site_creation_title);
+        }
+    }
+
+    protected void showHomeButton(boolean visible, boolean isCloseButton) {
+        ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(visible);
+            if (isCloseButton) {
+                actionBar.setHomeAsUpIndicator(R.drawable.ic_close_white_24dp);
+            }
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void onAttach(Context context) {
+        super.onAttach(context);
+
+        // this will throw if parent activity doesn't implement the login listener interface
+        mSiteCreationListener = (SiteCreationListenerType) context;
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        mSiteCreationListener = null;
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.menu_site_creation, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.help) {
+            onHelp();
+            return true;
+        }
+
+        return false;
+    }
+
+    protected void hideActionbar() {
+        ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.hide();
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationCategoryFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationCategoryFragment.java
@@ -1,0 +1,81 @@
+package org.wordpress.android.ui.sitecreation;
+
+import android.os.Bundle;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.Nullable;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.fluxc.store.ThemeStore;
+
+public class NewSiteCreationCategoryFragment extends NewSiteCreationBaseFormFragment<NewSiteCreationListener> {
+    public static final String TAG = "site_creation_category_fragment_tag";
+
+    @Override
+    protected @LayoutRes int getContentLayout() {
+        return R.layout.site_creation_category_screen;
+    }
+
+    @Override
+    protected void setupContent(ViewGroup rootView) {
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.site_creation_category_title);
+        rootView.findViewById(R.id.site_creation_card_blog).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                if (mSiteCreationListener != null) {
+                    mSiteCreationListener.withCategory(ThemeStore.MOBILE_FRIENDLY_CATEGORY_BLOG);
+                }
+            }
+        });
+
+        rootView.findViewById(R.id.site_creation_card_website).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                if (mSiteCreationListener != null) {
+                    mSiteCreationListener.withCategory(ThemeStore.MOBILE_FRIENDLY_CATEGORY_WEBSITE);
+                }
+            }
+        });
+
+        rootView.findViewById(R.id.site_creation_card_portfolio).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                if (mSiteCreationListener != null) {
+                    mSiteCreationListener.withCategory(ThemeStore.MOBILE_FRIENDLY_CATEGORY_PORTFOLIO);
+                }
+            }
+        });
+    }
+
+    @Override
+    protected void onHelp() {
+        if (mSiteCreationListener != null) {
+            mSiteCreationListener.helpCategoryScreen();
+        }
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ((WordPress) getActivity().getApplication()).component().inject(this);
+    }
+
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        if (savedInstanceState == null) {
+            AnalyticsTracker.track(AnalyticsTracker.Stat.SITE_CREATION_CATEGORY_VIEWED);
+        }
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        mSiteCreationListener = null;
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationCreatingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationCreatingFragment.java
@@ -1,0 +1,377 @@
+package org.wordpress.android.ui.sitecreation;
+
+import android.annotation.SuppressLint;
+import android.os.Bundle;
+import android.support.annotation.IdRes;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.ValueCallback;
+import android.webkit.WebView;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.R;
+import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationService.NewSiteCreationState;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationService.NewSiteCreationStep;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.AutoForeground.ServiceEventConnection;
+import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.URLFilteredWebViewClient;
+
+import java.util.HashMap;
+
+public class NewSiteCreationCreatingFragment extends NewSiteCreationBaseFormFragment<NewSiteCreationListener> {
+    public static final String TAG = "site_creating_fragment_tag";
+
+    private static final String ARG_SITE_TITLE = "ARG_SITE_TITLE";
+    private static final String ARG_SITE_TAGLINE = "ARG_SITE_TAGLINE";
+    private static final String ARG_SITE_SLUG = "ARG_SITE_SLUG";
+    private static final String ARG_SITE_THEME_ID = "ARG_SITE_THEME_ID";
+
+    private static final String KEY_WEBVIEW_LOADED_IN_TIME = "KEY_WEBVIEW_LOADED_IN_TIME";
+    private static final String KEY_TRACKED_SUCCESS = "KEY_TRACKED_SUCCESS";
+
+    private ServiceEventConnection mServiceEventConnection;
+
+    private ImageView mImageView;
+    private View mProgressContainer;
+    private View mErrorContainer;
+    private Button mRetryButton;
+    private View mCompletedContainer;
+    private WebView mWebView;
+    private View mTadaContainer;
+    private TextView[] mLabels;
+
+    private boolean mTrackedSuccess;
+    private boolean mWebViewLoadedInTime;
+    int mNewSiteLocalId;
+
+    private PreviewWebViewClient mPreviewWebViewClient;
+
+    public boolean isInModalMode() {
+        NewSiteCreationState state = NewSiteCreationService.getState();
+        return state != null && state.isInProgress();
+    }
+
+    public boolean isCreationSucceeded() {
+        NewSiteCreationState state = NewSiteCreationService.getState();
+        return state != null && NewSiteCreationService.getState().getStep() == NewSiteCreationStep.SUCCESS;
+    }
+
+    public boolean canGoBack() {
+        NewSiteCreationState state = NewSiteCreationService.getState();
+        if (state == null) {
+            return true;
+        }
+
+        if (state.getStep() == NewSiteCreationStep.FAILURE) {
+            state = (NewSiteCreationState) state.getPayload();
+        }
+
+        return !state.isAfterCreation();
+    }
+
+    public static NewSiteCreationCreatingFragment newInstance(String siteTitle, String siteTagline, String siteSlug,
+                                                              String themeId) {
+        NewSiteCreationCreatingFragment
+                fragment = new NewSiteCreationCreatingFragment();
+        Bundle args = new Bundle();
+        args.putString(ARG_SITE_TITLE, siteTitle);
+        args.putString(ARG_SITE_TAGLINE, siteTagline);
+        args.putString(ARG_SITE_SLUG, siteSlug);
+        args.putString(ARG_SITE_THEME_ID, themeId);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    protected @LayoutRes int getContentLayout() {
+        return R.layout.site_creation_creating_screen;
+    }
+
+    @Override
+    protected void setupContent(ViewGroup rootView) {
+        mImageView = rootView.findViewById(R.id.image);
+        mProgressContainer = rootView.findViewById(R.id.progress_container);
+        mErrorContainer = rootView.findViewById(R.id.error_container);
+        mRetryButton = rootView.findViewById(R.id.button_retry);
+        mCompletedContainer = rootView.findViewById(R.id.completed_container);
+        mWebView = rootView.findViewById(R.id.webview);
+        mTadaContainer = rootView.findViewById(R.id.tada_container);
+
+        // construct an array with the labels in reverse order
+        mLabels = new TextView[]{
+                rootView.findViewById(R.id.site_creation_creating_preparing_frontend),
+                rootView.findViewById(R.id.site_creation_creating_configuring_theme),
+                rootView.findViewById(R.id.site_creation_creating_configuring_content),
+                rootView.findViewById(R.id.site_creation_creating_fetching_info),
+                rootView.findViewById(R.id.site_creation_creating_laying_foundation)};
+    }
+
+    @Override
+    protected void setupBottomButtons(Button secondaryButton, Button primaryButton) {
+        secondaryButton.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+                if (isAdded()) {
+                    mSiteCreationListener.doConfigureSite(mNewSiteLocalId);
+                }
+            }
+        });
+        primaryButton.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+                if (isAdded()) {
+                    mSiteCreationListener.doWriteFirstPost(mNewSiteLocalId);
+                }
+            }
+        });
+    }
+
+    @Override
+    protected void onHelp() {
+        if (mSiteCreationListener != null) {
+            mSiteCreationListener.helpSiteCreatingScreen();
+        }
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (savedInstanceState == null) {
+            // on first appearance start the Service to perform the site creation
+            createSite(null);
+        } else {
+            mWebViewLoadedInTime = savedInstanceState.getBoolean(KEY_WEBVIEW_LOADED_IN_TIME, false);
+            mTrackedSuccess = savedInstanceState.getBoolean(KEY_TRACKED_SUCCESS, false);
+        }
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        showHomeButton(!isInModalMode(), false);
+
+        if (savedInstanceState == null) {
+            AnalyticsTracker.track(AnalyticsTracker.Stat.SITE_CREATION_CREATING_VIEWED);
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        // connect to the Service. We'll receive updates via EventBus.
+        mServiceEventConnection = new ServiceEventConnection(getContext(), NewSiteCreationService.class, this);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+
+        // disconnect from the Service
+        mServiceEventConnection.disconnect(getContext(), this);
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        outState.putBoolean(KEY_WEBVIEW_LOADED_IN_TIME, mWebViewLoadedInTime);
+        outState.putBoolean(KEY_TRACKED_SUCCESS, mTrackedSuccess);
+    }
+
+    void createSite(NewSiteCreationState retryFromState) {
+        String siteTitle = getArguments().getString(ARG_SITE_TITLE);
+        String siteTagline = getArguments().getString(ARG_SITE_TAGLINE);
+        String siteSlug = getArguments().getString(ARG_SITE_SLUG);
+        String themeId = getArguments().getString(ARG_SITE_THEME_ID);
+        NewSiteCreationService.createSite(getContext(), retryFromState, siteTitle, siteTagline, siteSlug, themeId);
+    }
+
+    private void mutateToCompleted(boolean showWebView) {
+        if (isAdded()) {
+            hideActionbar();
+            mProgressContainer.setVisibility(View.GONE);
+            mCompletedContainer.setVisibility(View.VISIBLE);
+            mWebView.setVisibility(showWebView ? View.VISIBLE : View.INVISIBLE);
+            mTadaContainer.setVisibility(showWebView ? View.INVISIBLE : View.VISIBLE);
+        }
+
+        if (!mTrackedSuccess) {
+            mTrackedSuccess = true;
+            HashMap<String, Object> successProperties = new HashMap<>();
+            successProperties.put("loaded_in_time", showWebView);
+            AnalyticsTracker.track(AnalyticsTracker.Stat.SITE_CREATION_SUCCESS_VIEWED, successProperties);
+        }
+    }
+
+    private PreviewWebViewClient loadWebview() {
+        String siteAddress = "https://" + getArguments().getString(ARG_SITE_SLUG) + ".wordpress.com";
+        PreviewWebViewClient client = new PreviewWebViewClient(siteAddress);
+        mWebView.setWebViewClient(client);
+        mWebView.loadUrl(siteAddress);
+        return client;
+    }
+
+    private static class PreviewWebViewClient extends URLFilteredWebViewClient {
+        boolean mIsPageFinished;
+
+        PreviewWebViewClient(String siteAddress) {
+            super(siteAddress);
+        }
+
+        @Override
+        public void onPageFinished(WebView view, String url) {
+            super.onPageFinished(view, url);
+            hideGetStartedBar(view);
+            
+            mIsPageFinished = true;
+        }
+    }
+
+    // Hacky solution to https://github.com/wordpress-mobile/WordPress-Android/issues/8233
+    // Ideally we would hide "get started" bar on server side
+    @SuppressLint("SetJavaScriptEnabled")
+    private static void hideGetStartedBar(@NonNull final WebView webView) {
+        webView.getSettings().setJavaScriptEnabled(true);
+        String javascript = "document.querySelector('html').style.cssText += '; margin-top: 0 !important;';\n"
+                            + "document.getElementById('wpadminbar').style.display = 'none';\n";
+
+        webView.evaluateJavascript(javascript, new ValueCallback<String>() {
+            @Override public void onReceiveValue(String value) {
+                webView.getSettings().setJavaScriptEnabled(false);
+            }
+        });
+    }
+
+    private void disableUntil(@IdRes int textViewId) {
+        boolean enabled = false;
+
+        // traverse the array (elements are in "reverse" order already) and disable them until the provided on is reach.
+        // From that point on, enable the labels found
+        for (TextView tv : mLabels) {
+            if (tv.getId() == textViewId) {
+                enabled = true;
+            }
+
+            tv.setEnabled(enabled);
+        }
+    }
+
+    private void configureBackButton() {
+        NewSiteCreationState currentState = NewSiteCreationService.getState();
+
+        NewSiteCreationState failedOnState = null;
+        if (currentState != null && currentState.getStep() == NewSiteCreationStep.FAILURE) {
+            failedOnState = (NewSiteCreationState) currentState.getPayload();
+        }
+
+        boolean isInModal = currentState != null && currentState.isInProgress();
+        boolean failedAfterCreation = failedOnState != null && failedOnState.isAfterCreation();
+        showHomeButton(!isInModal, failedAfterCreation);
+    }
+
+    private void configureImage(boolean hasFailure) {
+        mImageView.setImageResource(hasFailure ? R.drawable.img_site_error_camera_pencils_226dp
+                : R.drawable.img_site_wordpress_camera_pencils_226dp);
+    }
+
+    private void handleFailure(final NewSiteCreationState failedState) {
+        // update UI depending on which step the process failed so to properly offer retry options
+        mRetryButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                if (failedState == null) {
+                    AppLog.d(T.NUX, "User retries site creation but failedState is null :(");
+                    return;
+                }
+
+                AppLog.d(T.NUX, "User retries failed site creation on step: " + failedState.getStepName());
+                if (failedState.isTerminal()) {
+                    throw new RuntimeException("Internal inconsistency: Cannot resume site creation from "
+                                               + failedState.getStepName());
+                } else {
+                    createSite(failedState);
+                }
+            }
+        });
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN, sticky = true)
+    public void onSiteCreationStateUpdated(NewSiteCreationState event) {
+        AppLog.i(T.NUX, "Received state: " + event.getStepName());
+
+        mProgressContainer.setVisibility(View.VISIBLE);
+        mErrorContainer.setVisibility(View.GONE);
+
+        configureBackButton();
+
+        CharSequence statusAnnouncement = "";
+
+        switch (event.getStep()) {
+            case IDLE:
+                statusAnnouncement = getText(R.string.notification_site_creation_title_in_progress);
+                disableUntil(0);
+                configureImage(false);
+                break;
+            case NEW_SITE:
+                statusAnnouncement = getText(R.string.site_creation_creating_laying_foundation);
+                disableUntil(R.id.site_creation_creating_laying_foundation);
+                configureImage(false);
+                break;
+            case FETCHING_NEW_SITE:
+                statusAnnouncement = getText(R.string.site_creation_creating_fetching_info);
+                disableUntil(R.id.site_creation_creating_fetching_info);
+                configureImage(false);
+                break;
+            case SET_TAGLINE:
+                statusAnnouncement = getText(R.string.site_creation_creating_configuring_content);
+                disableUntil(R.id.site_creation_creating_configuring_content);
+                configureImage(false);
+                break;
+            case SET_THEME:
+                statusAnnouncement = getText(R.string.site_creation_creating_configuring_theme);
+                disableUntil(R.id.site_creation_creating_configuring_theme);
+                configureImage(false);
+                break;
+            case FAILURE:
+                statusAnnouncement = getText(R.string.notification_site_creation_failed);
+                configureImage(true);
+                mProgressContainer.setVisibility(View.GONE);
+                mErrorContainer.setVisibility(View.VISIBLE);
+                handleFailure((NewSiteCreationState) event.getPayload());
+                NetworkUtils.checkConnection(getContext());
+                break;
+            case PRELOAD:
+                statusAnnouncement = getText(R.string.site_creation_creating_preparing_frontend);
+                disableUntil(R.id.site_creation_creating_preparing_frontend);
+                configureImage(false);
+                mPreviewWebViewClient = loadWebview();
+                break;
+            case SUCCESS:
+                statusAnnouncement = getText(R.string.notification_site_creation_title_success);
+                mNewSiteLocalId = (Integer) event.getPayload();
+
+                if (mPreviewWebViewClient == null) {
+                    // Apparently view got rotated while at the final so, just reconfigure the WebView.
+                    loadWebview();
+                } else {
+                    mWebViewLoadedInTime = mPreviewWebViewClient.mIsPageFinished;
+                }
+
+                mutateToCompleted(mWebViewLoadedInTime);
+                break;
+        }
+        getView().announceForAccessibility(statusAnnouncement);
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationDomainAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationDomainAdapter.java
@@ -1,0 +1,287 @@
+package org.wordpress.android.ui.sitecreation;
+
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.support.v7.content.res.AppCompatResources;
+import android.support.v7.widget.RecyclerView;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
+import android.widget.EditText;
+import android.widget.RadioButton;
+import android.widget.TextView;
+
+import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.util.helpers.Debouncer;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class NewSiteCreationDomainAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+    private static final int VIEW_TYPE_HEADER = 0;
+    private static final int VIEW_TYPE_INPUT = 1;
+    private static final int VIEW_TYPE_ITEM = 2;
+
+    private static final int GET_SUGGESTIONS_INTERVAL_MS = 400;
+
+    public interface OnAdapterListener {
+        void onKeywordsChange(String keywords);
+
+        void onSelectionChange(String domain);
+    }
+
+    private boolean mIsLoading;
+    private String mInitialKeywords;
+    private List<String> mSuggestions;
+    private OnAdapterListener mOnAdapterListener;
+
+    private String mCarryOverDomain;
+    private String mSelectedDomain;
+    private boolean mNeedExtraLineForSelectedDomain;
+
+    private class HeaderViewHolder extends RecyclerView.ViewHolder {
+        private HeaderViewHolder(View itemView) {
+            super(itemView);
+        }
+    }
+
+    private class InputViewHolder extends RecyclerView.ViewHolder {
+        private final EditText mInput;
+        private final TextWatcher mTextWatcher;
+        private final View mProgressBar;
+
+        private boolean mIsDetached;
+        private boolean mKeepFocus;
+
+        private InputViewHolder(View itemView) {
+            super(itemView);
+            this.mInput = itemView.findViewById(R.id.input);
+            this.mInput.setCompoundDrawablesRelativeWithIntrinsicBounds(AppCompatResources.getDrawable(
+                    itemView.getContext(), R.drawable.ic_search_grey_24dp), null, null, null);
+            this.mProgressBar = itemView.findViewById(R.id.progress_bar);
+
+            this.mTextWatcher = new TextWatcher() {
+                private Debouncer mDebouncer = new Debouncer();
+
+                @Override
+                public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                }
+
+                @Override
+                public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                }
+
+                @Override
+                public void afterTextChanged(final Editable editable) {
+                    final String text = editable.toString();
+                    mDebouncer.debounce(Void.class, new Runnable() {
+                        @Override
+                        public void run() {
+                            // post the action on an properly initialised Handler so UI thread operations can succeed
+                            new Handler(Looper.getMainLooper()).post(new Runnable() {
+                                @Override
+                                public void run() {
+                                    mOnAdapterListener.onKeywordsChange(text);
+                                }
+                            });
+                        }
+                    }, GET_SUGGESTIONS_INTERVAL_MS, TimeUnit.MILLISECONDS);
+                }
+            };
+        }
+    }
+
+    private static class DomainViewHolder extends RecyclerView.ViewHolder {
+        private final RadioButton mRadioButton;
+
+        private DomainViewHolder(View itemView) {
+            super(itemView);
+            mRadioButton = itemView.findViewById(R.id.radio_button);
+        }
+    }
+
+    NewSiteCreationDomainAdapter(Context context, String initialKeywords, OnAdapterListener onAdapterListener) {
+        super();
+        ((WordPress) context.getApplicationContext()).component().inject(this);
+
+        // Stable IDs so the edittext doesn't lose focus on refresh
+        setHasStableIds(true);
+
+        mInitialKeywords = initialKeywords;
+        mOnAdapterListener = onAdapterListener;
+    }
+
+    void setData(boolean isLoading, String carryOverDomain, String selectedDomain, List<String> suggestions) {
+        if (isLoading != mIsLoading) {
+            notifyItemChanged(1);
+        }
+
+        mIsLoading = isLoading;
+        mSuggestions = suggestions;
+        mCarryOverDomain = carryOverDomain;
+        mSelectedDomain = selectedDomain;
+
+        mOnAdapterListener.onSelectionChange(mSelectedDomain);
+
+        mNeedExtraLineForSelectedDomain = carryOverDomain != null
+                                          && (suggestions == null || !suggestions.contains(carryOverDomain));
+
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        switch (viewType) {
+            case VIEW_TYPE_HEADER:
+                return new HeaderViewHolder(LayoutInflater.from(parent.getContext())
+                                                          .inflate(R.layout.site_creation_domain_header, parent,
+                                                                   false));
+            case VIEW_TYPE_INPUT:
+                return new InputViewHolder(LayoutInflater.from(parent.getContext())
+                                                         .inflate(R.layout.site_creation_domain_input, parent, false));
+            case VIEW_TYPE_ITEM:
+                return new DomainViewHolder(LayoutInflater.from(parent.getContext())
+                                                          .inflate(R.layout.site_creation_domain_item, parent, false));
+            default:
+                throw new RuntimeException("Unknown view type " + viewType);
+        }
+    }
+
+    @Override
+    public void onViewDetachedFromWindow(RecyclerView.ViewHolder holder) {
+        super.onViewDetachedFromWindow(holder);
+
+        if (holder instanceof InputViewHolder) {
+            ((InputViewHolder) holder).mIsDetached = true;
+        }
+    }
+
+    @Override
+    public void onViewAttachedToWindow(RecyclerView.ViewHolder holder) {
+        super.onViewAttachedToWindow(holder);
+
+        if (holder instanceof InputViewHolder) {
+            ((InputViewHolder) holder).mIsDetached = false;
+        }
+    }
+
+    @Override
+    public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
+        int viewType = getItemViewType(position);
+
+        switch (viewType) {
+            // case VIEW_TYPE_HEADER:
+            // nothing to be bound for VIEW_TYPE_HEADER so, just have this as a comment
+
+            case VIEW_TYPE_INPUT:
+                bindInput((InputViewHolder) holder);
+                break;
+            case VIEW_TYPE_ITEM:
+                bindSuggest((DomainViewHolder) holder, position);
+                break;
+        }
+    }
+
+    private void bindInput(final InputViewHolder inputViewHolder) {
+        inputViewHolder.mProgressBar.setVisibility(mIsLoading ? View.VISIBLE : View.GONE);
+
+        inputViewHolder.mInput.removeTextChangedListener(inputViewHolder.mTextWatcher);
+        if (inputViewHolder.mKeepFocus) {
+            inputViewHolder.mInput.requestFocus();
+        }
+        if (mInitialKeywords != null) {
+            inputViewHolder.mInput.setText(mInitialKeywords);
+            mInitialKeywords = null;
+        }
+        inputViewHolder.mInput.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+                if (actionId == EditorInfo.IME_ACTION_SEARCH
+                    || (event != null
+                        && event.getAction() == KeyEvent.ACTION_UP
+                        && event.getKeyCode() == KeyEvent.KEYCODE_ENTER)) {
+                    mOnAdapterListener.onKeywordsChange(inputViewHolder.mInput.getText().toString());
+                }
+
+                // always consume the event so the focus stays in the EditText
+                return true;
+            }
+        });
+        inputViewHolder.mInput.addTextChangedListener(inputViewHolder.mTextWatcher);
+        inputViewHolder.mInput.setOnFocusChangeListener(new View.OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View view, boolean focused) {
+                // when the focus is lost when out-of-view then it means we lost it because of the shadowing.
+                // Let's keep a note to restore focus when back-in-view.
+                inputViewHolder.mKeepFocus = !focused && inputViewHolder.mIsDetached;
+            }
+        });
+    }
+
+    private void bindSuggest(final DomainViewHolder domainViewHolder, int position) {
+        final String suggestion = getItem(position);
+        final boolean onSelectedItem = suggestion.equals(mSelectedDomain);
+        domainViewHolder.mRadioButton.setChecked(onSelectedItem);
+        domainViewHolder.mRadioButton.setText(suggestion);
+
+        View.OnClickListener clickListener = new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                if (!onSelectedItem) {
+                    mSelectedDomain = suggestion;
+                    notifyDataSetChanged();
+                    mOnAdapterListener.onSelectionChange(suggestion);
+                }
+            }
+        };
+
+        domainViewHolder.mRadioButton.setOnClickListener(clickListener);
+    }
+
+    @Override
+    public int getItemCount() {
+        int itemCount = 2; // the header and the input box
+
+        // extra line if the selected domain is not in the list
+        itemCount += mNeedExtraLineForSelectedDomain ? 1 : 0;
+
+        itemCount += mSuggestions == null ? 0 : mSuggestions.size();
+        return itemCount;
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        if (position == 0) {
+            return VIEW_TYPE_HEADER;
+        } else if (position == 1) {
+            return VIEW_TYPE_INPUT;
+        } else {
+            return VIEW_TYPE_ITEM;
+        }
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position; // just return the position itself. Items are all unique anyway.
+    }
+
+    private String getItem(int position) {
+        if (mNeedExtraLineForSelectedDomain) {
+            if (position == 2) {
+                // return the selected domain if we're on the first item on the listview
+                return mCarryOverDomain;
+            } else {
+                // otherwise return the suggestion from the data
+                return mSuggestions.get(position - 3);
+            }
+        } else {
+            return mSuggestions.get(position - 2);
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationDomainFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationDomainFragment.java
@@ -1,0 +1,229 @@
+package org.wordpress.android.ui.sitecreation;
+
+import android.os.Bundle;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.Nullable;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.text.TextUtils;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse;
+import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationDomainLoaderFragment.DomainSuggestionEvent;
+import org.wordpress.android.util.ActivityUtils;
+
+import java.util.ArrayList;
+
+import javax.inject.Inject;
+
+public class NewSiteCreationDomainFragment extends NewSiteCreationBaseFormFragment<NewSiteCreationListener> {
+    public static final String TAG = "site_creation_domain_fragment_tag";
+
+    private static final String ARG_SITE_TITLE = "ARG_SITE_TITLE";
+
+    private static final String KEY_QUERY_STRING = "KEY_QUERY_STRING";
+    private static final String KEY_KEYWORDS = "KEY_KEYWORDS";
+    private static final String KEY_CARRY_OVER_DOMAIN = "KEY_CARRY_OVER_DOMAIN";
+    private static final String KEY_SELECTED_DOMAIN = "KEY_SELECTED_DOMAIN";
+
+    private String mSiteTitle;
+    private String mKeywords = "";
+
+    private String mQueryString;
+
+    private String mCarryOverDomain;
+    private String mSelectedDomain;
+
+    private Button mFinishButton;
+
+    private NewSiteCreationDomainAdapter mSiteCreationDomainAdapter;
+
+    @Inject SiteStore mSiteStore;
+
+    public static NewSiteCreationDomainFragment newInstance(String siteTitle) {
+        NewSiteCreationDomainFragment
+                fragment = new NewSiteCreationDomainFragment();
+        Bundle args = new Bundle();
+        args.putString(ARG_SITE_TITLE, siteTitle);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    protected @LayoutRes int getContentLayout() {
+        return R.layout.site_creation_domain_screen;
+    }
+
+    @Override
+    protected void setupContent(ViewGroup rootView) {
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.site_creation_domain_selection_title);
+        RecyclerView recyclerView = rootView.findViewById(R.id.recycler_view);
+        recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        recyclerView.setAdapter(mSiteCreationDomainAdapter);
+
+        View bottomShadow = rootView.findViewById(R.id.bottom_shadow);
+        bottomShadow.setVisibility(View.VISIBLE);
+
+        ViewGroup bottomButtons = rootView.findViewById(R.id.bottom_buttons);
+        bottomButtons.setVisibility(View.VISIBLE);
+
+        mFinishButton = rootView.findViewById(R.id.finish_button);
+        mFinishButton.setVisibility(View.VISIBLE);
+        mFinishButton.setEnabled(mSelectedDomain != null);
+        mFinishButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                // hide keyboard before calling the site creation action
+                if (getActivity() != null) {
+                    ActivityUtils.hideKeyboardForced(getActivity().getCurrentFocus());
+                }
+
+                mSiteCreationListener.withDomain(mSelectedDomain);
+            }
+        });
+    }
+
+    @Override
+    protected void onHelp() {
+        if (mSiteCreationListener != null) {
+            mSiteCreationListener.helpThemeScreen();
+        }
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ((WordPress) getActivity().getApplication()).component().inject(this);
+
+        if (getArguments() != null) {
+            mSiteTitle = getArguments().getString(ARG_SITE_TITLE);
+        }
+
+        if (savedInstanceState != null) {
+            mQueryString = savedInstanceState.getString(KEY_QUERY_STRING);
+            mKeywords = savedInstanceState.getString(KEY_KEYWORDS);
+            mCarryOverDomain = savedInstanceState.getString(KEY_CARRY_OVER_DOMAIN);
+            mSelectedDomain = savedInstanceState.getString(KEY_SELECTED_DOMAIN);
+        } else {
+            mQueryString = mSiteTitle;
+        }
+
+        // Need to do this early so the mSiteCreationDomainAdapter gets initialized before RecyclerView needs it. This
+        // ensures that on rotation, the RecyclerView will have its data ready before layout and scroll position will
+        // hold correctly automatically.
+        EventBus.getDefault().register(this);
+
+        if (savedInstanceState == null) {
+            FragmentManager fragmentManager = getChildFragmentManager();
+            FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+            NewSiteCreationDomainLoaderFragment
+                    loaderFragment = NewSiteCreationDomainLoaderFragment.newInstance(mSiteTitle);
+            loaderFragment.setRetainInstance(true);
+            fragmentTransaction.add(loaderFragment, NewSiteCreationDomainLoaderFragment.TAG);
+            fragmentTransaction.commitNow();
+        }
+    }
+
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        if (savedInstanceState == null) {
+            AnalyticsTracker.track(AnalyticsTracker.Stat.SITE_CREATION_DOMAIN_VIEWED);
+        }
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        EventBus.getDefault().unregister(this);
+        mSiteCreationListener = null;
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        outState.putString(KEY_QUERY_STRING, mQueryString);
+        outState.putString(KEY_KEYWORDS, mKeywords);
+        outState.putString(KEY_CARRY_OVER_DOMAIN, mCarryOverDomain);
+        outState.putString(KEY_SELECTED_DOMAIN, mSelectedDomain);
+    }
+
+    private NewSiteCreationDomainLoaderFragment getLoaderFragment() {
+        return (NewSiteCreationDomainLoaderFragment) getChildFragmentManager()
+                .findFragmentByTag(NewSiteCreationDomainLoaderFragment.TAG);
+    }
+
+    private void updateFinishButton() {
+        // the UI will not be fully setup yet on the initial sticky event registration so, only update it if setup.
+        if (mFinishButton != null) {
+            mFinishButton.setEnabled(mSelectedDomain != null);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN, sticky = true)
+    public void onDomainSuggestionEvent(DomainSuggestionEvent event) {
+        if (mSiteCreationDomainAdapter == null) {
+            // Fragment is initializing or rotating so, just instantiate a new adapter.
+            mSiteCreationDomainAdapter = new NewSiteCreationDomainAdapter(
+                    getContext(), mKeywords,
+                    new NewSiteCreationDomainAdapter.OnAdapterListener() {
+                        @Override
+                        public void onKeywordsChange(String keywords) {
+                            mKeywords = keywords;
+                            mCarryOverDomain = mSelectedDomain;
+
+                            // fallback to using the provided site title as query if text is empty
+                            mQueryString = TextUtils.isEmpty(keywords.trim()) ? mSiteTitle : keywords;
+
+                            getLoaderFragment().load(mQueryString);
+                        }
+
+                        @Override
+                        public void onSelectionChange(String domain) {
+                            mSelectedDomain = domain;
+                            updateFinishButton();
+                        }
+                    });
+        }
+
+        switch (event.getStep()) {
+            case UPDATING:
+                mSelectedDomain = mCarryOverDomain;
+                mSiteCreationDomainAdapter.setData(true, mCarryOverDomain, mSelectedDomain, null);
+                break;
+            case ERROR:
+                mSiteCreationDomainAdapter.setData(false, mCarryOverDomain, mSelectedDomain, null);
+                break;
+            case FINISHED:
+                if (!event.getQuery().equals(mQueryString)) {
+                    // this is not the result for the latest query the debouncer sent so, ignore it
+                    break;
+                }
+
+                ArrayList<String> suggestions = new ArrayList<>();
+                for (DomainSuggestionResponse suggestionResponse : event.getEvent().suggestions) {
+                    suggestions.add(suggestionResponse.domain_name);
+                }
+
+                mSiteCreationDomainAdapter.setData(false, mCarryOverDomain, mSelectedDomain, suggestions);
+                break;
+        }
+
+        updateFinishButton();
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationDomainLoaderFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationDomainLoaderFragment.java
@@ -1,0 +1,110 @@
+package org.wordpress.android.ui.sitecreation;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.generated.SiteActionBuilder;
+import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains;
+import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.NetworkUtils;
+
+import javax.inject.Inject;
+
+public class NewSiteCreationDomainLoaderFragment extends Fragment {
+    public static final String TAG = "site_creation_domain_loader_fragment_tag";
+
+    private static final String ARG_USERNAME = "ARG_USERNAME";
+
+    public enum DomainUpdateStep {
+        UPDATING,
+        FINISHED,
+        ERROR
+    }
+
+    public static class DomainSuggestionEvent {
+        private final DomainUpdateStep mStep;
+        private final String mQuery;
+        private final OnSuggestedDomains mEvent;
+
+        DomainSuggestionEvent(DomainUpdateStep step, String query, OnSuggestedDomains event) {
+            mStep = step;
+            mQuery = query;
+            mEvent = event;
+        }
+
+        public OnSuggestedDomains getEvent() {
+            return mEvent;
+        }
+
+        public DomainUpdateStep getStep() {
+            return mStep;
+        }
+
+        public String getQuery() {
+            return mQuery;
+        }
+    }
+
+    @Inject Dispatcher mDispatcher;
+
+    // need to inject it even though we're not using it directly, otherwise we can't listen for its event responses
+    @Inject SiteStore mSiteStore;
+
+    private void postUpdate(DomainSuggestionEvent event) {
+        EventBus.getDefault().postSticky(event);
+    }
+
+    public static NewSiteCreationDomainLoaderFragment newInstance(String username) {
+        NewSiteCreationDomainLoaderFragment
+                fragment = new NewSiteCreationDomainLoaderFragment();
+        Bundle args = new Bundle();
+        args.putString(ARG_USERNAME, username);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ((WordPress) getActivity().getApplication()).component().inject(this);
+
+        mDispatcher.register(this);
+
+        load(getArguments().getString(ARG_USERNAME));
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        mDispatcher.unregister(this);
+    }
+
+    public void load(String keywords) {
+        // notify if no connectivity but continue anyway
+        NetworkUtils.checkConnection(getActivity());
+
+        postUpdate(new DomainSuggestionEvent(DomainUpdateStep.UPDATING, keywords, null));
+
+        SuggestDomainsPayload payload = new SuggestDomainsPayload(keywords, true, true, false, 20);
+        mDispatcher.dispatch(SiteActionBuilder.newSuggestDomainsAction(payload));
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onSuggestedDomains(OnSuggestedDomains event) {
+        if (event.isError()) {
+            AppLog.e(AppLog.T.API, "Error fetching domain suggestions: " + event.error.message);
+            postUpdate(new DomainSuggestionEvent(DomainUpdateStep.ERROR, event.query, event));
+        } else {
+            AppLog.d(AppLog.T.API, "WordPress.com domain suggestions fetch successful!");
+            postUpdate(new DomainSuggestionEvent(DomainUpdateStep.FINISHED, event.query, event));
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationListener.java
@@ -1,0 +1,30 @@
+package org.wordpress.android.ui.sitecreation;
+
+public interface NewSiteCreationListener {
+    // Site Creation Category callbacks
+    void withCategory(String category);
+
+    void helpCategoryScreen();
+
+    // Site Creation Theme Selection callbacks
+    void withTheme(String themeId);
+
+    void helpThemeScreen();
+
+    // Site Creation Site details callbacks
+    void withSiteDetails(String siteTitle, String siteTagline);
+
+    void helpSiteDetailsScreen();
+
+    // Site Creation Domain Selection callbacks
+    void withDomain(String domain);
+
+    void helpDomainScreen();
+
+    // Site Creation Creating and epilogue screen callbacks
+    void helpSiteCreatingScreen();
+
+    void doConfigureSite(int siteLocalId);
+
+    void doWriteFirstPost(int siteLocalId);
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationNewSiteDetailsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationNewSiteDetailsFragment.java
@@ -1,0 +1,140 @@
+package org.wordpress.android.ui.sitecreation;
+
+import android.graphics.Rect;
+import android.os.Bundle;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.Nullable;
+import android.text.Editable;
+import android.text.TextUtils;
+import android.text.TextWatcher;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ScrollView;
+
+import org.wordpress.android.R;
+import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.login.widgets.WPLoginInputRow;
+import org.wordpress.android.util.EditTextUtils;
+
+public class NewSiteCreationNewSiteDetailsFragment extends NewSiteCreationBaseFormFragment<NewSiteCreationListener>
+        implements TextWatcher {
+    public static final String TAG = "site_creation_site_details_fragment_tag";
+
+    private ScrollView mScrollView;
+    private WPLoginInputRow mSiteTitleInput;
+    private WPLoginInputRow mSiteTaglineInput;
+
+    @Override
+    protected @LayoutRes int getContentLayout() {
+        return R.layout.site_creation_site_details_screen;
+    }
+
+    @Override
+    protected void setupContent(ViewGroup rootView) {
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.site_creation_site_details_title);
+        mScrollView = rootView.findViewById(R.id.scroll_view);
+
+        mSiteTitleInput = rootView.findViewById(R.id.site_creation_site_title_row);
+        mSiteTitleInput.addTextChangedListener(this);
+        mSiteTitleInput.setOnEditorCommitListener(new WPLoginInputRow.OnEditorCommitListener() {
+            @Override
+            public void onEditorCommit() {
+                mSiteTaglineInput.getEditText().requestFocus();
+            }
+        });
+
+        mSiteTaglineInput = rootView.findViewById(R.id.site_creation_site_tagline_row);
+        mSiteTaglineInput.addTextChangedListener(this);
+        mSiteTaglineInput.setOnEditorCommitListener(new WPLoginInputRow.OnEditorCommitListener() {
+            @Override
+            public void onEditorCommit() {
+                next();
+            }
+        });
+
+        ViewGroup bottomButtons = rootView.findViewById(R.id.bottom_buttons);
+        bottomButtons.setVisibility(View.VISIBLE);
+    }
+
+    @Override
+    protected void setupBottomButtons(Button secondaryButton, Button primaryButton) {
+        primaryButton.setVisibility(View.VISIBLE);
+        primaryButton.setEnabled(false); // "Next" is disabled on start until the site title field gets some valid data
+        primaryButton.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+                next();
+            }
+        });
+    }
+
+    @Override
+    protected void onHelp() {
+        if (mSiteCreationListener != null) {
+            mSiteCreationListener.helpSiteDetailsScreen();
+        }
+    }
+
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        if (savedInstanceState == null) {
+            AnalyticsTracker.track(AnalyticsTracker.Stat.SITE_CREATION_DETAILS_VIEWED);
+        }
+    }
+
+    @Override
+    public void afterTextChanged(Editable s) {
+    }
+
+    @Override
+    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+    }
+
+    @Override
+    public void onTextChanged(CharSequence s, int start, int before, int count) {
+        showSiteTitleError(null);
+        getPrimaryButton().setEnabled(!TextUtils.isEmpty(getCleanedSiteTitle()));
+    }
+
+    private void next() {
+        final String siteTitle = getCleanedSiteTitle();
+
+        if (TextUtils.isEmpty(siteTitle)) {
+            showSiteTitleError(getString(R.string.site_creation_empty_site_title));
+            EditTextUtils.showSoftInput(mSiteTitleInput.getEditText());
+            return;
+        }
+
+        mSiteCreationListener.withSiteDetails(siteTitle, getCleanedSiteTagline());
+    }
+
+    private String getCleanedSiteTitle() {
+        return EditTextUtils.getText(mSiteTitleInput.getEditText()).trim();
+    }
+
+    private String getCleanedSiteTagline() {
+        return EditTextUtils.getText(mSiteTaglineInput.getEditText()).trim();
+    }
+
+    private void showSiteTitleError(String errorMessage) {
+        mSiteTitleInput.setError(errorMessage);
+
+        if (errorMessage != null) {
+            requestScrollToView(mSiteTitleInput);
+        }
+    }
+
+    private void requestScrollToView(final View view) {
+        view.post(new Runnable() {
+            @Override
+            public void run() {
+                Rect rect = new Rect(); // coordinates to scroll to
+                view.getHitRect(rect);
+                mScrollView.requestChildRectangleOnScreen(view, rect, false);
+            }
+        });
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationService.java
@@ -1,0 +1,555 @@
+package org.wordpress.android.ui.sitecreation;
+
+import android.app.Notification;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
+import android.text.TextUtils;
+
+import org.greenrobot.eventbus.EventBusException;
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.generated.SiteActionBuilder;
+import org.wordpress.android.fluxc.generated.ThemeActionBuilder;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.ThemeModel;
+import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
+import org.wordpress.android.fluxc.store.SiteStore.OnNewSiteCreated;
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
+import org.wordpress.android.fluxc.store.ThemeStore;
+import org.wordpress.android.fluxc.store.ThemeStore.OnThemeActivated;
+import org.wordpress.android.ui.prefs.SiteSettingsInterface;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationService.NewSiteCreationState;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.AutoForeground;
+import org.wordpress.android.util.AutoForegroundNotification;
+import org.wordpress.android.util.CrashlyticsUtils;
+import org.wordpress.android.util.LanguageUtils;
+import org.wordpress.android.util.LocaleManager;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+public class NewSiteCreationService extends AutoForeground<NewSiteCreationState> {
+    private static final String ARG_SITE_TITLE = "ARG_SITE_TITLE";
+    private static final String ARG_SITE_TAGLINE = "ARG_SITE_TAGLINE";
+    private static final String ARG_SITE_SLUG = "ARG_SITE_SLUG";
+    private static final String ARG_SITE_THEME_ID = "ARG_SITE_THEME_ID";
+
+    private static final String ARG_RESUME_PHASE = "ARG_RESUME_PHASE";
+
+    private static final int PRELOAD_TIMEOUT_MS = 3000;
+
+    public enum NewSiteCreationStep {
+        IDLE,
+        NEW_SITE(25),
+        FETCHING_NEW_SITE(50),
+        SET_TAGLINE(75),
+        SET_THEME(100),
+        PRELOAD,
+        SUCCESS,
+        FAILURE;
+
+        public final int progressPercent;
+
+        NewSiteCreationStep() {
+            this.progressPercent = 0;
+        }
+
+        NewSiteCreationStep(int progressPercent) {
+            this.progressPercent = progressPercent;
+        }
+    }
+
+    public static class NewSiteCreationState implements org.wordpress.android.util.AutoForeground.ServiceState {
+        private @NonNull final NewSiteCreationStep mStep;
+        private final Object mPayload;
+
+        NewSiteCreationState(@NonNull NewSiteCreationStep step, @Nullable Object payload) {
+            this.mStep = step;
+            this.mPayload = payload;
+        }
+
+        @NonNull
+        NewSiteCreationStep getStep() {
+            return mStep;
+        }
+
+        public Object getPayload() {
+            return mPayload;
+        }
+
+        @Override
+        public boolean isIdle() {
+            return mStep == NewSiteCreationStep.IDLE;
+        }
+
+        @Override
+        public boolean isInProgress() {
+            return mStep != NewSiteCreationStep.IDLE && !isTerminal();
+        }
+
+        @Override
+        public boolean isError() {
+            return mStep == NewSiteCreationStep.FAILURE;
+        }
+
+        @Override
+        public boolean isTerminal() {
+            return mStep == NewSiteCreationStep.SUCCESS || isError();
+        }
+
+        @Override
+        public String getStepName() {
+            return mStep.name();
+        }
+
+        boolean isAfterCreation() {
+            return mStep.ordinal() > NewSiteCreationStep.NEW_SITE.ordinal();
+        }
+    }
+
+    private static class NewSiteCreationNotification {
+        static Notification progress(Context context, int progress, @StringRes int titleString,
+                                     @StringRes int stepString) {
+            return AutoForegroundNotification.progress(context,
+                                                       context.getString(R.string.notification_channel_normal_id),
+                                                       progress,
+                                                       titleString,
+                                                       stepString,
+                                                       R.drawable.ic_my_sites_24dp,
+                                                       R.color.blue_wordpress);
+        }
+
+        static Notification success(Context context) {
+            return AutoForegroundNotification.success(context,
+                                                      context.getString(R.string.notification_channel_normal_id),
+                                                      R.string.notification_site_creation_title_success,
+                                                      R.string.notification_site_creation_created,
+                                                      R.drawable.ic_my_sites_24dp,
+                                                      R.color.blue_wordpress);
+        }
+
+        static Notification failure(Context context, @StringRes int content) {
+            return AutoForegroundNotification.failure(context,
+                                                      context.getString(R.string.notification_channel_normal_id),
+                                                      R.string.notification_site_creation_title_stopped,
+                                                      content,
+                                                      R.drawable.ic_my_sites_24dp,
+                                                      R.color.blue_wordpress);
+        }
+    }
+
+    @Inject Dispatcher mDispatcher;
+    @Inject SiteStore mSiteStore;
+    @Inject ThemeStore mThemeStore;
+
+    private boolean mIsRetry;
+
+    private String mSiteSlug;
+    private String mSiteTagline;
+    private ThemeModel mSiteTheme;
+    private SiteModel mNewSite;
+
+    public static void createSite(
+            Context context,
+            NewSiteCreationState retryFromState,
+            String siteTitle,
+            String siteTagline,
+            String siteSlug,
+            String siteThemeId) {
+        clearSiteCreationServiceState();
+
+        Intent intent = new Intent(context, NewSiteCreationService.class);
+
+        if (retryFromState != null) {
+            intent.putExtra(ARG_RESUME_PHASE, retryFromState.getStepName());
+        }
+
+        intent.putExtra(ARG_SITE_TITLE, siteTitle);
+        intent.putExtra(ARG_SITE_TAGLINE, siteTagline);
+        intent.putExtra(ARG_SITE_SLUG, siteSlug);
+        intent.putExtra(ARG_SITE_THEME_ID, siteThemeId);
+        context.startService(intent);
+    }
+
+    public static void clearSiteCreationServiceState() {
+        clearServiceState(NewSiteCreationState.class);
+    }
+
+    public static NewSiteCreationState getState() {
+        return getState(NewSiteCreationState.class);
+    }
+
+    public NewSiteCreationService() {
+        super(new NewSiteCreationState(NewSiteCreationStep.IDLE, null));
+    }
+
+    @Override
+    protected void onProgressStart() {
+        AppLog.i(T.NUX, "NewSiteCreationService registering on EventBus");
+        try {
+            // it seems that for some users, the Service tries to register more than once. Let's guard to collect info
+            //  on this. Ticket: https://github.com/wordpress-mobile/WordPress-Android/issues/7353
+            mDispatcher.register(this);
+        } catch (EventBusException e) {
+            AppLog.w(T.NUX, "Registering NewSiteCreationService to EventBus failed! " + e.getMessage());
+            CrashlyticsUtils.logException(e, T.NUX);
+        }
+    }
+
+    @Override
+    protected void onProgressEnd() {
+        AppLog.i(T.NUX, "NewSiteCreationService deregistering from EventBus");
+        mDispatcher.unregister(this);
+    }
+
+    @Override
+    public Notification getNotification(NewSiteCreationState state) {
+        switch (state.getStep()) {
+            case NEW_SITE:
+                return NewSiteCreationNotification.progress(this, 25, R.string.site_creation_creating_laying_foundation,
+                                                         R.string.notification_site_creation_step_creating);
+            case FETCHING_NEW_SITE:
+                return NewSiteCreationNotification.progress(this, 50, R.string.site_creation_creating_fetching_info,
+                                                         R.string.notification_site_creation_step_fetching);
+            case SET_TAGLINE:
+                return NewSiteCreationNotification
+                        .progress(this, 75, R.string.site_creation_creating_configuring_content,
+                                                         R.string.notification_site_creation_step_tagline);
+            case SET_THEME:
+            case PRELOAD:
+                // treat PRELOAD step as SET_THEME since when in background the UI isn't doing any preloading.
+                return NewSiteCreationNotification
+                        .progress(this, 100, R.string.site_creation_creating_configuring_theme,
+                                                         R.string.notification_site_creation_step_theme);
+            case SUCCESS:
+                return NewSiteCreationNotification.success(this);
+            case FAILURE:
+                return NewSiteCreationNotification.failure(this, R.string.notification_site_creation_failed);
+            case IDLE:
+                return null;
+        }
+        return null;
+    }
+
+    protected void trackStateUpdate(Map<String, ?> props) {
+        AnalyticsTracker.track(AnalyticsTracker.Stat.SITE_CREATION_BACKGROUND_SERVICE_UPDATE, props);
+    }
+
+    /**
+     * Helper method to create a new State object and set it as the new state.
+     *
+     * @param step The step of the new state
+     * @param payload The payload to attach to the new state
+     */
+    private void setState(NewSiteCreationStep step, Object payload) {
+        setState(new NewSiteCreationState(step, payload));
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        ((WordPress) getApplication()).component().inject(this);
+
+        AppLog.i(T.MAIN, "NewSiteCreationService > Created");
+
+        // TODO: Recover any site creations that were interrupted by the service being stopped?
+    }
+
+    @Override
+    public void onDestroy() {
+        AppLog.i(T.MAIN, "NewSiteCreationService > Destroyed");
+        super.onDestroy();
+    }
+
+    @Override
+    public int onStartCommand(@Nullable Intent intent, int flags, int startId) {
+        if (intent == null) {
+            return START_NOT_STICKY;
+        }
+
+        setState(NewSiteCreationStep.IDLE, null);
+
+        mSiteSlug = intent.getStringExtra(ARG_SITE_SLUG);
+        mSiteTagline = intent.getStringExtra(ARG_SITE_TAGLINE);
+        String themeId = intent.getStringExtra(ARG_SITE_THEME_ID);
+        mSiteTheme = mThemeStore.getWpComThemeByThemeId(themeId);
+
+        // load site from the DB. Note, this can be null if the site is not yet fetched from the network.
+        mNewSite = getWpcomSiteBySlug(mSiteSlug);
+
+        mIsRetry = intent.hasExtra(ARG_RESUME_PHASE);
+
+        final NewSiteCreationStep continueFromPhase = mIsRetry
+                ? NewSiteCreationStep.valueOf(intent.getStringExtra(ARG_RESUME_PHASE))
+                : NewSiteCreationStep.IDLE;
+
+        if (continueFromPhase == NewSiteCreationStep.IDLE && mNewSite != null) {
+            // site already exists but we're not in a retry attempt _after_ having issued the new-site creation call.
+            //  That means the slug requested corresponds to an already existing site! This is an indication that the
+            //  siteslug recommendation service is buggy.
+            AppLog.w(T.NUX, "WPCOM site with slug '" + mSiteSlug + "' already exists! Can't create a new one!");
+            notifyFailure();
+            return START_REDELIVER_INTENT;
+        }
+
+        if (new NewSiteCreationState(continueFromPhase, null).isTerminal()) {
+            throw new RuntimeException("Internal inconsistency: NewSiteCreationService can't resume a terminal step!");
+        } else if (continueFromPhase == NewSiteCreationStep.IDLE || continueFromPhase == NewSiteCreationStep.NEW_SITE) {
+            setState(NewSiteCreationStep.NEW_SITE, null);
+            createNewSite(intent.getStringExtra(ARG_SITE_TITLE), intent.getStringExtra(ARG_SITE_SLUG));
+        } else {
+            executePhase(continueFromPhase);
+        }
+
+        return START_REDELIVER_INTENT;
+    }
+
+    private SiteModel getWpcomSiteBySlug(String siteSlug) {
+        final String url = siteSlug + ".wordpress.com";
+        for (SiteModel site : mSiteStore.getSites()) {
+            if (Uri.parse(site.getUrl()).getHost().equals(url)) {
+                return site;
+            }
+        }
+
+        return null;
+    }
+
+    private void executePhase(NewSiteCreationStep phase) {
+        switch (phase) {
+            case FETCHING_NEW_SITE:
+                if (TextUtils.isEmpty(mSiteSlug)) {
+                    throw new RuntimeException("Internal inconsistency: Cannot resume, site slug is empty!");
+                }
+                setState(NewSiteCreationStep.FETCHING_NEW_SITE, null);
+                fetchNewSite();
+                break;
+            case SET_TAGLINE:
+                if (mNewSite == null) {
+                    AppLog.w(T.NUX, "NewSiteCreationService can't do tagline setup. mNewSite is null!");
+                    notifyFailure();
+                    return;
+                }
+                setState(NewSiteCreationStep.SET_TAGLINE, null);
+                setTagline();
+                break;
+            case SET_THEME:
+                if (mNewSite == null) {
+                    AppLog.w(T.NUX, "NewSiteCreationService can't do theme setup. mNewSite is null!");
+                    notifyFailure();
+                    return;
+                }
+                setState(NewSiteCreationStep.SET_THEME, null);
+                activateTheme(mSiteTheme);
+                break;
+            case PRELOAD:
+                if (mNewSite == null) {
+                    AppLog.w(T.NUX, "NewSiteCreationService can't do preload setup. mNewSite is null!");
+                    notifyFailure();
+                    return;
+                }
+                setState(NewSiteCreationStep.PRELOAD, null);
+                doPreloadDelay();
+                break;
+            case SUCCESS:
+                if (mNewSite == null) {
+                    AppLog.w(T.NUX, "NewSiteCreationService can't do success setup. mNewSite is null!");
+                    notifyFailure();
+                    return;
+                }
+                setState(NewSiteCreationStep.SUCCESS, mNewSite.getId());
+                break;
+            case IDLE:
+                break;
+            case NEW_SITE:
+                break;
+            case FAILURE:
+                break;
+        }
+    }
+
+    private void finishedPhase(NewSiteCreationStep phase) {
+        // we'll go to the next step in the sequence
+        NewSiteCreationStep nextPhase = NewSiteCreationStep.values()[phase.ordinal() + 1];
+        executePhase(nextPhase);
+    }
+
+    private void createNewSite(String siteTitle, String siteSlug) {
+        final String deviceLanguageCode = LanguageUtils.getPatchedCurrentDeviceLanguage(this);
+        /* Convert the device language code (codes defined by ISO 639-1) to a Language ID.
+         * Language IDs, used only by WordPress, are integer values that map to a language code.
+         * http://bit.ly/2H7gksN
+         */
+        Map<String, String> languageCodeToID = LocaleManager.generateLanguageMap(this);
+        String langID = null;
+        if (languageCodeToID.containsKey(deviceLanguageCode)) {
+            langID = languageCodeToID.get(deviceLanguageCode);
+        } else {
+            int pos = deviceLanguageCode.indexOf("_");
+            if (pos > -1) {
+                String newLang = deviceLanguageCode.substring(0, pos);
+                if (languageCodeToID.containsKey(newLang)) {
+                    langID = languageCodeToID.get(newLang);
+                }
+            }
+        }
+
+        if (langID == null) {
+            // fallback to device language code if there is no match
+            langID = deviceLanguageCode;
+        }
+
+        NewSitePayload newSitePayload = new NewSitePayload(
+                siteSlug,
+                siteTitle,
+                langID,
+                SiteStore.SiteVisibility.PUBLIC,
+                false);
+        mDispatcher.dispatch(SiteActionBuilder.newCreateNewSiteAction(newSitePayload));
+        AppLog.i(T.NUX, "User tries to create a new site, title: " + siteTitle + ", SiteName: " + siteSlug);
+    }
+
+    private void fetchNewSite() {
+        // We can't get all the site information from the new site endpoint, so we have to fetch the site list.
+        mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
+    }
+
+    private void setTagline() {
+        if (!TextUtils.isEmpty(mSiteTagline)) {
+            SiteSettingsInterface siteSettings = SiteSettingsInterface.getInterface(
+                    this, mNewSite,
+                    new SiteSettingsInterface.SiteSettingsListener() {
+                        @Override
+                        public void onSaveError(Exception error) {
+                            notifyFailure();
+                        }
+
+                        @Override
+                        public void onFetchError(Exception error) {
+                            notifyFailure();
+                        }
+
+                        @Override
+                        public void onSettingsUpdated() {
+                            // we'll just handle onSettingsSaved()
+                        }
+
+                        @Override
+                        public void onSettingsSaved() {
+                            finishedPhase(NewSiteCreationStep.SET_TAGLINE);
+                        }
+
+                        @Override
+                        public void onCredentialsValidated(Exception error) {
+                            if (error != null) {
+                                notifyFailure();
+                            }
+                        }
+                    });
+
+            if (siteSettings == null) {
+                notifyFailure();
+                return;
+            }
+
+            siteSettings.init(false);
+            siteSettings.setTagline(mSiteTagline);
+            siteSettings.saveSettings();
+        } else {
+            finishedPhase(NewSiteCreationStep.SET_TAGLINE);
+        }
+    }
+
+    private void activateTheme(final ThemeModel themeModel) {
+        mDispatcher.dispatch(
+                ThemeActionBuilder.newActivateThemeAction(new ThemeStore.SiteThemePayload(mNewSite, themeModel)));
+    }
+
+    private void doPreloadDelay() {
+        new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                finishedPhase(NewSiteCreationStep.PRELOAD);
+            }
+        }, PRELOAD_TIMEOUT_MS);
+    }
+
+    private void notifyFailure() {
+        NewSiteCreationState currentState = getState();
+
+        AppLog.e(T.NUX, "NewSiteCreationService entered state FAILURE while on step: "
+                        + (currentState == null ? "null" : currentState.getStep().name()));
+
+        // new state is FAILURE and pass the previous state as payload
+        setState(NewSiteCreationStep.FAILURE, currentState);
+    }
+
+    // OnChanged events
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onNewSiteCreated(OnNewSiteCreated event) {
+        AppLog.i(T.NUX, event.toString());
+        if (event.isError()) {
+            if (mIsRetry && event.error.type == SiteStore.NewSiteErrorType.SITE_NAME_EXISTS) {
+                // just move to the next step. The site was already created on the server by our previous attempt.
+                AppLog.w(T.NUX, "WPCOM site already created but we are in retrying mode so, just move on.");
+                finishedPhase(NewSiteCreationStep.NEW_SITE);
+                return;
+            }
+
+            notifyFailure();
+            return;
+        }
+
+        AnalyticsTracker.track(AnalyticsTracker.Stat.CREATED_SITE);
+
+        finishedPhase(NewSiteCreationStep.NEW_SITE);
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onSiteChanged(OnSiteChanged event) {
+        AppLog.i(T.NUX, event.toString());
+        if (event.isError()) {
+            // Site has been created but there was a error while fetching the sites. Can happen if we get
+            // a response including a broken Jetpack site. We can continue and check if the newly created
+            // site has been fetched.
+            AppLog.e(T.NUX, event.error.type.toString());
+        }
+
+        mNewSite = getWpcomSiteBySlug(mSiteSlug);
+        if (mNewSite == null) {
+            notifyFailure();
+            return;
+        }
+
+        finishedPhase(NewSiteCreationStep.FETCHING_NEW_SITE);
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onThemeActivated(OnThemeActivated event) {
+        if (event.isError()) {
+            AppLog.e(T.THEMES, "Error setting new site's theme: " + event.error.message);
+            notifyFailure();
+            return;
+        }
+
+        finishedPhase(NewSiteCreationStep.SET_THEME);
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteDetailsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteDetailsFragment.java
@@ -1,0 +1,140 @@
+package org.wordpress.android.ui.sitecreation;
+
+import android.graphics.Rect;
+import android.os.Bundle;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.Nullable;
+import android.text.Editable;
+import android.text.TextUtils;
+import android.text.TextWatcher;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ScrollView;
+
+import org.wordpress.android.R;
+import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.login.widgets.WPLoginInputRow;
+import org.wordpress.android.util.EditTextUtils;
+
+public class NewSiteCreationSiteDetailsFragment extends NewSiteCreationBaseFormFragment<NewSiteCreationListener>
+        implements TextWatcher {
+    public static final String TAG = "site_creation_site_details_fragment_tag";
+
+    private ScrollView mScrollView;
+    private WPLoginInputRow mSiteTitleInput;
+    private WPLoginInputRow mSiteTaglineInput;
+
+    @Override
+    protected @LayoutRes int getContentLayout() {
+        return R.layout.site_creation_site_details_screen;
+    }
+
+    @Override
+    protected void setupContent(ViewGroup rootView) {
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.site_creation_site_details_title);
+        mScrollView = rootView.findViewById(R.id.scroll_view);
+
+        mSiteTitleInput = rootView.findViewById(R.id.site_creation_site_title_row);
+        mSiteTitleInput.addTextChangedListener(this);
+        mSiteTitleInput.setOnEditorCommitListener(new WPLoginInputRow.OnEditorCommitListener() {
+            @Override
+            public void onEditorCommit() {
+                mSiteTaglineInput.getEditText().requestFocus();
+            }
+        });
+
+        mSiteTaglineInput = rootView.findViewById(R.id.site_creation_site_tagline_row);
+        mSiteTaglineInput.addTextChangedListener(this);
+        mSiteTaglineInput.setOnEditorCommitListener(new WPLoginInputRow.OnEditorCommitListener() {
+            @Override
+            public void onEditorCommit() {
+                next();
+            }
+        });
+
+        ViewGroup bottomButtons = rootView.findViewById(R.id.bottom_buttons);
+        bottomButtons.setVisibility(View.VISIBLE);
+    }
+
+    @Override
+    protected void setupBottomButtons(Button secondaryButton, Button primaryButton) {
+        primaryButton.setVisibility(View.VISIBLE);
+        primaryButton.setEnabled(false); // "Next" is disabled on start until the site title field gets some valid data
+        primaryButton.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+                next();
+            }
+        });
+    }
+
+    @Override
+    protected void onHelp() {
+        if (mSiteCreationListener != null) {
+            mSiteCreationListener.helpSiteDetailsScreen();
+        }
+    }
+
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        if (savedInstanceState == null) {
+            AnalyticsTracker.track(AnalyticsTracker.Stat.SITE_CREATION_DETAILS_VIEWED);
+        }
+    }
+
+    @Override
+    public void afterTextChanged(Editable s) {
+    }
+
+    @Override
+    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+    }
+
+    @Override
+    public void onTextChanged(CharSequence s, int start, int before, int count) {
+        showSiteTitleError(null);
+        getPrimaryButton().setEnabled(!TextUtils.isEmpty(getCleanedSiteTitle()));
+    }
+
+    private void next() {
+        final String siteTitle = getCleanedSiteTitle();
+
+        if (TextUtils.isEmpty(siteTitle)) {
+            showSiteTitleError(getString(R.string.site_creation_empty_site_title));
+            EditTextUtils.showSoftInput(mSiteTitleInput.getEditText());
+            return;
+        }
+
+        mSiteCreationListener.withSiteDetails(siteTitle, getCleanedSiteTagline());
+    }
+
+    private String getCleanedSiteTitle() {
+        return EditTextUtils.getText(mSiteTitleInput.getEditText()).trim();
+    }
+
+    private String getCleanedSiteTagline() {
+        return EditTextUtils.getText(mSiteTaglineInput.getEditText()).trim();
+    }
+
+    private void showSiteTitleError(String errorMessage) {
+        mSiteTitleInput.setError(errorMessage);
+
+        if (errorMessage != null) {
+            requestScrollToView(mSiteTitleInput);
+        }
+    }
+
+    private void requestScrollToView(final View view) {
+        view.post(new Runnable() {
+            @Override
+            public void run() {
+                Rect rect = new Rect(); // coordinates to scroll to
+                view.getHitRect(rect);
+                mScrollView.requestChildRectangleOnScreen(view, rect, false);
+            }
+        });
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationThemeAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationThemeAdapter.java
@@ -1,0 +1,143 @@
+package org.wordpress.android.ui.sitecreation;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.ImageView.ScaleType;
+import android.widget.TextView;
+
+import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.model.ThemeModel;
+import org.wordpress.android.ui.prefs.AppPrefs;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.util.image.ImageType;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+public class NewSiteCreationThemeAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+    private static final int VIEW_TYPE_HEADER = 0;
+    private static final int VIEW_TYPE_ITEM = 1;
+
+    private boolean mIsLoading;
+    private List<ThemeModel> mThemes;
+    private @StringRes int mErrorMessage;
+    private NewSiteCreationListener mSiteCreationListener;
+
+    @Inject ImageManager mImageManager;
+
+    public static class HeaderViewHolder extends RecyclerView.ViewHolder {
+        public final View progressContainer;
+        public final View progress;
+        public final TextView label;
+
+        HeaderViewHolder(View itemView) {
+            super(itemView);
+            this.progressContainer = itemView.findViewById(R.id.progress_container);
+            this.progress = itemView.findViewById(R.id.progress_bar);
+            this.label = itemView.findViewById(R.id.progress_label);
+        }
+    }
+
+    public static class ThemeViewHolder extends RecyclerView.ViewHolder {
+        private final ImageView mImageView;
+        private final TextView mNameView;
+
+        ThemeViewHolder(View view) {
+            super(view);
+            mImageView = view.findViewById(R.id.theme_grid_item_image);
+            mNameView = view.findViewById(R.id.theme_grid_item_name);
+        }
+    }
+
+    public NewSiteCreationThemeAdapter(Context context, NewSiteCreationListener siteCreationListener) {
+        super();
+        ((WordPress) context.getApplicationContext()).component().inject(this);
+
+        mSiteCreationListener = siteCreationListener;
+    }
+
+    public void setData(boolean isLoading, List<ThemeModel> themes, @StringRes int errorMessage) {
+        mIsLoading = isLoading;
+        mThemes = themes;
+        mErrorMessage = errorMessage;
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        if (viewType == VIEW_TYPE_HEADER) {
+            View itemView = LayoutInflater.from(parent.getContext()).inflate(R.layout.site_creation_theme_header,
+                                                                             parent, false);
+            return new HeaderViewHolder(itemView);
+        } else {
+            View itemView = LayoutInflater.from(parent.getContext()).inflate(R.layout.site_creation_theme_item, parent,
+                                                                             false);
+            return new ThemeViewHolder(itemView);
+        }
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
+        int viewType = getItemViewType(position);
+
+        if (viewType == VIEW_TYPE_HEADER) {
+            final HeaderViewHolder headerViewHolder = (HeaderViewHolder) holder;
+            headerViewHolder.progressContainer.setVisibility(mIsLoading || mThemes == null ? View.VISIBLE : View.GONE);
+            headerViewHolder.progress.setVisibility(mIsLoading ? View.VISIBLE : View.GONE);
+            if (!mIsLoading && mThemes == null) {
+                // this is an error situation so, show an error
+                headerViewHolder.label.setText(mErrorMessage);
+            } else {
+                headerViewHolder.label.setText(null);
+            }
+        } else {
+            final ThemeModel theme = getItem(position);
+            final ThemeViewHolder themeViewHolder = (ThemeViewHolder) holder;
+            themeViewHolder.mNameView.setText(theme.getName());
+            configureImageView(themeViewHolder, theme.getScreenshotUrl());
+
+            holder.itemView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    mSiteCreationListener.withTheme(theme.getThemeId());
+                }
+            });
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        return 1 + (mThemes == null ? 0 : mThemes.size());
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position == 0 ? RecyclerView.NO_ID : getItem(position).getId();
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        return position == 0 ? VIEW_TYPE_HEADER : VIEW_TYPE_ITEM;
+    }
+
+    private ThemeModel getItem(int position) {
+        return mThemes.get(position - 1);
+    }
+
+    private static final String THEME_IMAGE_PARAMETER = "?w=";
+
+    private void configureImageView(ThemeViewHolder themeViewHolder, String screenshotURL) {
+        int mViewWidth = AppPrefs.getThemeImageSizeWidth();
+        mImageManager
+                .load(themeViewHolder.mImageView, ImageType.THEME, screenshotURL + THEME_IMAGE_PARAMETER + mViewWidth,
+                        ScaleType.FIT_CENTER);
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationThemeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationThemeFragment.java
@@ -1,0 +1,124 @@
+package org.wordpress.android.ui.sitecreation;
+
+import android.os.Bundle;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.ViewGroup;
+
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.fluxc.model.ThemeModel;
+import org.wordpress.android.fluxc.store.ThemeStore;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationThemeLoaderFragment.OnThemeLoadingUpdated;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+public class NewSiteCreationThemeFragment extends NewSiteCreationBaseFormFragment<NewSiteCreationListener> {
+    public static final String TAG = "site_creation_theme_fragment_tag";
+
+    private static final String ARG_THEME_CATEGORY = "ARG_THEME_CATEGORY";
+
+    private String mThemeCategory;
+
+    private NewSiteCreationThemeAdapter mNewSiteCreationThemeAdapter;
+
+    @Inject ThemeStore mThemeStore;
+
+    public static NewSiteCreationThemeFragment newInstance(String themeCategory) {
+        NewSiteCreationThemeFragment
+                fragment = new NewSiteCreationThemeFragment();
+        Bundle args = new Bundle();
+        args.putString(ARG_THEME_CATEGORY, themeCategory);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    protected @LayoutRes int getContentLayout() {
+        return R.layout.site_creation_theme_screen;
+    }
+
+    @Override
+    protected void setupContent(ViewGroup rootView) {
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.site_creation_theme_selection_title);
+        RecyclerView recyclerView = rootView.findViewById(R.id.recycler_view);
+        recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        recyclerView.setAdapter(mNewSiteCreationThemeAdapter);
+    }
+
+    @Override
+    protected void onHelp() {
+        if (mSiteCreationListener != null) {
+            mSiteCreationListener.helpThemeScreen();
+        }
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ((WordPress) getActivity().getApplication()).component().inject(this);
+
+        if (getArguments() != null) {
+            mThemeCategory = getArguments().getString(ARG_THEME_CATEGORY);
+        }
+
+        // Will trigger the update method since the onThemeLoadingUpdated event is sticky.
+        // Need to do this early so the mNewSiteCreationThemeAdapter gets initialized before RecyclerView needs it. This
+        // ensures that on rotation, the RecyclerView will have its data ready before layout and scroll position will
+        // hold correctly automatically.
+        EventBus.getDefault().register(this);
+    }
+
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        if (savedInstanceState == null) {
+            AnalyticsTracker.track(AnalyticsTracker.Stat.SITE_CREATION_THEME_VIEWED);
+        }
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        EventBus.getDefault().unregister(this);
+        mSiteCreationListener = null;
+    }
+
+    private List<ThemeModel> getThemes() {
+        return mThemeStore.getWpComMobileFriendlyThemes(mThemeCategory);
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN, sticky = true)
+    public void onThemeLoadingUpdated(OnThemeLoadingUpdated event) {
+        if (mNewSiteCreationThemeAdapter == null) {
+            // Fragment is initializing or rotating so, just instantiate a new adapter.
+            mNewSiteCreationThemeAdapter = new NewSiteCreationThemeAdapter(getContext(), mSiteCreationListener);
+        }
+
+        switch (event.getPhase()) {
+            case UPDATING:
+                mNewSiteCreationThemeAdapter.setData(true, null, 0);
+                break;
+            case ERROR:
+                mNewSiteCreationThemeAdapter.setData(false, null, R.string.error_generic);
+                break;
+            case ERROR_NO_CONNECTIVITY:
+                mNewSiteCreationThemeAdapter.setData(false, null, R.string.error_generic_network);
+                break;
+            case FINISHED:
+                mNewSiteCreationThemeAdapter.setData(false, getThemes(), 0);
+                break;
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationThemeLoaderFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationThemeLoaderFragment.java
@@ -1,0 +1,115 @@
+package org.wordpress.android.ui.sitecreation;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.generated.ThemeActionBuilder;
+import org.wordpress.android.fluxc.store.ThemeStore;
+import org.wordpress.android.fluxc.store.ThemeStore.OnWpComThemesChanged;
+import org.wordpress.android.networking.ConnectionChangeReceiver;
+import org.wordpress.android.networking.ConnectionChangeReceiver.ConnectionChangeEvent;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.NetworkUtils;
+
+import javax.inject.Inject;
+
+public class NewSiteCreationThemeLoaderFragment extends Fragment {
+    public static final String TAG = "site_creation_theme_loader_fragment_tag";
+
+    public enum ThemesUpdateState {
+        UPDATING,
+        FINISHED,
+        ERROR,
+        ERROR_NO_CONNECTIVITY
+    }
+
+    static class OnThemeLoadingUpdated {
+        private final ThemesUpdateState mState;
+
+        OnThemeLoadingUpdated(ThemesUpdateState state) {
+            mState = state;
+        }
+
+        ThemesUpdateState getPhase() {
+            return mState;
+        }
+    }
+
+    @Inject Dispatcher mDispatcher;
+
+    // need to inject it even though we're not using it directly, otherwise we can't listen for its event responses
+    @Inject ThemeStore mThemeStore;
+
+    @Nullable
+    private OnThemeLoadingUpdated getState() {
+        return EventBus.getDefault().getStickyEvent(OnThemeLoadingUpdated.class);
+    }
+
+    private void postUpdate(ThemesUpdateState state) {
+        EventBus.getDefault().postSticky(new OnThemeLoadingUpdated(state));
+    }
+
+    private void update() {
+        postUpdate(ThemesUpdateState.UPDATING);
+        mDispatcher.dispatch(ThemeActionBuilder.newFetchWpComThemesAction());
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ((WordPress) getActivity().getApplication()).component().inject(this);
+
+        ConnectionChangeReceiver.getEventBus().register(this);
+        mDispatcher.register(this);
+
+        update();
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        mDispatcher.unregister(this);
+        ConnectionChangeReceiver.getEventBus().unregister(this);
+    }
+
+    @SuppressWarnings("unused")
+    public void onEventMainThread(ConnectionChangeEvent event) {
+        OnThemeLoadingUpdated onThemeLoadingUpdated = getState();
+        if (isAdded()
+            && event.isConnected()
+            && onThemeLoadingUpdated != null
+            && onThemeLoadingUpdated.getPhase() == ThemesUpdateState.ERROR_NO_CONNECTIVITY) {
+            update();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onThemesChanged(OnWpComThemesChanged event) {
+        if (event.isError()) {
+            if (NetworkUtils.isNetworkAvailable(getContext())) {
+                mDispatcher.unregister(this);
+                ConnectionChangeReceiver.getEventBus().unregister(this);
+
+                AppLog.e(AppLog.T.THEMES, "Error fetching themes: " + event.error.message);
+                postUpdate(ThemesUpdateState.ERROR);
+            } else {
+                AppLog.e(AppLog.T.THEMES, "Error fetching themes: " + event.error.message
+                                          + ". Seems connectivity is off though so, will try again when back online");
+                postUpdate(ThemesUpdateState.ERROR_NO_CONNECTIVITY);
+            }
+        } else {
+            mDispatcher.unregister(this);
+            ConnectionChangeReceiver.getEventBus().unregister(this);
+
+            AppLog.d(AppLog.T.THEMES, "WordPress.com Theme fetch successful!");
+            postUpdate(ThemesUpdateState.FINISHED);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #8497 

Goal of this ticket is to create a copy of the current Site Creation flow so we don't have to worry about breaking the old flow as we plan to run A/B tests.

- I copy-pasted all the related classes to a new package
- I introduced a new feature flag -> we'll replace the build time feature flag with a flag from Remote Firebase config as soon as we have support for it


To test:
1. Verify none of the legacy classes has been modified
2. Verify the new classes don't reference legacy classes (org.wordpress.android.ui.accounts.signup)
3. Verify the feature flag is correct and the app uses the legacy SiteCreation flow

Basically assume that we'll merge this PR to the develop within a week or so and it shouldn't have any effect whatsoever.

Note:
The change set is huge, but I just copy-pasted all the related classes. I believe you can review just e1d56d6 and 2395203 + `To test` steps.