### PR TITLE
Issue/editor history menu

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1021,9 +1021,9 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         MenuItem saveAsDraftMenuItem = menu.findItem(R.id.menu_save_as_draft_or_publish);
-        MenuItem historyMenuItem = menu.findItem(R.id.menu_history);
         MenuItem previewMenuItem = menu.findItem(R.id.menu_preview_post);
         MenuItem viewHtmlModeMenuItem = menu.findItem(R.id.menu_html_mode);
+        MenuItem historyMenuItem = menu.findItem(R.id.menu_history);
         MenuItem settingsMenuItem = menu.findItem(R.id.menu_post_settings);
         MenuItem discardChanges = menu.findItem(R.id.menu_discard_changes);
 
@@ -1036,11 +1036,6 @@ public class EditPostActivity extends AppCompatActivity implements
             }
         }
 
-        if (historyMenuItem != null) {
-            boolean hasHistory = !mIsNewPost && (mSite.isWPCom() || mSite.isJetpackConnected());
-            historyMenuItem.setVisible(showMenuItems && hasHistory);
-        }
-
         if (previewMenuItem != null) {
             previewMenuItem.setVisible(showMenuItems);
         }
@@ -1048,6 +1043,11 @@ public class EditPostActivity extends AppCompatActivity implements
         if (viewHtmlModeMenuItem != null) {
             viewHtmlModeMenuItem.setVisible(mEditorFragment instanceof AztecEditorFragment && showMenuItems);
             viewHtmlModeMenuItem.setTitle(mHtmlModeMenuStateOn ? R.string.menu_visual_mode : R.string.menu_html_mode);
+        }
+
+        if (historyMenuItem != null) {
+            boolean hasHistory = !mIsNewPost && (mSite.isWPCom() || mSite.isJetpackConnected());
+            historyMenuItem.setVisible(showMenuItems && hasHistory);
         }
 
         if (settingsMenuItem != null) {

--- a/WordPress/src/main/res/menu/edit_post.xml
+++ b/WordPress/src/main/res/menu/edit_post.xml
@@ -19,11 +19,6 @@
         </item>
 
         <item
-            android:id="@+id/menu_history"
-            android:title="@string/menu_history" >
-        </item>
-
-        <item
             android:id="@+id/menu_preview_post"
             android:title="@string/menu_preview" >
         </item>
@@ -31,6 +26,11 @@
         <item
             android:id="@+id/menu_html_mode"
             android:title="@string/menu_html_mode" >
+        </item>
+
+        <item
+            android:id="@+id/menu_history"
+            android:title="@string/menu_history" >
         </item>
 
         <item


### PR DESCRIPTION
### Fix
Move the history item below the HTML mode item in the editor overflow menu.

### Test
1. Go to ***My Site*** tab.
2. Tap ***Blog Posts*** item under ***Publish*** section.
3. Select blog post from list.
4. Tap overflow menu action.
5. Notice ***History*** item is below ***HTML Mode*** item.

### Review
Only one developer is required to review these changes, but anyone can perform the review.