### PR TITLE
Issue/8690 site creation titles

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -3,12 +3,12 @@
   <component name="CheckStyle-IDEA">
     <option name="configuration">
       <map>
-        <entry key="active-configuration" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
+        <entry key="active-configuration" value="LOCAL_FILE:$PROJECT_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="checkstyle-version" value="8.2" />
         <entry key="copy-libs" value="false" />
         <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
-        <entry key="location-2" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
+        <entry key="location-2" value="LOCAL_FILE:$PROJECT_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="scan-before-checkin" value="false" />
         <entry key="scanscope" value="AllSourcesWithTests" />
         <entry key="suppress-errors" value="false" />

--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -3,12 +3,12 @@
   <component name="CheckStyle-IDEA">
     <option name="configuration">
       <map>
-        <entry key="active-configuration" value="LOCAL_FILE:$PROJECT_DIR$/config/checkstyle.xml:a8c Style" />
+        <entry key="active-configuration" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="checkstyle-version" value="8.2" />
         <entry key="copy-libs" value="false" />
         <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
-        <entry key="location-2" value="LOCAL_FILE:$PROJECT_DIR$/config/checkstyle.xml:a8c Style" />
+        <entry key="location-2" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="scan-before-checkin" value="false" />
         <entry key="scanscope" value="AllSourcesWithTests" />
         <entry key="suppress-errors" value="false" />

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
@@ -61,14 +61,15 @@ class NewSiteCreationActivity : AppCompatActivity(),
     }
 
     private fun showStep(target: WizardNavigationTarget<SiteCreationStep, SiteCreationState>) {
+        val screenTitle = getScreenTitle(target.wizardStep)
         val fragment = when (target.wizardStep) {
-            SEGMENTS -> NewSiteCreationSegmentsFragment.newInstance(getScreenTitle(target.wizardStep))
+            SEGMENTS -> NewSiteCreationSegmentsFragment.newInstance(screenTitle)
             VERTICALS ->
                 NewSiteCreationVerticalsFragment.newInstance(
-                        getScreenTitle(target.wizardStep),
+                        screenTitle,
                         target.wizardState.segmentId!!
                 )
-            DOMAINS -> NewSiteCreationDomainFragment.newInstance(getScreenTitle(target.wizardStep), "Test site")
+            DOMAINS -> NewSiteCreationDomainFragment.newInstance(screenTitle, "Test site")
         }
         slideInFragment(fragment, target.wizardStep.toString())
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
@@ -10,6 +10,7 @@ import android.view.MenuItem
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleEmpty
 import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleStepCount
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
@@ -92,6 +93,7 @@ class NewSiteCreationActivity : AppCompatActivity(),
                     screenTitleData.stepsCount
             )
             is ScreenTitleGeneral -> getString(screenTitleData.resId)
+            is ScreenTitleEmpty -> screenTitleData.screenTitle
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
@@ -60,12 +60,20 @@ class NewSiteCreationActivity : AppCompatActivity(),
 
     private fun showStep(target: WizardNavigationTarget<SiteCreationStep, SiteCreationState>) {
         val fragment = when (target.wizardStep) {
-            SEGMENTS -> NewSiteCreationSegmentsFragment.newInstance()
+            SEGMENTS -> NewSiteCreationSegmentsFragment.newInstance(getScreenTitle(target.wizardStep))
             VERTICALS ->
-                NewSiteCreationVerticalsFragment.newInstance(target.wizardState.segmentId!!)
-            DOMAINS -> NewSiteCreationDomainFragment.newInstance("Test title")
+                NewSiteCreationVerticalsFragment.newInstance(
+                        getScreenTitle(target.wizardStep),
+                        target.wizardState.segmentId!!
+                )
+            DOMAINS -> NewSiteCreationDomainFragment.newInstance(getScreenTitle(target.wizardStep), "Test site")
         }
         slideInFragment(fragment, target.wizardStep.toString())
+    }
+
+    private fun getScreenTitle(step: SiteCreationStep): String {
+        val screenTitleData = mainViewModel.screenTitleForWizardStep(step)
+        return getString(screenTitleData.resId, screenTitleData.stepPosition, screenTitleData.stepsCount)
     }
 
     private fun slideInFragment(fragment: Fragment?, tag: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
@@ -10,6 +10,8 @@ import android.view.MenuItem
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleGeneral
+import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleStepCount
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.VERTICALS
@@ -73,7 +75,14 @@ class NewSiteCreationActivity : AppCompatActivity(),
 
     private fun getScreenTitle(step: SiteCreationStep): String {
         val screenTitleData = mainViewModel.screenTitleForWizardStep(step)
-        return getString(screenTitleData.resId, screenTitleData.stepPosition, screenTitleData.stepsCount)
+        return when (screenTitleData) {
+            is ScreenTitleStepCount -> getString(
+                    screenTitleData.resId,
+                    screenTitleData.stepPosition,
+                    screenTitleData.stepsCount
+            )
+            is ScreenTitleGeneral -> getString(screenTitleData.resId)
+        }
     }
 
     private fun slideInFragment(fragment: Fragment?, tag: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationBaseFormFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationBaseFormFragment.java
@@ -85,13 +85,7 @@ public abstract class NewSiteCreationBaseFormFragment<SiteCreationListenerType> 
         }
     }
 
-    private String getScreenTitle() {
-        Bundle arguments = getArguments();
-        if (arguments == null || !arguments.containsKey(EXTRA_SCREEN_TITLE)) {
-            throw new IllegalStateException("Required argument screen title is missing.");
-        }
-        return arguments.getString(EXTRA_SCREEN_TITLE);
-    }
+    protected abstract String getScreenTitle();
 
     protected void showHomeButton(boolean visible, boolean isCloseButton) {
         ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationBaseFormFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationBaseFormFragment.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.sitecreation;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.LayoutRes;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v7.app.ActionBar;
@@ -20,6 +21,7 @@ import android.widget.Button;
 import org.wordpress.android.R;
 
 public abstract class NewSiteCreationBaseFormFragment<SiteCreationListenerType> extends Fragment {
+    public static final String EXTRA_SCREEN_TITLE = "extra_screen_title";
     private Button mPrimaryButton;
     private Button mSecondaryButton;
 
@@ -48,37 +50,47 @@ public abstract class NewSiteCreationBaseFormFragment<SiteCreationListenerType> 
 
     protected ViewGroup createMainView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.site_creation_form_screen, container, false);
-        ViewStub formContainer = ((ViewStub) rootView.findViewById(R.id.site_creation_form_content_stub));
+        ViewStub formContainer = (rootView.findViewById(R.id.site_creation_form_content_stub));
         formContainer.setLayoutResource(getContentLayout());
         formContainer.inflate();
         return rootView;
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         ViewGroup rootView = createMainView(inflater, container, savedInstanceState);
 
         setupContent(rootView);
 
-        mPrimaryButton = (Button) rootView.findViewById(R.id.primary_button);
-        mSecondaryButton = (Button) rootView.findViewById(R.id.secondary_button);
+        mPrimaryButton = rootView.findViewById(R.id.primary_button);
+        mSecondaryButton = rootView.findViewById(R.id.secondary_button);
         setupBottomButtons(mSecondaryButton, mPrimaryButton);
 
         return rootView;
     }
 
     @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        Toolbar toolbar = (Toolbar) view.findViewById(R.id.toolbar);
+        Toolbar toolbar = view.findViewById(R.id.toolbar);
         ((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
 
         ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
         if (actionBar != null) {
             actionBar.setDisplayHomeAsUpEnabled(true);
-            actionBar.setTitle(R.string.site_creation_title);
+            actionBar.setTitle(getScreenTitle());
+            // important for accessibility
+            getActivity().setTitle(getScreenTitle());
         }
+    }
+
+    private String getScreenTitle() {
+        Bundle arguments = getArguments();
+        if (arguments == null || !arguments.containsKey(EXTRA_SCREEN_TITLE)) {
+            throw new IllegalStateException("Required argument screen title is missing.");
+        }
+        return arguments.getString(EXTRA_SCREEN_TITLE);
     }
 
     protected void showHomeButton(boolean visible, boolean isCloseButton) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationCreatingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationCreatingFragment.java
@@ -155,7 +155,7 @@ public class NewSiteCreationCreatingFragment extends NewSiteCreationBaseFormFrag
     }
 
     @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
         showHomeButton(!isInModalMode(), false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationCreatingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationCreatingFragment.java
@@ -374,4 +374,8 @@ public class NewSiteCreationCreatingFragment extends NewSiteCreationBaseFormFrag
         }
         getView().announceForAccessibility(statusAnnouncement);
     }
+
+    @Override protected String getScreenTitle() {
+        return "";
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationDomainFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationDomainFragment.java
@@ -225,4 +225,13 @@ public class NewSiteCreationDomainFragment extends NewSiteCreationBaseFormFragme
 
         updateFinishButton();
     }
+
+    @Override
+    protected String getScreenTitle() {
+        Bundle arguments = getArguments();
+        if (arguments == null || !arguments.containsKey(EXTRA_SCREEN_TITLE)) {
+            throw new IllegalStateException("Required argument screen title is missing.");
+        }
+        return arguments.getString(EXTRA_SCREEN_TITLE);
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationDomainFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationDomainFragment.java
@@ -51,10 +51,11 @@ public class NewSiteCreationDomainFragment extends NewSiteCreationBaseFormFragme
 
     @Inject SiteStore mSiteStore;
 
-    public static NewSiteCreationDomainFragment newInstance(String siteTitle) {
+    public static NewSiteCreationDomainFragment newInstance(String screenTitle, String siteTitle) {
         NewSiteCreationDomainFragment
                 fragment = new NewSiteCreationDomainFragment();
         Bundle args = new Bundle();
+        args.putString(NewSiteCreationBaseFormFragment.EXTRA_SCREEN_TITLE, screenTitle);
         args.putString(ARG_SITE_TITLE, siteTitle);
         fragment.setArguments(args);
         return fragment;
@@ -67,8 +68,6 @@ public class NewSiteCreationDomainFragment extends NewSiteCreationBaseFormFragme
 
     @Override
     protected void setupContent(ViewGroup rootView) {
-        // important for accessibility - talkback
-        getActivity().setTitle(R.string.site_creation_domain_selection_title);
         RecyclerView recyclerView = rootView.findViewById(R.id.recycler_view);
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
         recyclerView.setAdapter(mSiteCreationDomainAdapter);

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
@@ -70,7 +70,7 @@ class NewSiteCreationMainVM @Inject constructor() : ViewModel() {
         } else {
             ScreenTitleStepCount(
                     R.string.new_site_creation_screen_title_step_count,
-                    wizardManager.stepsCount() - 1, // -1 -> first item has general title - Create Site
+                    wizardManager.stepsCount - 1, // -1 -> first item has general title - Create Site
                     stepPosition - 1 // -1 -> first item has general title - Create Site
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.sitecreation
 
 import android.arch.lifecycle.Transformations
 import android.arch.lifecycle.ViewModel
+import android.support.annotation.StringRes
+import org.wordpress.android.R
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
 import org.wordpress.android.util.wizard.WizardState
@@ -58,4 +60,13 @@ class NewSiteCreationMainVM @Inject constructor() : ViewModel() {
     fun onSkipClicked() {
         wizardManager.showNextStep()
     }
+
+    fun screenTitleForWizardStep(step: SiteCreationStep): ScreenTitle =
+            ScreenTitle(
+                    R.string.new_site_creation_screen_title,
+                    wizardManager.stepsCount(),
+                    wizardManager.stepPosition(step)
+            )
+
+    data class ScreenTitle(@StringRes val resId: Int, val stepsCount: Int, val stepPosition: Int)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
@@ -4,6 +4,7 @@ import android.arch.lifecycle.Transformations
 import android.arch.lifecycle.ViewModel
 import android.support.annotation.StringRes
 import org.wordpress.android.R
+import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleEmpty
 import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleStepCount
 import org.wordpress.android.util.wizard.WizardManager
@@ -72,12 +73,16 @@ class NewSiteCreationMainVM @Inject constructor() : ViewModel() {
 
     fun screenTitleForWizardStep(step: SiteCreationStep): NewSiteCreationScreenTitle {
         val stepPosition = wizardManager.stepPosition(step)
-        return if (stepPosition == 1) {
-            ScreenTitleGeneral(R.string.new_site_creation_screen_title_general)
-        } else {
-            ScreenTitleStepCount(
+        val stepCount = wizardManager.stepsCount
+        val firstStep = stepPosition == 1
+        val lastStep = stepPosition == stepCount
+
+        return when {
+            firstStep -> ScreenTitleGeneral(R.string.new_site_creation_screen_title_general)
+            lastStep -> ScreenTitleEmpty
+            else -> ScreenTitleStepCount(
                     R.string.new_site_creation_screen_title_step_count,
-                    wizardManager.stepsCount - 1, // -1 -> first item has general title - Create Site
+                    stepCount - 2, // -2 -> first = general title (Create Site), last item = empty title
                     stepPosition - 1 // -1 -> first item has general title - Create Site
             )
         }
@@ -89,5 +94,9 @@ class NewSiteCreationMainVM @Inject constructor() : ViewModel() {
 
         data class ScreenTitleGeneral(@StringRes val resId: Int) :
                 NewSiteCreationScreenTitle()
+
+        object ScreenTitleEmpty : NewSiteCreationScreenTitle() {
+            const val screenTitle = ""
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
@@ -4,6 +4,8 @@ import android.arch.lifecycle.Transformations
 import android.arch.lifecycle.ViewModel
 import android.support.annotation.StringRes
 import org.wordpress.android.R
+import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleGeneral
+import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleStepCount
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
 import org.wordpress.android.util.wizard.WizardState
@@ -61,12 +63,24 @@ class NewSiteCreationMainVM @Inject constructor() : ViewModel() {
         wizardManager.showNextStep()
     }
 
-    fun screenTitleForWizardStep(step: SiteCreationStep): ScreenTitle =
-            ScreenTitle(
-                    R.string.new_site_creation_screen_title,
-                    wizardManager.stepsCount(),
-                    wizardManager.stepPosition(step)
+    fun screenTitleForWizardStep(step: SiteCreationStep): NewSiteCreationScreenTitle {
+        val stepPosition = wizardManager.stepPosition(step)
+        return if (stepPosition == 1) {
+            ScreenTitleGeneral(R.string.new_site_creation_screen_title_general)
+        } else {
+            ScreenTitleStepCount(
+                    R.string.new_site_creation_screen_title_step_count,
+                    wizardManager.stepsCount() - 1, // -1 -> first item has general title - Create Site
+                    stepPosition - 1 // -1 -> first item has general title - Create Site
             )
+        }
+    }
 
-    data class ScreenTitle(@StringRes val resId: Int, val stepsCount: Int, val stepPosition: Int)
+    sealed class NewSiteCreationScreenTitle {
+        data class ScreenTitleStepCount(@StringRes val resId: Int, val stepsCount: Int, val stepPosition: Int) :
+                NewSiteCreationScreenTitle()
+
+        data class ScreenTitleGeneral(@StringRes val resId: Int) :
+                NewSiteCreationScreenTitle()
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationNewSiteDetailsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationNewSiteDetailsFragment.java
@@ -32,8 +32,6 @@ public class NewSiteCreationNewSiteDetailsFragment extends NewSiteCreationBaseFo
 
     @Override
     protected void setupContent(ViewGroup rootView) {
-        // important for accessibility - talkback
-        getActivity().setTitle(R.string.site_creation_site_details_title);
         mScrollView = rootView.findViewById(R.id.scroll_view);
 
         mSiteTitleInput = rootView.findViewById(R.id.site_creation_site_title_row);
@@ -136,5 +134,9 @@ public class NewSiteCreationNewSiteDetailsFragment extends NewSiteCreationBaseFo
                 mScrollView.requestChildRectangleOnScreen(view, rect, false);
             }
         });
+    }
+
+    @Override protected String getScreenTitle() {
+        return getString(R.string.site_creation_site_details_title);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationPreviewFragment.kt
@@ -82,7 +82,23 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment<NewSiteCr
         }
     }
 
+    override fun getScreenTitle(): String {
+        val arguments = arguments
+        if (arguments == null || !arguments.containsKey(EXTRA_SCREEN_TITLE)) {
+            throw IllegalStateException("Required argument screen title is missing.")
+        }
+        return arguments.getString(EXTRA_SCREEN_TITLE)
+    }
+
     companion object {
         const val TAG = "site_creation_preview_fragment_tag"
+
+        fun newInstance(screenTitle: String): NewSiteCreationPreviewFragment {
+            val fragment = NewSiteCreationPreviewFragment()
+            val bundle = Bundle()
+            bundle.putString(NewSiteCreationBaseFormFragment.EXTRA_SCREEN_TITLE, screenTitle)
+            fragment.arguments = bundle
+            return fragment
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteDetailsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteDetailsFragment.java
@@ -32,8 +32,6 @@ public class NewSiteCreationSiteDetailsFragment extends NewSiteCreationBaseFormF
 
     @Override
     protected void setupContent(ViewGroup rootView) {
-        // important for accessibility - talkback
-        getActivity().setTitle(R.string.site_creation_site_details_title);
         mScrollView = rootView.findViewById(R.id.scroll_view);
 
         mSiteTitleInput = rootView.findViewById(R.id.site_creation_site_title_row);
@@ -136,5 +134,9 @@ public class NewSiteCreationSiteDetailsFragment extends NewSiteCreationBaseFormF
                 mScrollView.requestChildRectangleOnScreen(view, rect, false);
             }
         });
+    }
+
+    @Override protected String getScreenTitle() {
+        return getString(R.string.site_creation_site_details_title);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteInfoFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteInfoFragment.kt
@@ -91,11 +91,23 @@ class NewSiteCreationSiteInfoFragment : NewSiteCreationBaseFormFragment<NewSiteC
         }
     }
 
+    override fun getScreenTitle(): String {
+        val arguments = arguments
+        if (arguments == null || !arguments.containsKey(EXTRA_SCREEN_TITLE)) {
+            throw IllegalStateException("Required argument screen title is missing.")
+        }
+        return arguments.getString(EXTRA_SCREEN_TITLE)
+    }
+
     companion object {
         const val TAG = "site_creation_site_info_fragment_tag"
 
-        fun newInstance(): NewSiteCreationSiteInfoFragment {
-            return NewSiteCreationSiteInfoFragment()
+        fun newInstance(screenTitle: String): NewSiteCreationSiteInfoFragment {
+            val fragment = NewSiteCreationSiteInfoFragment()
+            val bundle = Bundle()
+            bundle.putString(NewSiteCreationBaseFormFragment.EXTRA_SCREEN_TITLE, screenTitle)
+            fragment.arguments = bundle
+            return fragment
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationThemeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationThemeFragment.java
@@ -48,8 +48,6 @@ public class NewSiteCreationThemeFragment extends NewSiteCreationBaseFormFragmen
 
     @Override
     protected void setupContent(ViewGroup rootView) {
-        // important for accessibility - talkback
-        getActivity().setTitle(R.string.site_creation_theme_selection_title);
         RecyclerView recyclerView = rootView.findViewById(R.id.recycler_view);
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
         recyclerView.setAdapter(mNewSiteCreationThemeAdapter);
@@ -120,5 +118,9 @@ public class NewSiteCreationThemeFragment extends NewSiteCreationBaseFormFragmen
                 mNewSiteCreationThemeAdapter.setData(false, getThemes(), 0);
                 break;
         }
+    }
+
+    @Override protected String getScreenTitle() {
+        return getString(R.string.site_creation_theme_selection_title);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
@@ -52,8 +52,6 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteC
     }
 
     override fun setupContent(rootView: ViewGroup) {
-        // important for accessibility - talkback
-        activity!!.setTitle(R.string.new_site_creation_segments_title)
         initErrorLayout(rootView)
         initRecyclerView(rootView)
         initViewModel()
@@ -152,8 +150,12 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteC
     companion object {
         const val TAG = "site_creation_segment_fragment_tag"
 
-        fun newInstance(): NewSiteCreationSegmentsFragment {
-            return NewSiteCreationSegmentsFragment()
+        fun newInstance(screenTitle: String): NewSiteCreationSegmentsFragment {
+            val fragment = NewSiteCreationSegmentsFragment()
+            val bundle = Bundle()
+            bundle.putString(NewSiteCreationBaseFormFragment.EXTRA_SCREEN_TITLE, screenTitle)
+            fragment.arguments = bundle
+            return fragment
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
@@ -147,6 +147,14 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteC
         (recyclerView.adapter as NewSiteCreationSegmentsAdapter).update(segments.items)
     }
 
+    override fun getScreenTitle(): String {
+        val arguments = arguments
+        if (arguments == null || !arguments.containsKey(EXTRA_SCREEN_TITLE)) {
+            throw IllegalStateException("Required argument screen title is missing.")
+        }
+        return arguments.getString(EXTRA_SCREEN_TITLE)
+    }
+
     companion object {
         const val TAG = "site_creation_segment_fragment_tag"
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
@@ -80,7 +80,6 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
     }
 
     override fun setupContent(rootView: ViewGroup) {
-        // TODO receive title from the MainVM
         fullscreenErrorLayout = rootView.findViewById(R.id.error_layout)
         fullscreenProgressLayout = rootView.findViewById(R.id.progress_layout)
         contentLayout = rootView.findViewById(R.id.content_layout)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
@@ -81,8 +81,6 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
 
     override fun setupContent(rootView: ViewGroup) {
         // TODO receive title from the MainVM
-        // important for accessibility - talkback
-        nonNullActivity.setTitle(R.string.new_site_creation_verticals_title)
         fullscreenErrorLayout = rootView.findViewById(R.id.error_layout)
         fullscreenProgressLayout = rootView.findViewById(R.id.progress_layout)
         contentLayout = rootView.findViewById(R.id.content_layout)
@@ -268,9 +266,10 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
         const val TAG = "site_creation_verticals_fragment_tag"
         private const val EXTRA_SEGMENT_ID = "extra_segment_id"
 
-        fun newInstance(segmentId: Long): NewSiteCreationVerticalsFragment {
+        fun newInstance(screenTitle: String, segmentId: Long): NewSiteCreationVerticalsFragment {
             val fragment = NewSiteCreationVerticalsFragment()
             val bundle = Bundle()
+            bundle.putString(NewSiteCreationBaseFormFragment.EXTRA_SCREEN_TITLE, screenTitle)
             bundle.putLong(EXTRA_SEGMENT_ID, segmentId)
             fragment.arguments = bundle
             return fragment

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
@@ -262,6 +262,14 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
         view.visibility = if (visible) View.VISIBLE else View.GONE
     }
 
+    override fun getScreenTitle(): String {
+        val arguments = arguments
+        if (arguments == null || !arguments.containsKey(EXTRA_SCREEN_TITLE)) {
+            throw IllegalStateException("Required argument screen title is missing.")
+        }
+        return arguments.getString(EXTRA_SCREEN_TITLE)
+    }
+
     companion object {
         const val TAG = "site_creation_verticals_fragment_tag"
         private const val EXTRA_SEGMENT_ID = "extra_segment_id"

--- a/WordPress/src/main/java/org/wordpress/android/util/wizard/WizardManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/wizard/WizardManager.kt
@@ -25,6 +25,19 @@ class WizardManager<T : WizardStep>(
     private fun isIndexValid(currentStepIndex: Int): Boolean {
         return currentStepIndex >= 0 && currentStepIndex < steps.size
     }
+
+    fun stepsCount(): Int = steps.size
+
+    /**
+     * Returns position of the step (starting from 1) or -1 if the step is not present.
+     */
+    fun stepPosition(T: WizardStep): Int {
+        return if (steps.contains(T)) {
+            steps.indexOf(T) + 1
+        } else {
+            -1
+        }
+    }
 }
 
 /**

--- a/WordPress/src/main/java/org/wordpress/android/util/wizard/WizardManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/wizard/WizardManager.kt
@@ -6,6 +6,8 @@ import org.wordpress.android.viewmodel.SingleLiveEvent
 class WizardManager<T : WizardStep>(
     private val steps: List<T>
 ) {
+    val stepsCount = steps.size
+
     private val _navigatorLiveData = SingleLiveEvent<T>()
     val navigatorLiveData: LiveData<T> = _navigatorLiveData
     private var currentStepIndex: Int = -1
@@ -26,16 +28,11 @@ class WizardManager<T : WizardStep>(
         return currentStepIndex >= 0 && currentStepIndex < steps.size
     }
 
-    fun stepsCount(): Int = steps.size
-
-    /**
-     * Returns position of the step (starting from 1) or -1 if the step is not present.
-     */
     fun stepPosition(T: WizardStep): Int {
         return if (steps.contains(T)) {
             steps.indexOf(T) + 1
         } else {
-            -1
+            throw IllegalStateException("Step $T is not present.")
         }
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2375,7 +2375,6 @@
     <string name="new_site_creation_preview_title">Your site has been created!</string>
     <string name="site_creation_segments_title">Tell us what kind of site you\’d like to make</string>
     <string name="site_creation_segments_subtitle">This helps us make recommendations. But you’re never locked in — all sites evolve!</string>
-    <string name="new_site_creation_segments_title">Create Site</string>
     <string name="site_creation_fetch_suggestions_error_no_connection">No connection</string>
     <string name="site_creation_fetch_suggestions_error_unknown">There was a problem</string>
     <string name="new_site_creation_site_info_header_title">Basic Information</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2370,6 +2370,7 @@
     <!-- END (News Card) -->
 
     <!-- Site Creation -->
+    <string name="new_site_creation_screen_title">%1$d of %2$d</string>
     <string name="new_site_creation_preview_title">Your site has been created!</string>
     <string name="site_creation_segments_title">Tell us what kind of site you\’d like to make</string>
     <string name="site_creation_segments_subtitle">This helps us make recommendations. But you’re never locked in — all sites evolve!</string>
@@ -2381,7 +2382,6 @@
     <string name="new_site_creation_business_name_hint">Business Name</string>
     <string name="new_site_creation_optional_tag_line_hint">Optional Tagline</string>
     <string name="new_site_creation_optional_tag_line_description">The tagline is a short line of text shown right below the title.</string>
-    <string name="new_site_creation_verticals_title">TODO</string>
     <string name="new_site_creation_button_skip">Skip</string>
     <string name="new_site_creation_verticals_custom_subtitle">Custom category</string>
     <string name="site_creation_error_generic_title">There was a problem</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2370,7 +2370,8 @@
     <!-- END (News Card) -->
 
     <!-- Site Creation -->
-    <string name="new_site_creation_screen_title">%1$d of %2$d</string>
+    <string name="new_site_creation_screen_title_general">Create Site</string>
+    <string name="new_site_creation_screen_title_step_count">%1$d of %2$d</string>
     <string name="new_site_creation_preview_title">Your site has been created!</string>
     <string name="site_creation_segments_title">Tell us what kind of site you\’d like to make</string>
     <string name="site_creation_segments_subtitle">This helps us make recommendations. But you’re never locked in — all sites evolve!</string>


### PR DESCRIPTION
Fixes #8690 

Adds correct screen titles to the steps in NewSiteCreation flow
- "Create Site" on the first step
- "Empty title" on the last step
- "n of x" on the remaining steps

To test:
- update`NEW_SITE_CREATION_ENABLED` in build.gradle
- Go to `My Site` -> `Switch Site` -> plus sign icon in the top right corner
- check the title of the Segments screen is "Create Site"
- select a segment
- check the title of the Verticals screen is "1 of 3"
- type something and select a vertical
- check the title of the Site Info screen is "2 of 3"
- click on the skip button
- check the title of the Domains screen is "3 of 3"
- press back button and check the title of the Site Info screen is "2 of 3"
- enter a SiteTitle and click on the next button
- check the title of the Domains screen is "3 of 3"

Bonus: you can test the title is being read by TalkBack when you enter or re-enter each step screen or we can leave it for the #8510 

