### PR TITLE
Create SelectedDateProvider to keep selected date and update use cases

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -109,6 +109,12 @@ class StatsFragment : DaggerFragment() {
                 }
             }
         })
+
+        viewModel.selectedDateChanged.observe(this, Observer { statsGranularity ->
+            statsGranularity?.let {
+                viewModel.onSelectedDateChange(statsGranularity)
+            }
+        })
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
@@ -1,0 +1,31 @@
+package org.wordpress.android.ui.stats.refresh.lists.sections.granular
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
+import java.util.Date
+import javax.inject.Inject
+
+class SelectedDateProvider
+@Inject constructor() {
+    private val mutableDates = mutableMapOf(
+            DAYS to Date(),
+            WEEKS to Date(),
+            MONTHS to Date(),
+            YEARS to Date()
+    )
+
+    private val mutableSelectedDateChanged = MutableLiveData<StatsGranularity>()
+    val selectedDateChanged: LiveData<StatsGranularity> = mutableSelectedDateChanged
+
+    fun selectDate(date: Date, statsGranularity: StatsGranularity) {
+        mutableDates[statsGranularity] = date
+        mutableSelectedDateChanged.value = statsGranularity
+    }
+
+    fun getSelectedDate(statsGranularity: StatsGranularity) = mutableDates[statsGranularity] ?: Date()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.NavigationAction.Companion.create
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.UseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.ReferrersUseCase.SelectedGroup
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
@@ -34,18 +35,27 @@ constructor(
     private val statsGranularity: StatsGranularity,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     private val referrersStore: ReferrersStore,
-    private val statsDateFormatter: StatsDateFormatter
+    private val statsDateFormatter: StatsDateFormatter,
+    private val selectedDateProvider: SelectedDateProvider
 ) : StatefulUseCase<ReferrersModel, SelectedGroup>(REFERRERS, mainDispatcher, SelectedGroup()) {
     override suspend fun loadCachedData(site: SiteModel) {
-        val dbModel = referrersStore.getReferrers(site, statsGranularity,
+        val dbModel = referrersStore.getReferrers(
+                site,
+                statsGranularity,
+                selectedDateProvider.getSelectedDate(statsGranularity),
                 PAGE_SIZE
         )
         dbModel?.let { onModel(it) }
     }
 
     override suspend fun fetchRemoteData(site: SiteModel, forced: Boolean) {
-        val response = referrersStore.fetchReferrers(site,
-                PAGE_SIZE, statsGranularity, forced)
+        val response = referrersStore.fetchReferrers(
+                site,
+                PAGE_SIZE,
+                statsGranularity,
+                selectedDateProvider.getSelectedDate(statsGranularity),
+                forced
+        )
         val model = response.model
         val error = response.error
 
@@ -114,14 +124,16 @@ constructor(
     @Inject constructor(
         @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
         private val referrersStore: ReferrersStore,
-        private val statsDateFormatter: StatsDateFormatter
+        private val statsDateFormatter: StatsDateFormatter,
+        private val selectedDateProvider: SelectedDateProvider
     ) : UseCaseFactory {
         override fun build(granularity: StatsGranularity) =
                 ReferrersUseCase(
                         granularity,
                         mainDispatcher,
                         referrersStore,
-                        statsDateFormatter
+                        statsDateFormatter,
+                        selectedDateProvider
                 )
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCaseTest.kt
@@ -35,16 +35,20 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LINK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM_WITH_ICON
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
+import java.util.Date
 
 private const val pageSize = 6
 private val statsGranularity = DAYS
+private val selectedDate = Date(0)
 
 class ClicksUseCaseTest : BaseUnitTest() {
     @Mock lateinit var store: ClicksStore
     @Mock lateinit var site: SiteModel
     @Mock lateinit var statsDateFormatter: StatsDateFormatter
+    @Mock lateinit var selectedDateProvider: SelectedDateProvider
     private lateinit var useCase: ClicksUseCase
     private val firstGroupViews = 50
     private val secondGroupViews = 30
@@ -57,17 +61,17 @@ class ClicksUseCaseTest : BaseUnitTest() {
                 statsGranularity,
                 Dispatchers.Unconfined,
                 store,
+                selectedDateProvider,
                 statsDateFormatter
         )
+        whenever((selectedDateProvider.getSelectedDate(statsGranularity))).thenReturn(selectedDate)
     }
 
     @Test
     fun `maps clicks to UI model`() = test {
         val forced = false
         val model = ClicksModel(10, 15, listOf(singleClick, group), false)
-        whenever(store.fetchClicks(site,
-                pageSize,
-                statsGranularity, forced)).thenReturn(
+        whenever(store.fetchClicks(site, pageSize, statsGranularity, selectedDate, forced)).thenReturn(
                 OnStatsFetched(
                         model
                 )
@@ -118,9 +122,9 @@ class ClicksUseCaseTest : BaseUnitTest() {
     fun `adds view more button when hasMore`() = test {
         val forced = false
         val model = ClicksModel(10, 15, listOf(singleClick), true)
-        whenever(store.fetchClicks(site,
-                pageSize,
-                statsGranularity, forced)).thenReturn(
+        whenever(
+                store.fetchClicks(site, pageSize, statsGranularity, selectedDate, forced)
+        ).thenReturn(
                 OnStatsFetched(
                         model
                 )
@@ -145,9 +149,9 @@ class ClicksUseCaseTest : BaseUnitTest() {
     @Test
     fun `maps empty clicks to UI model`() = test {
         val forced = false
-        whenever(store.fetchClicks(site,
-                pageSize,
-                statsGranularity, forced)).thenReturn(
+        whenever(
+                store.fetchClicks(site, pageSize, statsGranularity, selectedDate, forced)
+        ).thenReturn(
                 OnStatsFetched(ClicksModel(0, 0, listOf(), false))
         )
 
@@ -165,9 +169,9 @@ class ClicksUseCaseTest : BaseUnitTest() {
     fun `maps error item to UI model`() = test {
         val forced = false
         val message = "Generic error"
-        whenever(store.fetchClicks(site,
-                pageSize,
-                statsGranularity, forced)).thenReturn(
+        whenever(
+                store.fetchClicks(site, pageSize, statsGranularity, selectedDate, forced)
+        ).thenReturn(
                 OnStatsFetched(
                         StatsError(GENERIC_ERROR, message)
                 )

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCaseTest.kt
@@ -31,20 +31,31 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
+import java.util.Date
 
 private const val pageSize = 6
 private val statsGranularity = DAYS
+private val currentDate = Date(10)
 
 class PostsAndPagesUseCaseTest : BaseUnitTest() {
     @Mock lateinit var store: PostAndPageViewsStore
     @Mock lateinit var site: SiteModel
     @Mock lateinit var statsDateFormatter: StatsDateFormatter
+    @Mock lateinit var selectedDateProvider: SelectedDateProvider
     private lateinit var useCase: PostsAndPagesUseCase
     @Before
     fun setUp() {
-        useCase = PostsAndPagesUseCase(statsGranularity, Dispatchers.Unconfined, store, statsDateFormatter)
+        useCase = PostsAndPagesUseCase(
+                statsGranularity,
+                Dispatchers.Unconfined,
+                store,
+                statsDateFormatter,
+                selectedDateProvider
+        )
+        whenever((selectedDateProvider.getSelectedDate(statsGranularity))).thenReturn(currentDate)
     }
 
     @Test
@@ -57,6 +68,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                         site,
                         pageSize,
                         statsGranularity,
+                        currentDate,
                         forced
                 )
         ).thenReturn(OnStatsFetched(StatsError(GENERIC_ERROR, message)))
@@ -78,6 +90,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                         site,
                         pageSize,
                         statsGranularity,
+                        currentDate,
                         forced
                 )
         ).thenReturn(OnStatsFetched(emptyModel))
@@ -104,6 +117,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                         site,
                         pageSize,
                         statsGranularity,
+                        currentDate,
                         forced
                 )
         ).thenReturn(OnStatsFetched(model))
@@ -136,6 +150,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                         site,
                         pageSize,
                         statsGranularity,
+                        currentDate,
                         forced
                 )
         ).thenReturn(OnStatsFetched(model))
@@ -168,6 +183,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                         site,
                         pageSize,
                         statsGranularity,
+                        currentDate,
                         forced
                 )
         ).thenReturn(OnStatsFetched(model))
@@ -199,6 +215,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                         site,
                         pageSize,
                         statsGranularity,
+                        currentDate,
                         forced
                 )
         ).thenReturn(OnStatsFetched(model))
@@ -230,6 +247,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                         site,
                         pageSize,
                         statsGranularity,
+                        currentDate,
                         forced
                 )
         ).thenReturn(OnStatsFetched(model))

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCaseTest.kt
@@ -38,7 +38,7 @@ import java.util.Date
 
 private const val pageSize = 6
 private val statsGranularity = DAYS
-private val currentDate = Date(10)
+private val selectedDate = Date(0)
 
 class PostsAndPagesUseCaseTest : BaseUnitTest() {
     @Mock lateinit var store: PostAndPageViewsStore
@@ -55,7 +55,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 statsDateFormatter,
                 selectedDateProvider
         )
-        whenever((selectedDateProvider.getSelectedDate(statsGranularity))).thenReturn(currentDate)
+        whenever((selectedDateProvider.getSelectedDate(statsGranularity))).thenReturn(selectedDate)
     }
 
     @Test
@@ -68,7 +68,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                         site,
                         pageSize,
                         statsGranularity,
-                        currentDate,
+                        selectedDate,
                         forced
                 )
         ).thenReturn(OnStatsFetched(StatsError(GENERIC_ERROR, message)))
@@ -90,7 +90,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                         site,
                         pageSize,
                         statsGranularity,
-                        currentDate,
+                        selectedDate,
                         forced
                 )
         ).thenReturn(OnStatsFetched(emptyModel))
@@ -117,7 +117,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                         site,
                         pageSize,
                         statsGranularity,
-                        currentDate,
+                        selectedDate,
                         forced
                 )
         ).thenReturn(OnStatsFetched(model))
@@ -150,7 +150,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                         site,
                         pageSize,
                         statsGranularity,
-                        currentDate,
+                        selectedDate,
                         forced
                 )
         ).thenReturn(OnStatsFetched(model))
@@ -183,7 +183,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                         site,
                         pageSize,
                         statsGranularity,
-                        currentDate,
+                        selectedDate,
                         forced
                 )
         ).thenReturn(OnStatsFetched(model))
@@ -215,7 +215,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                         site,
                         pageSize,
                         statsGranularity,
-                        currentDate,
+                        selectedDate,
                         forced
                 )
         ).thenReturn(OnStatsFetched(model))
@@ -247,7 +247,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                         site,
                         pageSize,
                         statsGranularity,
-                        currentDate,
+                        selectedDate,
                         forced
                 )
         ).thenReturn(OnStatsFetched(model))

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCaseTest.kt
@@ -42,7 +42,7 @@ import java.util.Date
 
 private const val pageSize = 6
 private val statsGranularity = DAYS
-private val currentDate = Date(10)
+private val selectedDate = Date(0)
 
 class ReferrersUseCaseTest : BaseUnitTest() {
     @Mock lateinit var store: ReferrersStore
@@ -64,14 +64,14 @@ class ReferrersUseCaseTest : BaseUnitTest() {
                 statsDateFormatter,
                 selectedDateProvider
         )
-        whenever((selectedDateProvider.getSelectedDate(statsGranularity))).thenReturn(currentDate)
+        whenever((selectedDateProvider.getSelectedDate(statsGranularity))).thenReturn(selectedDate)
     }
 
     @Test
     fun `maps referrers to UI model`() = test {
         val forced = false
         val model = ReferrersModel(10, 15, listOf(singleReferrer, group), false)
-        whenever(store.fetchReferrers(site, pageSize, statsGranularity, currentDate, forced)).thenReturn(
+        whenever(store.fetchReferrers(site, pageSize, statsGranularity, selectedDate, forced)).thenReturn(
                 OnStatsFetched(
                         model
                 )
@@ -122,7 +122,7 @@ class ReferrersUseCaseTest : BaseUnitTest() {
     fun `adds view more button when hasMore`() = test {
         val forced = false
         val model = ReferrersModel(10, 15, listOf(singleReferrer), true)
-        whenever(store.fetchReferrers(site, pageSize, statsGranularity, currentDate, forced)).thenReturn(
+        whenever(store.fetchReferrers(site, pageSize, statsGranularity, selectedDate, forced)).thenReturn(
                 OnStatsFetched(
                         model
                 )
@@ -147,7 +147,7 @@ class ReferrersUseCaseTest : BaseUnitTest() {
     @Test
     fun `maps empty referrers to UI model`() = test {
         val forced = false
-        whenever(store.fetchReferrers(site, pageSize, statsGranularity, currentDate, forced)).thenReturn(
+        whenever(store.fetchReferrers(site, pageSize, statsGranularity, selectedDate, forced)).thenReturn(
                 OnStatsFetched(ReferrersModel(0, 0, listOf(), false))
         )
 
@@ -165,7 +165,7 @@ class ReferrersUseCaseTest : BaseUnitTest() {
     fun `maps error item to UI model`() = test {
         val forced = false
         val message = "Generic error"
-        whenever(store.fetchReferrers(site, pageSize, statsGranularity, currentDate, forced)).thenReturn(
+        whenever(store.fetchReferrers(site, pageSize, statsGranularity, selectedDate, forced)).thenReturn(
                 OnStatsFetched(
                         StatsError(GENERIC_ERROR, message)
                 )

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCaseTest.kt
@@ -35,16 +35,20 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LINK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM_WITH_ICON
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
+import java.util.Date
 
 private const val pageSize = 6
 private val statsGranularity = DAYS
+private val currentDate = Date(10)
 
 class ReferrersUseCaseTest : BaseUnitTest() {
     @Mock lateinit var store: ReferrersStore
     @Mock lateinit var site: SiteModel
     @Mock lateinit var statsDateFormatter: StatsDateFormatter
+    @Mock lateinit var selectedDateProvider: SelectedDateProvider
     private lateinit var useCase: ReferrersUseCase
     private val firstGroupViews = 50
     private val secondGroupViews = 30
@@ -57,17 +61,17 @@ class ReferrersUseCaseTest : BaseUnitTest() {
                 statsGranularity,
                 Dispatchers.Unconfined,
                 store,
-                statsDateFormatter
+                statsDateFormatter,
+                selectedDateProvider
         )
+        whenever((selectedDateProvider.getSelectedDate(statsGranularity))).thenReturn(currentDate)
     }
 
     @Test
     fun `maps referrers to UI model`() = test {
         val forced = false
         val model = ReferrersModel(10, 15, listOf(singleReferrer, group), false)
-        whenever(store.fetchReferrers(site,
-                pageSize,
-                statsGranularity, forced)).thenReturn(
+        whenever(store.fetchReferrers(site, pageSize, statsGranularity, currentDate, forced)).thenReturn(
                 OnStatsFetched(
                         model
                 )
@@ -118,9 +122,7 @@ class ReferrersUseCaseTest : BaseUnitTest() {
     fun `adds view more button when hasMore`() = test {
         val forced = false
         val model = ReferrersModel(10, 15, listOf(singleReferrer), true)
-        whenever(store.fetchReferrers(site,
-                pageSize,
-                statsGranularity, forced)).thenReturn(
+        whenever(store.fetchReferrers(site, pageSize, statsGranularity, currentDate, forced)).thenReturn(
                 OnStatsFetched(
                         model
                 )
@@ -145,9 +147,7 @@ class ReferrersUseCaseTest : BaseUnitTest() {
     @Test
     fun `maps empty referrers to UI model`() = test {
         val forced = false
-        whenever(store.fetchReferrers(site,
-                pageSize,
-                statsGranularity, forced)).thenReturn(
+        whenever(store.fetchReferrers(site, pageSize, statsGranularity, currentDate, forced)).thenReturn(
                 OnStatsFetched(ReferrersModel(0, 0, listOf(), false))
         )
 
@@ -165,9 +165,7 @@ class ReferrersUseCaseTest : BaseUnitTest() {
     fun `maps error item to UI model`() = test {
         val forced = false
         val message = "Generic error"
-        whenever(store.fetchReferrers(site,
-                pageSize,
-                statsGranularity, forced)).thenReturn(
+        whenever(store.fetchReferrers(site, pageSize, statsGranularity, currentDate, forced)).thenReturn(
                 OnStatsFetched(
                         StatsError(GENERIC_ERROR, message)
                 )

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'cec857188c14def19f8bdc51a6a3f0a7a8d743ce'
+    fluxCVersion = '6564cce70fa0304252fffa58ae0f82103360d2dd'
 }


### PR DESCRIPTION
FluxC PR must be merged at the same time as this PR - https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1023

This PR adds a `SelectedDateProvider` which keeps selected date per tabs. It provides a live data which is used to refresh the tabs. Whenever a user selects a date, the corresponding tab gets refreshed. 

The Selected date is used in requests to FluxC. 