### PR TITLE
Feature/8501 sc verticals ui

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -125,7 +125,6 @@ import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView;
 import org.wordpress.android.ui.reader.views.ReaderTagHeaderView;
 import org.wordpress.android.ui.reader.views.ReaderWebView;
 import org.wordpress.android.ui.sitecreation.NewSiteCreationActivity;
-import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentsFragment;
 import org.wordpress.android.ui.sitecreation.NewSiteCreationDomainAdapter;
 import org.wordpress.android.ui.sitecreation.NewSiteCreationDomainFragment;
 import org.wordpress.android.ui.sitecreation.NewSiteCreationDomainLoaderFragment;
@@ -134,6 +133,8 @@ import org.wordpress.android.ui.sitecreation.NewSiteCreationSiteDetailsFragment;
 import org.wordpress.android.ui.sitecreation.NewSiteCreationThemeAdapter;
 import org.wordpress.android.ui.sitecreation.NewSiteCreationThemeFragment;
 import org.wordpress.android.ui.sitecreation.NewSiteCreationThemeLoaderFragment;
+import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentsFragment;
+import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsFragment;
 import org.wordpress.android.ui.stats.StatsAbstractFragment;
 import org.wordpress.android.ui.stats.StatsActivity;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
@@ -240,6 +241,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(NewSiteCreationDomainLoaderFragment object);
 
     void inject(NewSiteCreationDomainAdapter object);
+
+    void inject(NewSiteCreationVerticalsFragment object);
 
     void inject(StatsWidgetConfigureActivity object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ThreadModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ThreadModule.kt
@@ -2,12 +2,12 @@ package org.wordpress.android.modules
 
 import dagger.Module
 import dagger.Provides
-import kotlinx.coroutines.experimental.CoroutineDispatcher
 import kotlinx.coroutines.experimental.CoroutineScope
 import kotlinx.coroutines.experimental.Dispatchers
 import kotlinx.coroutines.experimental.IO
 import kotlinx.coroutines.experimental.android.Main
 import javax.inject.Named
+import kotlin.coroutines.experimental.CoroutineContext
 
 const val UI_SCOPE = "UI_SCOPE"
 const val DEFAULT_SCOPE = "DEFAULT_SCOPE"
@@ -30,13 +30,13 @@ class ThreadModule {
 
     @Provides
     @Named(MAIN_DISPATCHER)
-    fun provideMainDispatcher(): CoroutineDispatcher {
+    fun provideMainDispatcher(): CoroutineContext {
         return Dispatchers.Main
     }
 
     @Provides
     @Named(IO_DISPATCHER)
-    fun provideIODispatcher(): CoroutineDispatcher {
+    fun provideIODispatcher(): CoroutineContext {
         return Dispatchers.IO
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -6,6 +6,7 @@ import android.arch.lifecycle.ViewModelProvider;
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel;
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel;
 import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentsViewModel;
+import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel;
 import org.wordpress.android.viewmodel.ViewModelFactory;
 import org.wordpress.android.viewmodel.ViewModelKey;
 import org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModel;
@@ -82,7 +83,12 @@ abstract class ViewModelModule {
     @Binds
     @IntoMap
     @ViewModelKey(NewSiteCreationSegmentsViewModel.class)
-    abstract ViewModel siteCreationCategoryViewModel(NewSiteCreationSegmentsViewModel viewModel);
+    abstract ViewModel siteCreationSegmentsViewModel(NewSiteCreationSegmentsViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(NewSiteCreationVerticalsViewModel.class)
+    abstract ViewModel siteCreationVerticalsViewModel(NewSiteCreationVerticalsViewModel viewModel);
 
     @Binds
     abstract ViewModelProvider.Factory provideViewModelFactory(ViewModelFactory viewModelFactory);

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.java
@@ -14,7 +14,7 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.main.SitePickerActivity;
-import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentsFragment;
+import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsFragment;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
@@ -48,7 +48,7 @@ public class NewSiteCreationActivity extends AppCompatActivity implements NewSit
             AnalyticsTracker.track(AnalyticsTracker.Stat.SITE_CREATION_ACCESSED);
 
             earlyLoadThemeLoaderFragment();
-            showFragment(new NewSiteCreationSegmentsFragment(), NewSiteCreationSegmentsFragment.Companion.getTAG());
+            showFragment(new NewSiteCreationVerticalsFragment(), NewSiteCreationVerticalsFragment.Companion.getTAG());
         } else {
             mCategory = savedInstanceState.getString(KEY_CATERGORY);
             mThemeId = savedInstanceState.getString(KEY_THEME_ID);

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModel.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.sitecreation.segments
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
-import kotlinx.coroutines.experimental.CoroutineDispatcher
 import kotlinx.coroutines.experimental.CoroutineScope
 import kotlinx.coroutines.experimental.Job
 import kotlinx.coroutines.experimental.launch
@@ -31,8 +30,8 @@ class NewSiteCreationSegmentsViewModel
 @Inject constructor(
     private val dispatcher: Dispatcher,
     private val fetchSegmentsUseCase: FetchSegmentsUseCase,
-    @Named(MAIN_DISPATCHER) private val MAIN: CoroutineDispatcher,
-    @Named(IO_DISPATCHER) private val IO: CoroutineDispatcher
+    @Named(MAIN_DISPATCHER) private val MAIN: CoroutineContext,
+    @Named(IO_DISPATCHER) private val IO: CoroutineContext
 ) : ViewModel(), CoroutineScope {
     private val fetchCategoriesJob: Job = Job()
     override val coroutineContext: CoroutineContext

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchVerticalsHeaderInfoUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchVerticalsHeaderInfoUseCase.kt
@@ -1,0 +1,62 @@
+package org.wordpress.android.ui.sitecreation.usecases
+
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.store.Store
+import org.wordpress.android.fluxc.store.VerticalStore
+import org.wordpress.android.fluxc.store.VerticalStore.VerticalErrorType
+import javax.inject.Inject
+import kotlin.coroutines.experimental.Continuation
+import kotlin.coroutines.experimental.suspendCoroutine
+
+/**
+ * Transforms EventBus event to a coroutines.
+ */
+class FetchVerticalsHeaderInfoUseCase @Inject constructor(
+    val dispatcher: Dispatcher,
+    @Suppress("unused") val verticalStore: VerticalStore
+) {
+    private var continuation: Continuation<DummyOnVerticalsHeaderInfoFetched>? = null
+
+    suspend fun fetchVerticalHeaderInfo(): DummyOnVerticalsHeaderInfoFetched {
+        if (continuation != null) {
+            throw IllegalStateException("Fetch already in progress.")
+        }
+        return suspendCoroutine { cont ->
+            continuation = cont
+            // TODO dispatcher.dispatch()
+            onVerticalHeaderInfoFetched(
+                    DummyOnVerticalsHeaderInfoFetched(
+                            DummyVerticalsHeaderInfoModel(
+                                    "What’s the focus of your business?",
+                                    "We’ll use your answer to add sections to your website.",
+                                    "eg. Landscaping, Consulting… etc"
+                            ),
+                            null
+                    )
+            )
+        }
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    @SuppressWarnings("unused")
+    fun onVerticalHeaderInfoFetched(event: DummyOnVerticalsHeaderInfoFetched) {
+        checkNotNull(continuation) { "onVerticalHeaderInfoFetched received without a suspended coroutine." }
+                .resume(event)
+        continuation = null
+    }
+}
+
+class DummyOnVerticalsHeaderInfoFetched(
+    val headerInfo: DummyVerticalsHeaderInfoModel?,
+    error: DummyFetchVerticalHeaderInfoError?
+) : Store.OnChanged<DummyFetchVerticalHeaderInfoError>() {
+    init {
+        this.error = error
+    }
+}
+
+class DummyFetchVerticalHeaderInfoError(val type: VerticalErrorType, val message: String? = null) : Store.OnChangedError
+
+data class DummyVerticalsHeaderInfoModel(val title: String, val subtitle: String, val inputHint: String)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchVerticalsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchVerticalsUseCase.kt
@@ -6,10 +6,8 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.VerticalActionBuilder
 import org.wordpress.android.fluxc.store.VerticalStore
-import org.wordpress.android.fluxc.store.VerticalStore.FetchVerticalsError
 import org.wordpress.android.fluxc.store.VerticalStore.FetchVerticalsPayload
 import org.wordpress.android.fluxc.store.VerticalStore.OnVerticalsFetched
-import org.wordpress.android.fluxc.store.VerticalStore.VerticalErrorType.GENERIC_ERROR
 import javax.inject.Inject
 import kotlin.coroutines.experimental.Continuation
 
@@ -41,7 +39,6 @@ class FetchVerticalsUseCase @Inject constructor(
     fun onVerticalsFetched(event: OnVerticalsFetched) {
         pair?.let {
             if (event.searchQuery == it.first) {
-                event.error = FetchVerticalsError(GENERIC_ERROR, "123msg")
                 checkNotNull(it.second) { "onVerticalsFetched received without a suspended coroutine." }
                         .resume(event)
                 pair = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchVerticalsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchVerticalsUseCase.kt
@@ -1,0 +1,40 @@
+package org.wordpress.android.ui.sitecreation.usecases
+
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.VerticalActionBuilder
+import org.wordpress.android.fluxc.store.VerticalStore
+import org.wordpress.android.fluxc.store.VerticalStore.FetchVerticalsPayload
+import org.wordpress.android.fluxc.store.VerticalStore.OnVerticalsFetched
+import javax.inject.Inject
+import kotlin.coroutines.experimental.Continuation
+import kotlin.coroutines.experimental.suspendCoroutine
+
+/**
+ * Transforms EventBus event to a coroutines.
+ */
+class FetchVerticalsUseCase @Inject constructor(
+    val dispatcher: Dispatcher,
+    @Suppress("unused") val verticalStore: VerticalStore
+) {
+    private var continuation: Continuation<OnVerticalsFetched>? = null
+
+    suspend fun fetchVerticals(query: String): OnVerticalsFetched {
+        if (continuation != null) {
+            throw IllegalStateException("Fetch already in progress.")
+        }
+        return suspendCoroutine { cont ->
+            continuation = cont
+            dispatcher.dispatch(VerticalActionBuilder.newFetchVerticalsAction(FetchVerticalsPayload(query)))
+        }
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    @SuppressWarnings("unused")
+    fun onVerticalsFetched(event: OnVerticalsFetched) {
+        checkNotNull(continuation) { "onVerticalsFetched received without a suspended coroutine." }
+                .resume(event)
+        continuation = null
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsAdapter.kt
@@ -1,0 +1,73 @@
+package org.wordpress.android.ui.sitecreation.verticals
+
+import android.support.v7.util.DiffUtil
+import android.support.v7.widget.RecyclerView.Adapter
+import android.view.ViewGroup
+import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewHolder.VerticalsErrorViewHolder
+import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewHolder.VerticalsSuggestionItemViewHolder
+import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsListItemUiState
+import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsListItemUiState.VerticalsFetchSuggestionsErrorUiState
+import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsListItemUiState.VerticalsModelUiState
+
+private const val headerViewType: Int = 1
+private const val searchInputViewType: Int = 2
+private const val suggestionItemViewType: Int = 3
+private const val suggestionErrorViewType: Int = 4
+
+class NewSiteCreationVerticalsAdapter(
+) : Adapter<NewSiteCreationVerticalsViewHolder>() {
+    private val items = mutableListOf<VerticalsListItemUiState>()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NewSiteCreationVerticalsViewHolder {
+        return when (viewType) {
+            suggestionItemViewType -> VerticalsSuggestionItemViewHolder(parent)
+            suggestionErrorViewType -> VerticalsErrorViewHolder(parent)
+            else -> throw NotImplementedError("Unknown ViewType")
+        }
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: NewSiteCreationVerticalsViewHolder, position: Int) {
+        holder.onBind(items[position])
+    }
+
+    fun update(newItems: List<VerticalsListItemUiState>) {
+        val diffResult = DiffUtil.calculateDiff(VerticalsDiffUtils(items.toList(), newItems))
+        items.clear()
+        items.addAll(newItems)
+        diffResult.dispatchUpdatesTo(this)
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when (items[position]) {
+            is VerticalsModelUiState -> suggestionItemViewType
+            is VerticalsFetchSuggestionsErrorUiState -> suggestionErrorViewType
+        }
+    }
+
+    private class VerticalsDiffUtils(
+        val oldItems: List<VerticalsListItemUiState>,
+        val newItems: List<VerticalsListItemUiState>
+    ) : DiffUtil.Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val oldItem = oldItems[oldItemPosition]
+            val newItem = newItems[newItemPosition]
+            if (oldItem::class != newItem::class) {
+                return false
+            }
+            return when (oldItem) {
+                is VerticalsFetchSuggestionsErrorUiState -> true
+                is VerticalsModelUiState -> oldItem.id == (newItem as VerticalsModelUiState).id
+            }
+        }
+
+        override fun getOldListSize(): Int = oldItems.size
+
+        override fun getNewListSize(): Int = newItems.size
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return oldItems[oldItemPosition] == newItems[newItemPosition]
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
@@ -1,0 +1,212 @@
+package org.wordpress.android.ui.sitecreation.verticals
+
+import android.arch.lifecycle.Observer
+import android.arch.lifecycle.ViewModelProvider
+import android.arch.lifecycle.ViewModelProviders
+import android.os.Bundle
+import android.os.Parcelable
+import android.support.annotation.LayoutRes
+import android.support.v4.app.FragmentActivity
+import android.support.v4.content.ContextCompat
+import android.support.v7.content.res.AppCompatResources
+import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.ui.sitecreation.NewSiteCreationBaseFormFragment
+import org.wordpress.android.ui.sitecreation.NewSiteCreationListener
+import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsHeaderUiState
+import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsListItemUiState
+import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsSearchInputUiState
+import javax.inject.Inject
+
+private const val keyListState = "list_state"
+
+class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSiteCreationListener>() {
+    private lateinit var nonNullActivity: FragmentActivity
+    private lateinit var linearLayoutManager: LinearLayoutManager
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var viewModel: NewSiteCreationVerticalsViewModel
+
+    private lateinit var fullscreenErrorLayout: ViewGroup
+    private lateinit var fullscreenProgressLayout: ViewGroup
+    private lateinit var contentLayout: ViewGroup
+    private lateinit var skipButton: Button
+
+    private lateinit var headerLayout: ViewGroup
+    private lateinit var headerTitle: TextView
+    private lateinit var headerSubtitle: TextView
+    private lateinit var searchEditText: EditText
+    private lateinit var searchEditTextProgressBar: View
+    private lateinit var clearAllButton: View
+
+    @Inject protected lateinit var viewModelFactory: ViewModelProvider.Factory
+
+    @LayoutRes
+    override fun getContentLayout(): Int {
+        return R.layout.new_site_creation_verticals_screen
+    }
+
+    override fun setupContent(rootView: ViewGroup) {
+        // TODO receive title from the MainVM
+        // important for accessibility - talkback
+        nonNullActivity.setTitle(R.string.new_site_creation_verticals_title)
+        fullscreenErrorLayout = rootView.findViewById(R.id.error_layout)
+        fullscreenProgressLayout = rootView.findViewById(R.id.progress_layout)
+        contentLayout = rootView.findViewById(R.id.content_layout)
+        initSearchEditText(rootView)
+        initHeader(rootView)
+        initRecyclerView(rootView)
+        initRetryButton(rootView)
+        initSkipButton(rootView)
+        initViewModel()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        nonNullActivity = activity!!
+        (nonNullActivity.application as WordPress).component().inject(this)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putParcelable(keyListState, linearLayoutManager.onSaveInstanceState())
+    }
+
+    override fun onViewStateRestored(savedInstanceState: Bundle?) {
+        super.onViewStateRestored(savedInstanceState)
+        savedInstanceState?.getParcelable<Parcelable>(keyListState)?.let {
+            linearLayoutManager.onRestoreInstanceState(it)
+        }
+        initTextWatcher()
+    }
+
+    private fun initHeader(rootView: ViewGroup) {
+        headerLayout = rootView.findViewById(R.id.header_layout)
+        headerTitle = headerLayout.findViewById(R.id.title)
+        headerSubtitle = headerLayout.findViewById(R.id.subtitle)
+    }
+
+    private fun initSearchEditText(rootView: ViewGroup) {
+        searchEditText = rootView.findViewById(R.id.input)
+        searchEditTextProgressBar = rootView.findViewById(R.id.progress_bar)
+        val drawable = AppCompatResources.getDrawable(nonNullActivity, R.drawable.ic_search_white_24dp)
+        drawable?.setTint(ContextCompat.getColor(nonNullActivity, R.color.grey))
+        searchEditText.setCompoundDrawablesRelativeWithIntrinsicBounds(drawable, null, null, null)
+        initClearTextButton(rootView)
+    }
+
+    private fun initClearTextButton(rootView: ViewGroup) {
+        clearAllButton = rootView.findViewById(R.id.clear_all_btn)
+        val drawable = AppCompatResources.getDrawable(nonNullActivity, R.drawable.ic_close_white_24dp)
+        drawable?.setTint(ContextCompat.getColor(nonNullActivity, R.color.grey))
+        clearAllButton.background = drawable
+
+        val clearAllLayout = rootView.findViewById<View>(R.id.clear_all_layout)
+        clearAllLayout.setOnClickListener{
+            viewModel.onClearTextBtnClicked()
+        }
+    }
+
+    private fun initRecyclerView(rootView: ViewGroup) {
+        recyclerView = rootView.findViewById(R.id.recycler_view)
+        val layoutManager = LinearLayoutManager(activity, LinearLayoutManager.VERTICAL, false)
+        linearLayoutManager = layoutManager
+        recyclerView.layoutManager = linearLayoutManager
+        initAdapter()
+    }
+
+    private fun initAdapter() {
+        val adapter = NewSiteCreationVerticalsAdapter()
+        recyclerView.adapter = adapter
+    }
+
+    private fun initRetryButton(rootView: ViewGroup) {
+        val retryBtn = rootView.findViewById<Button>(R.id.error_retry)
+        retryBtn.setOnClickListener { _ -> viewModel.onFetchHeaderInfoRetry() }
+    }
+
+    private fun initSkipButton(rootView: ViewGroup) {
+        skipButton = rootView.findViewById(R.id.btn_skip)
+        skipButton.setOnClickListener { _ ->
+            // TODO add skip action
+        }
+    }
+
+    private fun initTextWatcher() {
+        searchEditText.addTextChangedListener(object : TextWatcher {
+            override fun afterTextChanged(s: Editable?) {}
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                viewModel.updateQuery(s?.toString() ?: "")
+            }
+        })
+    }
+
+    private fun initViewModel() {
+        viewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
+                .get(NewSiteCreationVerticalsViewModel::class.java)
+
+        viewModel.uiState.observe(this, Observer { state ->
+            state?.let {
+                contentLayout.visibility = if (state.showContent) View.VISIBLE else View.GONE
+                fullscreenErrorLayout.visibility = if (state.showFullscreenError) View.VISIBLE else View.GONE
+                fullscreenProgressLayout.visibility = if (state.showFullscreenProgress) View.VISIBLE else View.GONE
+                skipButton.visibility = if (state.showSkipButton) View.VISIBLE else View.GONE
+                state.headerUiState?.let { headerState -> updateHeader(headerState) }
+                state.searchInputState?.let { inputState -> updateSearchInput(inputState) }
+                updateSuggestions(state.items)
+            }
+        })
+        viewModel.clearBtnClicked.observe(this, Observer {
+            searchEditText.setText("")
+        })
+
+        viewModel.start()
+    }
+
+    override fun onHelp() {
+        if (mSiteCreationListener != null) {
+            mSiteCreationListener.helpCategoryScreen()
+        }
+    }
+
+    private fun updateHeader(uiState: VerticalsHeaderUiState) {
+        if (!uiState.isVisible && headerLayout.visibility == View.VISIBLE) {
+            headerLayout.animate()
+                    .translationY(-headerLayout.height.toFloat())
+                    .withStartAction{
+                        headerLayout.visibility = View.GONE
+                    }
+        } else if (uiState.isVisible && headerLayout.visibility == View.GONE){
+            headerLayout.animate()
+                    .translationY(0f)
+                    .withStartAction{
+                        headerLayout.visibility = View.VISIBLE
+                    }
+        }
+        headerTitle.text = uiState.title
+        headerSubtitle.text = uiState.subtitle
+    }
+
+    private fun updateSearchInput(uiState: VerticalsSearchInputUiState) {
+        searchEditText.hint = uiState.hint
+        searchEditTextProgressBar.visibility = if (uiState.showProgress) View.VISIBLE else View.GONE
+        clearAllButton.visibility = if (uiState.showClearButton) View.VISIBLE else View.GONE
+    }
+
+    private fun updateSuggestions(suggestions: List<VerticalsListItemUiState>) {
+        (recyclerView.adapter as NewSiteCreationVerticalsAdapter).update(suggestions)
+    }
+
+    companion object {
+        val TAG = "site_creation_verticals_fragment_tag"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewHolder.kt
@@ -1,0 +1,60 @@
+package org.wordpress.android.ui.sitecreation.verticals
+
+import android.support.annotation.LayoutRes
+import android.support.v4.content.ContextCompat
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import org.wordpress.android.R
+import org.wordpress.android.R.color
+import org.wordpress.android.R.drawable
+import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsListItemUiState
+import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsListItemUiState.VerticalsFetchSuggestionsErrorUiState
+import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsListItemUiState.VerticalsModelUiState
+
+sealed class NewSiteCreationVerticalsViewHolder(internal val parent: ViewGroup, @LayoutRes layout: Int) :
+        RecyclerView.ViewHolder(LayoutInflater.from(parent.context).inflate(layout, parent, false)) {
+    abstract fun onBind(uiState: VerticalsListItemUiState)
+
+    class VerticalsSuggestionItemViewHolder(
+        parentView: ViewGroup
+    ) : NewSiteCreationVerticalsViewHolder(parentView, R.layout.new_site_creation_verticals_suggestion_item) {
+        private val suggestion = itemView.findViewById<TextView>(R.id.suggestion)
+        private val divider = itemView.findViewById<View>(R.id.divider)
+
+        override fun onBind(uiState: VerticalsListItemUiState) {
+            uiState as VerticalsModelUiState
+            suggestion.text = uiState.title
+            divider.visibility = if (uiState.showDivider) View.VISIBLE else View.GONE
+            // TODO add onClick listener
+        }
+    }
+
+    class VerticalsErrorViewHolder(
+        parentView: ViewGroup
+    ) : NewSiteCreationVerticalsViewHolder(parentView, R.layout.new_site_creation_verticals_error_item) {
+        private val text = itemView.findViewById<TextView>(R.id.error_text)
+        private val retry = itemView.findViewById<TextView>(R.id.retry)
+
+        init {
+            addRetryCompoundDrawable()
+        }
+
+        private fun addRetryCompoundDrawable() {
+            val drawable = itemView.context.getDrawable(drawable.retry_icon)
+            drawable.setTint(ContextCompat.getColor(itemView.context, color.wp_blue))
+            retry.setCompoundDrawables(drawable, null, null, null)
+        }
+
+        override fun onBind(uiState: VerticalsListItemUiState) {
+            uiState as VerticalsFetchSuggestionsErrorUiState
+            text.text = itemView.context.getText(uiState.messageResId)
+            retry.text = itemView.context.getText(uiState.retryButonResId)
+            itemView.setOnClickListener{
+                uiState.onItemTapped.invoke()
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
@@ -154,7 +154,7 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
                 VerticalsListItemUiState()
 
         data class VerticalsModelUiState(val id: String, val title: String) : VerticalsListItemUiState()
-        data class VerticalsNewModelUiState(val title: String, val subtitleResId: Int) :
+        data class VerticalsUnknownVerticalUiState(val title: String, val subtitleResId: Int) :
                 VerticalsListItemUiState()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
@@ -3,12 +3,14 @@ package org.wordpress.android.ui.sitecreation.verticals
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
+import android.support.annotation.StringRes
 import kotlinx.coroutines.experimental.CoroutineScope
 import kotlinx.coroutines.experimental.Job
 import kotlinx.coroutines.experimental.delay
 import kotlinx.coroutines.experimental.launch
 import kotlinx.coroutines.experimental.withContext
 import org.apache.commons.lang3.StringUtils
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.vertical.VerticalModel
 import org.wordpress.android.fluxc.store.VerticalStore.OnVerticalsFetched
@@ -17,10 +19,13 @@ import org.wordpress.android.models.networkresource.ListState.Error
 import org.wordpress.android.models.networkresource.ListState.Loading
 import org.wordpress.android.modules.IO_DISPATCHER
 import org.wordpress.android.modules.MAIN_DISPATCHER
+import org.wordpress.android.ui.sitecreation.usecases.DummyOnVerticalsHeaderInfoFetched
+import org.wordpress.android.ui.sitecreation.usecases.DummyVerticalsHeaderInfoModel
+import org.wordpress.android.ui.sitecreation.usecases.FetchVerticalsHeaderInfoUseCase
 import org.wordpress.android.ui.sitecreation.usecases.FetchVerticalsUseCase
-import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsListItemUiState.VerticalsHeaderUiState
+import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsListItemUiState.VerticalsFetchSuggestionsErrorUiState
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsListItemUiState.VerticalsModelUiState
-import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsListItemUiState.VerticalsSearchInputUiState
+import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.experimental.CoroutineContext
@@ -29,12 +34,13 @@ private const val throttleDelay: Int = 500
 
 class NewSiteCreationVerticalsViewModel @Inject constructor(
     private val dispatcher: Dispatcher,
+    private val fetchVerticalsHeaderInfoUseCase: FetchVerticalsHeaderInfoUseCase,
     private val fetchVerticalsUseCase: FetchVerticalsUseCase,
     @Named(IO_DISPATCHER) private val IO: CoroutineContext,
     @Named(MAIN_DISPATCHER) private val MAIN: CoroutineContext
-) : ViewModel(),
-        CoroutineScope {
+) : ViewModel(), CoroutineScope {
     private val job = Job()
+    private var fetchVerticalsJob: Job? = null
     override val coroutineContext: CoroutineContext
         get() = IO + job
     private var isStarted = false
@@ -42,7 +48,11 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
     private val _uiState: MutableLiveData<VerticalsUiState> = MutableLiveData()
     val uiState: LiveData<VerticalsUiState> = _uiState
 
-    private lateinit var listState: ListState<VerticalModel>
+    private var listState: ListState<VerticalModel> = ListState.Init()
+    private lateinit var headerInfo: DummyVerticalsHeaderInfoModel
+
+    private val _clearBtnClicked = SingleLiveEvent<Void>()
+    val clearBtnClicked = _clearBtnClicked
 
     init {
         dispatcher.register(fetchVerticalsUseCase)
@@ -58,19 +68,51 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
             return
         }
         isStarted = true
-        updateUiState("", ListState.Ready(emptyList()))
+        fetchHeaderInfo()
+    }
+
+    private fun fetchHeaderInfo() {
+        launch {
+            withContext(MAIN) {
+                updateUiStateToFullScreenProgress()
+            }
+            val headerInfoEvent = fetchVerticalsHeaderInfoUseCase.fetchVerticalHeaderInfo()
+            withContext(MAIN) {
+                onHeaderInfoFetched(headerInfoEvent)
+            }
+        }
+    }
+
+    private fun onHeaderInfoFetched(event: DummyOnVerticalsHeaderInfoFetched) {
+        if (event.isError) {
+            updateUiStateToFullScreenError()
+        } else {
+            headerInfo = event.headerInfo!!
+            updateUiStateToContent("", ListState.Ready(emptyList()))
+        }
+    }
+
+    fun onFetchHeaderInfoRetry() {
+        fetchHeaderInfo()
+    }
+
+    fun onClearTextBtnClicked() {
+        _clearBtnClicked.call()
     }
 
     fun updateQuery(query: String, delay: Int = throttleDelay) {
-        job.cancel() // cancel any previous requests
-        updateUiState(query, ListState.Ready(emptyList()))
-        fetchVerticals(query, delay)
+        fetchVerticalsJob?.cancel() // cancel any previous requests
+        if (query.isNotEmpty()) {
+            fetchVerticals(query, delay)
+        } else {
+            updateUiStateToContent(query, ListState.Ready(emptyList()))
+        }
     }
 
     private fun fetchVerticals(query: String, throttleDelay: Int) {
-        launch {
+        fetchVerticalsJob = launch {
             withContext(MAIN) {
-                updateUiState(query, ListState.Loading(listState, false))
+                updateUiStateToContent(query, ListState.Loading(ListState.Ready(emptyList()), false))
             }
             delay(throttleDelay)
             val fetchedVerticals = fetchVerticalsUseCase.fetchVerticals(query)
@@ -82,37 +124,72 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
 
     private fun onVerticalsFetched(query: String, event: OnVerticalsFetched) {
         if (event.isError) {
-            updateUiState(query, ListState.Error(listState, event.error.message))
+            updateUiStateToContent(query, ListState.Error(listState, event.error.message))
         } else {
-            updateUiState(query, ListState.Success(event.verticalList))
+            updateUiStateToContent(query, ListState.Success(event.verticalList))
         }
     }
 
-    private fun updateUiState(query: String, state: ListState<VerticalModel>) {
-        listState = state
+    private fun updateUiStateToFullScreenProgress() {
         _uiState.value = VerticalsUiState(
-                showError = state is Error,
-                showContent = state !is Error,
-                showSkipButton = StringUtils.isEmpty(query),
-                items = if (state is Error)
-                    emptyList()
-                else
-                    createUiStates(query, showProgress = state is Loading, data = state.data)
+                showFullscreenError = false,
+                showFullscreenProgress = true,
+                showContent = false,
+                showSkipButton = false,
+                items = emptyList()
         )
     }
 
-    private fun createUiStates(
-        query: String,
-        showProgress: Boolean,
-        data: List<VerticalModel>
+    private fun updateUiStateToFullScreenError() {
+        _uiState.value = VerticalsUiState(
+                showFullscreenError = true,
+                showFullscreenProgress = false,
+                showContent = false,
+                showSkipButton = false,
+                items = emptyList()
+        )
+    }
+
+    private fun updateUiStateToContent(query: String, state: ListState<VerticalModel>) {
+        listState = state
+        _uiState.value = VerticalsUiState(
+                showFullscreenError = false,
+                showFullscreenProgress = false,
+                showContent = true,
+                showSkipButton = StringUtils.isEmpty(query),
+                headerUiState = createHeaderUiState(shouldShowHeader(query), headerInfo),
+                searchInputState = createSearchInputUiState(
+                        query,
+                        showProgress = state is Loading,
+                        hint = headerInfo.inputHint
+                ),
+                items = createSuggestionsUiStates(
+                        onRetry = { updateQuery(query) },
+                        data = state.data,
+                        errorFetchingSuggestions = state is Error
+                )
+        )
+    }
+
+    private fun createSuggestionsUiStates(
+        onRetry: () -> Unit,
+        data: List<VerticalModel>,
+        errorFetchingSuggestions: Boolean
     ): List<VerticalsListItemUiState> {
         val items: ArrayList<VerticalsListItemUiState> = ArrayList()
-        if (shouldShowHeader(query)) {
-            addHeaderUiState(items)
+        if (errorFetchingSuggestions) {
+            val errorUiState = VerticalsFetchSuggestionsErrorUiState(
+                    messageResId = R.string.site_creation_fetch_suggestions_failed,
+                    retryButonResId = R.string.button_retry
+            )
+            errorUiState.onItemTapped = onRetry
+            items.add(errorUiState)
+        } else {
+            val lastItemIndex = data.size - 1
+            data.forEachIndexed { index, model ->
+                items.add(VerticalsModelUiState(model.verticalId, model.name, showDivider = index != lastItemIndex))
+            }
         }
-        addSearchInputUiState(query, showProgress, items)
-        addModelsUiState(data, items)
-        // TODO unknown vertical item
         return items
     }
 
@@ -120,42 +197,56 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
         return StringUtils.isEmpty(query)
     }
 
-    private fun addHeaderUiState(items: ArrayList<VerticalsListItemUiState>) {
-        // TODO replace with data from the server response
-        items.add(VerticalsHeaderUiState("dummyTitle", "dummySubtitle"))
+    private fun createHeaderUiState(
+        isVisible: Boolean,
+        headerInfo: DummyVerticalsHeaderInfoModel
+    ): VerticalsHeaderUiState {
+        return VerticalsHeaderUiState(isVisible, headerInfo.title, headerInfo.subtitle)
     }
 
-    private fun addSearchInputUiState(
+    private fun createSearchInputUiState(
         query: String,
         showProgress: Boolean,
-        items: ArrayList<VerticalsListItemUiState>
-    ) {
-        items.add(VerticalsSearchInputUiState(showProgress, !StringUtils.isEmpty(query)))
-    }
-
-    private fun addModelsUiState(
-        data: List<VerticalModel>,
-        items: ArrayList<VerticalsListItemUiState>
-    ) {
-        data.forEach { model ->
-            items.add(VerticalsModelUiState(model.verticalId, model.name))
-        }
+        hint: String
+    ): VerticalsSearchInputUiState {
+        return VerticalsSearchInputUiState(
+                hint,
+                showProgress,
+                showClearButton = !StringUtils.isEmpty(query)
+        )
     }
 
     data class VerticalsUiState(
-        val showError: Boolean,
-        val showContent: Boolean,
+        val showFullscreenError: Boolean,
+        val showFullscreenProgress: Boolean,
         val showSkipButton: Boolean,
+        val showContent: Boolean,
+        val headerUiState: VerticalsHeaderUiState? = null,
+        val searchInputState: VerticalsSearchInputUiState? = null,
         val items: List<VerticalsListItemUiState>
     )
 
+    data class VerticalsSearchInputUiState(
+        val hint: String,
+        val showProgress: Boolean,
+        val showClearButton: Boolean
+    )
+
+    data class VerticalsHeaderUiState(
+        val isVisible: Boolean,
+        val title: String,
+        val subtitle: String
+    )
+
     sealed class VerticalsListItemUiState {
-        data class VerticalsHeaderUiState(val title: String, val subtitle: String) : VerticalsListItemUiState()
-        data class VerticalsSearchInputUiState(val showProgress: Boolean, val showClearButton: Boolean) :
+        data class VerticalsModelUiState(val id: String, val title: String, val showDivider: Boolean) :
                 VerticalsListItemUiState()
 
-        data class VerticalsModelUiState(val id: String, val title: String) : VerticalsListItemUiState()
-        data class VerticalsUnknownVerticalUiState(val title: String, val subtitleResId: Int) :
-                VerticalsListItemUiState()
+        data class VerticalsFetchSuggestionsErrorUiState(
+            @StringRes val messageResId: Int,
+            @StringRes val retryButonResId: Int
+        ) : VerticalsListItemUiState() {
+            lateinit var onItemTapped: () -> Unit
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
@@ -1,0 +1,43 @@
+package org.wordpress.android.ui.sitecreation.verticals
+
+import android.arch.lifecycle.ViewModel
+import kotlinx.coroutines.experimental.CoroutineScope
+import kotlinx.coroutines.experimental.Job
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.modules.IO_DISPATCHER
+import org.wordpress.android.modules.MAIN_DISPATCHER
+import org.wordpress.android.ui.sitecreation.usecases.FetchVerticalsUseCase
+import javax.inject.Inject
+import javax.inject.Named
+import kotlin.coroutines.experimental.CoroutineContext
+
+private const val throttleDelay: Int = 500
+
+class NewSiteCreationVerticalsViewModel @Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val fetchVerticalsUseCase: FetchVerticalsUseCase,
+    @Named(IO_DISPATCHER) private val IO: CoroutineContext,
+    @Named(MAIN_DISPATCHER) private val MAIN: CoroutineContext
+) : ViewModel(),
+        CoroutineScope {
+    private val job = Job()
+    override val coroutineContext: CoroutineContext
+        get() = IO + job
+    private var isStarted = false
+
+    init {
+        dispatcher.register(fetchVerticalsUseCase)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        dispatcher.unregister(fetchVerticalsUseCase)
+    }
+
+    fun start() {
+        if (isStarted) {
+            return
+        }
+        isStarted = true
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
@@ -1,9 +1,13 @@
 package org.wordpress.android.ui.sitecreation.verticals
 
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
 import kotlinx.coroutines.experimental.CoroutineScope
 import kotlinx.coroutines.experimental.Job
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.vertical.VerticalModel
+import org.wordpress.android.models.networkresource.ListState
 import org.wordpress.android.modules.IO_DISPATCHER
 import org.wordpress.android.modules.MAIN_DISPATCHER
 import org.wordpress.android.ui.sitecreation.usecases.FetchVerticalsUseCase
@@ -25,6 +29,11 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
         get() = IO + job
     private var isStarted = false
 
+    private val _uiState: MutableLiveData<VerticalsUiState> = MutableLiveData()
+    val uiState: LiveData<VerticalsUiState> = _uiState
+
+    private lateinit var listState: ListState<VerticalModel>
+
     init {
         dispatcher.register(fetchVerticalsUseCase)
     }
@@ -39,5 +48,22 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
             return
         }
         isStarted = true
+    }
+
+    data class VerticalsUiState(
+        val showError: Boolean,
+        val showContent: Boolean,
+        val showSkipButton: Boolean,
+        val items: List<VerticalsListItemUiState>
+    )
+
+    sealed class VerticalsListItemUiState {
+        data class VerticalsHeaderUiState(val title: String, val subtitle: String) : VerticalsListItemUiState()
+        data class VerticalsSearchInputUiState(val showProgress: Boolean, val showClearButton: Boolean) :
+                VerticalsListItemUiState()
+
+        data class VerticalsModelUiState(val id: String, val title: String) : VerticalsListItemUiState()
+        data class VerticalsNewModelUiState(val title: String, val subtitleResId: Int) :
+                VerticalsListItemUiState()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
@@ -61,15 +61,17 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
         updateUiState("", ListState.Ready(emptyList()))
     }
 
-    fun updateQuery(query: String) {
-        fetchVerticals(query)
+    fun updateQuery(query: String, delay: Int = throttleDelay) {
+        job.cancel() // cancel any previous requests
+        fetchVerticals(query, delay)
     }
 
-    private fun fetchVerticals(query: String) {
+    private fun fetchVerticals(query: String, throttleDelay: Int) {
         launch {
             withContext(MAIN) {
                 updateUiState(query, ListState.Loading(listState, false))
             }
+            delay(throttleDelay)
             val fetchedVerticals = fetchVerticalsUseCase.fetchVerticals(query)
             withContext(MAIN) {
                 onVerticalsFetched(query, fetchedVerticals)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
@@ -79,6 +79,68 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
         }
     }
 
+    private fun onVerticalsFetched(query: String, event: OnVerticalsFetched) {
+        if (event.isError) {
+            updateUiState(query, ListState.Error(listState, event.error.message))
+        } else {
+            updateUiState(query, ListState.Success(event.verticalList))
+        }
+    }
+
+    private fun updateUiState(query: String, state: ListState<VerticalModel>) {
+        listState = state
+        _uiState.value = VerticalsUiState(
+                showError = state is Error,
+                showContent = state !is Error,
+                showSkipButton = StringUtils.isEmpty(query),
+                items = if (state is Error)
+                    emptyList()
+                else
+                    createUiStates(query, showProgress = state is Loading, data = state.data)
+        )
+    }
+
+    private fun createUiStates(
+        query: String,
+        showProgress: Boolean,
+        data: List<VerticalModel>
+    ): List<VerticalsListItemUiState> {
+        val items: ArrayList<VerticalsListItemUiState> = ArrayList()
+        if (shouldShowHeader(query)) {
+            addHeaderUiState(items)
+        }
+        addSearchInputUiState(query, showProgress, items)
+        addModelsUiState(data, items)
+        // TODO unknown vertical item
+        return items
+    }
+
+    private fun shouldShowHeader(query: String): Boolean {
+        return StringUtils.isEmpty(query)
+    }
+
+    private fun addHeaderUiState(items: ArrayList<VerticalsListItemUiState>) {
+        // TODO replace with data from the server response
+        items.add(VerticalsHeaderUiState("dummyTitle", "dummySubtitle"))
+    }
+
+    private fun addSearchInputUiState(
+        query: String,
+        showProgress: Boolean,
+        items: ArrayList<VerticalsListItemUiState>
+    ) {
+        items.add(VerticalsSearchInputUiState(showProgress, !StringUtils.isEmpty(query)))
+    }
+
+    private fun addModelsUiState(
+        data: List<VerticalModel>,
+        items: ArrayList<VerticalsListItemUiState>
+    ) {
+        data.forEach { model ->
+            items.add(VerticalsModelUiState(model.verticalId, model.name))
+        }
+    }
+
     data class VerticalsUiState(
         val showError: Boolean,
         val showContent: Boolean,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
@@ -63,6 +63,7 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
 
     fun updateQuery(query: String, delay: Int = throttleDelay) {
         job.cancel() // cancel any previous requests
+        updateUiState(query, ListState.Ready(emptyList()))
         fetchVerticals(query, delay)
     }
 

--- a/WordPress/src/main/res/layout/new_site_creation_progress.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_progress.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/progress_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical">
+
+    <ProgressBar
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+    <TextView
+        android:id="@+id/progress_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="TODO"/>
+</LinearLayout>

--- a/WordPress/src/main/res/layout/new_site_creation_segment_item.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_segment_item.xml
@@ -8,7 +8,7 @@
     android:layout_height="wrap_content"
     android:background="@color/white"
     android:foreground="?selectableItemBackground"
-    android:minHeight="@dimen/site_creation_list_min_item_height">
+    android:minHeight="@dimen/site_creation_segments_list_min_item_height">
 
     <ImageView
         android:id="@+id/icon"
@@ -29,7 +29,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/margin_extra_large"
-        android:layout_marginStart="@dimen/site_creation_list_divider_start_margin"
+        android:layout_marginStart="@dimen/site_creation_segments_list_divider_start_margin"
         android:layout_marginTop="@dimen/margin_extra_large"
         android:textColor="@color/wp_grey_dark"
         android:textSize="@dimen/text_sz_large"
@@ -47,7 +47,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/margin_extra_large"
         android:layout_marginEnd="@dimen/margin_extra_large"
-        android:layout_marginStart="@dimen/site_creation_list_divider_start_margin"
+        android:layout_marginStart="@dimen/site_creation_segments_list_divider_start_margin"
         android:textColor="@color/wp_grey_darken_20"
         android:textSize="@dimen/text_sz_medium"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -61,7 +61,7 @@
         android:id="@+id/divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_marginStart="@dimen/site_creation_list_divider_start_margin"
+        android:layout_marginStart="@dimen/site_creation_segments_list_divider_start_margin"
         android:background="@color/wp_grey_lighten_30"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WordPress/src/main/res/layout/new_site_creation_verticals_error_item.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_verticals_error_item.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                             xmlns:app="http://schemas.android.com/apk/res-auto"
+                                             xmlns:tools="http://schemas.android.com/tools"
+                                             android:id="@+id/container"
+                                             android:layout_width="match_parent"
+                                             android:layout_height="wrap_content"
+                                             android:background="@color/white"
+                                             android:foreground="?selectableItemBackground"
+                                             android:minHeight="@dimen/site_creation_verticals_list_min_item_height">
+
+    <TextView
+        android:id="@+id/error_text"
+        android:layout_width="272dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_extra_large"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:textColor="@color/wp_grey_dark"
+        android:textSize="@dimen/text_sz_large"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/retry"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.0"
+        tools:text="No connection"/>
+
+    <TextView
+        android:id="@+id/retry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_extra_large"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:drawablePadding="@dimen/margin_large"
+        android:gravity="center"
+        android:text="@string/retry"
+        android:textAllCaps="true"
+        android:textColor="@color/wp_blue"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="UnusedAttribute"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/WordPress/src/main/res/layout/new_site_creation_verticals_header_item.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_verticals_header_item.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/site_creation_segments_content_padding_vertical"
+    android:paddingEnd="@dimen/site_creation_segments_content_padding_horizontal"
+    android:paddingStart="@dimen/site_creation_segments_content_padding_horizontal"
+    android:paddingTop="@dimen/site_creation_segments_content_padding_vertical">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fontFamily="sans-serif-medium"
+        android:gravity="center"
+        android:textColor="@color/wp_grey_dark"
+        android:textSize="@dimen/text_sz_large"
+        tools:text="What's the focus of your business?"/>
+
+    <TextView
+        android:id="@+id/subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_medium"
+        android:gravity="center"
+        android:textColor="@color/wp_grey_darken_20"
+        android:textSize="@dimen/text_sz_medium"
+        tools:text="We’ll use your answer to add sections to your website."/>
+</LinearLayout>

--- a/WordPress/src/main/res/layout/new_site_creation_verticals_screen.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_verticals_screen.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingEnd="@dimen/site_creation_screen_horizontal_padding"
+    android:paddingStart="@dimen/site_creation_screen_horizontal_padding">
+
+    <include
+        layout="@layout/site_creation_error_with_retry"
+        tools:visibility="gone"/>
+
+    <include
+        layout="@layout/new_site_creation_progress"
+        tools:visibility="gone"/>
+
+    <android.support.constraint.ConstraintLayout
+        android:id="@+id/content_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:animateLayoutChanges="true">
+
+
+        <include
+            android:id="@+id/header_layout"
+            layout="@layout/new_site_creation_verticals_header_item"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toTopOf="@+id/search_input_layout"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0"/>
+
+        <include
+            android:id="@+id/search_input_layout"
+            layout="@layout/new_site_creation_verticals_search_input_item"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toTopOf="@+id/recycler_view"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/header_layout"
+            app:layout_constraintVertical_bias="0.0"
+            app:layout_goneMarginTop="@dimen/margin_extra_medium_large"/>
+
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="@dimen/margin_extra_large"
+            android:scrollbars="vertical"
+            app:layout_constraintBottom_toTopOf="@+id/btn_skip"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/search_input_layout"/>
+
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/btn_skip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_extra_large"
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:layout_marginTop="@dimen/margin_extra_large"
+            android:text="@string/new_site_creation_button_skip"
+            android:theme="@style/WordPress.Button"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="1.0"/>
+
+    </android.support.constraint.ConstraintLayout>
+</LinearLayout>

--- a/WordPress/src/main/res/layout/new_site_creation_verticals_search_input_item.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_verticals_search_input_item.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/white"
+    android:gravity="center_vertical"
+    android:orientation="vertical">
+
+    <EditText
+        android:id="@+id/input"
+        style="@style/Theme.AppCompat.Light"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_toStartOf="@+id/clear_all_layout"
+        android:background="@color/white"
+        android:drawablePadding="@dimen/margin_extra_large"
+        android:imeOptions="actionSearch"
+        android:inputType="text"
+        android:paddingBottom="@dimen/margin_large"
+        android:paddingStart="@dimen/margin_extra_large"
+        android:paddingTop="@dimen/margin_large"
+        android:singleLine="true"
+        android:textColor="@color/grey_dark"
+        android:textColorHint="@color/grey"
+        tools:hint="@string/site_creation_domain_keywords_hint"
+        tools:ignore="RtlSymmetry"
+        android:importantForAutofill="noExcludeDescendants"
+        tools:targetApi="o">
+    </EditText>
+
+    <FrameLayout
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:background="@color/white">
+
+        <ProgressBar
+            android:layout_width="@dimen/site_creation_verticals_search_progress_size"
+            android:layout_height="@dimen/site_creation_verticals_search_progress_size"
+            android:layout_marginStart="@dimen/margin_large"/>
+    </FrameLayout>
+
+    <LinearLayout
+        android:id="@+id/clear_all_layout"
+        android:layout_width="@dimen/site_creation_verticals_clear_search_clickable_area_width"
+        android:layout_height="match_parent"
+        android:layout_alignBottom="@+id/input"
+        android:layout_alignParentEnd="true"
+        android:layout_alignTop="@+id/input"
+        android:gravity="center">
+
+        <View
+            android:id="@+id/clear_all_btn"
+            android:layout_width="@dimen/site_creation_verticals_clear_search_icon_size"
+            android:layout_height="@dimen/site_creation_verticals_clear_search_icon_size"
+            android:background="@drawable/ic_close_white_24dp"/>
+
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_below="@+id/input"
+        android:background="@color/grey_lighten_30"/>
+</RelativeLayout>

--- a/WordPress/src/main/res/layout/new_site_creation_verticals_suggestion_item.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_verticals_suggestion_item.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                             xmlns:app="http://schemas.android.com/apk/res-auto"
+                                             xmlns:tools="http://schemas.android.com/tools"
+                                             android:id="@+id/container"
+                                             android:layout_width="match_parent"
+                                             android:layout_height="wrap_content"
+                                             android:background="@color/white"
+                                             android:foreground="?selectableItemBackground"
+                                             android:minHeight="@dimen/site_creation_verticals_list_min_item_height">
+
+    <TextView
+        android:id="@+id/suggestion"
+        android:layout_width="272dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_large"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:layout_marginTop="@dimen/margin_large"
+        android:textColor="@color/wp_grey_dark"
+        android:textSize="@dimen/text_sz_large"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.0"
+        tools:text="1 2 3 4 5 6 7 8 9 1 2 3 4 5 6 7 8 9 1 2 3 4 5 6 7 8 9"/>
+
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginStart="@dimen/site_creation_verticals_list_divider_start_margin"
+        android:background="@color/wp_grey_lighten_30"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="1.0"/>
+</android.support.constraint.ConstraintLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -353,9 +353,14 @@
     <!--site creation-->
     <dimen name="site_creation_screen_horizontal_padding">0dp</dimen>
     <dimen name="site_creation_segments_icon_size">24dp</dimen>
-    <dimen name="site_creation_list_divider_start_margin">72dp</dimen>
-    <dimen name="site_creation_list_min_item_height">72dp</dimen>
+    <dimen name="site_creation_segments_list_divider_start_margin">72dp</dimen>
+    <dimen name="site_creation_verticals_list_divider_start_margin">16dp</dimen>
+    <dimen name="site_creation_segments_list_min_item_height">72dp</dimen>
+    <dimen name="site_creation_verticals_list_min_item_height">48dp</dimen>
     <dimen name="site_creation_segments_content_padding_vertical">24dp</dimen>
     <dimen name="site_creation_segments_content_padding_horizontal">16dp</dimen>
+    <dimen name="site_creation_verticals_search_progress_size">24dp</dimen>
+    <dimen name="site_creation_verticals_clear_search_icon_size">24dp</dimen>
+    <dimen name="site_creation_verticals_clear_search_clickable_area_width">48dp</dimen>
 
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2341,8 +2341,13 @@
     <string name="news_card_announcement_action_sample_announcement">[Read more]</string>
     <!--suppress UnusedResources -->
     <string name="news_card_announcement_action_url_sample_announcement" translatable="false">https://en.blog.wordpress.com/2018/06/21/bookmark-posts-with-save-for-later/</string>
+    <!-- END (News Card) -->
+
+    <!-- Site Creation -->
     <string name="site_creation_segments_title">Tell us what kind of site you\’d like to make</string>
     <string name="site_creation_segments_subtitle">This helps us make recommendations. But you’re never locked in — all sites evolve!</string>
     <string name="new_site_creation_segments_title">Create Site</string>
-    <!-- END (News Card) -->
+    <string name="site_creation_fetch_suggestions_failed">No connection</string>
+    <string name="new_site_creation_verticals_title">TODO</string>
+    <string name="new_site_creation_button_skip">Skip</string>
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
@@ -37,6 +37,7 @@ class NewSiteCreationSegmentsViewModelTest {
                     "dummyTitle",
                     "dummySubtitle",
                     "http://dummy.com",
+                    "ffffff",
                     123
             )
     private val secondModel =
@@ -44,7 +45,8 @@ class NewSiteCreationSegmentsViewModelTest {
                     "dummyTitle",
                     "dummySubtitle",
                     "http://dummy.com",
-                    999
+                    "ffffff",
+                    456
             )
 
     private val progressState = UiState(false, true, listOf(HeaderUiState, ProgressUiState))

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
@@ -164,6 +164,6 @@ class NewSiteCreationSegmentsViewModelTest {
         viewModel.start()
 
         val items = viewModel.uiState.value!!.items
-        assertFalse((items[items.size-1] as SegmentUiState).showDivider)
+        assertFalse((items[items.size - 1] as SegmentUiState).showDivider)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'db2b65ad319aec4312dcc93a0a71ee80e8392a0a'
+    fluxCVersion = 'fd750b4d60f64ba80d8c36e87aa219ac1a6af668'
 }

--- a/libs/editor/WordPressEditor/src/main/res/drawable/retry_icon.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/retry_icon.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportHeight="24.0"
+        android:viewportWidth="24.0">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M17.91,14c-0.478,2.833 -2.943,5 -5.91,5c-3.308,0 -6,-2.692 -6,-6s2.692,-6 6,-6h2.172l-2.086,2.086L13.5,10.5L18,6l-4.5,-4.5l-1.414,1.414L14.172,5H12c-4.418,0 -8,3.582 -8,8s3.582,8 8,8c4.079,0 7.438,-3.055 7.931,-7H17.91z"/>
+</vector>


### PR DESCRIPTION
Fixes #8501 

Note:
1) This PR contains changes from #8618 - for easier review, merge #8618 first.
2)This is not a final version of the screen but just a first iteration. 

Adds a View layer for the SiteCreation Business Verticals screen.


To test:
1. Open the SiteCreation flow
2. Verify that the following requirements are met (rotate your device)

Header + Skip button
- visible only when the edittext is empty -> when the user enters the screen or whenever when the user deletes the content of the edittext

EditText
- typeahead/autocompletion functionality - with throttle
- contains icon on the left whenever the app is fetching suggestions the icon is replaced with an infinite progressbar
- contains clear button on the right - visible only when the edittext is not empty

