### PR TITLE
Remove aztec Toolbar from Gutenberg editor fragment

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -29,7 +29,6 @@ import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.aztec.IHistoryListener;
 import org.wordpress.aztec.source.SourceViewEditText;
-import org.wordpress.aztec.toolbar.AztecToolbar;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnGetContentTimeout;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnMediaLibraryButtonListener;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -47,7 +47,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     private EditTextWithKeyBackListener mTitle;
     private SourceViewEditText mSource;
-    private AztecToolbar mFormattingToolbar;
 
     private Handler mInvalidateOptionsHandler;
     private Runnable mInvalidateOptionsRunnable;
@@ -134,18 +133,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
         // We need to intercept the "Enter" key on the title field, and replace it with a space instead
         mSource.setHint("<p>" + getString(R.string.editor_content_hint) + "</p>");
-
-        mFormattingToolbar = view.findViewById(R.id.formatting_toolbar);
-        mFormattingToolbar.setExpanded(mIsToolbarExpanded);
-
-        mTitle.setOnFocusChangeListener(
-                new View.OnFocusChangeListener() {
-                    @Override
-                    public void onFocusChange(View view, boolean hasFocus) {
-                        mFormattingToolbar.enableFormatButtons(!hasFocus);
-                    }
-                }
-        );
 
         setHasOptionsMenu(true);
 

--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml
@@ -6,14 +6,6 @@
     android:layout_height="match_parent"
     android:layout_width="match_parent">
 
-    <org.wordpress.aztec.toolbar.AztecToolbar
-        android:id="@+id/formatting_toolbar"
-        android:layout_alignParentBottom="true"
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        aztec:advanced="true" >
-    </org.wordpress.aztec.toolbar.AztecToolbar>
-
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml
@@ -3,6 +3,7 @@
     xmlns:aztec="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/white"
     android:orientation="vertical">
 
     <RelativeLayout

--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout  xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:aztec="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white"

--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml
@@ -6,27 +6,22 @@
     android:background="@color/white"
     android:orientation="vertical">
 
-    <RelativeLayout
+    <org.wordpress.android.editor.EditTextWithKeyBackListener
+        android:id="@+id/title"
+        android:hint="@string/post_title"
+        android:inputType="textCapSentences|textAutoCorrect|textMultiLine"
+        android:background="@null"
         android:layout_height="wrap_content"
-        android:layout_width="match_parent" >
-
-        <org.wordpress.android.editor.EditTextWithKeyBackListener
-            android:id="@+id/title"
-            android:hint="@string/post_title"
-            android:inputType="textCapSentences|textAutoCorrect|textMultiLine"
-            android:background="@null"
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"
-            android:padding="@dimen/margin_extra_large"
-            android:fontFamily="serif"
-            android:textStyle="bold"
-            android:textSize="@dimen/aztec_title_size"
-            android:imeOptions="flagNoExtractUi"
-            android:lineSpacingExtra="@dimen/spacing_extra_title"
-            android:textColor="@color/grey_dark"
-            android:textColorHint="@color/hint_text">
-        </org.wordpress.android.editor.EditTextWithKeyBackListener>
-    </RelativeLayout>
+        android:layout_width="match_parent"
+        android:padding="@dimen/margin_extra_large"
+        android:fontFamily="serif"
+        android:textStyle="bold"
+        android:textSize="@dimen/aztec_title_size"
+        android:imeOptions="flagNoExtractUi"
+        android:lineSpacingExtra="@dimen/spacing_extra_title"
+        android:textColor="@color/grey_dark"
+        android:textColorHint="@color/hint_text">
+    </org.wordpress.android.editor.EditTextWithKeyBackListener>
 
     <View
         android:id="@+id/sourceview_horizontal_divider"

--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml
@@ -1,79 +1,70 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout  xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:aztec="http://schemas.android.com/apk/res-auto"
-    android:background="@color/white"
+    android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_width="match_parent">
+    android:orientation="vertical">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_above="@+id/formatting_toolbar"
-        android:orientation="vertical">
+    <RelativeLayout
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent" >
 
-        <RelativeLayout
+        <org.wordpress.android.editor.EditTextWithKeyBackListener
+            android:id="@+id/title"
+            android:hint="@string/post_title"
+            android:inputType="textCapSentences|textAutoCorrect|textMultiLine"
+            android:background="@null"
             android:layout_height="wrap_content"
-            android:layout_width="match_parent" >
+            android:layout_width="match_parent"
+            android:padding="@dimen/margin_extra_large"
+            android:fontFamily="serif"
+            android:textStyle="bold"
+            android:textSize="@dimen/aztec_title_size"
+            android:imeOptions="flagNoExtractUi"
+            android:lineSpacingExtra="@dimen/spacing_extra_title"
+            android:textColor="@color/grey_dark"
+            android:textColorHint="@color/hint_text">
+        </org.wordpress.android.editor.EditTextWithKeyBackListener>
+    </RelativeLayout>
 
-            <org.wordpress.android.editor.EditTextWithKeyBackListener
-                android:id="@+id/title"
-                android:hint="@string/post_title"
-                android:inputType="textCapSentences|textAutoCorrect|textMultiLine"
-                android:background="@null"
-                android:layout_height="wrap_content"
-                android:layout_width="match_parent"
-                android:padding="@dimen/margin_extra_large"
-                android:fontFamily="serif"
-                android:textStyle="bold"
-                android:textSize="@dimen/aztec_title_size"
-                android:imeOptions="flagNoExtractUi"
-                android:lineSpacingExtra="@dimen/spacing_extra_title"
-                android:textColor="@color/grey_dark"
-                android:textColorHint="@color/hint_text">
-            </org.wordpress.android.editor.EditTextWithKeyBackListener>
-        </RelativeLayout>
+    <View
+        android:id="@+id/sourceview_horizontal_divider"
+        android:layout_width="fill_parent"
+        android:layout_height="@dimen/format_bar_horizontal_divider_height"
+        android:layout_marginLeft="@dimen/sourceview_side_margin"
+        android:layout_marginRight="@dimen/sourceview_side_margin"
+        style="@style/DividerSourceView"/>
 
-        <View
-            android:id="@+id/sourceview_horizontal_divider"
-            android:layout_width="fill_parent"
-            android:layout_height="@dimen/format_bar_horizontal_divider_height"
-            android:layout_marginLeft="@dimen/sourceview_side_margin"
-            android:layout_marginRight="@dimen/sourceview_side_margin"
-            style="@style/DividerSourceView"/>
+    <FrameLayout
+        android:layout_height="match_parent"
+        android:layout_width="match_parent" >
 
-        <FrameLayout
+        <com.facebook.react.ReactRootView
+            android:id="@+id/gutenberg"
+            android:hint="@string/editor_content_hint"
             android:layout_height="match_parent"
-            android:layout_width="match_parent" >
+            android:layout_width="match_parent"
+        />
 
-            <com.facebook.react.ReactRootView
-                android:id="@+id/gutenberg"
-                android:hint="@string/editor_content_hint"
-                android:layout_height="match_parent"
-                android:layout_width="match_parent"
-            />
+        <org.wordpress.aztec.source.SourceViewEditText
+            android:id="@+id/source"
+            android:gravity="top|start"
+            android:inputType="textNoSuggestions|textMultiLine"
+            android:layout_height="match_parent"
+            android:layout_width="match_parent"
+            android:paddingTop="16dp"
+            android:paddingLeft="16dp"
+            android:paddingStart="16dp"
+            android:paddingRight="16dp"
+            android:paddingEnd="16dp"
+            android:scrollbars="vertical"
+            android:textColorHint="@color/hint_text"
+            android:background="@null"
+            android:textSize="14sp"
+            android:visibility="gone"
+            android:fontFamily="monospace"
+            android:imeOptions="flagNoExtractUi" />
 
-            <org.wordpress.aztec.source.SourceViewEditText
-                android:id="@+id/source"
-                android:gravity="top|start"
-                android:inputType="textNoSuggestions|textMultiLine"
-                android:layout_height="match_parent"
-                android:layout_width="match_parent"
-                android:paddingTop="16dp"
-                android:paddingLeft="16dp"
-                android:paddingStart="16dp"
-                android:paddingRight="16dp"
-                android:paddingEnd="16dp"
-                android:scrollbars="vertical"
-                android:textColorHint="@color/hint_text"
-                android:background="@null"
-                android:textSize="14sp"
-                android:visibility="gone"
-                android:fontFamily="monospace"
-                android:imeOptions="flagNoExtractUi" />
+    </FrameLayout>
 
-        </FrameLayout>
-
-    </LinearLayout>
-
-</RelativeLayout>
+</LinearLayout>


### PR DESCRIPTION
This PR removes the `AztecToolbar`  from `GutenbergEditorFragment`.

