### PR TITLE
Site Creation: Enable new site creation flow for DEBUG builds in WIP branch

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -58,7 +58,6 @@ android {
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
 
         buildConfigField "boolean", "REVISIONS_ENABLED", "false"
-        buildConfigField "boolean", "NEW_SITE_CREATION_ENABLED", "false"
     }
 
     flavorDimensions "buildType"

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -535,7 +535,7 @@ public class ActivityLauncher {
 
     public static void newBlogForResult(Activity activity) {
         Intent intent = new Intent(activity,
-                BuildConfig.NEW_SITE_CREATION_ENABLED ? NewSiteCreationActivity.class : SiteCreationActivity.class);
+                BuildConfig.DEBUG ? NewSiteCreationActivity.class : SiteCreationActivity.class);
         activity.startActivityForResult(intent, RequestCodes.CREATE_SITE);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchVerticalsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchVerticalsUseCase.kt
@@ -34,7 +34,7 @@ class FetchVerticalsUseCase @Inject constructor(
         }
     }
 
-    @Subscribe(threadMode = ThreadMode.MAIN)
+    @Subscribe(threadMode = ThreadMode.BACKGROUND)
     @SuppressWarnings("unused")
     fun onVerticalsFetched(event: OnVerticalsFetched) {
         pair?.let {


### PR DESCRIPTION
This PR enables the new site creation flow for DEBUG builds. Since we are keeping everything in a separate branch for now, the PR removes the extra `NEW_SITE_CREATION_ENABLED` flag and instead uses `BuildConfig.DEBUG`. We could revert this change before we merge it to `develop`, but until then this will make it easier to work with this branch without risking an accidental release. (which was very unlikely anyway)

It also fixes a very minor issue in `FetchVerticalsUseCase` where we needed to observe the fetch event in the bg thread instead of main.

To test:
* Go to Site selection screen
* Tap on + and select "Create WordPress.com site"
* Verify that the new flow shows up starting from the Verticals screen which has a header starting with "Tell us what kind of site you'd like to make"

