### PR TITLE
NewSitePreview - > Transition animation + OnConfigChange fix

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationPreviewFragment.kt
@@ -319,12 +319,12 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment<NewSiteCr
     }
 
     private fun createWebViewContainerAnimator(contentHeight: Float): ObjectAnimator =
-            createSlidInFromBottomAnimator(webviewContainer, contentHeight)
+            createSlideInFromBottomAnimator(webviewContainer, contentHeight)
 
     private fun createOkButtonContainerAnimator(contentHeight: Float): ObjectAnimator =
-            createSlidInFromBottomAnimator(sitePreviewOkButtonContainer, contentHeight)
+            createSlideInFromBottomAnimator(sitePreviewOkButtonContainer, contentHeight)
 
-    private fun createSlidInFromBottomAnimator(view: View, contentHeight: Float): ObjectAnimator {
+    private fun createSlideInFromBottomAnimator(view: View, contentHeight: Float): ObjectAnimator {
         return ObjectAnimator.ofFloat(
                 view,
                 "translationY",

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSitePreviewViewModel.kt
@@ -59,7 +59,7 @@ class NewSitePreviewViewModel @Inject constructor(
     private val _uiState: MutableLiveData<SitePreviewUiState> = MutableLiveData()
     val uiState: LiveData<SitePreviewUiState> = _uiState
 
-    private val _preloadPreview: SingleLiveEvent<String> = SingleLiveEvent()
+    private val _preloadPreview: MutableLiveData<String> = MutableLiveData()
     val preloadPreview: LiveData<String> = _preloadPreview
 
     private val _startCreateSiteService: SingleLiveEvent<SitePreviewStartServiceData> = SingleLiveEvent()
@@ -193,25 +193,31 @@ class NewSitePreviewViewModel @Inject constructor(
     }
 
     fun onUrlLoaded() {
-        val subDomain = UrlUtils.extractSubDomain(urlWithoutScheme)
-        val fullUrl = UrlUtils.addUrlSchemeIfNeeded(urlWithoutScheme, true)
-        val subDomainIndices: Pair<Int, Int> = Pair(0, subDomain.length)
-        val domainIndices: Pair<Int, Int> = Pair(
-                Math.min(subDomainIndices.second, urlWithoutScheme.length),
-                urlWithoutScheme.length
-        )
-
-        updateUiState(
-                SitePreviewContentUiState(
-                        SitePreviewData(
-                                fullUrl,
-                                urlWithoutScheme,
-                                subDomainIndices,
-                                domainIndices
-                        )
-                )
-        )
         _hideGetStartedBar.call()
+        /**
+         * Update the ui state if the loading or error screen is being shown.
+         * In other words don't update it after a configuration change.
+         */
+        if (uiState.value !is SitePreviewContentUiState) {
+            val subDomain = UrlUtils.extractSubDomain(urlWithoutScheme)
+            val fullUrl = UrlUtils.addUrlSchemeIfNeeded(urlWithoutScheme, true)
+            val subDomainIndices: Pair<Int, Int> = Pair(0, subDomain.length)
+            val domainIndices: Pair<Int, Int> = Pair(
+                    Math.min(subDomainIndices.second, urlWithoutScheme.length),
+                    urlWithoutScheme.length
+            )
+
+            updateUiState(
+                    SitePreviewContentUiState(
+                            SitePreviewData(
+                                    fullUrl,
+                                    urlWithoutScheme,
+                                    subDomainIndices,
+                                    domainIndices
+                            )
+                    )
+            )
+        }
     }
 
     private fun updateUiState(uiState: SitePreviewUiState) {


### PR DESCRIPTION
Fixes #8583 and #8821 

**NOTE: `feature/8512-create-site-UI` is set as target branch. Replace it with `feature/master-site-creation` when #8825 is merged.**

NewSiteCreation
Fixes issue where the preview WebView's content was cleared on rotation.

Adds transition animation from Loading screen to SitePreview screen.
![varianta_2](https://user-images.githubusercontent.com/2261188/50296016-c0942900-0479-11e9-81d4-20c9cae35db5.gif)


To test:
My Site -> Switch Site -> Plus sign Icon -> Create WordPress.com site -> select a segment -> skip verticals -> skip Site info -> type and select a domain -> observer the transition animation

cc @SylvesterWilmott 