### PR TITLE
Editor: verify Aztec mode before running Aztec's media uploading checking methods

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -535,9 +535,11 @@ public class EditPostActivity extends AppCompatActivity implements
             mOriginalPost = mPost.clone();
             mOriginalPostHadLocalChangesOnOpen = mOriginalPost.isLocallyChanged();
             mPost = UploadService.updatePostWithCurrentlyCompletedUploads(mPost);
-            mMediaMarkedUploadingOnStartIds =
-                    AztecEditorFragment.getMediaMarkedUploadingInPostContent(this, mPost.getContent());
-            Collections.sort(mMediaMarkedUploadingOnStartIds);
+            if (mShowAztecEditor) {
+                mMediaMarkedUploadingOnStartIds =
+                        AztecEditorFragment.getMediaMarkedUploadingInPostContent(this, mPost.getContent());
+                Collections.sort(mMediaMarkedUploadingOnStartIds);
+            }
             mIsPage = mPost.isPage();
 
             EventBus.getDefault().postSticky(
@@ -1598,9 +1600,11 @@ public class EditPostActivity extends AppCompatActivity implements
         // update the original post object, so we'll know of new changes
         mOriginalPost = mPost.clone();
 
-        // update the list of uploading ids
-        mMediaMarkedUploadingOnStartIds =
-                AztecEditorFragment.getMediaMarkedUploadingInPostContent(this, mPost.getContent());
+        if (mShowAztecEditor) {
+            // update the list of uploading ids
+            mMediaMarkedUploadingOnStartIds =
+                    AztecEditorFragment.getMediaMarkedUploadingInPostContent(this, mPost.getContent());
+        }
     }
 
     @Override
@@ -2419,6 +2423,10 @@ public class EditPostActivity extends AppCompatActivity implements
       * URLs will have been replaced with the remote ones.
      */
     private boolean compareCurrentMediaMarkedUploadingToOriginal(String newContent) {
+        // this method makes use of AztecEditorFragment methods. Make sure to only run if Aztec is the current editor.
+        if (!mShowAztecEditor) {
+            return false;
+        }
         List<String> currentUploadingMedia = AztecEditorFragment.getMediaMarkedUploadingInPostContent(this, newContent);
         Collections.sort(currentUploadingMedia);
         return !mMediaMarkedUploadingOnStartIds.equals(currentUploadingMedia);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2397,7 +2397,7 @@ public class EditPostActivity extends AppCompatActivity implements
         if (mMediaInsertedOnCreation) {
             mMediaInsertedOnCreation = false;
             contentChanged = true;
-        } else if (compareCurrentMediaMarkedUploadingToOriginal(content)) {
+        } else if (isCurrentMediaMarkedUploadingDifferentToOriginal(content)) {
             contentChanged = true;
         } else {
             contentChanged = mPost.getContent().compareTo(content) != 0;
@@ -2422,7 +2422,7 @@ public class EditPostActivity extends AppCompatActivity implements
       * won't be equal and thus we'll know we need to save the Post content as it's changed, given the local
       * URLs will have been replaced with the remote ones.
      */
-    private boolean compareCurrentMediaMarkedUploadingToOriginal(String newContent) {
+    private boolean isCurrentMediaMarkedUploadingDifferentToOriginal(String newContent) {
         // this method makes use of AztecEditorFragment methods. Make sure to only run if Aztec is the current editor.
         if (!mShowAztecEditor) {
             return false;


### PR DESCRIPTION
Fixes a random crash, that is hard to reproduce.

Basically, this PR does not execute Aztec-specific code when Aztec is not the currently configured Editor. Before the introduction of Gutenberg we assumed Aztec to be the only "modern" editor, hence the checks were valid.

### To test:

Unfortunately, I didn't keep the copy of the stacktrace log :( , but will update this issue if I manage to make it happen again.

It was (is) very hard to reproduce, but I managed to make it happen twice for me on a Google Pixel emulator with Android 8.0 by pasting the Gutenberg mobile demo content in https://github.com/wordpress-mobile/gutenberg-mobile/blob/master/src/app/initial-html.js into a new Gutenberg post in a self-hosted WordPress site using Gutenberg. Then, trying to open the post from the Posts list resulted in different crashes, one of which I was able to identify as happening specifically within `updatePostContentNewEditor` in [the call to `compareCurrentMediaMarkedUploadingToOriginal`](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L2396).


In this PR , I'm introducing [this check](https://github.com/wordpress-mobile/WordPress-Android/compare/fix/gutenberg-crash-on-uploading-media-check?expand=1#diff-38b6aea9cfff5f3e0e4b7389b44de602R2427) (where the original stacktrace started) to other checks where AztecEditorFragment was being used.

I'm still investigating in identifying the other situations of crash and plan to open issues accordingly.


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
