### PR TITLE
Enabled animating GIFs in gutenberg-mobile

### DIFF
--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -69,4 +69,8 @@
 -dontwarn org.wordpress.aztec.glideloader.**
 
 -dontwarn com.github.godness84.RNRecyclerViewList.**
+
+-keep class com.facebook.imagepipeline.animated.factory.AnimatedFactoryImpl {
+  public AnimatedFactoryImpl(com.facebook.imagepipeline.bitmaps.PlatformBitmapFactory, com.facebook.imagepipeline.core.ExecutorSupplier);
+}
 ###### React Native - end

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -73,6 +73,16 @@ dependencies {
     // React Native
     implementation "com.facebook.react:react-native:+" // From node_modules.
 
+    // For animated GIF support
+    implementation 'com.facebook.fresco:animated-gif:1.10.0'
+
+    // For WebP support, including animated WebP
+    implementation 'com.facebook.fresco:animated-webp:1.10.0'
+    implementation 'com.facebook.fresco:webpsupport:1.10.0'
+
+    // For WebP support, without animations
+    implementation 'com.facebook.fresco:webpsupport:1.10.0'
+
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.1.4"
     implementation "org.jsoup:jsoup:1.10.3"


### PR DESCRIPTION
Adds the native libraries to enable React Native to animate GIFs.

To test:
1. Follow the steps in Test 1 or 2 from #8522 to run compile/run the integrated app
2. Open a Gutenberg post and add an image block
3. Tap on the "Media Library" button to select an image
4. Select an animated GIF and hit the "checkmark" on the app bar to commit
5. Notice the GIF animating inside the editor