### PR TITLE
Fixes help button on NewSiteCreation segments, verticals and site info screens

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -150,7 +150,9 @@ class HelpActivity : AppCompatActivity() {
         SITE_CREATION_THEME("origin:site-create-site-theme"),
         SITE_CREATION_DETAILS("origin:site-create-site-details"),
         SITE_CREATION_DOMAIN("origin:site-create-site-domain"),
-        SITE_CREATION_CREATING("origin:site-create-creating");
+        SITE_CREATION_CREATING("origin:site-create-creating"),
+        NEW_SITE_CREATION_SEGMENTS("origin:new-site-create-site-segments"),
+        NEW_SITE_CREATION_VERTICALS("origin:new-site-create-site-verticals");
 
         override fun toString(): String {
             return stringValue

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -152,7 +152,8 @@ class HelpActivity : AppCompatActivity() {
         SITE_CREATION_DOMAIN("origin:site-create-site-domain"),
         SITE_CREATION_CREATING("origin:site-create-creating"),
         NEW_SITE_CREATION_SEGMENTS("origin:new-site-create-site-segments"),
-        NEW_SITE_CREATION_VERTICALS("origin:new-site-create-site-verticals");
+        NEW_SITE_CREATION_VERTICALS("origin:new-site-create-site-verticals"),
+        NEW_SITE_CREATION_SITE_INFO("origin:new-site-create-site-info");
 
         override fun toString(): String {
             return stringValue

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
@@ -10,6 +10,8 @@ import android.view.MenuItem
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.accounts.HelpActivity.Origin
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_INFO
@@ -26,7 +28,8 @@ class NewSiteCreationActivity : AppCompatActivity(),
         SegmentsScreenListener,
         VerticalsScreenListener,
         SiteInfoScreenListener,
-        OnSkipClickedListener {
+        OnSkipClickedListener,
+        OnHelpClickedListener {
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var mainViewModel: NewSiteCreationMainVM
 
@@ -59,6 +62,10 @@ class NewSiteCreationActivity : AppCompatActivity(),
 
     override fun onSkipClicked() {
         mainViewModel.onSkipClicked()
+    }
+
+    override fun onHelpClicked(origin: Origin) {
+        ActivityLauncher.viewHelpAndSupport(this, origin, null, null)
     }
 
     override fun onSiteInfoFinished(siteTitle: String, tagLine: String?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteInfoFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteInfoFragment.kt
@@ -14,6 +14,8 @@ import android.text.TextWatcher
 import android.view.ViewGroup
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel
 import javax.inject.Inject
 
@@ -83,12 +85,21 @@ class NewSiteCreationSiteInfoFragment : NewSiteCreationBaseFormFragment<NewSiteC
                 }
             }
         })
+
+        viewModel.onHelpClicked.observe(
+                this,
+                Observer {
+                    ActivityLauncher.viewHelpAndSupport(
+                            activity!!,
+                            HelpActivity.Origin.NEW_SITE_CREATION_SITE_INFO,
+                            null,
+                            null
+                    )
+                })
     }
 
     override fun onHelp() {
-        if (mSiteCreationListener != null) {
-            mSiteCreationListener.helpCategoryScreen()
-        }
+        viewModel.onHelpClicked()
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteInfoFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteInfoFragment.kt
@@ -15,7 +15,6 @@ import android.text.TextWatcher
 import android.view.ViewGroup
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
-import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel
 import javax.inject.Inject
@@ -31,6 +30,7 @@ class NewSiteCreationSiteInfoFragment : NewSiteCreationBaseFormFragment<NewSiteC
     private lateinit var tagLineEditText: TextInputEditText
 
     private lateinit var skipClickedListener: OnSkipClickedListener
+    private lateinit var helpClickedListener: OnHelpClickedListener
     private lateinit var siteInfoScreenListener: SiteInfoScreenListener
 
     override fun onAttach(context: Context?) {
@@ -38,10 +38,14 @@ class NewSiteCreationSiteInfoFragment : NewSiteCreationBaseFormFragment<NewSiteC
         if (context !is OnSkipClickedListener) {
             throw IllegalStateException("Parent activity must implement OnSkipClickedListener.")
         }
+        if (context !is OnHelpClickedListener) {
+            throw IllegalStateException("Parent activity must implement OnHelpClickedListener.")
+        }
         if (context !is SiteInfoScreenListener) {
             throw IllegalStateException("Parent activity must implement SiteInfoScreenListener.")
         }
         skipClickedListener = context
+        helpClickedListener = context
         siteInfoScreenListener = context
     }
 
@@ -106,16 +110,9 @@ class NewSiteCreationSiteInfoFragment : NewSiteCreationBaseFormFragment<NewSiteC
                 }
             }
         })
-        viewModel.onHelpClicked.observe(
-                this,
-                Observer {
-                    ActivityLauncher.viewHelpAndSupport(
-                            activity!!,
-                            HelpActivity.Origin.NEW_SITE_CREATION_SITE_INFO,
-                            null,
-                            null
-                    )
-                })
+        viewModel.onHelpClicked.observe(this, Observer {
+            helpClickedListener.onHelpClicked(HelpActivity.Origin.NEW_SITE_CREATION_SITE_INFO)
+        })
         viewModel.skipBtnClicked.observe(this, Observer {
             skipClickedListener.onSkipClicked()
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/OnHelpClickedListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/OnHelpClickedListener.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.ui.sitecreation
+
+import org.wordpress.android.ui.accounts.HelpActivity
+
+interface OnHelpClickedListener {
+    fun onHelpClicked(origin: HelpActivity.Origin)
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
@@ -15,10 +15,10 @@ import android.widget.Button
 import android.widget.TextView
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
-import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.sitecreation.NewSiteCreationBaseFormFragment
 import org.wordpress.android.ui.sitecreation.NewSiteCreationListener
+import org.wordpress.android.ui.sitecreation.OnHelpClickedListener
 import org.wordpress.android.ui.sitecreation.segments.SegmentsUiState.SegmentsContentUiState
 import org.wordpress.android.ui.sitecreation.segments.SegmentsUiState.SegmentsErrorUiState
 import org.wordpress.android.util.image.ImageManager
@@ -38,13 +38,18 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteC
     @Inject internal lateinit var imageManager: ImageManager
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
 
+    private lateinit var helpClickedListener: OnHelpClickedListener
     private lateinit var segmentsScreenListener: SegmentsScreenListener
 
     override fun onAttach(context: Context?) {
         super.onAttach(context)
+        if (context !is OnHelpClickedListener) {
+            throw IllegalStateException("Parent activity must implement OnHelpClickedListener.")
+        }
         if (context !is SegmentsScreenListener) {
             throw IllegalStateException("Parent activity must implement SegmentsScreenListener.")
         }
+        helpClickedListener = context
         segmentsScreenListener = context
     }
 
@@ -104,17 +109,9 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteC
         viewModel.segmentSelected.observe(
                 this,
                 Observer { segmentId -> segmentId?.let { segmentsScreenListener.onSegmentSelected(segmentId) } })
-        viewModel.onHelpClicked.observe(
-                this,
-                Observer {
-                    ActivityLauncher.viewHelpAndSupport(
-                            activity!!,
-                            HelpActivity.Origin.NEW_SITE_CREATION_SEGMENTS,
-                            null,
-                            null
-                    )
-                }
-        )
+        viewModel.onHelpClicked.observe(this, Observer {
+            helpClickedListener.onHelpClicked(HelpActivity.Origin.NEW_SITE_CREATION_SEGMENTS)
+        })
         viewModel.start()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
@@ -15,6 +15,8 @@ import android.widget.Button
 import android.widget.TextView
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.sitecreation.NewSiteCreationBaseFormFragment
 import org.wordpress.android.ui.sitecreation.NewSiteCreationListener
 import org.wordpress.android.ui.sitecreation.segments.SegmentsUiState.SegmentsContentUiState
@@ -102,6 +104,17 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteC
         viewModel.segmentSelected.observe(
                 this,
                 Observer { segmentId -> segmentId?.let { segmentsScreenListener.onSegmentSelected(segmentId) } })
+        viewModel.onHelpClicked.observe(
+                this,
+                Observer {
+                    ActivityLauncher.viewHelpAndSupport(
+                            activity!!,
+                            HelpActivity.Origin.NEW_SITE_CREATION_SEGMENTS,
+                            null,
+                            null
+                    )
+                }
+        )
         viewModel.start()
     }
 
@@ -123,9 +136,7 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment<NewSiteC
     }
 
     override fun onHelp() {
-        if (mSiteCreationListener != null) {
-            mSiteCreationListener.helpCategoryScreen()
-        }
+        viewModel.onHelpClicked()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModel.kt
@@ -54,6 +54,9 @@ class NewSiteCreationSegmentsViewModel
     private val _segmentSelected = SingleLiveEvent<Long>()
     val segmentSelected: LiveData<Long> = _segmentSelected
 
+    private val _onHelpClicked = SingleLiveEvent<Unit>()
+    val onHelpClicked: LiveData<Unit> = _onHelpClicked
+
     fun start() {
         if (isStarted) return
         isStarted = true
@@ -115,6 +118,10 @@ class NewSiteCreationSegmentsViewModel
 
     fun onRetryClicked() {
         fetchCategories()
+    }
+
+    fun onHelpClicked() {
+        _onHelpClicked.call()
     }
 
     private fun onSegmentSelected(segmentId: Long) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationSiteInfoViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationSiteInfoViewModel.kt
@@ -8,6 +8,7 @@ import android.support.annotation.StringRes
 import org.wordpress.android.R
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel.SiteInfoUiState.SkipNextButtonState.NEXT
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel.SiteInfoUiState.SkipNextButtonState.SKIP
+import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 import kotlin.properties.Delegates
 
@@ -24,8 +25,15 @@ class NewSiteCreationSiteInfoViewModel @Inject constructor() : ViewModel() {
     private val _uiState: MutableLiveData<SiteInfoUiState> = MutableLiveData()
     val uiState: LiveData<SiteInfoUiState> = _uiState
 
+    private val _onHelpClicked = SingleLiveEvent<Unit>()
+    val onHelpClicked: LiveData<Unit> = _onHelpClicked
+
     init {
         _uiState.value = currentUiState
+    }
+
+    fun onHelpClicked() {
+        _onHelpClicked.call()
     }
 
     fun updateBusinessName(businessName: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
@@ -17,10 +17,10 @@ import android.widget.TextView
 import kotlinx.android.synthetic.main.site_creation_error_with_retry.view.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
-import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.sitecreation.NewSiteCreationBaseFormFragment
 import org.wordpress.android.ui.sitecreation.NewSiteCreationListener
+import org.wordpress.android.ui.sitecreation.OnHelpClickedListener
 import org.wordpress.android.ui.sitecreation.OnSkipClickedListener
 import org.wordpress.android.ui.sitecreation.SearchInputWithHeader
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel.VerticalsListItemUiState
@@ -47,6 +47,7 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
     private lateinit var searchInputWithHeader: SearchInputWithHeader
 
     private lateinit var verticalsScreenListener: VerticalsScreenListener
+    private lateinit var helpClickedListener: OnHelpClickedListener
     private lateinit var skipClickedListener: OnSkipClickedListener
 
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
@@ -56,10 +57,14 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
         if (context !is VerticalsScreenListener) {
             throw IllegalStateException("Parent activity must implement VerticalsScreenListener.")
         }
+        if (context !is OnHelpClickedListener) {
+            throw IllegalStateException("Parent activity must implement OnHelpClickedListener.")
+        }
         if (context !is OnSkipClickedListener) {
             throw IllegalStateException("Parent activity must implement OnSkipClickedListener.")
         }
         verticalsScreenListener = context
+        helpClickedListener = context
         skipClickedListener = context
     }
 
@@ -161,16 +166,9 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
             verticalId?.let { verticalsScreenListener.onVerticalSelected(verticalId) }
         })
         viewModel.skipBtnClicked.observe(this, Observer { skipClickedListener.onSkipClicked() })
-        viewModel.onHelpClicked.observe(
-                this,
-                Observer {
-                    ActivityLauncher.viewHelpAndSupport(
-                            activity!!,
-                            HelpActivity.Origin.NEW_SITE_CREATION_VERTICALS,
-                            null,
-                            null
-                    )
-                })
+        viewModel.onHelpClicked.observe(this, Observer {
+            helpClickedListener.onHelpClicked(HelpActivity.Origin.NEW_SITE_CREATION_VERTICALS)
+        })
         viewModel.start(segmentId)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
@@ -23,6 +23,8 @@ import android.widget.TextView
 import kotlinx.android.synthetic.main.site_creation_error_with_retry.view.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.sitecreation.NewSiteCreationBaseFormFragment
 import org.wordpress.android.ui.sitecreation.NewSiteCreationListener
 import org.wordpress.android.ui.sitecreation.OnSkipClickedListener
@@ -206,6 +208,16 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
             verticalId?.let { verticalsScreenListener.onVerticalSelected(verticalId) }
         })
         viewModel.skipBtnClicked.observe(this, Observer { skipClickedListener.onSkipClicked() })
+        viewModel.onHelpClicked.observe(
+                this,
+                Observer {
+                    ActivityLauncher.viewHelpAndSupport(
+                            activity!!,
+                            HelpActivity.Origin.NEW_SITE_CREATION_VERTICALS,
+                            null,
+                            null
+                    )
+                })
         viewModel.start(segmentId)
     }
 
@@ -229,9 +241,7 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
     }
 
     override fun onHelp() {
-        if (mSiteCreationListener != null) {
-            mSiteCreationListener.helpCategoryScreen()
-        }
+        viewModel.onHelpClicked()
     }
 
     private fun updateHeader(uiState: VerticalsHeaderUiState?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
@@ -61,14 +61,17 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
 
     private var segmentId: Long? = null
 
-    private val _clearBtnClicked = SingleLiveEvent<Void>()
+    private val _clearBtnClicked = SingleLiveEvent<Unit>()
     val clearBtnClicked = _clearBtnClicked
 
     private val _verticalSelected = SingleLiveEvent<String>()
     val verticalSelected: LiveData<String> = _verticalSelected
 
-    private val _skipBtnClicked = SingleLiveEvent<Void>()
-    val skipBtnClicked: LiveData<Void> = _skipBtnClicked
+    private val _skipBtnClicked = SingleLiveEvent<Unit>()
+    val skipBtnClicked: LiveData<Unit> = _skipBtnClicked
+
+    private val _onHelpClicked = SingleLiveEvent<Unit>()
+    val onHelpClicked: LiveData<Unit> = _onHelpClicked
 
     init {
         dispatcher.register(fetchVerticalsUseCase)
@@ -134,6 +137,10 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
 
     fun onSkipStepBtnClicked() {
         _skipBtnClicked.call()
+    }
+
+    fun onHelpClicked() {
+        _onHelpClicked.call()
     }
 
     fun updateQuery(query: String) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.sitecreation.segments
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.Observer
+import com.nhaarman.mockito_kotlin.anyOrNull
 import com.nhaarman.mockito_kotlin.inOrder
 import com.nhaarman.mockito_kotlin.whenever
 import junit.framework.Assert.assertFalse
@@ -105,6 +106,7 @@ class NewSiteCreationSegmentsViewModelTest {
 
     @Mock private lateinit var uiStateObserver: Observer<SegmentsUiState>
     @Mock private lateinit var segmentSelectedObserver: Observer<Long>
+    @Mock private lateinit var onHelpClickedObserver: Observer<Unit>
 
     @Before
     fun setUp() {
@@ -117,6 +119,7 @@ class NewSiteCreationSegmentsViewModelTest {
         )
         viewModel.segmentsUiState.observeForever(uiStateObserver)
         viewModel.segmentSelected.observeForever(segmentSelectedObserver)
+        viewModel.onHelpClicked.observeForever(onHelpClickedObserver)
         whenever(networkUtils.isNetworkAvailable()).thenReturn(true)
     }
 
@@ -211,6 +214,15 @@ class NewSiteCreationSegmentsViewModelTest {
         inOrder(uiStateObserver).apply {
             verify(uiStateObserver).onChanged(PROGRESS_STATE)
             verify(uiStateObserver).onChanged(SegmentsErrorUiState.SegmentsConnectionErrorUiState)
+            verifyNoMoreInteractions()
+        }
+    }
+
+    @Test
+    fun verifyOnHelpClickedPropagated() = test {
+        viewModel.onHelpClicked()
+        inOrder(onHelpClickedObserver).apply {
+            verify(onHelpClickedObserver).onChanged(anyOrNull())
             verifyNoMoreInteractions()
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/siteinfo/NewSiteCreationSiteInfoViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/siteinfo/NewSiteCreationSiteInfoViewModelTest.kt
@@ -2,13 +2,16 @@ package org.wordpress.android.ui.sitecreation.siteinfo
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.Observer
+import com.nhaarman.mockito_kotlin.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.test
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel.SiteInfoUiState
 
@@ -22,6 +25,7 @@ class NewSiteCreationSiteInfoViewModelTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
     @Mock private lateinit var uiStateObserver: Observer<SiteInfoUiState>
+    @Mock private lateinit var onHelpClickedObserver: Observer<Unit>
 
     private lateinit var viewModel: NewSiteCreationSiteInfoViewModel
 
@@ -29,6 +33,7 @@ class NewSiteCreationSiteInfoViewModelTest {
     fun setUp() {
         viewModel = NewSiteCreationSiteInfoViewModel()
         viewModel.uiState.observeForever(uiStateObserver)
+        viewModel.onHelpClicked.observeForever(onHelpClickedObserver)
     }
 
     @Test
@@ -48,5 +53,14 @@ class NewSiteCreationSiteInfoViewModelTest {
         viewModel.updateTagLine(TAG_LINE)
         val updatedUiState = EMPTY_UI_STATE.copy(tagLine = TAG_LINE)
         assertThat(viewModel.uiState.value).isEqualToComparingFieldByField(updatedUiState)
+    }
+
+    @Test
+    fun verifyOnHelpClickedPropagated() = test {
+        viewModel.onHelpClicked()
+        val captor = ArgumentCaptor.forClass(Unit::class.java)
+        verify(onHelpClickedObserver).onChanged(captor.capture())
+
+        assertThat(captor.allValues.size).isEqualTo(1)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModelTest.kt
@@ -102,9 +102,10 @@ class NewSiteCreationVerticalsViewModelTest {
     @Mock lateinit var fetchVerticalsUseCase: FetchVerticalsUseCase
     @Mock lateinit var fetchSegmentsPromptUseCase: FetchSegmentPromptUseCase
     @Mock private lateinit var uiStateObserver: Observer<VerticalsUiState>
-    @Mock private lateinit var clearBtnObserver: Observer<Void>
+    @Mock private lateinit var clearBtnObserver: Observer<Unit>
     @Mock private lateinit var verticalSelectedObserver: Observer<String?>
-    @Mock private lateinit var skipBtnClickedObservable: Observer<Void>
+    @Mock private lateinit var skipBtnClickedObservable: Observer<Unit>
+    @Mock private lateinit var onHelpClickedObserver: Observer<Unit>
     @Mock private lateinit var networkUtils: NetworkUtilsWrapper
 
     private lateinit var viewModel: NewSiteCreationVerticalsViewModel
@@ -123,6 +124,7 @@ class NewSiteCreationVerticalsViewModelTest {
         viewModel.clearBtnClicked.observeForever(clearBtnObserver)
         viewModel.verticalSelected.observeForever(verticalSelectedObserver)
         viewModel.skipBtnClicked.observeForever(skipBtnClickedObservable)
+        viewModel.onHelpClicked.observeForever(onHelpClickedObserver)
         whenever(networkUtils.isNetworkAvailable()).thenReturn(true)
     }
 
@@ -375,11 +377,19 @@ class NewSiteCreationVerticalsViewModelTest {
     fun verifyOnSkipIsPropagated() = testWithSuccessResponses {
         viewModel.start(SEGMENT_ID)
         viewModel.onSkipStepBtnClicked()
-        val captor = ArgumentCaptor.forClass(Void::class.java)
+        val captor = ArgumentCaptor.forClass(Unit::class.java)
         verify(skipBtnClickedObservable).onChanged(captor.capture())
 
         assertThat(captor.allValues.size).isEqualTo(1)
-        assertThat(captor.lastValue).isNull()
+    }
+
+    @Test
+    fun verifyOnHelpClickedPropagated() = testWithSuccessResponses {
+        viewModel.onHelpClicked()
+        val captor = ArgumentCaptor.forClass(Unit::class.java)
+        verify(onHelpClickedObserver).onChanged(captor.capture())
+
+        assertThat(captor.allValues.size).isEqualTo(1)
     }
 
     @Test


### PR DESCRIPTION
Fixes #8711 

Fixes `Help` button in the toolbar on Segments, Verticals and Site Info screens.
I didn't want to create unnecessary conflicts on the domain screen so I didn't fix it there, but we can fix it in a PR for #8507.

To test:
- set `NEW_SITE_CREATION_ENABLED` in build.gradle to true
1. `My Site` -> `Switch site` -> plus sign icon
2. Click on `Help` button in the top right corner
3. Make sure it works
4. Press back
5. Select a segment
6. Click on `Help` button in the top right corner
7. Make sure it works
8. Type something
9. Select a vertical
10. Click on `Help` button in the top right corner
11. Make sure it works
