### PR TITLE
Remove android.permission.SYSTEM_ALERT_WINDOW in release builds

### DIFF
--- a/WordPress/src/release/AndroidManifest.xml
+++ b/WordPress/src/release/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <!-- This needs to be explictly removed because React Native adds it for all build types
+         See https://github.com/facebook/react-native/issues/5886 -->
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" tools:node="remove"/>
+</manifest>
+


### PR DESCRIPTION
React Native adds permissions that are only needed for debug purposes in all builds. `android.permission.SYSTEM_ALERT_WINDOW` is used for the debug overlay so can be removed for release builds.

The react native issue is https://github.com/facebook/react-native/issues/5886.

To test:

- Run `./gradlew assembleVanillaDebug assembleVanillaRelease`
- Check that the debug build has `android.permission.SYSTEM_ALERT_WINDOW` with `apkanalyzer manifest permissions WordPress/build/outputs/apk/vanilla/debug/WordPress-vanilla-debug.apk`
- Check that the release build doesn't have `android.permission.SYSTEM_ALERT_WINDOW` with `apkanalyzer manifest permissions WordPress/build/outputs/apk/vanilla/release/WordPress-vanilla-release.apk`
