### PR TITLE
Issue/8868 site creation tagline

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteInfoFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteInfoFragment.kt
@@ -14,6 +14,7 @@ import android.support.v4.view.ViewCompat
 import android.support.v7.widget.AppCompatButton
 import android.text.Editable
 import android.text.TextWatcher
+import android.view.KeyEvent
 import android.view.ViewGroup
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -88,6 +89,11 @@ class NewSiteCreationSiteInfoFragment : NewSiteCreationBaseFormFragment<NewSiteC
         }
         addTextWatcher(siteTitleEditText) { viewModel.updateSiteTitle(it) }
         addTextWatcher(tagLineEditText) { viewModel.updateTagLine(it) }
+        tagLineEditText.setOnKeyListener { _, keyCode, _ ->
+            // Consume only Enter keyboard events.  The onKey method returns true if the listener has consumed the event
+            // and false otherwise allowing users to input anything for a tagline except newlines, which mimics the web.
+            keyCode == KeyEvent.KEYCODE_ENTER
+        }
     }
 
     private fun initViewModel() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteInfoFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationSiteInfoFragment.kt
@@ -13,9 +13,11 @@ import android.support.v4.content.ContextCompat
 import android.support.v4.view.ViewCompat
 import android.support.v7.widget.AppCompatButton
 import android.text.Editable
+import android.text.InputType
 import android.text.TextWatcher
 import android.view.KeyEvent
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.accounts.HelpActivity
@@ -94,6 +96,8 @@ class NewSiteCreationSiteInfoFragment : NewSiteCreationBaseFormFragment<NewSiteC
             // and false otherwise allowing users to input anything for a tagline except newlines, which mimics the web.
             keyCode == KeyEvent.KEYCODE_ENTER
         }
+        tagLineEditText.setRawInputType(InputType.TYPE_CLASS_TEXT)
+        tagLineEditText.imeOptions = EditorInfo.IME_ACTION_DONE
     }
 
     private fun initViewModel() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationSiteInfoViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationSiteInfoViewModel.kt
@@ -87,7 +87,7 @@ class NewSiteCreationSiteInfoViewModel @Inject constructor(
     fun onSkipNextClicked() {
         when (currentUiState.skipButtonState) {
             SKIP -> _skipBtnClicked.call()
-            NEXT -> _nextBtnClicked.value = currentUiState
+            NEXT -> _nextBtnClicked.value = removeNewlinesFromTagline()
         }
     }
 
@@ -98,6 +98,10 @@ class NewSiteCreationSiteInfoViewModel @Inject constructor(
                 _onTitleInputFocusRequested.call()
             }
         }
+    }
+
+    private fun removeNewlinesFromTagline(): SiteInfoUiState {
+        return SiteInfoUiState(currentUiState.siteTitle, currentUiState.tagLine.replace("\n", ""))
     }
 
     data class SiteInfoUiState(

--- a/WordPress/src/main/res/layout/new_site_creation_site_info_screen.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_site_info_screen.xml
@@ -92,6 +92,7 @@
                     android:layout_height="wrap_content"
                     android:backgroundTint="@color/wp_grey"
                     android:inputType="textMultiLine"
+                    android:imeOptions="actionDone"
                     android:textColor="@color/wp_grey_dark">
                 </android.support.design.widget.TextInputEditText>
             </android.support.design.widget.TextInputLayout>

--- a/WordPress/src/main/res/layout/new_site_creation_site_info_screen.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_site_info_screen.xml
@@ -91,8 +91,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:backgroundTint="@color/wp_grey"
-                    android:inputType="textMultiLine"
-                    android:imeOptions="actionDone"
                     android:textColor="@color/wp_grey_dark">
                 </android.support.design.widget.TextInputEditText>
             </android.support.design.widget.TextInputLayout>

--- a/WordPress/src/main/res/layout/new_site_creation_site_info_screen.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_site_info_screen.xml
@@ -91,8 +91,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:backgroundTint="@color/wp_grey"
-                    android:inputType="text"
-                    android:singleLine="true"
+                    android:inputType="textMultiLine"
                     android:textColor="@color/wp_grey_dark">
                 </android.support.design.widget.TextInputEditText>
             </android.support.design.widget.TextInputLayout>


### PR DESCRIPTION
### Fix
Update the _**Tagline**_ field on screen _**2 of 3**_ in the site creation flow to be a multi-line input as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8868.  See the screenshots below for illustration.

![site_creation_tagline](https://user-images.githubusercontent.com/3827611/50427218-c6ba4900-086f-11e9-85e1-d207e1033197.png)

#### Note
I'm not entirely sure the multi-line input enhancement should be added for a few reasons.  Enabling multi-line input while excluding newlines requires multiple hackish tricks, which could be buggy for some Android variations.  Screen _**2 of 3**_ supports landscape orientation, which allows users to see more of the _**Tagline**_ input without scrolling horizontally and could be sufficient.  The web uses single-line input with horizontal scrolling.

I think it would be better if we could get opinions from multiple developers and multiple designers before merging this code.

### Test
1. Go to _**Sites**_ tab.
2. Tap _**Switch Site**_ button in top card view.
3. Tap _**Add New Site**_ action in toolbar.
4. Tap _**Create WordPress.com Site**_ option in dialog.
5. Tap any site type in the list.
6. Tap _**Skip**_ button on _**1 of 3**_ screen.
7. Tap _**Tagline**_ field on _**2 of 3**_ screen.
8. Enter enough characters to wrap to second line.
9. Notice text wraps to second line.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.