### PR TITLE
Site Creation: Add a timeout to preload of preview WebView

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationPreviewFragment.kt
@@ -358,7 +358,7 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment<NewSiteCr
 private class PreviewWebViewClient internal constructor(
     val pageLoadedListener: PageFullyLoadedListener,
     siteAddress: String
-) : URLFilteredWebViewClient(siteAddress) {
+) : URLFilteredWebViewClient(siteAddress, false) {
     interface PageFullyLoadedListener {
         fun onPageFullyLoaded()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationPreviewFragment.kt
@@ -20,6 +20,7 @@ import android.view.ViewGroup
 import android.view.animation.DecelerateInterpolator
 import android.webkit.WebView
 import android.widget.TextView
+import com.facebook.shimmer.ShimmerFrameLayout
 import kotlinx.android.synthetic.main.new_site_creation_preview_screen.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -53,6 +54,7 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment<NewSiteCr
     private lateinit var fullscreenProgressLayout: ViewGroup
     private lateinit var contentLayout: ViewGroup
     private lateinit var sitePreviewWebView: WebView
+    private lateinit var sitePreviewWebViewShimmerLayout: ShimmerFrameLayout
     private lateinit var sitePreviewWebUrlTitle: TextView
 
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
@@ -92,6 +94,7 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment<NewSiteCr
         fullscreenProgressLayout = rootView.findViewById(R.id.progress_layout)
         contentLayout = rootView.findViewById(R.id.content_layout)
         sitePreviewWebView = rootView.findViewById(R.id.sitePreviewWebView)
+        sitePreviewWebViewShimmerLayout = rootView.findViewById(R.id.sitePreviewWebViewShimmerLayout)
         sitePreviewWebUrlTitle = rootView.findViewById(R.id.sitePreviewWebUrlTitle)
         initViewModel()
         initRetryButton()
@@ -106,7 +109,7 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment<NewSiteCr
         viewModel.uiState.observe(this, Observer { uiState ->
             uiState?.let {
                 when (uiState) {
-                    is SitePreviewContentUiState-> updateContentLayout(uiState.data)
+                    is SitePreviewContentUiState -> updateContentLayout(uiState.data)
                     is SitePreviewLoadingShimmerState -> updateContentLayout(uiState.data)
                     is SitePreviewFullscreenProgressUiState -> updateLoadingLayout(uiState)
                     is SitePreviewFullscreenErrorUiState -> updateErrorLayout(uiState)
@@ -130,7 +133,7 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment<NewSiteCr
         viewModel.startCreateSiteService.observe(this, Observer { startServiceData ->
             startServiceData?.let {
                 NewSiteCreationService.createSite(
-                        activity!!,
+                        requireNotNull(activity),
                         startServiceData.previousState,
                         startServiceData.serviceData
                 )
@@ -148,6 +151,9 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment<NewSiteCr
             createSiteState?.let {
                 sitePreviewScreenListener.onSitePreviewScreenDismissed(createSiteState)
             }
+        })
+        viewModel.toastMessage.observe(this, Observer {
+            it?.show(requireNotNull(activity))
         })
 
         viewModel.start(arguments!![ARG_DATA] as SiteCreationState)
@@ -175,7 +181,12 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment<NewSiteCr
 
     private fun updateContentLayout(sitePreviewData: SitePreviewData) {
         sitePreviewData.apply {
-            sitePreviewWebUrlTitle.text = createSpannableUrl(activity!!, shortUrl, subDomainIndices, domainIndices)
+            sitePreviewWebUrlTitle.text = createSpannableUrl(
+                    requireNotNull(activity),
+                    shortUrl,
+                    subDomainIndices,
+                    domainIndices
+            )
         }
         // The view is about to become visible
         if (contentLayout.visibility == View.GONE) {
@@ -213,7 +224,7 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment<NewSiteCr
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        (activity!!.application as WordPress).component().inject(this)
+        (requireNotNull(activity).application as WordPress).component().inject(this)
         if (savedInstanceState == null) {
             // we need to manually clear the NewSiteCreationService state so we don't for example receive sticky events
             // from the previous run of the SiteCreation flow.

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationPreviewFragment.kt
@@ -24,9 +24,11 @@ import kotlinx.android.synthetic.main.new_site_creation_preview_screen.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.accounts.HelpActivity
+import org.wordpress.android.ui.sitecreation.NewSitePreviewViewModel.SitePreviewData
 import org.wordpress.android.ui.sitecreation.NewSitePreviewViewModel.SitePreviewUiState.SitePreviewContentUiState
 import org.wordpress.android.ui.sitecreation.NewSitePreviewViewModel.SitePreviewUiState.SitePreviewFullscreenErrorUiState
 import org.wordpress.android.ui.sitecreation.NewSitePreviewViewModel.SitePreviewUiState.SitePreviewFullscreenProgressUiState
+import org.wordpress.android.ui.sitecreation.NewSitePreviewViewModel.SitePreviewUiState.SitePreviewLoadingShimmerState
 import org.wordpress.android.ui.sitecreation.PreviewWebViewClient.PageFullyLoadedListener
 import org.wordpress.android.ui.sitecreation.creation.NewSiteCreationService
 import org.wordpress.android.ui.sitecreation.creation.SitePreviewScreenListener
@@ -104,12 +106,15 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment<NewSiteCr
         viewModel.uiState.observe(this, Observer { uiState ->
             uiState?.let {
                 when (uiState) {
-                    is SitePreviewContentUiState -> updateContentLayout(uiState)
+                    is SitePreviewContentUiState-> updateContentLayout(uiState.data)
+                    is SitePreviewLoadingShimmerState -> updateContentLayout(uiState.data)
                     is SitePreviewFullscreenProgressUiState -> updateLoadingLayout(uiState)
                     is SitePreviewFullscreenErrorUiState -> updateErrorLayout(uiState)
                 }
                 updateVisibility(fullscreenProgressLayout, uiState.fullscreenProgressLayoutVisibility)
                 updateVisibility(contentLayout, uiState.contentLayoutVisibility)
+                updateVisibility(sitePreviewWebView, uiState.webViewVisibility)
+                updateVisibility(sitePreviewWebViewShimmerLayout, uiState.shimmerVisibility)
                 updateVisibility(fullscreenErrorLayout, uiState.fullscreenErrorLayoutVisibility)
             }
         })
@@ -168,8 +173,8 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment<NewSiteCr
         okBtn.setOnClickListener { viewModel.onOkButtonClicked() }
     }
 
-    private fun updateContentLayout(uiState: SitePreviewContentUiState) {
-        uiState.data.apply {
+    private fun updateContentLayout(sitePreviewData: SitePreviewData) {
+        sitePreviewData.apply {
             sitePreviewWebUrlTitle.text = createSpannableUrl(activity!!, shortUrl, subDomainIndices, domainIndices)
         }
         // The view is about to become visible

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSitePreviewViewModel.kt
@@ -29,8 +29,10 @@ import org.wordpress.android.ui.sitecreation.creation.NewSiteCreationServiceStat
 import org.wordpress.android.ui.sitecreation.creation.NewSiteCreationServiceState.NewSiteCreationStep.IDLE
 import org.wordpress.android.ui.sitecreation.creation.NewSiteCreationServiceState.NewSiteCreationStep.SUCCESS
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.util.UrlUtils
 import org.wordpress.android.viewmodel.SingleLiveEvent
+import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.experimental.CoroutineContext
@@ -77,6 +79,9 @@ class NewSitePreviewViewModel @Inject constructor(
 
     private val _onOkButtonClicked = SingleLiveEvent<CreateSiteState>()
     val onOkButtonClicked: LiveData<CreateSiteState> = _onOkButtonClicked
+
+    private val _toastMessage = SingleLiveEvent<ToastMessageHolder>()
+    val toastMessage: LiveData<ToastMessageHolder> = _toastMessage
 
     init {
         dispatcher.register(fetchWpComSiteUseCase)
@@ -191,11 +196,15 @@ class NewSitePreviewViewModel @Inject constructor(
 
     private fun startPreLoadingWebView() {
         launch(IO) {
-            // Keep showing the full screen loading screen for 1 more second or until the webview is loaded whichever
-            // happens first. This will give us some more time to fetch the newly created site.
+            /**
+             * Keep showing the full screen loading screen for 1 more second or until the webview is loaded whichever
+             * happens first. This will give us some more time to fetch the newly created site.
+             */
             delay(DELAY_TO_SHOW_WEB_VIEW_LOADING_SHIMMER)
-            // If the webview is still not loaded after some delay, we'll show the loading shimmer animation instead
-            // of the full screen progress, so the user is not blocked for taking actions.
+            /**
+             * If the webview is still not loaded after some delay, we'll show the loading shimmer animation instead
+             * of the full screen progress, so the user is not blocked for taking actions.
+             */
             withContext(MAIN) {
                 if (uiState.value !is SitePreviewContentUiState) {
                     updateUiState(SitePreviewLoadingShimmerState(createSitePreviewData()))
@@ -214,6 +223,7 @@ class NewSitePreviewViewModel @Inject constructor(
          */
         if (uiState.value !is SitePreviewContentUiState) {
             updateUiState(SitePreviewContentUiState(createSitePreviewData()))
+            _toastMessage.value = ToastMessageHolder(R.string.preview_screen_links_disabled, Duration.SHORT)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSitePreviewViewModel.kt
@@ -242,34 +242,24 @@ class NewSitePreviewViewModel @Inject constructor(
     }
 
     sealed class SitePreviewUiState(
-        val fullscreenProgressLayoutVisibility: Boolean,
-        val contentLayoutVisibility: Boolean,
-        val webViewVisibility: Boolean,
-        val shimmerVisibility: Boolean,
-        val fullscreenErrorLayoutVisibility: Boolean
+        val fullscreenProgressLayoutVisibility: Boolean = false,
+        val contentLayoutVisibility: Boolean = false,
+        val webViewVisibility: Boolean = false,
+        val shimmerVisibility: Boolean = false,
+        val fullscreenErrorLayoutVisibility: Boolean = false
     ) {
         data class SitePreviewContentUiState(val data: SitePreviewData) : SitePreviewUiState(
-                fullscreenProgressLayoutVisibility = false,
                 contentLayoutVisibility = true,
-                webViewVisibility = true,
-                shimmerVisibility = false,
-                fullscreenErrorLayoutVisibility = false
+                webViewVisibility = true
         )
 
         data class SitePreviewLoadingShimmerState(val data: SitePreviewData) : SitePreviewUiState(
-                fullscreenProgressLayoutVisibility = false,
                 contentLayoutVisibility = true,
-                webViewVisibility = false,
-                shimmerVisibility = true,
-                fullscreenErrorLayoutVisibility = false
+                shimmerVisibility = true
         )
 
         object SitePreviewFullscreenProgressUiState : SitePreviewUiState(
-                fullscreenProgressLayoutVisibility = true,
-                contentLayoutVisibility = false,
-                webViewVisibility = false,
-                shimmerVisibility = false,
-                fullscreenErrorLayoutVisibility = false
+                fullscreenProgressLayoutVisibility = true
         ) {
             const val loadingTextResId = R.string.notification_new_site_creation_creating_site_subtitle
         }
@@ -280,10 +270,6 @@ class NewSitePreviewViewModel @Inject constructor(
             val showContactSupport: Boolean = false,
             val showCancelWizardButton: Boolean = true
         ) : SitePreviewUiState(
-                fullscreenProgressLayoutVisibility = false,
-                contentLayoutVisibility = false,
-                webViewVisibility = false,
-                shimmerVisibility = false,
                 fullscreenErrorLayoutVisibility = true
         ) {
             object SitePreviewGenericErrorUiState :

--- a/WordPress/src/main/java/org/wordpress/android/util/URLFilteredWebViewClient.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/URLFilteredWebViewClient.java
@@ -18,12 +18,18 @@ import java.util.Set;
 public class URLFilteredWebViewClient extends WebViewClient {
     private Set<String> mAllowedURLs = new LinkedHashSet<>();
     private int mLinksDisabledMessageResId = org.wordpress.android.R.string.preview_screen_links_disabled;
+    private boolean mShouldDisplayLinksDisabledToast = true;
 
     public URLFilteredWebViewClient() {
     }
 
     public URLFilteredWebViewClient(String url) {
+        this(url, true);
+    }
+
+    public URLFilteredWebViewClient(String url, boolean shouldDisplayLinksDisabledToast) {
         mAllowedURLs.add(url);
+        mShouldDisplayLinksDisabledToast = shouldDisplayLinksDisabledToast;
     }
 
     public URLFilteredWebViewClient(Collection<String> urls) {
@@ -49,7 +55,7 @@ public class URLFilteredWebViewClient extends WebViewClient {
 
         if (isAllURLsAllowed() || mAllowedURLs.contains(url)) {
             view.loadUrl(url);
-        } else {
+        } else if (mShouldDisplayLinksDisabledToast) {
             // show "links are disabled" message.
             Context ctx = WordPress.getContext();
             Toast.makeText(ctx, ctx.getText(mLinksDisabledMessageResId), Toast.LENGTH_SHORT).show();

--- a/WordPress/src/main/res/layout/new_site_creation_preview_screen.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_preview_screen.xml
@@ -76,6 +76,12 @@
                     android:layout_height="match_parent"
                     android:layout_marginBottom="@dimen/margin_medium"
                     android:scrollbarStyle="insideInset"/>
+
+                <com.facebook.shimmer.ShimmerFrameLayout
+                    android:id="@+id/sitePreviewWebViewShimmerLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="@color/wp_grey_lighten_30"/>
             </LinearLayout>
         </android.support.v7.widget.CardView>
 


### PR DESCRIPTION
Fixes #8824. When a new site is created, we'll try to load it in a webview in the background before we show it to the user. This could technically take a lot of time and the user could get stuck with a full screen progress bar. To address this issue, we are adding a 1 second timeout and once it's over if the content is still not loaded, we'll show the content of the page with a shimmer animation over where the webview will appear. We are adding that 1 second delay to give us some time to fetch the newly created site, so we can select it once the flow is over.

There is a bit of moving around in this code that makes the diff larger than what it actually is (even then, it is pretty small). Here is a list of changes made:

* We are no longer relying on `URLFilteredWebViewClient` to show the `links are disabled` toast. If we did, it could show up before the content is loaded. Instead, we'll trigger a toast from the `ViewModel` once the content is loaded. We _might_ want to update the timing once we do the design review. I have added a note for this to #8864.
* We now have another `SitePreviewUiState` for the shimmer animation. We also have `boolean`s for whether the webview or the shimmer should be visible. We could make this a bit more structured by separating the content visibility to a new model, but when I tried it, it felt a bit of an overkill. If the state gets more complicated we can re-visit this.
* I have replaced the `activity!!` mentions with `requireNotNull(activity)`. It doesn't really change anything, but I feel `requireNotNull` is more meaningful than `!!` operator.

_We'll be doing a full design review at the end of site creation project, so a design review is not required for this PR._

Here is a gif that showcases the behavior where the site loads immediately in the webview: https://cloudup.com/cgWFsqk2YXp and here is another gif that shows the shimmer animation for about 2 seconds before the content shows up because of an artificial delay added with the diff in the bottom: https://cloudup.com/ct2fEkceFtg

_P.S: I think a progress bar would be better than a shimmer animation, but since the issue described it as a shimmer animation, I followed it. I did however add a note to ask about this to #8864._

**To test:**
* I suggest adding a delay to when we start loading the webview content to make it easier to follow the states. You can apply the diff in the bottom for this.
* Go to Site Picker, tap on `+` and select `Create WordPress.com site`
* Select any segment, pick a vertical or simply skip and fill in site info or simply skip
* Select a domain and create the site
* Verify that the full screen progress layout is shown first.
* Then (if you added the delay) verify that the content becomes visible with a shimmer animation over where the webview will eventually show up.
* Finally, verify that the webview is loaded correctly and your new site shows up with a toast telling you that the links are disabled. The shimmer animation should not be visible while the webview is showing.
* At any stage while the content is shown, you should be able to tap on the `OK` button even if the webview is not fully loaded.

Note that, we have a separate PR #8869 that ties to this behavior by handling the state where the site is not fetched after it's created successfully.

One reviewer should be enough for this PR, I only asked two developers so whoever is available can take it.

```
diff --git a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSitePreviewViewModel.kt b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSitePreviewViewModel.kt
index 035ae2fd82..da0eb3b61b 100644
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSitePreviewViewModel.kt
@@ -212,7 +212,10 @@ class NewSitePreviewViewModel @Inject constructor(
             }
         }
         // Load the newly created site in the webview
-        _preloadPreview.postValue(UrlUtils.addUrlSchemeIfNeeded(urlWithoutScheme, true))
+        launch(IO) {
+            delay(3000)
+            _preloadPreview.postValue(UrlUtils.addUrlSchemeIfNeeded(urlWithoutScheme, true))
+        }
     }
 
     fun onUrlLoaded() {

```