### PR TITLE
Latest post summary actions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockItemViewHolder.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.stats.refresh
 
 import android.content.Context
+import android.graphics.Typeface
 import android.support.annotation.LayoutRes
 import android.support.v4.content.ContextCompat
 import android.support.v7.widget.RecyclerView.ViewHolder
@@ -94,6 +95,7 @@ sealed class BlockItemViewHolder(
 
                 override fun updateDrawState(ds: TextPaint?) {
                     ds?.color = ContextCompat.getColor(context, R.color.blue_wordpress)
+                    ds?.typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD);
                     ds?.isUnderlineText = false
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockItemViewHolder.kt
@@ -95,7 +95,7 @@ sealed class BlockItemViewHolder(
 
                 override fun updateDrawState(ds: TextPaint?) {
                     ds?.color = ContextCompat.getColor(context, R.color.blue_wordpress)
-                    ds?.typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD);
+                    ds?.typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
                     ds?.isUnderlineText = false
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/InsightsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/InsightsViewModel.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.stats.refresh
 
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MediatorLiveData
 import kotlinx.coroutines.experimental.CoroutineScope
 import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.withContext
@@ -28,6 +30,15 @@ class InsightsViewModel
     private val insightsAllTimeViewModel: InsightsAllTimeViewModel,
     private val latestPostSummaryViewModel: LatestPostSummaryViewModel
 ) {
+    private val mediatorNavigationTarget: MediatorLiveData<NavigationTarget> = MediatorLiveData()
+    val navigationTarget: LiveData<NavigationTarget> = mediatorNavigationTarget
+
+    init {
+        mediatorNavigationTarget.addSource(latestPostSummaryViewModel.navigationTarget) {
+            mediatorNavigationTarget.value = it
+        }
+    }
+
     private suspend fun load(site: SiteModel, type: InsightsTypes, forced: Boolean): InsightsItem {
         return when (type) {
             ALL_TIME_STATS -> insightsAllTimeViewModel.loadAllTimeInsights(site, forced)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/LatestPostSummaryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/LatestPostSummaryViewModel.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.stats.refresh
 
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
 import org.wordpress.android.R
 import org.wordpress.android.R.string
 import org.wordpress.android.fluxc.model.SiteModel
@@ -7,6 +9,9 @@ import org.wordpress.android.fluxc.model.stats.InsightsLatestPostModel
 import org.wordpress.android.fluxc.store.InsightsStore
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Title
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.AddNewPost
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.SharePost
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewMore
 import javax.inject.Inject
 
 class LatestPostSummaryViewModel
@@ -14,6 +19,9 @@ class LatestPostSummaryViewModel
     private val insightsStore: InsightsStore,
     private val latestPostSummaryMapper: LatestPostSummaryMapper
 ) {
+    private val mutableNavigationTarget = MutableLiveData<NavigationTarget>()
+    val navigationTarget: LiveData<NavigationTarget> = mutableNavigationTarget
+
     suspend fun loadLatestPostSummary(site: SiteModel, forced: Boolean = false): InsightsItem {
         val response = insightsStore.fetchLatestPostInsights(site, forced)
         val model = response.model
@@ -50,9 +58,20 @@ class LatestPostSummaryViewModel
 
     private fun buildLink(model: InsightsLatestPostModel?): Link {
         return when {
-            model == null -> Link(R.drawable.ic_create_blue_medium_24dp, R.string.stats_insights_create_post) {}
-            model.hasData() -> Link(text = R.string.stats_insights_view_more) {}
-            else -> Link(R.drawable.ic_share_blue_medium_24dp, R.string.stats_insights_share_post) {}
+            model == null -> Link(R.drawable.ic_create_blue_medium_24dp, R.string.stats_insights_create_post) {
+                mutableNavigationTarget.value = AddNewPost
+            }
+            model.hasData() -> Link(text = R.string.stats_insights_view_more) {
+                mutableNavigationTarget.value = ViewMore(
+                        model.siteId,
+                        model.postId.toString(),
+                        model.postTitle,
+                        model.postURL
+                )
+            }
+            else -> Link(R.drawable.ic_share_blue_medium_24dp, R.string.stats_insights_share_post) {
+                mutableNavigationTarget.value = SharePost(model.postURL, model.postTitle)
+            }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListFragment.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.stats.refresh
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProvider
 import android.arch.lifecycle.ViewModelProviders
+import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
 import android.support.v4.app.Fragment
@@ -15,8 +16,15 @@ import kotlinx.android.synthetic.main.stats_list_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.stats.StatsConstants
+import org.wordpress.android.ui.stats.models.StatsPostModel
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.AddNewPost
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.SharePost
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewMore
 import org.wordpress.android.ui.stats.refresh.StatsListViewModel.StatsListType
 import org.wordpress.android.util.DisplayUtils
+import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.widgets.RecyclerItemDecoration
 import javax.inject.Inject
 
@@ -89,13 +97,40 @@ class StatsListFragment : Fragment() {
         }
         viewModel.start(site, statsType)
 
-        setupObservers()
+        setupObservers(site)
     }
 
-    private fun setupObservers() {
+    private fun setupObservers(site: SiteModel) {
         viewModel.data.observe(this, Observer {
             if (it != null) {
                 updateInsights(it)
+            }
+        })
+
+        viewModel.navigationTarget.observe(this, Observer {
+            when (it) {
+                is AddNewPost -> ActivityLauncher.addNewPostOrPageForResult(activity, site, false, false)
+                is SharePost -> {
+                    val intent = Intent(Intent.ACTION_SEND)
+                    intent.type = "text/plain"
+                    intent.putExtra(Intent.EXTRA_TEXT, it.url)
+                    intent.putExtra(Intent.EXTRA_SUBJECT, it.title)
+                    try {
+                        startActivity(Intent.createChooser(intent, getString(R.string.share_link)))
+                    } catch (ex: android.content.ActivityNotFoundException) {
+                        ToastUtils.showToast(activity, R.string.reader_toast_err_share_intent)
+                    }
+                }
+                is ViewMore -> {
+                    val postModel = StatsPostModel(
+                            it.siteID,
+                            it.postID,
+                            it.postTitle,
+                            it.postUrl,
+                            StatsConstants.ITEM_TYPE_POST
+                    )
+                    ActivityLauncher.viewStatsSinglePostDetails(activity, postModel)
+                }
             }
         })
     }
@@ -110,4 +145,11 @@ class StatsListFragment : Fragment() {
         }
         adapter.update(insightsState.data)
     }
+}
+
+sealed class NavigationTarget {
+    object AddNewPost : NavigationTarget()
+    data class SharePost(val url: String, val title: String) : NavigationTarget()
+    data class ViewMore(val siteID: Long, val postID: String, val postTitle: String, val postUrl: String) :
+            NavigationTarget()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListFragment.kt
@@ -109,7 +109,7 @@ class StatsListFragment : Fragment() {
 
         viewModel.navigationTarget.observe(this, Observer {
             when (it) {
-                is AddNewPost -> ActivityLauncher.addNewPostOrPageForResult(activity, site, false, false)
+                is AddNewPost -> ActivityLauncher.addNewPostForResult(activity, site, false)
                 is SharePost -> {
                     val intent = Intent(Intent.ACTION_SEND)
                     intent.type = "text/plain"

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListViewModel.kt
@@ -29,6 +29,8 @@ class StatsListViewModel
     private val mutableData: MutableLiveData<InsightsUiState> = MutableLiveData()
     val data: LiveData<InsightsUiState> = mutableData
 
+    val navigationTarget: LiveData<NavigationTarget> = insightsViewModel.navigationTarget
+
     private lateinit var statsType: StatsListType
 
     fun start(site: SiteModel, statsType: StatsListType) {


### PR DESCRIPTION
Fixes #8332 
This PR is adding actions to the button on the Latest post summary block. The actions are either creating a new Post when there is no post yet created, sharing the last post when it has no values or a link to the Detail activity for the other usecases.

@SylvesterWilmott  The design should be now final (I've fixed the "bold" link to the blog).

To test:
* Open Stats for a site with no posts
* The button links to the "New post" editor screen

To test 2:
* Open Stats for a site with a post with no views
* The button links to "Share" action

To test 3:
* Open Stats for a site with a post with views
* The button links to the Post detail screen

