### PR TITLE
Create comments block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -222,6 +222,19 @@ public class ActivityLauncher {
         context.startActivity(intent);
     }
 
+    public static void viewCommentsStats(Context context, SiteModel site) {
+        Intent intent = new Intent(context, StatsViewAllActivity.class);
+        intent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, StatsViewType.COMMENTS);
+        intent.putExtra(StatsAbstractFragment.ARGS_TIMEFRAME, StatsTimeframe.DAY);
+        intent.putExtra(StatsAbstractFragment.ARGS_SELECTED_DATE, "");
+        intent.putExtra(StatsAbstractFragment.ARGS_IS_SINGLE_VIEW, true);
+        intent.putExtra(StatsActivity.ARG_LOCAL_TABLE_SITE_ID, site.getId());
+
+        String title = context.getResources().getString(R.string.stats_view_comments);
+        intent.putExtra(StatsViewAllActivity.ARG_STATS_VIEW_ALL_TITLE, title);
+        context.startActivity(intent);
+    }
+
     public static void viewBlogStatsAfterJetpackSetup(Context context, SiteModel site) {
         Intent intent = new Intent(context, StatsActivity.class);
         intent.putExtra(WordPress.SITE, site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockItemViewHolder.kt
@@ -17,6 +17,7 @@ import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
 import android.view.LayoutInflater
 import android.view.View
+import android.view.View.GONE
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
@@ -32,6 +33,7 @@ import org.wordpress.android.ui.stats.refresh.BlockListItem.Information
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Item
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Label
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Link
+import org.wordpress.android.ui.stats.refresh.BlockListItem.ListItem
 import org.wordpress.android.ui.stats.refresh.BlockListItem.TabsItem
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Text
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Title
@@ -95,6 +97,27 @@ sealed class BlockItemViewHolder(
 
         fun bind(item: UserItem) {
             imageManager.loadIntoCircle(icon, AVATAR, item.avatarUrl)
+            text.text = item.text
+            value.text = item.value
+            divider.visibility = if (item.showDivider) {
+                View.VISIBLE
+            } else {
+                View.GONE
+            }
+        }
+    }
+
+    class ListItemViewHolder(parent: ViewGroup) : BlockItemViewHolder(
+            parent,
+            R.layout.stats_block_item
+    ) {
+        private val icon = itemView.findViewById<ImageView>(R.id.icon)
+        private val text = itemView.findViewById<TextView>(R.id.text)
+        private val value = itemView.findViewById<TextView>(R.id.value)
+        private val divider = itemView.findViewById<View>(R.id.divider)
+
+        fun bind(item: ListItem) {
+            icon.visibility = GONE
             text.text = item.text
             value.text = item.value
             divider.visibility = if (item.showDivider) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockListAdapter.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.InformationVie
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.ItemViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.LabelViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.LinkViewHolder
+import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.ListItemViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.TabsViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.TextViewHolder
 import org.wordpress.android.ui.stats.refresh.BlockItemViewHolder.TitleViewHolder
@@ -19,6 +20,7 @@ import org.wordpress.android.ui.stats.refresh.BlockListItem.Information
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Item
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Label
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Link
+import org.wordpress.android.ui.stats.refresh.BlockListItem.ListItem
 import org.wordpress.android.ui.stats.refresh.BlockListItem.TabsItem
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Text
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Title
@@ -29,6 +31,7 @@ import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.INFO
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.ITEM
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.LABEL
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.LINK
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.LIST_ITEM
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TABS
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TEXT
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TITLE
@@ -49,6 +52,7 @@ class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockItemViewHo
             TITLE -> TitleViewHolder(parent)
             ITEM -> ItemViewHolder(parent)
             USER_ITEM -> UserItemViewHolder(parent, imageManager)
+            LIST_ITEM -> ListItemViewHolder(parent)
             EMPTY -> EmptyViewHolder(parent)
             TEXT -> TextViewHolder(parent)
             COLUMNS -> ColumnsViewHolder(parent)
@@ -72,6 +76,7 @@ class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockItemViewHo
             is TitleViewHolder -> holder.bind(item as Title)
             is ItemViewHolder -> holder.bind(item as Item)
             is UserItemViewHolder -> holder.bind(item as UserItem)
+            is ListItemViewHolder -> holder.bind(item as ListItem)
             is TextViewHolder -> holder.bind(item as Text)
             is ColumnsViewHolder -> holder.bind(item as Columns)
             is LinkViewHolder -> holder.bind(item as Link)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockListItem.kt
@@ -10,13 +10,14 @@ import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.INFO
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.ITEM
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.LABEL
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.LINK
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.LIST_ITEM
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TABS
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TEXT
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TITLE
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.USER_ITEM
 
 sealed class BlockListItem(val type: Type) {
-    enum class Type { TITLE, ITEM, USER_ITEM, INFO, EMPTY, TEXT, COLUMNS, LINK, BAR_CHART, TABS, LABEL }
+    enum class Type { TITLE, ITEM, USER_ITEM, LIST_ITEM, INFO, EMPTY, TEXT, COLUMNS, LINK, BAR_CHART, TABS, LABEL }
     data class Title(@StringRes val text: Int) : BlockListItem(TITLE)
     data class Item(
         @DrawableRes val icon: Int,
@@ -31,6 +32,12 @@ sealed class BlockListItem(val type: Type) {
         val value: String,
         val showDivider: Boolean = true
     ) : BlockListItem(USER_ITEM)
+
+    data class ListItem(
+        val text: String,
+        val value: String,
+        val showDivider: Boolean = true
+    ) : BlockListItem(LIST_ITEM)
 
     data class Information(val text: String) : BlockListItem(INFO)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/CommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/CommentsUseCase.kt
@@ -27,15 +27,20 @@ class CommentsUseCase
     private val mutableNavigationTarget = MutableLiveData<NavigationTarget>()
     val navigationTarget: LiveData<NavigationTarget> = mutableNavigationTarget
 
-    suspend fun loadComments(site: SiteModel, forced: Boolean = false): InsightsItem {
-        val response = insightsStore.fetchComments(site, forced)
-        val model = response.model
-        val error = response.error
+    suspend fun loadComments(site: SiteModel, refresh: Boolean = false, forced: Boolean = false): InsightsItem {
+        val dbModel = insightsStore.getComments(site)
+        return if (!refresh && dbModel != null) {
+            loadComments(site, dbModel)
+        } else {
+            val response = insightsStore.fetchComments(site, forced)
+            val model = response.model
+            val error = response.error
 
-        return when {
-            error != null -> Failed(R.string.stats_view_comments, error.message ?: error.type.name)
-            model != null -> loadComments(site, model)
-            else -> throw IllegalArgumentException("Unexpected empty body")
+            when {
+                error != null -> Failed(R.string.stats_view_comments, error.message ?: error.type.name)
+                model != null -> loadComments(site, model)
+                else -> throw IllegalArgumentException("Unexpected empty body")
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/CommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/CommentsUseCase.kt
@@ -1,0 +1,86 @@
+package org.wordpress.android.ui.stats.refresh
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
+import org.wordpress.android.R
+import org.wordpress.android.R.string
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.CommentsModel
+import org.wordpress.android.fluxc.store.InsightsStore
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Empty
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Label
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Link
+import org.wordpress.android.ui.stats.refresh.BlockListItem.ListItem
+import org.wordpress.android.ui.stats.refresh.BlockListItem.TabsItem
+import org.wordpress.android.ui.stats.refresh.BlockListItem.TabsItem.Tab
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Title
+import org.wordpress.android.ui.stats.refresh.BlockListItem.UserItem
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewFollowersStats
+import javax.inject.Inject
+
+private const val PAGE_SIZE = 6
+
+class CommentsUseCase
+@Inject constructor(
+    private val insightsStore: InsightsStore
+) {
+    private val mutableNavigationTarget = MutableLiveData<NavigationTarget>()
+    val navigationTarget: LiveData<NavigationTarget> = mutableNavigationTarget
+
+    suspend fun loadComments(site: SiteModel, forced: Boolean = false): InsightsItem {
+        val response = insightsStore.fetchComments(site, forced)
+        val model = response.model
+        val error = response.error
+
+        return when {
+            error != null -> Failed(R.string.stats_view_comments, error.message ?: error.type.name)
+            model != null -> loadComments(site, model)
+            else -> throw IllegalArgumentException("Unexpected empty body")
+        }
+    }
+
+    private fun loadComments(site: SiteModel, model: CommentsModel): ListInsightItem {
+        val items = mutableListOf<BlockListItem>()
+        items.add(Title(string.stats_view_comments))
+        items.add(TabsItem(listOf(buildAuthorsTab(model.authors), buildPostsTab(model.posts))))
+        items.add(Link(text = string.stats_insights_view_more) {
+            mutableNavigationTarget.value = ViewFollowersStats(site.siteId)
+        })
+        return ListInsightItem(items)
+    }
+
+    private fun buildAuthorsTab(authors: List<CommentsModel.Author>): Tab {
+        val mutableItems = mutableListOf<BlockListItem>()
+        if (authors.isNotEmpty()) {
+            mutableItems.add(Label(R.string.stats_comments_author_label, R.string.stats_comments_label))
+            mutableItems.addAll(authors.take(PAGE_SIZE).mapIndexed { index, author ->
+                UserItem(
+                        author.gravatar,
+                        author.name,
+                        author.comments.toFormattedString(),
+                        index < authors.size - 1
+                )
+            })
+        } else {
+            mutableItems.add(Empty)
+        }
+        return Tab(R.string.stats_comments_authors, mutableItems)
+    }
+
+    private fun buildPostsTab(posts: List<CommentsModel.Post>): Tab {
+        val mutableItems = mutableListOf<BlockListItem>()
+        if (posts.isNotEmpty()) {
+            mutableItems.add(Label(R.string.stats_comments_title_label, R.string.stats_comments_label))
+            mutableItems.addAll(posts.take(PAGE_SIZE).mapIndexed { index, post ->
+                ListItem(
+                        post.name,
+                        post.comments.toFormattedString(),
+                        index < posts.size - 1
+                )
+            })
+        } else {
+            mutableItems.add(Empty)
+        }
+        return Tab(R.string.stats_comments_posts_and_pages, mutableItems)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/CommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/CommentsUseCase.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.ui.stats.refresh.BlockListItem.TabsItem
 import org.wordpress.android.ui.stats.refresh.BlockListItem.TabsItem.Tab
 import org.wordpress.android.ui.stats.refresh.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.BlockListItem.UserItem
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewFollowersStats
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewCommentsStats
 import javax.inject.Inject
 
 private const val PAGE_SIZE = 6
@@ -44,7 +44,7 @@ class CommentsUseCase
         items.add(Title(string.stats_view_comments))
         items.add(TabsItem(listOf(buildAuthorsTab(model.authors), buildPostsTab(model.posts))))
         items.add(Link(text = string.stats_insights_view_more) {
-            mutableNavigationTarget.value = ViewFollowersStats(site.siteId)
+            mutableNavigationTarget.value = ViewCommentsStats(site.siteId)
         })
         return ListInsightItem(items)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/InsightsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/InsightsViewModel.kt
@@ -30,6 +30,7 @@ class InsightsViewModel
     private val insightsAllTimeViewModel: InsightsAllTimeViewModel,
     private val latestPostSummaryViewModel: LatestPostSummaryViewModel,
     private val todayStatsUseCase: TodayStatsUseCase,
+    private val commentsUseCase: CommentsUseCase,
     private val followersUseCase: FollowersUseCase
 ) {
     private val mediatorNavigationTarget: MediatorLiveData<NavigationTarget> = MediatorLiveData()
@@ -50,11 +51,11 @@ class InsightsViewModel
             LATEST_POST_SUMMARY -> latestPostSummaryViewModel.loadLatestPostSummary(site, forced)
             TODAY_STATS -> todayStatsUseCase.loadTodayStats(site, forced)
             FOLLOWERS -> followersUseCase.loadFollowers(site, forced)
+            COMMENTS -> commentsUseCase.loadComments(site, forced)
             MOST_POPULAR_DAY_AND_HOUR,
             FOLLOWER_TOTALS,
             TAGS_AND_CATEGORIES,
             ANNUAL_SITE_STATS,
-            COMMENTS,
             POSTING_ACTIVITY,
             PUBLICIZE -> NotImplemented(type.name)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/InsightsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/InsightsViewModel.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.stats.refresh
 
 import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.MediatorLiveData
 import kotlinx.coroutines.experimental.CoroutineScope
 import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.withContext
@@ -20,6 +19,7 @@ import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.PUBLICIZE
 import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.TAGS_AND_CATEGORIES
 import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.TODAY_STATS
 import org.wordpress.android.modules.DEFAULT_SCOPE
+import org.wordpress.android.util.merge
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -33,17 +33,11 @@ class InsightsViewModel
     private val commentsUseCase: CommentsUseCase,
     private val followersUseCase: FollowersUseCase
 ) {
-    private val mediatorNavigationTarget: MediatorLiveData<NavigationTarget> = MediatorLiveData()
-    val navigationTarget: LiveData<NavigationTarget> = mediatorNavigationTarget
-
-    init {
-        mediatorNavigationTarget.addSource(latestPostSummaryViewModel.navigationTarget) {
-            mediatorNavigationTarget.value = it
-        }
-        mediatorNavigationTarget.addSource(followersUseCase.navigationTarget) {
-            mediatorNavigationTarget.value = it
-        }
-    }
+    val navigationTarget: LiveData<NavigationTarget> = merge(
+            latestPostSummaryViewModel.navigationTarget,
+            followersUseCase.navigationTarget,
+            commentsUseCase.navigationTarget
+    )
 
     private suspend fun load(site: SiteModel, type: InsightsTypes, forced: Boolean): InsightsItem {
         return when (type) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListFragment.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.stats.StatsConstants
 import org.wordpress.android.ui.stats.models.StatsPostModel
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.AddNewPost
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.SharePost
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewCommentsStats
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewFollowersStats
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewPostDetailStats
 import org.wordpress.android.ui.stats.refresh.StatsListViewModel.StatsListType
@@ -137,6 +138,9 @@ class StatsListFragment : Fragment() {
                 is ViewFollowersStats -> {
                     ActivityLauncher.viewFollowersStats(activity, site)
                 }
+                is ViewCommentsStats -> {
+                    ActivityLauncher.viewCommentsStats(activity, site)
+                }
             }
         })
     }
@@ -164,4 +168,5 @@ sealed class NavigationTarget {
     ) : NavigationTarget()
 
     data class ViewFollowersStats(val siteID: Long) : NavigationTarget()
+    data class ViewCommentsStats(val siteID: Long) : NavigationTarget()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListFragment.kt
@@ -26,8 +26,10 @@ import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewFollowersStat
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewPostDetailStats
 import org.wordpress.android.ui.stats.refresh.StatsListViewModel.StatsListType
 import org.wordpress.android.util.DisplayUtils
+import org.wordpress.android.util.Event
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.image.ImageManager
+import org.wordpress.android.util.observeEvent
 import org.wordpress.android.widgets.RecyclerItemDecoration
 import javax.inject.Inject
 
@@ -111,7 +113,7 @@ class StatsListFragment : Fragment() {
             }
         })
 
-        viewModel.navigationTarget.observe(this, Observer {
+        viewModel.navigationTarget.observeEvent(this) {
             when (it) {
                 is AddNewPost -> ActivityLauncher.addNewPostForResult(activity, site, false)
                 is SharePost -> {
@@ -142,7 +144,8 @@ class StatsListFragment : Fragment() {
                     ActivityLauncher.viewCommentsStats(activity, site)
                 }
             }
-        })
+            true
+        }
     }
 
     private fun updateInsights(insightsState: InsightsUiState) {
@@ -157,7 +160,7 @@ class StatsListFragment : Fragment() {
     }
 }
 
-sealed class NavigationTarget {
+sealed class NavigationTarget : Event() {
     object AddNewPost : NavigationTarget()
     data class SharePost(val url: String, val title: String) : NavigationTarget()
     data class ViewPostDetailStats(

--- a/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.util
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MediatorLiveData
+
+fun <T> merge(vararg sources: LiveData<T>): LiveData<T> {
+    val mediator = MediatorLiveData<T>()
+    for (source in sources) {
+        mediator.addSource(source) {
+            mediator.value = it
+        }
+    }
+    return mediator
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
@@ -1,7 +1,9 @@
 package org.wordpress.android.util
 
+import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MediatorLiveData
+import android.arch.lifecycle.Observer
 
 fun <T> merge(vararg sources: LiveData<T>): LiveData<T> {
     val mediator = MediatorLiveData<T>()
@@ -12,3 +14,18 @@ fun <T> merge(vararg sources: LiveData<T>): LiveData<T> {
     }
     return mediator
 }
+
+/**
+ * Use this in order to observe an emission only once - for example for displaying a Snackbar message
+ */
+fun <T : Event> LiveData<T>.observeEvent(owner: LifecycleOwner, observer: (T) -> Boolean) {
+    this.observe(owner, Observer {
+        if (it != null && !it.hasBeenHandled) {
+            if (observer(it)) {
+                it.hasBeenHandled = true
+            }
+        }
+    })
+}
+
+open class Event(var hasBeenHandled: Boolean = false)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -778,6 +778,11 @@
     <string name="stats_followers_count_message">Total %1$s Followers: %2$s</string>
     <string name="stats_follower_label">Follower</string>
     <string name="stats_follower_since_label">Since</string>
+    <string name="stats_comments_authors">Authors</string>
+    <string name="stats_comments_posts_and_pages">Posts and pages</string>
+    <string name="stats_comments_author_label">Author</string>
+    <string name="stats_comments_title_label">Title</string>
+    <string name="stats_comments_label">Comments</string>
 
     <!-- Jetpack install -->
     <string name="jetpack">Jetpack</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/CommentsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/CommentsUseCaseTest.kt
@@ -1,0 +1,173 @@
+package org.wordpress.android.ui.stats.refresh
+
+import com.nhaarman.mockito_kotlin.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.R
+import org.wordpress.android.R.string
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.CommentsModel
+import org.wordpress.android.fluxc.store.InsightsStore
+import org.wordpress.android.fluxc.store.InsightsStore.OnInsightsFetched
+import org.wordpress.android.fluxc.store.InsightsStore.StatsError
+import org.wordpress.android.fluxc.store.InsightsStore.StatsErrorType.GENERIC_ERROR
+import org.wordpress.android.test
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Empty
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Label
+import org.wordpress.android.ui.stats.refresh.BlockListItem.ListItem
+import org.wordpress.android.ui.stats.refresh.BlockListItem.TabsItem
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Title
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.LABEL
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.LIST_ITEM
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.TITLE
+import org.wordpress.android.ui.stats.refresh.BlockListItem.Type.USER_ITEM
+import org.wordpress.android.ui.stats.refresh.BlockListItem.UserItem
+import org.wordpress.android.ui.stats.refresh.InsightsItem.Type.FAILED
+import org.wordpress.android.ui.stats.refresh.InsightsItem.Type.LIST_INSIGHTS
+
+@RunWith(MockitoJUnitRunner::class)
+class CommentsUseCaseTest {
+    @Mock lateinit var insightsStore: InsightsStore
+    @Mock lateinit var site: SiteModel
+    private lateinit var useCase: CommentsUseCase
+    private val postId: Long = 10
+    private val postTitle = "Post"
+    private val avatar = "avatar.jpg"
+    private val user = "John Smith"
+    private val url = "www.url.com"
+    private val totalCount = 50
+    @Before
+    fun setUp() {
+        useCase = CommentsUseCase(insightsStore)
+    }
+
+    @Test
+    fun `maps posts comments to UI model`() = test {
+        val forced = false
+        whenever(insightsStore.fetchComments(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        CommentsModel(listOf(CommentsModel.Post(postId, postTitle, totalCount, url)), listOf())
+                )
+        )
+
+        val result = useCase.loadComments(site, forced)
+
+        assertThat(result.type).isEqualTo(LIST_INSIGHTS)
+        (result as ListInsightItem).apply {
+            assertThat(this.items).hasSize(3)
+            assertTitle(this.items[0])
+            val tabsItem = this.items[1] as TabsItem
+
+            assertThat(tabsItem.tabs[0].title).isEqualTo(string.stats_comments_authors)
+            assertThat(tabsItem.tabs[0].items).containsOnly(Empty)
+
+            assertThat(tabsItem.tabs[1].title).isEqualTo(string.stats_comments_posts_and_pages)
+            assertTabWithPosts(tabsItem.tabs[1])
+        }
+    }
+
+    @Test
+    fun `maps comment authors to UI model`() = test {
+        val forced = false
+        whenever(insightsStore.fetchComments(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        CommentsModel(listOf(), listOf(CommentsModel.Author(user, totalCount, url, avatar)))
+                )
+        )
+
+        val result = useCase.loadComments(site, forced)
+
+        assertThat(result.type).isEqualTo(LIST_INSIGHTS)
+        (result as ListInsightItem).apply {
+            assertThat(this.items).hasSize(3)
+            assertTitle(this.items[0])
+            val tabsItem = this.items[1] as TabsItem
+
+            assertThat(tabsItem.tabs[0].title).isEqualTo(string.stats_comments_authors)
+            assertTabWithUsers(tabsItem.tabs[0])
+
+            assertThat(tabsItem.tabs[1].title).isEqualTo(string.stats_comments_posts_and_pages)
+            assertThat(tabsItem.tabs[1].items).containsOnly(Empty)
+        }
+    }
+
+    @Test
+    fun `maps empty comments to UI model`() = test {
+        val forced = false
+        whenever(insightsStore.fetchComments(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        CommentsModel(listOf(), listOf())
+                )
+        )
+
+        val result = useCase.loadComments(site, forced)
+
+        assertThat(result.type).isEqualTo(LIST_INSIGHTS)
+        (result as ListInsightItem).apply {
+            assertThat(this.items).hasSize(3)
+            assertTitle(this.items[0])
+            val tabsItem = this.items[1] as TabsItem
+
+            assertThat(tabsItem.tabs[0].title).isEqualTo(string.stats_comments_authors)
+            assertThat(tabsItem.tabs[0].items).containsOnly(Empty)
+
+            assertThat(tabsItem.tabs[1].title).isEqualTo(string.stats_comments_posts_and_pages)
+            assertThat(tabsItem.tabs[1].items).containsOnly(Empty)
+        }
+    }
+
+    @Test
+    fun `maps error item to UI model`() = test {
+        val forced = false
+        val message = "Generic error"
+        whenever(insightsStore.fetchComments(site, forced)).thenReturn(
+                OnInsightsFetched(
+                        StatsError(GENERIC_ERROR, message)
+                )
+        )
+
+        val result = useCase.loadComments(site, forced)
+
+        assertThat(result.type).isEqualTo(FAILED)
+        (result as Failed).apply {
+            assertThat(this.failedType).isEqualTo(string.stats_view_comments)
+            assertThat(this.errorMessage).isEqualTo(message)
+        }
+    }
+
+    private fun assertTabWithPosts(tab: TabsItem.Tab) {
+        val labelItem = tab.items[0]
+        assertThat(labelItem.type).isEqualTo(LABEL)
+        assertThat((labelItem as Label).leftLabel).isEqualTo(R.string.stats_comments_title_label)
+        assertThat(labelItem.rightLabel).isEqualTo(R.string.stats_comments_label)
+
+        val userItem = tab.items[1]
+        assertThat(userItem.type).isEqualTo(LIST_ITEM)
+        assertThat((userItem as ListItem).text).isEqualTo(postTitle)
+        assertThat(userItem.showDivider).isEqualTo(false)
+        assertThat(userItem.value).isEqualTo(totalCount.toString())
+    }
+
+    private fun assertTabWithUsers(tab: TabsItem.Tab) {
+        val labelItem = tab.items[0]
+        assertThat(labelItem.type).isEqualTo(LABEL)
+        assertThat((labelItem as Label).leftLabel).isEqualTo(R.string.stats_comments_author_label)
+        assertThat(labelItem.rightLabel).isEqualTo(R.string.stats_comments_label)
+
+        val userItem = tab.items[1]
+        assertThat(userItem.type).isEqualTo(USER_ITEM)
+        assertThat((userItem as UserItem).avatarUrl).isEqualTo(avatar)
+        assertThat(userItem.showDivider).isEqualTo(false)
+        assertThat(userItem.text).isEqualTo(user)
+        assertThat(userItem.value).isEqualTo(totalCount.toString())
+    }
+
+    private fun assertTitle(item: BlockListItem) {
+        assertThat(item.type).isEqualTo(TITLE)
+        assertThat((item as Title).text).isEqualTo(R.string.stats_view_comments)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '4affc2aea562a209fafd8add086064adff261703'
+    fluxCVersion = 'eb943acfcdab8e383f279cac9a53992b4133067e'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'f7c231a93f51c5a7cd52209687232bc351ae5e4e'
+    fluxCVersion = '3de2ac4233162226f014d736a349cb58d105e3aa'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'eb943acfcdab8e383f279cac9a53992b4133067e'
+    fluxCVersion = 'f7c231a93f51c5a7cd52209687232bc351ae5e4e'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '3de2ac4233162226f014d736a349cb58d105e3aa'
+    fluxCVersion = '73ac5d135bb43797e73e10209b4f56860fbb146d'
 }


### PR DESCRIPTION
Fixes #8529 

Add a Comments block to the Stats screen with two tabs - a list of top commenting authors and a list of top commented posts. The view more button links to a more detailed screen (with the original designs).  

To test:
* Open stats
* You see a Comments block
* Switch tabs
* There is a "No data yet" message when the comments are empty
* View more button links to the detail screen
