### PR TITLE
Issue/update notifications layout

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,4 @@
 * Add Importing from Giphy in Editor and Media Library
 * Adds support for .blog subdomains on new sites.
 * First version of the refreshed stats project - all tabs and all the blocks are completely rewritten in new design
+* Update the Notifications list layout for better readability

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -203,7 +203,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         if (note == null) {
             return;
         }
-        noteViewHolder.itemView.setTag(note.getId());
+        noteViewHolder.mContentView.setTag(note.getId());
 
         // Display group header
         Note.NoteTimeGroup timeGroup = Note.getTimeGroupForTimestamp(note.getTimestamp());
@@ -215,8 +215,10 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         }
 
         if (previousTimeGroup != null && previousTimeGroup == timeGroup) {
-            noteViewHolder.mHeaderView.setVisibility(View.GONE);
+            noteViewHolder.mHeaderText.setVisibility(View.GONE);
         } else {
+            noteViewHolder.mHeaderText.setVisibility(View.VISIBLE);
+
             if (timeGroup == Note.NoteTimeGroup.GROUP_TODAY) {
                 noteViewHolder.mHeaderText.setText(R.string.stats_timeframe_today);
             } else if (timeGroup == Note.NoteTimeGroup.GROUP_YESTERDAY) {
@@ -228,8 +230,6 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
             } else {
                 noteViewHolder.mHeaderText.setText(R.string.older_month);
             }
-
-            noteViewHolder.mHeaderView.setVisibility(View.VISIBLE);
         }
 
         CommentStatus commentStatus = CommentStatus.ALL;
@@ -347,10 +347,8 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
     }
 
     class NoteViewHolder extends RecyclerView.ViewHolder {
-        private final View mHeaderView;
         private final View mContentView;
         private final TextView mHeaderText;
-
         private final TextView mTxtSubject;
         private final TextView mTxtSubjectNoticon;
         private final TextView mTxtDetail;
@@ -359,16 +357,15 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
 
         NoteViewHolder(View view) {
             super(view);
-            mHeaderView = view.findViewById(R.id.time_header);
             mContentView = view.findViewById(R.id.note_content_container);
-            mHeaderText = view.findViewById(R.id.header_date_text);
+            mHeaderText = view.findViewById(R.id.header_text);
             mTxtSubject = view.findViewById(R.id.note_subject);
             mTxtSubjectNoticon = view.findViewById(R.id.note_subject_noticon);
             mTxtDetail = view.findViewById(R.id.note_detail);
             mImgAvatar = view.findViewById(R.id.note_avatar);
             mNoteIcon = view.findViewById(R.id.note_icon);
 
-            itemView.setOnClickListener(mOnClickListener);
+            mContentView.setOnClickListener(mOnClickListener);
         }
     }
 

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -62,8 +62,7 @@
                 android:layout_marginTop="35dp"
                 android:layout_width="@dimen/note_icon_sz"
                 android:textColor="@color/white"
-                android:textSize="14sp"
-                tools:text="@string/noticon_note" >
+                android:textSize="14sp" >
             </org.wordpress.android.widgets.NoticonTextView>
 
         </FrameLayout>

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -1,159 +1,137 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:layout_width="match_parent"
+    android:orientation="vertical" >
 
-    <LinearLayout
-        android:focusable="true"
-        android:clickable="false"
-        android:id="@+id/time_header"
-        android:layout_width="match_parent"
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/header_text"
+        android:background="@color/background_grey"
+        android:gravity="center_vertical"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:background="@color/white"
-        android:visibility="gone"
-        tools:visibility="visible"
+        android:layout_width="match_parent"
+        android:paddingBottom="@dimen/margin_large"
         android:paddingEnd="@dimen/margin_extra_large"
-        android:paddingStart="@dimen/margin_extra_large">
-
-        <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:paddingBottom="@dimen/margin_small"
-            android:paddingTop="@dimen/margin_small">
-
-            <org.wordpress.android.widgets.NoticonTextView
-                android:id="@+id/header_date_icon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_marginBottom="-1dp"
-                android:textColor="@color/grey_darken_10"
-                android:textSize="18sp"
-                android:text="@string/noticon_clock" />
-
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/header_date_text"
-                style="@style/Calypso.Text.Header"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_marginStart="@dimen/margin_small"
-                android:textAllCaps="true"
-                tools:text="TODAY" />
-        </LinearLayout>
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@drawable/notifications_list_divider_full_width" />
-
-    </LinearLayout>
+        android:paddingStart="@dimen/margin_extra_large"
+        android:paddingTop="@dimen/margin_large"
+        android:textAppearance="@style/Base.TextAppearance.AppCompat.Body2"
+        android:textColor="@color/grey_darken_20"
+        android:visibility="gone"
+        tools:text="Today"
+        tools:visibility="visible" >
+    </org.wordpress.android.widgets.WPTextView>
 
     <LinearLayout
-        android:focusable="true"
         android:id="@+id/note_content_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
         android:background="?android:selectableItemBackground"
-        android:orientation="vertical">
+        android:clickable="true"
+        android:focusable="true"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:orientation="vertical" >
 
         <LinearLayout
-            android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:layout_width="match_parent"
             android:orientation="horizontal"
             android:paddingBottom="@dimen/margin_medium"
-            android:paddingTop="@dimen/margin_medium"
             android:paddingEnd="@dimen/margin_extra_large"
-            android:paddingStart="@dimen/margin_extra_large">
+            android:paddingStart="@dimen/margin_extra_large"
+            android:paddingTop="@dimen/margin_medium" >
 
             <FrameLayout
-                android:id="@+id/avatar_wrapper"
-                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="1dp">
+                android:layout_marginTop="1dp"
+                android:layout_width="wrap_content" >
 
                 <ImageView
                     android:id="@+id/note_avatar"
-                    android:layout_width="@dimen/notifications_avatar_sz"
+                    android:contentDescription="@null"
                     android:layout_height="@dimen/notifications_avatar_sz"
-                    android:layout_marginEnd="@dimen/notifications_adjusted_font_margin"
+                    android:layout_marginEnd="@dimen/activity_log_icon_margin"
                     android:layout_marginTop="@dimen/margin_small"
-                    android:contentDescription="@null"/>
+                    android:layout_width="@dimen/notifications_avatar_sz"
+                    tools:src="@drawable/bg_oval_grey_user_32dp" >
+                </ImageView>
 
                 <org.wordpress.android.widgets.NoticonTextView
                     android:id="@+id/note_icon"
-                    android:layout_width="@dimen/note_icon_sz"
+                    android:background="@drawable/shape_oval_blue_white_stroke"
+                    android:gravity="center"
                     android:layout_height="@dimen/note_icon_sz"
                     android:layout_marginStart="31dp"
                     android:layout_marginTop="35dp"
-                    android:background="@drawable/shape_oval_blue_white_stroke"
-                    android:gravity="center"
+                    android:layout_width="@dimen/note_icon_sz"
                     android:textColor="@color/white"
                     android:textSize="14sp"
-                    tools:text="@string/noticon_note" />
+                    tools:text="@string/noticon_note" >
+                </org.wordpress.android.widgets.NoticonTextView>
+
             </FrameLayout>
 
-
             <LinearLayout
-                android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
-                android:orientation="vertical">
+                android:layout_width="fill_parent"
+                android:orientation="vertical" >
 
                 <FrameLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    android:layout_width="match_parent" >
 
                     <org.wordpress.android.widgets.NoticonTextView
                         android:id="@+id/note_subject_noticon"
-                        android:layout_width="wrap_content"
+                        android:gravity="start"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/margin_extra_small"
-                        android:textColor="@color/grey_darken_10"
+                        android:layout_width="wrap_content"
                         android:textAlignment="viewStart"
-                        android:gravity="start"
-                        android:textSize="18sp" />
+                        android:textColor="@color/grey_darken_10"
+                        android:textSize="@dimen/text_sz_larger" >
+                    </org.wordpress.android.widgets.NoticonTextView>
 
                     <org.wordpress.android.widgets.WPTextView
                         android:id="@+id/note_subject"
-                        android:layout_width="fill_parent"
-                        android:layout_height="wrap_content"
                         android:ellipsize="end"
+                        android:gravity="start"
+                        android:layout_height="wrap_content"
+                        android:layout_width="fill_parent"
                         android:maxLines="2"
+                        android:textAlignment="viewStart"
                         android:textColor="@color/grey_dark"
                         android:textSize="@dimen/text_sz_large"
-                        android:textAlignment="viewStart"
-                        android:gravity="start"
-                        tools:text="Bob Ross commented on your post Happy Trees" />
+                        tools:text="Bob Ross commented on your post Happy Trees" >
+                    </org.wordpress.android.widgets.WPTextView>
 
                 </FrameLayout>
 
                 <org.wordpress.android.widgets.WPTextView
-                    android:importantForAccessibility="no"
                     android:id="@+id/note_detail"
-                    android:layout_width="wrap_content"
+                    android:ellipsize="end"
+                    android:importantForAccessibility="no"
+                    android:maxLines="2"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="-1dp"
-                    android:ellipsize="end"
-                    android:maxLines="2"
-                    android:textColor="@color/grey_text_min"
+                    android:layout_width="wrap_content"
+                    android:textColor="@color/grey_darken_10"
                     android:textSize="@dimen/text_sz_large"
                     android:visibility="gone"
                     tools:text="What an amazing post!"
-                    tools:visibility="visible" />
+                    tools:visibility="visible" >
+                </org.wordpress.android.widgets.WPTextView>
+
             </LinearLayout>
 
         </LinearLayout>
 
         <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginTop="1dp"
-            android:background="@drawable/notifications_list_divider" />
+            android:background="@color/grey_lighten_30"
+            android:layout_height="@dimen/list_divider_height"
+            android:layout_width="match_parent" >
+        </View>
 
     </LinearLayout>
 

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout
+<RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="wrap_content"
-    android:layout_width="match_parent"
-    android:orientation="vertical" >
+    android:layout_width="match_parent" >
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/header_text"
@@ -24,115 +23,106 @@
         tools:visibility="visible" >
     </org.wordpress.android.widgets.WPTextView>
 
-    <LinearLayout
+    <RelativeLayout
         android:id="@+id/note_content_container"
         android:background="?android:selectableItemBackground"
         android:clickable="true"
         android:focusable="true"
-        android:layout_height="match_parent"
+        android:layout_below="@+id/header_text"
+        android:layout_height="wrap_content"
         android:layout_width="match_parent"
-        android:orientation="vertical" >
+        android:minHeight="?attr/listPreferredItemHeight"
+        android:paddingBottom="@dimen/margin_medium"
+        android:paddingEnd="@dimen/margin_extra_large"
+        android:paddingStart="@dimen/margin_extra_large"
+        android:paddingTop="@dimen/margin_medium" >
 
-        <LinearLayout
-            android:layout_height="match_parent"
-            android:layout_width="match_parent"
-            android:orientation="horizontal"
-            android:paddingBottom="@dimen/margin_medium"
-            android:paddingEnd="@dimen/margin_extra_large"
-            android:paddingStart="@dimen/margin_extra_large"
-            android:paddingTop="@dimen/margin_medium" >
+        <FrameLayout
+            android:id="@+id/note_avatar_container"
+            android:layout_alignParentStart="true"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content" >
 
-            <FrameLayout
-                android:layout_height="wrap_content"
-                android:layout_marginTop="1dp"
-                android:layout_width="wrap_content" >
+            <ImageView
+                android:id="@+id/note_avatar"
+                android:contentDescription="@null"
+                android:layout_height="@dimen/notifications_avatar_sz"
+                android:layout_marginEnd="@dimen/activity_log_icon_margin"
+                android:layout_marginTop="@dimen/margin_small"
+                android:layout_width="@dimen/notifications_avatar_sz"
+                tools:src="@drawable/bg_oval_grey_user_32dp" >
+            </ImageView>
 
-                <ImageView
-                    android:id="@+id/note_avatar"
-                    android:contentDescription="@null"
-                    android:layout_height="@dimen/notifications_avatar_sz"
-                    android:layout_marginEnd="@dimen/activity_log_icon_margin"
-                    android:layout_marginTop="@dimen/margin_small"
-                    android:layout_width="@dimen/notifications_avatar_sz"
-                    tools:src="@drawable/bg_oval_grey_user_32dp" >
-                </ImageView>
+            <org.wordpress.android.widgets.NoticonTextView
+                android:id="@+id/note_icon"
+                android:background="@drawable/shape_oval_blue_white_stroke"
+                android:gravity="center"
+                android:layout_height="@dimen/note_icon_sz"
+                android:layout_marginStart="31dp"
+                android:layout_marginTop="35dp"
+                android:layout_width="@dimen/note_icon_sz"
+                android:textColor="@color/white"
+                android:textSize="14sp"
+                tools:text="@string/noticon_note" >
+            </org.wordpress.android.widgets.NoticonTextView>
 
-                <org.wordpress.android.widgets.NoticonTextView
-                    android:id="@+id/note_icon"
-                    android:background="@drawable/shape_oval_blue_white_stroke"
-                    android:gravity="center"
-                    android:layout_height="@dimen/note_icon_sz"
-                    android:layout_marginStart="31dp"
-                    android:layout_marginTop="35dp"
-                    android:layout_width="@dimen/note_icon_sz"
-                    android:textColor="@color/white"
-                    android:textSize="14sp"
-                    tools:text="@string/noticon_note" >
-                </org.wordpress.android.widgets.NoticonTextView>
+        </FrameLayout>
 
-            </FrameLayout>
-
-            <LinearLayout
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_width="fill_parent"
-                android:orientation="vertical" >
-
-                <FrameLayout
-                    android:layout_height="wrap_content"
-                    android:layout_width="match_parent" >
-
-                    <org.wordpress.android.widgets.NoticonTextView
-                        android:id="@+id/note_subject_noticon"
-                        android:gravity="start"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_extra_small"
-                        android:layout_width="wrap_content"
-                        android:textAlignment="viewStart"
-                        android:textColor="@color/grey_darken_10"
-                        android:textSize="@dimen/text_sz_larger" >
-                    </org.wordpress.android.widgets.NoticonTextView>
-
-                    <org.wordpress.android.widgets.WPTextView
-                        android:id="@+id/note_subject"
-                        android:ellipsize="end"
-                        android:gravity="start"
-                        android:layout_height="wrap_content"
-                        android:layout_width="fill_parent"
-                        android:maxLines="2"
-                        android:textAlignment="viewStart"
-                        android:textColor="@color/grey_dark"
-                        android:textSize="@dimen/text_sz_large"
-                        tools:text="Bob Ross commented on your post Happy Trees" >
-                    </org.wordpress.android.widgets.WPTextView>
-
-                </FrameLayout>
-
-                <org.wordpress.android.widgets.WPTextView
-                    android:id="@+id/note_detail"
-                    android:ellipsize="end"
-                    android:importantForAccessibility="no"
-                    android:maxLines="2"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="-1dp"
-                    android:layout_width="wrap_content"
-                    android:textColor="@color/grey_darken_10"
-                    android:textSize="@dimen/text_sz_large"
-                    android:visibility="gone"
-                    tools:text="What an amazing post!"
-                    tools:visibility="visible" >
-                </org.wordpress.android.widgets.WPTextView>
-
-            </LinearLayout>
-
-        </LinearLayout>
-
-        <View
-            android:background="@color/grey_lighten_30"
-            android:layout_height="@dimen/list_divider_height"
+        <FrameLayout
+            android:id="@+id/note_subject_container"
+            android:layout_toEndOf="@+id/note_avatar_container"
+            android:layout_height="wrap_content"
             android:layout_width="match_parent" >
-        </View>
 
-    </LinearLayout>
+            <org.wordpress.android.widgets.NoticonTextView
+                android:id="@+id/note_subject_noticon"
+                android:gravity="start"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_extra_small"
+                android:layout_width="wrap_content"
+                android:textAlignment="viewStart"
+                android:textColor="@color/grey_darken_10"
+                android:textSize="@dimen/text_sz_larger" >
+            </org.wordpress.android.widgets.NoticonTextView>
 
-</LinearLayout>
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/note_subject"
+                android:ellipsize="end"
+                android:gravity="start"
+                android:layout_height="wrap_content"
+                android:layout_width="fill_parent"
+                android:maxLines="2"
+                android:textAlignment="viewStart"
+                android:textColor="@color/grey_dark"
+                android:textSize="@dimen/text_sz_large"
+                tools:text="Bob Ross commented on your post Happy Trees" >
+            </org.wordpress.android.widgets.WPTextView>
+
+        </FrameLayout>
+
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/note_detail"
+            android:ellipsize="end"
+            android:importantForAccessibility="no"
+            android:maxLines="2"
+            android:layout_below="@+id/note_subject_container"
+            android:layout_height="wrap_content"
+            android:layout_toEndOf="@+id/note_avatar_container"
+            android:layout_width="wrap_content"
+            android:textColor="@color/grey_darken_10"
+            android:textSize="@dimen/text_sz_large"
+            android:visibility="gone"
+            tools:text="What an amazing post!"
+            tools:visibility="visible" >
+        </org.wordpress.android.widgets.WPTextView>
+
+    </RelativeLayout>
+
+    <View
+        android:background="@color/grey_lighten_30"
+        android:layout_below="@+id/note_content_container"
+        android:layout_height="@dimen/list_divider_height"
+        android:layout_width="match_parent" >
+    </View>
+
+</RelativeLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -105,6 +105,7 @@
     <dimen name="text_sz_small">12sp</dimen>
     <dimen name="text_sz_medium">14sp</dimen>
     <dimen name="text_sz_large">16sp</dimen>
+    <dimen name="text_sz_larger">18sp</dimen>
     <dimen name="text_sz_extra_large">20sp</dimen>
     <dimen name="text_sz_double_extra_large">24sp</dimen>
     <dimen name="text_sz_triple_extra_large">26sp</dimen>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1729,10 +1729,6 @@
     <string name="previous_button" translatable="false">&lt;</string>
     <string name="next_button" translatable="false">&gt;</string>
 
-    <!-- Noticons -->
-    <string name="noticon_clock" translatable="false">\uf303</string>
-    <string name="noticon_note" translatable="false">\uf814</string>
-
     <!-- Publicize and sharing -->
     <string name="sharing">Sharing</string>
     <string name="sharing_disabled">Sharing module disabled</string>

--- a/WordPress/src/main/res/values/styles_calypso.xml
+++ b/WordPress/src/main/res/values/styles_calypso.xml
@@ -103,12 +103,6 @@
         <item name="android:textColor">@color/grey_dark</item>
     </style>
 
-    <style name="Calypso.Text.Header" parent="android:Widget.TextView">
-        <item name="android:textSize">@dimen/text_sz_medium</item>
-        <item name="android:textColor">@color/grey_darken_10</item>
-        <item name="android:textStyle">bold</item>
-    </style>
-
     <style name="Calypso.SegmentedControl" parent="Widget.AppCompat.CompoundButton.RadioButton">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>


### PR DESCRIPTION
### Fix
Update the **_Notifications_** tab layout to use the new list style from **_Activity Log_** and **_History_**.  The list item layout was also reduced from four to two view layers for better performance.  See the screenshots below for illustration.

![notifications_list](https://user-images.githubusercontent.com/3827611/50379363-5e245f80-0616-11e9-8449-899954c0a367.png)

### Test
1. Go to **_Notifications_** tab.
2. Notice list layout as shown in screenshots above.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
The `RELEASE-NOTES.txt` document was updated in adaed9a with the following:
<blockquote>
Update the Notifications list layout for better readability
</blockquote>