### PR TITLE
Site Creation: Handle the case in which the site is created but couldn't be fetched

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -312,19 +312,14 @@ public class SitePickerActivity extends AppCompatActivity
         } else if (getIntent() != null) {
             mCurrentLocalId = getIntent().getIntExtra(KEY_LOCAL_ID, 0);
             siteCreatedButNotFetched = getIntent().getBooleanExtra(KEY_SITE_CREATED_BUT_NOT_FETCHED, false);
+            // Make sure we only handle this extra once
+            getIntent().removeExtra(KEY_SITE_CREATED_BUT_NOT_FETCHED);
         }
 
         setNewAdapter(lastSearch, isInSearchMode);
         if (siteCreatedButNotFetched) {
             showSiteCreatedButNotFetchedSnackbar();
         }
-    }
-
-    private void showSiteCreatedButNotFetchedSnackbar() {
-        int duration = AccessibilityUtils
-                .getSnackbarDuration(this, getResources().getInteger(R.integer.site_creation_snackbar_duration));
-        String message = getString(R.string.site_created_but_not_fetched_snackbar_message);
-        WPDialogSnackbar.make(findViewById(R.id.coordinatorLayout), message, duration).show();
     }
 
     private void setupActionBar() {
@@ -698,5 +693,12 @@ public class SitePickerActivity extends AppCompatActivity
         dialogBuilder.setNegativeButton(getResources().getText(R.string.no), null);
         dialogBuilder.setCancelable(false);
         dialogBuilder.create().show();
+    }
+
+    private void showSiteCreatedButNotFetchedSnackbar() {
+        int duration = AccessibilityUtils
+                .getSnackbarDuration(this, getResources().getInteger(R.integer.site_creation_snackbar_duration));
+        String message = getString(R.string.site_created_but_not_fetched_snackbar_message);
+        WPDialogSnackbar.make(findViewById(R.id.coordinatorLayout), message, duration).show();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -206,15 +206,16 @@ public class SitePickerActivity extends AppCompatActivity
             case RequestCodes.CREATE_SITE:
                 if (resultCode == RESULT_OK) {
                     debounceLoadSites();
-
                     if (data == null) {
                         data = new Intent();
                     }
-
-                    data.putExtra(WPMainActivity.ARG_CREATE_SITE, RequestCodes.CREATE_SITE);
-
-                    setResult(resultCode, data);
-                    finish();
+                    if (data.getBooleanExtra(KEY_SITE_CREATED_BUT_NOT_FETCHED, false)) {
+                        showSiteCreatedButNotFetchedSnackbar();
+                    } else {
+                        data.putExtra(WPMainActivity.ARG_CREATE_SITE, RequestCodes.CREATE_SITE);
+                        setResult(resultCode, data);
+                        finish();
+                    }
                 }
                 break;
         }
@@ -302,7 +303,6 @@ public class SitePickerActivity extends AppCompatActivity
 
     private void restoreSavedInstanceState(Bundle savedInstanceState) {
         boolean isInSearchMode = false;
-        boolean siteCreatedButNotFetched = false;
         String lastSearch = "";
 
         if (savedInstanceState != null) {
@@ -311,15 +311,9 @@ public class SitePickerActivity extends AppCompatActivity
             lastSearch = savedInstanceState.getString(KEY_LAST_SEARCH);
         } else if (getIntent() != null) {
             mCurrentLocalId = getIntent().getIntExtra(KEY_LOCAL_ID, 0);
-            siteCreatedButNotFetched = getIntent().getBooleanExtra(KEY_SITE_CREATED_BUT_NOT_FETCHED, false);
-            // Make sure we only handle this extra once
-            getIntent().removeExtra(KEY_SITE_CREATED_BUT_NOT_FETCHED);
         }
 
         setNewAdapter(lastSearch, isInSearchMode);
-        if (siteCreatedButNotFetched) {
-            showSiteCreatedButNotFetchedSnackbar();
-        }
     }
 
     private void setupActionBar() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -47,6 +47,7 @@ import org.wordpress.android.ui.main.SitePickerAdapter.SiteList;
 import org.wordpress.android.ui.main.SitePickerAdapter.SiteRecord;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.stats.datasets.StatsTable;
+import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DeviceUtils;
@@ -56,6 +57,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.Debouncer;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
+import org.wordpress.android.widgets.WPDialogSnackbar;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -72,6 +74,7 @@ public class SitePickerActivity extends AppCompatActivity
         SitePickerAdapter.OnSelectedCountChangedListener,
         SearchView.OnQueryTextListener {
     public static final String KEY_LOCAL_ID = "local_id";
+    public static final String KEY_SITE_CREATED_BUT_NOT_FETCHED = "key_site_created_but_not_fetched";
     private static final String KEY_IS_IN_SEARCH_MODE = "is_in_search_mode";
     private static final String KEY_LAST_SEARCH = "last_search";
     private static final String KEY_REFRESHING = "refreshing_sites";
@@ -299,6 +302,7 @@ public class SitePickerActivity extends AppCompatActivity
 
     private void restoreSavedInstanceState(Bundle savedInstanceState) {
         boolean isInSearchMode = false;
+        boolean siteCreatedButNotFetched = false;
         String lastSearch = "";
 
         if (savedInstanceState != null) {
@@ -307,9 +311,20 @@ public class SitePickerActivity extends AppCompatActivity
             lastSearch = savedInstanceState.getString(KEY_LAST_SEARCH);
         } else if (getIntent() != null) {
             mCurrentLocalId = getIntent().getIntExtra(KEY_LOCAL_ID, 0);
+            siteCreatedButNotFetched = getIntent().getBooleanExtra(KEY_SITE_CREATED_BUT_NOT_FETCHED, false);
         }
 
         setNewAdapter(lastSearch, isInSearchMode);
+        if (siteCreatedButNotFetched) {
+            showSiteCreatedButNotFetchedSnackbar();
+        }
+    }
+
+    private void showSiteCreatedButNotFetchedSnackbar() {
+        int duration = AccessibilityUtils
+                .getSnackbarDuration(this, getResources().getInteger(R.integer.site_creation_snackbar_duration));
+        String message = getString(R.string.site_created_but_not_fetched_snackbar_message);
+        WPDialogSnackbar.make(findViewById(R.id.coordinatorLayout), message, duration).show();
     }
 
     private void setupActionBar() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
@@ -68,18 +68,19 @@ class NewSiteCreationActivity : AppCompatActivity(),
         mainViewModel.wizardFinishedObservable.observe(this, Observer { createSiteState ->
             createSiteState?.let {
                 val intent = Intent()
-                val localSiteId = when (createSiteState) {
-                    is SiteNotCreated -> null // site creation flow was canceled
+                val (siteCreated, localSiteId) = when (createSiteState) {
+                    // site creation flow was canceled
+                    is SiteNotCreated -> Pair(false, null)
                     is SiteNotInLocalDb -> {
                         // Site was created, but we haven't been able to fetch it, let `SitePickerActivity` handle
                         // this with a Snackbar message.
                         intent.putExtra(SitePickerActivity.KEY_SITE_CREATED_BUT_NOT_FETCHED, true)
-                        null
+                        Pair(true, null)
                     }
-                    is SiteCreationCompleted -> createSiteState.localSiteId
+                    is SiteCreationCompleted -> Pair(true, createSiteState.localSiteId)
                 }
                 intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, localSiteId)
-                setResult(Activity.RESULT_OK, intent)
+                setResult(if (siteCreated) Activity.RESULT_OK else Activity.RESULT_CANCELED, intent)
                 finish()
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
@@ -69,8 +69,13 @@ class NewSiteCreationActivity : AppCompatActivity(),
             createSiteState?.let {
                 val intent = Intent()
                 val localSiteId = when (createSiteState) {
-                    // TODO will be handled correctly in #8822
-                    is SiteNotCreated, is SiteNotInLocalDb -> null
+                    is SiteNotCreated -> null // site creation flow was canceled
+                    is SiteNotInLocalDb -> {
+                        // Site was created, but we haven't been able to fetch it, let `SitePickerActivity` handle
+                        // this with a Snackbar message.
+                        intent.putExtra(SitePickerActivity.KEY_SITE_CREATED_BUT_NOT_FETCHED, true)
+                        null
+                    }
                     is SiteCreationCompleted -> createSiteState.localSiteId
                 }
                 intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, localSiteId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationPreviewFragment.kt
@@ -159,8 +159,8 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment<NewSiteCr
     }
 
     private fun initCancelWizardButton() {
-        val retryBtn = fullscreenErrorLayout.findViewById<View>(R.id.cancel_wizard_button)
-        retryBtn.setOnClickListener { viewModel.onCancelWizardClicked() }
+        val cancelBtn = fullscreenErrorLayout.findViewById<View>(R.id.cancel_wizard_button)
+        cancelBtn.setOnClickListener { viewModel.onCancelWizardClicked() }
     }
 
     private fun initOkButton() {

--- a/WordPress/src/main/res/layout/site_picker_activity.xml
+++ b/WordPress/src/main/res/layout/site_picker_activity.xml
@@ -1,43 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<RelativeLayout
+<android.support.design.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinatorLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <org.wordpress.android.ui.ActionableEmptyView
-        android:id="@+id/actionable_empty_view"
-        android:layout_height="match_parent"
-        android:layout_width="match_parent"
-        android:visibility="gone"
-        app:aevTitle="@string/site_picker_remove_site_empty"
-        tools:visibility="visible" >
-    </org.wordpress.android.ui.ActionableEmptyView>
-
-    <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
-        android:id="@+id/ptr_layout"
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <android.support.v7.widget.RecyclerView
-            android:id="@+id/recycler_view"
+        <org.wordpress.android.ui.ActionableEmptyView
+            android:id="@+id/actionable_empty_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:clipToPadding="false"
-            android:paddingTop="@dimen/margin_medium"
-            android:scrollbars="vertical" />
+            android:visibility="gone"
+            app:aevTitle="@string/site_picker_remove_site_empty"
+            tools:visibility="visible">
+        </org.wordpress.android.ui.ActionableEmptyView>
 
-    </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
+        <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
+            android:id="@+id/ptr_layout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
-    <ProgressBar
-        android:id="@+id/progress"
-        style="?android:attr/progressBarStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:visibility="gone"
-        tools:visibility="visible" />
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/recycler_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:paddingTop="@dimen/margin_medium"
+                android:scrollbars="vertical"/>
 
-</RelativeLayout>
+        </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
+
+        <ProgressBar
+            android:id="@+id/progress"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:visibility="gone"
+            tools:visibility="visible"/>
+    </RelativeLayout>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/values/integers.xml
+++ b/WordPress/src/main/res/values/integers.xml
@@ -40,4 +40,7 @@
     <!-- Stats -->
     <integer name="stats_number_of_columns">1</integer>
 
+    <!--Site Creation-->
+    <integer name="site_creation_snackbar_duration">5000</integer>
+
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2467,4 +2467,5 @@
     <string name="notification_new_site_creation_failed">There was a problem</string>
     <string name="notification_new_site_creation_creating_site_subtitle">We\'re creating your new site</string>
     <string name="cancel_new_site_wizard_content_description">Cancel Site Creation Wizard</string>
+    <string name="site_created_but_not_fetched_snackbar_message">It seems like you\'re on a slow connection. If you don\'t see your new site in the list, try refreshing.</string>
 </resources>


### PR DESCRIPTION
Fixes #8822. This PR handles a specific case in which the site is created successfully using the new site creation flow, but we fail to fetch a copy of it, so can't select it when the flow is done. This case will only happen if the fetch fails 3 times since we have retry mechanism.

As described in #8822, we'll handle this case by showing a snackbar in the site picker page which lets the user that they might need to refresh their site list for the new site to show up.

I can't say that I am 100% happy about the solution we are going for here, but one of the requirements of this site creation project is to make sure that the old flow is not touched. This particular approach is picked because it's non-invasive and shouldn't affect the current flow.

We'll be doing a full design review at the end of site creation project, so a design review is not required for this PR.

Here is a gif showcasing this case: https://cloudup.com/cLoju7Eif6D

**To test:**
* Apply the diff in the bottom to simulate a fetch site error
* Create a site by following the steps as shown in the gif: (Tap on + in the site picker, create a WordPress.com site, pick any segment, select a vertical or simply skip, fill details of the site or simply skip, pick a domain and create the site)
* Tap `OK` on the site preview page
* Verify that you land on the site picker page and a snackbar is shown telling you that you might need to refresh your list due to a possible slow connection

One reviewer should be enough for this PR, I only asked two developers so whoever is available can take it.

```
diff --git a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/creation/FetchWpComSiteUseCase.kt b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/creation/FetchWpComSiteUseCase.kt
index ad9134ba25..559c52227c 100644
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/creation/FetchWpComSiteUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/creation/FetchWpComSiteUseCase.kt
@@ -4,13 +4,13 @@ import kotlinx.coroutines.experimental.delay
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
+import org.wordpress.android.fluxc.store.SiteStore.SiteError
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import javax.inject.Inject
 import kotlin.coroutines.experimental.Continuation
-import kotlin.coroutines.experimental.suspendCoroutine
 
 private const val FETCH_SITE_BASE_RETRY_DELAY_IN_MILLIS = 1000
 private const val DEFAULT_NUMBER_OF_RETRIES = 3
@@ -42,10 +42,13 @@ class FetchWpComSiteUseCase @Inject constructor(
     }
 
     private suspend fun fetchSite(siteId: Long): OnSiteChanged {
-        return suspendCoroutine { cont ->
-            continuation = cont
-            dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(createWpComSiteModel(siteId)))
-        }
+        val event = OnSiteChanged(0)
+        event.error = SiteError(SiteErrorType.GENERIC_ERROR)
+        return event
+//        return suspendCoroutine { cont ->
+//            continuation = cont
+//            dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(createWpComSiteModel(siteId)))
+//        }
     }
 
     private fun createWpComSiteModel(siteId: Long): SiteModel {

```