### PR TITLE
added gutenberg as possibe value in editor_source

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -132,8 +132,10 @@ public class PostUtils {
                     AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.EDITOR_UPDATED_POST, site, properties);
                 } else {
                     properties.put("word_count", AnalyticsUtils.getWordCount(post.getContent()));
-                    properties.put("editor_source", AppPrefs.isAztecEditorEnabled() ? "aztec"
-                            : AppPrefs.isVisualEditorEnabled() ? "hybrid" : "legacy");
+                    properties.put("editor_source",
+                            AppPrefs.isGutenbergEditorEnabled() ? "gutenberg" :
+                                    (AppPrefs.isAztecEditorEnabled() ? "aztec"
+                                        : AppPrefs.isVisualEditorEnabled() ? "hybrid" : "legacy"));
 
                     properties.put(AnalyticsUtils.HAS_GUTENBERG_BLOCKS_KEY,
                             PostUtils.contentContainsGutenbergBlocks(post.getContent()));

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -278,8 +278,10 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
                 sCurrentUploadingPostAnalyticsProperties = new HashMap<>();
                 sCurrentUploadingPostAnalyticsProperties
                         .put("word_count", AnalyticsUtils.getWordCount(mPost.getContent()));
-                sCurrentUploadingPostAnalyticsProperties.put("editor_source", AppPrefs.isAztecEditorEnabled() ? "aztec"
-                        : AppPrefs.isVisualEditorEnabled() ? "hybrid" : "legacy");
+                sCurrentUploadingPostAnalyticsProperties.put("editor_source",
+                        AppPrefs.isGutenbergEditorEnabled() ? "gutenberg" :
+                                (AppPrefs.isAztecEditorEnabled() ? "aztec"
+                                        : AppPrefs.isVisualEditorEnabled() ? "hybrid" : "legacy"));
 
                 if (hasGallery()) {
                     sCurrentUploadingPostAnalyticsProperties.put("with_galleries", true);


### PR DESCRIPTION
Adds `gutenberg` as a possible value of property `editor_source` in Post-publishing related events in Tracks

To test:
1. enable Gutenberg on a zalpha or wasabi build (Me -> App Settings -> Enable Gutenberg)
2. start a new post
3. publish it
4. verify on Tracks the `editor_source` is `gutenberg`, and/or check logcat and see:

`
12-03 15:32:13.645 12655-12655/org.wordpress.android I/WordPress-STATS: 🔵 Tracked: editor_post_published, Properties: {"editor_source":"gutenberg","with_categories":true,"via_new_editor":false,"word_count":44,"blog_id":118247108,"post_id":599,"has_gutenberg_blocks":true,"is_jetpack":true}
`

