### PR TITLE
Issue/5107 add change password

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -275,9 +275,9 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
             return;
         }
 
-        showChangePasswordProgressDialog(false);
-
         if (event.isError()) {
+            showChangePasswordProgressDialog(false);
+
             switch (event.error.type) {
                 case SETTINGS_FETCH_ERROR:
                     ToastUtils
@@ -291,6 +291,12 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
                     break;
             }
         } else {
+            // When account change is caused by password change, progress dialog will be shown (i.e. not null).
+            if (mChangePasswordProgressDialog != null) {
+                showChangePasswordProgressDialog(false);
+                ToastUtils.showToast(getActivity(), R.string.change_password_confirmation, ToastUtils.Duration.LONG);
+            }
+
             refreshAccountDetails();
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.prefs;
 
+import android.app.ProgressDialog;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.preference.Preference;
@@ -43,6 +44,7 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
     private DetailListPreference mPrimarySitePreference;
     private EditTextPreferenceWithValidation mWebAddressPreference;
     private EditTextPreferenceWithValidation mChangePasswordPreference;
+    private ProgressDialog mChangePasswordProgressDialog;
     private Snackbar mEmailSnackbar;
 
     @Inject Dispatcher mDispatcher;
@@ -144,6 +146,7 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
             updateWebAddress(newValue.toString());
             return false;
         } else if (preference == mChangePasswordPreference) {
+            showChangePasswordProgressDialog(true);
             updatePassword(newValue.toString());
         }
 
@@ -160,6 +163,19 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
 
     private void setTextAlignment(EditText editText) {
         editText.setTextAlignment(View.TEXT_ALIGNMENT_VIEW_START);
+    }
+
+    private void showChangePasswordProgressDialog(boolean show) {
+        if (show && mChangePasswordProgressDialog == null) {
+            mChangePasswordProgressDialog = new ProgressDialog(getActivity());
+            mChangePasswordProgressDialog.setCancelable(false);
+            mChangePasswordProgressDialog.setIndeterminate(true);
+            mChangePasswordProgressDialog.setMessage(getString(R.string.change_password_dialog_message));
+            mChangePasswordProgressDialog.show();
+        } else if (!show && mChangePasswordProgressDialog != null) {
+            mChangePasswordProgressDialog.dismiss();
+            mChangePasswordProgressDialog = null;
+        }
     }
 
     private void refreshAccountDetails() {
@@ -258,6 +274,8 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
         if (!isAdded()) {
             return;
         }
+
+        showChangePasswordProgressDialog(false);
 
         if (event.isError()) {
             switch (event.error.type) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -42,6 +42,7 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
     private EditTextPreferenceWithValidation mEmailPreference;
     private DetailListPreference mPrimarySitePreference;
     private EditTextPreferenceWithValidation mWebAddressPreference;
+    private EditTextPreferenceWithValidation mChangePasswordPreference;
     private Snackbar mEmailSnackbar;
 
     @Inject Dispatcher mDispatcher;
@@ -61,6 +62,8 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
         mPrimarySitePreference = (DetailListPreference) findPreference(getString(R.string.pref_key_primary_site));
         mWebAddressPreference =
                 (EditTextPreferenceWithValidation) findPreference(getString(R.string.pref_key_web_address));
+        mChangePasswordPreference =
+                (EditTextPreferenceWithValidation) findPreference(getString(R.string.pref_key_change_password));
 
         mEmailPreference.getEditText()
                         .setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS);
@@ -68,13 +71,18 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
         mWebAddressPreference.getEditText().setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_URI);
         mWebAddressPreference.setValidationType(EditTextPreferenceWithValidation.ValidationType.URL);
         mWebAddressPreference.setDialogMessage(R.string.web_address_dialog_hint);
+        mChangePasswordPreference.getEditText().setInputType(InputType.TYPE_TEXT_VARIATION_PASSWORD);
+        mChangePasswordPreference.setValidationType(EditTextPreferenceWithValidation.ValidationType.PASSWORD);
+        mChangePasswordPreference.setDialogMessage(R.string.change_password_dialog_hint);
 
         mEmailPreference.setOnPreferenceChangeListener(this);
         mPrimarySitePreference.setOnPreferenceChangeListener(this);
         mWebAddressPreference.setOnPreferenceChangeListener(this);
+        mChangePasswordPreference.setOnPreferenceChangeListener(this);
 
         setTextAlignment(mEmailPreference.getEditText());
         setTextAlignment(mWebAddressPreference.getEditText());
+        setTextAlignment(mChangePasswordPreference.getEditText());
 
         // load site list asynchronously
         new LoadSitesTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
@@ -135,6 +143,8 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
             mWebAddressPreference.setSummary(newValue.toString());
             updateWebAddress(newValue.toString());
             return false;
+        } else if (preference == mChangePasswordPreference) {
+            updatePassword(newValue.toString());
         }
 
         return true;
@@ -232,6 +242,13 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
         PushAccountSettingsPayload payload = new PushAccountSettingsPayload();
         payload.params = new HashMap<>();
         payload.params.put("user_URL", newWebAddress);
+        mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
+    }
+
+    public void updatePassword(String newPassword) {
+        PushAccountSettingsPayload payload = new PushAccountSettingsPayload();
+        payload.params = new HashMap<>();
+        payload.params.put("password", newPassword);
         mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -289,8 +289,6 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
                 refreshAccountDetails();
             }
         } else {
-            showChangePasswordProgressDialog(false);
-
             if (event.isError()) {
                 switch (event.error.type) {
                     case SETTINGS_FETCH_ERROR:

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/EditTextPreferenceWithValidation.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/EditTextPreferenceWithValidation.java
@@ -3,8 +3,11 @@ package org.wordpress.android.ui.prefs;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
+import android.text.Editable;
 import android.text.TextUtils;
+import android.text.TextWatcher;
 import android.text.method.PasswordTransformationMethod;
 import android.util.AttributeSet;
 import android.view.View;
@@ -35,7 +38,7 @@ public class EditTextPreferenceWithValidation extends SummaryEditTextPreference 
         super.showDialog(state);
 
         final AlertDialog dialog = (AlertDialog) getDialog();
-        Button positiveButton = dialog.getButton(DialogInterface.BUTTON_POSITIVE);
+        final Button positiveButton = dialog.getButton(DialogInterface.BUTTON_POSITIVE);
         if (positiveButton != null) {
             positiveButton.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -60,6 +63,35 @@ public class EditTextPreferenceWithValidation extends SummaryEditTextPreference 
                     } else {
                         callChangeListener(text);
                         dialog.dismiss();
+                    }
+                }
+            });
+
+            positiveButton.setTextColor(ContextCompat.getColorStateList(getContext(), R.color.dialog_button_selector));
+
+            getEditText().addTextChangedListener(new TextWatcher() {
+                @Override
+                public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                }
+
+                @Override
+                public void onTextChanged(CharSequence s, int start, int before, int count) {
+                }
+
+                @Override
+                public void afterTextChanged(Editable s) {
+                    switch (mValidationType) {
+                        case NONE:
+                            break;
+                        case EMAIL:
+                            positiveButton.setEnabled(ValidationUtils.validateEmail(s));
+                            break;
+                        case PASSWORD:
+                            positiveButton.setEnabled(ValidationUtils.validatePassword(s));
+                            break;
+                        case URL:
+                            positiveButton.setEnabled(ValidationUtils.validateUrl(s));
+                            break;
                     }
                 }
             });

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/EditTextPreferenceWithValidation.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/EditTextPreferenceWithValidation.java
@@ -6,7 +6,6 @@ import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.text.Editable;
-import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.text.method.PasswordTransformationMethod;
 import android.util.AttributeSet;
@@ -43,27 +42,8 @@ public class EditTextPreferenceWithValidation extends SummaryEditTextPreference 
             positiveButton.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    String error = null;
-                    CharSequence text = getEditText().getText();
-                    if (mValidationType == ValidationType.EMAIL) {
-                        error = ValidationUtils.validateEmail(text) ? null
-                                : getContext().getString(R.string.invalid_email_message);
-                    } else if (!TextUtils.isEmpty(text)) {
-                        if (mValidationType == ValidationType.URL) {
-                            error = ValidationUtils.validateUrl(text) ? null
-                                    : getContext().getString(R.string.invalid_url_message);
-                        } else if (mValidationType == ValidationType.PASSWORD) {
-                            error = ValidationUtils.validatePassword(text) ? null
-                                    : getContext().getString(R.string.change_password_invalid_message);
-                        }
-                    }
-
-                    if (error != null) {
-                        getEditText().setError(error);
-                    } else {
-                        callChangeListener(text);
-                        dialog.dismiss();
-                    }
+                    callChangeListener(getEditText().getText());
+                    dialog.dismiss();
                 }
             });
 
@@ -104,9 +84,6 @@ public class EditTextPreferenceWithValidation extends SummaryEditTextPreference 
             getEditText().setText(summary);
             getEditText().setSelection(0, summary.length());
         }
-
-        // clear previous errors
-        getEditText().setError(null);
 
         // Use "hidden" input type for passwords so characters are replaced with dots for added security.
         hideInputCharacters(mValidationType == ValidationType.PASSWORD);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/EditTextPreferenceWithValidation.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/EditTextPreferenceWithValidation.java
@@ -44,9 +44,14 @@ public class EditTextPreferenceWithValidation extends SummaryEditTextPreference 
                     if (mValidationType == ValidationType.EMAIL) {
                         error = ValidationUtils.validateEmail(text) ? null
                                 : getContext().getString(R.string.invalid_email_message);
-                    } else if (!TextUtils.isEmpty(text) && mValidationType == ValidationType.URL) {
-                        error = ValidationUtils.validateUrl(text) ? null
-                                : getContext().getString(R.string.invalid_url_message);
+                    } else if (!TextUtils.isEmpty(text)) {
+                        if (mValidationType == ValidationType.URL) {
+                            error = ValidationUtils.validateUrl(text) ? null
+                                    : getContext().getString(R.string.invalid_url_message);
+                        } else if (mValidationType == ValidationType.PASSWORD) {
+                            error = ValidationUtils.validatePassword(text) ? null
+                                    : getContext().getString(R.string.change_password_invalid_message);
+                        }
                     }
 
                     if (error != null) {
@@ -80,6 +85,6 @@ public class EditTextPreferenceWithValidation extends SummaryEditTextPreference 
     }
 
     public enum ValidationType {
-        NONE, EMAIL, URL
+        NONE, EMAIL, PASSWORD, URL
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/EditTextPreferenceWithValidation.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/EditTextPreferenceWithValidation.java
@@ -5,6 +5,7 @@ import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.v7.app.AlertDialog;
 import android.text.TextUtils;
+import android.text.method.PasswordTransformationMethod;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.Button;
@@ -74,6 +75,9 @@ public class EditTextPreferenceWithValidation extends SummaryEditTextPreference 
 
         // clear previous errors
         getEditText().setError(null);
+
+        // Use "hidden" input type for passwords so characters are replaced with dots for added security.
+        hideInputCharacters(mValidationType == ValidationType.PASSWORD);
     }
 
     public void setValidationType(ValidationType validationType) {
@@ -82,6 +86,13 @@ public class EditTextPreferenceWithValidation extends SummaryEditTextPreference 
 
     public void setStringToIgnoreForPrefilling(String stringToIgnoreForPrefilling) {
         mStringToIgnoreForPrefilling = stringToIgnoreForPrefilling;
+    }
+
+    private void hideInputCharacters(boolean hide) {
+        int selectionStart = getEditText().getSelectionStart();
+        int selectionEnd = getEditText().getSelectionEnd();
+        getEditText().setTransformationMethod(hide ? PasswordTransformationMethod.getInstance() : null);
+        getEditText().setSelection(selectionStart, selectionEnd);
     }
 
     public enum ValidationType {

--- a/WordPress/src/main/java/org/wordpress/android/util/ValidationUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ValidationUtils.kt
@@ -5,13 +5,15 @@ package org.wordpress.android.util
 import android.util.Patterns
 import java.util.regex.Pattern
 
-private val IPv4_PATTERN = Pattern.compile(
-        "^(([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.){3}([01]?\\d\\d?|2[0-4]\\d|25[0-5])$")
+private val IPv4_PATTERN = Pattern.compile("^(([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.){3}([01]?\\d\\d?|2[0-4]\\d|25[0-5])$")
+private val PASSWORD_PATTERN = Pattern.compile("^(.){6,}$")
 
 fun validateEmail(text: CharSequence): Boolean = validate(Patterns.EMAIL_ADDRESS, text)
 
 fun validateUrl(text: CharSequence): Boolean = validate(Patterns.WEB_URL, text)
 
 fun validateIPv4(text: CharSequence): Boolean = validate(IPv4_PATTERN, text)
+
+fun validatePassword(text: CharSequence): Boolean = validate(PASSWORD_PATTERN, text)
 
 private fun validate(pattern: Pattern, text: CharSequence): Boolean = pattern.matcher(text).matches()

--- a/WordPress/src/main/res/color-v23/dialog_button_selector.xml
+++ b/WordPress/src/main/res/color-v23/dialog_button_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:color="@color/dialog_button_text" android:state_enabled="false" android:alpha="?android:attr/disabledAlpha" />
+    <item android:color="@color/dialog_button_text" />
+
+</selector>

--- a/WordPress/src/main/res/color/dialog_button_selector.xml
+++ b/WordPress/src/main/res/color/dialog_button_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:color="@color/grey_disabled" android:state_enabled="false" />
+    <item android:color="@color/dialog_button_text" />
+
+</selector>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -168,6 +168,7 @@
     <!-- Misc -->
     <color name="pressed_wordpress">@color/blue_light_translucent_80</color>
     <color name="background_grey">@color/grey_lighten_30</color>
+    <color name="dialog_button_text">@color/blue_medium</color>
 
     <!--Me-->
     <color name="me_divider">#D8E3EA</color>

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -86,6 +86,7 @@
     <string name="pref_key_email" translatable="false">wp_pref_key_email</string>
     <string name="pref_key_primary_site" translatable="false">wp_pref_key_primary_site></string>
     <string name="pref_key_web_address" translatable="false">wp_pref_key_web_address</string>
+    <string name="pref_key_change_password" translatable="false">pref_key_change_password</string>
     <string name="pref_key_site_start_over_screen" translatable="false">wp_pref_key_site_start_over_screen</string>
     <!-- Speed up your site -->
     <string name="pref_key_speed_up_your_site_screen" translatable="false">wp_pref_speed_up_your_site_screen</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1909,6 +1909,7 @@
     <string name="web_address">Web Address</string>
     <string name="web_address_dialog_hint">Shown publicly when you comment.</string>
     <string name="change_password">Change password</string>
+    <string name="change_password_confirmation">Password changed successfully</string>
     <string name="change_password_dialog_hint">Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ &amp; ).</string>
     <string name="change_password_dialog_message">Changing password&#8230;</string>
     <string name="exporting_content_progress">Exporting content…</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1910,6 +1910,7 @@
     <string name="web_address_dialog_hint">Shown publicly when you comment.</string>
     <string name="change_password">Change password</string>
     <string name="change_password_dialog_hint">Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ &amp; ).</string>
+    <string name="change_password_dialog_message">Changing password&#8230;</string>
     <string name="exporting_content_progress">Exporting content…</string>
     <string name="export_email_sent">Export email sent!</string>
     <string name="export_your_content">Export your content</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1909,6 +1909,8 @@
     <string name="primary_site">Primary site</string>
     <string name="web_address">Web Address</string>
     <string name="web_address_dialog_hint">Shown publicly when you comment.</string>
+    <string name="change_password">Change password</string>
+    <string name="change_password_dialog_hint">Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ &amp; ).</string>
     <string name="change_password_invalid_message">Your password isn\'t valid</string>
     <string name="exporting_content_progress">Exporting content…</string>
     <string name="export_email_sent">Export email sent!</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1906,7 +1906,7 @@
     <string name="account_settings">Account Settings</string>
     <string name="pending_email_change_snackbar">Click the verification link in the email sent to %1$s to confirm your new address</string>
     <string name="primary_site">Primary site</string>
-    <string name="web_address">Web Address</string>
+    <string name="web_address">Web address</string>
     <string name="web_address_dialog_hint">Shown publicly when you comment.</string>
     <string name="change_password">Change password</string>
     <string name="change_password_confirmation">Password changed successfully</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1909,6 +1909,7 @@
     <string name="primary_site">Primary site</string>
     <string name="web_address">Web Address</string>
     <string name="web_address_dialog_hint">Shown publicly when you comment.</string>
+    <string name="change_password_invalid_message">Your password isn\'t valid</string>
     <string name="exporting_content_progress">Exporting content…</string>
     <string name="export_email_sent">Export email sent!</string>
     <string name="export_your_content">Export your content</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -970,7 +970,6 @@
 
     <!-- invalid_url -->
     <string name="invalid_site_url_message">Check that the site URL entered is valid</string>
-    <string name="invalid_url_message">Check that the URL entered is valid</string>
 
     <!-- QuickPress -->
     <string name="quickpress_window_title">Select blog for QuickPress shortcut</string>
@@ -1911,7 +1910,6 @@
     <string name="web_address_dialog_hint">Shown publicly when you comment.</string>
     <string name="change_password">Change password</string>
     <string name="change_password_dialog_hint">Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ &amp; ).</string>
-    <string name="change_password_invalid_message">Your password isn\'t valid</string>
     <string name="exporting_content_progress">Exporting content…</string>
     <string name="export_email_sent">Export email sent!</string>
     <string name="export_your_content">Export your content</string>

--- a/WordPress/src/main/res/xml/account_settings.xml
+++ b/WordPress/src/main/res/xml/account_settings.xml
@@ -24,4 +24,9 @@
         android:layout="@layout/wp_preference_layout"
         android:title="@string/web_address" />
 
+    <org.wordpress.android.ui.prefs.EditTextPreferenceWithValidation
+        android:key="@string/pref_key_change_password"
+        android:layout="@layout/wp_preference_layout"
+        android:title="@string/change_password" />
+
 </PreferenceScreen>

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '8cc0b68301d74d03fffc61891f445b7fd2b46022'
+    fluxCVersion = '6dc8ef82104eea4a6b76a830665d7c1f8b3dc34e'
 }


### PR DESCRIPTION
### Fix
Add a ***Change Password*** option to ***Account Settings*** on the ***Me*** tab as described in https://github.com/wordpress-mobile/WordPress-Android/issues/5107.  See the animation below for illustration.

<img src="https://user-images.githubusercontent.com/3827611/48287223-c5eb6600-e42d-11e8-898d-caf6de66f427.gif" width="320">

The progress dialog was included for slow network connections to block the user from exiting the ***Account Settings*** screen before the password change completes, which could leave their account and the app in a bad state.  The confirmation message was included to reassure the user that their password has been successfully changed since there is no visual verification on the ***Account Settings*** screen once the progress dialog is dismissed like the other preferences.

This pull request also includes changes to how edit text preferences with validation work.  Previously, users were allowed to enter anything and tap the ***OK*** button.  If the input was invalid, an error message was shown.  With these changes, users aren't allowed to tap the ***OK*** button until the input is valid.  This mimics the behavior while entering the address when deleting a site in the ***My Site*** > ***Settings*** > ***Delete Site*** dialog.  See the screenshots below for illustration.

<img src="https://user-images.githubusercontent.com/3827611/48287231-cbe14700-e42d-11e8-955f-31980d818742.png">

### Test
1. Go to ***Me*** tab.
2. Tap ***Account Settings*** option.
3. Tap ***Change password*** item.
4. Enter zero to five characters.
5. Notice ***OK*** button is disabled.
6. Enter six or more characters.
7. Notice ***OK*** button is enabled.
8. Tap ***OK*** button.
9. Notice ***Changing password...*** progress dialog is shown.
10. Notice ***Password changed successfully*** message is shown.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.