### PR TITLE
Update FluxC hash to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '8cc0b68301d74d03fffc61891f445b7fd2b46022'
+    fluxCVersion = 'c452ef2e9059b0a29d77ea0a03026bacf79f46a9'
 }


### PR DESCRIPTION
This PR updates the FluxC hash to latest and it includes two minor improvements to post list.

1. When the post list was visited for the first time, we could have duplicate requests running to fetch the same post if it was missing from the list
2. If the connection is very slow, when the post list was visited after being visited at least once (so some posts are fetched beforehand), we'd have the `fetching posts` shown longer than we should.

To test first issue:
1. Logout and login so the posts are deleted (or do a fresh installation)
2. Go to Blog Posts page and make sure all posts are loaded. (no missing posts)

To test second issue:
1. Visit Blog Posts of a site that has at least one post
2. Go back
3. Change your network to a slower connection `EDGE` should be enough
4. Re-visit the Blog Posts page and make sure the posts are loaded quickly even though the fetch for the first page is still going on. (previously we'd have to wait for the initial fetch to complete)