### PR TITLE
Issue/8596 refresh quota bar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -55,6 +55,8 @@ import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.CancelMediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
+import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
@@ -103,6 +105,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
     @Inject Dispatcher mDispatcher;
     @Inject MediaStore mMediaStore;
+    @Inject SiteStore mSiteStore;
 
     private SiteModel mSite;
 
@@ -1047,6 +1050,17 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     private void reloadMediaGrid() {
         if (mMediaGridFragment != null) {
             mMediaGridFragment.reload();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onSiteChanged(OnSiteChanged event) {
+        SiteModel site = mSiteStore.getSiteByLocalId(mSite.getId());
+
+        if (site != null) {
+            mSite = site;
+            showQuota(true);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -48,6 +48,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
+import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -719,6 +720,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onMediaUploaded(OnMediaUploaded event) {
+        mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(mSite));
+
         if (event.media != null) {
             updateMediaGridItem(event.media, event.isError());
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -1053,6 +1053,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     private void reloadMediaGrid() {
         if (mMediaGridFragment != null) {
             mMediaGridFragment.reload();
+            mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(mSite));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -26,6 +26,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
+import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -692,6 +693,11 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
             FetchMediaListPayload payload =
                     new FetchMediaListPayload(mSite, NUM_MEDIA_PER_FETCH, loadMore, mFilter.toMimeType());
             mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(payload));
+
+            if (!loadMore) {
+                // Fetch site to refresh space quota in activity.
+                mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(mSite));
+            }
         }
     }
 

--- a/WordPress/src/main/res/layout/media_browser_activity.xml
+++ b/WordPress/src/main/res/layout/media_browser_activity.xml
@@ -34,7 +34,9 @@
         android:layout_alignParentBottom="true"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
-        android:padding="@dimen/margin_small" >
+        android:padding="@dimen/margin_small"
+        android:visibility="gone"
+        tools:visibility="visible" >
 
         <TextView
             android:id="@+id/quota_text"


### PR DESCRIPTION
### Fix
Add updating the space quota view on the ***WordPress Media*** screen when uploading/deleting/refreshing as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8596.

### Test
#### Uploading
1. Go to ***My Site*** tab.
2. Tap ***Media*** item under ***Publish*** section.
3. Notice space quota value *on app*.
4. Add media *on app* equal to at least 0.1% of quota.
5. Notice space quota value *on app*.

#### Deleting
1. Go to ***My Site*** tab.
2. Tap ***Media*** item under ***Publish*** section.
3. Notice space quota value *on app*.
4. Delete media *on app* equal to at least 0.1% of quota *on app*.
5. Notice space quota value *on app*.

#### Refreshing
1. Go to ***My Site*** tab.
2. Tap ***Media*** item under ***Publish*** section.
3. Notice space quota value *on app*.
4. Add media *on web* equal to at least 0.1% of quota.
5. Notice space quota value *on web*.
6. Notice added media is not *on app*.
7. Swipe to refresh media list.
8. Notice space quota value *on app*.

### Review
Only one developer is required to review these changes, but anyone can perform the review.