### PR TITLE
Improve release scripts

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -323,7 +323,7 @@ if (["storeFile", "storePassword", "keyAlias", "keyPassword"].count { !project.h
     android {
         signingConfigs {
             release {
-                storeFile = file(project.storeFile)
+                storeFile = file(project.storeFile.replaceFirst("^~", System.getProperty("user.home")))
                 storePassword = project.storePassword
                 keyAlias = project.keyAlias
                 keyPassword = project.keyPassword

--- a/tools/release-checks.sh
+++ b/tools/release-checks.sh
@@ -76,8 +76,8 @@ function printVersion() {
 
 function checkGradleProperties() {
   /bin/echo -n "Check gradle.properties..."
-  checksum=`cat gradle.properties | grep -v "^wp.debug." | grep "^wp."|tr "[A-Z]" "[a-z]" | sed "s/ //g" | sort | sha1sum | cut -d- -f1 | sed "s/ //g"`
-  known_checksum="0b736c33e6c9645b430550db08b09f513e2e8549"
+  checksum=`cat gradle.properties | grep -v "^wp.debug." | grep "^wp."|tr "[A-Z]" "[a-z]" | sed "s/ //g" | sort | shasum | cut -d- -f1 | sed "s/ //g"`
+  known_checksum="06779f08b9ef192a1dd88f3e9aa3f5441387981f"
   if [ x$checksum != x$known_checksum ]; then
     pFail
     exit 5
@@ -87,6 +87,7 @@ function checkGradleProperties() {
 
 function checkFileAgainstHash() {
   filename=$1
+  filename="${filename/#\~/$HOME}" # expand ~ if it is present
   known_checksum=$2
   checksum=`sha1sum "$filename" | cut -d" " -f1`
   if [ x$checksum != x$known_checksum ]; then
@@ -99,7 +100,7 @@ function checkFileAgainstHash() {
 function checkKeystore() {
   keystore=`cat gradle.properties | grep storeFile | cut -d= -f 2 | sed -e 's/^[ \t]*//'`
   /bin/echo -n "Check Keystore..."
-  checkFileAgainstHash "WordPress/$keystore" 7b20577a43b217b668fa875693c006d693679c0c
+  checkFileAgainstHash $keystore 7b20577a43b217b668fa875693c006d693679c0c
 }
 
 function checkGoogleServiceConfig() {

--- a/tools/update-translations.sh
+++ b/tools/update-translations.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-LANG_FILE=../tools/exported-language-codes.csv
-RESDIR=../WordPress/src/main/res/
+SCRIPT_DIR=$(dirname "$0")
+LANG_FILE="${SCRIPT_DIR}/../tools/exported-language-codes.csv"
+RESDIR="${SCRIPT_DIR}/../WordPress/src/main/res/"
 
 # Language definitions resource file
 HEADER=\<?xml\ version=\"1.0\"\ encoding=\"UTF-8\"?\>\\n\<!--Warning:\ Auto-generated\ file,\ don\'t\ edit\ it.--\>\\n\<resources\>\\n\<string-array\ name=\"available_languages\"\ translatable=\"false\"\>


### PR DESCRIPTION
I encountered a few small issues when running the release scripts on Monday. This fixes them:

- Unlike the other scripts in `tools/`, `update-translations.sh` had to be run from within the `tools/` directory. I've updated it so that it can be run from anywhere.
- `release-checks.sh`:
    - Use `shasum` instead of `sha1sum` (the former is installed on macOS by default).
    - Update sha1 for `gradle.properties`.
    - Update keystore check to use absolute directory and expand `~` if needed.
- `build.gradle`: `./gradlew assembleVanillaRelease` could fail to find the keystore if that path contained `~`. It now expands this as needed.

To test:

- Run `./tools/update-translations.sh`. It should work correctly.
- Run `./tools/release-checks.sh`. All checks should run correctly.
- Run `./gradlew assembleVanillaRelease`, it should succeed, including signing with the keystore.