### PR TITLE
Issue/update help dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/SupportHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportHelper.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.support
 
 import android.content.Context
 import android.support.v7.app.AlertDialog
+import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.View.GONE
@@ -35,7 +36,7 @@ class SupportHelper {
         val (layout, emailEditText, nameEditText) =
                 supportIdentityInputDialogLayout(context, isNameInputHidden, email, name)
 
-        val dialog = AlertDialog.Builder(context, R.style.Calypso_Dialog)
+        val dialog = AlertDialog.Builder(ContextThemeWrapper(context, R.style.Calypso_Dialog))
                 .setView(layout)
                 .setPositiveButton(android.R.string.ok, null)
                 .setNegativeButton(android.R.string.cancel, null)

--- a/WordPress/src/main/res/layout/support_email_and_name_dialog.xml
+++ b/WordPress/src/main/res/layout/support_email_and_name_dialog.xml
@@ -1,41 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_width="match_parent"
     android:orientation="vertical"
-    android:padding="@dimen/margin_dialog">
+    android:padding="@dimen/margin_dialog" >
 
     <TextView
         android:id="@+id/support_identity_input_dialog_message"
-        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/margin_dialog"
-        android:textColor="@color/grey_darken_10"
-        android:textSize="@dimen/text_sz_large"/>
-
-    <TextView
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/support_identity_input_dialog_email_label"
-        android:textColor="@color/blue_medium"
-        android:textSize="@dimen/text_sz_small"/>
+        android:textColor="@color/grey_darken_10"
+        android:textSize="@dimen/text_sz_large" >
+    </TextView>
 
-    <EditText
-        android:id="@+id/support_identity_input_dialog_email_edit_text"
-        android:layout_width="match_parent"
+    <android.support.design.widget.TextInputLayout
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_large"
-        android:inputType="textEmailAddress"
-        android:textColor="@color/grey_dark"
-        android:textSize="@dimen/text_sz_medium"/>
+        android:layout_width="match_parent" >
 
-    <EditText
-        android:id="@+id/support_identity_input_dialog_name_edit_text"
-        android:layout_width="match_parent"
+        <android.support.design.widget.TextInputEditText
+            android:id="@+id/support_identity_input_dialog_email_edit_text"
+            android:hint="@string/support_identity_input_dialog_email_label"
+            android:inputType="textEmailAddress"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_large"
+            android:layout_width="match_parent"
+            android:maxLength="@integer/max_length_support_name"
+            android:textColor="@color/grey_dark"
+            android:textSize="@dimen/text_sz_medium" >
+        </android.support.design.widget.TextInputEditText>
+
+    </android.support.design.widget.TextInputLayout>
+
+    <android.support.design.widget.TextInputLayout
         android:layout_height="wrap_content"
-        android:inputType="text"
-        android:maxLength="@integer/max_length_support_name"
-        android:textColor="@color/grey_dark"
-        android:textSize="@dimen/text_sz_medium"/>
+        android:layout_width="match_parent" >
+
+        <android.support.design.widget.TextInputEditText
+            android:id="@+id/support_identity_input_dialog_name_edit_text"
+            android:inputType="text"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:maxLength="@integer/max_length_support_name"
+            android:textColor="@color/grey_dark"
+            android:textSize="@dimen/text_sz_medium" >
+        </android.support.design.widget.TextInputEditText>
+
+    </android.support.design.widget.TextInputLayout>
+
 </LinearLayout>

--- a/WordPress/src/main/res/layout/support_email_and_name_dialog.xml
+++ b/WordPress/src/main/res/layout/support_email_and_name_dialog.xml
@@ -2,6 +2,7 @@
 
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
     android:orientation="vertical"
@@ -13,7 +14,8 @@
         android:layout_marginBottom="@dimen/margin_dialog"
         android:layout_width="wrap_content"
         android:textColor="@color/grey_darken_10"
-        android:textSize="@dimen/text_sz_large" >
+        android:textSize="@dimen/text_sz_large"
+        tools:text="@string/support_identity_input_dialog_enter_email_and_name" >
     </TextView>
 
     <android.support.design.widget.TextInputLayout

--- a/WordPress/src/main/res/layout/support_email_and_name_dialog.xml
+++ b/WordPress/src/main/res/layout/support_email_and_name_dialog.xml
@@ -40,6 +40,7 @@
 
         <android.support.design.widget.TextInputEditText
             android:id="@+id/support_identity_input_dialog_name_edit_text"
+            android:hint="@string/support_identity_input_dialog_name_label"
             android:inputType="text"
             android:layout_height="wrap_content"
             android:layout_width="match_parent"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1633,6 +1633,7 @@
     <string name="support_identity_input_dialog_enter_email_and_name">To continue please enter your email address and name</string>
     <string name="support_identity_input_dialog_enter_email">Please enter your email address</string>
     <string name="support_identity_input_dialog_email_label">Email</string>
+    <string name="support_identity_input_dialog_name_label">Name</string>
 
     <!--Me-->
     <string name="me_profile_photo">Profile Photo</string>


### PR DESCRIPTION
### Fix
Update the dialog input fields on the ***Help and Support*** screen including replacing `EditText` with `TextInputLayout` and `TextInputEditText` views as well as adding the `ContextThemeWrapper` usage for the dialog context.  That allows for an updated input field interface and the dialog to be themed with the `Calypso,Dialog` style, respectively.  Also, the added `hint` attributes resolve accessibility issues for both input fields.  See the screenshots below for details.

![help_dialog](https://user-images.githubusercontent.com/3827611/48321983-d7c63800-e5ea-11e8-9ad5-ef7ed3f75c7c.png)

### Test
1. Go to ***Me*** tab.
2. Tap ***Help & Support*** item.
3. Tap ***My Tickets*** item.
4. Notice dialog as shown above.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.