### PR TITLE
Minor fixes in SiteCreation tests - follow up

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchSegmentsPromptUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchSegmentsPromptUseCaseTest.kt
@@ -21,6 +21,8 @@ import org.wordpress.android.fluxc.store.VerticalStore.FetchSegmentPromptPayload
 import org.wordpress.android.fluxc.store.VerticalStore.OnSegmentPromptFetched
 import org.wordpress.android.test
 
+private const val SEGMENT_ID = 1L
+
 @RunWith(MockitoJUnitRunner::class)
 class FetchSegmentsPromptUseCaseTest {
     @Rule
@@ -30,7 +32,7 @@ class FetchSegmentsPromptUseCaseTest {
     @Mock lateinit var store: VerticalStore
     private lateinit var useCase: FetchSegmentPromptUseCase
     private lateinit var dispatchCaptor: KArgumentCaptor<Action<FetchSegmentPromptPayload>>
-    private val event = OnSegmentPromptFetched(1L, SegmentPromptModel("", "", ""), null)
+    private val event = OnSegmentPromptFetched(SEGMENT_ID, SegmentPromptModel("", "", ""), null)
 
     @Before
     fun setUp() {
@@ -42,10 +44,10 @@ class FetchSegmentsPromptUseCaseTest {
     fun coroutineResumedWhenResultEventDispatched() = test {
         whenever(dispatcher.dispatch(any())).then { useCase.onSegmentPromptFetched(event) }
 
-        val resultEvent = useCase.fetchSegmentsPrompt(1L)
+        val resultEvent = useCase.fetchSegmentsPrompt(SEGMENT_ID)
 
         verify(dispatcher).dispatch(dispatchCaptor.capture())
-        Assert.assertEquals(1L, dispatchCaptor.lastValue.payload.segmentId)
+        Assert.assertEquals(SEGMENT_ID, dispatchCaptor.lastValue.payload.segmentId)
         Assert.assertEquals(event, resultEvent)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchVerticalsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchVerticalsUseCaseTest.kt
@@ -20,6 +20,8 @@ import org.wordpress.android.fluxc.store.VerticalStore.FetchVerticalsPayload
 import org.wordpress.android.fluxc.store.VerticalStore.OnVerticalsFetched
 import org.wordpress.android.test
 
+private const val SEARCH_QUERY = "test"
+
 @RunWith(MockitoJUnitRunner::class)
 class FetchVerticalsUseCaseTest {
     @Rule
@@ -29,7 +31,7 @@ class FetchVerticalsUseCaseTest {
     @Mock lateinit var store: VerticalStore
     private lateinit var useCase: FetchVerticalsUseCase
     private lateinit var dispatchCaptor: KArgumentCaptor<Action<FetchVerticalsPayload>>
-    private val event = OnVerticalsFetched("test", emptyList(), null)
+    private val event = OnVerticalsFetched(SEARCH_QUERY, emptyList(), null)
 
     @Before
     fun setUp() {
@@ -41,10 +43,10 @@ class FetchVerticalsUseCaseTest {
     fun coroutineResumedWhenResultEventDispatched() = test {
         whenever(dispatcher.dispatch(any())).then { useCase.onVerticalsFetched(event) }
 
-        val resultEvent = useCase.fetchVerticals("test")
+        val resultEvent = useCase.fetchVerticals(SEARCH_QUERY)
 
         verify(dispatcher).dispatch(dispatchCaptor.capture())
-        assertEquals(dispatchCaptor.lastValue.payload.searchQuery, "test")
+        assertEquals(dispatchCaptor.lastValue.payload.searchQuery, SEARCH_QUERY)
         assertEquals(event, resultEvent)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModelTest.kt
@@ -38,44 +38,44 @@ import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsV
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsListItemUiState.VerticalsModelUiState
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsUiState
 
-const val SEGMENT_ID = 1L
-const val ZERO_DELAY = 0
-const val EMPTY_STRING = ""
+private const val SEGMENT_ID = 1L
+private const val ZERO_DELAY = 0
+private const val EMPTY_STRING = ""
 
-const val DUMMY_HINT = "dummyHint"
-const val DUMMY_TITLE = "dummyTitle"
-const val DUMMY_SUBTITLE = "dummySubtitle"
+private const val DUMMY_HINT = "dummyHint"
+private const val DUMMY_TITLE = "dummyTitle"
+private const val DUMMY_SUBTITLE = "dummySubtitle"
 
-const val FIRST_MODEL_QUERY = "success_1"
-const val SECOND_MODEL_QUERY = "success_2"
-const val ERROR_MODEL_QUERY = "error"
+private const val FIRST_MODEL_QUERY = "success_1"
+private const val SECOND_MODEL_QUERY = "success_2"
+private const val ERROR_MODEL_QUERY = "error"
 
-const val FIRST_MODEL_NAME = "firstModel"
-const val FIRST_MODEL_ID = "1"
-const val SECOND_MODEL_NAME = "secondModel"
-const val SECOND_MODEL_ID = "2"
+private const val FIRST_MODEL_NAME = "firstModel"
+private const val FIRST_MODEL_ID = "1"
+private const val SECOND_MODEL_NAME = "secondModel"
+private const val SECOND_MODEL_ID = "2"
 
-val SUCCESSFUL_HEADER_PROMPT_FETCHED = OnSegmentPromptFetched(
+private val SUCCESSFUL_HEADER_PROMPT_FETCHED = OnSegmentPromptFetched(
         SEGMENT_ID,
         SegmentPromptModel(DUMMY_TITLE, DUMMY_SUBTITLE, DUMMY_HINT), null
 )
-val FAILED_HEADER_PROMPT_FETCHED = OnSegmentPromptFetched(
+private val FAILED_HEADER_PROMPT_FETCHED = OnSegmentPromptFetched(
         SEGMENT_ID,
         null,
         FetchSegmentPromptError(GENERIC_ERROR, null)
 )
 
-val FIRST_MODEL_ON_VERTICALS_FETCHED = OnVerticalsFetched(
+private val FIRST_MODEL_ON_VERTICALS_FETCHED = OnVerticalsFetched(
         FIRST_MODEL_QUERY,
         listOf(VerticalModel(FIRST_MODEL_NAME, FIRST_MODEL_ID)),
         null
 )
-val SECOND_MODEL_ON_VERTICALS_FETCHED = OnVerticalsFetched(
+private val SECOND_MODEL_ON_VERTICALS_FETCHED = OnVerticalsFetched(
         SECOND_MODEL_QUERY,
         listOf(VerticalModel(SECOND_MODEL_NAME, SECOND_MODEL_ID)),
         null
 )
-val ERROR_ON_VERTICALS_FETCHED = OnVerticalsFetched(
+private val ERROR_ON_VERTICALS_FETCHED = OnVerticalsFetched(
         ERROR_MODEL_QUERY,
         emptyList(),
         FetchVerticalsError(GENERIC_ERROR, null)


### PR DESCRIPTION
Fixes couple of minor issues I overlooked in the #8620.

https://github.com/wordpress-mobile/WordPress-Android/pull/8620#discussion_r236366264
I moved them so I could use capital letters with underscores to highlight they are "constant" fields. However, if you prefer to move them back, just let me know.