### PR TITLE
Issue/8661 crash notifications settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -582,7 +582,8 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         }
 
         for (final SubscriptionModel subscription : subscriptions) {
-            if (context == null) {
+            // Subscriptions with a "false" blogId are for feeds and don't have notifications settings.
+            if (context == null || subscription.getBlogId().equalsIgnoreCase("false")) {
                 return;
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2122,10 +2122,13 @@ public class ReaderPostListFragment extends Fragment
         if (ReaderPostTable.isPostFollowed(post)) {
             menuItems.add(ReaderMenuAdapter.ITEM_UNFOLLOW);
 
-            if (ReaderBlogTable.isNotificationsEnabled(post.blogId)) {
-                menuItems.add(ReaderMenuAdapter.ITEM_NOTIFICATIONS_OFF);
-            } else {
-                menuItems.add(ReaderMenuAdapter.ITEM_NOTIFICATIONS_ON);
+            // When blogId and feedId are not equal, post is not a feed so show notifications option.
+            if (post.blogId != post.feedId) {
+                if (ReaderBlogTable.isNotificationsEnabled(post.blogId)) {
+                    menuItems.add(ReaderMenuAdapter.ITEM_NOTIFICATIONS_OFF);
+                } else {
+                    menuItems.add(ReaderMenuAdapter.ITEM_NOTIFICATIONS_ON);
+                }
             }
         } else {
             menuItems.add(ReaderMenuAdapter.ITEM_FOLLOW);


### PR DESCRIPTION
### Fix
Add excluding feeds from the ***Followed Sites*** list on the ***Notification Settings*** screen and including the ***Turn on site notifications*** or ***Turn off site notifications*** option only for non-feed posts in the ***Reader*** to avoid the `NumberFormatException` crash described in https://github.com/wordpress-mobile/WordPress-Android/issues/8661.

Since this crash is affecting a small percentage of users, there doesn't need to be a hotfix and these changes can be included in the next release.

### Test
A feed must be followed in order to test these changes.  In order to follow a feed from the web, go to https://wordpress.com/following/manage, enter ***nytimes.com*** into the ***Search or enter URL to follow...*** field, and click the ***Follow nytimes.com*** button.

#### Notification Settings
1. Go to ***Me*** tab.
2. Tap ***Notification Settings*** item.
3. Notice ***Followed Sites*** section.
4. Notice feed is not shown in ***Followed Sites*** list.
5. Tap ***Search*** action in toolbar.
6. Notice feed is not shown in ***Followed Sites*** list.
7. Enter name or URL of feed.
8. Notice feed is not shown in ***Followed Sites*** list.

#### Reader
1. Go to ***Reader*** tab.
2. Tap overflow menu button of followed site without notifications.
3. Notice ***Turn on site notifications*** item.
4. Tap overflow menu button of followed site with notifications.
5. Notice ***Turn off site notifications*** item.
6. Tap overflow menu button of followed feed.
7. Notice neither ***Turn on site notifications*** nor ***Turn off site notifications*** item.

### Review
Only one developer is required to review these changes, but anyone can perform the review.