### PR TITLE
Do not track QS task completion on self-hosted sites.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -186,7 +186,7 @@ class QuickStartUtils {
             val siteId = site.id.toLong()
 
             if (quickStartStore.getQuickStartCompleted(siteId) || isEveryQuickStartTaskDone(quickStartStore) ||
-                    quickStartStore.hasDoneTask(siteId, task)) {
+                    quickStartStore.hasDoneTask(siteId, task) || !isQuickStartAvailableForTheSite(site)) {
                 return
             }
 


### PR DESCRIPTION
Quick Start should not be available for self-hosted users, but we noticed that almost all self-hosted users have a `publish_post` task completed. `publish_post` is the only task that we track for everyone because you can publish a post right after site creation, without going to My Site screen and enabling Quick Start. We wanted the task to be marked as “completed” in case you publish a post and start Quick Start later.

Because of the above-mentioned feature, self-hosted users can complete `publish_post` task.

This PR adds a check for Quick Start availability on a specific site before marking a task as completed.


To test:

1. Put a breakpoint [here](https://github.com/wordpress-mobile/WordPress-Android/blob/ac9b89f4d33b993cf026428732cc2d6fa377b0e9/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt#L193).
2. On a self-hosted website open the editor and confirm that breakpoint is not triggered.