### PR TITLE
Fix SiteCreation segment icon color tint

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentViewHolder.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.sitecreation.segments
 
 import android.graphics.Color
+import android.graphics.PorterDuff
 import android.support.annotation.LayoutRes
 import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
@@ -36,7 +37,7 @@ sealed class NewSiteCreationSegmentViewHolder(internal val parent: ViewGroup, @L
             subtitle.text = uiState.subtitle
             imageManager.load(icon, IMAGE, uiState.iconUrl)
             try {
-                icon.setColorFilter(Color.parseColor(uiState.iconColor))
+                icon.setColorFilter(Color.parseColor(uiState.iconColor),PorterDuff.Mode.SRC_IN)
             } catch (e: IllegalArgumentException) {
                 AppLog.e(AppLog.T.SITE_CREATION, "Error parsing segment icon color: ${uiState.iconColor}")
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentViewHolder.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.sitecreation.segments
 
+import android.graphics.Color
 import android.support.annotation.LayoutRes
 import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
@@ -11,6 +12,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentsViewModel.ItemUiState
 import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentsViewModel.ItemUiState.HeaderUiState
 import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentsViewModel.ItemUiState.SegmentUiState
+import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.IMAGE
 
@@ -33,6 +35,11 @@ sealed class NewSiteCreationSegmentViewHolder(internal val parent: ViewGroup, @L
             title.text = uiState.title
             subtitle.text = uiState.subtitle
             imageManager.load(icon, IMAGE, uiState.iconUrl)
+            try {
+                icon.setColorFilter(Color.parseColor(uiState.iconColor))
+            } catch (e: IllegalArgumentException) {
+                AppLog.e(AppLog.T.SITE_CREATION, "Error parsing segment icon color: ${uiState.iconColor}")
+            }
             container.setOnClickListener { uiState.onItemTapped }
             divider.visibility = if (uiState.showDivider) View.VISIBLE else View.GONE
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentViewHolder.kt
@@ -37,7 +37,7 @@ sealed class NewSiteCreationSegmentViewHolder(internal val parent: ViewGroup, @L
             subtitle.text = uiState.subtitle
             imageManager.load(icon, IMAGE, uiState.iconUrl)
             try {
-                icon.setColorFilter(Color.parseColor(uiState.iconColor),PorterDuff.Mode.SRC_IN)
+                icon.setColorFilter(Color.parseColor(uiState.iconColor), PorterDuff.Mode.SRC_IN)
             } catch (e: IllegalArgumentException) {
                 AppLog.e(AppLog.T.SITE_CREATION, "Error parsing segment icon color: ${uiState.iconColor}")
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModel.kt
@@ -143,6 +143,7 @@ class NewSiteCreationSegmentsViewModel
                     model.title,
                     model.subtitle,
                     model.iconUrl,
+                    model.iconColor,
                     showDivider = !isLastItem
             )
             segment.onItemTapped = { onSegmentSelected(model.segmentId) }
@@ -169,6 +170,7 @@ class NewSiteCreationSegmentsViewModel
             val title: String,
             val subtitle: String,
             val iconUrl: String,
+            val iconColor: String,
             val showDivider: Boolean
         ) : ItemUiState() {
             lateinit var onItemTapped: (Long) -> Unit

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
@@ -60,6 +60,7 @@ class NewSiteCreationSegmentsViewModelTest {
                             firstModel.title,
                             firstModel.subtitle,
                             firstModel.iconUrl,
+                            firstModel.iconColor,
                             false
                     )
             )
@@ -73,6 +74,7 @@ class NewSiteCreationSegmentsViewModelTest {
                             secondModel.title,
                             secondModel.subtitle,
                             secondModel.iconUrl,
+                            secondModel.iconColor,
                             false
                     )
             )

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -50,7 +50,8 @@ public class AppLog {
         PLUGINS,
         ACTIVITY_LOG,
         JETPACK_REMOTE_INSTALL,
-        SUPPORT
+        SUPPORT,
+        SITE_CREATION
     }
 
     public static final String TAG = "WordPress";


### PR DESCRIPTION
Fixes #8673 

Adds a colorFilter to the icon on the SiteCreation segments screen.

To test:
1. Go to My Site
2. Click on Switch Site
3. Click on plus sign in the top right corner
4. Select Create a WordPress.com site
5. Notice the icons has a tint

