### PR TITLE
Prioritize JitPack over NPM CDNs

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -15,7 +15,6 @@ repositories {
     jcenter()
     maven { url 'http://wordpress-mobile.github.io/WordPress-Android' }
     maven { url 'https://maven.fabric.io/public' }
-    maven { url "https://jitpack.io" }
     maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ allprojects {
         google()
         jcenter()
         maven { url "https://dl.bintray.com/wordpress-mobile/maven" }
+        maven { url "https://jitpack.io" }
 
         if (rootProject.ext.buildGutenbergFromSource) {
             maven {

--- a/build.gradle
+++ b/build.gradle
@@ -39,11 +39,11 @@ allprojects {
         } else {
             maven {
                 // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-                url "https://unpkg.com/react-native@0.57.5/android"
+                url "https://cdn.jsdelivr.net/npm/react-native@0.57.5/android"
             }
             maven {
                 // Local Maven repo containing AARs with JSC library built for Android
-                url "https://unpkg.com/jsc-android@224109.1.0/dist/"
+                url "https://cdn.jsdelivr.net/npm/jsc-android@224109.1.0/dist/"
             }
         }
     }

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -21,6 +21,9 @@ repositories {
 // import the `submoduleGitHash()` function
 apply from: 'https://gist.githubusercontent.com/hypest/e06f6097065728b6db7b7c462f8fef1a/raw/38557f55d0a3be9605c82b1df9ced4c846fd3aea/submoduleGitHash.gradle'
 
+// import the `waitJitpack()` function
+apply from: 'https://gist.githubusercontent.com/hypest/f526fe0775dedce0ce0133f1400d22a4/raw/0008b271a0d28fc79957fd3c2a027f57e98f796a/wait-jitpack.gradle'
+
 android {
     compileSdkVersion 27
     buildToolsVersion '27.0.3'
@@ -63,7 +66,7 @@ dependencies {
     if (rootProject.ext.buildGutenbergFromSource) {
         implementation project(':react-native-gutenberg-bridge')
     } else {
-        implementation ('com.github.wordpress-mobile:gutenberg-mobile:' + submoduleGitHash('../../../', 'libs/gutenberg-mobile'))
+        implementation (waitJitpack('com.github.wordpress-mobile', 'gutenberg-mobile', submoduleGitHash('../../../', 'libs/gutenberg-mobile')))
     }
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 // import the `submoduleGitHash()` function
-apply from: 'https://gist.githubusercontent.com/hypest/e06f6097065728b6db7b7c462f8fef1a/raw/38557f55d0a3be9605c82b1df9ced4c846fd3aea/submoduleGitHash.gradle'
+apply from: 'https://gist.githubusercontent.com/hypest/e06f6097065728b6db7b7c462f8fef1a/raw/3b91756fca76e4c2a9b573313e186c47842e1f7d/submoduleGitHash.gradle'
 
 // import the `waitJitpack()` function
 apply from: 'https://gist.githubusercontent.com/hypest/f526fe0775dedce0ce0133f1400d22a4/raw/0008b271a0d28fc79957fd3c2a027f57e98f796a/wait-jitpack.gradle'


### PR DESCRIPTION
This PR:

* Prioritizes the JitPack maven repo over the NPM packages CDN, to try getting the gutenberg-mobile artifact from JitPack first

* Similar to https://github.com/wordpress-mobile/react-native-aztec/pull/91, uses jsdelivr.net as the NPM CDN to workaround some recent unpkg.com problems

* Use the `waitJitpack()` Gradle helper to wait on the JitPack build of the gutenberg-mobile binary artifact. See https://github.com/wordpress-mobile/gutenberg-mobile/pull/333.

* Updates to latest of gutenberg-mobile

* Updates to latest of [submoduleGitHash](https://gist.github.com/hypest/e06f6097065728b6db7b7c462f8fef1a) to include a fix with the string literals expansion

To test:

* Build and run zalpha to try out the Block editor. The build should succeed and the block editor should be able to run as normal.