### PR TITLE
Move React Native/Gutenberg repositories to project build.gradle to fix ordering

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -16,6 +16,33 @@ repositories {
     maven { url 'http://wordpress-mobile.github.io/WordPress-Android' }
     maven { url 'https://maven.fabric.io/public' }
     maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
+    maven { url "https://jitpack.io" }
+
+    if (rootProject.ext.buildGutenbergFromSource) {
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url "$rootDir/libs/gutenberg-mobile/node_modules/react-native/android"
+        }
+        maven {
+            // Local Maven repo containing AARs with JSC library built for Android
+            url "$rootDir/libs/gutenberg-mobile/node_modules/jsc-android/dist"
+        }
+    } else {
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url "https://cdn.jsdelivr.net/npm/react-native@0.57.5/android"
+        }
+        maven {
+            // Local Maven repo containing AARs with JSC library built for Android
+            url "https://cdn.jsdelivr.net/npm/jsc-android@224109.1.0/dist/"
+        }
+    }
+}
+
+configurations.all {
+    resolutionStrategy {
+        force 'org.webkit:android-jsc:r224109'
+    }
 }
 
 apply plugin: 'com.android.application'

--- a/build.gradle
+++ b/build.gradle
@@ -25,33 +25,6 @@ allprojects {
         google()
         jcenter()
         maven { url "https://dl.bintray.com/wordpress-mobile/maven" }
-        maven { url "https://jitpack.io" }
-
-        if (rootProject.ext.buildGutenbergFromSource) {
-            maven {
-                // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-                url "$rootDir/libs/gutenberg-mobile/node_modules/react-native/android"
-            }
-            maven {
-                // Local Maven repo containing AARs with JSC library built for Android
-                url "$rootDir/libs/gutenberg-mobile/node_modules/jsc-android/dist"
-            }
-        } else {
-            maven {
-                // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-                url "https://cdn.jsdelivr.net/npm/react-native@0.57.5/android"
-            }
-            maven {
-                // Local Maven repo containing AARs with JSC library built for Android
-                url "https://cdn.jsdelivr.net/npm/jsc-android@224109.1.0/dist/"
-            }
-        }
-    }
-
-    configurations.all {
-        resolutionStrategy {
-            force 'org.webkit:android-jsc:r224109'
-        }
     }
 
     task checkstyle(type: Checkstyle) {


### PR DESCRIPTION
The repos/CDN for Gutenberg dependencies currently lives in the root `build.gradle`. This means that they could be used to try and resolve project dependencies before the other project repos. Moving them to the project `build.gradle` allows us to order them.

To test:

- Run `./gradlew assembleVanillaRelease`

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
