### PR TITLE
Issue/contributing drawable resources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ Some vector drawables may come from a SVG file and they are not the easiest file
 Please use the following naming convention for naming drawables:
 
 * Use `ic_` for icons (i.e. simple, usually single color, usually square shape) and `img_` for images (i.e. complex, usually multiple colors).
-* Use the [gridicon](https://github.com/Automattic/gridicons/tree/master/svg) name if applicable (examples: `ic_my_sites` or `ic_reply`).
+* Use the [gridicon](http://automattic.github.io/gridicons/) name if applicable (examples: `ic_my_sites` or `ic_reply`).
 * Use the color to icons (example: `ic_reply_grey`).
 * Use the width in dp (example: `ic_reply_grey_32dp`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ Adding a vector drawable (to `WordPress/src/main/res/drawable/`) should be the f
 
 Some vector drawables may come from a SVG file and they are not the easiest file type to edit. If the SVG file is specific to the WPAndroid project (like a banner image or unlike a gridicon), then add the SVG source in `WordPress/src/future/svg/`. This will make sure we can find and edit the SVG file and then export it in vector drawable format.
 
-Please use the following naming convention for naming drawables:
+Please use the following naming convention for drawables:
 
 * Use `ic_` for icons (i.e. simple, usually single color, usually square shape) and `img_` for images (i.e. complex, usually multiple colors).
 * Use the [gridicon](http://automattic.github.io/gridicons/) name if applicable (examples: `ic_my_sites` or `ic_reply`).


### PR DESCRIPTION
### Fix
Update the broken link to Gridicons and remove redundant text from the ***Drawable Resources*** section of the [`CONTRIBUTING.md`](https://github.com/wordpress-mobile/WordPress-Android/blob/26ac62af74abf163eda97b29e05dc07bcd594bc5/CONTRIBUTING.md) file.

### Test
1. Open [CONTRIBUTING.md](https://github.com/wordpress-mobile/WordPress-Android/blob/26ac62af74abf163eda97b29e05dc07bcd594bc5/CONTRIBUTING.md) file.
2. Notice `Please use the following naming convention for drawables:` refers to `naming` once.
3. Tap ***gridicons*** link.
4. Notice [Gridicons](http://automattic.github.io/gridicons/) repository is shown.