### PR TITLE
Decrease the severity of lint vectorPath issue from error to warning

### DIFF
--- a/WordPress/lint.xml
+++ b/WordPress/lint.xml
@@ -68,7 +68,6 @@
     <issue id="UnusedAttribute" severity="error" />
     <issue id="IconXmlAndPng" severity="error" />
     <issue id="RtlSymmetry" severity="error" />
-    <issue id="VectorPath" severity="error" />
 
 
     <!-- IGNORE -->


### PR DESCRIPTION
Decreases the severity of the lint vectorPath issue from error to warning.

Background info paqN3M-O-p2

To test:
- Successful Travis build is enough
