### PR TITLE
Issue/8492 fixing image settings size attributes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -933,13 +933,11 @@ public class MediaSettingsActivity extends AppCompatActivity
     }
 
     private void updateImageSizeParameters() {
-        if (mImageSize == MediaSettingsImageSize.FULL) {
-            // caption will not render without width and height attributes
-            if (TextUtils.isEmpty(mEditorImageMetaData.getCaption())) {
-                mEditorImageMetaData.setWidth(null);
-                mEditorImageMetaData.setHeight(null);
-                return;
-            }
+        // if caption is empty we can safely remove width and height attributes
+        if (mImageSize == MediaSettingsImageSize.FULL && TextUtils.isEmpty(mEditorImageMetaData.getCaption())) {
+            mEditorImageMetaData.setWidth(null);
+            mEditorImageMetaData.setHeight(null);
+            return;
         }
 
         int imageWidth = mEditorImageMetaData.getWidthInt();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -916,8 +916,9 @@ public class MediaSettingsActivity extends AppCompatActivity
                 mEditorImageMetaData.setLinkUrl(linkUrl);
                 mEditorImageMetaData.setLinkTargetBlank(linkTargetBlank);
 
-                // size affects multiple attributes, so we want to make sure we updated them only if they were changed
-                if (hasSizeChanged) {
+                // we only update width and height attributes on self hosted and Jetpack sites
+                // because css image size classes wont have any effect there
+                if (!mSite.isWPCom() && hasSizeChanged) {
                     updateImageSizeParameters();
                 }
 
@@ -933,9 +934,12 @@ public class MediaSettingsActivity extends AppCompatActivity
 
     private void updateImageSizeParameters() {
         if (mImageSize == MediaSettingsImageSize.FULL) {
-            mEditorImageMetaData.setWidth(null);
-            mEditorImageMetaData.setHeight(null);
-            return;
+            // caption will not render without width and height attributes
+            if (TextUtils.isEmpty(mEditorImageMetaData.getCaption())) {
+                mEditorImageMetaData.setWidth(null);
+                mEditorImageMetaData.setHeight(null);
+                return;
+            }
         }
 
         int imageWidth = mEditorImageMetaData.getWidthInt();
@@ -1118,11 +1122,11 @@ public class MediaSettingsActivity extends AppCompatActivity
     }
 
     public enum MediaSettingsImageSize {
-        THUMBNAIL(R.string.image_size_thumbnail_label, R.string.image_size_thumbnail_class,
+        THUMBNAIL(R.string.image_size_thumbnail_label, R.string.image_size_thumbnail_css_class,
                 R.integer.image_size_thumbnail_px),
-        MEDIUM(R.string.image_size_medium_label, R.string.image_size_medium_class, R.integer.image_size_medium_px),
-        LARGE(R.string.image_size_large_label, R.string.image_size_large_class, R.integer.image_size_large_px),
-        FULL(R.string.image_size_full_label, R.string.image_size_full_class, -1);
+        MEDIUM(R.string.image_size_medium_label, R.string.image_size_medium_css_class, R.integer.image_size_medium_px),
+        LARGE(R.string.image_size_large_label, R.string.image_size_large_css_class, R.integer.image_size_large_px),
+        FULL(R.string.image_size_full_label, R.string.image_size_full_css_class, R.integer.image_size_large_px);
 
         private final int mLabel;
         private final int mCssClass;

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1266,10 +1266,10 @@
     <string name="image_size_large_label">Large</string>
     <string name="image_size_full_label">Full Size</string>
 
-    <string name="image_size_thumbnail_class" translatable="false">size-thumbnail</string>
-    <string name="image_size_medium_class" translatable="false">size-medium</string>
-    <string name="image_size_large_class" translatable="false">size-large</string>
-    <string name="image_size_full_class" translatable="false">size-full</string>
+    <string name="image_size_thumbnail_css_class" translatable="false">size-thumbnail</string>
+    <string name="image_size_medium_css_class" translatable="false">size-medium</string>
+    <string name="image_size_large_css_class" translatable="false">size-large</string>
+    <string name="image_size_full_css_class" translatable="false">size-full</string>
 
     <!-- About View -->
     <string name="app_title">WordPress for Android</string>


### PR DESCRIPTION
Fixes #8492 

This PR fixes crash caused by missing width attribute when Caption was set.
I alligned functionality with iOS, to not change `img` tag's `width` and `height` attributes.

We will still change `img` tag's `width` and `height` attributes on self hosted and jetpack websites, because they do not support Calypso's css image size classes.

In addition, I changed names of some string values, because for a brief period of time they missed `translatable="false"` flag, and some of them got translated. By renaming them we will force the script to remove unused, erroneously translated ones.

To test:

**On wpcom website**
1. Create a post and add an image to it.
2. Switch to HTML mode, and make sure the image has `width` and `height` attributes.
3. Tap on the image and navigate to Media Settings.
4. Using the image size slider select Thumbnail.
5. Add a Caption to the image.
6. Close Media Settings.
7. Switch to HTML mode, and make sure the image has `width` and `height` attributes.
8. Tap on the image and navigate to Media Settings.
9. Using the image size slider select Full Size.
10. Close Media Settings.
11. Notice that the app is not crashing.
12. Switch to HTML mode, and make sure the image has `width` and `height` attributes.

**On self-hosted or Jetpack website**
1. Create a post and add an image to it.
2. Switch to HTML mode, and make sure the image has `width` and `height` attributes.
3. Tap on the image and navigate to Media Settings.
4. Using the image size slider select Thumbnail.
5. Add a Caption to the image.
6. Close Media Settings.
7. Switch to HTML mode, and make sure the image has `width` and `height` attributes.
8. Tap on the image and navigate to Media Settings.
9. Using the image size slider select Full Size.
10. Close Media Settings.
11. Notice app is not crashing.
12. Switch to HTML mode, and make sure the image has `width` and `height` attributes.

**On self-hosted or Jetpack website**
1. Ceate a post and add an image to it.
2. Switch to HTML mode, and make sure the image has `width` and `height` attributes.
3. Tap on the image and navigate to Media Settings.
4. Using the image size slider select Thumbnail.
5. Close Media Settings.
6. Switch to HTML mode, and make sure the image has `width` and `height` attributes.
7. Tap on the image and navigate to Media Settings.
8. Using the image size slider select Full Size.
9. Close Media Settings.
10. Switch to HTML mode, and make sure the image does not have `width` and `height` attributes.


