### PR TITLE
Update Aztec to 1.3.11

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -52,9 +52,9 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'org.wordpress:utils:1.22'
 
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.11')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.3.11')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.3.11')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:53b1d0975f05138016b63ef65dee26b4b6f392c3')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:53b1d0975f05138016b63ef65dee26b4b6f392c3')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:53b1d0975f05138016b63ef65dee26b4b6f392c3')
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.1.4"

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -52,9 +52,9 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'org.wordpress:utils:1.22'
 
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.10')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.3.10')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.3.10')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.11')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.3.11')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.3.11')
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.1.4"


### PR DESCRIPTION
This PR updates the Aztec editor to 1.3.11 for WPAndroid 11.1.1 in order to fix the repeating characters issue.
