### PR TITLE
Ability to set the Image block's image from the media library

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -94,6 +94,7 @@ import org.wordpress.aztec.util.AztecLog;
 import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder;
 import org.wordpress.mobile.ReactNativeAztec.ReactAztecPackage;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent;
+import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.MediaSelectedCallback;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.RNReactNativeGutenbergBridgePackage;
 import org.xml.sax.Attributes;
 
@@ -173,6 +174,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     private ReactInstanceManager mReactInstanceManager;
     private ReactContext mReactContext;
     private RNReactNativeGutenbergBridgePackage mRnReactNativeGutenbergBridgePackage;
+    private MediaSelectedCallback mPendingMediaSelectedCallback;
 
     private String mContentHtml = "";
     private CountDownLatch mGetContentCountDownLatch;
@@ -257,8 +259,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                 mGetContentCountDownLatch.countDown();
             }
 
-            @Override
-            public void onMediaLibraryPress() {
+            @Override public void onMediaLibraryPress(MediaSelectedCallback mediaSelectedCallback) {
+                mPendingMediaSelectedCallback = mediaSelectedCallback;
                 onToolbarMediaButtonClicked();
             }
         });
@@ -1071,7 +1073,10 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
             return;
         }
 
-        mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule().setImageSource(mediaUrl);
+        if (mPendingMediaSelectedCallback != null) {
+            mPendingMediaSelectedCallback.onMediaSelected(mediaUrl);
+            mPendingMediaSelectedCallback = null;
+        }
 
 //        if (URLUtil.isNetworkUrl(mediaUrl)) {
 //            final AztecAttributes attributes = new AztecAttributes();

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -256,6 +256,11 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                 mContentHtml = html;
                 mGetContentCountDownLatch.countDown();
             }
+
+            @Override
+            public void onMediaLibraryPress() {
+                onToolbarMediaButtonClicked();
+            }
         });
         return Arrays.asList(
                 new MainReactPackage(),
@@ -1058,14 +1063,16 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void appendMediaFile(final MediaFile mediaFile, final String mediaUrl, ImageLoader imageLoader) {
-//        if (getActivity() == null) {
-//            // appendMediaFile may be called from a background thread (example: EditPostActivity.java#L2165) and
-//            // Activity may have already be gone.
-//            // Ticket: https://github.com/wordpress-mobile/WordPress-Android/issues/7386
-//            AppLog.d(T.MEDIA, "appendMediaFile() called but Activity is null! mediaUrl: " + mediaUrl);
-//            return;
-//        }
-//
+        if (getActivity() == null) {
+            // appendMediaFile may be called from a background thread (example: EditPostActivity.java#L2165) and
+            // Activity may have already be gone.
+            // Ticket: https://github.com/wordpress-mobile/WordPress-Android/issues/7386
+            AppLog.d(T.MEDIA, "appendMediaFile() called but Activity is null! mediaUrl: " + mediaUrl);
+            return;
+        }
+
+        mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule().setImageSource(mediaUrl);
+
 //        if (URLUtil.isNetworkUrl(mediaUrl)) {
 //            final AztecAttributes attributes = new AztecAttributes();
 //            attributes.setValue(ATTR_SRC, mediaUrl);
@@ -1675,23 +1682,27 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         }
     };
 
-//    @Override
-//    public boolean onToolbarMediaButtonClicked() {
-//        mEditorFragmentListener.onTrackableEvent(TrackableEvent.MEDIA_BUTTON_TAPPED);
-//
-//        if (isActionInProgress()) {
-//            ToastUtils.showToast(getActivity(), R.string.alert_action_while_uploading, ToastUtils.Duration.LONG);
-//        }
-//
-//        if (mSource.isFocused()) {
-//            ToastUtils.showToast(getActivity(), R.string.alert_insert_image_html_mode, ToastUtils.Duration.LONG);
-//        } else {
-//            mEditorFragmentListener.onAddMediaClicked();
-//        }
-//
-//        return true;
-//    }
-//
+    public boolean onToolbarMediaButtonClicked() {
+        mEditorFragmentListener.onTrackableEvent(TrackableEvent.MEDIA_BUTTON_TAPPED);
+
+        if (isActionInProgress()) {
+            ToastUtils.showToast(getActivity(), R.string.alert_action_while_uploading, ToastUtils.Duration.LONG);
+        }
+
+        if (mSource.isFocused()) {
+            ToastUtils.showToast(getActivity(), R.string.alert_insert_image_html_mode, ToastUtils.Duration.LONG);
+        } else {
+            getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    mEditorFragmentListener.onAddMediaClicked();
+                }
+            });
+        }
+
+        return true;
+    }
+
 //    @Override
 //    public void onImageTapped(@NonNull AztecAttributes attrs, int naturalWidth, int naturalHeight) {
 //        onMediaTapped(attrs, naturalWidth, naturalHeight, MediaType.IMAGE);


### PR DESCRIPTION
Target's the still in progress #8522. Let's wait for that one to get merged first.

Adds the ability to select an image from the media library to set on the Image block.

Depends on this PR on the gutenberg-mobile repo: https://github.com/wordpress-mobile/gutenberg-mobile/pull/220.

To test:
1. Follow the steps in Test 1 or 2 from #8522 to run compile/run the integrated app
2. In the native app, add a new Image block by focusing a block, tapping on the "+" button and choosing the Image block from the Inserter
3. Tap on the "MEDIA LIBRARY" button on the image placeholder block to trigger the media picker
4. Use the *WP media library* tab to pick an image from the ones already uploaded to the WP site
5. Notice the image getting updated on the post