### PR TITLE
open Gutenberg editor for empty-bodied Posts if Gutenberg is enabled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -369,6 +369,8 @@ public class PostUtils {
 
     public static boolean shouldShowGutenbergEditor(boolean isNewPost, PostModel post) {
         return AppPrefs.isGutenbergEditorEnabled()
-               && (isNewPost || contentContainsGutenbergBlocks(post.getContent()));
+               && (isNewPost
+                   || contentContainsGutenbergBlocks(post.getContent())
+                   || TextUtils.isEmpty(post.getContent()));
     }
 }


### PR DESCRIPTION
Fixes #8776 

To test:
1. Create a new post with Gutenberg enabled
2. Gutenberg will launch
3. Put in a title but leave the content completely empty. Go back
4. A draft will be created
5. Open the draft. Notice that Gutenberg is now used as the editor (it was Aztec previously)

cc @etoledom for awareness to implement the same check for iOS

