### PR TITLE
Exclude EditPostActivity from handling orientation change for alpha

### DIFF
--- a/WordPress/src/zalpha/AndroidManifest.xml
+++ b/WordPress/src/zalpha/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="org.wordpress.android"
+          xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
+          android:installLocation="auto">
+
+    <application
+        android:name=".WordPress"
+        tools:node="merge"
+        >
+
+        <!-- Posts activities -->
+        <activity
+            android:name=".ui.posts.EditPostActivity"
+            tools:node="merge"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+            android:windowSoftInputMode="stateHidden|adjustResize">
+        </activity>
+    </application>
+</manifest>


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/377, https://github.com/wordpress-mobile/WordPress-Android/issues/8739, and load time issues mentioned in https://github.com/wordpress-mobile/WordPress-Android/issues/8739#issuecomment-446882973 and elsewhere

This PR adds a specific [`AndroidManifest.xml` merge](https://developer.android.com/studio/build/manifest-merge) for `EditPostActivity`, declaring the following attributes:
[`keyboard|keyboardHidden|orientation|screenSize`](https://developer.android.com/guide/topics/manifest/activity-element#config). What this effectively means is that `EditPostActivity` now does not handle orientation changes, and lets the changes in configuration be listened to and handled by the underlying RN implementation.

Been looking into this and trying different approaches: 
 - first one the natural/default approach being actually handling the orientation change ourselves which would mean to do all kinds of artifacts to keep undo/redo history for each block + keeping the scroll and caret positioning stated to re-set those on re-render. But this meant not only a lot of code and maintenance problems, but also a time overhead in re-loading Post on each time the Activity would be re-created.
- While into this, realized the common problem was that the RN setup  + loading of the Post took too long, so ideally we would need to make the Post available on rotation right away. Given most of our code lives in `GutenbergEditorFragment` as a host, a first idea was to use `setRetainInstance(true)` (see https://github.com/wordpress-mobile/WordPress-Android/pull/8790 and https://github.com/wordpress-mobile/gutenberg-mobile/pull/382) and keep the fragment's instance alive with the RN code alive as well. Unfortunately, even by doing this meant the re-wiring needed was not trivial, and even if so, the RN lifecycle relies heavily on listening to the host's Activity lifecycle [#](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java) [#](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java), apparently re-initializing things internally as the Activity lifecycle wired events were run (so, keeping the Fragment instance wasn't really helping here).
- Looked into the demo apps, realized [they were using the `orientation|screenSize`](https://github.com/wordpress-mobile/gutenberg-mobile/blob/master/android/app/src/main/AndroidManifest.xml#L22) modifiers in the `orientation` attribute, which indicates the Activity [is in charge of handling orientation changes](https://developer.android.com/guide/topics/resources/runtime-changes#HandlingTheChange) (and thus it not going to be destroyed for this reason). Also searching a bit for it found out most of the work is handled by RN itself on one activity, so it makes sense generally speaking to keep the Activity instance as well [#](https://github.com/facebook/react-native/issues/3219).

Given the situation in which the user is writing has the `EditPostActivity` on the foreground most of the time, an orientation change losing the focus / scroll position or making the user wait to reload seems less than ideal. On the contrary, if the user is writing and switches the app to do something else, then it perfectly makes sense for it to occasionally need to re-load the content.
This seems a good solution for the situation we're trying to handle, which aims at recognizing the orientaiton change (which RN does well and adjusts the contents to fit the new screen size after rotation) while not affecting the writing flow (which until this PR  meant waiting for reload, losing scroll position and undo/redo history among other hurdles).


**Note**: this PR makes the `EditPostActivity` not be killed on screen orientation changes also for Aztec and Visual Editors as the implementation for each is done by means of Fragments, but I chose to keep the PR simple for `alpha` only as opposed to making a new `EditPostActivity` class only for Gutenberg. We'll have to create one though, once we get into Beta.

To test:
1. load up a long Gutenberg post
2. scroll somewhere, place the caret at a specific location
3. rotate the device
4. observe the caret remains there
5. rotate again
6. observe position and caret is kept
8. do some edits and rotate
9. observe the undo/redo history is kept as well.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
