### PR TITLE
Create date block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockDiffCallback.kt
@@ -3,21 +3,22 @@ package org.wordpress.android.ui.stats.refresh
 import android.support.v7.util.DiffUtil.Callback
 import org.wordpress.android.ui.stats.refresh.BlockDiffCallback.BlockListPayload.COLUMNS_VALUE_CHANGED
 import org.wordpress.android.ui.stats.refresh.BlockDiffCallback.BlockListPayload.EXPAND_CHANGED
-import org.wordpress.android.ui.stats.refresh.BlockDiffCallback.BlockListPayload.TAB_CHANGED
 import org.wordpress.android.ui.stats.refresh.BlockDiffCallback.BlockListPayload.SELECTED_BAR_CHANGED
 import org.wordpress.android.ui.stats.refresh.BlockDiffCallback.BlockListPayload.SELECTED_COLUMN_CHANGED
+import org.wordpress.android.ui.stats.refresh.BlockDiffCallback.BlockListPayload.TAB_CHANGED
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarChartItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Columns
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ExpandableItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TabsItem
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.BACKGROUND_INFO
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.BAR_CHART
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.COLUMNS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.DIVIDER
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.EMPTY
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.EXPANDABLE_ITEM
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.INFO
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.HEADER
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.INFO
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LINK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM_WITH_ICON
@@ -49,6 +50,7 @@ class BlockDiffCallback(
                 LINK,
                 TEXT,
                 INFO,
+                BACKGROUND_INFO,
                 HEADER,
                 TITLE,
                 DIVIDER,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -13,14 +13,15 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.UseCaseFactory
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.AuthorsUseCase.AuthorsUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.ClicksUseCase.ClicksUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.CountryViewsUseCase.CountryViewsUseCaseFactory
-import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.AuthorsUseCase.AuthorsUseCaseFactory
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.DateUseCase.DateUseCaseFactory
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.OverviewUseCase.OverviewUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.PostsAndPagesUseCase.PostsAndPagesUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.ReferrersUseCase.ReferrersUseCaseFactory
-import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.VideoPlaysUseCase.VideoPlaysUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.SearchTermsUseCase.SearchTermsUseCaseFactory
-import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.OverviewUseCase.OverviewUseCaseFactory
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.VideoPlaysUseCase.VideoPlaysUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.AllTimeStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.CommentsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.FollowersUseCase
@@ -90,7 +91,8 @@ class StatsModule {
         videoPlaysUseCaseFactory: VideoPlaysUseCaseFactory,
         searchTermsUseCaseFactory: SearchTermsUseCaseFactory,
         authorsUseCaseFactory: AuthorsUseCaseFactory,
-        overviewUseCaseFactory: OverviewUseCaseFactory
+        overviewUseCaseFactory: OverviewUseCaseFactory,
+        dateUseCaseFactory: DateUseCaseFactory
     ): List<@JvmSuppressWildcards UseCaseFactory> {
         return listOf(
                 postsAndPagesUseCaseFactory,
@@ -100,7 +102,8 @@ class StatsModule {
                 videoPlaysUseCaseFactory,
                 searchTermsUseCaseFactory,
                 authorsUseCaseFactory,
-                overviewUseCaseFactory
+                overviewUseCaseFactory,
+                dateUseCaseFactory
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.ui.stats.refresh.BlockDiffCallback
 import org.wordpress.android.ui.stats.refresh.BlockDiffCallback.BlockListPayload.EXPAND_CHANGED
 import org.wordpress.android.ui.stats.refresh.BlockDiffCallback.BlockListPayload.SELECTED_BAR_CHANGED
 import org.wordpress.android.ui.stats.refresh.BlockDiffCallback.BlockListPayload.TAB_CHANGED
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BackgroundInformation
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarChartItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Columns
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ExpandableItem
@@ -19,6 +20,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.MapIt
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TabsItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Text
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.BACKGROUND_INFO
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.BAR_CHART
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.COLUMNS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.DIVIDER
@@ -34,6 +36,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TEXT
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.values
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItemViewHolder.BackgroundInformationViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItemViewHolder.BarChartViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItemViewHolder.ColumnsViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItemViewHolder.DividerViewHolder
@@ -91,6 +94,7 @@ class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockListItemVi
             BAR_CHART -> BarChartViewHolder(parent)
             TABS -> TabsViewHolder(parent, imageManager)
             INFO -> InformationViewHolder(parent)
+            BACKGROUND_INFO -> BackgroundInformationViewHolder(parent)
             HEADER -> HeaderViewHolder(parent)
             EXPANDABLE_ITEM -> ExpandableItemViewHolder(parent, imageManager)
             DIVIDER -> DividerViewHolder(parent)
@@ -116,6 +120,7 @@ class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockListItemVi
             is BarChartViewHolder -> holder.bind(item as BarChartItem, payloads.contains(SELECTED_BAR_CHANGED))
             is TabsViewHolder -> holder.bind(item as TabsItem, payloads.contains(TAB_CHANGED))
             is InformationViewHolder -> holder.bind(item as Information)
+            is BackgroundInformationViewHolder -> holder.bind(item as BackgroundInformation)
             is HeaderViewHolder -> holder.bind(item as Header)
             is ExpandableItemViewHolder -> holder.bind(
                     item as ExpandableItem,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.stats.refresh.lists.sections
 import android.support.annotation.DrawableRes
 import android.support.annotation.StringRes
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon.IconStyle.NORMAL
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.BACKGROUND_INFO
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.BAR_CHART
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.COLUMNS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.DIVIDER
@@ -30,6 +31,7 @@ sealed class BlockListItem(val type: Type) {
         LIST_ITEM,
         LIST_ITEM_WITH_ICON,
         INFO,
+        BACKGROUND_INFO,
         EMPTY,
         TEXT,
         COLUMNS,
@@ -75,6 +77,8 @@ sealed class BlockListItem(val type: Type) {
     }
 
     data class Information(val text: String) : BlockListItem(INFO)
+
+    data class BackgroundInformation(val text: String) : BlockListItem(BACKGROUND_INFO)
 
     data class Text(val text: String, val links: List<Clickable>? = null) : BlockListItem(TEXT) {
         data class Clickable(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItemViewHolder.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.experimental.launch
 import org.wordpress.android.R
 import org.wordpress.android.ui.stats.refresh.BlockDiffCallback.BlockListPayload.COLUMNS_VALUE_CHANGED
 import org.wordpress.android.ui.stats.refresh.BlockDiffCallback.BlockListPayload.SELECTED_COLUMN_CHANGED
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BackgroundInformation
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarChartItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Columns
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ExpandableItem
@@ -48,9 +49,9 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Infor
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.MapItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon.IconStyle.AVATAR
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon.IconStyle.NORMAL
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.MapItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TabsItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Text
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
@@ -80,6 +81,16 @@ sealed class BlockListItemViewHolder(
     ) {
         private val text = itemView.findViewById<TextView>(R.id.text)
         fun bind(item: Information) {
+            text.text = item.text
+        }
+    }
+
+    class BackgroundInformationViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
+            parent,
+            R.layout.stats_block_background_information_item
+    ) {
+        private val text = itemView.findViewById<TextView>(R.id.text)
+        fun bind(item: BackgroundInformation) {
             text.text = item.text
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/DateUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/DateUseCase.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 
 import kotlinx.coroutines.experimental.CoroutineDispatcher
-import org.wordpress.android.R
+import org.wordpress.android.R.string
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.DATE
@@ -25,13 +25,8 @@ constructor(
     private val resourceProvider: ResourceProvider,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
 ) : StatelessUseCase<Date>(DATE, mainDispatcher) {
-    override fun buildLoadingItem(): List<BlockListItem> = listOf(
-            BackgroundInformation(
-                    statsDateFormatter.printDate(
-                            selectedDateProvider.getSelectedDate(statsGranularity)
-                    )
-            )
-    )
+    override fun buildLoadingItem(): List<BlockListItem> =
+            listOf(getUiModel(selectedDateProvider.getSelectedDate(statsGranularity)))
 
     override suspend fun loadCachedData(site: SiteModel) {
         onModel(selectedDateProvider.getSelectedDate(statsGranularity))
@@ -42,11 +37,16 @@ constructor(
     }
 
     override fun buildUiModel(domainModel: Date): List<BlockListItem> {
-        return listOf(
-                BackgroundInformation(
-                        resourceProvider.getString(
-                                R.string.stats_for,
-                                statsDateFormatter.printDate(domainModel)
+        return listOf(getUiModel(domainModel))
+    }
+
+    private fun getUiModel(domainModel: Date): BackgroundInformation {
+        return BackgroundInformation(
+                resourceProvider.getString(
+                        string.stats_for,
+                        statsDateFormatter.printGranularDate(
+                                domainModel,
+                                statsGranularity
                         )
                 )
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/DateUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/DateUseCase.kt
@@ -1,0 +1,71 @@
+package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
+
+import kotlinx.coroutines.experimental.CoroutineDispatcher
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.DATE
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatelessUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BackgroundInformation
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.UseCaseFactory
+import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
+import org.wordpress.android.viewmodel.ResourceProvider
+import java.util.Date
+import javax.inject.Inject
+import javax.inject.Named
+
+class DateUseCase
+constructor(
+    private val statsGranularity: StatsGranularity,
+    private val selectedDateProvider: SelectedDateProvider,
+    private val statsDateFormatter: StatsDateFormatter,
+    private val resourceProvider: ResourceProvider,
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
+) : StatelessUseCase<Date>(DATE, mainDispatcher) {
+    override fun buildLoadingItem(): List<BlockListItem> = listOf(
+            BackgroundInformation(
+                    statsDateFormatter.printDate(
+                            selectedDateProvider.getSelectedDate(statsGranularity)
+                    )
+            )
+    )
+
+    override suspend fun loadCachedData(site: SiteModel) {
+        onModel(selectedDateProvider.getSelectedDate(statsGranularity))
+    }
+
+    override suspend fun fetchRemoteData(site: SiteModel, forced: Boolean) {
+        onModel(selectedDateProvider.getSelectedDate(statsGranularity))
+    }
+
+    override fun buildUiModel(domainModel: Date): List<BlockListItem> {
+        return listOf(
+                BackgroundInformation(
+                        resourceProvider.getString(
+                                R.string.stats_for,
+                                statsDateFormatter.printDate(domainModel)
+                        )
+                )
+        )
+    }
+
+    class DateUseCaseFactory
+    @Inject constructor(
+        @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+        private val selectedDateProvider: SelectedDateProvider,
+        private val resourceProvider: ResourceProvider,
+        private val statsDateFormatter: StatsDateFormatter
+    ) : UseCaseFactory {
+        override fun build(granularity: StatsGranularity) =
+                DateUseCase(
+                        granularity,
+                        selectedDateProvider,
+                        statsDateFormatter,
+                        resourceProvider,
+                        mainDispatcher
+                )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
@@ -29,7 +29,14 @@ constructor(
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
 ) : StatefulUseCase<VisitsAndViewsModel, UiState>(OVERVIEW, mainDispatcher, UiState()) {
     override fun buildLoadingItem(): List<BlockListItem> =
-            listOf(Title(text = statsDateFormatter.printDate(selectedDateProvider.getCurrentDate())))
+            listOf(
+                    Title(
+                            text = statsDateFormatter.printGranularDate(
+                                    selectedDateProvider.getCurrentDate(),
+                                    statsGranularity
+                            )
+                    )
+            )
 
     override suspend fun loadCachedData(site: SiteModel) {
         val dbModel = visitsAndViewsStore.getVisits(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/BaseStatsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/BaseStatsViewHolder.kt
@@ -7,6 +7,7 @@ import android.support.v7.widget.StaggeredGridLayoutManager
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.LATEST_POST_SUMMARY
+import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.DATE
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.OVERVIEW
 import org.wordpress.android.ui.stats.refresh.lists.StatsBlock
 
@@ -16,7 +17,7 @@ abstract class BaseStatsViewHolder<T : StatsBlock>(
 ) : ViewHolder(LayoutInflater.from(parent.context).inflate(layout, parent, false)) {
     @CallSuper
     open fun bind(item: T) {
-        if (item.statsTypes == OVERVIEW || item.statsTypes == LATEST_POST_SUMMARY) {
+        if (item.statsTypes == OVERVIEW || item.statsTypes == LATEST_POST_SUMMARY || item.statsTypes == DATE) {
             val layoutParams = itemView.layoutParams as? StaggeredGridLayoutManager.LayoutParams
             layoutParams?.isFullSpan = true
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/BlockListViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/BlockListViewHolder.kt
@@ -1,10 +1,13 @@
 package org.wordpress.android.ui.stats.refresh.lists.viewholders
 
+import android.graphics.Color
+import android.support.v7.widget.CardView
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 import android.view.ViewGroup
 import org.wordpress.android.R
 import org.wordpress.android.R.layout
+import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.DATE
 import org.wordpress.android.ui.stats.refresh.lists.BlockList
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListAdapter
 import org.wordpress.android.util.image.ImageManager
@@ -13,9 +16,14 @@ class BlockListViewHolder(parent: ViewGroup, val imageManager: ImageManager) : B
         parent,
         layout.stats_list_block
 ) {
+    private val container: CardView = itemView.findViewById(R.id.container)
     private val list: RecyclerView = itemView.findViewById(R.id.stats_block_list)
     override fun bind(item: BlockList) {
         super.bind(item)
+        if (item.statsTypes == DATE) {
+            container.setCardBackgroundColor(Color.TRANSPARENT)
+            container.cardElevation = 0F
+        }
         list.isNestedScrollingEnabled = false
         if (list.adapter == null) {
             list.layoutManager = LinearLayoutManager(list.context, LinearLayoutManager.VERTICAL, false)

--- a/WordPress/src/main/res/layout/stats_block_background_information_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_background_information_item.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/text"
+    style="@style/StatsBlockBackground"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/one_line_list_item_height"
+    android:layout_gravity="center"
+    android:gravity="center"
+    android:text="@string/unknown"/>

--- a/WordPress/src/main/res/layout/stats_list_block.xml
+++ b/WordPress/src/main/res/layout/stats_list_block.xml
@@ -4,6 +4,7 @@
                                     android:layout_width="match_parent"
                                     android:layout_height="wrap_content"
                                     android:animateLayoutChanges="false"
+                                    android:id="@+id/container"
                                     app:cardCornerRadius="@dimen/cardview_default_radius"
                                     app:cardElevation="@dimen/cardview_default_elevation"
                                     style="@style/StatsBlock">

--- a/WordPress/src/main/res/layout/stats_loading_view.xml
+++ b/WordPress/src/main/res/layout/stats_loading_view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-                                    style="@style/StatsBlock"
+                                    style="@style/StatsLoadingBlock"
                                     android:layout_width="match_parent"
                                     android:layout_height="wrap_content"
                                     android:animateLayoutChanges="false">

--- a/WordPress/src/main/res/values/stats_styles.xml
+++ b/WordPress/src/main/res/values/stats_styles.xml
@@ -100,6 +100,9 @@
 
     <style name="StatsBlock">
         <item name="android:background">@color/white</item>
+    </style>
+
+    <style name="StatsLoadingBlock" parent="StatsBlock">
         <item name="android:minHeight">96dp</item>
     </style>
 
@@ -125,6 +128,11 @@
 
     <style name="StatsBlockEmpty" parent="TextAppearance.AppCompat.Body1">
         <item name="android:textColor">@color/grey_darken_20</item>
+        <item name="android:textSize">@dimen/text_sz_large</item>
+    </style>
+
+    <style name="StatsBlockBackground" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">@color/grey_darken_10</item>
         <item name="android:textSize">@dimen/text_sz_large</item>
     </style>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -805,6 +805,7 @@
     <string name="stats_category_folded_name">%1$s | %2$s</string>
     <string name="stats_publicize_service_label">Service</string>
     <string name="stats_publicize_followers_label">Followers</string>
+    <string name="stats_from_to_dates_in_week_label">%1$s - %2$s</string>
 
     <!-- Jetpack install -->
     <string name="jetpack">Jetpack</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/DateUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/DateUseCaseTest.kt
@@ -1,0 +1,67 @@
+package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
+
+import com.nhaarman.mockito_kotlin.whenever
+import kotlinx.coroutines.experimental.Dispatchers
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.test
+import org.wordpress.android.ui.stats.refresh.lists.BlockList
+import org.wordpress.android.ui.stats.refresh.lists.StatsBlock
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BackgroundInformation
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.BACKGROUND_INFO
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
+import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
+import org.wordpress.android.viewmodel.ResourceProvider
+import java.util.Date
+
+private val statsGranularity = DAYS
+private val selectedDate = Date(0)
+
+class DateUseCaseTest : BaseUnitTest() {
+    @Mock lateinit var site: SiteModel
+    @Mock lateinit var statsDateFormatter: StatsDateFormatter
+    @Mock lateinit var selectedDateProvider: SelectedDateProvider
+    @Mock lateinit var resourceProvider: ResourceProvider
+    private lateinit var useCase: DateUseCase
+    @Before
+    fun setUp() {
+        useCase = DateUseCase(
+                statsGranularity,
+                selectedDateProvider,
+                statsDateFormatter,
+                resourceProvider,
+                Dispatchers.Unconfined
+        )
+        whenever((selectedDateProvider.getSelectedDate(statsGranularity))).thenReturn(selectedDate)
+    }
+
+    @Test
+    fun `maps date to UI model`() = test {
+        val granularDate = "today"
+        whenever(statsDateFormatter.printGranularDate(selectedDate, statsGranularity)).thenReturn(granularDate)
+        val label = "Stats for today"
+        whenever(resourceProvider.getString(R.string.stats_for, granularDate)).thenReturn(label)
+        val result = loadData(true, false)
+
+        (result as BlockList).apply {
+            Assertions.assertThat(this.items).hasSize(1)
+            val item = this.items[0]
+            assertThat(item.type).isEqualTo(BACKGROUND_INFO)
+            assertThat((item as BackgroundInformation).text).isEqualTo(label)
+        }
+    }
+
+    private suspend fun loadData(refresh: Boolean, forced: Boolean): StatsBlock {
+        var result: StatsBlock? = null
+        useCase.liveData.observeForever { result = it }
+        useCase.fetch(site, refresh, forced)
+        return checkNotNull(result)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateFormatterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateFormatterTest.kt
@@ -6,16 +6,23 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.util.LocaleManagerWrapper
+import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Locale
 
 class StatsDateFormatterTest : BaseUnitTest() {
     @Mock lateinit var localeManagerWrapper: LocaleManagerWrapper
+    @Mock lateinit var resourceProvider: ResourceProvider
     private lateinit var statsDateFormatter: StatsDateFormatter
     @Before
     fun setUp() {
         whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
-        statsDateFormatter = StatsDateFormatter(localeManagerWrapper)
+        statsDateFormatter = StatsDateFormatter(localeManagerWrapper, resourceProvider)
     }
 
     @Test
@@ -25,5 +32,114 @@ class StatsDateFormatterTest : BaseUnitTest() {
         val parsedDate = statsDateFormatter.printDate(unparsedDate)
 
         assertThat(parsedDate).isEqualTo("Nov 25, 2018")
+    }
+
+    @Test
+    fun `prints a day date`() {
+        val unparsedDate = "2018-11-25"
+
+        val parsedDate = statsDateFormatter.printGranularDate(unparsedDate, DAYS)
+
+        assertThat(parsedDate).isEqualTo("Nov 25, 2018")
+    }
+
+    @Test
+    fun `prints a week date`() {
+        val unparsedDate = "2018W12W19"
+        val result = "Dec 17 - Dec 23"
+        whenever(
+                resourceProvider.getString(
+                        R.string.stats_from_to_dates_in_week_label,
+                        "Dec 17",
+                        "Dec 23"
+                )
+        ).thenReturn(result)
+
+        val parsedDate = statsDateFormatter.printGranularDate(unparsedDate, WEEKS)
+
+        assertThat(parsedDate).isEqualTo("Dec 17 - Dec 23")
+    }
+
+    @Test
+    fun `prints a week date with year when week overlaps years`() {
+        val unparsedDate = "2011W12W31"
+        val result = "Dec 26, 2011 - Jan 1, 2012"
+        whenever(
+                resourceProvider.getString(
+                        R.string.stats_from_to_dates_in_week_label,
+                        "Dec 26, 2011",
+                        "Jan 1, 2012"
+                )
+        ).thenReturn(result)
+
+        val parsedDate = statsDateFormatter.printGranularDate(unparsedDate, WEEKS)
+
+        assertThat(parsedDate).isEqualTo(result)
+    }
+
+    @Test
+    fun `prints a month date`() {
+        val unparsedDate = "2018-12"
+
+        val parsedDate = statsDateFormatter.printGranularDate(unparsedDate, MONTHS)
+
+        assertThat(parsedDate).isEqualTo("Dec, 2018")
+    }
+
+    @Test
+    fun `prints a year date`() {
+        val unparsedDate = "2018-12-01"
+
+        val parsedDate = statsDateFormatter.printGranularDate(unparsedDate, YEARS)
+
+        assertThat(parsedDate).isEqualTo("2018")
+    }
+
+    @Test
+    fun `parses a date in another language`() {
+        whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.forLanguageTag("cs"))
+        val unparsedDate = "2018-11-25"
+
+        val parsedDate = statsDateFormatter.printDate(unparsedDate)
+
+        assertThat(parsedDate).isEqualTo("25.11.2018")
+    }
+
+    @Test
+    fun `prints a day date in another language`() {
+        val unparsedDate = "2018-11-25"
+        whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.forLanguageTag("cs"))
+
+        val parsedDate = statsDateFormatter.printGranularDate(unparsedDate, DAYS)
+
+        assertThat(parsedDate).isEqualTo("25.11.2018")
+    }
+
+    @Test
+    fun `prints a week date in another language`() {
+        val result = "17.12 - 23.12"
+        whenever(
+                resourceProvider.getString(
+                        R.string.stats_from_to_dates_in_week_label,
+                        "17.12",
+                        "23.12"
+                )
+        ).thenReturn(result)
+        whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.forLanguageTag("cs"))
+        val unparsedDate = "2018W12W19"
+
+        val parsedDate = statsDateFormatter.printGranularDate(unparsedDate, WEEKS)
+
+        assertThat(parsedDate).isEqualTo(result)
+    }
+
+    @Test
+    fun `prints a month date in another language`() {
+        whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.forLanguageTag("cs"))
+        val unparsedDate = "2018-12"
+
+        val parsedDate = statsDateFormatter.printGranularDate(unparsedDate, MONTHS)
+
+        assertThat(parsedDate).isEqualTo("Pro, 2018")
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -83,5 +83,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'fae823d2c711f516dcced34e7ee47dc8d6c4838f'
+    fluxCVersion = 'a3864fc925e563e74028510b492be8dee80e45f9'
 }


### PR DESCRIPTION
Fixes #8834
This PR is adding a Date block under the Overview block to Stats. The Date block doesn't have the CardView background. I'm also changing the text label of the date in this PR.
* In the Days block we show the date as `Dec 20, 2018`
* In the Weeks block we show `Dec 17 - Dec 23` in most cases and `Dec 31, 2017 - Jan 06, 2018` when the week overlaps the year
* In the Months block we show `Dec, 2018`
* In the Years block we show `2018`

![screenshot_1545293789](https://user-images.githubusercontent.com/1079756/50272439-1811a500-0438-11e9-9f91-389ed367a355.png)


To test:
* Open stats
* Go to Day/Week/Month/Year tabs
* There is a block with no background on the second position saying "Stats for ..." where the date shown is the same as the title of the Overview block
* Rotate the screen
* On bigger devices when you see 2 columns, the Date block spreads over both.
