### PR TITLE
Add attribution details to README Play Store link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/wordpress-mobile/WordPress-Android.svg?branch=develop)](https://travis-ci.org/wordpress-mobile/WordPress-Android)
 
 If you're just looking to install WordPress for Android, you can find
-it on [Google Play](https://play.google.com/store/apps/details?id=org.wordpress.android). If you're a developer wanting to contribute, read on.
+it on [Google Play](https://play.google.com/store/apps/details?id=org.wordpress.android&referrer=utm_source%3Dgithub%26utm_medium%3Dwebsite). If you're a developer wanting to contribute, read on.
 
 
 ## Build Instructions ##


### PR DESCRIPTION
This change adds attribution details to the app's Google Play Store link, so we can tell when the README refers traffic to the app in the play store.
