### PR TITLE
Feature/8537 site creation segments ui

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentViewHolder.kt
@@ -8,19 +8,19 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.vertical.VerticalSegmentModel
-import org.wordpress.android.util.StringUtils
+import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentsViewModel.ItemUiState
+import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentsViewModel.ItemUiState.HeaderUiState
+import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentsViewModel.ItemUiState.SegmentUiState
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.IMAGE
 
 sealed class NewSiteCreationSegmentViewHolder(internal val parent: ViewGroup, @LayoutRes layout: Int) :
         RecyclerView.ViewHolder(LayoutInflater.from(parent.context).inflate(layout, parent, false)) {
-    abstract fun onBind(model: VerticalSegmentModel, isLast: Boolean)
+    abstract fun onBind(uiState: ItemUiState)
 
-    class SegmentViewHolder(
+    class SegmentsItemViewHolder(
         parentView: ViewGroup,
-        private val imageManager: ImageManager,
-        private val onItemTapped: (VerticalSegmentModel) -> Unit
+        private val imageManager: ImageManager
     ) : NewSiteCreationSegmentViewHolder(parentView, R.layout.new_site_creation_segment_item) {
         private val container = itemView.findViewById<ViewGroup>(R.id.container)
         private val icon = itemView.findViewById<ImageView>(R.id.icon)
@@ -28,12 +28,32 @@ sealed class NewSiteCreationSegmentViewHolder(internal val parent: ViewGroup, @L
         private val subtitle = itemView.findViewById<TextView>(R.id.subtitle)
         private val divider = itemView.findViewById<View>(R.id.divider)
 
-        override fun onBind(model: VerticalSegmentModel, isLast: Boolean) {
-            title.text = model.title
-            subtitle.text = model.subtitle
-            imageManager.load(icon, IMAGE, model.iconUrl)
-            container.setOnClickListener { onItemTapped(model) }
-            divider.visibility = if (isLast) View.GONE else View.VISIBLE
+        override fun onBind(uiState: ItemUiState) {
+            uiState as SegmentUiState
+            title.text = uiState.title
+            subtitle.text = uiState.subtitle
+            imageManager.load(icon, IMAGE, uiState.iconUrl)
+            container.setOnClickListener { uiState.onItemTapped }
+            divider.visibility = if (uiState.showDivider) View.VISIBLE else View.GONE
         }
+    }
+
+    class SegmentsHeaderViewHolder(
+        parentView: ViewGroup
+    ) : NewSiteCreationSegmentViewHolder(parentView, R.layout.new_site_creation_segments_header_item) {
+        private val title = itemView.findViewById<TextView>(R.id.title)
+        private val subtitle = itemView.findViewById<TextView>(R.id.subtitle)
+
+        override fun onBind(uiState: ItemUiState) {
+            uiState as HeaderUiState
+            title.text = parent.context.getText(uiState.titleResId)
+            subtitle.text = parent.context.getText(uiState.subtitleResId)
+        }
+    }
+
+    class SegmentsProgressViewHolder(
+        parentView: ViewGroup
+    ) : NewSiteCreationSegmentViewHolder(parentView, R.layout.new_site_creation_segments_progress) {
+        override fun onBind(uiState: ItemUiState) {}
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentViewHolder.kt
@@ -1,0 +1,39 @@
+package org.wordpress.android.ui.sitecreation.segments
+
+import android.support.annotation.LayoutRes
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.vertical.VerticalSegmentModel
+import org.wordpress.android.util.StringUtils
+import org.wordpress.android.util.image.ImageManager
+import org.wordpress.android.util.image.ImageType.IMAGE
+
+sealed class NewSiteCreationSegmentViewHolder(internal val parent: ViewGroup, @LayoutRes layout: Int) :
+        RecyclerView.ViewHolder(LayoutInflater.from(parent.context).inflate(layout, parent, false)) {
+    abstract fun onBind(model: VerticalSegmentModel, isLast: Boolean)
+
+    class SegmentViewHolder(
+        parentView: ViewGroup,
+        private val imageManager: ImageManager,
+        private val onItemTapped: (VerticalSegmentModel) -> Unit
+    ) : NewSiteCreationSegmentViewHolder(parentView, R.layout.new_site_creation_segment_item) {
+        private val container = itemView.findViewById<ViewGroup>(R.id.container)
+        private val icon = itemView.findViewById<ImageView>(R.id.icon)
+        private val title = itemView.findViewById<TextView>(R.id.title)
+        private val subtitle = itemView.findViewById<TextView>(R.id.subtitle)
+        private val divider = itemView.findViewById<View>(R.id.divider)
+
+        override fun onBind(model: VerticalSegmentModel, isLast: Boolean) {
+            title.text = model.title
+            subtitle.text = model.subtitle
+            imageManager.load(icon, IMAGE, StringUtils.notNullStr(model.iconUrl))
+            container.setOnClickListener { onItemTapped(model) }
+            divider.visibility = if (isLast) View.GONE else View.VISIBLE
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentViewHolder.kt
@@ -31,7 +31,7 @@ sealed class NewSiteCreationSegmentViewHolder(internal val parent: ViewGroup, @L
         override fun onBind(model: VerticalSegmentModel, isLast: Boolean) {
             title.text = model.title
             subtitle.text = model.subtitle
-            imageManager.load(icon, IMAGE, StringUtils.notNullStr(model.iconUrl))
+            imageManager.load(icon, IMAGE, model.iconUrl)
             container.setOnClickListener { onItemTapped(model) }
             divider.visibility = if (isLast) View.GONE else View.VISIBLE
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsAdapter.kt
@@ -13,7 +13,7 @@ class NewSiteCreationSegmentsAdapter(
 ) : Adapter<NewSiteCreationSegmentViewHolder>() {
     private val items = mutableListOf<VerticalSegmentModel>()
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SegmentViewHolder {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NewSiteCreationSegmentViewHolder {
         return SegmentViewHolder(parent, imageManager, onItemTapped)
     }
 
@@ -33,8 +33,7 @@ class NewSiteCreationSegmentsAdapter(
     private class SegmentsDiffUtils(
         val oldItems: List<VerticalSegmentModel>,
         val newItems: List<VerticalSegmentModel>
-    ) :
-            DiffUtil.Callback() {
+    ) : DiffUtil.Callback() {
         override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
             val oldItem = oldItems[oldItemPosition]
             val newItem = newItems[newItemPosition]

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsAdapter.kt
@@ -30,7 +30,10 @@ class NewSiteCreationSegmentsAdapter(
         diffResult.dispatchUpdatesTo(this)
     }
 
-    private class SegmentsDiffUtils(val oldItems: List<VerticalSegmentModel>, val newItems: List<VerticalSegmentModel>) :
+    private class SegmentsDiffUtils(
+        val oldItems: List<VerticalSegmentModel>,
+        val newItems: List<VerticalSegmentModel>
+    ) :
             DiffUtil.Callback() {
         override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
             val oldItem = oldItems[oldItemPosition]

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsAdapter.kt
@@ -1,0 +1,49 @@
+package org.wordpress.android.ui.sitecreation.segments
+
+import android.support.v7.util.DiffUtil
+import android.support.v7.widget.RecyclerView.Adapter
+import android.view.ViewGroup
+import org.wordpress.android.fluxc.model.vertical.VerticalSegmentModel
+import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentViewHolder.SegmentViewHolder
+import org.wordpress.android.util.image.ImageManager
+
+class NewSiteCreationSegmentsAdapter(
+    private val onItemTapped: (VerticalSegmentModel) -> Unit = { },
+    private val imageManager: ImageManager
+) : Adapter<NewSiteCreationSegmentViewHolder>() {
+    private val items = mutableListOf<VerticalSegmentModel>()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SegmentViewHolder {
+        return SegmentViewHolder(parent, imageManager, onItemTapped)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: NewSiteCreationSegmentViewHolder, position: Int) {
+        holder.onBind(items[position], isLast = position == items.size - 1)
+    }
+
+    fun update(newItems: List<VerticalSegmentModel>) {
+        val diffResult = DiffUtil.calculateDiff(SegmentsDiffUtils(items.toList(), newItems))
+        items.clear()
+        items.addAll(newItems)
+        diffResult.dispatchUpdatesTo(this)
+    }
+
+    private class SegmentsDiffUtils(val oldItems: List<VerticalSegmentModel>, val newItems: List<VerticalSegmentModel>) :
+            DiffUtil.Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val oldItem = oldItems[oldItemPosition]
+            val newItem = newItems[newItemPosition]
+            return oldItem.segmentId == newItem.segmentId
+        }
+
+        override fun getOldListSize(): Int = oldItems.size
+
+        override fun getNewListSize(): Int = newItems.size
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return oldItems[oldItemPosition] == newItems[newItemPosition]
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
@@ -13,9 +13,9 @@ import android.view.ViewGroup
 import android.widget.Button
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
-import org.wordpress.android.fluxc.model.vertical.VerticalSegmentModel
 import org.wordpress.android.ui.sitecreation.NewSiteCreationBaseFormFragment
 import org.wordpress.android.ui.sitecreation.NewSiteCreationListener
+import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentsViewModel.ItemUiState
 import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
 
@@ -26,9 +26,7 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteC
     private lateinit var recyclerView: RecyclerView
     private lateinit var viewModel: NewSiteCreationSegmentsViewModel
 
-    private lateinit var progressLayout: ViewGroup
     private lateinit var errorLayout: ViewGroup
-    private lateinit var headerLayout: ViewGroup
 
     @Inject protected lateinit var imageManager: ImageManager
     @Inject protected lateinit var viewModelFactory: ViewModelProvider.Factory
@@ -41,8 +39,6 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteC
     override fun setupContent(rootView: ViewGroup) {
         // important for accessibility - talkback
         activity!!.setTitle(R.string.new_site_creation_segments_title)
-        headerLayout = rootView.findViewById(R.id.header_layout)
-        progressLayout = rootView.findViewById(R.id.progress_layout)
         errorLayout = rootView.findViewById(R.id.error_layout)
         initRecyclerView(rootView)
         initViewModel()
@@ -58,10 +54,7 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteC
     }
 
     private fun initAdapter() {
-        val adapter = NewSiteCreationSegmentsAdapter(
-                onItemTapped = { segment -> viewModel.onSegmentSelected(segment.segmentId) },
-                imageManager = imageManager
-        )
+        val adapter = NewSiteCreationSegmentsAdapter(imageManager = imageManager)
         recyclerView.adapter = adapter
     }
 
@@ -71,11 +64,9 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteC
 
         viewModel.uiState.observe(this, Observer { state ->
             state?.let {
-                progressLayout.visibility = if (state.showProgress) View.VISIBLE else View.GONE
-                headerLayout.visibility = if (state.showHeader) View.VISIBLE else View.GONE
                 recyclerView.visibility = if (state.showList) View.VISIBLE else View.GONE
                 errorLayout.visibility = if (state.showError) View.VISIBLE else View.GONE
-                updateSegments(state.data)
+                updateSegments(state.items)
             }
         })
 
@@ -110,7 +101,7 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteC
         }
     }
 
-    private fun updateSegments(segments: List<VerticalSegmentModel>) {
+    private fun updateSegments(segments: List<ItemUiState>) {
         (recyclerView.adapter as NewSiteCreationSegmentsAdapter).update(segments)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
@@ -64,7 +64,7 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteC
 
         viewModel.uiState.observe(this, Observer { state ->
             state?.let {
-                recyclerView.visibility = if (state.showList) View.VISIBLE else View.GONE
+                recyclerView.visibility = if (state.showContent) View.VISIBLE else View.GONE
                 errorLayout.visibility = if (state.showError) View.VISIBLE else View.GONE
                 updateSegments(state.items)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
@@ -1,21 +1,36 @@
 package org.wordpress.android.ui.sitecreation.segments
 
+import android.arch.lifecycle.Observer
+import android.arch.lifecycle.ViewModelProvider
+import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.os.Parcelable
 import android.support.annotation.LayoutRes
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
+import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.model.vertical.VerticalSegmentModel
 import org.wordpress.android.ui.sitecreation.NewSiteCreationBaseFormFragment
 import org.wordpress.android.ui.sitecreation.NewSiteCreationListener
-import org.wordpress.android.util.DisplayUtils
-import org.wordpress.android.widgets.RecyclerItemDecoration
+import org.wordpress.android.util.image.ImageManager
+import javax.inject.Inject
 
 class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteCreationListener>() {
-    private var linearLayoutManager: LinearLayoutManager? = null
     private val keyListState = "list_state"
+    private lateinit var linearLayoutManager: LinearLayoutManager
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var viewModel: NewSiteCreationSegmentsViewModel
+
+    private lateinit var contentLayout: ViewGroup
+    private lateinit var progressLayout: ViewGroup
+    private lateinit var errorLayout: ViewGroup
+
+    @Inject protected lateinit var imageManager: ImageManager
+    @Inject protected lateinit var viewModelFactory: ViewModelProvider.Factory
 
     @LayoutRes
     override fun getContentLayout(): Int {
@@ -24,21 +39,48 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteC
 
     override fun setupContent(rootView: ViewGroup) {
         // important for accessibility - talkback
-        activity!!.setTitle(R.string.site_creation_category_title)
+        activity!!.setTitle(R.string.new_site_creation_segments_title)
+        contentLayout = rootView.findViewById(R.id.content_layout)
+        progressLayout = rootView.findViewById(R.id.progress_layout)
+        errorLayout = rootView.findViewById(R.id.error_layout)
         initRecyclerView(rootView)
+        initViewModel()
+        initRetryButton(rootView)
     }
 
     private fun initRecyclerView(rootView: ViewGroup) {
-        val recyclerView = rootView.findViewById<RecyclerView>(R.id.recycler_view)
+        recyclerView = rootView.findViewById(R.id.recycler_view)
         val layoutManager = LinearLayoutManager(activity, LinearLayoutManager.VERTICAL, false)
         linearLayoutManager = layoutManager
         recyclerView.layoutManager = linearLayoutManager
-        recyclerView.addItemDecoration(
-                RecyclerItemDecoration(
-                        DisplayUtils.dpToPx(activity, 72),
-                        DisplayUtils.dpToPx(activity, 1)
-                )
-        )
+    }
+
+    private fun initViewModel() {
+        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+                .get(NewSiteCreationSegmentsViewModel::class.java)
+
+        viewModel.categories.observe(this, Observer { segments -> segments?.let { updateSegments(segments) } })
+        viewModel.showError.observe(this, Observer { showError ->
+            showError?.let {
+                if (showError) {
+                    showError()
+                }
+            }
+        })
+        viewModel.showProgress.observe(this, Observer { showProgress ->
+            showProgress?.let {
+                if (showProgress) {
+                    showProgress()
+                }
+            }
+        })
+
+        viewModel.start()
+    }
+
+    private fun initRetryButton(rootView: ViewGroup) {
+        val retryBtn = rootView.findViewById<Button>(R.id.error_retry)
+        retryBtn.setOnClickListener { view -> viewModel.onRetryClicked() }
     }
 
     override fun onHelp() {
@@ -54,16 +96,51 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteC
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        linearLayoutManager?.let {
-            outState.putParcelable(keyListState, it.onSaveInstanceState())
-        }
+        outState.putParcelable(keyListState, linearLayoutManager.onSaveInstanceState())
     }
 
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
         super.onViewStateRestored(savedInstanceState)
         savedInstanceState?.getParcelable<Parcelable>(keyListState)?.let {
-            linearLayoutManager?.onRestoreInstanceState(it)
+            linearLayoutManager.onRestoreInstanceState(it)
         }
+    }
+
+    private fun updateSegments(segments: List<VerticalSegmentModel>) {
+        val adapter: NewSiteCreationSegmentsAdapter
+        if (recyclerView.adapter == null) {
+            adapter = NewSiteCreationSegmentsAdapter(
+                    onItemTapped = { segment -> viewModel.onSegmentSelected(segment.segmentId) },
+                    imageManager = imageManager
+            )
+            recyclerView.adapter = adapter
+        } else {
+            adapter = recyclerView.adapter as NewSiteCreationSegmentsAdapter
+        }
+
+        showContent()
+        adapter.update(segments)
+    }
+
+    private fun showContent() {
+        contentLayout.visibility = View.VISIBLE
+        recyclerView.visibility = View.VISIBLE
+        progressLayout.visibility = View.GONE
+        errorLayout.visibility = View.GONE
+    }
+
+    private fun showProgress() {
+        contentLayout.visibility = View.VISIBLE
+        recyclerView.visibility = View.GONE
+        progressLayout.visibility = View.VISIBLE
+        errorLayout.visibility = View.GONE
+    }
+
+    private fun showError() {
+        contentLayout.visibility = View.GONE
+        progressLayout.visibility = View.GONE
+        recyclerView.visibility = View.GONE
+        errorLayout.visibility = View.VISIBLE
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
@@ -19,13 +19,13 @@ import org.wordpress.android.ui.sitecreation.NewSiteCreationListener
 import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
 
+private const val keyListState = "list_state"
+
 class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteCreationListener>() {
-    private val keyListState = "list_state"
     private lateinit var linearLayoutManager: LinearLayoutManager
     private lateinit var recyclerView: RecyclerView
     private lateinit var viewModel: NewSiteCreationSegmentsViewModel
 
-    private lateinit var contentLayout: ViewGroup
     private lateinit var progressLayout: ViewGroup
     private lateinit var errorLayout: ViewGroup
     private lateinit var headerLayout: ViewGroup

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModel.kt
@@ -30,7 +30,7 @@ class NewSiteCreationSegmentsViewModel
     @Named(MAIN_DISPATCHER) private val MAIN: CoroutineDispatcher,
     @Named(IO_DISPATCHER) private val IO: CoroutineDispatcher
 ) : ViewModel(), CoroutineScope {
-    val fetchCategoriesJob: Job = Job()
+    private val fetchCategoriesJob: Job = Job()
     override val coroutineContext: CoroutineContext
         get() = IO + fetchCategoriesJob
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModel.kt
@@ -103,8 +103,11 @@ class NewSiteCreationSegmentsViewModel
         listState = state
         _uiState.value = UiState(
                 showError = state is Error,
-                showList = state !is Error,
-                items = createUiStatesForItems(state is Loading, state.data)
+                showContent = state !is Error,
+                items = if (state is Error)
+                    emptyList()
+                else
+                    createUiStatesForItems(showProgress = state is Loading, segments = state.data)
         )
     }
 
@@ -150,7 +153,7 @@ class NewSiteCreationSegmentsViewModel
 
     data class UiState(
         val showError: Boolean,
-        val showList: Boolean,
+        val showContent: Boolean,
         val items: List<ItemUiState>
     )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.experimental.CoroutineScope
 import kotlinx.coroutines.experimental.Job
 import kotlinx.coroutines.experimental.launch
 import kotlinx.coroutines.experimental.withContext
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.vertical.VerticalSegmentModel
@@ -49,7 +50,13 @@ class NewSiteCreationSegmentsViewModel
     }
 
     private fun fetchCategories() {
-        if (!listState.shouldFetch(loadMore = false)) throw IllegalStateException("Fetch already in progress.")
+        if (!listState.shouldFetch(loadMore = false)) {
+            if(BuildConfig.DEBUG){
+                throw IllegalStateException("Fetch already in progress.")
+            } else {
+                return
+            }
+        }
         launch {
             withContext(MAIN) {
                 updateUIState(ListState.Loading(listState))

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModel.kt
@@ -81,7 +81,7 @@ class NewSiteCreationSegmentsViewModel
         fetchCategories()
     }
 
-    fun onSegmentSelected(segmentId: Int) {
+    fun onSegmentSelected(segmentId: Long) {
         // TODO send result to the SCMainVM
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchSegmentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchSegmentsUseCase.kt
@@ -4,6 +4,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.VerticalActionBuilder
+import org.wordpress.android.fluxc.store.VerticalStore
 import org.wordpress.android.fluxc.store.VerticalStore.OnSegmentsFetched
 import javax.inject.Inject
 import kotlin.coroutines.experimental.Continuation
@@ -12,7 +13,10 @@ import kotlin.coroutines.experimental.suspendCoroutine
 /**
  * Transforms EventBus event to a coroutines.
  */
-class FetchSegmentsUseCase @Inject constructor(val dispatcher: Dispatcher) {
+class FetchSegmentsUseCase @Inject constructor(
+    val dispatcher: Dispatcher,
+    @Suppress("unused") val verticalStore: VerticalStore
+) {
     private var continuation: Continuation<OnSegmentsFetched>? = null
 
     suspend fun fetchCategories(): OnSegmentsFetched {

--- a/WordPress/src/main/res/layout/new_site_creation_segment_item.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_segment_item.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/white"
+    android:foreground="?selectableItemBackground"
+    android:minHeight="@dimen/site_creation_list_min_item_height">
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="@dimen/site_creation_segments_icon_size"
+        android:layout_height="@dimen/site_creation_segments_icon_size"
+        android:layout_marginEnd="@dimen/margin_medium"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:contentDescription="@null"
+        app:layout_constraintBottom_toTopOf="@+id/subtitle"
+        app:layout_constraintEnd_toStartOf="@+id/title"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/title"
+        tools:srcCompat="@drawable/ic_add_grey_24dp"/>
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/site_creation_list_divider_start_margin"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:textColor="@color/wp_grey_dark"
+        android:textSize="@dimen/text_sz_large"
+        app:layout_constraintBottom_toTopOf="@+id/subtitle"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="1 2 3 4 5 6 7 8 9 1 2 3 4 5 6 7 8 9 1 2 3 4 5 6 7 8 9"/>
+
+    <TextView
+        android:id="@+id/subtitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_extra_large"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/site_creation_list_divider_start_margin"
+        android:textColor="@color/wp_grey_darken_20"
+        android:textSize="@dimen/text_sz_medium"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/title"
+        tools:text="1 2 3 4 5 6 7 8 9 1 2 3 4 5 6 7 8 9 1 2 3 4 5 6 7 8 9 1 2 3 4 5 6 7 8 9 1 2 3 4 5 6 7 8 9 1 2 3 4 5 6 7 8 9 1 2 3 4 5 6 7 8 9 "/>
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginStart="@dimen/site_creation_list_divider_start_margin"
+        android:background="@color/wp_grey_lighten_30"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="1.0"/>
+</android.support.constraint.ConstraintLayout>

--- a/WordPress/src/main/res/layout/new_site_creation_segments_header_item.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_segments_header_item.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/site_creation_segments_content_padding_vertical"
+    android:paddingEnd="@dimen/site_creation_segments_content_padding_horizontal"
+    android:paddingStart="@dimen/site_creation_segments_content_padding_horizontal"
+    android:paddingTop="@dimen/site_creation_segments_content_padding_vertical">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fontFamily="sans-serif-medium"
+        android:gravity="center"
+        android:textColor="@color/wp_grey_dark"
+        android:textSize="@dimen/text_sz_large"
+        tools:text="Tell us what kind of site you'd like to make"/>
+
+    <TextView
+        android:id="@+id/subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_medium"
+        android:gravity="center"
+        android:textColor="@color/wp_grey_darken_20"
+        android:textSize="@dimen/text_sz_medium"
+        tools:text="This helps us make recommendations. But you're never locked in - all sites evolve!"/>
+</LinearLayout>

--- a/WordPress/src/main/res/layout/new_site_creation_segments_progress.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_segments_progress.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/progress_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content"
+    android:gravity="center">
 
     <ProgressBar
         android:id="@+id/progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"/>
-</FrameLayout>
+        android:layout_gravity="center"
+        android:layout_marginBottom="@dimen/margin_large"
+        android:layout_marginTop="@dimen/margin_large"/>
+</LinearLayout>

--- a/WordPress/src/main/res/layout/new_site_creation_segments_screen.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_segments_screen.xml
@@ -1,13 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <android.support.v7.widget.RecyclerView
-        android:id="@+id/recyclerView"
+    <LinearLayout
+        android:id="@+id/content_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:scrollbars="vertical"/>
+        android:orientation="vertical">
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:orientation="vertical"
+            android:paddingBottom="@dimen/site_creation_segments_content_padding_vertical"
+            android:paddingEnd="@dimen/site_creation_segments_content_padding_horizontal"
+            android:paddingStart="@dimen/site_creation_segments_content_padding_horizontal"
+            android:paddingTop="@dimen/site_creation_segments_content_padding_vertical">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-medium"
+                android:gravity="center"
+                android:text="@string/site_creation_segments_title"
+                android:textColor="@color/wp_grey_dark"
+                android:textSize="@dimen/text_sz_large"
+                tools:text="Tell us what kind of site you'd like to make"/>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_medium"
+                android:gravity="center"
+                android:text="@string/site_creation_segments_subtitle"
+                android:textColor="@color/wp_grey_darken_20"
+                android:textSize="@dimen/text_sz_medium"
+                tools:text="This helps us make recommendations. But you're never locked in - all sites evolve!"/>
+        </LinearLayout>
+
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scrollbars="vertical"
+            />
+
+        <include
+            layout="@layout/site_creation_progress"
+            tools:visibility="gone"/>
+
+    </LinearLayout>
+
+    <include
+        layout="@layout/site_creation_error_with_retry"/>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/new_site_creation_segments_screen.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_segments_screen.xml
@@ -12,54 +12,10 @@
         layout="@layout/site_creation_error_with_retry"
         tools:visibility="gone"/>
 
-    <LinearLayout
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
-
-        <LinearLayout
-            android:id="@+id/header_layout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:orientation="vertical"
-            android:paddingBottom="@dimen/site_creation_segments_content_padding_vertical"
-            android:paddingEnd="@dimen/site_creation_segments_content_padding_horizontal"
-            android:paddingStart="@dimen/site_creation_segments_content_padding_horizontal"
-            android:paddingTop="@dimen/site_creation_segments_content_padding_vertical">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:fontFamily="sans-serif-medium"
-                android:gravity="center"
-                android:text="@string/site_creation_segments_title"
-                android:textColor="@color/wp_grey_dark"
-                android:textSize="@dimen/text_sz_large"
-                tools:text="Tell us what kind of site you'd like to make"/>
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_medium"
-                android:gravity="center"
-                android:text="@string/site_creation_segments_subtitle"
-                android:textColor="@color/wp_grey_darken_20"
-                android:textSize="@dimen/text_sz_medium"
-                tools:text="This helps us make recommendations. But you're never locked in - all sites evolve!"/>
-        </LinearLayout>
-
-        <android.support.v7.widget.RecyclerView
-            android:id="@+id/recycler_view"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scrollbars="vertical"
-            />
-
-        <include
-            layout="@layout/site_creation_progress"
-            tools:visibility="gone"/>
-
-    </LinearLayout>
-
+        android:scrollbars="vertical"
+        />
 </LinearLayout>

--- a/WordPress/src/main/res/layout/new_site_creation_segments_screen.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_segments_screen.xml
@@ -4,10 +4,13 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:paddingEnd="@dimen/site_creation_screen_horizontal_padding"
+    android:paddingStart="@dimen/site_creation_screen_horizontal_padding">
 
     <include
-        layout="@layout/site_creation_error_with_retry"/>
+        layout="@layout/site_creation_error_with_retry"
+        tools:visibility="gone"/>
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/new_site_creation_segments_screen.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_segments_screen.xml
@@ -6,13 +6,16 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <include
+        layout="@layout/site_creation_error_with_retry"/>
+
     <LinearLayout
-        android:id="@+id/content_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
 
         <LinearLayout
+            android:id="@+id/header_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -56,6 +59,4 @@
 
     </LinearLayout>
 
-    <include
-        layout="@layout/site_creation_error_with_retry"/>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/site_creation_error_with_retry.xml
+++ b/WordPress/src/main/res/layout/site_creation_error_with_retry.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/error_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/error_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="TODO"/>
+
+    <Button
+        android:id="@+id/error_retry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/retry"/>
+</LinearLayout>

--- a/WordPress/src/main/res/layout/site_creation_progress.xml
+++ b/WordPress/src/main/res/layout/site_creation_progress.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/progress_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"/>
+</FrameLayout>

--- a/WordPress/src/main/res/values-sw600dp/dimens.xml
+++ b/WordPress/src/main/res/values-sw600dp/dimens.xml
@@ -9,4 +9,5 @@
     <dimen name="media_settings_margin">@dimen/media_settings_margin_tablet</dimen>
 
     <dimen name="bottom_sheet_dialog_width">300dp</dimen>
+    <dimen name="site_creation_screen_horizontal_padding">128dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -350,4 +350,11 @@
     <dimen name="post_list_row_skeleton_view_date_width">80dp</dimen>
     <dimen name="post_list_row_skeleton_view_date_height">@dimen/margin_extra_large</dimen>
 
+    <!--site creation-->
+    <dimen name="site_creation_segments_icon_size">24dp</dimen>
+    <dimen name="site_creation_list_divider_start_margin">72dp</dimen>
+    <dimen name="site_creation_list_min_item_height">72dp</dimen>
+    <dimen name="site_creation_segments_content_padding_vertical">24dp</dimen>
+    <dimen name="site_creation_segments_content_padding_horizontal">16dp</dimen>
+
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -351,6 +351,7 @@
     <dimen name="post_list_row_skeleton_view_date_height">@dimen/margin_extra_large</dimen>
 
     <!--site creation-->
+    <dimen name="site_creation_screen_horizontal_padding">0dp</dimen>
     <dimen name="site_creation_segments_icon_size">24dp</dimen>
     <dimen name="site_creation_list_divider_start_margin">72dp</dimen>
     <dimen name="site_creation_list_min_item_height">72dp</dimen>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2341,5 +2341,8 @@
     <string name="news_card_announcement_action_sample_announcement">[Read more]</string>
     <!--suppress UnusedResources -->
     <string name="news_card_announcement_action_url_sample_announcement" translatable="false">https://en.blog.wordpress.com/2018/06/21/bookmark-posts-with-save-for-later/</string>
+    <string name="site_creation_segments_title">Tell us what kind of site you\’d like to make</string>
+    <string name="site_creation_segments_subtitle">This helps us make recommendations. But you’re never locked in — all sites evolve!</string>
+    <string name="new_site_creation_segments_title">Create Site</string>
     <!-- END (News Card) -->
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
@@ -164,6 +164,6 @@ class NewSiteCreationSegmentsViewModelTest {
         viewModel.start()
 
         val items = viewModel.uiState.value!!.items
-        assertFalse((items[items.size-1] as SegmentUiState).showDivider)
+        assertFalse((items[items.size - 1] as SegmentUiState).showDivider)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchSegmentsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchSegmentsUseCaseTest.kt
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.store.VerticalStore
 import org.wordpress.android.fluxc.store.VerticalStore.OnSegmentsFetched
 import org.wordpress.android.test
 
@@ -20,12 +21,13 @@ class FetchSegmentsUseCaseTest {
     @JvmField val rule = InstantTaskExecutorRule()
 
     @Mock lateinit var dispatcher: Dispatcher
+    @Mock lateinit var store: VerticalStore
     private lateinit var useCase: FetchSegmentsUseCase
     private val event = OnSegmentsFetched(emptyList(), null)
 
     @Before
     fun setUp() {
-        useCase = FetchSegmentsUseCase(dispatcher)
+        useCase = FetchSegmentsUseCase(dispatcher, store)
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '8df94afedd2d293299dac1e3caacf09503dcbb72'
+    fluxCVersion = 'db2b65ad319aec4312dcc93a0a71ee80e8392a0a'
 }


### PR DESCRIPTION
Fixes #8537 

This PR is based on the branch from #8532 and therefor it's change set is big -> I recommend reviewing it after the #8532 is merged.

Adds UI to the SiteCreation - segments screen. 

Error screen - We don't have a design for the error screen yet, therefor this PR introduces just a dummy screen.

To test - change `NEW_SITE_CREATION_ENABLED` build time variable to 'true' in build.gradle
1. Go to My Site 
2. Click on Switch Site
3. Click on Plus sign icon
4. Select Create WordPress.com site
5. Test the screen - progress, list, error with retry (+rotate your device and test tablet layout)
Notes: 
- Selecting a Segment doesn't have any effect yet.
- you need to modify code in order to test error state since we are using a mocked api -> for example add `event.error = FetchSegmentsError(GENERIC_ERROR,"test")` into `FetchSegmentsUseCase.onSiteCategoriesFetched()`
