### PR TITLE
Issue/update me layout

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,4 @@
 * Add Importing from Giphy in Editor and Media Library
 * Adds support for .blog subdomains on new sites.
 * First version of the refreshed stats project - all tabs and all the blocks are completely rewritten in new design
+* Update the Me tab layout for tablets and large devices

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -2,7 +2,6 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -23,7 +22,10 @@
                 android:id="@+id/card_avatar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="@dimen/me_content_margin">
+                android:layout_marginBottom="@dimen/margin_large"
+                android:layout_marginEnd="@dimen/content_margin"
+                android:layout_marginStart="@dimen/content_margin"
+                android:layout_marginTop="@dimen/margin_large">
 
                 <RelativeLayout
                     android:layout_width="match_parent"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -210,7 +210,6 @@
     <dimen name="my_site_margin_general">10dp</dimen>
 
     <!--me-->
-    <dimen name="me_content_margin">@dimen/margin_large</dimen>
     <dimen name="me_list_row_icon_size">24dp</dimen>
     <dimen name="me_list_row_padding_horizontal">@dimen/content_margin</dimen>
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -212,7 +212,7 @@
     <!--me-->
     <dimen name="me_content_margin">@dimen/margin_large</dimen>
     <dimen name="me_list_row_icon_size">24dp</dimen>
-    <dimen name="me_list_row_padding_horizontal">@dimen/me_content_margin</dimen>
+    <dimen name="me_list_row_padding_horizontal">@dimen/content_margin</dimen>
 
     <!--site picker-->
     <dimen name="site_picker_blavatar_margin_left">7dp</dimen>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -377,8 +377,8 @@
         <item name="android:layout_height">1dp</item>
         <item name="android:layout_gravity">center_vertical</item>
         <item name="android:background">@color/me_divider</item>
-        <item name="android:layout_marginEnd" >@dimen/me_content_margin</item>
-        <item name="android:layout_marginStart" >@dimen/me_content_margin</item>
+        <item name="android:layout_marginEnd" >@dimen/content_margin</item>
+        <item name="android:layout_marginStart" >@dimen/content_margin</item>
     </style>
 
     <!-- Used in Notifications and Site settings to animate nested preference screens -->


### PR DESCRIPTION
### Fix
Update the **_Me_** tab layout with margins optimized for tablets and large devices.  The layout mimics **_Sites_**, **_Reader_**, and **_Notifications_** by using the [`content_margin`](https://github.com/wordpress-mobile/WordPress-Android/blob/3c02e90e5d14079b725548ed45273bfd3a9009eb/WordPress/src/main/res/values/dimens.xml#L52) value for horizontal margins.  See the screenshots below for illustration.

![me_tablet](https://user-images.githubusercontent.com/3827611/50377235-ad9f6700-05e7-11e9-8550-760ec13b73b6.png)

### Test
0. Use device with height or width larger than 600dp.
1. Go to ***Sites*** tab.
2. Notice horizontal margins.
3. Go to ***Reader*** tab.
4. Notice horizontal margins.
5. Go to ***Me*** tab.
6. Notice horizontal margins.
7. Go to ***Notifications*** tab.
8. Notice horizontal margins.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
The `RELEASE-NOTES.txt` document was updated in f1495ca with the following:
<blockquote>
Update the Me tab layout for tablets and large devices
</blockquote>
