### PR TITLE
Site Creation: SearchInputWithHeader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SearchInputWithHeader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SearchInputWithHeader.kt
@@ -1,0 +1,55 @@
+package org.wordpress.android.ui.sitecreation
+
+import android.support.v4.content.ContextCompat
+import android.support.v7.content.res.AppCompatResources
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.TextView
+import org.wordpress.android.R
+
+class SearchInputWithHeader(rootView: View, onClear: () -> Unit) {
+    private val headerLayout = rootView.findViewById<ViewGroup>(R.id.header_layout)
+    private val headerTitle = rootView.findViewById<TextView>(R.id.title)
+    private val headerSubtitle = rootView.findViewById<TextView>(R.id.subtitle)
+    private val searchInput = rootView.findViewById<EditText>(R.id.input)
+    private val progressBar = rootView.findViewById<TextView>(R.id.progress_bar)
+    private val clearAllButton = rootView.findViewById<TextView>(R.id.clear_all_btn)
+
+    init {
+        val context = rootView.context
+
+        val drawable = AppCompatResources.getDrawable(context, R.drawable.ic_search_white_24dp)
+        drawable?.setTint(ContextCompat.getColor(context, R.color.grey))
+        searchInput.setCompoundDrawablesRelativeWithIntrinsicBounds(drawable, null, null, null)
+        clearAllButton.background = drawable
+
+        val clearAllLayout = rootView.findViewById<View>(R.id.clear_all_layout)
+        clearAllLayout.setOnClickListener {
+            onClear()
+        }
+    }
+
+    private fun updateHeader(uiState: SiteCreationHeaderUiState?) {
+        uiState?.let {
+            if (headerLayout.visibility == View.VISIBLE) {
+                headerLayout.animate().translationY(-headerLayout.height.toFloat())
+            } else if (headerLayout.visibility == View.GONE) {
+                headerLayout.animate().translationY(0f)
+            }
+            updateVisibility(headerLayout, true)
+            headerTitle.text = uiState.title
+            headerSubtitle.text = uiState.subtitle
+        } ?: updateVisibility(headerLayout, false)
+    }
+
+    private fun updateSearchInput(uiState: SiteCreationSearchInputUiState) {
+        searchInput.hint = uiState.hint
+        updateVisibility(progressBar, uiState.showProgress)
+        updateVisibility(clearAllButton, uiState.showClearButton)
+    }
+
+    private fun updateVisibility(view: View, visible: Boolean) {
+        view.visibility = if (visible) View.VISIBLE else View.GONE
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SearchInputWithHeader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SearchInputWithHeader.kt
@@ -50,12 +50,13 @@ class SearchInputWithHeader(rootView: View, onClear: () -> Unit) {
     }
 
     fun updateHeader(uiState: SiteCreationHeaderUiState?) {
+        val headerShouldBeVisible = uiState != null
+        if (!headerShouldBeVisible && headerLayout.visibility == View.VISIBLE) {
+            headerLayout.animate().translationY(-headerLayout.height.toFloat())
+        } else if (headerShouldBeVisible && headerLayout.visibility == View.GONE) {
+            headerLayout.animate().translationY(0f)
+        }
         uiState?.let {
-            if (headerLayout.visibility == View.VISIBLE) {
-                headerLayout.animate().translationY(-headerLayout.height.toFloat())
-            } else if (headerLayout.visibility == View.GONE) {
-                headerLayout.animate().translationY(0f)
-            }
             updateVisibility(headerLayout, true)
             headerTitle.text = uiState.title
             headerSubtitle.text = uiState.subtitle

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SearchInputWithHeader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SearchInputWithHeader.kt
@@ -10,13 +10,15 @@ import android.widget.EditText
 import android.widget.TextView
 import org.wordpress.android.R
 
-class SearchInputWithHeader(rootView: View, onClear: () -> Unit, onTextChanged: (String) -> Unit) {
+class SearchInputWithHeader(rootView: View, onClear: () -> Unit) {
     private val headerLayout = rootView.findViewById<ViewGroup>(R.id.header_layout)
     private val headerTitle = rootView.findViewById<TextView>(R.id.title)
     private val headerSubtitle = rootView.findViewById<TextView>(R.id.subtitle)
     private val searchInput = rootView.findViewById<EditText>(R.id.input)
     private val progressBar = rootView.findViewById<View>(R.id.progress_bar)
     private val clearAllButton = rootView.findViewById<View>(R.id.clear_all_btn)
+
+    var onTextChanged: ((String) -> Unit)? = null
 
     init {
         val context = rootView.context
@@ -35,7 +37,7 @@ class SearchInputWithHeader(rootView: View, onClear: () -> Unit, onTextChanged: 
             override fun afterTextChanged(s: Editable?) {}
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                onTextChanged(s?.toString() ?: "")
+                onTextChanged?.invoke(s?.toString() ?: "")
             }
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SearchInputWithHeader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SearchInputWithHeader.kt
@@ -2,19 +2,21 @@ package org.wordpress.android.ui.sitecreation
 
 import android.support.v4.content.ContextCompat
 import android.support.v7.content.res.AppCompatResources
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.TextView
 import org.wordpress.android.R
 
-class SearchInputWithHeader(rootView: View, onClear: () -> Unit) {
+class SearchInputWithHeader(rootView: View, onClear: () -> Unit, onTextChanged: (String) -> Unit) {
     private val headerLayout = rootView.findViewById<ViewGroup>(R.id.header_layout)
     private val headerTitle = rootView.findViewById<TextView>(R.id.title)
     private val headerSubtitle = rootView.findViewById<TextView>(R.id.subtitle)
     private val searchInput = rootView.findViewById<EditText>(R.id.input)
-    private val progressBar = rootView.findViewById<TextView>(R.id.progress_bar)
-    private val clearAllButton = rootView.findViewById<TextView>(R.id.clear_all_btn)
+    private val progressBar = rootView.findViewById<View>(R.id.progress_bar)
+    private val clearAllButton = rootView.findViewById<View>(R.id.clear_all_btn)
 
     init {
         val context = rootView.context
@@ -28,9 +30,24 @@ class SearchInputWithHeader(rootView: View, onClear: () -> Unit) {
         clearAllLayout.setOnClickListener {
             onClear()
         }
+
+        searchInput.addTextChangedListener(object : TextWatcher {
+            override fun afterTextChanged(s: Editable?) {}
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                onTextChanged(s?.toString() ?: "")
+            }
+        })
     }
 
-    private fun updateHeader(uiState: SiteCreationHeaderUiState?) {
+    fun setInputText(text: String) {
+        // If the text hasn't changed avoid triggering the text watcher
+        if (searchInput.text.toString() != text) {
+            searchInput.setText(text)
+        }
+    }
+
+    fun updateHeader(uiState: SiteCreationHeaderUiState?) {
         uiState?.let {
             if (headerLayout.visibility == View.VISIBLE) {
                 headerLayout.animate().translationY(-headerLayout.height.toFloat())
@@ -43,7 +60,7 @@ class SearchInputWithHeader(rootView: View, onClear: () -> Unit) {
         } ?: updateVisibility(headerLayout, false)
     }
 
-    private fun updateSearchInput(uiState: SiteCreationSearchInputUiState) {
+    fun updateSearchInput(uiState: SiteCreationSearchInputUiState) {
         searchInput.hint = uiState.hint
         updateVisibility(progressBar, uiState.showProgress)
         updateVisibility(clearAllButton, uiState.showClearButton)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationHeaderUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationHeaderUiState.kt
@@ -1,0 +1,3 @@
+package org.wordpress.android.ui.sitecreation
+
+data class SiteCreationHeaderUiState(val title: String, val subtitle: String)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationSearchInputUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationSearchInputUiState.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.ui.sitecreation
+
+data class SiteCreationSearchInputUiState(
+    val hint: String,
+    val showProgress: Boolean,
+    val showClearButton: Boolean
+)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
@@ -79,8 +79,7 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
         errorLayout = rootView.findViewById(R.id.error_layout)
         searchInputWithHeader = SearchInputWithHeader(
                 rootView = rootView,
-                onClear = { viewModel.onClearTextBtnClicked() },
-                onTextChanged = { viewModel.updateQuery(it) }
+                onClear = { viewModel.onClearTextBtnClicked() }
         )
         initRecyclerView(rootView)
         initRetryButton(rootView)
@@ -108,6 +107,9 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
         savedInstanceState?.getParcelable<Parcelable>(KEY_LIST_STATE)?.let {
             linearLayoutManager.onRestoreInstanceState(it)
         }
+        // we need to set the `onTextChanged` after the viewState has been restored otherwise the viewModel.updateQuery
+        // is called when the system sets the restored value to the EditText which results in an unnecessary request
+        searchInputWithHeader.onTextChanged = { viewModel.updateQuery(it) }
     }
 
     private fun initRecyclerView(rootView: ViewGroup) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
@@ -26,9 +26,9 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.ui.sitecreation.NewSiteCreationBaseFormFragment
 import org.wordpress.android.ui.sitecreation.NewSiteCreationListener
 import org.wordpress.android.ui.sitecreation.OnSkipClickedListener
-import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsHeaderUiState
+import org.wordpress.android.ui.sitecreation.SiteCreationHeaderUiState
+import org.wordpress.android.ui.sitecreation.SiteCreationSearchInputUiState
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsListItemUiState
-import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsSearchInputUiState
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsUiState.VerticalsContentUiState
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsUiState.VerticalsFullscreenErrorUiState
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsUiState.VerticalsFullscreenProgressUiState
@@ -234,7 +234,7 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
         }
     }
 
-    private fun updateHeader(uiState: VerticalsHeaderUiState?) {
+    private fun updateHeader(uiState: SiteCreationHeaderUiState?) {
         uiState?.let {
             if (headerLayout.visibility == View.VISIBLE) {
                 if (contentLayout.layoutTransition == null) {
@@ -250,7 +250,7 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
         } ?: updateVisibility(headerLayout, false)
     }
 
-    private fun updateSearchInput(uiState: VerticalsSearchInputUiState) {
+    private fun updateSearchInput(uiState: SiteCreationSearchInputUiState) {
         searchEditText.hint = uiState.hint
         updateVisibility(searchEditTextProgressBar, uiState.showProgress)
         updateVisibility(clearAllButton, uiState.showClearButton)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.sitecreation.verticals
 
-import android.animation.LayoutTransition
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProvider
 import android.arch.lifecycle.ViewModelProviders
@@ -74,7 +73,6 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
         fullscreenErrorLayout = rootView.findViewById(R.id.error_layout)
         fullscreenProgressLayout = rootView.findViewById(R.id.progress_layout)
         contentLayout = rootView.findViewById(R.id.content_layout)
-        contentLayout.layoutTransition = LayoutTransition() // animate layout changes
 
         errorLayout = rootView.findViewById(R.id.error_layout)
         searchInputWithHeader = SearchInputWithHeader(

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
@@ -9,16 +9,11 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.support.annotation.LayoutRes
 import android.support.v4.app.FragmentActivity
-import android.support.v4.content.ContextCompat
-import android.support.v7.content.res.AppCompatResources
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
-import android.text.Editable
-import android.text.TextWatcher
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.EditText
 import android.widget.TextView
 import kotlinx.android.synthetic.main.site_creation_error_with_retry.view.*
 import org.wordpress.android.R
@@ -26,8 +21,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.ui.sitecreation.NewSiteCreationBaseFormFragment
 import org.wordpress.android.ui.sitecreation.NewSiteCreationListener
 import org.wordpress.android.ui.sitecreation.OnSkipClickedListener
-import org.wordpress.android.ui.sitecreation.SiteCreationHeaderUiState
-import org.wordpress.android.ui.sitecreation.SiteCreationSearchInputUiState
+import org.wordpress.android.ui.sitecreation.SearchInputWithHeader
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsListItemUiState
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsUiState.VerticalsContentUiState
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsUiState.VerticalsFullscreenErrorUiState
@@ -49,13 +43,7 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
     private lateinit var contentLayout: ViewGroup
     private lateinit var errorLayout: ViewGroup
     private lateinit var skipButton: Button
-
-    private lateinit var headerLayout: ViewGroup
-    private lateinit var headerTitle: TextView
-    private lateinit var headerSubtitle: TextView
-    private lateinit var searchEditText: EditText
-    private lateinit var searchEditTextProgressBar: View
-    private lateinit var clearAllButton: View
+    private lateinit var searchInputWithHeader: SearchInputWithHeader
 
     private lateinit var verticalsScreenListener: VerticalsScreenListener
     private lateinit var skipClickedListener: OnSkipClickedListener
@@ -86,10 +74,14 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
         fullscreenErrorLayout = rootView.findViewById(R.id.error_layout)
         fullscreenProgressLayout = rootView.findViewById(R.id.progress_layout)
         contentLayout = rootView.findViewById(R.id.content_layout)
+        contentLayout.layoutTransition = LayoutTransition() // animate layout changes
+
         errorLayout = rootView.findViewById(R.id.error_layout)
-        initSearchEditText(rootView)
-        initClearTextButton(rootView)
-        initHeader(rootView)
+        searchInputWithHeader = SearchInputWithHeader(
+                rootView = rootView,
+                onClear = { viewModel.onClearTextBtnClicked() },
+                onTextChanged = { viewModel.updateQuery(it) }
+        )
         initRecyclerView(rootView)
         initRetryButton(rootView)
         initSkipButton(rootView)
@@ -116,35 +108,6 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
         savedInstanceState?.getParcelable<Parcelable>(KEY_LIST_STATE)?.let {
             linearLayoutManager.onRestoreInstanceState(it)
         }
-        // we need to init the text watcher after the viewState has been restored otherwise the viewModel.updateQuery
-        // is called when the system sets the restored value to the EditText which results in an unnecessary request
-        initTextWatcher()
-    }
-
-    private fun initHeader(rootView: ViewGroup) {
-        headerLayout = rootView.findViewById(R.id.header_layout)
-        headerTitle = headerLayout.findViewById(R.id.title)
-        headerSubtitle = headerLayout.findViewById(R.id.subtitle)
-    }
-
-    private fun initSearchEditText(rootView: ViewGroup) {
-        searchEditText = rootView.findViewById(R.id.input)
-        searchEditTextProgressBar = rootView.findViewById(R.id.progress_bar)
-        val drawable = AppCompatResources.getDrawable(nonNullActivity, R.drawable.ic_search_white_24dp)
-        drawable?.setTint(ContextCompat.getColor(nonNullActivity, R.color.grey))
-        searchEditText.setCompoundDrawablesRelativeWithIntrinsicBounds(drawable, null, null, null)
-    }
-
-    private fun initClearTextButton(rootView: ViewGroup) {
-        clearAllButton = rootView.findViewById(R.id.clear_all_btn)
-        val drawable = AppCompatResources.getDrawable(nonNullActivity, R.drawable.ic_close_white_24dp)
-        drawable?.setTint(ContextCompat.getColor(nonNullActivity, R.color.grey))
-        clearAllButton.background = drawable
-
-        val clearAllLayout = rootView.findViewById<View>(R.id.clear_all_layout)
-        clearAllLayout.setOnClickListener {
-            viewModel.onClearTextBtnClicked()
-        }
     }
 
     private fun initRecyclerView(rootView: ViewGroup) {
@@ -170,16 +133,6 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
         skipButton.setOnClickListener { viewModel.onSkipStepBtnClicked() }
     }
 
-    private fun initTextWatcher() {
-        searchEditText.addTextChangedListener(object : TextWatcher {
-            override fun afterTextChanged(s: Editable?) {}
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                viewModel.updateQuery(s?.toString() ?: "")
-            }
-        })
-    }
-
     private fun initViewModel() {
         viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get(NewSiteCreationVerticalsViewModel::class.java)
@@ -199,7 +152,7 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
             }
         })
         viewModel.clearBtnClicked.observe(this, Observer {
-            searchEditText.setText("")
+            searchInputWithHeader.setInputText("")
         })
 
         viewModel.verticalSelected.observe(this, Observer { verticalId ->
@@ -211,8 +164,8 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
 
     private fun updateContentLayout(uiState: VerticalsContentUiState) {
         updateVisibility(skipButton, uiState.showSkipButton)
-        updateHeader(uiState.headerUiState)
-        updateSearchInput(uiState.searchInputUiState)
+        searchInputWithHeader.updateHeader(uiState.headerUiState)
+        searchInputWithHeader.updateSearchInput(uiState.searchInputUiState)
         updateSuggestions(uiState.items)
     }
 
@@ -232,28 +185,6 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
         if (mSiteCreationListener != null) {
             mSiteCreationListener.helpCategoryScreen()
         }
-    }
-
-    private fun updateHeader(uiState: SiteCreationHeaderUiState?) {
-        uiState?.let {
-            if (headerLayout.visibility == View.VISIBLE) {
-                if (contentLayout.layoutTransition == null) {
-                    contentLayout.layoutTransition = LayoutTransition() // animate layout changes
-                }
-                headerLayout.animate().translationY(-headerLayout.height.toFloat())
-            } else if (headerLayout.visibility == View.GONE) {
-                headerLayout.animate().translationY(0f)
-            }
-            updateVisibility(headerLayout, true)
-            headerTitle.text = uiState.title
-            headerSubtitle.text = uiState.subtitle
-        } ?: updateVisibility(headerLayout, false)
-    }
-
-    private fun updateSearchInput(uiState: SiteCreationSearchInputUiState) {
-        searchEditText.hint = uiState.hint
-        updateVisibility(searchEditTextProgressBar, uiState.showProgress)
-        updateVisibility(clearAllButton, uiState.showClearButton)
     }
 
     private fun updateSuggestions(suggestions: List<VerticalsListItemUiState>) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
@@ -22,6 +22,8 @@ import org.wordpress.android.models.networkresource.ListState.Loading
 import org.wordpress.android.models.networkresource.ListState.Ready
 import org.wordpress.android.modules.IO_DISPATCHER
 import org.wordpress.android.modules.MAIN_DISPATCHER
+import org.wordpress.android.ui.sitecreation.SiteCreationHeaderUiState
+import org.wordpress.android.ui.sitecreation.SiteCreationSearchInputUiState
 import org.wordpress.android.ui.sitecreation.usecases.FetchSegmentPromptUseCase
 import org.wordpress.android.ui.sitecreation.usecases.FetchVerticalsUseCase
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsListItemUiState.VerticalsCustomModelUiState
@@ -266,16 +268,16 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
     private fun createHeaderUiState(
         isVisible: Boolean,
         segmentsPrompt: SegmentPromptModel
-    ): VerticalsHeaderUiState? {
-        return if (isVisible) VerticalsHeaderUiState(segmentsPrompt.title, segmentsPrompt.subtitle) else null
+    ): SiteCreationHeaderUiState? {
+        return if (isVisible) SiteCreationHeaderUiState(segmentsPrompt.title, segmentsPrompt.subtitle) else null
     }
 
     private fun createSearchInputUiState(
         query: String,
         showProgress: Boolean,
         hint: String
-    ): VerticalsSearchInputUiState {
-        return VerticalsSearchInputUiState(
+    ): SiteCreationSearchInputUiState {
+        return SiteCreationSearchInputUiState(
                 hint,
                 showProgress,
                 showClearButton = !StringUtils.isEmpty(query)
@@ -288,8 +290,8 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
         val fullscreenErrorLayoutVisibility: Boolean
     ) {
         data class VerticalsContentUiState(
-            val searchInputUiState: VerticalsSearchInputUiState,
-            val headerUiState: VerticalsHeaderUiState?,
+            val searchInputUiState: SiteCreationSearchInputUiState,
+            val headerUiState: SiteCreationHeaderUiState?,
             val showSkipButton: Boolean,
             val items: List<VerticalsListItemUiState>
         ) : VerticalsUiState(
@@ -322,14 +324,6 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
             )
         }
     }
-
-    data class VerticalsSearchInputUiState(
-        val hint: String,
-        val showProgress: Boolean,
-        val showClearButton: Boolean
-    )
-
-    data class VerticalsHeaderUiState(val title: String, val subtitle: String)
 
     sealed class VerticalsListItemUiState {
         var onItemTapped: (() -> Unit)? = null

--- a/WordPress/src/main/res/layout/new_site_creation_verticals_screen.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_verticals_screen.xml
@@ -20,7 +20,8 @@
     <android.support.constraint.ConstraintLayout
         android:id="@+id/content_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:animateLayoutChanges="true">
 
         <include
             android:id="@+id/header_layout"


### PR DESCRIPTION
This PR introduces a reusable header view component with a built in search input. I basically extracted the header from the verticals screen and created `SearchInputWithHeader`, so we can use it in the domains screen and possibly in other screens. I kept the logic and the way things are setup pretty much the same except for some really minor changes.

I've recently found some issues such as #8751 and #8752 in verticals screen. This PR doesn't handle these issues for now. It also doesn't try to improve the introduced component. If we integrate this into the domain screen, our needs will be more clear which will make it easier to improve the component.

To test:
* Enable `NEW_SITE_CREATION_ENABLED` feature flag
* Go to site selection screen, tap on the `+` menu button and select "Create WordPress.com site"
* Tap on any of the mocked segments
* Enter input, rotate the device and pretty much ensure that the behavior is the same as it was before.

Here is the original PR that introduced the verticals screen: https://github.com/wordpress-mobile/WordPress-Android/pull/8619 which could be useful to compare and test this PR.