### PR TITLE
Only prompt if Gutenberg is not enabled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -13,6 +13,7 @@ import de.greenrobot.event.EventBus
 import org.apache.commons.text.StringEscapeUtils
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.Dispatcher
@@ -329,9 +330,15 @@ class PostListViewModel @Inject constructor(
         localPostIdForPublishDialog = null
     }
 
+    private fun isGutenbergEnabled(): Boolean {
+        return BuildConfig.OFFER_GUTENBERG && AppPrefs.isGutenbergEditorEnabled()
+    }
+
     private fun editPostButtonAction(site: SiteModel, post: PostModel) {
         // Show Gutenberg Warning Dialog if post contains GB blocks and it's not disabled
-        if (PostUtils.contentContainsGutenbergBlocks(post.content) && !AppPrefs.isGutenbergWarningDialogDisabled()) {
+        if (!isGutenbergEnabled()
+                && PostUtils.contentContainsGutenbergBlocks(post.content)
+                && !AppPrefs.isGutenbergWarningDialogDisabled()) {
             _postListAction.postValue(ShowGutenbergWarningDialog(site, post))
         } else {
             editPost(site, post)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -336,9 +336,9 @@ class PostListViewModel @Inject constructor(
 
     private fun editPostButtonAction(site: SiteModel, post: PostModel) {
         // Show Gutenberg Warning Dialog if post contains GB blocks and it's not disabled
-        if (!isGutenbergEnabled()
-                && PostUtils.contentContainsGutenbergBlocks(post.content)
-                && !AppPrefs.isGutenbergWarningDialogDisabled()) {
+        if (!isGutenbergEnabled() &&
+                PostUtils.contentContainsGutenbergBlocks(post.content) &&
+                !AppPrefs.isGutenbergWarningDialogDisabled()) {
             _postListAction.postValue(ShowGutenbergWarningDialog(site, post))
         } else {
             editPost(site, post)


### PR DESCRIPTION
When Gutenberg is enabled, there is no need to prompt the user about it so, avoid the dialog popup.

### To test

1. Run either `wasabi` or `zalpha` and enable Gutenberg from the Me -> App settings section
2. Open a post that is known to have blocks and notice that there is no "Before you continue" prompt before entering the editor
3. Try the same test with the setting disable and notice that the prompt comes up
4. Try the same test with `vanilla` and notice that the prompt comes up
