### PR TITLE
Replace obsolete configuration in build.gradle

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -215,7 +215,7 @@ dependencies {
 
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
-    androidTestCompile 'tools.fastlane:screengrab:1.2.0',  {
+    androidTestImplementation 'tools.fastlane:screengrab:1.2.0',  {
         exclude group: 'com.android.support.test.uiautomator', module: 'uiautomator-v18'
     }
 


### PR DESCRIPTION
This PR updates the deprecated `androidTestCompile` configuration to the current `androidTestImplementation` in the Fastlane screenshot configuration.

To test:
1. Verify the projects builds 
2. Verify the deprecation warning is gone (https://travis-ci.org/wordpress-mobile/WordPress-Android/jobs/469336812#L1800)
3. Run `bundle exec fastlane screenshots` and verify the tool still works

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
