### PR TITLE
Fix SVG lib missing build tools

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -18,16 +18,9 @@ repositories {
     maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
     maven { url "https://jitpack.io" }
 
-    if (rootProject.ext.buildGutenbergFromSource) {
-        maven {
-            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url "$rootDir/libs/gutenberg-mobile/node_modules/react-native/android"
-        }
-        maven {
-            // Local Maven repo containing AARs with JSC library built for Android
-            url "$rootDir/libs/gutenberg-mobile/node_modules/jsc-android/dist"
-        }
-    } else {
+    if (!rootProject.ext.buildGutenbergFromSource) {
+        // When building from binaries, add the RN maven repos here instead of the top level, to minimize false negatives
+        //  when gradle tries to get artifacts we know don't exist in the NPM CDNS (example: Zendesk artifacts)
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "https://cdn.jsdelivr.net/npm/react-native@0.57.5/android"

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,19 @@ allprojects {
         google()
         jcenter()
         maven { url "https://dl.bintray.com/wordpress-mobile/maven" }
+
+        if (rootProject.ext.buildGutenbergFromSource) {
+            // nested RN libraries need the RN maven repo defined from outside so, do it here when building from source
+
+            maven {
+                // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+                url "$rootDir/libs/gutenberg-mobile/node_modules/react-native/android"
+            }
+            maven {
+                // Local Maven repo containing AARs with JSC library built for Android
+                url "$rootDir/libs/gutenberg-mobile/node_modules/jsc-android/dist"
+            }
+        }
     }
 
     task checkstyle(type: Checkstyle) {


### PR DESCRIPTION
Recent source-level builds started to stop with `Could not find com.android.tools.build:gradle:2.2.3`. This is something alredy fixed with https://github.com/wordpress-mobile/gutenberg-mobile/pull/348 so, this PR updates to latest gutenberg-mobile master.

Also, fixing the above surfaces another problem when building from source, where various gutenberg-mobile dependencies fail to find the RN binaries needed. A regression that slipped through us in https://github.com/wordpress-mobile/WordPress-Android/pull/8765. 33de1a3 adds a fix for that by setting the RN maven repos for all projects, when building from source.

To test:

1. Set `wp.BUILD_GUTENBERG_FROM_SOURCE` to `true` in `gradle.properties`
2. Do `git submodule update --init --recursive`
3. Do `yarn install` inside the `libs/gutenberg-mobile` folder
4. Back in the root folder, build the app `./gradlew assembleWasabiDebug` and it should succeed

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
