### PR TITLE
Gutenberg Mobile: Limit to media library picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3122,6 +3122,9 @@ public class EditPostActivity extends AppCompatActivity implements
     public void onAddMediaClicked() {
         if (isPhotoPickerShowing()) {
             hidePhotoPicker();
+        } else if (mShowGutenbergEditor) {
+            // show the WP media library only since that's the only mode integrated currently from Gutenberg-mobile
+            ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.EDITOR_PICKER);
         } else if (WPMediaUtils.currentUserCanUploadMedia(mSite)) {
             showPhotoPicker();
         } else {


### PR DESCRIPTION
The integration with gutenberg-mobile currently only supports selecting an image from the site's media library so, only launch that part of the picker.

To test:
1. Follow the steps in Test 1 or 2 from #8522 to run compile/run the integrated app
2. Open a Gutenberg post and add an image block
3. Tap on the "Media Library" button to select an image
4. Notice that only the media library view launches
5. Select an image and hit the "checkmart" icon on the appbar
6. Notice the editor coming to foreground again and the image getting shown on the block a few moments later