### PR TITLE
Editor: fix "discard local changes" behavior

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -19,6 +19,7 @@ import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback;
 import android.support.v4.app.Fragment;
@@ -225,6 +226,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private static final String STATE_KEY_HTML_MODE_ON = "stateKeyHtmlModeOn";
     private static final String STATE_KEY_REVISION = "stateKeyRevision";
     private static final String TAG_DISCARDING_CHANGES_ERROR_DIALOG = "tag_discarding_changes_error_dialog";
+    private static final String TAG_DISCARDING_CHANGES_NO_NETWORK_DIALOG = "tag_discarding_changes_no_network_dialog";
     private static final String TAG_PUBLISH_CONFIRMATION_DIALOG = "tag_publish_confirmation_dialog";
     private static final String TAG_REMOVE_FAILED_UPLOADS_DIALOG = "tag_remove_failed_uploads_dialog";
 
@@ -1074,7 +1076,8 @@ public class EditPostActivity extends AppCompatActivity implements
     private void showHideDiscardLocalChangesMenuOption(boolean showMenuItems, MenuItem discardChanges) {
         if (discardChanges != null) {
             if (mIsNewPost) {
-                // if this is a new Post, then there aren't any local changes to discard yet.
+                // by "local changes" we mean changes that are only local (that is to say, are not in the remote yet).
+                // if this is a new Post, then there aren't any local changes to discard yet (everything is local).
                 discardChanges.setVisible(false);
                 return;
             }
@@ -1240,12 +1243,19 @@ public class EditPostActivity extends AppCompatActivity implements
                             });
                 }
             } else if (itemId == R.id.menu_discard_changes) {
-                AnalyticsTracker.track(Stat.EDITOR_DISCARDED_CHANGES);
-                showDialogProgress(true);
-                mPostForUndo = mPost.clone();
-                mIsDiscardingChanges = true;
-                RemotePostPayload payload = new RemotePostPayload(mPost, mSite);
-                mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(payload));
+                if (NetworkUtils.isNetworkAvailable(getBaseContext())) {
+                    AnalyticsTracker.track(Stat.EDITOR_DISCARDED_CHANGES);
+                    showDialogProgress(true);
+                    mPostForUndo = mPost.clone();
+                    mIsDiscardingChanges = true;
+                    RemotePostPayload payload = new RemotePostPayload(mPost, mSite);
+                    mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(payload));
+                } else {
+                    showDialogError(R.string.local_changes_discarding_no_connection,
+                            R.string.dialog_button_ok,
+                            TAG_DISCARDING_CHANGES_NO_NETWORK_DIALOG,
+                            false);
+                }
             }
         }
         return false;
@@ -1256,11 +1266,12 @@ public class EditPostActivity extends AppCompatActivity implements
         fillContentEditorFields();
     }
 
-    private void showDialogError() {
+    private void showDialogError(@StringRes int resIdMessage, @StringRes int resIdPositiveButton, String tag,
+                                 boolean showCancel) {
         BasicFragmentDialog dialog = new BasicFragmentDialog();
-        dialog.initialize(TAG_DISCARDING_CHANGES_ERROR_DIALOG, "", getString(R.string.local_changes_discarding_error),
-                getString(R.string.contact_support), getString(R.string.cancel), null);
-        dialog.show(getSupportFragmentManager(), TAG_DISCARDING_CHANGES_ERROR_DIALOG);
+        dialog.initialize(tag, "", getString(resIdMessage),
+                getString(resIdPositiveButton), showCancel ? getString(R.string.cancel) : null, null);
+        dialog.show(getSupportFragmentManager(), tag);
     }
 
     private void showDialogProgress(boolean show) {
@@ -1513,6 +1524,7 @@ public class EditPostActivity extends AppCompatActivity implements
         switch (instanceTag) {
             case ASYNC_PROMO_DIALOG_TAG:
             case TAG_DISCARDING_CHANGES_ERROR_DIALOG:
+            case TAG_DISCARDING_CHANGES_NO_NETWORK_DIALOG:
             case TAG_PUBLISH_CONFIRMATION_DIALOG:
             case TAG_REMOVE_FAILED_UPLOADS_DIALOG:
                 break;
@@ -1530,6 +1542,9 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override
     public void onPositiveClicked(@NonNull String instanceTag) {
         switch (instanceTag) {
+            case TAG_DISCARDING_CHANGES_NO_NETWORK_DIALOG:
+                // no op
+                break;
             case TAG_DISCARDING_CHANGES_ERROR_DIALOG:
                 mZendeskHelper.createNewTicket(this, Origin.DISCARD_CHANGES, mSite);
                 break;
@@ -3553,7 +3568,9 @@ public class EditPostActivity extends AppCompatActivity implements
                 }
             } else {
                 if (mIsDiscardingChanges) {
-                    showDialogError();
+                    showDialogError(R.string.local_changes_discarding_error, R.string.contact_support,
+                            TAG_DISCARDING_CHANGES_ERROR_DIALOG,
+                            true);
                 }
 
                 mIsDiscardingChanges = false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1057,23 +1057,7 @@ public class EditPostActivity extends AppCompatActivity implements
             settingsMenuItem.setVisible(showMenuItems);
         }
 
-        if (discardChanges != null) {
-            if (mPost != null && showMenuItems) {
-                boolean showDiscardChanges = mPost.isLocallyChanged();
-                if (mEditorFragment instanceof AztecEditorFragment) {
-                    if (((AztecEditorFragment) mEditorFragment).hasHistory()
-                        && ((AztecEditorFragment) mEditorFragment).canUndo()) {
-                        showDiscardChanges = true;
-                    } else {
-                        // we don't have history, so hide/show depending on the original post flag value
-                        showDiscardChanges = mOriginalPostHadLocalChangesOnOpen;
-                    }
-                }
-                discardChanges.setVisible(showDiscardChanges);
-            } else {
-                discardChanges.setVisible(false);
-            }
-        }
+        showHideDiscardLocalChangesMenuOption(showMenuItems, discardChanges);
 
         // Set text of the save button in the ActionBar
         if (mPost != null) {
@@ -1085,6 +1069,34 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         return super.onPrepareOptionsMenu(menu);
+    }
+
+    private void showHideDiscardLocalChangesMenuOption(boolean showMenuItems, MenuItem discardChanges) {
+        if (discardChanges != null) {
+            if (mIsNewPost) {
+                // if this is a new Post, then there aren't any local changes to discard yet.
+                discardChanges.setVisible(false);
+                return;
+            }
+
+            if (mPost != null && showMenuItems) {
+                // don't show Discard Local Changes option if it's a completely local draft
+                boolean showDiscardChanges = mPost.isLocallyChanged() && !mPost.isLocalDraft();
+                if (mEditorFragment instanceof AztecEditorFragment) {
+                    if (((AztecEditorFragment) mEditorFragment).hasHistory()
+                        && ((AztecEditorFragment) mEditorFragment).canUndo()
+                            && !mPost.isLocalDraft()) {
+                        showDiscardChanges = true;
+                    } else {
+                        // we don't have history, so hide/show depending on the original post flag value
+                        showDiscardChanges = mOriginalPostHadLocalChangesOnOpen;
+                    }
+                }
+                discardChanges.setVisible(showDiscardChanges);
+            } else {
+                discardChanges.setVisible(false);
+            }
+        }
     }
 
     @Override

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1310,6 +1310,7 @@
     <string name="local_changes_discarded">Local changes discarded</string>
     <string name="local_changes_discarding">Discarding local changes</string>
     <string name="local_changes_discarding_error">There was an error in discarding your local changes. Please contact support for more assistance.</string>
+    <string name="local_changes_discarding_no_connection">A connection is required to perform this action. Please check your connection and try again.</string>
 
     <!-- message on post preview explaining what local changes, local drafts and drafts are -->
     <string name="local_changes_explainer">This post has local changes which haven\'t been published</string>

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -554,9 +554,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         mSource.displayStyledAndFormattedHtml(postContent);
         mContent.fromHtml(postContent, true);
 
-        // if a copy of remote has been fetched, we need to clear history and start over.
-        mContent.getHistory().clearHistory();
-
         updateFailedAndUploadingMedia();
 
         mAztecReady = true;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -554,6 +554,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         mSource.displayStyledAndFormattedHtml(postContent);
         mContent.fromHtml(postContent, true);
 
+        // if a copy of remote has been fetched, we need to clear history and start over.
+        mContent.getHistory().clearHistory();
+
         updateFailedAndUploadingMedia();
 
         mAztecReady = true;


### PR DESCRIPTION
Fixes #8770

This PR takes into account whether this is a new Post, and the PostModel's  `isLocallyChanged` and `isLocalDraft` flags to make a more consistent sense of when `Discard local changes` option should be hidden/shown.
Also, this functionality relies on a network connection being present, so the error handling was improved to reflect this beforehand (rather than telling the user there was a problem and contact support if it was not the case otherwise).

- e7b6ff4 moves the show/hide logic to a separate private method to make it easier to read, and now includes the checks for new Post and LocalDraft.
- ddab1a1 checks for network connection and refactors the error dialog to handle the new case.


#### KNOWN issue 1:
- When you type something on an existing Post, both the Undo and "Discard local changes" become available. ~If you tap on Discard Local changes, then Undo/Redo should be disabled  (history should be cleared as a copy of the remote is fetched). However, it's still there.
Will address this on another PR (tried on 6961059 but then reverted it in c96a424 as it requires  more work and exceeds this particular PR).~ it's been decided to make undo/redo go along the lines of Gutenberg and include a history revision load  action into Aztec's history as well.

#### KNOWN issue 2 (visual editor):
- tapping on Discard local changes doesn't really feed the Visual editor with the new PostModel contents, thus not really discarding the contents.


#### To test:
CASE A: OFFLINE
1. start a new post
2. observe the menu doesn't show the "Discard local changes" option.
3. type something in the post.
4. observe the "Undo" is enabled, but "Discard local changes" option is still not shown.
5. set the device's airplane mode ON
6. tap BACK, a local draft will be saved.
7. go to blog posts -> open the post that has just been saved (top of the blog post list, should read `Local draft` in its status in the list)
8. observe the "Discard local changes" option is not shown (given it's a local draft, every change made is a local change).


CASE B: ONLINE (set airplane mode OFF)
1. start a new post
2. observe the menu doesn't show the "Discard local changes" option.
3. type something in the post.
4. observe the "Undo" is enabled, but "Discard local changes" option is still not shown.
5. tap BACK, the draft will be saved online.
6. look for it in the posts list (the yellow state should read 'draft')
7. open it, and observe the menu has greyed undo/redo buttons and doesn't have a "Discard local changes" option.
8. now type a word
9. open the menu and observe the "Discard local changes" option is now shown.
10. tap UNDO
11. tap on the three dots again. Observe the UNDO is now greyed out, the REDO is enabled, and "Discard local changes" is NOT shown.
12. tap REDO
13. tap on the three dots again. Observe the REDO is now greyed out, the UNDO is enabled, and "Discard local changes" IS shown.
14. tap on "Discard local changes".
15. observe the latest online copy is retrieved from the server.
16. now enable airplane mode
17. type something and then tap Back
18. the post will show in the Posts list with status "Local changes"
19. open it
20. tap on Discard local changes, observe an error dialog is shown.
21. disable airplane mode
22. tap on Discard local changes, observe the latest online copy is retrieved from the server.
23. observe the Undo/Redo buttons are now disabled (as history has been restarted)


CASE C: Visual editor
On the visual editor, try this:
1. start a new draft, and write something
2. tap back so the draft gets sent to the server
3. open it again
4. turn airplane mode ON
5. type some more
6. tap BACK - changes will be saved locally
7. open the post again, and open the menu. Observe  "Discard local changes" is present.


