### PR TITLE
Site Creation: Fixes the lint issue in domain input layout in new site creation

### DIFF
--- a/WordPress/src/main/res/layout/new_site_creation_domain_input.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_domain_input.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/white"
@@ -17,12 +18,15 @@
         android:drawableTint="@color/grey_text_min"
         android:hint="@string/site_creation_domain_keywords_hint"
         android:imeOptions="actionSearch"
+        android:importantForAutofill="noExcludeDescendants"
+        android:inputType="text"
         android:paddingBottom="@dimen/margin_extra_large"
         android:paddingEnd="@dimen/margin_extra_large"
         android:paddingStart="@dimen/margin_extra_large"
         android:paddingTop="@dimen/margin_extra_large"
         android:singleLine="true"
-        android:textColorHint="@color/grey_darken_10"/>
+        android:textColorHint="@color/grey_darken_10"
+        tools:ignore="UnusedAttribute"/>
 
     <!-- ProgressBar seems to render correctly after when scrolled away only when in a container :( -->
     <FrameLayout


### PR DESCRIPTION
This is small PR to fix a lint issue in our base branch for the site creation. It also fixes a few other AS warnings in the layout.

**To test:**

* No test necessary for this PR since we are changing that screen anyway. If you really want to test, check that the domain screen in the new site creation flow is still working as it used to (which was partial at best).

P.S: If you don't know what all that means, you don't really need to test 🙈 
