### PR TITLE
Gutenberg mobile: Detect content change

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1010,7 +1010,7 @@ public class EditPostActivity extends AppCompatActivity implements
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
         MenuInflater inflater = getMenuInflater();
-        if (mShowNewEditor || mShowAztecEditor) {
+        if (mShowNewEditor || mShowAztecEditor || mShowGutenbergEditor) {
             inflater.inflate(R.menu.edit_post, menu);
         } else {
             inflater.inflate(R.menu.edit_post_legacy, menu);
@@ -1173,7 +1173,8 @@ public class EditPostActivity extends AppCompatActivity implements
         } else {
             // Disable other action bar buttons while a media upload is in progress
             // (unnecessary for Aztec since it supports progress reattachment)
-            if (!mShowAztecEditor && (mEditorFragment.isUploadingMedia() || mEditorFragment.isActionInProgress())) {
+            if (!(mShowAztecEditor || mShowGutenbergEditor)
+                        && (mEditorFragment.isUploadingMedia() || mEditorFragment.isActionInProgress())) {
                 ToastUtils.showToast(this, R.string.editor_toast_uploading_please_wait, Duration.SHORT);
                 return false;
             }
@@ -1403,7 +1404,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // Update post object from fragment fields
         boolean postTitleOrContentChanged = false;
         if (mEditorFragment != null) {
-            if (mShowNewEditor || mShowAztecEditor) {
+            if (mShowNewEditor || mShowAztecEditor || mShowGutenbergEditor) {
                 postTitleOrContentChanged =
                         updatePostContentNewEditor(isAutosave, (String) mEditorFragment.getTitle(),
                                 (String) mEditorFragment.getContent(mPost.getContent()));
@@ -1710,7 +1711,7 @@ public class EditPostActivity extends AppCompatActivity implements
             savePostToDb();
             PostUtils.trackSavePostAnalytics(mPost, mSiteStore.getSiteByLocalId(mPost.getLocalSiteId()));
 
-            UploadService.setLegacyMode(!mShowNewEditor && !mShowAztecEditor);
+            UploadService.setLegacyMode(!mShowNewEditor && !mShowAztecEditor && !mShowGutenbergEditor);
             if (mIsFirstTimePublish) {
                 UploadService.uploadPostAndTrackAnalytics(EditPostActivity.this, mPost);
             } else {
@@ -1749,7 +1750,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 // Changes have been made - save the post and ask for the post list to refresh
                 // We consider this being "manual save", it will replace some Android "spans" by an html
                 // or a shortcode replacement (for instance for images and galleries)
-                if (mShowNewEditor || mShowAztecEditor) {
+                if (mShowNewEditor || mShowAztecEditor || mShowGutenbergEditor) {
                     // Update the post object directly, without re-fetching the fields from the EditorFragment
                     updatePostContentNewEditor(false, mPost.getTitle(), mPost.getContent());
                 }
@@ -2208,7 +2209,7 @@ public class EditPostActivity extends AppCompatActivity implements
         if (mPost != null) {
             if (!TextUtils.isEmpty(mPost.getContent()) && !mHasSetPostContent) {
                 mHasSetPostContent = true;
-                if (mPost.isLocalDraft() && !mShowNewEditor && !mShowAztecEditor) {
+                if (mPost.isLocalDraft() && !mShowNewEditor && !mShowAztecEditor && !mShowGutenbergEditor) {
                     // TODO: Unnecessary for new editor, as all images are uploaded right away, even for local drafts
                     // Load local post content in the background, as it may take time to generate images
                     new LoadPostContentTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
@@ -2638,7 +2639,7 @@ public class EditPostActivity extends AppCompatActivity implements
             Uri optimizedMedia = WPMediaUtils.getOptimizedMedia(activity, path, isVideo);
             if (optimizedMedia != null) {
                 mediaUri = optimizedMedia;
-            } else if (mShowNewEditor || mShowAztecEditor) {
+            } else if (mShowNewEditor || mShowAztecEditor || mShowGutenbergEditor) {
                 // Fix for the rotation issue https://github.com/wordpress-mobile/WordPress-Android/issues/5737
                 if (!mSite.isWPCom()) {
                     // If it's not wpcom we must rotate the picture locally
@@ -2673,7 +2674,7 @@ public class EditPostActivity extends AppCompatActivity implements
             runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    if (mShowNewEditor || mShowAztecEditor) {
+                    if (mShowNewEditor || mShowAztecEditor || mShowGutenbergEditor) {
                         addMediaVisualEditor(mediaUri, path);
                     } else {
                         addMediaLegacyEditor(mediaUri, isVideo);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -329,6 +329,10 @@ public class EditPostActivity extends AppCompatActivity implements
     // for keeping the media uri while asking for permissions
     private ArrayList<Uri> mDroppedMediaUris;
 
+    private boolean isModernEditor() {
+        return mShowNewEditor || mShowAztecEditor || mShowGutenbergEditor;
+    }
+
     private Runnable mFetchMediaRunnable = new Runnable() {
         @Override
         public void run() {
@@ -1010,7 +1014,7 @@ public class EditPostActivity extends AppCompatActivity implements
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
         MenuInflater inflater = getMenuInflater();
-        if (mShowNewEditor || mShowAztecEditor || mShowGutenbergEditor) {
+        if (isModernEditor()) {
             inflater.inflate(R.menu.edit_post, menu);
         } else {
             inflater.inflate(R.menu.edit_post_legacy, menu);
@@ -1404,7 +1408,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // Update post object from fragment fields
         boolean postTitleOrContentChanged = false;
         if (mEditorFragment != null) {
-            if (mShowNewEditor || mShowAztecEditor || mShowGutenbergEditor) {
+            if (isModernEditor()) {
                 postTitleOrContentChanged =
                         updatePostContentNewEditor(isAutosave, (String) mEditorFragment.getTitle(),
                                 (String) mEditorFragment.getContent(mPost.getContent()));
@@ -1711,7 +1715,7 @@ public class EditPostActivity extends AppCompatActivity implements
             savePostToDb();
             PostUtils.trackSavePostAnalytics(mPost, mSiteStore.getSiteByLocalId(mPost.getLocalSiteId()));
 
-            UploadService.setLegacyMode(!mShowNewEditor && !mShowAztecEditor && !mShowGutenbergEditor);
+            UploadService.setLegacyMode(!isModernEditor());
             if (mIsFirstTimePublish) {
                 UploadService.uploadPostAndTrackAnalytics(EditPostActivity.this, mPost);
             } else {
@@ -1750,7 +1754,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 // Changes have been made - save the post and ask for the post list to refresh
                 // We consider this being "manual save", it will replace some Android "spans" by an html
                 // or a shortcode replacement (for instance for images and galleries)
-                if (mShowNewEditor || mShowAztecEditor || mShowGutenbergEditor) {
+                if (isModernEditor()) {
                     // Update the post object directly, without re-fetching the fields from the EditorFragment
                     updatePostContentNewEditor(false, mPost.getTitle(), mPost.getContent());
                 }
@@ -2209,7 +2213,7 @@ public class EditPostActivity extends AppCompatActivity implements
         if (mPost != null) {
             if (!TextUtils.isEmpty(mPost.getContent()) && !mHasSetPostContent) {
                 mHasSetPostContent = true;
-                if (mPost.isLocalDraft() && !mShowNewEditor && !mShowAztecEditor && !mShowGutenbergEditor) {
+                if (mPost.isLocalDraft() && !isModernEditor()) {
                     // TODO: Unnecessary for new editor, as all images are uploaded right away, even for local drafts
                     // Load local post content in the background, as it may take time to generate images
                     new LoadPostContentTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
@@ -2639,7 +2643,7 @@ public class EditPostActivity extends AppCompatActivity implements
             Uri optimizedMedia = WPMediaUtils.getOptimizedMedia(activity, path, isVideo);
             if (optimizedMedia != null) {
                 mediaUri = optimizedMedia;
-            } else if (mShowNewEditor || mShowAztecEditor || mShowGutenbergEditor) {
+            } else if (isModernEditor()) {
                 // Fix for the rotation issue https://github.com/wordpress-mobile/WordPress-Android/issues/5737
                 if (!mSite.isWPCom()) {
                     // If it's not wpcom we must rotate the picture locally
@@ -2674,7 +2678,7 @@ public class EditPostActivity extends AppCompatActivity implements
             runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    if (mShowNewEditor || mShowAztecEditor || mShowGutenbergEditor) {
+                    if (isModernEditor()) {
                         addMediaVisualEditor(mediaUri, path);
                     } else {
                         addMediaLegacyEditor(mediaUri, isVideo);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -177,6 +177,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     private MediaSelectedCallback mPendingMediaSelectedCallback;
 
     private String mContentHtml = "";
+    private boolean mContentChanged;
     private CountDownLatch mGetContentCountDownLatch;
 
     private static final String PROP_NAME_INITIAL_DATA = "initialData";
@@ -254,8 +255,9 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     protected List<ReactPackage> getPackages() {
         mRnReactNativeGutenbergBridgePackage = new RNReactNativeGutenbergBridgePackage(new GutenbergBridgeJS2Parent() {
             @Override
-            public void responseHtml(String html) {
+            public void responseHtml(String html, boolean changed) {
                 mContentHtml = html;
+                mContentChanged = changed;
                 mGetContentCountDownLatch.countDown();
             }
 
@@ -1040,7 +1042,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                 Thread.currentThread().interrupt();
             }
 
-            return StringUtils.notNullStr(mContentHtml);
+            return mContentChanged ? StringUtils.notNullStr(mContentHtml) : originalContent;
         } else {
             Log.d("QWER", "context is null");
         }


### PR DESCRIPTION
Addresses part of https://github.com/wordpress-mobile/gutenberg-mobile/issues/182

Uses a new boolean passed back from the RN app denoting that the html content has changed since the original html was provided to the editor.

To test:
1. Follow the steps in Test 1 or 2 from #8522 to run compile/run the integrated app
2. Open a Gutenberg post that has no local changes. Don't make any changes and go "Back".
3. Notice the post retaining the status it had before, without marking the post as having local changes.


Marked you both for review @daniloercoli and @mzorz but just one should probably be fine. Just catering for timezone coverage here 😄 