### PR TITLE
CircleCI improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ copy_gradle_properties: &copy_gradle_properties
 
 version: 2.0
 jobs:
-  build_and_test:
+  test:
     <<: *android_config
     steps:
       - checkout
@@ -24,9 +24,6 @@ jobs:
       - run:
           name: Validate login strings
           command: ./tools/validate-login-strings.sh
-      - run:
-          name: Build
-          command: $GRADLE assembleVanillaRelease
       - run:
           name: Test
           command: $GRADLE testVanillaRelease
@@ -86,6 +83,6 @@ workflows:
   version: 2
   wordpress_android:
     jobs:
-      - build_and_test
+      - test
       - lint
       - danger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ jobs:
           paths:
             - ~/.gradle
           key: wordpress-android-gradle-build-cache-{{ checksum "build.gradle" }}-{{ checksum "WordPress/build.gradle" }}
+      - store_test_results:
+          path: WordPress/build/test-results/testVanillaReleaseUnitTest
   lint:
     <<: *android_config
     steps:
@@ -57,6 +59,9 @@ jobs:
           paths:
             - ~/.gradle
           key: wordpress-android-gradle-lint-cache-{{ checksum "build.gradle" }}-{{ checksum "WordPress/build.gradle" }}
+      - store_artifacts:
+          path: WordPress/build/reports
+          destination: reports
   danger:
     docker:
       - image: circleci/ruby:2.3-browsers


### PR DESCRIPTION
This PR has two small improvements to the CircleCI config:

- Store test and lint results in the CircleCI run. They will be displayed in the UI. This means you don't have to search through the build log for failures.
- Don't explicitly run `./gradlew assembleVanillaRelease` to avoid duplicate work since we already run `testVanillaRelease` and `lint`. This brings execution time down to around 2 minutes.

To test:

- The CircleCI checks on this PR should still be green and display lint and test results.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
