### PR TITLE
Update gutenberg-mobile to 0.3-RC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,12 @@ allprojects {
         }
     }
 
+    configurations.all {
+        resolutionStrategy {
+            force 'org.webkit:android-jsc:r224109'
+        }
+    }
+
     task checkstyle(type: Checkstyle) {
         source 'src'
 
@@ -51,12 +57,6 @@ allprojects {
     checkstyle {
         toolVersion = '8.3'
         configFile file("${project.rootDir}/config/checkstyle.xml")
-    }
-}
-
-configurations.all {
-    resolutionStrategy {
-        force 'org.webkit:android-jsc:r224109'
     }
 }
 


### PR DESCRIPTION
This PR points the Gutenberg mobile submodule to the hash for ~v0.3.0-rc.0~ v0.3.0-rc.1  of gutenberg-mobile.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
