### PR TITLE
Hide the Gutenberg debug menu in release builds

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -197,6 +197,16 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        if (menu != null) {
+            MenuItem debugMenuItem = menu.findItem(R.id.debugmenu);
+            debugMenuItem.setVisible(BuildConfig.DEBUG);
+        }
+
+        super.onPrepareOptionsMenu(menu);
+    }
+
+    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.debugmenu) {
             mWPAndroidGlueCode.showDevOptionsDialog();


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/370

This PR hides the extra menu item that launches the React Native debug menu in gutenberg-mobile if its a `release` build. The menu is available in `debug` builds.

To test:
0. With the `wp.BUILD_GUTENBERG_FROM_SOURCE` gradle.properties flag set to `false` (there's a bug currently if `true` and the build is a `release` one)
1. Try running `wasabiRelease` and verify that the debug menu in the block editor **is not** available
2. Try running `wasabiDebug` and verify that the debug menu in the block editor **is** available

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
