### PR TITLE
Release tools: add release prechecks lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -96,6 +96,24 @@ ENV[GHHELPER_REPO="wordpress-mobile/WordPress-android"]
       source_files: files, 
       release_version: options[:version])
   end 
+  
+  #####################################################################################
+  # finalize_release
+  # -----------------------------------------------------------------------------------
+  # This lane finalize a release: updates store metadata and runs the release checks
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane finalize_release [skip_confirm:<skip confirm>] 
+  #
+  # Example:
+  # bundle exec fastlane finalize_release 
+  # bundle exec fastlane finalize_release skip_confirm:true 
+  #####################################################################################
+  desc "Updates store metadata and runs the release checks"
+  lane :finalize_release do | options |
+    android_finalize_prechecks(options)
+    android_update_metadata(options) unless android_current_branch_is_hotfix
+  end
 
   #####################################################################################
   # download_metadata_string 

--- a/fastlane/actions/android_current_branch_is_hotfix.rb
+++ b/fastlane/actions/android_current_branch_is_hotfix.rb
@@ -1,0 +1,46 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      ANDROID_CURRENT_BRANCH_IS_HOTFIX_CUSTOM_VALUE = :ANDROID_CURRENT_BRANCH_IS_HOTFIX_CUSTOM_VALUE
+    end
+
+    class AndroidCurrentBranchIsHotfixAction < Action
+      def self.run(params)
+        require_relative '../helpers/android_version_helper.rb'
+        Fastlane::Helpers::AndroidVersionHelper::is_hotfix(Fastlane::Helpers::AndroidVersionHelper::get_version_name)
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Checks if the current branch is for a hotfix"
+      end
+
+      def self.details
+        "Checks if the current branch is for a hotfix"
+      end
+
+      def self.available_options
+        
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        "True if the branch is for a hotfix, false otherwise"
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end

--- a/fastlane/actions/android_finalize_prechecks.rb
+++ b/fastlane/actions/android_finalize_prechecks.rb
@@ -1,0 +1,74 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      ANDROID_FINALIZE_PRECHECKS_CUSTOM_VALUE = :ANDROID_FINALIZE_PRECHECKS_CUSTOM_VALUE
+    end
+
+    class AndroidFinalizePrechecksAction < Action
+      def self.run(params)
+        UI.message "Skip confirm: #{params[:skip_confirm]}"
+        
+        require_relative '../helpers/android_version_helper.rb'
+        require_relative '../helpers/android_git_helper.rb'
+
+        UI.user_error!("This is not a release branch. Abort.") unless other_action.git_branch.start_with?("release/")
+
+        version = Fastlane::Helpers::AndroidVersionHelper::get_version_name
+        message = "Finalizing release: #{version}\n"
+        if (!params[:skip_confirm])
+          if (!UI.confirm("#{message}Do you want to continue?"))
+            UI.user_error!("Aborted by user request")
+          end
+        else 
+          UI.message(message)
+        end
+
+        # Check local repo status
+        other_action.ensure_git_status_clean()
+
+        version
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Runs some prechecks before finalizing a release"
+      end
+
+      def self.details
+        "Runs some prechecks before finalizing a release"
+      end
+
+      def self.available_options
+        # Define all options your action supports. 
+        
+        # Below a few examples
+        [
+          FastlaneCore::ConfigItem.new(key: :skip_confirm,
+                                       env_name: "FL_ANDROID_FINALIZE_PRECHECKS_SKIPCONFIRM",
+                                       description: "Skips confirmation",
+                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       default_value: false) # the default value if the user didn't provide one
+        ]
+      end
+
+      def self.output
+         
+      end
+
+      def self.return_value
+        "The current app version"
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end

--- a/fastlane/actions/android_update_metadata.rb
+++ b/fastlane/actions/android_update_metadata.rb
@@ -1,0 +1,48 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      ANDROID_UPDATE_METADATA_CUSTOM_VALUE = :ANDROID_UPDATE_METADATA_CUSTOM_VALUE
+    end
+
+    class AndroidUpdateMetadataAction < Action
+      def self.run(params)
+        require_relative '../helpers/android_git_helper.rb'
+
+        Fastlane::Helpers::AndroidGitHelper.update_metadata()
+        Fastlane::Action::sh("./tools/release-checks.sh")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Downloads translated metadata from the translation system"
+      end
+
+      def self.details
+        "Downloads translated metadata from the translation system"
+      end
+
+      def self.available_options
+        
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end

--- a/fastlane/helpers/android_git_helper.rb
+++ b/fastlane/helpers/android_git_helper.rb
@@ -13,6 +13,15 @@ module Fastlane
         Action.sh("git checkout -b #{branch}")
         Action.sh("git push --set-upstream origin #{branch}")
       end
+
+      def self.update_metadata()
+        Action.sh("./tools/update-translations.sh")
+        Action.sh("./gradlew build")
+        Action.sh("git add ./WordPress/src/main/res")
+        Action.sh("git commit -m \"Updates translations\"")
+
+        Action.sh("git push")
+      end
     end
   end
 end

--- a/fastlane/helpers/android_version_helper.rb
+++ b/fastlane/helpers/android_version_helper.rb
@@ -3,7 +3,9 @@ module Fastlane
     module AndroidVersionHelper
       MAJOR_NUMBER = 0
       MINOR_NUMBER = 1
+      HOTFIX_NUMBER = 2
       ALPHA_PREFIX = "alpha-"
+      RC_SUFFIX = "-rc"
 
       def self.get_version_name
         get_version_name_from_file("./WordPress/build.gradle")
@@ -15,6 +17,10 @@ module Fastlane
 
       def self.is_alpha_version(version)
         version.start_with?(ALPHA_PREFIX)
+      end
+
+      def self.is_beta_version(version)
+        version.include?(RC_SUFFIX)
       end
 
       def self.calc_next_alpha_version_name(version)
@@ -32,6 +38,12 @@ module Fastlane
         end
         
          "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}"
+      end
+
+      def self.is_hotfix(version)
+        return false if is_alpha_version(version)
+        vp = get_version_parts(version)
+        return (vp.length > 2) && (vp[HOTFIX_NUMBER] != 0)
       end
 
       # private 


### PR DESCRIPTION
This PR adds a new lane that downloads the app translations from GlotPress and runs the release checks.

### To Test:
1. Run `bundle exec fastlane finalize_release` and verify that it fails because this is not a release branch.
2. Checkout a new branch from this one, with `release/` in the name. Push the branch and set the branch tracking.
3. Modify the version name in `build.gradle` to a beta or final one (like `11.3`).
4. Run `bundle exec fastlane finalize_release` and verify that:
 -  the strings are downloaded.
 - a test build is executed.
 - the strings are commited.
 - the `release-checks.sh` script is executed. 
5. Delete the test branch from GitHub.
