### PR TITLE
Focus on title when the new post loads

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2006,7 +2006,7 @@ public class EditPostActivity extends AppCompatActivity implements
                     // TODO: Remove editor options after testing.
                     if (mShowGutenbergEditor) {
                         return GutenbergEditorFragment.newInstance("", "",
-                                AppPrefs.isAztecEditorToolbarExpanded());
+                                AppPrefs.isAztecEditorToolbarExpanded(), mIsNewPost);
                     } else if (mShowAztecEditor) {
                         return AztecEditorFragment.newInstance("", "",
                                                                AppPrefs.isAztecEditorToolbarExpanded());

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -64,7 +64,10 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         mWPAndroidGlueCode = new WPAndroidGlueCode();
     }
 
-    public static GutenbergEditorFragment newInstance(String title, String content, boolean isExpanded, boolean isNewPost) {
+    public static GutenbergEditorFragment newInstance(String title,
+                                                      String content,
+                                                      boolean isExpanded,
+                                                      boolean isNewPost) {
         mIsToolbarExpanded = isExpanded;
         GutenbergEditorFragment fragment = new GutenbergEditorFragment();
         Bundle args = new Bundle();
@@ -178,7 +181,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         mWPAndroidGlueCode.onPause(getActivity());
 
         // Reset soft input mode to default as we have change it in onResume()
-        setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN | WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+        setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN
+                | WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
     }
 
     private void setSoftInputMode(int mode) {
@@ -186,8 +190,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     private void showImplicitKeyboard() {
-        final InputMethodManager keyboard = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
-        keyboard.toggleSoftInput(InputMethodManager.SHOW_IMPLICIT,0);
+        InputMethodManager keyboard = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+        keyboard.toggleSoftInput(InputMethodManager.SHOW_IMPLICIT, 0);
     }
 
     @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -60,6 +60,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     private WPAndroidGlueCode mWPAndroidGlueCode;
 
+    private boolean mIsNewPost;
+
     public GutenbergEditorFragment() {
         mWPAndroidGlueCode = new WPAndroidGlueCode();
     }
@@ -163,8 +165,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         mEditorFragmentListener.onEditorFragmentInitialized();
 
         if (getArguments() != null) {
-            boolean isNewPost = getArguments().getBoolean(ARG_IS_NEW_POST);
-            if (isNewPost) {
+            mIsNewPost = getArguments().getBoolean(ARG_IS_NEW_POST);
+            if (mIsNewPost) {
                 mTitle.requestFocus();
                 showImplicitKeyboard();
             }
@@ -186,7 +188,9 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     private void setSoftInputMode(int mode) {
-        getActivity().getWindow().setSoftInputMode(mode);
+        if (mIsNewPost && mTitle.hasFocus()) {
+            getActivity().getWindow().setSoftInputMode(mode);
+        }
     }
 
     private void showImplicitKeyboard() {

--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml
@@ -3,7 +3,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:focusable="false"
+    android:focusableInTouchMode="true">
 
     <org.wordpress.android.editor.EditTextWithKeyBackListener
         android:id="@+id/title"


### PR DESCRIPTION
Based on [the issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/357) .

On **Gutenberg**
- New post -> title should be in focus and keyboard should be visible
- Existing post -> nothing should be in focus and keyboard shouldn't be visible


Note: I have a problem to convert demonstration of this feature into .gif :(
