### PR TITLE
Include comment likes in the Likes notification filter

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Note.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.java
@@ -117,6 +117,10 @@ public class Note {
     }
 
     public Boolean isLikeType() {
+        return isPostLikeType() || isCommentLikeType();
+    }
+
+    public Boolean isPostLikeType() {
         return isType(NOTE_LIKE_TYPE);
     }
 
@@ -138,7 +142,7 @@ public class Note {
     }
 
     public Boolean isUserList() {
-        return isLikeType() || isCommentLikeType() || isFollowType() || isReblogType();
+        return isLikeType() || isFollowType() || isReblogType();
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -527,8 +527,7 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
             // The block will not have a type, and its id will match the comment reply id in the Note.
             return (blockObject.getType() == null
                     && mNote.getCommentReplyId() == commentReplyId);
-        } else if (mNote.isFollowType() || mNote.isLikeType()
-                   || mNote.isCommentLikeType() || mNote.isReblogType()) {
+        } else if (mNote.isFollowType() || mNote.isLikeType() || mNote.isReblogType()) {
             // User list notifications have a footer if they have 10 or more users in the body
             // The last block will not have a type, so we can use that to determine if it is the footer
             return blockObject.getType() == null;


### PR DESCRIPTION
Fixes #8582.

To test:
1. Go to the Notifications
2. Look at the All tab notifications and notice the post and comment likes
3. Switch to the Likes filter tab
4. Notice that both the comment likes and post likes are shown