### PR TITLE
Add RELEASE-NOTES.txt file to encourage adding release notes iteratively

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
 Fixes #
 
 To test:
+
+Update release notes:
+
+- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

--- a/fastlane/helpers/android_git_helper.rb
+++ b/fastlane/helpers/android_git_helper.rb
@@ -11,7 +11,15 @@ module Fastlane
         Action.sh("git checkout develop")
         Action.sh("git pull")
         Action.sh("git checkout -b #{branch}")
+        commit_release_notes_for_code_freeze
         Action.sh("git push --set-upstream origin #{branch}")
+      end
+
+      def self.commit_release_notes_for_code_freeze
+        Action.sh("cp RELEASE-NOTES.txt WordPress/metadata/release_notes.txt")
+        Action.sh("echo > RELEASE-NOTES.txt")
+        Action.sh("git add RELEASE-NOTES.txt WordPress/metadata/release_notes.txt")
+        Action.sh("git commit -m \"Update release notes for code freeze\"")
       end
 
       def self.update_metadata()


### PR DESCRIPTION
As discussed, it would be great to start adding release notes throughout the development cycle. The equivalent changes for WordPress-iOS have been merged in https://github.com/wordpress-mobile/WordPress-iOS/pull/10574

The change is this:

- A file, `RELEASE-NOTES.txt`, is in the root of the repo. Changes should be added to it through the cycle. It will be cleared and copied to WordPress/metadata/release_notes.txt on code freeze so it can be uploaded to the Play Store.
- I have also added a reminder to the Pull Request template (see below) to help us remember to add release notes when needed.

To test:

- Run `bundle exec fastlane code_freeze` should copy and clear release notes.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.