### PR TITLE
Issue/8546 site search

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -977,11 +977,22 @@ public class ReaderPostListFragment extends Fragment
                         if (mPostSearchAdapterPos > 0) {
                             mRecyclerView.scrollRecycleViewToPosition(mPostSearchAdapterPos);
                         }
+                        if (getPostAdapter().isEmpty()) {
+                            setEmptyTitleDescriptionAndButton(false);
+                            showEmptyView();
+                        } else {
+                            hideEmptyView();
+                        }
                     } else if (tab.getPosition() == TAB_SITES) {
                         mRecyclerView.setAdapter(getSiteSearchAdapter());
                         if (mSiteSearchAdapterPos > 0) {
                             mRecyclerView.scrollRecycleViewToPosition(mSiteSearchAdapterPos);
                         }
+                        if (getSiteSearchAdapter().isEmpty()) {
+                            setEmptyTitleDescriptionAndButton(false);
+                            showEmptyView();
+                        } else {
+                            hideEmptyView();
                         }
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -893,7 +893,9 @@ public class ReaderPostListFragment extends Fragment
             return;
         }
 
-        mRecyclerView.setRefreshing(false);
+        if (!isUpdating()) {
+            mRecyclerView.setRefreshing(false);
+        }
         showLoadingProgress(false);
 
         ReaderSiteSearchAdapter adapter = getSiteSearchAdapter();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -982,11 +982,6 @@ public class ReaderPostListFragment extends Fragment
                         if (mSiteSearchAdapterPos > 0) {
                             mRecyclerView.scrollRecycleViewToPosition(mSiteSearchAdapterPos);
                         }
-                        // perform a site search if the user switched to the site tab and results aren't already showing
-                        if (getSiteSearchAdapter().isEmpty()
-                            && !TextUtils.isEmpty(mCurrentSearchQuery)
-                            && !isEmptyViewShowing()) {
-                            updateSitesInCurrentSearch(0);
                         }
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1405,8 +1405,12 @@ public class ReaderPostListFragment extends Fragment
                 return;
             }
             if (isEmpty) {
-                setEmptyTitleDescriptionAndButton(false);
-                showEmptyView();
+                if (getPostListType() != ReaderPostListType.SEARCH_RESULTS
+                    || getSearchTabsPosition() == TAB_SITES && getSiteSearchAdapter().isEmpty()
+                    || getSearchTabsPosition() == TAB_POSTS && getPostAdapter().isEmpty()) {
+                    setEmptyTitleDescriptionAndButton(false);
+                    showEmptyView();
+                }
             } else {
                 hideEmptyView();
                 if (mRestorePosition > 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -876,12 +876,7 @@ public class ReaderPostListFragment extends Fragment
         mPostAdapter.setCurrentTag(searchTag);
         mCurrentSearchQuery = trimQuery;
         updatePostsInCurrentSearch(0);
-
-        // only submit a site search if the sites tab is active - otherwise we'll delay the site search
-        // until the user taps the sites tab
-        if (getSearchTabsPosition() == TAB_SITES) {
-            updateSitesInCurrentSearch(0);
-        }
+        updateSitesInCurrentSearch(0);
 
         // track that the user performed a search
         if (!trimQuery.equals("")) {


### PR DESCRIPTION
Fixes #8546.

To test:
1. Open the reader and tap the search icon in the top right to access the reader site search
2. Search for "jeffsbiketour.com"
3. Wait for the search to finish
4. **Notice the post list is empty**
5. Switch to the Sites tab
6. **Notice the list contains one entry**
7. Switch back to the Posts tab
8. **Notice the list is still empty**
9. Switch to the Sites tab
10. Search for "jeffsbiketour"
11. Wait for the search to finish
12. **Notice the list still contains 1 site result**
13. Switch to the Posts tab
14. **Notice the list contains multiple results now**