### PR TITLE
Remove unused Maven repository

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -13,7 +13,6 @@ buildscript {
 repositories {
     google()
     jcenter()
-    maven { url 'http://wordpress-mobile.github.io/WordPress-Android' }
     maven { url 'https://maven.fabric.io/public' }
     maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
     maven { url "https://jitpack.io" }


### PR DESCRIPTION
I noticed this unused repo when looking at the Gutenberg integration. As well as being unneeded, it also poses a risk of MITM attack as it uses `http://`.

To test:

- Run `./gradlew assembleVanillaRelease --refresh-dependencies`, see that it succeeds without this.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
