### PR TITLE
Fix/start gutenberg for new posts

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -99,6 +99,11 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         View view = inflater.inflate(R.layout.fragment_gutenberg_editor, container, false);
 
         mTitle = view.findViewById(R.id.title);
+
+        if (getArguments() != null) {
+            mIsNewPost = getArguments().getBoolean(ARG_IS_NEW_POST);
+        }
+
         mWPAndroidGlueCode.onCreateView(
                 view.findViewById(R.id.gutenberg),
                 mHtmlModeEnabled,
@@ -109,7 +114,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                 },
                 getActivity().getApplication(),
                 BuildConfig.DEBUG,
-                BuildConfig.BUILD_GUTENBERG_FROM_SOURCE);
+                BuildConfig.BUILD_GUTENBERG_FROM_SOURCE,
+                mIsNewPost);
         mSource = view.findViewById(R.id.source);
 
         mTitle.addTextChangedListener(mTextWatcher);
@@ -164,12 +170,9 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
         mEditorFragmentListener.onEditorFragmentInitialized();
 
-        if (getArguments() != null) {
-            mIsNewPost = getArguments().getBoolean(ARG_IS_NEW_POST);
-            if (mIsNewPost) {
-                mTitle.requestFocus();
-                showImplicitKeyboard();
-            }
+        if (mIsNewPost) {
+            mTitle.requestFocus();
+            showImplicitKeyboard();
         }
 
         return view;


### PR DESCRIPTION

This PR points to bridge code changes in https://github.com/wordpress-mobile/gutenberg-mobile/pull/437

This PR fixes a bug introduced in https://github.com/wordpress-mobile/WordPress-Android/pull/8851 (which was reverted back in https://github.com/wordpress-mobile/WordPress-Android/pull/8855 and reintroduced here).


The bug consisted of not being able to write new posts, because Gutenberg RN App was not started until `setContent` was called in #8851. Now we're passing the `mIsNewPost` flag to the bridge so it can initialize RN properly

To test:
On `alpha`, go to Me->App settings and turn Gutenberg editor ON.

CASE A:
1. try start a new post
2. observe you can write and insert blocks, etc.

CASE B: 
1. follow as inidicated in https://github.com/wordpress-mobile/gutenberg-mobile/pull/431 and verify it works.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
