### PR TITLE
Fix crash on api level < 24 in APP settings

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -619,7 +619,7 @@
     <string name="site_settings_whitelist_none_summary" translatable="false">@string/none</string>
     <string name="site_settings_optimize_images_summary">Enable to resize and compress pictures</string>
     <string name="site_settings_optimize_video_summary">Enable to resize and compress videos</string>
-    <string name="site_settings_enable_gutenberg_summary">This is still an experimental version of Gutenberg 🙈</string>
+    <string name="site_settings_enable_gutenberg_summary">This is still an experimental version of Gutenberg</string>
 
     <string name="detail_approve_manual">Require manual approval for everyone\'s comments.</string>
     <string name="detail_approve_auto_if_previously_approved">Automatically approve if the user has a previously approved comment</string>


### PR DESCRIPTION

Fixes #8713

This is apparently due to  API level < 24 not handling emojis in strings.xml well, introduced in commit https://github.com/wordpress-mobile/WordPress-Android/commit/818c2eb04303ea4f345c6d29076dcdb885eb39ca#diff-96c14faed2c61eacb909ae0349b44cef  in PR #8695

To test:
On an API level < 24 emulator
1. go to Me > App Settings
2. observe the app doesn't crash