### PR TITLE
Specify the mediaToolbarAvailable flag

### DIFF
--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
@@ -11,7 +11,8 @@
         android:layout_alignParentBottom="true"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
-        aztec:advanced="true" >
+        aztec:advanced="true"
+        aztec:mediaToolbarAvailable="true">
     </org.wordpress.aztec.toolbar.AztecToolbar>
 
     <ScrollView


### PR DESCRIPTION
Fixes #8726 

This fixes #8726, caused by the attribute being set in react-native-aztec and merged via the gutenberg-mobile lib.

To test:

0. With Gutenberg disabled via the App settings (in case you're trying a non-vanilla build)
1. Open a post in Aztec and tap on the "3-dots" button in the bottom toolbar
2. The toolbar should expand and the app not crash