### PR TITLE
Add/configuration validation

### DIFF
--- a/.configure
+++ b/.configure
@@ -1,0 +1,14 @@
+{
+  "branch": "master",
+  "pinned_hash": "98cf6abc2244f0beaf7ff1a176494dbe7dd8ba75",
+  "files_to_copy": [
+    {
+      "file": "android/WPAndroid/gradle.properties",
+      "destination": "gradle.properties"
+    },
+    {
+      "file": "android/WPAndroid/google-services.json",
+      "destination": "WordPress/google-services.json"
+    }
+  ]
+}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: a569711c6bdd4026f1c3e929f743a42189bfba0c
-  tag: 0.1.1
+  revision: 944d435bdd187878e636c599dc1a61bc4428a59a
+  tag: 0.1.2
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.1.1)
+    fastlane-plugin-wpmreleasetoolkit (0.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -220,6 +220,16 @@ ENV[GHHELPER_REPO="wordpress-mobile/WordPress-android"]
       locales: SUPPORTED_LOCALES)
   end 
 
+#####################################################################################
+# release_preflight
+# -----------------------------------------------------------------------------------
+# Run pre-build checks to ensure we're ready for release!
+#####################################################################################
+desc "Run release preflight checks"
+ lane :release_preflight do | options |
+     configure_validate()
+ end
+
 ########################################################################
 # Helper Lanes
 ########################################################################  

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', :tag => '0.1.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', :tag => '0.1.2'


### PR DESCRIPTION
Adds a fastlane lane to ensure everything that configuration secrets are in sync as part of the release build process.

**To Test**
You can test by running `bundle exec fastlane android release_preflight`. On a clean repo it'll succeed.

On a repo with changes, it likely won't. Running `bundle exec fastlane run configure_apply` will overwrite any local configuration changes with the latest from the mobile secrets repo.

To test this, you can add something new to your `gradle.properties` file, and note that the validation fails.
