### PR TITLE
Travis CI: Pass '--stacktrace' to gradle to help debug failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,4 +63,4 @@ install:
   - cp libs/login/gradle.properties-example libs/login/gradle.properties
 
 script:
-  - ./gradlew -PdisablePreDex $GRADLE_TASKS || (grep -A20 -B2 'severity="Error"' -r --include="*.xml" WordPress libs; exit 1)
+  - ./gradlew --stacktrace -PdisablePreDex $GRADLE_TASKS || (grep -A20 -B2 'severity="Error"' -r --include="*.xml" WordPress libs; exit 1)


### PR DESCRIPTION
Gradle failures can be tricky to debug on Travis because there is not much detail in the logs. This passes `--stacktrace` to help with that.

To test:

- The travis build log for this PR will now be much more detailed.