### PR TITLE
Disable Danger for forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
           key: wordpress-android-gems-{{ checksum "Gemfile.lock" }}
       - run:
           name: Danger
-          command: bundle exec danger --fail-on-errors=true
+          command: if [ -n "$DANGER_GITHUB_API_TOKEN" ]; then bundle exec danger --fail-on-errors=true; else echo "Not running danger because $DANGER_GITHUB_API_TOKEN is not found"; fi
 
 workflows:
   version: 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
         - bundle install
       script:
         - ./tools/validate-login-strings.sh
-        - bundle exec danger --fail-on-errors=true
+        - if [ -n "$DANGER_GITHUB_API_TOKEN" ]; then bundle exec danger --fail-on-errors=true; else echo "Not running danger because $DANGER_GITHUB_API_TOKEN is not found"; fi
 
 install:
   # Setup gradle.properties


### PR DESCRIPTION
This PR disables Danger on PRs from forks as it's actually failing because the GitHub Api key that it uses is not shared with forks.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
