### PR TITLE
Issue/history list diffs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/history/RevisionItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/RevisionItemViewHolder.kt
@@ -41,6 +41,8 @@ class RevisionItemViewHolder(
         if (boundRevision.totalAdditions == 0 && boundRevision.totalDeletions == 0) {
             diffLayout.visibility = View.GONE
         } else {
+            diffLayout.visibility = View.VISIBLE
+
             if (boundRevision.totalAdditions > 0) {
                 diffAdditions.text = boundRevision.totalAdditions.toString()
                 diffAdditions.visibility = View.VISIBLE


### PR DESCRIPTION
### Fix
Update the visibility setting of the difference layout view on the ***History*** screen.  Due to the recycling of views, long lists of revisions with at least one item without additions and deletions caused the difference layout to be gone for subsequent items with additions or deletions.

### Test
1. Go to ***Sites*** tab.
2. Tap ***Blog Posts*** item under ***Publish*** section.
3. Tap post with many revisions *and* one revision without addition or deletion (i.e. minor changes).
4. Tap more menu in top toolbar.
5. Tap ***History*** item in menu.
6. Notice revisions without addition and deletions hide difference view.
7. Notice revisions with addition or deletions show difference view.

### Review
Only one developer is required to review these changes, but anyone can perform the review.