### PR TITLE
Issue/support helper selection

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/SupportHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportHelper.kt
@@ -105,7 +105,7 @@ private fun supportIdentityInputDialogLayout(
 
     val emailEditText = layout.findViewById<EditText>(R.id.support_identity_input_dialog_email_edit_text)
     emailEditText.setText(emailSuggestion)
-    emailEditText.setSelection(0, emailSuggestion?.length ?: 0)
+    emailEditText.selectAll()
 
     val nameEditText = layout.findViewById<EditText>(R.id.support_identity_input_dialog_name_edit_text)
     nameEditText.setText(nameSuggestion)

--- a/WordPress/src/main/res/layout/support_email_and_name_dialog.xml
+++ b/WordPress/src/main/res/layout/support_email_and_name_dialog.xml
@@ -29,7 +29,6 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/margin_large"
             android:layout_width="match_parent"
-            android:maxLength="@integer/max_length_support_name"
             android:textColor="@color/grey_dark"
             android:textSize="@dimen/text_sz_medium" >
         </android.support.design.widget.TextInputEditText>


### PR DESCRIPTION
### Fix
Remove the `maxLength` attribute from the email `EditText` view ([`support_identity_input_dialog_email_edit_text`](https://github.com/wordpress-mobile/WordPress-Android/blob/e79d33fda404de5075e132f6cb8a36408c688832/WordPress/src/main/res/layout/support_email_and_name_dialog.xml#L25-L34)) and update the view from programmatically selecting the first and last characters of the user's email address to select all using the [`EditText.selectAll()`](https://developer.android.com/reference/android/widget/EditText.html#selectAll()) method to avoid `IndexOutOfBoundsException`.