### PR TITLE
Refactor SegmentViewModelTest

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
@@ -25,6 +25,72 @@ import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentsVie
 import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentsViewModel.UiState
 import org.wordpress.android.ui.sitecreation.usecases.FetchSegmentsUseCase
 
+private const val FIRST_MODEL_TITLE = "first_title"
+private const val FIRST_MODEL_SUBTITLE = "first_subtitle"
+private const val FIRST_MODEL_ICON_URL = "http://first_url.com"
+private const val FIRST_MODEL_ICON_COLOR = "first_icon_color"
+private const val FIRST_MODEL_SEGMENT_ID = 1L
+
+private const val SECOND_MODEL_TITLE = "second_title"
+private const val SECOND_MODEL_SUBTITLE = "second_subtitle"
+private const val SECOND_MODEL_ICON_URL = "http://second_url.com"
+private const val SECOND_MODEL_ICON_COLOR = "second_icon_color"
+private const val SECOND_MODEL_SEGMENT_ID = 2L
+
+private const val ERROR_MESSAGE = "dummy_error_message"
+
+private val FIRST_MODEL =
+        VerticalSegmentModel(
+                FIRST_MODEL_TITLE,
+                FIRST_MODEL_SUBTITLE,
+                FIRST_MODEL_ICON_URL,
+                FIRST_MODEL_ICON_COLOR,
+                FIRST_MODEL_SEGMENT_ID
+        )
+
+private val SECOND_MODEL =
+        VerticalSegmentModel(
+                SECOND_MODEL_TITLE,
+                SECOND_MODEL_SUBTITLE,
+                SECOND_MODEL_ICON_URL,
+                SECOND_MODEL_ICON_COLOR,
+                SECOND_MODEL_SEGMENT_ID
+        )
+
+private val PROGRESS_STATE = UiState(false, true, listOf(HeaderUiState, ProgressUiState))
+private val ERROR_STATE = UiState(true, false, emptyList())
+private val HEADER_AND_FIRST_ITEM_STATE = UiState(
+        false, true,
+        listOf(
+                HeaderUiState,
+                SegmentUiState(
+                        FIRST_MODEL.segmentId,
+                        FIRST_MODEL.title,
+                        FIRST_MODEL.subtitle,
+                        FIRST_MODEL.iconUrl,
+                        false
+                )
+        )
+)
+private val HEADER_AND_SECOND_ITEM_STATE = UiState(
+        false, true,
+        listOf(
+                HeaderUiState,
+                SegmentUiState(
+                        SECOND_MODEL.segmentId,
+                        SECOND_MODEL.title,
+                        SECOND_MODEL.subtitle,
+                        SECOND_MODEL.iconUrl,
+                        false
+                )
+        )
+)
+
+private val FIRST_MODEL_EVENT = OnSegmentsFetched(listOf(FIRST_MODEL))
+private val SECOND_MODEL_EVENT = OnSegmentsFetched(listOf(SECOND_MODEL))
+private val FIRST_AND_SECOND_MODEL_EVENT = OnSegmentsFetched(listOf(FIRST_MODEL, SECOND_MODEL))
+private val ERROR_EVENT = OnSegmentsFetched(emptyList(), FetchSegmentsError(GENERIC_ERROR, ERROR_MESSAGE))
+
 @RunWith(MockitoJUnitRunner::class)
 class NewSiteCreationSegmentsViewModelTest {
     @Rule
@@ -32,56 +98,8 @@ class NewSiteCreationSegmentsViewModelTest {
 
     @Mock lateinit var dispatcher: Dispatcher
     @Mock lateinit var fetchSegmentsUseCase: FetchSegmentsUseCase
-    private val firstModel =
-            VerticalSegmentModel(
-                    "dummyTitle",
-                    "dummySubtitle",
-                    "http://dummy.com",
-                    "ffffff",
-                    123
-            )
-    private val secondModel =
-            VerticalSegmentModel(
-                    "dummyTitle",
-                    "dummySubtitle",
-                    "http://dummy.com",
-                    "ffffff",
-                    456
-            )
 
-    private val progressState = UiState(false, true, listOf(HeaderUiState, ProgressUiState))
-    private val errorState = UiState(true, false, emptyList())
-    private val headerAndFirstItemState = UiState(
-            false, true,
-            listOf(
-                    HeaderUiState,
-                    SegmentUiState(
-                            firstModel.segmentId,
-                            firstModel.title,
-                            firstModel.subtitle,
-                            firstModel.iconUrl,
-                            false
-                    )
-            )
-    )
-    private val headerAndSecondItemState = UiState(
-            false, true,
-            listOf(
-                    HeaderUiState,
-                    SegmentUiState(
-                            secondModel.segmentId,
-                            secondModel.title,
-                            secondModel.subtitle,
-                            secondModel.iconUrl,
-                            false
-                    )
-            )
-    )
 
-    private val firstModelEvent = OnSegmentsFetched(listOf(firstModel))
-    private val secondModelEvent = OnSegmentsFetched(listOf(secondModel))
-    private val firstAndSecondModelEvent = OnSegmentsFetched(listOf(firstModel, secondModel))
-    private val errorEvent = OnSegmentsFetched(emptyList(), FetchSegmentsError(GENERIC_ERROR, "dummyError"))
 
     private lateinit var viewModel: NewSiteCreationSegmentsViewModel
 
@@ -95,74 +113,73 @@ class NewSiteCreationSegmentsViewModelTest {
                 Dispatchers.Unconfined,
                 Dispatchers.Unconfined
         )
-        val uiStateObservable = viewModel.uiState
-        uiStateObservable.observeForever(uiStateObserver)
+        viewModel.uiState.observeForever(uiStateObserver)
     }
 
     @Test
     fun onStartFetchesCategories() = test {
-        whenever(fetchSegmentsUseCase.fetchCategories()).thenReturn(firstModelEvent)
+        whenever(fetchSegmentsUseCase.fetchCategories()).thenReturn(FIRST_MODEL_EVENT)
         viewModel.start()
 
-        assertTrue(viewModel.uiState.value!! == headerAndFirstItemState)
+        assertTrue(viewModel.uiState.value!! == HEADER_AND_FIRST_ITEM_STATE)
     }
 
     @Test
     fun onRetryFetchesCategories() = test {
-        whenever(fetchSegmentsUseCase.fetchCategories()).thenReturn(firstModelEvent)
+        whenever(fetchSegmentsUseCase.fetchCategories()).thenReturn(FIRST_MODEL_EVENT)
         viewModel.start()
 
-        assertTrue(viewModel.uiState.value!! == headerAndFirstItemState)
+        assertTrue(viewModel.uiState.value!! == HEADER_AND_FIRST_ITEM_STATE)
 
-        whenever(fetchSegmentsUseCase.fetchCategories()).thenReturn(secondModelEvent)
+        whenever(fetchSegmentsUseCase.fetchCategories()).thenReturn(SECOND_MODEL_EVENT)
         viewModel.onRetryClicked()
 
-        assertTrue(viewModel.uiState.value!! == headerAndSecondItemState)
+        assertTrue(viewModel.uiState.value!! == HEADER_AND_SECOND_ITEM_STATE)
     }
 
     @Test
     fun fetchCategoriesChangesStateToProgress() = test {
-        whenever(fetchSegmentsUseCase.fetchCategories()).thenReturn(firstModelEvent)
+        whenever(fetchSegmentsUseCase.fetchCategories()).thenReturn(FIRST_MODEL_EVENT)
         viewModel.start()
 
         inOrder(uiStateObserver).apply {
-            verify(uiStateObserver).onChanged(progressState)
-            verify(uiStateObserver).onChanged(headerAndFirstItemState)
+            verify(uiStateObserver).onChanged(PROGRESS_STATE)
+            verify(uiStateObserver).onChanged(HEADER_AND_FIRST_ITEM_STATE)
             verifyNoMoreInteractions()
         }
     }
 
     @Test
     fun onErrorEventChangesStateToError() = test {
-        whenever(fetchSegmentsUseCase.fetchCategories()).thenReturn(errorEvent)
+        whenever(fetchSegmentsUseCase.fetchCategories()).thenReturn(ERROR_EVENT)
         viewModel.start()
 
         inOrder(uiStateObserver).apply {
-            verify(uiStateObserver).onChanged(progressState)
-            verify(uiStateObserver).onChanged(errorState)
+            verify(uiStateObserver).onChanged(PROGRESS_STATE)
+            verify(uiStateObserver).onChanged(ERROR_STATE)
             verifyNoMoreInteractions()
         }
     }
 
     @Test
     fun onSuccessfulRetryRemovesErrorState() = test {
-        whenever(fetchSegmentsUseCase.fetchCategories()).thenReturn(errorEvent)
+        whenever(fetchSegmentsUseCase.fetchCategories()).thenReturn(ERROR_EVENT)
         viewModel.start()
-        whenever(fetchSegmentsUseCase.fetchCategories()).thenReturn(secondModelEvent)
+        whenever(fetchSegmentsUseCase.fetchCategories()).thenReturn(SECOND_MODEL_EVENT)
         viewModel.onRetryClicked()
 
         inOrder(uiStateObserver).apply {
-            verify(uiStateObserver).onChanged(progressState)
-            verify(uiStateObserver).onChanged(errorState)
-            verify(uiStateObserver).onChanged(progressState)
-            verify(uiStateObserver).onChanged(headerAndSecondItemState)
+            verify(uiStateObserver).onChanged(PROGRESS_STATE)
+            verify(uiStateObserver).onChanged(ERROR_STATE)
+            verify(uiStateObserver).onChanged(PROGRESS_STATE)
+            verify(uiStateObserver).onChanged(HEADER_AND_SECOND_ITEM_STATE)
             verifyNoMoreInteractions()
         }
     }
 
     @Test
-    fun verifyLastItemDoesntShowDivider() = test {
-        whenever(fetchSegmentsUseCase.fetchCategories()).thenReturn(firstAndSecondModelEvent)
+    fun verifyLastItemDoesNotShowDivider() = test {
+        whenever(fetchSegmentsUseCase.fetchCategories()).thenReturn(FIRST_AND_SECOND_MODEL_EVENT)
         viewModel.start()
 
         val items = viewModel.uiState.value!!.items

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
@@ -99,8 +99,6 @@ class NewSiteCreationSegmentsViewModelTest {
     @Mock lateinit var dispatcher: Dispatcher
     @Mock lateinit var fetchSegmentsUseCase: FetchSegmentsUseCase
 
-
-
     private lateinit var viewModel: NewSiteCreationSegmentsViewModel
 
     @Mock private lateinit var uiStateObserver: Observer<UiState>


### PR DESCRIPTION
I've moved constant values and predefined states/models out of the tests class and I renamed them to UPPER_CASE to make the test a bit more readable.

To be honest I find this approach with predefined models and states in tests more readable than the approach we took in the [NewSiteCreationVerticalsViewModelTest](https://github.com/wordpress-mobile/WordPress-Android/blob/feature/master-site-creation/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModelTest.kt). Wdyt?