### PR TITLE
Avoid Gutenberg reload times on rotation

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -71,6 +71,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setRetainInstance(true);
 
         mWPAndroidGlueCode.onCreate(getContext());
 


### PR DESCRIPTION
This PR uses `setRetainInstance(true)` to keep the ReactNative host fragment from being re-created on rotation.

To test:
1. open a Gutenberg post on WPAndroid (with Gutenberg enabled in settings)
2. rotate the device
3. observe the content is still there and it doesn't take as long as previously to load

Corresponding mobile Gutenberg PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/382

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
