### PR TITLE
Changes how the app going into the background is detected.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -758,11 +758,11 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
                 case TRIM_MEMORY_RUNNING_LOW:
                     evictBitmaps = true;
                     break;
-                case TRIM_MEMORY_BACKGROUND:
                 case TRIM_MEMORY_UI_HIDDEN:
                     // See https://android.jlelse.eu/how-to-detect-android-application-open-and-close-background-and-foreground-events-1b4713784b57
                     onAppGoesToBackground();
                     break;
+                case TRIM_MEMORY_BACKGROUND:
                 default:
                     break;
             }

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -801,6 +801,9 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
 
         private void onAppGoesToBackground() {
             AppLog.i(T.UTILS, "App goes to background");
+            if (sAppIsInTheBackground) {
+                return;
+            }
             sAppIsInTheBackground = true;
             String lastActivityString = AppPrefs.getLastActivityStr();
             ActivityId lastActivity = ActivityId.getActivityIdFromName(lastActivityString);

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -759,7 +759,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
                     evictBitmaps = true;
                     break;
                 case TRIM_MEMORY_UI_HIDDEN:
-                    // See https://android.jlelse.eu/how-to-detect-android-application-open-and-close-background-and-foreground-events-1b4713784b57
+                    // See https://goo.gl/DuKVfX
                     onAppGoesToBackground();
                     break;
                 case TRIM_MEMORY_BACKGROUND:

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -730,12 +730,9 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
      */
     private class ApplicationLifecycleMonitor implements Application.ActivityLifecycleCallbacks, ComponentCallbacks2 {
         private static final int DEFAULT_TIMEOUT = 2 * 60; // 2 minutes
-        private static final long MAX_ACTIVITY_TRANSITION_TIME_MS = 2000;
 
         private Date mLastPingDate;
         private Date mApplicationOpenedDate;
-        private Timer mActivityTransitionTimer;
-        private TimerTask mActivityTransitionTimerTask;
         private boolean mConnectionReceiverRegistered;
 
         boolean mFirstActivityResumed = true;
@@ -763,6 +760,9 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
                     break;
                 case TRIM_MEMORY_BACKGROUND:
                 case TRIM_MEMORY_UI_HIDDEN:
+                    // See https://android.jlelse.eu/how-to-detect-android-application-open-and-close-background-and-foreground-events-1b4713784b57
+                    onAppGoesToBackground();
+                    break;
                 default:
                     break;
             }
@@ -799,33 +799,6 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
             }
         }
 
-        /**
-         * The two methods below (startActivityTransitionTimer and stopActivityTransitionTimer)
-         * are used to track when the app goes to background.
-         * <p>
-         * Our implementation uses `onActivityPaused` and `onActivityResumed` of ApplicationLifecycleMonitor
-         * to start and stop the timer that detects when the app goes to background.
-         * <p>
-         * So when the user is simply navigating between the activities, the onActivityPaused()
-         * calls `startActivityTransitionTimer` and starts the timer, but almost immediately the new activity being
-         * entered, the ApplicationLifecycleMonitor cancels the timer in its onActivityResumed method, that in order
-         * calls `stopActivityTransitionTimer` and so mIsInBackground would be false.
-         * <p>
-         * In the case the app is sent to background, the TimerTask is instead executed, and the code that handles all
-         * the background logic is run.
-         */
-        private void startActivityTransitionTimer() {
-            this.mActivityTransitionTimer = new Timer();
-            this.mActivityTransitionTimerTask = new TimerTask() {
-                public void run() {
-                    onAppGoesToBackground();
-                }
-            };
-
-            this.mActivityTransitionTimer.schedule(mActivityTransitionTimerTask,
-                                                   MAX_ACTIVITY_TRANSITION_TIME_MS);
-        }
-
         private void onAppGoesToBackground() {
             AppLog.i(T.UTILS, "App goes to background");
             sAppIsInTheBackground = true;
@@ -853,18 +826,6 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
                     Crashlytics.logException(e);
                 }
             }
-        }
-
-        private void stopActivityTransitionTimer() {
-            if (this.mActivityTransitionTimerTask != null) {
-                this.mActivityTransitionTimerTask.cancel();
-            }
-
-            if (this.mActivityTransitionTimer != null) {
-                this.mActivityTransitionTimer.cancel();
-            }
-
-            sAppIsInTheBackground = false;
         }
 
         /**
@@ -930,7 +891,6 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
                 // was in background before
                 onAppComesFromBackground(activity);
             }
-            stopActivityTransitionTimer();
 
             sAppIsInTheBackground = false;
             if (mFirstActivityResumed) {
@@ -950,7 +910,6 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         @Override
         public void onActivityPaused(Activity arg0) {
             mLastPingDate = new Date();
-            startActivityTransitionTimer();
         }
 
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -96,8 +96,6 @@ import java.lang.reflect.Field;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -725,7 +723,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
      * Turns out that when your app has no more visible UI, a callback is triggered.
      * The callback, implemented in this custom class, is called ComponentCallbacks2 (yes, with a two).
      * <p>
-     * This class also uses ActivityLifecycleCallbacks and a timer used as guard,
+     * This class also uses ActivityLifecycleCallbacks
      * to make sure to detect the send to background event and not other events.
      */
     private class ApplicationLifecycleMonitor implements Application.ActivityLifecycleCallbacks, ComponentCallbacks2 {


### PR DESCRIPTION
This PR attempts to improve how we detect the app entering the background. 

The timer-based approach works pretty well but interprets the app being backgrounded when certain system dialogs are presented, even if the UI is still visible to the user.  The change I'm proposing moves away from setting a timer in `onActivityPaused` and instead relies on `onTrimMemory`, an approach inspired by [this article](https://android.jlelse.eu/how-to-detect-android-application-open-and-close-background-and-foreground-events-1b4713784b57).  This seems to work well from my testing in the emulator and I haven't noticed any unintended side effects but I would not be surprised to learn I'd overlooked something. 😬  Please scrutinize this change carefully. 

To test:
- Confirm the issue by setting breakpoints in `onAppComesFromBackground` and `onAppGoesToBackground` (or just watch for the relevant tracks events in the log) by going to a reader detail and tapping the share icon to open a share dialog.

- Apply this patch and repeat the test and confirm that `onAppGoesToBackground` and `onAppComesFromBackground` are no longer called when the share dialog is shown. 

- Confirm that sending the app to the background and resuming the app correctly trigger `onAppGoesToBackground` and `onAppComesFromBackground`.  

- At your discretion, test with other system dialogs, or scenarios where the app should be treated as being backgrounded (like viewing the recent apps list) and confirm that the methods are called as expected.

@oguzkocer @mzorz and @daniloercoli it would be awesome if a couple of you could take a peek at this.  
