### PR TITLE
Increase severity of AS issue for protected field in final class

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -11,6 +11,7 @@
       <scope name="Tests" level="ERROR" enabled="false" />
     </inspection_tool>
     <inspection_tool class="KotlinUnusedImport" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="ProtectedInFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="RedundantSemicolon" enabled="true" level="ERROR" enabled_by_default="true" />
   </profile>
 </component>


### PR DESCRIPTION
Increases severity of Android Studio static analysis issue for using `protected` keyword in a final class.
It's typically misused with `@Inject` annotation which doesn't work on `private` fields. `Internal` keyword should be used instead.

