### PR TITLE
InstallationReferrerService: add permission

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -652,8 +652,10 @@
 
         <service
             android:name=".util.analytics.service.InstallationReferrerService"
-            android:exported="false"
+            android:exported="true"
+            android:permission="com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE"
             android:label="Installation Referrer Service" />
+
         <service
             android:name=".util.analytics.service.InstallationReferrerJobService"
             android:permission="android.permission.BIND_JOB_SERVICE"


### PR DESCRIPTION
Fixes #8830  

Comes from https://github.com/wordpress-mobile/WordPress-Android/issues/8830#issuecomment-449858737

This PR makes the following modifications to the `AndroidManifest`, as per @theck13 's suggestion:
1. add `android:exported="true"` to make it available,  and 
2. add `android:permission="com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE"`  to restrict it to only be called from the vending app. 

To test:

To test @jkmassel , we'd need to deliver a new alpha (or something even more reduced if possible) through Google Play and try (that's the only way to test that path as it's not possible to issue 3rd party app intents artificially even from `adb` connected through USB, for security reasons).


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
