### PR TITLE
Wire up toggling html mode for gutenberg-mobile

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1043,7 +1043,8 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         if (viewHtmlModeMenuItem != null) {
-            viewHtmlModeMenuItem.setVisible(mEditorFragment instanceof AztecEditorFragment && showMenuItems);
+            viewHtmlModeMenuItem.setVisible(((mEditorFragment instanceof AztecEditorFragment)
+                                             || (mEditorFragment instanceof GutenbergEditorFragment)) && showMenuItems);
             viewHtmlModeMenuItem.setTitle(mHtmlModeMenuStateOn ? R.string.menu_visual_mode : R.string.menu_html_mode);
         }
 
@@ -1215,17 +1216,22 @@ public class EditPostActivity extends AppCompatActivity implements
                 // toggle HTML mode
                 if (mEditorFragment instanceof AztecEditorFragment) {
                     ((AztecEditorFragment) mEditorFragment).onToolbarHtmlButtonClicked();
-                    UploadUtils.showSnackbarSuccessActionOrange(findViewById(R.id.editor_activity),
-                            mHtmlModeMenuStateOn ? R.string.menu_html_mode_done_snackbar
-                                    : R.string.menu_visual_mode_done_snackbar,
-                            R.string.menu_undo_snackbar_action,
-                            new View.OnClickListener() {
-                                @Override
-                                public void onClick(View view) {
-                                    // switch back
-                                    ((AztecEditorFragment) mEditorFragment).onToolbarHtmlButtonClicked();
-                                }
-                            });
+                    toggledHtmlModeSnackbar(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            // switch back
+                            ((AztecEditorFragment) mEditorFragment).onToolbarHtmlButtonClicked();
+                        }
+                    });
+                } else if (mEditorFragment instanceof GutenbergEditorFragment) {
+                    ((GutenbergEditorFragment) mEditorFragment).onToggleHtmlMode();
+                    toggledHtmlModeSnackbar(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            // switch back
+                            ((GutenbergEditorFragment) mEditorFragment).onToggleHtmlMode();
+                        }
+                    });
                 }
             } else if (itemId == R.id.menu_discard_changes) {
                 AnalyticsTracker.track(Stat.EDITOR_DISCARDED_CHANGES);
@@ -1237,6 +1243,14 @@ public class EditPostActivity extends AppCompatActivity implements
             }
         }
         return false;
+    }
+
+    private void toggledHtmlModeSnackbar(View.OnClickListener onUndoClickListener) {
+        UploadUtils.showSnackbarSuccessActionOrange(findViewById(R.id.editor_activity),
+                mHtmlModeMenuStateOn ? R.string.menu_html_mode_done_snackbar
+                        : R.string.menu_visual_mode_done_snackbar,
+                R.string.menu_undo_snackbar_action,
+                onUndoClickListener);
     }
 
     private void refreshEditorContent() {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -38,7 +38,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         EditorMediaUploadListener,
         IHistoryListener {
     private static final String KEY_HTML_MODE_ENABLED = "KEY_HTML_MODE_ENABLED";
-
     private static final String GUTENBERG_BLOCK_START = "<!-- wp:";
 
     private static boolean mIsToolbarExpanded = false;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -297,10 +297,10 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     private void toggleHtmlMode() {
+        mHtmlModeEnabled = !mHtmlModeEnabled;
+
         mEditorFragmentListener.onTrackableEvent(TrackableEvent.HTML_BUTTON_TAPPED);
         mEditorFragmentListener.onHtmlModeToggledInToolbar();
-
-        mHtmlModeEnabled = !mHtmlModeEnabled;
 
         mWPAndroidGlueCode.toggleEditorMode();
     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -37,12 +37,15 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         View.OnTouchListener,
         EditorMediaUploadListener,
         IHistoryListener {
+    private static final String KEY_HTML_MODE_ENABLED = "KEY_HTML_MODE_ENABLED";
+
     private static final String GUTENBERG_BLOCK_START = "<!-- wp:";
 
     private static boolean mIsToolbarExpanded = false;
 
     private boolean mEditorWasPaused = false;
     private boolean mHideActionBarOnSoftKeyboardUp = false;
+    private boolean mHtmlModeEnabled;
 
     private EditTextWithKeyBackListener mTitle;
     private SourceViewEditText mSource;
@@ -76,6 +79,10 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
         ProfilingUtils.start("Visual Editor Startup");
         ProfilingUtils.split("EditorFragment.onCreate");
+
+        if (savedInstanceState != null) {
+            mHtmlModeEnabled = savedInstanceState.getBoolean(KEY_HTML_MODE_ENABLED);
+        }
     }
 
     @Override
@@ -85,6 +92,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         mTitle = view.findViewById(R.id.title);
         mWPAndroidGlueCode.onCreateView(
                 view.findViewById(R.id.gutenberg),
+                mHtmlModeEnabled,
                 new OnMediaLibraryButtonListener() {
                     @Override public void onMediaLibraryButtonClick() {
                         onToolbarMediaButtonClicked();
@@ -192,6 +200,11 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
+    public void onSaveInstanceState(Bundle outState) {
+        outState.putBoolean(KEY_HTML_MODE_ENABLED, mHtmlModeEnabled);
+    }
+
+    @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.menu_gutenberg, menu);
     }
@@ -276,6 +289,22 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         mWPAndroidGlueCode.setContent(postContent);
     }
 
+    public void onToggleHtmlMode() {
+        if (!isAdded()) {
+            return;
+        }
+
+        toggleHtmlMode();
+    }
+
+    private void toggleHtmlMode() {
+        mEditorFragmentListener.onTrackableEvent(TrackableEvent.HTML_BUTTON_TAPPED);
+        mEditorFragmentListener.onHtmlModeToggledInToolbar();
+
+        mHtmlModeEnabled = !mHtmlModeEnabled;
+
+        mWPAndroidGlueCode.toggleEditorMode();
+    }
 
     /*
         Note the way we detect we're in presence of Gutenberg blocks logic is taken from


### PR DESCRIPTION
Adds support for switching between html and visual mode for gutenberg-mobile.

Depends on this gutenberg-mobile PR (will update the submodule hash after that one gets merged): https://github.com/wordpress-mobile/gutenberg-mobile/pull/364

To test:
* Open a Gutenberg post and try switching modes via the 3-dots menu in the top-right (appbar)
* Also try rotating the device to verify that the mode is persisted

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
