### PR TITLE
Pages: Fix for a crash when setting a page parent

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/coroutines/CoroutineHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/coroutines/CoroutineHelpers.kt
@@ -1,13 +1,15 @@
 package org.wordpress.android.util.coroutines
 
+import kotlinx.coroutines.experimental.coroutineScope
 import kotlinx.coroutines.experimental.suspendCancellableCoroutine
 import kotlinx.coroutines.experimental.withTimeoutOrNull
-import java.util.concurrent.TimeUnit.MILLISECONDS
 import kotlin.coroutines.experimental.Continuation
 
 suspend inline fun <T> suspendCoroutineWithTimeout(
     timeout: Long,
     crossinline block: (Continuation<T>) -> Unit
-) = withTimeoutOrNull(timeout, MILLISECONDS) {
-    suspendCancellableCoroutine(block = block)
+) = coroutineScope {
+    withTimeoutOrNull(timeout) {
+        suspendCancellableCoroutine(block = block)
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/ActionPerformer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/ActionPerformer.kt
@@ -4,15 +4,15 @@ import kotlinx.coroutines.experimental.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded
-import javax.inject.Inject
 import org.wordpress.android.fluxc.model.CauseOfOnPostChanged
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
+import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded
 import org.wordpress.android.util.coroutines.suspendCoroutineWithTimeout
 import org.wordpress.android.viewmodel.pages.ActionPerformer.PageAction.EventType
 import org.wordpress.android.viewmodel.pages.ActionPerformer.PageAction.EventType.DELETE
 import org.wordpress.android.viewmodel.pages.ActionPerformer.PageAction.EventType.UPDATE
 import org.wordpress.android.viewmodel.pages.ActionPerformer.PageAction.EventType.UPLOAD
+import javax.inject.Inject
 import kotlin.coroutines.experimental.Continuation
 
 class ActionPerformer

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/ActionPerformer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/ActionPerformer.kt
@@ -37,10 +37,10 @@ class ActionPerformer
             launch { action.perform() }
         }
         continuations.remove(action.remoteId to action.event)
-        result?.let { (success, remoteId) ->
-            action.remoteId = remoteId
 
+        result?.let { (success, remoteId) ->
             if (success) {
+                action.remoteId = remoteId
                 action.onSuccess?.let { it() }
             } else {
                 action.onError?.let { it() }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/ActionPerformer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/ActionPerformer.kt
@@ -38,9 +38,9 @@ class ActionPerformer
         continuations.remove(action.remoteId)
 
         if (success == true) {
-            action.onSuccess()
+            action.onSuccess?.let { it() }
         } else {
-            action.onError()
+            action.onError?.let { it() }
         }
     }
 
@@ -70,9 +70,9 @@ class ActionPerformer
             }
 
     data class PageAction(val remoteId: Long, val event: EventType, val perform: () -> Unit) {
-        var onSuccess: () -> Unit = { }
-        var onError: () -> Unit = { }
-        var undo: () -> Unit = { }
+        var onSuccess: (() -> Unit)? = null
+        var onError: (() -> Unit)? = null
+        var undo: (() -> Unit)? = null
 
         enum class EventType { UPLOAD, UPDATE, DELETE }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageParentViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageParentViewModel.kt
@@ -57,6 +57,7 @@ class PageParentViewModel
 
     private fun loadPages(pageId: Long) = defaultScope.launch {
         page = if (pageId < 0) {
+            // negative local page ID used as a temp remote post ID for local-only pages (assigned by the PageStore)
             pageStore.getPageByLocalId(-pageId.toInt(), site)
         } else {
             pageStore.getPageByRemoteId(pageId, site)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.page.PageModel
 import org.wordpress.android.fluxc.model.page.PageStatus
+import org.wordpress.android.fluxc.model.page.PageStatus.TRASHED
 import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded
 import org.wordpress.android.modules.DEFAULT_SCOPE
@@ -390,7 +391,11 @@ class PagesViewModel
 
             checkIfNewPageButtonShouldBeVisible()
 
-            pageStore.deletePageFromServer(page)
+            if (page.remoteId < 0) {
+                pageStore.deletePageFromDb(page)
+            } else {
+                pageStore.deletePageFromServer(page)
+            }
         }
         action.onSuccess = {
             defaultScope.launch {
@@ -422,7 +427,10 @@ class PagesViewModel
 
                 refreshPages()
 
-                pageStore.uploadPageToServer(updatedPage)
+                // Local pages can be trashed locally
+                if (status != TRASHED || remoteId > 0) {
+                    pageStore.uploadPageToServer(updatedPage)
+                }
             }
 
             action.undo = {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -333,18 +333,16 @@ class PagesViewModel
             }
         }
 
-        // if page was local-only (negative remote ID), skip the undo option
-        if (page.remoteId > 0) {
-            action.undo = {
-                defaultScope.launch {
-                    pageMap[page.remoteId]?.let { changed ->
-                        val updatedPage = updateParent(changed, oldParent)
+        action.undo = {
+            defaultScope.launch {
+                pageMap[action.remoteId]?.let { changed ->
+                    val updatedPage = updateParent(changed, oldParent)
 
-                        pageStore.uploadPageToServer(updatedPage)
-                    }
+                    pageStore.uploadPageToServer(updatedPage)
                 }
             }
         }
+
         action.onSuccess = {
             defaultScope.launch {
                 reloadPages()
@@ -427,6 +425,8 @@ class PagesViewModel
                 pageStore.uploadPageToServer(updatedPage)
             }
 
+            action.undo = {
+                val updatedPage = updatePageStatus(page.copy(remoteId = action.remoteId), oldStatus)
                 defaultScope.launch {
                     pageStore.updatePageInDb(updatedPage)
                     refreshPages()
@@ -435,19 +435,6 @@ class PagesViewModel
                 }
             }
 
-            if (remoteId > 0) {
-                action.undo = {
-                    val updatedPage = updatePageStatus(page, oldStatus)
-                    defaultScope.launch {
-                        pageStore.updatePageInDb(updatedPage)
-                        refreshPages()
-
-                        pageStore.uploadPageToServer(updatedPage)
-                    }
-                }
-            }
-
-            // if page was local-only (negative remote ID), skip the undo option
             action.onSuccess = {
                 defaultScope.launch {
                     delay(ACTION_DELAY)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.ui.pages.PageItem.Action.VIEW_PAGE
 import org.wordpress.android.ui.pages.PageItem.Page
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.coroutines.suspendCoroutineWithTimeout
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.pages.ActionPerformer.PageAction
 import org.wordpress.android.viewmodel.pages.ActionPerformer.PageAction.EventType.DELETE
@@ -46,11 +47,11 @@ import java.util.SortedMap
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.experimental.Continuation
-import kotlin.coroutines.experimental.suspendCoroutine
 
 private const val ACTION_DELAY = 100
 private const val SEARCH_DELAY = 200
 private const val SEARCH_COLLAPSE_DELAY = 500
+private const val PAGE_UPLOAD_TIMEOUT = 5000L
 
 class PagesViewModel
 @Inject constructor(
@@ -185,10 +186,11 @@ class PagesViewModel
 
     private suspend fun waitForPageUpdate(remotePageId: Long) {
         _arePageActionsEnabled = false
-        suspendCoroutine<Unit> { cont ->
+        suspendCoroutineWithTimeout<Unit>(PAGE_UPLOAD_TIMEOUT) { cont ->
             pageUpdateContinuations[remotePageId] = cont
         }
         _arePageActionsEnabled = true
+        refreshPages()
     }
 
     fun onPageParentSet(pageId: Long, parentId: Long) {


### PR DESCRIPTION
Fixes #8597. 

This bug was caused by attempts to change a parent of a local-only page that doesn't have a remote ID yet. 

We now try to use a local page ID. Since for local pages we don't know a required remote page ID for undoing actions (both page status and page parent change), we skip it to prevent a crash.

#### To test:
1. Open Site pages with at least 1 published page
2. Turn on the flight mode
3. Create a local-only page
4. Turn off the flight mode
5. Open the Set parent screen for the local page
6. Change the page parent and tap Save
7. Wait for the page list to update successfully
8. Notice the snackbar doesn't offer the Undo action