### PR TITLE
Create followers block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -58,10 +58,14 @@ import org.wordpress.android.ui.prefs.MyProfileActivity;
 import org.wordpress.android.ui.prefs.notifications.NotificationsSettingsActivity;
 import org.wordpress.android.ui.publicize.PublicizeListActivity;
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity;
+import org.wordpress.android.ui.stats.StatsAbstractFragment;
 import org.wordpress.android.ui.stats.StatsActivity;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
 import org.wordpress.android.ui.stats.StatsConstants;
 import org.wordpress.android.ui.stats.StatsSingleItemDetailsActivity;
+import org.wordpress.android.ui.stats.StatsTimeframe;
+import org.wordpress.android.ui.stats.StatsViewAllActivity;
+import org.wordpress.android.ui.stats.StatsViewType;
 import org.wordpress.android.ui.stats.models.StatsPostModel;
 import org.wordpress.android.ui.stats.refresh.StatsListActivity;
 import org.wordpress.android.ui.stockmedia.StockMediaPickerActivity;
@@ -202,6 +206,19 @@ public class ActivityLauncher {
     public static void viewBlogStats(Context context, SiteModel site) {
         Intent intent = new Intent(context, StatsListActivity.class);
         intent.putExtra(WordPress.SITE, site);
+        context.startActivity(intent);
+    }
+
+    public static void viewFollowersStats(Context context, SiteModel site) {
+        Intent intent = new Intent(context, StatsViewAllActivity.class);
+        intent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, StatsViewType.FOLLOWERS);
+        intent.putExtra(StatsAbstractFragment.ARGS_TIMEFRAME, StatsTimeframe.DAY);
+        intent.putExtra(StatsAbstractFragment.ARGS_SELECTED_DATE, "");
+        intent.putExtra(StatsAbstractFragment.ARGS_IS_SINGLE_VIEW, true);
+        intent.putExtra(StatsActivity.ARG_LOCAL_TABLE_SITE_ID, site.getId());
+
+        String title = context.getResources().getString(R.string.stats_view_followers);
+        intent.putExtra(StatsViewAllActivity.ARG_STATS_VIEW_ALL_TITLE, title);
         context.startActivity(intent);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -383,15 +383,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
         }
 
         if (rangeType == FormattableRangeType.FOLLOW) {
-            Intent intent = new Intent(this, StatsViewAllActivity.class);
-            intent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, StatsViewType.FOLLOWERS);
-            intent.putExtra(StatsAbstractFragment.ARGS_TIMEFRAME, StatsTimeframe.DAY);
-            intent.putExtra(StatsAbstractFragment.ARGS_SELECTED_DATE, "");
-            intent.putExtra(StatsAbstractFragment.ARGS_IS_SINGLE_VIEW, true);
-            intent.putExtra(StatsActivity.ARG_LOCAL_TABLE_SITE_ID, site.getId());
-
-            intent.putExtra(StatsViewAllActivity.ARG_STATS_VIEW_ALL_TITLE, getString(R.string.stats_view_followers));
-            startActivity(intent);
+            ActivityLauncher.viewFollowersStats(this, site);
         } else {
             ActivityLauncher.viewBlogStats(this, site);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -42,11 +42,6 @@ import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveCli
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
-import org.wordpress.android.ui.stats.StatsAbstractFragment;
-import org.wordpress.android.ui.stats.StatsActivity;
-import org.wordpress.android.ui.stats.StatsTimeframe;
-import org.wordpress.android.ui.stats.StatsViewAllActivity;
-import org.wordpress.android.ui.stats.StatsViewType;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.StringUtils;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockItemViewHolder.kt
@@ -28,7 +28,9 @@ import kotlinx.coroutines.experimental.launch
 import org.wordpress.android.R
 import org.wordpress.android.ui.stats.refresh.BlockListItem.BarChartItem
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Columns
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Information
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Item
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Label
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.BlockListItem.TabsItem
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Text
@@ -48,6 +50,16 @@ sealed class BlockItemViewHolder(
         private val text = itemView.findViewById<TextView>(R.id.text)
         fun bind(item: Title) {
             text.setText(item.text)
+        }
+    }
+
+    class InformationViewHolder(parent: ViewGroup) : BlockItemViewHolder(
+            parent,
+            R.layout.stats_block_information
+    ) {
+        private val text = itemView.findViewById<TextView>(R.id.text)
+        fun bind(item: Information) {
+            text.text = item.text
         }
     }
 
@@ -221,6 +233,18 @@ sealed class BlockItemViewHolder(
                     (list.adapter as BlockListAdapter).update(item.tabs[tab.position].items)
                 }
             } )
+        }
+    }
+
+    class LabelViewHolder(parent: ViewGroup) : BlockItemViewHolder(
+            parent,
+            R.layout.stats_block_label
+    ) {
+        private val leftLabel = itemView.findViewById<TextView>(R.id.left_label)
+        private val rightLabel = itemView.findViewById<TextView>(R.id.right_label)
+        fun bind(item: Label) {
+            leftLabel.setText(item.leftLabel)
+            rightLabel.setText(item.rightLabel)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockItemViewHolder.kt
@@ -213,15 +213,16 @@ sealed class BlockItemViewHolder(
         private val list = itemView.findViewById<RecyclerView>(R.id.recycler_view)
 
         fun bind(item: TabsItem) {
-            item.tabs.forEach {
-                tabLayout.addTab(tabLayout.newTab().setText(it.title))
+            if (tabLayout.tabCount == 0) {
+                item.tabs.forEach {
+                    tabLayout.addTab(tabLayout.newTab().setText(it.title))
+                }
             }
-
             list.layoutManager = LinearLayoutManager(list.context, LinearLayoutManager.VERTICAL, false)
             if (list.adapter == null) {
                 list.adapter = BlockListAdapter(imageManager)
             }
-            (list.adapter as BlockListAdapter).update(item.tabs[0].items)
+            (list.adapter as BlockListAdapter).update(item.tabs[tabLayout.selectedTabPosition].items)
             tabLayout.addOnTabSelectedListener(object : OnTabSelectedListener {
                 override fun onTabReselected(tab: Tab) {
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockItemViewHolder.kt
@@ -222,7 +222,7 @@ sealed class BlockItemViewHolder(
                 list.adapter = BlockListAdapter(imageManager)
             }
             (list.adapter as BlockListAdapter).update(item.tabs[0].items)
-            tabLayout.addOnTabSelectedListener(object: OnTabSelectedListener {
+            tabLayout.addOnTabSelectedListener(object : OnTabSelectedListener {
                 override fun onTabReselected(tab: Tab) {
                 }
 
@@ -232,7 +232,7 @@ sealed class BlockItemViewHolder(
                 override fun onTabSelected(tab: Tab) {
                     (list.adapter as BlockListAdapter).update(item.tabs[tab.position].items)
                 }
-            } )
+            })
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockListAdapter.kt
@@ -5,7 +5,9 @@ import android.view.ViewGroup
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.BarChartViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.ColumnsViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.EmptyViewHolder
+import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.InformationViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.ItemViewHolder
+import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.LabelViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.LinkViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.TabsViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.TextViewHolder
@@ -13,7 +15,9 @@ import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.TitleViewHolde
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.UserItemViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockListItem.BarChartItem
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Columns
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Information
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Item
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Label
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.BlockListItem.TabsItem
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Text
@@ -21,7 +25,9 @@ import org.wordpress.android.ui.stats.refresh.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.BAR_CHART
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.COLUMNS
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.EMPTY
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.INFO
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.ITEM
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.LABEL
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.LINK
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TABS
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TEXT
@@ -49,6 +55,8 @@ class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockItemViewHo
             LINK -> LinkViewHolder(parent)
             BAR_CHART -> BarChartViewHolder(parent)
             TABS -> TabsViewHolder(parent, imageManager)
+            INFO -> InformationViewHolder(parent)
+            LABEL -> LabelViewHolder(parent)
         }
     }
 
@@ -69,6 +77,8 @@ class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockItemViewHo
             is LinkViewHolder -> holder.bind(item as Link)
             is BarChartViewHolder -> holder.bind(item as BarChartItem)
             is TabsViewHolder -> holder.bind(item as TabsItem)
+            is InformationViewHolder -> holder.bind(item as Information)
+            is LabelViewHolder -> holder.bind(item as Label)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockListAdapter.kt
@@ -7,12 +7,15 @@ import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.ColumnsViewHol
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.EmptyViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.ItemViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.LinkViewHolder
+import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.TabsViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.TextViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.TitleViewHolder
+import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.UserItemViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockListItem.BarChartItem
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Columns
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Item
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Link
+import org.wordpress.android.ui.stats.refresh.BlockListItem.TabsItem
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Text
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.BAR_CHART
@@ -20,11 +23,15 @@ import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.COLUMNS
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.EMPTY
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.ITEM
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.LINK
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TABS
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TEXT
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TITLE
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.USER_ITEM
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.values
+import org.wordpress.android.ui.stats.refresh.BlockListItem.UserItem
+import org.wordpress.android.util.image.ImageManager
 
-class BlockListAdapter : Adapter<BlockItemViewHolder>() {
+class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockItemViewHolder>() {
     private var items: List<BlockListItem> = listOf()
     fun update(newItems: List<BlockListItem>) {
         items = newItems
@@ -35,11 +42,13 @@ class BlockListAdapter : Adapter<BlockItemViewHolder>() {
         return when (values()[viewType]) {
             TITLE -> TitleViewHolder(parent)
             ITEM -> ItemViewHolder(parent)
+            USER_ITEM -> UserItemViewHolder(parent, imageManager)
             EMPTY -> EmptyViewHolder(parent)
             TEXT -> TextViewHolder(parent)
             COLUMNS -> ColumnsViewHolder(parent)
             LINK -> LinkViewHolder(parent)
             BAR_CHART -> BarChartViewHolder(parent)
+            TABS -> TabsViewHolder(parent, imageManager)
         }
     }
 
@@ -54,10 +63,12 @@ class BlockListAdapter : Adapter<BlockItemViewHolder>() {
         when (holder) {
             is TitleViewHolder -> holder.bind(item as Title)
             is ItemViewHolder -> holder.bind(item as Item)
+            is UserItemViewHolder -> holder.bind(item as UserItem)
             is TextViewHolder -> holder.bind(item as Text)
             is ColumnsViewHolder -> holder.bind(item as Columns)
             is LinkViewHolder -> holder.bind(item as Link)
             is BarChartViewHolder -> holder.bind(item as BarChartItem)
+            is TabsViewHolder -> holder.bind(item as TabsItem)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockListItem.kt
@@ -32,18 +32,21 @@ sealed class BlockListItem(val type: Type) {
         val showDivider: Boolean = true
     ) : BlockListItem(USER_ITEM)
 
-    data class Information(val text: String): BlockListItem(INFO)
+    data class Information(val text: String) : BlockListItem(INFO)
 
     data class Text(val text: String, val links: List<Clickable>? = null) : BlockListItem(TEXT) {
         data class Clickable(val link: String, val action: (Context) -> Unit)
     }
+
     data class Columns(val headers: List<Int>, val values: List<String>) : BlockListItem(COLUMNS)
     data class Link(@DrawableRes val icon: Int? = null, @StringRes val text: Int, val action: () -> Unit) :
             BlockListItem(LINK)
+
     data class BarChartItem(val entries: List<Pair<String, Int>>) : BlockListItem(BAR_CHART)
     data class TabsItem(val tabs: List<Tab>) : BlockListItem(TABS) {
         data class Tab(@StringRes val title: Int, val items: List<BlockListItem>)
     }
+
     data class Label(@StringRes val leftLabel: Int, @StringRes val rightLabel: Int) : BlockListItem(LABEL)
     object Empty : BlockListItem(EMPTY)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockListItem.kt
@@ -8,11 +8,13 @@ import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.COLUMNS
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.EMPTY
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.ITEM
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.LINK
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TABS
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TEXT
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TITLE
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.USER_ITEM
 
 sealed class BlockListItem(val type: Type) {
-    enum class Type { TITLE, ITEM, EMPTY, TEXT, COLUMNS, LINK, BAR_CHART }
+    enum class Type { TITLE, ITEM, USER_ITEM, EMPTY, TEXT, COLUMNS, LINK, BAR_CHART, TABS }
     data class Title(@StringRes val text: Int) : BlockListItem(TITLE)
     data class Item(
         @DrawableRes val icon: Int,
@@ -21,6 +23,13 @@ sealed class BlockListItem(val type: Type) {
         val showDivider: Boolean = true
     ) : BlockListItem(ITEM)
 
+    data class UserItem(
+        val avatarUrl: String,
+        val text: String,
+        val value: String,
+        val showDivider: Boolean = true
+    ) : BlockListItem(USER_ITEM)
+
     data class Text(val text: String, val links: List<Clickable>? = null) : BlockListItem(TEXT) {
         data class Clickable(val link: String, val action: (Context) -> Unit)
     }
@@ -28,5 +37,8 @@ sealed class BlockListItem(val type: Type) {
     data class Link(@DrawableRes val icon: Int? = null, @StringRes val text: Int, val action: () -> Unit) :
             BlockListItem(LINK)
     data class BarChartItem(val entries: List<Pair<String, Int>>) : BlockListItem(BAR_CHART)
+    data class TabsItem(val tabs: List<Tab>) : BlockListItem(TABS) {
+        data class Tab(@StringRes val title: Int, val items: List<BlockListItem>)
+    }
     object Empty : BlockListItem(EMPTY)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockListItem.kt
@@ -6,7 +6,9 @@ import android.support.annotation.StringRes
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.BAR_CHART
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.COLUMNS
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.EMPTY
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.INFO
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.ITEM
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.LABEL
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.LINK
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TABS
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TEXT
@@ -14,7 +16,7 @@ import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TITLE
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.USER_ITEM
 
 sealed class BlockListItem(val type: Type) {
-    enum class Type { TITLE, ITEM, USER_ITEM, EMPTY, TEXT, COLUMNS, LINK, BAR_CHART, TABS }
+    enum class Type { TITLE, ITEM, USER_ITEM, INFO, EMPTY, TEXT, COLUMNS, LINK, BAR_CHART, TABS, LABEL }
     data class Title(@StringRes val text: Int) : BlockListItem(TITLE)
     data class Item(
         @DrawableRes val icon: Int,
@@ -30,6 +32,8 @@ sealed class BlockListItem(val type: Type) {
         val showDivider: Boolean = true
     ) : BlockListItem(USER_ITEM)
 
+    data class Information(val text: String): BlockListItem(INFO)
+
     data class Text(val text: String, val links: List<Clickable>? = null) : BlockListItem(TEXT) {
         data class Clickable(val link: String, val action: (Context) -> Unit)
     }
@@ -40,5 +44,6 @@ sealed class BlockListItem(val type: Type) {
     data class TabsItem(val tabs: List<Tab>) : BlockListItem(TABS) {
         data class Tab(@StringRes val title: Int, val items: List<BlockListItem>)
     }
+    data class Label(@StringRes val leftLabel: Int, @StringRes val rightLabel: Int) : BlockListItem(LABEL)
     object Empty : BlockListItem(EMPTY)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockTabPagerAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockTabPagerAdapter.kt
@@ -1,0 +1,45 @@
+package org.wordpress.android.ui.stats.refresh
+
+import android.content.Context
+import android.support.v4.view.PagerAdapter
+import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
+import android.view.View
+import android.view.ViewGroup
+import org.wordpress.android.ui.stats.refresh.BlockListItem.TabsItem
+import org.wordpress.android.util.image.ImageManager
+
+class BlockTabPagerAdapter(val imageManager: ImageManager, val context: Context, val item: TabsItem) : PagerAdapter() {
+    override fun isViewFromObject(view: View, `object`: Any): Boolean {
+        return view == `object`
+    }
+
+    override fun instantiateItem(container: ViewGroup, position: Int): Any {
+//        val layout = LayoutInflater.from(container.context)
+//                .inflate(layout.recycler_view, container, false)
+        val list = container.getChildAt(position) as RecyclerView
+//        val list = layout.findViewById<RecyclerView>(id.recycler_view)
+        list.layoutManager = LinearLayoutManager(
+                list.context,
+                LinearLayoutManager.VERTICAL,
+                false
+        )
+        if (list.adapter == null) {
+            list.adapter = BlockListAdapter(imageManager)
+        }
+        (list.adapter as BlockListAdapter).update(item.tabs[position].items)
+        return list
+    }
+
+    override fun getPageTitle(position: Int): CharSequence? {
+        return context.resources.getString(item.tabs[position].title)
+    }
+
+    override fun destroyItem(container: ViewGroup, position: Int, view: Any) {
+        container.removeView(view as View)
+    }
+
+    override fun getCount(): Int {
+        return item.tabs.size
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/FollowersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/FollowersUseCase.kt
@@ -1,0 +1,65 @@
+package org.wordpress.android.ui.stats.refresh
+
+import kotlinx.coroutines.experimental.GlobalScope
+import kotlinx.coroutines.experimental.async
+import org.wordpress.android.R
+import org.wordpress.android.R.string
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.FollowersModel
+import org.wordpress.android.fluxc.model.stats.FollowersModel.FollowerModel
+import org.wordpress.android.fluxc.store.InsightsStore
+import org.wordpress.android.ui.stats.StatsUtilsWrapper
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Link
+import org.wordpress.android.ui.stats.refresh.BlockListItem.TabsItem
+import org.wordpress.android.ui.stats.refresh.BlockListItem.TabsItem.Tab
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Title
+import org.wordpress.android.ui.stats.refresh.BlockListItem.UserItem
+import javax.inject.Inject
+
+class FollowersUseCase
+@Inject constructor(private val insightsStore: InsightsStore, private val statsUtilsWrapper: StatsUtilsWrapper) {
+    suspend fun loadFollowers(site: SiteModel, forced: Boolean = false): InsightsItem {
+        val deferredWpComResponse = GlobalScope.async {insightsStore.fetchWpComFollowers(site, forced)}
+        val deferredEmailResponse = GlobalScope.async {insightsStore.fetchEmailFollowers(site, forced)}
+        val wpComResponse = deferredWpComResponse.await()
+        val emailResponse = deferredEmailResponse.await()
+        val wpComModel = wpComResponse.model
+        val emailModel = emailResponse.model
+        val error = wpComResponse.error ?: emailResponse.error
+
+        return when {
+            error != null -> Failed(R.string.stats_view_followers, error.message ?: error.type.name)
+            wpComModel != null || emailModel != null -> loadFollowers(wpComModel, emailModel)
+            else -> throw IllegalArgumentException("Unexpected empty body")
+        }
+    }
+
+    private fun loadFollowers(wpComModel: FollowersModel?, emailModel: FollowersModel?): ListInsightItem {
+        val items = mutableListOf<BlockListItem>()
+        items.add(Title(string.stats_view_followers))
+        val wpComFollowerItems = wpComModel?.followers?.toUserItems() ?: listOf()
+        val emailFollowersItems = emailModel?.followers?.toUserItems() ?: listOf()
+        items.add(
+                TabsItem(
+                        listOf(
+                                Tab(R.string.wordpress_dot_com, wpComFollowerItems),
+                                Tab(R.string.email, emailFollowersItems)
+                        )
+                )
+        )
+
+        items.add(Link(text = string.stats_insights_view_more) {})
+        return ListInsightItem(items)
+    }
+
+    private fun List<FollowerModel>.toUserItems(): List<UserItem> {
+        return this.mapIndexed { index, follower ->
+            UserItem(
+                    follower.avatar,
+                    follower.label,
+                    statsUtilsWrapper.getSinceLabelLowerCase(follower.dateSubscribed),
+                    index < this.size -1
+            )
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/FollowersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/FollowersUseCase.kt
@@ -48,7 +48,11 @@ class FollowersUseCase
         }
     }
 
-    private fun loadFollowers(site: SiteModel, wpComModel: FollowersModel?, emailModel: FollowersModel?): ListInsightItem {
+    private fun loadFollowers(
+        site: SiteModel,
+        wpComModel: FollowersModel?,
+        emailModel: FollowersModel?
+    ): ListInsightItem {
         val items = mutableListOf<BlockListItem>()
         items.add(Title(string.stats_view_followers))
         items.add(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/InsightsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/InsightsAdapter.kt
@@ -8,8 +8,9 @@ import org.wordpress.android.ui.stats.refresh.InsightsItem.Type.FAILED
 import org.wordpress.android.ui.stats.refresh.InsightsItem.Type.LIST_INSIGHTS
 import org.wordpress.android.ui.stats.refresh.InsightsItem.Type.NOT_IMPLEMENTED
 import org.wordpress.android.ui.stats.refresh.InsightsItem.Type.values
+import org.wordpress.android.util.image.ImageManager
 
-class InsightsAdapter : Adapter<InsightsViewHolder>() {
+class InsightsAdapter(val imageManager: ImageManager) : Adapter<InsightsViewHolder>() {
     private var items: List<InsightsItem> = listOf()
     fun update(newItems: List<InsightsItem>) {
         val diffResult = DiffUtil.calculateDiff(
@@ -26,7 +27,7 @@ class InsightsAdapter : Adapter<InsightsViewHolder>() {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): InsightsViewHolder {
         return when (values()[viewType]) {
             NOT_IMPLEMENTED -> NotImplementedViewHolder(parent)
-            LIST_INSIGHTS -> ListInsightsViewHolder(parent)
+            LIST_INSIGHTS -> ListInsightsViewHolder(parent, imageManager)
             FAILED -> FailedViewHolder(parent)
             EMPTY -> EmptyInsightsViewHolder(parent)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/InsightsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/InsightsViewModel.kt
@@ -29,7 +29,8 @@ class InsightsViewModel
     @Named(DEFAULT_SCOPE) private val scope: CoroutineScope,
     private val insightsAllTimeViewModel: InsightsAllTimeViewModel,
     private val latestPostSummaryViewModel: LatestPostSummaryViewModel,
-    private val todayStatsUseCase: TodayStatsUseCase
+    private val todayStatsUseCase: TodayStatsUseCase,
+    private val followersUseCase: FollowersUseCase
 ) {
     private val mediatorNavigationTarget: MediatorLiveData<NavigationTarget> = MediatorLiveData()
     val navigationTarget: LiveData<NavigationTarget> = mediatorNavigationTarget
@@ -45,12 +46,12 @@ class InsightsViewModel
             ALL_TIME_STATS -> insightsAllTimeViewModel.loadAllTimeInsights(site, forced)
             LATEST_POST_SUMMARY -> latestPostSummaryViewModel.loadLatestPostSummary(site, forced)
             TODAY_STATS -> todayStatsUseCase.loadTodayStats(site, forced)
+            FOLLOWERS -> followersUseCase.loadFollowers(site, forced)
             MOST_POPULAR_DAY_AND_HOUR,
             FOLLOWER_TOTALS,
             TAGS_AND_CATEGORIES,
             ANNUAL_SITE_STATS,
             COMMENTS,
-            FOLLOWERS,
             POSTING_ACTIVITY,
             PUBLICIZE -> NotImplemented(type.name)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/InsightsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/InsightsViewModel.kt
@@ -39,6 +39,9 @@ class InsightsViewModel
         mediatorNavigationTarget.addSource(latestPostSummaryViewModel.navigationTarget) {
             mediatorNavigationTarget.value = it
         }
+        mediatorNavigationTarget.addSource(followersUseCase.navigationTarget) {
+            mediatorNavigationTarget.value = it
+        }
     }
 
     private suspend fun load(site: SiteModel, type: InsightsTypes, forced: Boolean): InsightsItem {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/LatestPostSummaryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/LatestPostSummaryViewModel.kt
@@ -11,7 +11,7 @@ import org.wordpress.android.ui.stats.refresh.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.AddNewPost
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.SharePost
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewMore
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewPostDetailStats
 import javax.inject.Inject
 
 class LatestPostSummaryViewModel
@@ -62,7 +62,7 @@ class LatestPostSummaryViewModel
                 mutableNavigationTarget.value = AddNewPost
             }
             model.hasData() -> Link(text = R.string.stats_insights_view_more) {
-                mutableNavigationTarget.value = ViewMore(
+                mutableNavigationTarget.value = ViewPostDetailStats(
                         model.siteId,
                         model.postId.toString(),
                         model.postTitle,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/ListInsightsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/ListInsightsViewHolder.kt
@@ -5,13 +5,17 @@ import android.support.v7.widget.RecyclerView
 import android.view.ViewGroup
 import org.wordpress.android.R
 import org.wordpress.android.R.layout
+import org.wordpress.android.util.image.ImageManager
 
-class ListInsightsViewHolder(parent: ViewGroup) : InsightsViewHolder(parent, layout.stats_list_block) {
+class ListInsightsViewHolder(parent: ViewGroup, val imageManager: ImageManager) : InsightsViewHolder(
+        parent,
+        layout.stats_list_block
+) {
     private val list: RecyclerView = itemView.findViewById(R.id.stats_block_list)
     fun bind(item: ListInsightItem) {
         list.layoutManager = LinearLayoutManager(list.context, LinearLayoutManager.VERTICAL, false)
         if (list.adapter == null) {
-            list.adapter = BlockListAdapter()
+            list.adapter = BlockListAdapter(imageManager)
         }
         (list.adapter as BlockListAdapter).update(item.items)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListFragment.kt
@@ -156,7 +156,12 @@ class StatsListFragment : Fragment() {
 sealed class NavigationTarget {
     object AddNewPost : NavigationTarget()
     data class SharePost(val url: String, val title: String) : NavigationTarget()
-    data class ViewPostDetailStats(val siteID: Long, val postID: String, val postTitle: String, val postUrl: String) :
-            NavigationTarget()
-    data class ViewFollowersStats(val siteID: Long): NavigationTarget()
+    data class ViewPostDetailStats(
+        val siteID: Long,
+        val postID: String,
+        val postTitle: String,
+        val postUrl: String
+    ) : NavigationTarget()
+
+    data class ViewFollowersStats(val siteID: Long) : NavigationTarget()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListFragment.kt
@@ -24,12 +24,14 @@ import org.wordpress.android.ui.stats.refresh.NavigationTarget.SharePost
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewMore
 import org.wordpress.android.ui.stats.refresh.StatsListViewModel.StatsListType
 import org.wordpress.android.util.DisplayUtils
+import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.widgets.RecyclerItemDecoration
 import javax.inject.Inject
 
 class StatsListFragment : Fragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject lateinit var imageManager: ImageManager
     private lateinit var viewModel: StatsListViewModel
 
     private var linearLayoutManager: LinearLayoutManager? = null
@@ -138,7 +140,7 @@ class StatsListFragment : Fragment() {
     private fun updateInsights(insightsState: InsightsUiState) {
         val adapter: InsightsAdapter
         if (recyclerView.adapter == null) {
-            adapter = InsightsAdapter()
+            adapter = InsightsAdapter(imageManager)
             recyclerView.adapter = adapter
         } else {
             adapter = recyclerView.adapter as InsightsAdapter

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListFragment.kt
@@ -21,11 +21,12 @@ import org.wordpress.android.ui.stats.StatsConstants
 import org.wordpress.android.ui.stats.models.StatsPostModel
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.AddNewPost
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.SharePost
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewMore
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewFollowersStats
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewPostDetailStats
 import org.wordpress.android.ui.stats.refresh.StatsListViewModel.StatsListType
 import org.wordpress.android.util.DisplayUtils
-import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.widgets.RecyclerItemDecoration
 import javax.inject.Inject
 
@@ -99,10 +100,10 @@ class StatsListFragment : Fragment() {
         }
         viewModel.start(site, statsType)
 
-        setupObservers(site)
+        setupObservers(activity, site)
     }
 
-    private fun setupObservers(site: SiteModel) {
+    private fun setupObservers(activity: FragmentActivity, site: SiteModel) {
         viewModel.data.observe(this, Observer {
             if (it != null) {
                 updateInsights(it)
@@ -123,7 +124,7 @@ class StatsListFragment : Fragment() {
                         ToastUtils.showToast(activity, R.string.reader_toast_err_share_intent)
                     }
                 }
-                is ViewMore -> {
+                is ViewPostDetailStats -> {
                     val postModel = StatsPostModel(
                             it.siteID,
                             it.postID,
@@ -132,6 +133,9 @@ class StatsListFragment : Fragment() {
                             StatsConstants.ITEM_TYPE_POST
                     )
                     ActivityLauncher.viewStatsSinglePostDetails(activity, postModel)
+                }
+                is ViewFollowersStats -> {
+                    ActivityLauncher.viewFollowersStats(activity, site)
                 }
             }
         })
@@ -152,6 +156,7 @@ class StatsListFragment : Fragment() {
 sealed class NavigationTarget {
     object AddNewPost : NavigationTarget()
     data class SharePost(val url: String, val title: String) : NavigationTarget()
-    data class ViewMore(val siteID: Long, val postID: String, val postTitle: String, val postUrl: String) :
+    data class ViewPostDetailStats(val siteID: Long, val postID: String, val postTitle: String, val postUrl: String) :
             NavigationTarget()
+    data class ViewFollowersStats(val siteID: Long): NavigationTarget()
 }

--- a/WordPress/src/main/res/layout/recycler_view.xml
+++ b/WordPress/src/main/res/layout/recycler_view.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.RecyclerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/recycler_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"/>

--- a/WordPress/src/main/res/layout/recycler_view.xml
+++ b/WordPress/src/main/res/layout/recycler_view.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.RecyclerView
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/recycler_view"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"/>

--- a/WordPress/src/main/res/layout/stats_block_information.xml
+++ b/WordPress/src/main/res/layout/stats_block_information.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              style="@style/StatsBlockLine"
+              android:paddingStart="16dp"
+              android:paddingEnd="16dp"
+              android:orientation="horizontal">
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_gravity="center_vertical"
+        style="@style/StatsBlockText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:text="@string/unknown"/>
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/stats_block_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_item.xml
@@ -7,8 +7,8 @@
 
     <ImageView
         android:id="@+id/icon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
         android:layout_gravity="center_vertical"
         android:layout_marginEnd="32dp"
         android:contentDescription="@string/icon"/>

--- a/WordPress/src/main/res/layout/stats_block_label.xml
+++ b/WordPress/src/main/res/layout/stats_block_label.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              style="@style/StatsBlockLine"
+              android:paddingStart="16dp"
+              android:paddingEnd="16dp"
+              android:layout_width="match_parent"
+              android:orientation="horizontal">
+
+    <TextView
+        android:id="@+id/left_label"
+        style="@style/StatsBlockLabel"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_weight="1"
+        android:gravity="start"
+        android:text="@string/unknown"/>
+
+    <TextView
+        android:id="@+id/right_label"
+        style="@style/StatsBlockLabel"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_weight="1"
+        android:gravity="end"
+        android:text="@string/unknown"/>
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/stats_block_tabs_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_tabs_item.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <android.support.design.widget.TabLayout
+        android:id="@+id/tab_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top"
+        app:tabGravity="fill"
+        app:tabIndicatorColor="@color/wp_blue"
+        app:tabSelectedTextColor="@color/wp_blue"
+        app:tabTextColor="@color/wp_grey_darken_20"/>
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
+</LinearLayout>

--- a/WordPress/src/main/res/values/stats_styles.xml
+++ b/WordPress/src/main/res/values/stats_styles.xml
@@ -134,6 +134,11 @@
         <item name="android:textSize">@dimen/text_sz_medium</item>
     </style>
 
+    <style name="StatsBlockLabel" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">@color/wp_grey</item>
+        <item name="android:textSize">@dimen/text_sz_medium</item>
+    </style>
+
     <style name="StatsBlockLink" parent="TextAppearance.AppCompat.Body2">
         <item name="android:textColor">@color/blue_wordpress</item>
         <item name="android:textSize">@dimen/text_sz_medium</item>

--- a/WordPress/src/main/res/values/stats_styles.xml
+++ b/WordPress/src/main/res/values/stats_styles.xml
@@ -134,7 +134,7 @@
         <item name="android:textSize">@dimen/text_sz_medium</item>
     </style>
 
-    <style name="StatsBlockLabel" parent="TextAppearance.AppCompat.Body1">
+    <style name="StatsBlockLabel" parent="TextAppearance.AppCompat.Body2">
         <item name="android:textColor">@color/wp_grey</item>
         <item name="android:textSize">@dimen/text_sz_medium</item>
     </style>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -773,6 +773,11 @@
     <string name="stats_empty_insights_title">No insights added yet</string>
     <string name="stats_empty_insights_description">Customise your insights and get the low-down on your site’s performance</string>
     <string name="stats_button_manage_insights">Manage insights</string>
+    <string name="stats_followers_wordpress_com">WordPress.com</string>
+    <string name="stats_followers_email">Email</string>
+    <string name="stats_followers_count_message">Total %1$s Followers: %2$s</string>
+    <string name="stats_follower_label">Follower</string>
+    <string name="stats_follower_since_label">Since</string>
 
     <!-- Jetpack install -->
     <string name="jetpack">Jetpack</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/FollowersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/FollowersUseCaseTest.kt
@@ -1,0 +1,242 @@
+package org.wordpress.android.ui.stats.refresh
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.whenever
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.R
+import org.wordpress.android.R.string
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.FollowersModel
+import org.wordpress.android.fluxc.model.stats.FollowersModel.FollowerModel
+import org.wordpress.android.fluxc.store.InsightsStore
+import org.wordpress.android.fluxc.store.InsightsStore.OnInsightsFetched
+import org.wordpress.android.fluxc.store.InsightsStore.StatsError
+import org.wordpress.android.fluxc.store.InsightsStore.StatsErrorType.GENERIC_ERROR
+import org.wordpress.android.test
+import org.wordpress.android.ui.stats.StatsUtilsWrapper
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Empty
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Information
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Label
+import org.wordpress.android.ui.stats.refresh.BlockListItem.TabsItem
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Title
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.INFO
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.LABEL
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TITLE
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.USER_ITEM
+import org.wordpress.android.ui.stats.refresh.BlockListItem.UserItem
+import org.wordpress.android.ui.stats.refresh.InsightsItem.Type.FAILED
+import org.wordpress.android.ui.stats.refresh.InsightsItem.Type.LIST_INSIGHTS
+import org.wordpress.android.viewmodel.ResourceProvider
+import java.util.Date
+
+@RunWith(MockitoJUnitRunner::class)
+class FollowersUseCaseTest {
+    @Mock lateinit var insightsStore: InsightsStore
+    @Mock lateinit var statsUtilsWrapper: StatsUtilsWrapper
+    @Mock lateinit var resourceProvider: ResourceProvider
+    @Mock lateinit var site: SiteModel
+    private lateinit var useCase: FollowersUseCase
+    private val avatar = "avatar.jpg"
+    private val user = "John Smith"
+    private val url = "www.url.com"
+    private val dateSubscribed = Date(10)
+    private val sinceLabel = "4 days"
+    private val totalCount = 50
+    private val wordPressLabel = "wordpress"
+    val message = "Total followers count is 50"
+    @Before
+    fun setUp() {
+        useCase = FollowersUseCase(insightsStore, statsUtilsWrapper, resourceProvider)
+        whenever(statsUtilsWrapper.getSinceLabelLowerCase(dateSubscribed)).thenReturn(sinceLabel)
+        whenever(resourceProvider.getString(any())).thenReturn(wordPressLabel)
+        whenever(resourceProvider.getString(eq(R.string.stats_followers_count_message), any(), any())).thenReturn(
+                message
+        )
+    }
+
+    @Test
+    fun `maps WPCOM followers to UI model`() = test {
+        val forced = false
+        whenever(insightsStore.fetchWpComFollowers(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        FollowersModel(totalCount, listOf(FollowerModel(avatar, user, url, dateSubscribed)))
+                )
+        )
+        whenever(insightsStore.fetchEmailFollowers(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        model = FollowersModel(
+                                0,
+                                listOf()
+                        )
+                )
+        )
+
+        val result = useCase.loadFollowers(site, forced)
+
+        Assertions.assertThat(result.type).isEqualTo(LIST_INSIGHTS)
+        (result as ListInsightItem).apply {
+            Assertions.assertThat(this.items).hasSize(3)
+            assertTitle(this.items[0])
+            val tabsItem = this.items[1] as TabsItem
+
+            assertThat(tabsItem.tabs[0].title).isEqualTo(string.stats_followers_wordpress_com)
+            assertTabWithFollower(tabsItem.tabs[0])
+
+            assertThat(tabsItem.tabs[1].title).isEqualTo(string.stats_followers_email)
+            assertThat(tabsItem.tabs[1].items).containsOnly(Empty)
+        }
+    }
+
+    @Test
+    fun `maps email followers to UI model`() = test {
+        val forced = false
+        whenever(insightsStore.fetchWpComFollowers(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        model = FollowersModel(
+                                0,
+                                listOf()
+                        )
+                )
+        )
+        whenever(insightsStore.fetchEmailFollowers(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        FollowersModel(totalCount, listOf(FollowerModel(avatar, user, url, dateSubscribed)))
+                )
+        )
+
+        val result = useCase.loadFollowers(site, forced)
+
+        Assertions.assertThat(result.type).isEqualTo(LIST_INSIGHTS)
+        (result as ListInsightItem).apply {
+            Assertions.assertThat(this.items).hasSize(3)
+            assertTitle(this.items[0])
+            val tabsItem = this.items[1] as TabsItem
+
+            assertThat(tabsItem.tabs[0].title).isEqualTo(string.stats_followers_wordpress_com)
+            assertThat(tabsItem.tabs[0].items).containsOnly(Empty)
+
+            assertThat(tabsItem.tabs[1].title).isEqualTo(string.stats_followers_email)
+            assertTabWithFollower(tabsItem.tabs[1])
+        }
+    }
+
+    @Test
+    fun `maps empty followers to UI model`() = test {
+        val forced = false
+        whenever(insightsStore.fetchWpComFollowers(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        model = FollowersModel(
+                                0,
+                                listOf()
+                        )
+                )
+        )
+        whenever(insightsStore.fetchEmailFollowers(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        model = FollowersModel(
+                                0,
+                                listOf()
+                        )
+                )
+        )
+
+        val result = useCase.loadFollowers(site, forced)
+
+        Assertions.assertThat(result.type).isEqualTo(LIST_INSIGHTS)
+        (result as ListInsightItem).apply {
+            Assertions.assertThat(this.items).hasSize(3)
+            assertTitle(this.items[0])
+            val tabsItem = this.items[1] as TabsItem
+
+            assertThat(tabsItem.tabs[0].title).isEqualTo(string.stats_followers_wordpress_com)
+            assertThat(tabsItem.tabs[0].items).containsOnly(Empty)
+
+            assertThat(tabsItem.tabs[1].title).isEqualTo(string.stats_followers_email)
+            assertThat(tabsItem.tabs[1].items).containsOnly(Empty)
+        }
+    }
+
+    @Test
+    fun `maps WPCOM error item to UI model`() = test {
+        val forced = false
+        val message = "Generic error"
+        whenever(insightsStore.fetchWpComFollowers(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        StatsError(GENERIC_ERROR, message)
+                )
+        )
+        whenever(insightsStore.fetchEmailFollowers(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        model = FollowersModel(
+                                0,
+                                listOf()
+                        )
+                )
+        )
+
+        val result = useCase.loadFollowers(site, forced)
+
+        assertThat(result.type).isEqualTo(FAILED)
+        (result as Failed).apply {
+            assertThat(this.failedType).isEqualTo(R.string.stats_view_followers)
+            assertThat(this.errorMessage).isEqualTo(message)
+        }
+    }
+
+    @Test
+    fun `maps email error item to UI model`() = test {
+        val forced = false
+        val message = "Generic error"
+        whenever(insightsStore.fetchWpComFollowers(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        model = FollowersModel(
+                                0,
+                                listOf()
+                        )
+                )
+        )
+        whenever(insightsStore.fetchEmailFollowers(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        StatsError(GENERIC_ERROR, message)
+                )
+        )
+
+        val result = useCase.loadFollowers(site, forced)
+
+        assertThat(result.type).isEqualTo(FAILED)
+        (result as Failed).apply {
+            assertThat(this.failedType).isEqualTo(R.string.stats_view_followers)
+            assertThat(this.errorMessage).isEqualTo(message)
+        }
+    }
+
+    private fun assertTabWithFollower(tab: TabsItem.Tab) {
+        val infoItem = tab.items[0]
+        assertThat(infoItem.type).isEqualTo(INFO)
+        assertThat((infoItem as Information).text).isEqualTo(message)
+
+        val labelItem = tab.items[1]
+        assertThat(labelItem.type).isEqualTo(LABEL)
+        assertThat((labelItem as Label).leftLabel).isEqualTo(R.string.stats_follower_label)
+        assertThat(labelItem.rightLabel).isEqualTo(R.string.stats_follower_since_label)
+
+        val userItem = tab.items[2]
+        assertThat(userItem.type).isEqualTo(USER_ITEM)
+        assertThat((userItem as UserItem).avatarUrl).isEqualTo(avatar)
+        assertThat(userItem.showDivider).isEqualTo(false)
+        assertThat(userItem.text).isEqualTo(user)
+        assertThat(userItem.value).isEqualTo(sinceLabel)
+    }
+
+    private fun assertTitle(item: BlockListItem) {
+        assertThat(item.type).isEqualTo(TITLE)
+        assertThat((item as Title).text).isEqualTo(R.string.stats_view_followers)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/LatestPostSummaryViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/LatestPostSummaryViewModelTest.kt
@@ -25,7 +25,7 @@ import org.wordpress.android.ui.stats.refresh.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Text
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.SharePost
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewMore
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewPostDetailStats
 import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
@@ -152,8 +152,8 @@ class LatestPostSummaryViewModelTest {
             assertThat(link.text).isEqualTo(R.string.stats_insights_view_more)
 
             link.toNavigationTarget().apply {
-                assertThat(this).isInstanceOf(ViewMore::class.java)
-                assertThat((this as ViewMore).postUrl).isEqualTo(model.postURL)
+                assertThat(this).isInstanceOf(ViewPostDetailStats::class.java)
+                assertThat((this as ViewPostDetailStats).postUrl).isEqualTo(model.postURL)
                 assertThat(this.postTitle).isEqualTo(model.postTitle)
                 assertThat(this.postID).isEqualTo(model.postId.toString())
                 assertThat(this.siteID).isEqualTo(model.siteId)

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'fa79a8153801ed82b90f67648bdd0bb684b4db55'
+    fluxCVersion = '4affc2aea562a209fafd8add086064adff261703'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '2d29e71c6f7f4025e1b74f9b11c93e633fa3c246'
+    fluxCVersion = 'fa79a8153801ed82b90f67648bdd0bb684b4db55'
 }


### PR DESCRIPTION
Fixes #8441 

Creates a Followers block with two tabs - WPCOM and Email followers, in Stats. Clicking the `View more` button redirects the user to the old Followers screen. 

I'm adding two new BlockItems - one to contains a centered piece of information and the second to contain labels for two columns items. We could consider renaming them. At the moment we already have more items than I expected and it might be hard to understand what they represent. 

To test:
* Open Stats
* You see a Followers block
* You can switch between WordPress.com and Email tabs
* Clicking ViewMore redirects you to the Followers detail screen
