### PR TITLE
Feature/8759 site creation connect steps

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
@@ -12,6 +12,8 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_INFO
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.VERTICALS
 import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentsFragment
 import org.wordpress.android.ui.sitecreation.segments.SegmentsScreenListener
@@ -58,12 +60,18 @@ class NewSiteCreationActivity : AppCompatActivity(),
         mainViewModel.onSkipClicked()
     }
 
+    fun onInfoScreenFinished(siteTitle: String, tagLine: String?) {
+        mainViewModel.onInfoScreenFinished(siteTitle, tagLine)
+    }
+
     private fun showStep(target: WizardNavigationTarget<SiteCreationStep, SiteCreationState>) {
         val fragment = when (target.wizardStep) {
             SEGMENTS -> NewSiteCreationSegmentsFragment.newInstance()
             VERTICALS ->
                 NewSiteCreationVerticalsFragment.newInstance(target.wizardState.segmentId!!)
             DOMAINS -> NewSiteCreationDomainFragment.newInstance("Test title")
+            SITE_INFO -> NewSiteCreationSiteInfoFragment.newInstance()
+            SITE_PREVIEW -> NewSiteCreationPreviewFragment.newInstance()
         }
         slideInFragment(fragment, target.wizardStep.toString())
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
@@ -25,6 +25,7 @@ import javax.inject.Inject
 class NewSiteCreationActivity : AppCompatActivity(),
         SegmentsScreenListener,
         VerticalsScreenListener,
+        SiteInfoScreenListener,
         OnSkipClickedListener {
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var mainViewModel: NewSiteCreationMainVM
@@ -60,7 +61,7 @@ class NewSiteCreationActivity : AppCompatActivity(),
         mainViewModel.onSkipClicked()
     }
 
-    fun onInfoScreenFinished(siteTitle: String, tagLine: String?) {
+    override fun onSiteInfoFinished(siteTitle: String, tagLine: String?) {
         mainViewModel.onInfoScreenFinished(siteTitle, tagLine)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
@@ -23,7 +23,9 @@ class NewSiteCreationMainVM @Inject constructor() : ViewModel() {
             listOf(
                     SiteCreationStep.fromString("site_creation_segments"),
                     SiteCreationStep.fromString("site_creation_verticals"),
-                    SiteCreationStep.fromString("site_creation_domains")
+                    SiteCreationStep.fromString("site_creation_site_info"),
+                    SiteCreationStep.fromString("site_creation_domains"),
+                    SiteCreationStep.fromString("site_creation_site_preview")
             )
     )
     private var isStarted = false
@@ -56,6 +58,11 @@ class NewSiteCreationMainVM @Inject constructor() : ViewModel() {
     }
 
     fun onSkipClicked() {
+        wizardManager.showNextStep()
+    }
+
+    fun onInfoScreenFinished(siteTitle: String, tagLine: String?) {
+        siteCreationState = siteCreationState.copy(siteTitle = siteTitle, siteTagLine = tagLine)
         wizardManager.showNextStep()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationPreviewFragment.kt
@@ -85,7 +85,7 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment<NewSiteCr
     companion object {
         const val TAG = "site_creation_preview_fragment_tag"
 
-        fun newInstance(): NewSiteCreationPreviewFragment{
+        fun newInstance(): NewSiteCreationPreviewFragment {
             return NewSiteCreationPreviewFragment()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationPreviewFragment.kt
@@ -84,5 +84,9 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment<NewSiteCr
 
     companion object {
         const val TAG = "site_creation_preview_fragment_tag"
+
+        fun newInstance(): NewSiteCreationPreviewFragment{
+            return NewSiteCreationPreviewFragment()
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteInfoFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteInfoFragment.kt
@@ -24,7 +24,7 @@ class NewSiteCreationSiteInfoFragment : NewSiteCreationBaseFormFragment<NewSiteC
     private lateinit var viewModel: NewSiteCreationSiteInfoViewModel
 
     private lateinit var skipNextButton: AppCompatButton
-    private lateinit var businessNameEditText: TextInputEditText
+    private lateinit var siteTitleEditText: TextInputEditText
     private lateinit var tagLineEditText: TextInputEditText
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -41,7 +41,7 @@ class NewSiteCreationSiteInfoFragment : NewSiteCreationBaseFormFragment<NewSiteC
     override fun setupContent(rootView: ViewGroup) {
         // TODO: Get the title from the main VM
         skipNextButton = rootView.findViewById(R.id.site_info_skip_or_next_button)
-        businessNameEditText = rootView.findViewById(R.id.site_info_business_name)
+        siteTitleEditText = rootView.findViewById(R.id.site_info_site_title)
         tagLineEditText = rootView.findViewById(R.id.site_info_tag_line)
         initViewModel()
         initTextWatchers()
@@ -57,7 +57,7 @@ class NewSiteCreationSiteInfoFragment : NewSiteCreationBaseFormFragment<NewSiteC
                 }
             })
         }
-        addTextWatcher(businessNameEditText) { viewModel.updateBusinessName(it) }
+        addTextWatcher(siteTitleEditText) { viewModel.updateSiteTitle(it) }
         addTextWatcher(tagLineEditText) { viewModel.updateTagLine(it) }
     }
 
@@ -72,7 +72,7 @@ class NewSiteCreationSiteInfoFragment : NewSiteCreationBaseFormFragment<NewSiteC
                         editText.setText(value)
                     }
                 }
-                updateEditTextIfDifferent(businessNameEditText, state.businessName)
+                updateEditTextIfDifferent(siteTitleEditText, state.siteTitle)
                 updateEditTextIfDifferent(tagLineEditText, state.tagLine)
                 state.skipButtonState.let { buttonState ->
                     skipNextButton.apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteInfoFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteInfoFragment.kt
@@ -83,7 +83,7 @@ class NewSiteCreationSiteInfoFragment : NewSiteCreationBaseFormFragment<NewSiteC
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
+        viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get(NewSiteCreationSiteInfoViewModel::class.java)
         viewModel.uiState.observe(this, Observer {
             it?.let { state ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
@@ -3,14 +3,16 @@ package org.wordpress.android.ui.sitecreation
 import org.wordpress.android.util.wizard.WizardStep
 
 enum class SiteCreationStep : WizardStep {
-    SEGMENTS, VERTICALS, DOMAINS;
+    SEGMENTS, VERTICALS, SITE_INFO, DOMAINS, SITE_PREVIEW;
 
     companion object {
         fun fromString(input: String): SiteCreationStep {
             return when (input) {
                 "site_creation_segments" -> SEGMENTS
                 "site_creation_verticals" -> VERTICALS
+                "site_creation_site_info" -> SITE_INFO
                 "site_creation_domains" -> DOMAINS
+                "site_creation_site_preview" -> SITE_PREVIEW
                 // TODO we should consider skipping the step when it's unknown
                 else -> throw IllegalArgumentException("SiteCreationStep not recognized: \$input")
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteInfoScreenListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteInfoScreenListener.kt
@@ -1,0 +1,5 @@
+package org.wordpress.android.ui.sitecreation
+
+interface SiteInfoScreenListener {
+    fun onSiteInfoFinished(siteTitle: String, tagLine: String?)
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationSiteInfoViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationSiteInfoViewModel.kt
@@ -14,7 +14,7 @@ import kotlin.properties.Delegates
 class NewSiteCreationSiteInfoViewModel @Inject constructor() : ViewModel() {
     private var currentUiState: SiteInfoUiState by Delegates.observable(
             SiteInfoUiState(
-                    businessName = "",
+                    siteTitle = "",
                     tagLine = ""
             )
     ) { _, _, newValue ->
@@ -28,9 +28,9 @@ class NewSiteCreationSiteInfoViewModel @Inject constructor() : ViewModel() {
         _uiState.value = currentUiState
     }
 
-    fun updateBusinessName(businessName: String) {
-        if (currentUiState.businessName != businessName) {
-            currentUiState = currentUiState.copy(businessName = businessName)
+    fun updateSiteTitle(siteTitle: String) {
+        if (currentUiState.siteTitle != siteTitle) {
+            currentUiState = currentUiState.copy(siteTitle = siteTitle)
         }
     }
 
@@ -41,7 +41,7 @@ class NewSiteCreationSiteInfoViewModel @Inject constructor() : ViewModel() {
     }
 
     data class SiteInfoUiState(
-        val businessName: String,
+        val siteTitle: String,
         val tagLine: String
     ) {
         enum class SkipNextButtonState(
@@ -61,6 +61,6 @@ class NewSiteCreationSiteInfoViewModel @Inject constructor() : ViewModel() {
             )
         }
 
-        val skipButtonState = if (businessName.isEmpty() && tagLine.isEmpty()) SKIP else NEXT
+        val skipButtonState = if (siteTitle.isEmpty() && tagLine.isEmpty()) SKIP else NEXT
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationSiteInfoViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationSiteInfoViewModel.kt
@@ -8,6 +8,7 @@ import android.support.annotation.StringRes
 import org.wordpress.android.R
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel.SiteInfoUiState.SkipNextButtonState.NEXT
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel.SiteInfoUiState.SkipNextButtonState.SKIP
+import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 import kotlin.properties.Delegates
 
@@ -24,6 +25,12 @@ class NewSiteCreationSiteInfoViewModel @Inject constructor() : ViewModel() {
     private val _uiState: MutableLiveData<SiteInfoUiState> = MutableLiveData()
     val uiState: LiveData<SiteInfoUiState> = _uiState
 
+    private val _skipBtnClicked = SingleLiveEvent<Unit>()
+    val skipBtnClicked: LiveData<Unit> = _skipBtnClicked
+
+    private val _nextBtnClicked = SingleLiveEvent<SiteInfoUiState>()
+    val nextBtnClicked: LiveData<SiteInfoUiState> = _nextBtnClicked
+
     init {
         _uiState.value = currentUiState
     }
@@ -37,6 +44,13 @@ class NewSiteCreationSiteInfoViewModel @Inject constructor() : ViewModel() {
     fun updateTagLine(tagLine: String) {
         if (currentUiState.tagLine != tagLine) {
             currentUiState = currentUiState.copy(tagLine = tagLine)
+        }
+    }
+
+    fun onSkipNextClicked() {
+        when (currentUiState.skipButtonState) {
+            SKIP -> _skipBtnClicked.call()
+            NEXT -> _nextBtnClicked.value = currentUiState
         }
     }
 

--- a/WordPress/src/main/res/layout/new_site_creation_site_info_screen.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_site_info_screen.xml
@@ -45,18 +45,18 @@
             app:layout_constraintTop_toBottomOf="@id/site_info_header_title"/>
 
         <android.support.design.widget.TextInputLayout
-            android:id="@+id/site_info_business_name_layout"
+            android:id="@+id/site_info_site_title_layout"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
-            android:hint="@string/new_site_creation_business_name_hint"
+            android:hint="@string/new_site_creation_site_title_hint"
             android:textColorHint="@color/wp_grey"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/site_info_header_subtitle">
 
             <android.support.design.widget.TextInputEditText
-                android:id="@+id/site_info_business_name"
+                android:id="@+id/site_info_site_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:backgroundTint="@color/wp_grey"
@@ -75,7 +75,7 @@
             android:textColorHint="@color/wp_grey"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/site_info_business_name_layout">
+            app:layout_constraintTop_toBottomOf="@id/site_info_site_title_layout">
 
             <android.support.design.widget.TextInputEditText
                 android:id="@+id/site_info_tag_line"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2378,7 +2378,7 @@
     <string name="site_creation_fetch_suggestions_error_unknown">There was a problem</string>
     <string name="new_site_creation_site_info_header_title">Basic Information</string>
     <string name="new_site_creation_site_info_header_subtitle">Tell us more about the site you are creating</string>
-    <string name="new_site_creation_business_name_hint">Business Name</string>
+    <string name="new_site_creation_site_title_hint">Site Title</string>
     <string name="new_site_creation_optional_tag_line_hint">Optional Tagline</string>
     <string name="new_site_creation_optional_tag_line_description">The tagline is a short line of text shown right below the title.</string>
     <string name="new_site_creation_verticals_title">TODO</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/siteinfo/NewSiteCreationSiteInfoViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/siteinfo/NewSiteCreationSiteInfoViewModelTest.kt
@@ -2,11 +2,13 @@ package org.wordpress.android.ui.sitecreation.siteinfo
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.Observer
+import com.nhaarman.mockito_kotlin.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel
@@ -22,6 +24,8 @@ class NewSiteCreationSiteInfoViewModelTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
     @Mock private lateinit var uiStateObserver: Observer<SiteInfoUiState>
+    @Mock private lateinit var onSkipClickedObserver: Observer<Unit>
+    @Mock private lateinit var onNextClickedObserver: Observer<SiteInfoUiState>
 
     private lateinit var viewModel: NewSiteCreationSiteInfoViewModel
 
@@ -29,6 +33,8 @@ class NewSiteCreationSiteInfoViewModelTest {
     fun setUp() {
         viewModel = NewSiteCreationSiteInfoViewModel()
         viewModel.uiState.observeForever(uiStateObserver)
+        viewModel.skipBtnClicked.observeForever(onSkipClickedObserver)
+        viewModel.nextBtnClicked.observeForever(onNextClickedObserver)
     }
 
     @Test
@@ -48,5 +54,27 @@ class NewSiteCreationSiteInfoViewModelTest {
         viewModel.updateTagLine(TAG_LINE)
         val updatedUiState = EMPTY_UI_STATE.copy(tagLine = TAG_LINE)
         assertThat(viewModel.uiState.value).isEqualToComparingFieldByField(updatedUiState)
+    }
+
+    @Test
+    fun verifyOnSkipPropagatedWhenUiStateIsEmpty() {
+        viewModel.onSkipNextClicked()
+        val captor = ArgumentCaptor.forClass(Unit::class.java)
+        verify(onSkipClickedObserver).onChanged(captor.capture())
+
+        assertThat(captor.allValues.size).isEqualTo(1)
+    }
+
+    @Test
+    fun verifyOnNextPropagatedWhenSiteTitleIsNotEmpty() {
+        viewModel.updateSiteTitle(SITE_TITLE)
+        val updatedUiState = EMPTY_UI_STATE.copy(siteTitle = SITE_TITLE)
+
+        viewModel.onSkipNextClicked()
+        val captor = ArgumentCaptor.forClass(SiteInfoUiState::class.java)
+        verify(onNextClickedObserver).onChanged(captor.capture())
+
+        assertThat(captor.allValues.size).isEqualTo(1)
+        assertThat(captor.value).isEqualTo(updatedUiState)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/siteinfo/NewSiteCreationSiteInfoViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/siteinfo/NewSiteCreationSiteInfoViewModelTest.kt
@@ -12,10 +12,10 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel.SiteInfoUiState
 
-private const val BUSINESS_NAME = "Test Business Name"
+private const val SITE_TITLE = "Test Site Title"
 private const val TAG_LINE = "Test Tag Line"
 
-private val EMPTY_UI_STATE = SiteInfoUiState(businessName = "", tagLine = "")
+private val EMPTY_UI_STATE = SiteInfoUiState(siteTitle = "", tagLine = "")
 
 @RunWith(MockitoJUnitRunner::class)
 class NewSiteCreationSiteInfoViewModelTest {
@@ -37,9 +37,9 @@ class NewSiteCreationSiteInfoViewModelTest {
     }
 
     @Test
-    fun verifyUpdateBusinessName() {
-        viewModel.updateBusinessName(BUSINESS_NAME)
-        val updatedUiState = EMPTY_UI_STATE.copy(businessName = BUSINESS_NAME)
+    fun verifyUpdateSiteTitle() {
+        viewModel.updateSiteTitle(SITE_TITLE)
+        val updatedUiState = EMPTY_UI_STATE.copy(siteTitle = SITE_TITLE)
         assertThat(viewModel.uiState.value).isEqualToComparingFieldByField(updatedUiState)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/siteinfo/SiteInfoUiStateTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/siteinfo/SiteInfoUiStateTest.kt
@@ -5,10 +5,10 @@ import org.junit.Test
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel.SiteInfoUiState
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel.SiteInfoUiState.SkipNextButtonState
 
-private const val BUSINESS_NAME = "Test Business Name"
+private const val SITE_TITLE = "Test Business Name"
 private const val TAG_LINE = "Test Tag Line"
 
-private val EMPTY_UI_STATE = SiteInfoUiState(businessName = "", tagLine = "")
+private val EMPTY_UI_STATE = SiteInfoUiState(siteTitle = "", tagLine = "")
 
 class SiteInfoUiStateTest {
     @Test
@@ -18,7 +18,7 @@ class SiteInfoUiStateTest {
 
     @Test
     fun verifyStateIsNextWhenBusinessNameIsNotEmpty() {
-        val uiStateWithBusinessName = EMPTY_UI_STATE.copy(businessName = BUSINESS_NAME)
+        val uiStateWithBusinessName = EMPTY_UI_STATE.copy(siteTitle = SITE_TITLE)
         assertThat(uiStateWithBusinessName.skipButtonState).isEqualTo(SkipNextButtonState.NEXT)
     }
 


### PR DESCRIPTION
Fixes #8759 

Note: It might be better to review this PR commit by commit. If you want me to create two separate PRs, just let me know.

Note 2: I didn't want to introduce unnecessary conflicts on the Domains screen so the "Create Site" button doesn't work yet.

Changes
- [6cce51d](https://github.com/wordpress-mobile/WordPress-Android/commit/6cce51dad7f32047bf54f0e0c71c165b33905d64) -> Adds Info Screen and SitePreview to the NewSiteCreationFlow(Main ViewModel)


- [88497ae](https://github.com/wordpress-mobile/WordPress-Android/commit/88497ae94d751881b1f2b1aef177a5fd76a94db3) -> Replaces "Business Name" on the SiteInfo screen with "Site Title" + renames all the relevant fields/method names etc

- [7311a45](https://github.com/wordpress-mobile/WordPress-Android/commit/7311a45d2b4ce58fa4f085b4a9e4b1b26e7c12b3) -> Adds onSkip and onNext click listeners to the SiteInfo screen

- [4ba18dd](https://github.com/wordpress-mobile/WordPress-Android/pull/8761/commits/4ba18dd3658d8a7cbd7114d87e1e741d8ce40b15) -> Replace owner of the NewSiteInfoViewModel, so the state is cleared when we go back and forth in the flow


To test:
- change `NEW_SITE_CREATION_ENABLED` in build.gradle to `true`
1. `My Site` -> `Switch Site` -> click on the plus sign in the top right corner
2. Go back and forth in the flow and make sure everything works as expected (see Note 2)
