### PR TITLE
Run Gradle build scan on CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ android_config: &android_config
   docker:
     - image: circleci/android:api-27-alpha
   environment:
-    GRADLE: "./gradlew --build-cache --stacktrace -PdisablePreDex -PjavaMaxHeapSize=2g"
+    GRADLE: "./gradlew --stacktrace -PdisablePreDex -PjavaMaxHeapSize=2g"
 
 copy_gradle_properties: &copy_gradle_properties
   run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - wordpress-android-gradle-build-cache-{{ checksum "build.gradle" }}-{{ checksum "WordPress/build.gradle" }}
-            - wordpress-android-gradle-build-cache-{{ checksum "build.gradle" }}-
-            - wordpress-android-gradle-build-cache-
+            - wordpress-android-cache-v2-gradle-build-cache-{{ checksum "build.gradle" }}-{{ checksum "WordPress/build.gradle" }}
+            - wordpress-android-cache-v2-gradle-build-cache-{{ checksum "build.gradle" }}-
+            - wordpress-android-cache-v2-gradle-build-cache-
       - <<: *copy_gradle_properties
       - run:
           name: Validate login strings
@@ -30,7 +30,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle
-          key: wordpress-android-gradle-build-cache-{{ checksum "build.gradle" }}-{{ checksum "WordPress/build.gradle" }}
+          key: wordpress-android-cache-v2-gradle-build-cache-{{ checksum "build.gradle" }}-{{ checksum "WordPress/build.gradle" }}
       - store_test_results:
           path: WordPress/build/test-results/testVanillaReleaseUnitTest
   lint:
@@ -39,9 +39,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - wordpress-android-gradle-lint-cache-{{ checksum "build.gradle" }}-{{ checksum "WordPress/build.gradle" }}
-            - wordpress-android-gradle-lint-cache-{{ checksum "build.gradle" }}-
-            - wordpress-android-gradle-lint-cache-
+            - wordpress-android-cache-v2-gradle-lint-cache-{{ checksum "build.gradle" }}-{{ checksum "WordPress/build.gradle" }}
+            - wordpress-android-cache-v2-gradle-lint-cache-{{ checksum "build.gradle" }}-
+            - wordpress-android-cache-v2-gradle-lint-cache-
       - <<: *copy_gradle_properties
       - run:
           name: Checkstyle
@@ -55,7 +55,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle
-          key: wordpress-android-gradle-lint-cache-{{ checksum "build.gradle" }}-{{ checksum "WordPress/build.gradle" }}
+          key: wordpress-android-cache-v2-gradle-lint-cache-{{ checksum "build.gradle" }}-{{ checksum "WordPress/build.gradle" }}
       - store_artifacts:
           path: WordPress/build/reports
           destination: reports
@@ -66,15 +66,15 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - wordpress-android-gems-{{ checksum "Gemfile.lock" }}
-            - wordpress-android-gems-
+            - wordpress-android-cache-v2-gems-{{ checksum "Gemfile.lock" }}
+            - wordpress-android-cache-v2-gems-
       - run:
           name: Bundle install
           command: bundle install --path=vendor/bundle
       - save_cache:
           paths:
             - vendor/bundle
-          key: wordpress-android-gems-{{ checksum "Gemfile.lock" }}
+          key: wordpress-android-cache-v2-gems-{{ checksum "Gemfile.lock" }}
       - run:
           name: Danger
           command: bundle exec danger --fail-on-errors=true

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ buildscript {
     }
 }
 
+plugins {
+  id 'com.gradle.build-scan' version '1.16'
+}
+
 apply plugin: 'com.automattic.android.fetchstyle'
 
 project.ext.preDexLibs = !project.hasProperty('disablePreDex')
@@ -84,4 +88,13 @@ subprojects {
 
 ext {
     fluxCVersion = 'c452ef2e9059b0a29d77ea0a03026bacf79f46a9'
+}
+
+buildScan {
+    licenseAgreementUrl = 'https://gradle.com/terms-of-service'
+    licenseAgree = 'yes'
+    if (System.getenv('CI')) {
+        publishAlways()
+        tag 'CI'
+    }
 }


### PR DESCRIPTION
This makes [Gradle build scan](https://scans.gradle.com/) run on CI builds so we can check build performance

To test:

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
