### PR TITLE
Use explicit Aztec version v1.3.13

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -59,9 +59,9 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'org.wordpress:utils:1.22'
 
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:254feae6f05587a1b1614ba1527038c25d75ee4a')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:254feae6f05587a1b1614ba1527038c25d75ee4a')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:254feae6f05587a1b1614ba1527038c25d75ee4a')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.13')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.3.13')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.3.13')
 
     if (rootProject.ext.buildGutenbergFromSource) {
         implementation project(':react-native-gutenberg-bridge')


### PR DESCRIPTION
Updating to use the Aztec tag. Also updated the gutenberg ref so there is no conflict

Related:

- https://github.com/wordpress-mobile/gutenberg-mobile/pull/416
- https://github.com/wordpress-mobile/react-native-aztec/pull/102

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
