### PR TITLE
Notifications: Fix notifications enabled check for API 26+

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -1,17 +1,16 @@
 package org.wordpress.android.ui.notifications.utils;
 
 import android.app.AlertDialog;
-import android.app.AppOpsManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.pm.ApplicationInfo;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v4.app.NotificationManagerCompat;
 import android.text.Layout;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
@@ -50,9 +49,6 @@ import org.wordpress.android.util.PackageUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.image.getters.WPCustomImageGetter;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -478,33 +474,11 @@ public class NotificationsUtils {
         AnalyticsTracker.track(AnalyticsTracker.Stat.PUSH_AUTHENTICATION_APPROVED);
     }
 
-    // Checks if global notifications toggle is enabled in the Android app settings
-    // See: https://code.google.com/p/android/issues/detail?id=38482#c15
-    @SuppressWarnings("unchecked")
+    /**
+     * Checks if global notifications toggle is enabled in the Android app settings
+     */
     public static boolean isNotificationsEnabled(Context context) {
-        AppOpsManager mAppOps = (AppOpsManager) context.getSystemService(Context.APP_OPS_SERVICE);
-        ApplicationInfo appInfo = context.getApplicationInfo();
-        String pkg = context.getApplicationContext().getPackageName();
-        int uid = appInfo.uid;
-
-        Class appOpsClass;
-        try {
-            appOpsClass = Class.forName(AppOpsManager.class.getName());
-
-            Method checkOpNoThrowMethod =
-                    appOpsClass.getMethod(CHECK_OP_NO_THROW, Integer.TYPE, Integer.TYPE, String.class);
-
-            Field opPostNotificationValue = appOpsClass.getDeclaredField(OP_POST_NOTIFICATION);
-            int value = (int) opPostNotificationValue.get(Integer.class);
-
-            return ((int) checkOpNoThrowMethod.invoke(mAppOps, value, uid, pkg) == AppOpsManager.MODE_ALLOWED);
-        } catch (ClassNotFoundException | NoSuchFieldException | NoSuchMethodException
-                | IllegalAccessException | InvocationTargetException e) {
-            AppLog.e(T.NOTIFS, e.getMessage());
-        }
-
-        // Default to assuming notifications are enabled
-        return true;
+        return NotificationManagerCompat.from(context.getApplicationContext()).areNotificationsEnabled();
     }
 
     public static boolean buildNoteObjectFromBundleAndSaveIt(Bundle data) {


### PR DESCRIPTION
We use `NotificationsUtils.isNotificationsEnabled()` in a few places to check whether the user has disabled notifications for the app at the system level. While porting over notifications logic to the WooCommerce app, I noticed that this isn't working correctly on Android P. From my tests it looks like it's been broken since at least Android O (API 26).

This affected two things:
1. We were tracking push notification-related analytics events even when notifications were turned off for those API levels
2. The in-app notifications screen wasn't letting the user know that they have notifications disabled:

![device-2018-11-29-135331](https://user-images.githubusercontent.com/9613966/49250444-d66b7c80-f3ec-11e8-900f-7da601cbd766.png)

(That screenshot is API 23 working correctly - with the notifications off on API 26+ no warning is shown.)

It looks like since API 24 there's a [method in `NotificationManagerCompat`](https://developer.android.com/reference/android/support/v4/app/NotificationManagerCompat#arenotificationsenabled) that does the correct check for 24+, but also falls back to the old reflection-based method we were using for API 23 and below.

### To test:
First, confirm the issue:
1. Build `develop` on a device running API 26 or higher
2. In the system settings for the app, disable all notifications
3. In the app, go to _Me_ > _Notification Settings_ and open any site
4. Notice that you get no warning about app notifications being disabled

You can also verify this by generating a push notification and observing that you get a log:
> WooCommerce-UTILS: 🔵 Tracked: push_notification_received

even though notifications are disabled and nothing shows up.

Then, build this branch and run through the above steps with notifications enabled and disabled - there should be no difference between API 21-23 and 25+.