### PR TITLE
Today's stats block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/InsightsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/InsightsViewModel.kt
@@ -27,7 +27,7 @@ class InsightsViewModel
     @Named(DEFAULT_SCOPE) private val scope: CoroutineScope,
     private val insightsAllTimeViewModel: InsightsAllTimeViewModel,
     private val latestPostSummaryViewModel: LatestPostSummaryViewModel,
-        private val todayStatsUseCase: TodayStatsUseCase
+    private val todayStatsUseCase: TodayStatsUseCase
 ) {
     private suspend fun load(site: SiteModel, type: InsightsTypes, forced: Boolean): InsightsItem {
         return when (type) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/InsightsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/InsightsViewModel.kt
@@ -26,19 +26,20 @@ class InsightsViewModel
     private val statsStore: StatsStore,
     @Named(DEFAULT_SCOPE) private val scope: CoroutineScope,
     private val insightsAllTimeViewModel: InsightsAllTimeViewModel,
-    private val latestPostSummaryViewModel: LatestPostSummaryViewModel
+    private val latestPostSummaryViewModel: LatestPostSummaryViewModel,
+        private val todayStatsUseCase: TodayStatsUseCase
 ) {
     private suspend fun load(site: SiteModel, type: InsightsTypes, forced: Boolean): InsightsItem {
         return when (type) {
             ALL_TIME_STATS -> insightsAllTimeViewModel.loadAllTimeInsights(site, forced)
             LATEST_POST_SUMMARY -> latestPostSummaryViewModel.loadLatestPostSummary(site, forced)
+            TODAY_STATS -> todayStatsUseCase.loadTodayStats(site, forced)
             MOST_POPULAR_DAY_AND_HOUR,
             FOLLOWER_TOTALS,
             TAGS_AND_CATEGORIES,
             ANNUAL_SITE_STATS,
             COMMENTS,
             FOLLOWERS,
-            TODAY_STATS,
             POSTING_ACTIVITY,
             PUBLICIZE -> NotImplemented(type.name)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/TodayStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/TodayStatsUseCase.kt
@@ -1,0 +1,79 @@
+package org.wordpress.android.ui.stats.refresh
+
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.VisitsModel
+import org.wordpress.android.fluxc.store.InsightsStore
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Empty
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Item
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Title
+import javax.inject.Inject
+
+class TodayStatsUseCase
+@Inject constructor(private val insightsStore: InsightsStore) {
+    suspend fun loadTodayStats(site: SiteModel, forced: Boolean = false): InsightsItem {
+        val response = insightsStore.fetchTodayInsights(site, forced)
+        val model = response.model
+        val error = response.error
+
+        return when {
+            error != null -> Failed(R.string.stats_insights_today_stats, error.message ?: error.type.name)
+            model != null -> loadLatestPostSummaryItem(model)
+            else -> throw IllegalArgumentException("Unexpected empty body")
+        }
+    }
+
+    private fun loadLatestPostSummaryItem(model: VisitsModel): ListInsightItem {
+        val items = mutableListOf<BlockListItem>()
+        items.add(Title(R.string.stats_insights_today_stats))
+        val hasViews = model.views > 0
+        val hasVisitors = model.visitors > 0
+        val hasLikes = model.likes > 0
+        val hasComments = model.comments > 0
+        if (!hasViews && !hasVisitors && !hasLikes && !hasComments) {
+            items.add(Empty)
+        } else {
+            if (hasViews) {
+                items.add(
+                        Item(
+                                R.drawable.ic_visible_on_grey_dark_24dp,
+                                R.string.stats_views,
+                                model.views.toFormattedString(),
+                                showDivider = hasVisitors || hasLikes || hasComments
+                        )
+                )
+            }
+            if (hasVisitors) {
+                items.add(
+                        Item(
+                                R.drawable.ic_user_grey_dark_24dp,
+                                R.string.stats_visitors,
+                                model.visitors.toFormattedString(),
+                                showDivider = hasLikes || hasComments
+                        )
+                )
+            }
+            if (hasLikes) {
+                items.add(
+                        Item(
+                                R.drawable.ic_star_grey_dark_24dp,
+                                R.string.stats_likes,
+                                model.likes.toFormattedString(),
+                                showDivider = hasComments
+                        )
+                )
+            }
+            if (hasComments) {
+                items.add(
+                        Item(
+                                R.drawable.ic_comment_grey_dark_24dp,
+                                R.string.stats_comments,
+                                model.comments.toFormattedString(),
+                                showDivider = false
+                        )
+                )
+            }
+        }
+        return ListInsightItem(items)
+    }
+}

--- a/WordPress/src/main/res/drawable/ic_comment_grey_dark_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_comment_grey_dark_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="@color/grey_dark"
+        android:pathData="M3,6v9c0,1.1 0.9,2 2,2h9v5l5.3,-3.8c1,-0.8 1.7,-2 1.7,-3.3V6c0,-1.1 -0.9,-2 -2,-2H5C3.9,4 3,4.9 3,6z" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/drawable/ic_star_grey_dark_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_star_grey_dark_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="36.0"
+    android:viewportWidth="36.0" >
+
+    <path
+        android:fillColor="@color/grey_dark"
+        android:pathData="M16,2.7l3.4,9.3l9.9,0.4l-7.8,6.1l2.7,9.5L16,22.5L7.8,28l2.7,-9.5l-7.8,-6.1l9.9,-0.4" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -960,6 +960,7 @@
     <string name="stats_insights_most_popular_hour">Most popular hour</string>
     <string name="stats_insights_most_popular_percent_views">%1$d%% of views</string>
     <string name="stats_insights_best_ever">Best Views Ever</string>
+    <string name="stats_insights_today_stats">Today\'s Stats</string>
 
     <!-- Stats refreshed insights -->
     <string name="stats_insights_all_time_stats">All Time Stats</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/TodayStatsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/TodayStatsUseCaseTest.kt
@@ -16,7 +16,8 @@ import org.wordpress.android.fluxc.store.InsightsStore.StatsError
 import org.wordpress.android.fluxc.store.InsightsStore.StatsErrorType.GENERIC_ERROR
 import org.wordpress.android.test
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Title
-import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.*
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.ITEM
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TITLE
 import org.wordpress.android.ui.stats.refresh.InsightsItem.Type.FAILED
 import org.wordpress.android.ui.stats.refresh.InsightsItem.Type.LIST_INSIGHTS
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/TodayStatsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/TodayStatsUseCaseTest.kt
@@ -1,0 +1,157 @@
+package org.wordpress.android.ui.stats.refresh
+
+import com.nhaarman.mockito_kotlin.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.VisitsModel
+import org.wordpress.android.fluxc.store.InsightsStore
+import org.wordpress.android.fluxc.store.InsightsStore.OnInsightsFetched
+import org.wordpress.android.fluxc.store.InsightsStore.StatsError
+import org.wordpress.android.fluxc.store.InsightsStore.StatsErrorType.GENERIC_ERROR
+import org.wordpress.android.test
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Title
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.*
+import org.wordpress.android.ui.stats.refresh.InsightsItem.Type.FAILED
+import org.wordpress.android.ui.stats.refresh.InsightsItem.Type.LIST_INSIGHTS
+
+@RunWith(MockitoJUnitRunner::class)
+class TodayStatsUseCaseTest {
+    @Mock lateinit var insightsStore: InsightsStore
+    @Mock lateinit var site: SiteModel
+    private lateinit var useCase: TodayStatsUseCase
+    private val views = 10
+    private val visitors = 15
+    private val likes = 20
+    private val comments = 30
+    @Before
+    fun setUp() {
+        useCase = TodayStatsUseCase(insightsStore)
+    }
+
+    @Test
+    fun `maps full stats item to UI model`() = test {
+        val forced = false
+        whenever(insightsStore.fetchTodayInsights(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        VisitsModel("2018-10-02", views, visitors, likes, 0, comments, 0)
+                )
+        )
+
+        val result = useCase.loadTodayStats(site, forced)
+
+        assertThat(result.type).isEqualTo(LIST_INSIGHTS)
+        (result as ListInsightItem).apply {
+            assertThat(this.items).hasSize(5)
+            assertTitle(this.items[0])
+            assertViews(this.items[1], showDivider = true)
+            assertVisitors(this.items[2], showDivider = true)
+            assertLikes(this.items[3], showDivider = true)
+            assertComments(this.items[4], showDivider = false)
+        }
+    }
+
+    @Test
+    fun `maps partial stats item to UI model`() = test {
+        val forced = false
+        whenever(insightsStore.fetchTodayInsights(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        VisitsModel("2018-10-02", 0, visitors, likes, 0, 0, 0)
+                )
+        )
+
+        val result = useCase.loadTodayStats(site, forced)
+
+        assertThat(result.type).isEqualTo(LIST_INSIGHTS)
+        (result as ListInsightItem).apply {
+            assertThat(this.items).hasSize(3)
+            assertTitle(this.items[0])
+            assertVisitors(this.items[1], showDivider = true)
+            assertLikes(this.items[2], showDivider = false)
+        }
+    }
+
+    @Test
+    fun `maps empty stats item to UI model`() = test {
+        val forced = false
+        whenever(insightsStore.fetchTodayInsights(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        VisitsModel("2018-10-02", 0, 0, 0, 0, 0, 0)
+                )
+        )
+
+        val result = useCase.loadTodayStats(site, forced)
+
+        assertThat(result.type).isEqualTo(LIST_INSIGHTS)
+        (result as ListInsightItem).apply {
+            assertThat(this.items).hasSize(2)
+            assertTitle(this.items[0])
+            assertThat(this.items[1]).isEqualTo(BlockListItem.Empty)
+        }
+    }
+
+    @Test
+    fun `maps error item to UI model`() = test {
+        val forced = false
+        val message = "Generic error"
+        whenever(insightsStore.fetchTodayInsights(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        StatsError(GENERIC_ERROR, message)
+                )
+        )
+
+        val result = useCase.loadTodayStats(site, forced)
+
+        assertThat(result.type).isEqualTo(FAILED)
+        (result as Failed).apply {
+            assertThat(this.failedType).isEqualTo(R.string.stats_insights_today_stats)
+            assertThat(this.errorMessage).isEqualTo(message)
+        }
+    }
+
+    private fun assertTitle(item: BlockListItem) {
+        assertThat(item.type).isEqualTo(TITLE)
+        assertThat((item as Title).text).isEqualTo(R.string.stats_insights_today_stats)
+    }
+
+    private fun assertViews(blockListItem: BlockListItem, showDivider: Boolean = false) {
+        assertThat(blockListItem.type).isEqualTo(ITEM)
+        val item = blockListItem as BlockListItem.Item
+        assertThat(item.text).isEqualTo(R.string.stats_views)
+        assertThat(item.showDivider).isEqualTo(showDivider)
+        assertThat(item.icon).isEqualTo(R.drawable.ic_visible_on_grey_dark_24dp)
+        assertThat(item.value).isEqualTo(views.toString())
+    }
+
+    private fun assertVisitors(blockListItem: BlockListItem, showDivider: Boolean = false) {
+        assertThat(blockListItem.type).isEqualTo(ITEM)
+        val item = blockListItem as BlockListItem.Item
+        assertThat(item.text).isEqualTo(R.string.stats_visitors)
+        assertThat(item.showDivider).isEqualTo(showDivider)
+        assertThat(item.icon).isEqualTo(R.drawable.ic_user_grey_dark_24dp)
+        assertThat(item.value).isEqualTo(visitors.toString())
+    }
+
+    private fun assertLikes(blockListItem: BlockListItem, showDivider: Boolean = false) {
+        assertThat(blockListItem.type).isEqualTo(ITEM)
+        val item = blockListItem as BlockListItem.Item
+        assertThat(item.text).isEqualTo(R.string.stats_likes)
+        assertThat(item.showDivider).isEqualTo(showDivider)
+        assertThat(item.icon).isEqualTo(R.drawable.ic_star_grey_dark_24dp)
+        assertThat(item.value).isEqualTo(likes.toString())
+    }
+
+    private fun assertComments(blockListItem: BlockListItem, showDivider: Boolean = false) {
+        assertThat(blockListItem.type).isEqualTo(ITEM)
+        val item = blockListItem as BlockListItem.Item
+        assertThat(item.text).isEqualTo(R.string.stats_comments)
+        assertThat(item.showDivider).isEqualTo(showDivider)
+        assertThat(item.icon).isEqualTo(R.drawable.ic_comment_grey_dark_24dp)
+        assertThat(item.value).isEqualTo(comments.toString())
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '541da043da76a9600f2dfe16cd2b71d94b8c485d'
+    fluxCVersion = '933c3e22910732fe29e37da9fa5d937b021031b3'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '933c3e22910732fe29e37da9fa5d937b021031b3'
+    fluxCVersion = '2d29e71c6f7f4025e1b74f9b11c93e633fa3c246'
 }


### PR DESCRIPTION
Fixes #8528 

Adds a Today stats block on the second position to Stats page. The block contains Views/Visitors/Likes/Comments and hides any of those when they are == 0. When there are not data, we show an empty message.

This PR is a good one for someone who hasn't reviewed anything on the Stats refresh yet and wants to try - @malinajirka @theck13 @khaykov. It doesn't need more than one reviewer but feel free to check it if you want.

To test:
* Open Stats on a site with higher traffic
* See the Today's stats block with relevant lines with data

To test 2:
* Open Stats on a site with no traffic
* See the Today's stats block with an `No data yet` message
