### PR TITLE
 Use Bintray mirror of React Native dependencies instead of jsdelivr CDN

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -16,25 +16,6 @@ repositories {
     maven { url 'https://maven.fabric.io/public' }
     maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
     maven { url "https://jitpack.io" }
-
-    if (!rootProject.ext.buildGutenbergFromSource) {
-        // When building from binaries, add the RN maven repos here instead of the top level, to minimize false negatives
-        //  when gradle tries to get artifacts we know don't exist in the NPM CDNS (example: Zendesk artifacts)
-        maven {
-            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url "https://cdn.jsdelivr.net/npm/react-native@0.57.5/android"
-        }
-        maven {
-            // Local Maven repo containing AARs with JSC library built for Android
-            url "https://cdn.jsdelivr.net/npm/jsc-android@224109.1.0/dist/"
-        }
-    }
-}
-
-configurations.all {
-    resolutionStrategy {
-        force 'org.webkit:android-jsc:r224109'
-    }
 }
 
 apply plugin: 'com.android.application'

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ allprojects {
                 // Local Maven repo containing AARs with JSC library built for Android
                 url "$rootDir/libs/gutenberg-mobile/node_modules/jsc-android/dist"
             }
+        } else {
+            maven { url "https://dl.bintray.com/wordpress-mobile/react-native-mirror/" }
         }
     }
 
@@ -49,6 +51,12 @@ allprojects {
     checkstyle {
         toolVersion = '8.3'
         configFile file("${project.rootDir}/config/checkstyle.xml")
+    }
+}
+
+configurations.all {
+    resolutionStrategy {
+        force 'org.webkit:android-jsc:r224109'
     }
 }
 

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -59,9 +59,9 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'org.wordpress:utils:1.22'
 
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.12')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.3.12')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.3.12')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:254feae6f05587a1b1614ba1527038c25d75ee4a')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:254feae6f05587a1b1614ba1527038c25d75ee4a')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:254feae6f05587a1b1614ba1527038c25d75ee4a')
 
     if (rootProject.ext.buildGutenbergFromSource) {
         implementation project(':react-native-gutenberg-bridge')


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/8783

Currently we use the jsdelivr.net CDN as a pseudo maven repo to fetch React Native when building form source. This has caused some issues, including repeated failed builds.

This PR solves this by replacing our usage of the CDN with an actual Maven repo where we are mirroring the React Native dependencies. See also: https://github.com/wordpress-mobile/gutenberg-mobile/pull/400

To test:

With `wp.BUILD_GUTENBERG_FROM_SOURCE` set to false:

- Build and run `wasabiDebug`, enable Gutenberg in settings and confirm the editor works correctly.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
