### PR TITLE
Introduce GutenbergEditPostActivity

### DIFF
--- a/WordPress/lint-baseline.xml
+++ b/WordPress/lint-baseline.xml
@@ -1,23 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="4" by="lint 3.2.1">
-
-    <issue
-        id="WrongViewCast"
-        message="Unexpected cast to `EditorWebViewAbstract`: layout tag was `WebView`">
-        <location
-            file="src/main/java/org/wordpress/android/editor/EditorFragment.java"
-            line="294"/>
-        <location
-            file="src/main/java/org/wordpress/android/editor/EditorFragment.java"
-            line="294"/>
-    </issue>
+<issues format="4" by="lint 3.1.3">
 
     <issue
         id="ExifInterface"
-        message="Avoid using `android.media.ExifInterface`; use `android.support.media.ExifInterface` from the support library instead">
+        message="Avoid using `android.media.ExifInterface`; use `android.support.media.ExifInterface` from the support library instead"
+        errorLine1="import android.media.ExifInterface;"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/util/ImageUtils.java"
-            line="17"/>
+            line="17"
+            column="8"/>
     </issue>
 
     <issue
@@ -35,523 +27,455 @@
     </issue>
 
     <issue
-        id="OldTargetApi"
-        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the android.os.Build.VERSION_CODES javadoc for details.">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="OldTargetApi"
-        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the android.os.Build.VERSION_CODES javadoc for details.">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="OldTargetApi"
-        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the android.os.Build.VERSION_CODES javadoc for details.">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="OldTargetApi"
-        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the android.os.Build.VERSION_CODES javadoc for details.">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="OldTargetApi"
-        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the android.os.Build.VERSION_CODES javadoc for details.">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="OldTargetApi"
-        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the android.os.Build.VERSION_CODES javadoc for details.">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="OldTargetApi"
-        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the android.os.Build.VERSION_CODES javadoc for details.">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="Registered"
-        message="The `&lt;application> org.wordpress.android.WordPress` is not registered in the manifest">
-        <location
-            file="src/main/java/org/wordpress/android/WordPress.java"
-            line="111"/>
-    </issue>
-
-    <issue
         id="UnusedAttribute"
-        message="Attribute `drawableTint` is only used in API level 23 and higher (current min is 21)">
+        message="Attribute `drawableTint` is only used in API level 23 and higher (current min is 21)"
+        errorLine1="                android:drawableTint=&quot;@color/blue_wordpress&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/people_invite_fragment.xml"
-            line="133"/>
+            line="133"
+            column="17"/>
     </issue>
 
     <issue
         id="UnusedAttribute"
-        message="Attribute `drawableTint` is only used in API level 23 and higher (current min is 21)">
+        message="Attribute `drawableTint` is only used in API level 23 and higher (current min is 21)"
+        errorLine1="        android:drawableTint=&quot;@color/grey_text_min&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/site_creation_domain_input.xml"
-            line="16"/>
+            line="16"
+            column="9"/>
     </issue>
 
     <issue
-        id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        id="WrongCall"
+        message="Suspicious method call; should probably call &quot;`layout`&quot; rather than &quot;`onLayout`&quot;"
+        errorLine1="                    onLayout(false, getLeft(), getTop(), getRight(), getBottom());"
+        errorLine2="                    ~~~~~~~~">
         <location
-            file="src/main/java/org/wordpress/android/ui/posts/AddCategoryFragment.java"
-            line="56"/>
+            file="src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollView.java"
+            line="364"
+            column="21"/>
     </issue>
 
     <issue
         id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
-        <location
-            file="src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java"
-            line="167"/>
-    </issue>
-
-    <issue
-        id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
-        <location
-            file="src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java"
-            line="249"/>
-    </issue>
-
-    <issue
-        id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
-        <location
-            file="src/main/java/org/wordpress/android/ui/prefs/DeleteSiteDialogFragment.java"
-            line="111"/>
-    </issue>
-
-    <issue
-        id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
-        <location
-            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java"
-            line="723"/>
-    </issue>
-
-    <issue
-        id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
-        <location
-            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LinkDialogFragment.java"
-            line="29"/>
-    </issue>
-
-    <issue
-        id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
-        <location
-            file="/Users/mariozorz/proyectos/WordPress-Android/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginHttpAuthDialogFragment.java"
-            line="55"/>
-    </issue>
-
-    <issue
-        id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
-        <location
-            file="/Users/mariozorz/proyectos/WordPress-Android/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressHelpDialogFragment.java"
-            line="47"/>
-    </issue>
-
-    <issue
-        id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
-        <location
-            file="src/main/java/org/wordpress/android/ui/posts/PostSettingsInputDialogFragment.java"
-            line="85"/>
-    </issue>
-
-    <issue
-        id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
-        <location
-            file="src/main/java/org/wordpress/android/ui/prefs/ProfileInputDialogFragment.java"
-            line="49"/>
-    </issue>
-
-    <issue
-        id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
-        <location
-            file="src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserDialogFragment.java"
-            line="51"/>
-    </issue>
-
-    <issue
-        id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
-        <location
-            file="src/main/java/org/wordpress/android/ui/prefs/RelatedPostsDialog.java"
-            line="65"/>
-    </issue>
-
-    <issue
-        id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
-        <location
-            file="src/main/java/org/wordpress/android/ui/prefs/RelatedPostsDialog.java"
-            line="98"/>
-    </issue>
-
-    <issue
-        id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
-        <location
-            file="/Users/mariozorz/proyectos/WordPress-Android/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupBottomSheetDialog.java"
-            line="19"/>
-    </issue>
-
-    <issue
-        id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
-        <location
-            file="src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTimezoneDialog.java"
-            line="88"/>
-    </issue>
-
-    <issue
-        id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="    val layout = LayoutInflater.from(context).inflate(R.layout.support_email_and_name_dialog, null)"
+        errorLine2="                                                                                              ~~~~">
         <location
             file="src/main/java/org/wordpress/android/support/SupportHelper.kt"
-            line="96"/>
+            line="96"
+            column="95"/>
     </issue>
 
     <issue
         id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="        mContentView = LayoutInflater.from(view.getContext()).inflate(R.layout.dialog_snackbar, null);"
+        errorLine2="                                                                                                ~~~~">
         <location
             file="src/main/java/org/wordpress/android/widgets/WPDialogSnackbar.java"
-            line="34"/>
-    </issue>
-
-    <issue
-        id="InflateParams"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
-        <location
-            file="src/main/java/org/wordpress/android/widgets/WPPrefView.java"
-            line="396"/>
+            line="34"
+            column="97"/>
     </issue>
 
     <issue
         id="ManifestOrder"
-        message="`&lt;uses-permission>` tag appears after `&lt;application>` tag">
+        message="`&lt;uses-permission>` tag appears after `&lt;application>` tag"
+        errorLine1="    &lt;uses-permission android:name=&quot;android.permission.DISABLE_KEYGUARD&quot;/>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/debug/AndroidManifest.xml"
-            line="18"/>
+            line="18"
+            column="5"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.android.support.constraint:constraint-layout than 1.1.2 is available: 1.1.3">
+        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1"
+        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.1.2&apos;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build.gradle"/>
+            file="build.gradle"
+            line="7"
+            column="9"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.android.support:multidex than 1.0.2 is available: 1.0.3">
+        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1"
+        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.1.2&apos;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build.gradle"/>
+            file="build.gradle"
+            line="7"
+            column="9"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1">
+        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1"
+        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.1.2&apos;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build.gradle"/>
+            file="build.gradle"
+            line="7"
+            column="9"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1">
+        message="A newer version of com.android.tools.build:gradle than 3.1.3 is available: 3.2.1"
+        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.1.3&apos;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build.gradle"/>
+            file="build.gradle"
+            line="7"
+            column="9"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1">
+        message="A newer version of com.android.tools.build:gradle than 3.1.4 is available: 3.2.1"
+        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.1.4&apos;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build.gradle"/>
+            file="build.gradle"
+            line="9"
+            column="9"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1">
+        message="A newer version of com.android.tools.build:gradle than 3.1.4 is available: 3.2.1"
+        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.1.4&apos;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build.gradle"/>
+            file="build.gradle"
+            line="9"
+            column="9"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.android.tools.build:gradle than 3.1.3 is available: 3.2.1">
+        message="A newer version of com.android.tools.build:gradle than 3.1.4 is available: 3.2.1"
+        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.1.4&apos;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build.gradle"/>
+            file="build.gradle"
+            line="22"
+            column="9"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.android.tools.build:gradle than 3.1.4 is available: 3.2.1">
+        message="A newer version of com.android.support:design than 27.1.1 is available: 28.0.0"
+        errorLine1="    implementation &apos;com.android.support:design:27.1.1&apos;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build.gradle"/>
+            file="build.gradle"
+            line="23"
+            column="5"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.android.tools.build:gradle than 3.1.4 is available: 3.2.1">
+        message="A newer version of org.wordpress:utils than 1.19.0 is available: 1.22"
+        errorLine1="    implementation &apos;org.wordpress:utils:1.19.0&apos;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build.gradle"/>
+            file="build.gradle"
+            line="23"
+            column="5"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.google.android.gms:play-services-auth than 15.0.1 is available: 16.0.1">
+        message="A newer version of com.android.support:recyclerview-v7 than 27.1.1 is available: 28.0.0"
+        errorLine1="    implementation &apos;com.android.support:recyclerview-v7:27.1.1&apos;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build.gradle"/>
+            file="build.gradle"
+            line="24"
+            column="5"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.google.android.gms:play-services-auth than 15.0.1 is available: 16.0.1">
+        message="A newer version of org.wordpress:utils than 1.18.1 is available: 1.22"
+        errorLine1="    implementation &apos;org.wordpress:utils:1.18.1&apos;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build.gradle"/>
+            file="build.gradle"
+            line="32"
+            column="5"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.google.android.gms:play-services-places than 15.0.1 is available: 16.0.0">
+        message="A newer version of org.wordpress:utils than 1.20.3 is available: 1.22"
+        errorLine1="    implementation (&apos;org.wordpress:utils:1.20.3&apos;) {"
+        errorLine2="    ^">
         <location
-            file="build.gradle"/>
+            file="build.gradle"
+            line="34"
+            column="5"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.google.code.gson:gson than 2.6.2 is available: 2.8.5">
+        message="A newer version of com.google.android.gms:play-services-auth than 15.0.1 is available: 16.0.1"
+        errorLine1="    api &apos;com.google.android.gms:play-services-auth:15.0.1&apos;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of com.google.code.gson:gson than 2.6.2 is available: 2.8.5">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of com.google.dexmaker:dexmaker-mockito than 1.0 is available: 1.2">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of com.google.firebase:firebase-messaging than 17.0.0 is available: 17.3.4">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of com.google.gms:google-services than 3.2.0 is available: 4.2.0">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of com.squareup.okio:okio than 1.13.0 is available: 1.14.0">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of com.squareup.okio:okio than 1.13.0 is available: 1.14.0">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of org.jetbrains.kotlin:kotlin-stdlib than 1.1.4 is available: 1.2.71">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of org.mockito:mockito-core than 1.10.19 is available: 2.20.1">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of org.objenesis:objenesis than 2.1 is available: 2.6">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of org.wordpress:utils than 1.18.1 is available: 1.22">
-        <location
-            file="build.gradle"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of org.wordpress:utils than 1.19.0 is available: 1.22">
-        <location
-            file="build.gradle"/>
+            file="build.gradle"
+            line="41"
+            column="5"/>
     </issue>
 
     <issue
         id="GradleDynamicVersion"
-        message="Avoid using + in version numbers; can lead to unpredictable and unrepeatable builds (io.fabric.tools:gradle:1.+)">
+        message="Avoid using + in version numbers; can lead to unpredictable and unrepeatable builds (com.facebook.react:react-native:+)"
+        errorLine1="    implementation &apos;com.facebook.react:react-native:+&apos;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build.gradle"/>
+            file="build.gradle"
+            line="36"
+            column="5"/>
     </issue>
 
     <issue
         id="PrivateResource"
-        message="The resource `@dimen/design_fab_size_normal` is marked as private in com.android.support:design">
+        message="The resource `@dimen/design_fab_size_normal` is marked as private in com.android.support:design"
+        errorLine1="                context.getResources().getDimensionPixelSize(android.support.design.R.dimen.design_fab_size_normal);"
+        errorLine2="                                                                                            ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/util/AniUtils.java"
-            line="86"/>
+            line="86"
+            column="93"/>
     </issue>
 
     <issue
         id="SetJavaScriptEnabled"
-        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully.">
+        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully."
+        errorLine1="                    webView.settings.javaScriptEnabled = true"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItemViewHolder.kt"
-            line="502"/>
+            line="502"
+            column="21"/>
     </issue>
 
     <issue
         id="SetJavaScriptEnabled"
-        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully.">
+        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully."
+        errorLine1="        mWebView.getSettings().setJavaScriptEnabled(true);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java"
-            line="102"/>
+            line="102"
+            column="9"/>
     </issue>
 
     <issue
         id="SetJavaScriptEnabled"
-        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully.">
+        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully."
+        errorLine1="        mWebView.getSettings().setJavaScriptEnabled(true);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/reader/ReaderVideoViewerActivity.java"
-            line="39"/>
+            line="39"
+            column="9"/>
     </issue>
 
     <issue
         id="SetJavaScriptEnabled"
-        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully.">
+        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully."
+        errorLine1="                webView.getSettings().setJavaScriptEnabled(true);"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java"
-            line="163"/>
+            line="163"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="org/jsoup/helper/HttpConnection$Response$2.class"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="org/jsoup/helper/HttpConnection$Response$2.class"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="org/jsoup/helper/HttpConnection$Response$2.class"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="org/jsoup/helper/HttpConnection$Response$2.class"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="org/jsoup/helper/HttpConnection$Response$2.class"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="org/jsoup/helper/HttpConnection$Response$2.class"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="org/jsoup/helper/HttpConnection$Response$2.class"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="org/jsoup/helper/HttpConnection$Response$2.class"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        message="Unnecessary; SDK_INT is never &lt; 21">
+        message="Unnecessary; SDK_INT is never &lt; 21"
+        errorLine1="        if (Build.VERSION.SDK_INT &lt; Build.VERSION_CODES.JELLY_BEAN_MR1) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/util/DeviceUtils.java"
-            line="52"/>
+            line="52"
+            column="13"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        message="Unnecessary; SDK_INT is always >= 21">
+        message="Unnecessary; SDK_INT is always >= 21"
+        errorLine1="        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/util/DeviceUtils.java"
-            line="144"/>
+            line="144"
+            column="13"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        message="Unnecessary; SDK_INT is never &lt; 21">
+        message="Unnecessary; SDK_INT is never &lt; 21"
+        errorLine1="        if (Build.VERSION.SDK_INT &lt; 17) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/editor/EditorFragment.java"
-            line="571"/>
+            line="571"
+            column="13"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        message="Unnecessary; SDK_INT is always >= 21">
+        message="Unnecessary; SDK_INT is always >= 21"
+        errorLine1="        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/editor/EditorFragment.java"
-            line="913"/>
+            line="913"
+            column="13"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        message="Unnecessary; SDK_INT is never &lt; 21">
+        message="Unnecessary; SDK_INT is never &lt; 21"
+        errorLine1="        if (Build.VERSION.SDK_INT &lt;= 19) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/editor/EditorWebView.java"
-            line="23"/>
+            line="23"
+            column="13"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        message="Unnecessary; SDK_INT is always >= 21">
+        message="Unnecessary; SDK_INT is always >= 21"
+        errorLine1="    private static final boolean HAS_EMOJI = SDK_INT >= VERSION_CODES.JELLY_BEAN;"
+        errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/util/EmoticonsUtils.java"
-            line="19"/>
+            line="19"
+            column="46"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        message="Unnecessary; SDK_INT is always >= 21">
+        message="Unnecessary; SDK_INT is always >= 21"
+        errorLine1="        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/horcrux/svg/GroupView.java"
+            line="146"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; SDK_INT is always >= 21"
+        errorLine1="        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;"
+        errorLine2="                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/util/MediaUtils.java"
-            line="440"/>
+            line="440"
+            column="34"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        message="Unnecessary; SDK_INT is never &lt; 21">
+        message="Unnecessary; SDK_INT is never &lt; 21"
+        errorLine1="        if (Build.VERSION.SDK_INT &lt; Build.VERSION_CODES.JELLY_BEAN_MR1) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/util/NetworkUtils.java"
-            line="79"/>
+            line="79"
+            column="13"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        message="Unnecessary; SDK_INT is always >= 21">
+        message="Unnecessary; SDK_INT is always >= 21"
+        errorLine1="        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/util/ViewUtils.java"
-            line="27"/>
+            line="27"
+            column="13"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        message="Unnecessary; SDK_INT is always >= 21">
+        message="Unnecessary; SDK_INT is always >= 21"
+        errorLine1="                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java"
-            line="104"/>
+            line="104"
+            column="21"/>
     </issue>
 
     <issue
@@ -584,3983 +508,2312 @@
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.prefs.AccountSettingsFragment.LoadSitesTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.prefs.AccountSettingsFragment.LoadSitesTask)"
+        errorLine1="    private class LoadSitesTask extends AsyncTask&lt;Void, Void, Void> {"
+        errorLine2="                  ~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java"
-            line="339"/>
+            line="339"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (anonymous android.os.AsyncTask)">
+        message="This AsyncTask class should be static or leaks might occur (anonymous android.os.AsyncTask)"
+        errorLine1="        new AsyncTask&lt;Void, Void, Bitmap>() {"
+        errorLine2="        ^">
         <location
             file="src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java"
-            line="41"/>
+            line="41"
+            column="9"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.comments.CommentAdapter.LoadCommentsTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.comments.CommentAdapter.LoadCommentsTask)"
+        errorLine1="    private class LoadCommentsTask extends AsyncTask&lt;Void, Void, Boolean> {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java"
-            line="407"/>
+            line="407"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostActivity.SavePostOnlineAndFinishTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostActivity.SavePostOnlineAndFinishTask)"
+        errorLine1="    private class SavePostOnlineAndFinishTask extends AsyncTask&lt;Void, Void, Void> {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java"
-            line="1630"/>
+            line="1630"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostActivity.SavePostLocallyAndFinishTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostActivity.SavePostLocallyAndFinishTask)"
+        errorLine1="    private class SavePostLocallyAndFinishTask extends AsyncTask&lt;Void, Void, Boolean> {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java"
-            line="1674"/>
+            line="1674"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostActivity.LoadPostContentTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostActivity.LoadPostContentTask)"
+        errorLine1="    private class LoadPostContentTask extends AsyncTask&lt;String, Spanned, Spanned> {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java"
-            line="2069"/>
+            line="2069"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostPreviewFragment.LoadPostPreviewTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostPreviewFragment.LoadPostPreviewTask)"
+        errorLine1="    private class LoadPostPreviewTask extends AsyncTask&lt;Void, Void, Spanned> {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/posts/EditPostPreviewFragment.java"
-            line="104"/>
+            line="104"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostSettingsFragment.FetchAndSetAddressAsyncTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostSettingsFragment.FetchAndSetAddressAsyncTask)"
+        errorLine1="    private class FetchAndSetAddressAsyncTask extends AsyncTask&lt;Double, Void, Address> {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java"
-            line="928"/>
+            line="928"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.GutenbergEditPostActivity.SavePostOnlineAndFinishTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.GutenbergEditPostActivity.SavePostOnlineAndFinishTask)"
+        errorLine1="    private class SavePostOnlineAndFinishTask extends AsyncTask&lt;Void, Void, Void> {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java"
-            line="1503"/>
+            line="1503"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.GutenbergEditPostActivity.SavePostLocallyAndFinishTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.GutenbergEditPostActivity.SavePostLocallyAndFinishTask)"
+        errorLine1="    private class SavePostLocallyAndFinishTask extends AsyncTask&lt;Void, Void, Boolean> {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java"
-            line="1547"/>
+            line="1547"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.editor.LegacyEditorFragment.AddMediaFileTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.editor.LegacyEditorFragment.AddMediaFileTask)"
+        errorLine1="    private class AddMediaFileTask extends AsyncTask&lt;Void, Void, WPEditImageSpan> {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java"
-            line="1059"/>
+            line="1059"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.main.MeFragment.SignOutWordPressComAsync)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.main.MeFragment.SignOutWordPressComAsync)"
+        errorLine1="    private class SignOutWordPressComAsync extends AsyncTask&lt;Void, Void, Void> {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/main/MeFragment.java"
-            line="514"/>
+            line="514"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.notifications.adapters.NotesAdapter.ReloadNotesFromDBTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.notifications.adapters.NotesAdapter.ReloadNotesFromDBTask)"
+        errorLine1="    private class ReloadNotesFromDBTask extends AsyncTask&lt;Void, Void, ArrayList&lt;Note>> {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java"
-            line="335"/>
+            line="335"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.notifications.NotificationsDetailListFragment.LoadNoteBlocksTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.notifications.NotificationsDetailListFragment.LoadNoteBlocksTask)"
+        errorLine1="    private class LoadNoteBlocksTask extends AsyncTask&lt;Void, Boolean, List&lt;NoteBlock>> {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java"
-            line="322"/>
+            line="322"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.photopicker.PhotoPickerAdapter.BuildDeviceMediaListTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.photopicker.PhotoPickerAdapter.BuildDeviceMediaListTask)"
+        errorLine1="    private class BuildDeviceMediaListTask extends AsyncTask&lt;Void, Void, Boolean> {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java"
-            line="411"/>
+            line="411"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.uploads.PostUploadHandler.UploadPostTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.uploads.PostUploadHandler.UploadPostTask)"
+        errorLine1="    private class UploadPostTask extends AsyncTask&lt;PostModel, Boolean, Boolean> {"
+        errorLine2="                  ~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java"
-            line="188"/>
+            line="188"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter.LoadServicesTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter.LoadServicesTask)"
+        errorLine1="    private class LoadServicesTask extends AsyncTask&lt;Void, Void, Boolean> {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java"
-            line="174"/>
+            line="174"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.adapters.ReaderBlogAdapter.LoadBlogsTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.adapters.ReaderBlogAdapter.LoadBlogsTask)"
+        errorLine1="    private class LoadBlogsTask extends AsyncTask&lt;Void, Void, Boolean> {"
+        errorLine2="                  ~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java"
-            line="206"/>
+            line="206"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.adapters.ReaderCommentAdapter.LoadCommentsTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.adapters.ReaderCommentAdapter.LoadCommentsTask)"
+        errorLine1="    private class LoadCommentsTask extends AsyncTask&lt;Void, Void, Boolean> {"
+        errorLine2="                  ~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java"
-            line="512"/>
+            line="512"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.adapters.ReaderPostAdapter.LoadPostsTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.adapters.ReaderPostAdapter.LoadPostsTask)"
+        errorLine1="    private class LoadPostsTask extends AsyncTask&lt;Void, Void, Boolean> {"
+        errorLine2="                  ~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java"
-            line="1155"/>
+            line="1155"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.ReaderPostDetailFragment.ShowPostTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.ReaderPostDetailFragment.ShowPostTask)"
+        errorLine1="    private class ShowPostTask extends AsyncTask&lt;Void, Void, Boolean> {"
+        errorLine2="                  ~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java"
-            line="1098"/>
+            line="1098"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.ReaderPostListFragment.LoadTagsTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.ReaderPostListFragment.LoadTagsTask)"
+        errorLine1="    private class LoadTagsTask extends AsyncTask&lt;Void, Void, ReaderTagList> {"
+        errorLine2="                  ~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java"
-            line="2290"/>
+            line="2290"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.adapters.ReaderTagAdapter.LoadTagsTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.adapters.ReaderTagAdapter.LoadTagsTask)"
+        errorLine1="    private class LoadTagsTask extends AsyncTask&lt;Void, Void, ReaderTagList> {"
+        errorLine2="                  ~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java"
-            line="146"/>
+            line="146"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.main.SitePickerAdapter.LoadSitesTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.main.SitePickerAdapter.LoadSitesTask)"
+        errorLine1="    private class LoadSitesTask extends AsyncTask&lt;Void, Void, SiteList[]&gt; {"
+        errorLine2="                  ~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java"
-            line="561"/>
+            line="561"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="Do not place Android context classes in static fields (static reference to `StatsDatabaseHelper` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)">
+        message="Do not place Android context classes in static fields (static reference to `StatsDatabaseHelper` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)"
+        errorLine1="    private static StatsDatabaseHelper mDatabaseHelper;"
+        errorLine2="            ~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/stats/datasets/StatsDatabaseHelper.java"
-            line="25"/>
+            line="25"
+            column="13"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.stats.StatsWidgetConfigureAdapter.LoadSitesTask)">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.stats.StatsWidgetConfigureAdapter.LoadSitesTask)"
+        errorLine1="    private class LoadSitesTask extends AsyncTask&lt;Void, Void, Void> {"
+        errorLine2="                  ~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureAdapter.java"
-            line="169"/>
+            line="169"
+            column="19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)">
+        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)"
+        errorLine1="    private static RestClientUtils sRestClientUtils;"
+        errorLine2="            ~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/WordPress.java"
-            line="117"/>
+            line="117"
+            column="13"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)">
+        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)"
+        errorLine1="    private static RestClientUtils sRestClientUtilsVersion1p1;"
+        errorLine2="            ~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/WordPress.java"
-            line="118"/>
+            line="118"
+            column="13"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)">
+        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)"
+        errorLine1="    private static RestClientUtils sRestClientUtilsVersion1p2;"
+        errorLine2="            ~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/WordPress.java"
-            line="119"/>
+            line="119"
+            column="13"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)">
+        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)"
+        errorLine1="    private static RestClientUtils sRestClientUtilsVersion1p3;"
+        errorLine2="            ~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/WordPress.java"
-            line="120"/>
+            line="120"
+            column="13"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)">
+        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)"
+        errorLine1="    private static RestClientUtils sRestClientUtilsVersion0;"
+        errorLine2="            ~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/WordPress.java"
-            line="121"/>
+            line="121"
+            column="13"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        message="Do not place Android context classes in static fields; this is a memory leak (and also breaks Instant Run)">
+        message="Do not place Android context classes in static fields; this is a memory leak (and also breaks Instant Run)"
+        errorLine1="    private static Context mContext;"
+        errorLine2="            ~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/WordPress.java"
-            line="127"/>
+            line="127"
+            column="13"/>
     </issue>
 
     <issue
         id="UseCompoundDrawables"
-        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable">
+        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable"
+        errorLine1="        &lt;LinearLayout"
+        errorLine2="        ^">
         <location
             file="src/main/res/layout/plugin_browser_row.xml"
-            line="51"/>
+            line="51"
+            column="9"/>
     </issue>
 
     <issue
         id="UseCompoundDrawables"
-        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable">
+        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable"
+        errorLine1="    &lt;LinearLayout"
+        errorLine2="    ^">
         <location
             file="src/main/res/layout/start_over_preference.xml"
-            line="15"/>
+            line="15"
+            column="5"/>
     </issue>
 
     <issue
         id="UseCompoundDrawables"
-        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable">
+        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable"
+        errorLine1="            &lt;LinearLayout"
+        errorLine2="            ^">
         <location
             file="src/main/res/layout/stats_widget_layout.xml"
-            line="63"/>
+            line="63"
+            column="13"/>
     </issue>
 
     <issue
         id="UseCompoundDrawables"
-        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable">
+        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable"
+        errorLine1="            &lt;LinearLayout"
+        errorLine2="            ^">
         <location
             file="src/main/res/layout/stats_widget_layout.xml"
-            line="109"/>
+            line="109"
+            column="13"/>
     </issue>
 
     <issue
         id="UseCompoundDrawables"
-        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable">
+        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable"
+        errorLine1="            &lt;LinearLayout"
+        errorLine2="            ^">
         <location
             file="src/main/res/layout/stats_widget_layout.xml"
-            line="155"/>
+            line="155"
+            column="13"/>
     </issue>
 
     <issue
         id="UseCompoundDrawables"
-        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable">
+        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable"
+        errorLine1="            &lt;LinearLayout"
+        errorLine2="            ^">
         <location
             file="src/main/res/layout/stats_widget_layout.xml"
-            line="201"/>
+            line="201"
+            column="13"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (811 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (811 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M26.3,26.4c0.4,0.3,0.8,0.6,1.3,0.8c0.5,0.2,1,0.3,1.5,0.3c0.5,0,1.1-0.1,1.5-0.3c0.4-0.2,0.6-0.5,0.6-0.9 c0-0.2-0.1-0.4-0.2-0.6c-0.1-0.2-0.3-0.4-0.6-0.5c-0.3-0.1-0.7-0.2-1.1-0.3c-0.5-0.1-1.1-0.1-1.7-0.1V23c0.8,0.1,1.6-0.1,2.4-0.4 c0.4-0.2,0.7-0.6,0.7-1c0-0.3-0.1-0.7-0.4-0.9c-0.4-0.2-0.8-0.3-1.2-0.3c-0.4,0-0.9,0.1-1.2,0.3c-0.4,0.2-0.8,0.4-1.2,0.7l-1.3-1.5 c0.5-0.4,1.1-0.7,1.8-1c0.7-0.2,1.4-0.4,2.1-0.4c0.6,0,1.1,0.1,1.7,0.2c0.5,0.1,0.9,0.3,1.3,0.6c0.4,0.2,0.6,0.5,0.9,0.9 c0.2,0.4,0.3,0.8,0.3,1.2c0,0.5-0.2,1-0.6,1.4c-0.5,0.4-1,0.7-1.6,0.9v0.1c0.7,0.2,1.3,0.5,1.8,0.9c0.5,0.4,0.7,1,0.7,1.7 c0,0.5-0.1,0.9-0.4,1.3c-0.3,0.4-0.6,0.7-1,1c-0.4,0.3-0.9,0.5-1.4,0.6c-0.6,0.1-1.1,0.2-1.7,0.2c-0.9,0-1.7-0.1-2.5-0.4 c-0.6-0.2-1.2-0.6-1.7-1.1L26.3,26.4z M20.7,22.9h-4.4v-4.4h-2.2v10.9h2.2v-4.4h4.4v4.4h2.2V18.5h-2.2V22.9z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/format_bar_button_heading_3.xml"
-            line="13"/>
+            line="13"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (811 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (811 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M26.3,26.4c0.4,0.3,0.8,0.6,1.3,0.8c0.5,0.2,1,0.3,1.5,0.3c0.5,0,1.1-0.1,1.5-0.3c0.4-0.2,0.6-0.5,0.6-0.9 c0-0.2-0.1-0.4-0.2-0.6c-0.1-0.2-0.3-0.4-0.6-0.5c-0.3-0.1-0.7-0.2-1.1-0.3c-0.5-0.1-1.1-0.1-1.7-0.1V23c0.8,0.1,1.6-0.1,2.4-0.4 c0.4-0.2,0.7-0.6,0.7-1c0-0.3-0.1-0.7-0.4-0.9c-0.4-0.2-0.8-0.3-1.2-0.3c-0.4,0-0.9,0.1-1.2,0.3c-0.4,0.2-0.8,0.4-1.2,0.7l-1.3-1.5 c0.5-0.4,1.1-0.7,1.8-1c0.7-0.2,1.4-0.4,2.1-0.4c0.6,0,1.1,0.1,1.7,0.2c0.5,0.1,0.9,0.3,1.3,0.6c0.4,0.2,0.6,0.5,0.9,0.9 c0.2,0.4,0.3,0.8,0.3,1.2c0,0.5-0.2,1-0.6,1.4c-0.5,0.4-1,0.7-1.6,0.9v0.1c0.7,0.2,1.3,0.5,1.8,0.9c0.5,0.4,0.7,1,0.7,1.7 c0,0.5-0.1,0.9-0.4,1.3c-0.3,0.4-0.6,0.7-1,1c-0.4,0.3-0.9,0.5-1.4,0.6c-0.6,0.1-1.1,0.2-1.7,0.2c-0.9,0-1.7-0.1-2.5-0.4 c-0.6-0.2-1.2-0.6-1.7-1.1L26.3,26.4z M20.7,22.9h-4.4v-4.4h-2.2v10.9h2.2v-4.4h4.4v4.4h2.2V18.5h-2.2V22.9z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/format_bar_button_heading_3_disabled.xml"
-            line="13"/>
+            line="13"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (811 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (811 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M26.3,26.4c0.4,0.3,0.8,0.6,1.3,0.8c0.5,0.2,1,0.3,1.5,0.3c0.5,0,1.1-0.1,1.5-0.3c0.4-0.2,0.6-0.5,0.6-0.9 c0-0.2-0.1-0.4-0.2-0.6c-0.1-0.2-0.3-0.4-0.6-0.5c-0.3-0.1-0.7-0.2-1.1-0.3c-0.5-0.1-1.1-0.1-1.7-0.1V23c0.8,0.1,1.6-0.1,2.4-0.4 c0.4-0.2,0.7-0.6,0.7-1c0-0.3-0.1-0.7-0.4-0.9c-0.4-0.2-0.8-0.3-1.2-0.3c-0.4,0-0.9,0.1-1.2,0.3c-0.4,0.2-0.8,0.4-1.2,0.7l-1.3-1.5 c0.5-0.4,1.1-0.7,1.8-1c0.7-0.2,1.4-0.4,2.1-0.4c0.6,0,1.1,0.1,1.7,0.2c0.5,0.1,0.9,0.3,1.3,0.6c0.4,0.2,0.6,0.5,0.9,0.9 c0.2,0.4,0.3,0.8,0.3,1.2c0,0.5-0.2,1-0.6,1.4c-0.5,0.4-1,0.7-1.6,0.9v0.1c0.7,0.2,1.3,0.5,1.8,0.9c0.5,0.4,0.7,1,0.7,1.7 c0,0.5-0.1,0.9-0.4,1.3c-0.3,0.4-0.6,0.7-1,1c-0.4,0.3-0.9,0.5-1.4,0.6c-0.6,0.1-1.1,0.2-1.7,0.2c-0.9,0-1.7-0.1-2.5-0.4 c-0.6-0.2-1.2-0.6-1.7-1.1L26.3,26.4z M20.7,22.9h-4.4v-4.4h-2.2v10.9h2.2v-4.4h4.4v4.4h2.2V18.5h-2.2V22.9z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/format_bar_button_heading_3_highlighted.xml"
-            line="13"/>
+            line="13"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (960 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (960 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M22.9,29.5h-2.2v-4.4h-4.4v4.4h-2.2V18.5h2.2v4.4h4.4v-4.4h2.2V29.5z M32.3,21.3c-0.3-0.2-0.6-0.4-0.9-0.5 c-0.7-0.3-1.4-0.3-2.1,0c-0.3,0.1-0.6,0.3-0.9,0.6c-0.3,0.3-0.5,0.6-0.6,1c-0.2,0.5-0.3,1-0.3,1.6c0.4-0.4,0.9-0.6,1.4-0.8 c0.4-0.2,0.9-0.3,1.4-0.3c0.5,0,0.9,0.1,1.3,0.2c0.4,0.1,0.8,0.3,1.1,0.6c0.3,0.3,0.6,0.6,0.7,1c0.2,0.4,0.3,0.9,0.3,1.4 c0,0.5-0.1,1-0.3,1.5c-0.2,0.4-0.5,0.8-0.9,1.1c-0.4,0.3-0.8,0.5-1.3,0.7c-1.1,0.3-2.2,0.3-3.3-0.1c-0.6-0.2-1.1-0.5-1.5-0.9 c-0.5-0.5-0.8-1-1.1-1.6c-0.3-0.8-0.4-1.6-0.3-2.4c0-0.9,0.1-1.7,0.4-2.6c0.2-0.7,0.6-1.3,1.1-1.8c0.4-0.5,1-0.8,1.6-1 c0.6-0.2,1.2-0.3,1.9-0.3c0.7,0,1.5,0.1,2.2,0.4c0.5,0.2,1.1,0.5,1.5,0.9L32.3,21.3z M29.7,27.6c0.2,0,0.4,0,0.7-0.1 c0.2-0.1,0.4-0.1,0.6-0.3c0.2-0.1,0.3-0.3,0.4-0.5c0.1-0.2,0.1-0.5,0.1-0.8c0-0.4-0.1-0.9-0.5-1.2c-0.4-0.3-0.8-0.4-1.2-0.4 c-0.4,0-0.7,0.1-1.1,0.2c-0.4,0.2-0.8,0.5-1.1,0.8c0.1,0.4,0.2,0.7,0.3,1.1c0.1,0.3,0.3,0.5,0.5,0.7c0.2,0.2,0.4,0.3,0.6,0.4 C29.2,27.7,29.4,27.7,29.7,27.6z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/format_bar_button_heading_6.xml"
-            line="13"/>
+            line="13"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (960 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (960 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M22.9,29.5h-2.2v-4.4h-4.4v4.4h-2.2V18.5h2.2v4.4h4.4v-4.4h2.2V29.5z M32.3,21.3c-0.3-0.2-0.6-0.4-0.9-0.5 c-0.7-0.3-1.4-0.3-2.1,0c-0.3,0.1-0.6,0.3-0.9,0.6c-0.3,0.3-0.5,0.6-0.6,1c-0.2,0.5-0.3,1-0.3,1.6c0.4-0.4,0.9-0.6,1.4-0.8 c0.4-0.2,0.9-0.3,1.4-0.3c0.5,0,0.9,0.1,1.3,0.2c0.4,0.1,0.8,0.3,1.1,0.6c0.3,0.3,0.6,0.6,0.7,1c0.2,0.4,0.3,0.9,0.3,1.4 c0,0.5-0.1,1-0.3,1.5c-0.2,0.4-0.5,0.8-0.9,1.1c-0.4,0.3-0.8,0.5-1.3,0.7c-1.1,0.3-2.2,0.3-3.3-0.1c-0.6-0.2-1.1-0.5-1.5-0.9 c-0.5-0.5-0.8-1-1.1-1.6c-0.3-0.8-0.4-1.6-0.3-2.4c0-0.9,0.1-1.7,0.4-2.6c0.2-0.7,0.6-1.3,1.1-1.8c0.4-0.5,1-0.8,1.6-1 c0.6-0.2,1.2-0.3,1.9-0.3c0.7,0,1.5,0.1,2.2,0.4c0.5,0.2,1.1,0.5,1.5,0.9L32.3,21.3z M29.7,27.6c0.2,0,0.4,0,0.7-0.1 c0.2-0.1,0.4-0.1,0.6-0.3c0.2-0.1,0.3-0.3,0.4-0.5c0.1-0.2,0.1-0.5,0.1-0.8c0-0.4-0.1-0.9-0.5-1.2c-0.4-0.3-0.8-0.4-1.2-0.4 c-0.4,0-0.7,0.1-1.1,0.2c-0.4,0.2-0.8,0.5-1.1,0.8c0.1,0.4,0.2,0.7,0.3,1.1c0.1,0.3,0.3,0.5,0.5,0.7c0.2,0.2,0.4,0.3,0.6,0.4 C29.2,27.7,29.4,27.7,29.7,27.6z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/format_bar_button_heading_6_disabled.xml"
-            line="13"/>
+            line="13"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (960 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (960 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M22.9,29.5h-2.2v-4.4h-4.4v4.4h-2.2V18.5h2.2v4.4h4.4v-4.4h2.2V29.5z M32.3,21.3c-0.3-0.2-0.6-0.4-0.9-0.5 c-0.7-0.3-1.4-0.3-2.1,0c-0.3,0.1-0.6,0.3-0.9,0.6c-0.3,0.3-0.5,0.6-0.6,1c-0.2,0.5-0.3,1-0.3,1.6c0.4-0.4,0.9-0.6,1.4-0.8 c0.4-0.2,0.9-0.3,1.4-0.3c0.5,0,0.9,0.1,1.3,0.2c0.4,0.1,0.8,0.3,1.1,0.6c0.3,0.3,0.6,0.6,0.7,1c0.2,0.4,0.3,0.9,0.3,1.4 c0,0.5-0.1,1-0.3,1.5c-0.2,0.4-0.5,0.8-0.9,1.1c-0.4,0.3-0.8,0.5-1.3,0.7c-1.1,0.3-2.2,0.3-3.3-0.1c-0.6-0.2-1.1-0.5-1.5-0.9 c-0.5-0.5-0.8-1-1.1-1.6c-0.3-0.8-0.4-1.6-0.3-2.4c0-0.9,0.1-1.7,0.4-2.6c0.2-0.7,0.6-1.3,1.1-1.8c0.4-0.5,1-0.8,1.6-1 c0.6-0.2,1.2-0.3,1.9-0.3c0.7,0,1.5,0.1,2.2,0.4c0.5,0.2,1.1,0.5,1.5,0.9L32.3,21.3z M29.7,27.6c0.2,0,0.4,0,0.7-0.1 c0.2-0.1,0.4-0.1,0.6-0.3c0.2-0.1,0.3-0.3,0.4-0.5c0.1-0.2,0.1-0.5,0.1-0.8c0-0.4-0.1-0.9-0.5-1.2c-0.4-0.3-0.8-0.4-1.2-0.4 c-0.4,0-0.7,0.1-1.1,0.2c-0.4,0.2-0.8,0.5-1.1,0.8c0.1,0.4,0.2,0.7,0.3,1.1c0.1,0.3,0.3,0.5,0.5,0.7c0.2,0.2,0.4,0.3,0.6,0.4 C29.2,27.7,29.4,27.7,29.7,27.6z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/format_bar_button_heading_6_highlighted.xml"
-            line="13"/>
+            line="13"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1201 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1201 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M19.6,31.6h14.2v-2.2H19.6V31.6z M19.6,25.1h14.2v-2.2H19.6V25.1z M19.6,16.4v2.2h14.2v-2.2H19.6z M14.8,16.6 c0.1-0.1,0.2-0.2,0.3-0.3c0,0.2,0,0.5,0,0.8v2.5h1.3V15h-1.1l-1.6,1.3l0.7,0.8L14.8,16.6z M15.2,25.1c0.5-0.5,0.9-0.8,1-0.9 c0.2-0.2,0.3-0.3,0.4-0.5c0.1-0.2,0.2-0.3,0.2-0.5c0-0.2,0.1-0.3,0.1-0.5c0-0.2-0.1-0.5-0.2-0.7s-0.3-0.3-0.6-0.5 c-0.2-0.1-0.5-0.2-0.8-0.2c-0.2,0-0.5,0-0.7,0.1c-0.2,0-0.4,0.1-0.5,0.2c-0.2,0.1-0.4,0.2-0.6,0.5l0.7,0.8c0.2-0.2,0.4-0.3,0.5-0.4 c0.2-0.1,0.3-0.1,0.4-0.1c0.1,0,0.3,0,0.3,0.1c0.1,0.1,0.1,0.2,0.1,0.3c0,0.1,0,0.2-0.1,0.3s-0.1,0.2-0.2,0.3 c-0.1,0.1-0.3,0.4-0.6,0.7l-1.1,1.2v0.8h3.4v-1L15.2,25.1L15.2,25.1L15.2,25.1z M15.8,30.3L15.8,30.3c0.3-0.1,0.6-0.3,0.8-0.5 c0.2-0.2,0.3-0.5,0.3-0.7c0-0.3-0.1-0.6-0.4-0.8c-0.3-0.2-0.7-0.3-1.1-0.3c-0.3,0-0.6,0-0.9,0.1c-0.3,0.1-0.5,0.2-0.8,0.4l0.5,0.8 c0.3-0.2,0.6-0.3,0.9-0.3c0.2,0,0.3,0,0.4,0.1c0.1,0.1,0.1,0.2,0.1,0.3c0,0.3-0.3,0.5-1,0.5h-0.3v0.9h0.3c0.2,0,0.4,0,0.6,0.1 c0.1,0,0.3,0.1,0.3,0.2c0.1,0.1,0.1,0.2,0.1,0.3c0,0.2-0.1,0.3-0.2,0.4c-0.1,0.1-0.3,0.1-0.6,0.1c-0.2,0-0.4,0-0.6-0.1 c-0.2,0-0.4-0.1-0.6-0.2v1c0.2,0.1,0.5,0.2,0.7,0.2c0.2,0,0.4,0.1,0.7,0.1c0.6,0,1.1-0.1,1.4-0.4c0.3-0.2,0.5-0.6,0.5-1 C16.9,30.8,16.5,30.4,15.8,30.3z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/format_bar_button_ol.xml"
-            line="13"/>
+            line="13"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1201 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1201 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M19.6,31.6h14.2v-2.2H19.6V31.6z M19.6,25.1h14.2v-2.2H19.6V25.1z M19.6,16.4v2.2h14.2v-2.2H19.6z M14.8,16.6 c0.1-0.1,0.2-0.2,0.3-0.3c0,0.2,0,0.5,0,0.8v2.5h1.3V15h-1.1l-1.6,1.3l0.7,0.8L14.8,16.6z M15.2,25.1c0.5-0.5,0.9-0.8,1-0.9 c0.2-0.2,0.3-0.3,0.4-0.5c0.1-0.2,0.2-0.3,0.2-0.5c0-0.2,0.1-0.3,0.1-0.5c0-0.2-0.1-0.5-0.2-0.7s-0.3-0.3-0.6-0.5 c-0.2-0.1-0.5-0.2-0.8-0.2c-0.2,0-0.5,0-0.7,0.1c-0.2,0-0.4,0.1-0.5,0.2c-0.2,0.1-0.4,0.2-0.6,0.5l0.7,0.8c0.2-0.2,0.4-0.3,0.5-0.4 c0.2-0.1,0.3-0.1,0.4-0.1c0.1,0,0.3,0,0.3,0.1c0.1,0.1,0.1,0.2,0.1,0.3c0,0.1,0,0.2-0.1,0.3s-0.1,0.2-0.2,0.3 c-0.1,0.1-0.3,0.4-0.6,0.7l-1.1,1.2v0.8h3.4v-1L15.2,25.1L15.2,25.1L15.2,25.1z M15.8,30.3L15.8,30.3c0.3-0.1,0.6-0.3,0.8-0.5 c0.2-0.2,0.3-0.5,0.3-0.7c0-0.3-0.1-0.6-0.4-0.8c-0.3-0.2-0.7-0.3-1.1-0.3c-0.3,0-0.6,0-0.9,0.1c-0.3,0.1-0.5,0.2-0.8,0.4l0.5,0.8 c0.3-0.2,0.6-0.3,0.9-0.3c0.2,0,0.3,0,0.4,0.1c0.1,0.1,0.1,0.2,0.1,0.3c0,0.3-0.3,0.5-1,0.5h-0.3v0.9h0.3c0.2,0,0.4,0,0.6,0.1 c0.1,0,0.3,0.1,0.3,0.2c0.1,0.1,0.1,0.2,0.1,0.3c0,0.2-0.1,0.3-0.2,0.4c-0.1,0.1-0.3,0.1-0.6,0.1c-0.2,0-0.4,0-0.6-0.1 c-0.2,0-0.4-0.1-0.6-0.2v1c0.2,0.1,0.5,0.2,0.7,0.2c0.2,0,0.4,0.1,0.7,0.1c0.6,0,1.1-0.1,1.4-0.4c0.3-0.2,0.5-0.6,0.5-1 C16.9,30.8,16.5,30.4,15.8,30.3z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/format_bar_button_ol_disabled.xml"
-            line="13"/>
+            line="13"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1201 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1201 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M19.6,31.6h14.2v-2.2H19.6V31.6z M19.6,25.1h14.2v-2.2H19.6V25.1z M19.6,16.4v2.2h14.2v-2.2H19.6z M14.8,16.6 c0.1-0.1,0.2-0.2,0.3-0.3c0,0.2,0,0.5,0,0.8v2.5h1.3V15h-1.1l-1.6,1.3l0.7,0.8L14.8,16.6z M15.2,25.1c0.5-0.5,0.9-0.8,1-0.9 c0.2-0.2,0.3-0.3,0.4-0.5c0.1-0.2,0.2-0.3,0.2-0.5c0-0.2,0.1-0.3,0.1-0.5c0-0.2-0.1-0.5-0.2-0.7s-0.3-0.3-0.6-0.5 c-0.2-0.1-0.5-0.2-0.8-0.2c-0.2,0-0.5,0-0.7,0.1c-0.2,0-0.4,0.1-0.5,0.2c-0.2,0.1-0.4,0.2-0.6,0.5l0.7,0.8c0.2-0.2,0.4-0.3,0.5-0.4 c0.2-0.1,0.3-0.1,0.4-0.1c0.1,0,0.3,0,0.3,0.1c0.1,0.1,0.1,0.2,0.1,0.3c0,0.1,0,0.2-0.1,0.3s-0.1,0.2-0.2,0.3 c-0.1,0.1-0.3,0.4-0.6,0.7l-1.1,1.2v0.8h3.4v-1L15.2,25.1L15.2,25.1L15.2,25.1z M15.8,30.3L15.8,30.3c0.3-0.1,0.6-0.3,0.8-0.5 c0.2-0.2,0.3-0.5,0.3-0.7c0-0.3-0.1-0.6-0.4-0.8c-0.3-0.2-0.7-0.3-1.1-0.3c-0.3,0-0.6,0-0.9,0.1c-0.3,0.1-0.5,0.2-0.8,0.4l0.5,0.8 c0.3-0.2,0.6-0.3,0.9-0.3c0.2,0,0.3,0,0.4,0.1c0.1,0.1,0.1,0.2,0.1,0.3c0,0.3-0.3,0.5-1,0.5h-0.3v0.9h0.3c0.2,0,0.4,0,0.6,0.1 c0.1,0,0.3,0.1,0.3,0.2c0.1,0.1,0.1,0.2,0.1,0.3c0,0.2-0.1,0.3-0.2,0.4c-0.1,0.1-0.3,0.1-0.6,0.1c-0.2,0-0.4,0-0.6-0.1 c-0.2,0-0.4-0.1-0.6-0.2v1c0.2,0.1,0.5,0.2,0.7,0.2c0.2,0,0.4,0.1,0.7,0.1c0.6,0,1.1-0.1,1.4-0.4c0.3-0.2,0.5-0.6,0.5-1 C16.9,30.8,16.5,30.4,15.8,30.3z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/format_bar_button_ol_highlighted.xml"
-            line="13"/>
+            line="13"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1068 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1068 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm6.918 6h-3.215c-0.188-1.424-0.42-2.65-0.565-3.357 1.593 0.682 2.916 1.87 3.78 3.357zm-5.904-3.928c0.068 0.352 0.387 2.038 0.645 3.928h-3.32c0.26-1.89 0.578-3.576 0.646-3.928C11.32 4.03 11.656 4 12 4s0.68 0.03 1.014 0.072zM14 12c0 0.598-0.043 1.286-0.11 2h-3.78c-0.067-0.714-0.11-1.402-0.11-2s0.043-1.286 0.11-2h3.78c0.067 0.714 0.11 1.402 0.11 2zM8.862 4.643C8.717 5.35 8.485 6.576 8.297 8H5.082c0.864-1.487 2.187-2.675 3.78-3.357zM4.262 10h3.822c-0.05 0.668-0.084 1.344-0.084 2s0.033 1.332 0.085 2H4.263C4.097 13.36 4 12.692 4 12s0.098-1.36 0.263-2zm0.82 6h3.215c0.188 1.424 0.42 2.65 0.565 3.357-1.593-0.682-2.916-1.87-3.78-3.357zm5.904 3.928c-0.068-0.353-0.388-2.038-0.645-3.928h3.32c-0.26 1.89-0.578 3.576-0.646 3.928-0.333 0.043-0.67 0.072-1.014 0.072s-0.68-0.03-1.014-0.072zm4.152-0.57c0.145-0.708 0.377-1.934 0.565-3.358h3.215c-0.864 1.487-2.187 2.675-3.78 3.357zm4.6-5.358h-3.822c0.05-0.668 0.084-1.344 0.084-2s-0.033-1.332-0.085-2h3.82c0.167 0.64 0.265 1.308 0.265 2s-0.097 1.36-0.263 2z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/ic_domains_grey_24dp.xml"
-            line="10"/>
+            line="10"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1068 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1068 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm6.918 6h-3.215c-0.188-1.424-0.42-2.65-0.565-3.357 1.593 0.682 2.916 1.87 3.78 3.357zm-5.904-3.928c0.068 0.352 0.387 2.038 0.645 3.928h-3.32c0.26-1.89 0.578-3.576 0.646-3.928C11.32 4.03 11.656 4 12 4s0.68 0.03 1.014 0.072zM14 12c0 0.598-0.043 1.286-0.11 2h-3.78c-0.067-0.714-0.11-1.402-0.11-2s0.043-1.286 0.11-2h3.78c0.067 0.714 0.11 1.402 0.11 2zM8.862 4.643C8.717 5.35 8.485 6.576 8.297 8H5.082c0.864-1.487 2.187-2.675 3.78-3.357zM4.262 10h3.822c-0.05 0.668-0.084 1.344-0.084 2s0.033 1.332 0.085 2H4.263C4.097 13.36 4 12.692 4 12s0.098-1.36 0.263-2zm0.82 6h3.215c0.188 1.424 0.42 2.65 0.565 3.357-1.593-0.682-2.916-1.87-3.78-3.357zm5.904 3.928c-0.068-0.353-0.388-2.038-0.645-3.928h3.32c-0.26 1.89-0.578 3.576-0.646 3.928-0.333 0.043-0.67 0.072-1.014 0.072s-0.68-0.03-1.014-0.072zm4.152-0.57c0.145-0.708 0.377-1.934 0.565-3.358h3.215c-0.864 1.487-2.187 2.675-3.78 3.357zm4.6-5.358h-3.822c0.05-0.668 0.084-1.344 0.084-2s-0.033-1.332-0.085-2h3.82c0.167 0.64 0.265 1.308 0.265 2s-0.097 1.36-0.263 2z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/ic_domains_white_24dp.xml"
-            line="12"/>
+            line="12"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1040 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1040 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zM3.5 12c0-1.232 0.264-2.402 0.736-3.46L8.29 19.65C5.456 18.272 3.5 15.365 3.5 12zm8.5 8.5c-0.834 0-1.64-0.12-2.4-0.345l2.55-7.41 2.613 7.157c0.017 0.042 0.038 0.08 0.06 0.117-0.884 0.31-1.833 0.48-2.823 0.48zm1.172-12.485c0.512-0.027 0.973-0.08 0.973-0.08 0.458-0.055 0.404-0.728-0.054-0.702 0 0-1.376 0.108-2.265 0.108-0.835 0-2.24-0.107-2.24-0.107-0.458-0.026-0.51 0.674-0.053 0.7 0 0 0.434 0.055 0.892 0.082l1.324 3.63-1.86 5.578-3.096-9.208c0.512-0.027 0.973-0.08 0.973-0.08 0.458-0.055 0.403-0.728-0.055-0.702 0 0-1.376 0.108-2.265 0.108-0.16 0-0.347-0.003-0.547-0.01C6.418 5.025 9.03 3.5 12 3.5c2.213 0 4.228 0.846 5.74 2.232-0.037-0.002-0.072-0.007-0.11-0.007-0.835 0-1.427 0.727-1.427 1.51 0 0.7 0.404 1.292 0.835 1.993 0.323 0.566 0.7 1.293 0.7 2.344 0 0.727-0.28 1.572-0.646 2.748l-0.848 2.833-3.072-9.138zm3.1 11.332l2.597-7.506c0.484-1.212 0.645-2.18 0.645-3.044 0-0.313-0.02-0.603-0.057-0.874 0.664 1.21 1.042 2.6 1.042 4.078 0 3.136-1.7 5.874-4.227 7.347z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/ic_wordpress_grey_20dp.xml"
-            line="10"/>
+            line="10"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1087 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1087 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="    &lt;path android:fillColor=&quot;#004F81&quot; android:pathData=&quot;M82.1,113.1c0.7,-0.4 1.5,-0.8 2.3,-1c0.8,-0.3 1.6,-0.4 2.4,-0.5c0.8,-0.1 1.7,0 2.5,0.1c0.8,0.1 1.6,0.3 2.5,0.6c0.4,0.1 0.6,0.4 0.6,0.8l0,0.1c0.1,1 0.5,2.2 1,3.1c0.5,1 1.2,1.8 2,2.3c1,0.6 2,1.2 3.1,1.6c1.1,0.4 2.2,0.8 3.3,1c0.4,0.1 0.8,0.4 0.9,0.8l0,0c1.7,6.7 4.3,13.4 8,19.3c1.9,2.9 4,5.7 6.6,7.8c2.6,2.2 5.7,3.7 9,4.1c1.7,0.2 3.3,0.1 4.9,-0.2c1.6,-0.4 3.1,-1.1 4.4,-2.1c2.6,-2 4.3,-5.1 5.3,-8.4c1.1,-3.3 1.7,-6.7 2,-10.2c0.2,-1.7 0.3,-3.5 0.4,-5.3c0.1,-1.8 0.1,-3.5 0,-5.3l0,0c0,-0.2 0.1,-0.3 0.3,-0.3c0.2,0 0.3,0.1 0.3,0.3c0.6,3.6 0.7,7.1 0.6,10.7c-0.2,3.6 -0.7,7.2 -1.8,10.7c-1.1,3.5 -2.9,6.9 -6,9.4c-1.5,1.2 -3.3,2 -5.2,2.5c-1.9,0.4 -3.8,0.5 -5.7,0.3c-3.8,-0.4 -7.3,-2.2 -10.2,-4.5c-2.9,-2.4 -5.2,-5.3 -7.1,-8.3c-1.9,-3.1 -3.5,-6.3 -4.9,-9.7c-1.3,-3.4 -2.5,-6.7 -3.3,-10.3l0.9,0.8c-1.4,-0.3 -2.5,-0.7 -3.7,-1.2c-1.2,-0.5 -2.3,-1.1 -3.4,-1.8c-1.2,-0.8 -2.1,-1.9 -2.7,-3.1c-0.6,-1.2 -1,-2.5 -1.2,-3.9l0.6,0.9c-0.6,-0.2 -1.3,-0.4 -2,-0.5c-0.7,-0.1 -1.4,-0.1 -2.1,-0.1c-0.7,0 -1.4,0.1 -2.1,0.2c-0.7,0.1 -1.4,0.3 -2.1,0.6l0,0c-0.4,0.1 -0.7,-0.1 -0.8,-0.4C81.7,113.6 81.8,113.2 82.1,113.1z&quot;/>"
+        errorLine2="                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_email_alert_120dp.xml"
-            line="29"/>
+            line="29"
+            column="57"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (3673 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (3673 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M32.8 35.8c-1.5 0-2.7-1.2-2.7-2.7V22.6c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7V33c0.1 1.5-1.1 2.8-2.7 2.8zm0-23.5c-1.5 0-2.7-1.2-2.7-2.7V2.7c0-1.5 1.2-2.7 2.7-2.7h6.8c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.7-2.7 2.7h-4.1v4.1c0.1 1.6-1.1 2.8-2.7 2.8zm247.5-6.8h-13.4c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.7-2.7 2.7zm26.1 0H293c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.7-2.7 2.7zm-52.8 0h-13.4c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.7-2.7 2.7zm-26.8 0h-13.4c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.7-2.7 2.7zm-26.7 0h-13.4c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.7-2.7 2.7zm-26.8 0H160c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.8 2.7-2.8h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.8-2.8 2.8zm-26.7 0h-13.4c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.7-2.7 2.7zm-26.7 0h-13.4c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.8 2.7-2.8h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.8-2.7 2.8zm-26.8 0H79.8c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.8 2.7-2.8h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.8-2.8 2.8zm-26.7 0H53c-1.5 0-2.7-1.2-2.7-2.7C50.3 1.3 51.5 0 53 0h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.8-2.7 2.8zm259 6.8c-1.5 0-2.7-1.2-2.7-2.7V5.5h-4.1c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h6.8c1.5 0 2.7 1.2 2.7 2.7v6.8c0.1 1.5-1.1 2.7-2.7 2.7zm0 185.1c-1.5 0-2.7-1.2-2.7-2.7v-13.4c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v13.4c0.1 1.5-1.1 2.7-2.7 2.7zm0-50.7c-1.5 0-2.7-1.2-2.7-2.7v-13.4c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7V144c0.1 1.5-1.1 2.7-2.7 2.7zm0 25c-1.5 0-2.7-1.2-2.7-2.7v-13.4c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7V169c0.1 1.5-1.1 2.7-2.7 2.7zm0-51.9c-1.5 0-2.7-1.2-2.7-2.7v-13.4c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v13.4c0.1 1.5-1.1 2.7-2.7 2.7zm0-26.9c-1.5 0-2.7-1.2-2.7-2.7V76.8c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v13.4c0.1 1.5-1.1 2.7-2.7 2.7zm0-26.8c-1.5 0-2.7-1.2-2.7-2.7V49.9c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v13.4c0.1 1.5-1.1 2.8-2.7 2.8zm0-26.9c-1.5 0-2.7-1.2-2.7-2.7V23c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v13.4c0.1 1.6-1.1 2.8-2.7 2.8zm0 179.6c-1.5 0-2.7-1.2-2.7-2.7v-6.8c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v6.8c0.1 1.5-1.1 2.7-2.7 2.7zm-42.9 39.6h-6.8c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h6.8c1.5 0 2.7 1.2 2.7 2.7 0 1.4-1.2 2.7-2.7 2.7zm-21.8 0H247c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.7c1.5 0 2.7 1.2 2.7 2.7 0 1.4-1.2 2.7-2.7 2.7zm-56 0h-13.8c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.8c1.5 0 2.7 1.2 2.7 2.7 0 1.4-1.2 2.7-2.7 2.7zm27.3 0h-13.8c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7H232c1.5 0 2.7 1.2 2.7 2.7 0 1.4-1.2 2.7-2.7 2.7zm-54.8 0h-13.7c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.7c1.5 0 2.7 1.2 2.7 2.7 0 1.4-1.2 2.7-2.7 2.7zm-27.5 0h-13.8c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.8c1.5 0 2.7 1.2 2.7 2.7 0 1.4-1.2 2.7-2.7 2.7zm-27.5 0h-13.8c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.8c1.5 0 2.7 1.2 2.7 2.7 0 1.4-1.2 2.7-2.7 2.7zm-27.5 0H80.9c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.7c1.5 0 2.7 1.2 2.7 2.7 0.1 1.4-1.1 2.7-2.6 2.7zm-27.5 0H53.4c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.7c1.5 0 2.7 1.2 2.7 2.7 0.1 1.4-1.1 2.7-2.6 2.7zm-27.5 0h-6.8c-1.5 0-2.7-1.2-2.7-2.7v-6.8c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v4.1h4.1c1.5 0 2.7 1.2 2.7 2.7 0 1.4-1.2 2.7-2.7 2.7zm7.4-35.1c-1.5 0-2.7-1.2-2.7-2.7v-15.2c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v15.2c0 1.5-1.2 2.7-2.7 2.7zm0-30.4c-1.5 0-2.7-1.2-2.7-2.7V175c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v15.2c0 1.5-1.2 2.7-2.7 2.7z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_add_media_150dp.xml"
-            line="14"/>
+            line="14"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1011 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1011 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M213.2 98.2l15.6-0.3-1.6 1.3c0.6-3.5 1.6-6.8 3.1-10 1.4-3.2 3.3-6.3 5.9-8.9 2.6-2.6 6.1-4.5 9.9-4.9 1.9-0.3 3.7-0.2 5.6 0.2 1.9 0.4 3.7 1.2 5.3 2.5 1.6 1.2 2.8 2.9 3.6 4.6 0.2 0.4 0.4 0.9 0.6 1.3 0 0.1 0.1 0.2 0.2 0.3 0.2 0.2 0.4 0.2 0.6 0.2 0.1 0 0 0 0.2-0.1l0.7-0.3c0.4-0.2 0.9-0.4 1.3-0.5 0.9-0.3 1.8-0.5 2.8-0.7 1.9-0.3 3.7-0.3 5.6-0.1 0.9 0.1 1.8 0.2 2.7 0.5l1.5 0.5c0.5 0.2 0.9 0.5 1.4 0.7 1.8 1.1 3.1 2.8 3.9 4.5 1.6 3.6 1.9 7.2 1.6 10.8l-1.6-1.8c5.9 0 11.8 0.3 17.8 0.4 0.7 0 1.3 0.6 1.2 1.3 0 0.7-0.6 1.2-1.2 1.2-5.9 0.1-11.8 0.3-17.8 0.4-0.9 0-1.6-0.7-1.6-1.6v-0.2c0.2-3-0.2-6.4-1.5-8.9-0.7-1.3-1.5-2.3-2.6-3l-0.9-0.5-1-0.3c-0.7-0.2-1.5-0.3-2.2-0.4-1.5-0.2-3.1-0.2-4.5 0.1-0.7 0.1-1.4 0.3-2.1 0.5-0.3 0.1-0.7 0.3-1 0.4l-0.5 0.2c-0.2 0.1-0.6 0.3-0.9 0.4-1.4 0.4-3 0.1-4.1-0.9-0.6-0.5-1-1.1-1.2-1.8-0.1-0.3-0.3-0.7-0.4-1-0.6-1.3-1.5-2.4-2.6-3.3-2.1-1.7-5.2-2.4-8.2-1.9-2.9 0.3-5.6 1.7-7.8 3.9-4.4 4.3-7 10.7-8.3 16.9v0.1c-0.2 0.7-0.8 1.2-1.5 1.2l-15.6-0.3c-0.7 0-1.3-0.6-1.2-1.3-0.4-0.8 0.1-1.3 0.8-1.4z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_add_media_150dp.xml"
-            line="69"/>
+            line="69"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (817 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (817 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M92.4,29.9c0.4,0.3 0.8,0.6 1.2,1l1.1,1.1l2.2,2.2h-0.5c0.7,-0.7 1.5,-1.4 2.2,-2.2c0.7,-0.7 1.5,-1.4 2.4,-2c0,0 0.1,0 0.1,0c0,0 0,0 0,0v0.1c-0.6,0.9 -1.3,1.6 -2,2.4c-0.7,0.7 -1.4,1.5 -2.2,2.2c-0.2,0.1 -0.4,0.1 -0.5,0l-2.2,-2.2l-1.1,-1.2c-0.4,-0.4 -0.7,-0.8 -1,-1.2c-0.1,-0.1 0,-0.3 0.1,-0.3C92.3,29.9 92.3,29.9 92.4,29.9zM104.1,51.2c1.3,1 2.3,2.3 3.2,3.7c0.4,0.7 0.8,1.4 1.1,2.1c0.2,0.3 0.3,0.7 0.5,1.1l0.5,1.2c1.1,3 1.8,6.2 2.2,9.4c0.3,3.2 0.4,6.4 0.3,9.6l-0.1,2.4l-0.3,2.4c-0.1,0.8 -0.2,1.6 -0.3,2.4s-0.3,1.6 -0.4,2.4c0,0.1 -0.1,0.1 -0.1,0.1c-0.1,0 -0.1,-0.1 -0.1,-0.1c0.2,-3.2 0.6,-6.3 0.7,-9.5c0.1,-3.2 0.1,-6.3 -0.3,-9.5c-0.3,-3.1 -1,-6.2 -2.1,-9.2l-0.4,-1.1c-0.1,-0.3 -0.3,-0.7 -0.5,-1.1c-0.3,-0.7 -0.7,-1.4 -1.1,-2c-0.8,-1.3 -1.8,-2.5 -2.9,-3.7c-0.1,-0.1 -0.1,-0.2 0,-0.3C104,51.1 104,51.1 104.1,51.2L104.1,51.2z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="75"/>
+            line="75"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (846 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (846 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M95.1,25.1c0.2,0.1 0.5,0.2 0.8,0.2c0.3,0 0.5,-0.1 0.7,-0.3c0.1,-0.1 0.2,-0.1 0.3,0c0.1,0.1 0.1,0.1 0.1,0.2c-0.1,0.2 -0.3,0.4 -0.5,0.5c-0.2,0.1 -0.4,0.2 -0.7,0.1c-0.2,0 -0.5,-0.1 -0.7,-0.1c-0.2,-0.1 -0.4,-0.3 -0.5,-0.5c-0.1,-0.1 0,-0.3 0.1,-0.3S95,25 95.1,25.1L95.1,25.1zM93.6,19.2c-0.3,0 -0.5,0 -0.8,0.1c-0.3,0.1 -0.6,0.1 -0.8,0.2h-0.1c-0.1,0.1 -0.3,0 -0.3,-0.1v-0.2c0.3,-0.3 0.6,-0.5 1,-0.5c0.2,0 0.4,0 0.6,0c0.2,0 0.4,0.1 0.6,0.3c0.1,0.1 0.1,0.2 0,0.3c-0.1,0.1 -0.1,0.1 -0.1,0.1C93.8,19.2 93.6,19.2 93.6,19.2zM97.1,18.7c0.2,-0.2 0.5,-0.4 0.7,-0.4c0.2,-0.1 0.5,-0.1 0.7,0c0.5,0.1 0.9,0.3 1.1,0.7c0.1,0.2 0.1,0.4 -0.1,0.5c0,0 -0.1,0 -0.1,0c-0.1,0 -0.1,0.1 -0.2,0.1H99c-0.2,0 -0.5,0 -0.7,-0.1c-0.1,0 -0.3,-0.1 -0.4,-0.1c-0.1,0 -0.2,-0.1 -0.3,-0.1c-0.2,0.1 -0.5,0.1 -0.6,-0.1c0,0 0,0 0,0C96.9,19.1 96.9,18.8 97.1,18.7C97.1,18.7 97.1,18.7 97.1,18.7z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="110"/>
+            line="110"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1003 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1003 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M98.8,38.1c-0.1,0.8 -0.5,1.6 -1.1,2.2c-0.5,0.6 -1.2,1.2 -1.8,1.6c-0.1,0.1 -0.3,0.1 -0.5,0c0,0 0,0 0,0c-0.1,-0.1 -0.1,-0.2 0,-0.3c0.2,-0.4 0.4,-0.8 0.5,-1.2c0.1,-0.2 0.1,-0.4 0.1,-0.6c0.1,-0.2 0,-0.4 0,-0.3c0,0.1 -0.1,0 -0.2,0.1c-0.2,0.1 -0.3,0.2 -0.4,0.3c-0.3,0.3 -0.5,0.7 -0.7,1c-0.3,0.3 -0.4,0.7 -0.6,1.2l-0.3,0.6c-0.1,0.2 -0.3,0.4 -0.5,0.6c-0.4,0.3 -0.8,0.6 -1.3,0.7c-0.4,0.2 -0.8,0.4 -1.2,0.5c-1.6,0.7 -3.2,1.5 -4.7,2.4c-1.5,0.9 -2.8,2.2 -3.6,3.7c0,0.1 -0.1,0.1 -0.1,0.1c-0.1,0 -0.1,-0.1 -0.1,-0.1c0.7,-1.8 1.9,-3.2 3.5,-4.2c1.5,-1 3.1,-1.8 4.8,-2.5c0.4,-0.2 0.8,-0.3 1.2,-0.5c0.4,-0.2 0.7,-0.4 1.1,-0.6c0.1,-0.2 0.2,-0.3 0.3,-0.5l0.3,-0.6c0.2,-0.4 0.4,-0.8 0.7,-1.2c0.2,-0.4 0.5,-0.8 0.8,-1.2c0.2,-0.2 0.4,-0.4 0.6,-0.5c0.1,-0.1 0.3,-0.1 0.5,-0.1h0.3c0.1,0 0.2,0.1 0.3,0.1c0.1,0.1 0.1,0.2 0.2,0.3c0.1,0.1 0.1,0.2 0.1,0.3v0.4c-0.1,0.2 -0.1,0.5 -0.2,0.7c-0.1,0.5 -0.3,0.9 -0.6,1.3l-0.5,-0.5c0.6,-0.4 1.2,-0.9 1.7,-1.5c0.5,-0.5 0.9,-1.2 1.2,-1.8c0.1,-0.1 0.2,-0.2 0.3,-0.1C98.8,37.9 98.9,38 98.8,38.1z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="130"/>
+            line="130"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1304 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1304 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M111.2,49.3c-0.3,0.3 -0.6,0.7 -0.7,1.2l-0.6,1.2c-0.4,0.8 -0.7,1.7 -1.1,2.6c-0.3,0.9 -0.7,1.8 -0.9,2.6l-0.2,0.7l-0.1,0.1c0,0.1 0,0.1 -0.1,0.2c-0.1,0.2 -0.2,0.3 -0.3,0.4c-0.4,0.3 -0.9,0.6 -1.4,0.7c-0.2,0.1 -0.4,0.1 -0.6,0.2l0.1,-0.1c0.1,-0.1 0.1,-0.1 0.1,-0.2v-0.1c0,0.1 0,0.1 0.1,0.1c0,0 0,0.1 0.1,0.1c0.1,0.1 0.3,0.1 0.5,0.1c0.2,0 0.5,0 0.7,0c0.1,0 0.2,0 0.3,0.1c0.1,0 0.1,0.1 0.2,0.1c0.1,0.1 0.2,0.2 0.2,0.3c0,0.3 -0.1,0.3 -0.1,0.4l-0.2,0.2c-0.2,0.2 -0.4,0.3 -0.6,0.4l-1.2,0.7c-0.4,0.3 -0.8,0.5 -1.1,0.7c-0.3,0.2 -0.6,0.5 -0.7,0.9c0,0.5 0,0.9 0.3,1.1c0.4,0.2 0.8,0.3 1.2,0.3c0.1,0 0.1,0.1 0.1,0.1c0,0.1 -0.1,0.1 -0.1,0.1c-0.5,0.1 -1,0 -1.5,-0.2c-0.2,-0.1 -0.4,-0.4 -0.5,-0.7c-0.1,-0.2 -0.1,-0.5 -0.1,-0.7c0,-0.3 0.1,-0.6 0.3,-0.8c0.2,-0.2 0.3,-0.4 0.5,-0.5c0.4,-0.3 0.8,-0.6 1.1,-0.9c0.4,-0.3 0.8,-0.5 1.2,-0.7c0.2,-0.1 0.4,-0.3 0.5,-0.4c0.1,-0.1 0.1,0 0.1,-0.1v0.1c0.1,0.1 0.1,0.1 0.1,0.1h-0.1c-0.3,-0.1 -0.9,0.2 -1.6,-0.1c-0.2,-0.1 -0.3,-0.2 -0.4,-0.4c-0.1,-0.1 -0.1,-0.1 -0.1,-0.2V59c0,-0.1 0,-0.2 0.1,-0.3c0.1,-0.1 0.1,-0.1 0.2,-0.1c0.3,-0.1 0.5,-0.2 0.7,-0.3c0.4,-0.1 0.8,-0.3 1.1,-0.5l0.1,-0.1c0,-0.1 0,-0.1 0.1,-0.1l0.1,-0.2l0.2,-0.7c0.3,-0.9 0.6,-1.8 1,-2.6c0.4,-0.9 0.7,-1.8 1.2,-2.6C109.8,50.6 110.4,49.9 111.2,49.3L111.2,49.3C111.2,49.3 111.2,49.3 111.2,49.3C111.2,49.3 111.2,49.3 111.2,49.3z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="140"/>
+            line="140"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1692 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1692 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M46.9,89c1.4,-1.1 2.4,-2.7 2.9,-4.4c0.5,-1.7 0.6,-3.5 0.4,-5.3c-0.5,-3.5 -1.6,-6.9 -3.4,-10c-1.8,-3.1 -4.2,-5.7 -7,-7.9c-1.4,-1 -3,-1.9 -4.6,-2.5c-1.6,-0.6 -3.4,-0.7 -5.1,-0.2c-1.6,0.5 -3,1.7 -3.8,3.2c-0.8,1.5 -1.1,3.3 -0.8,5c0.3,3.5 1.8,6.8 3.4,10c1.7,3.2 3.7,6.1 6.1,8.7c1.2,1.3 2.6,2.5 4.1,3.5c0.7,0.5 1.5,0.8 2.4,1.1c0.8,0.2 1.7,0.2 2.5,-0.2c0.1,-0.1 0.1,0 0.2,0.1c0.1,0.1 0,0.1 -0.1,0.2c-0.8,0.4 -1.8,0.5 -2.7,0.3c-0.9,-0.2 -1.8,-0.6 -2.6,-1c-1.5,-1 -2.9,-2.1 -4.2,-3.5c-2.5,-2.6 -4.6,-5.6 -6.3,-8.7c-0.9,-1.6 -1.6,-3.2 -2.2,-4.9c-0.6,-1.7 -1.1,-3.5 -1.3,-5.3c-0.3,-1.9 0,-3.8 0.9,-5.5c0.9,-1.7 2.4,-2.9 4.3,-3.5c1.8,-0.5 3.8,-0.4 5.5,0.3c1.7,0.6 3.3,1.5 4.8,2.6c2.9,2.2 5.4,4.9 7.2,8.1c0.9,1.6 1.6,3.3 2.2,5c0.6,1.7 1,3.5 1.1,5.4c0.2,1.8 0,3.7 -0.5,5.4c-0.6,1.8 -1.6,3.3 -3.1,4.4H47C46.9,89.2 46.9,89.1 46.9,89zM54.1,93.6c-0.9,-1.4 -1.4,-3.1 -1.5,-4.7c-0.1,-1.7 0.1,-3.3 0.6,-4.9c1,-3.2 2.9,-6.1 5.4,-8.3c0.1,-0.1 0.3,-0.1 0.5,0c0,0 0,0 0,0c0.1,0.1 0.1,0.1 0.1,0.1l1.6,5.7l-0.7,0.1l0.8,-6.4c0,-0.1 0.1,-0.3 0.3,-0.3c1.5,-0.5 3.1,-0.6 4.6,-0.3c0.8,0.2 1.5,0.4 2.2,0.8c0.7,0.4 1.2,1 1.7,1.6c1,1.2 1.5,2.7 1.7,4.3c0.1,1.5 -0.2,3.1 -0.7,4.5c-1.2,2.8 -3.2,5.2 -5.7,6.9c-1.2,0.9 -2.5,1.6 -4,2c-1.5,0.5 -3,0.5 -4.5,-0.1c-0.1,0 -0.1,-0.1 -0.1,-0.2c0,-0.1 0.1,-0.1 0.2,-0.1c1.4,0.5 2.9,0.4 4.3,-0.1c1.4,-0.5 2.7,-1.2 3.8,-2c2.4,-1.8 4.2,-4.1 5.4,-6.8c0.6,-1.3 0.8,-2.8 0.7,-4.2c-0.1,-1.4 -0.7,-2.8 -1.6,-3.9c-0.4,-0.5 -0.9,-1 -1.5,-1.4c-0.6,-0.3 -1.3,-0.6 -2,-0.7c-1.4,-0.2 -2.8,-0.2 -4.2,0.3l0.3,-0.3L61,81.5c0,0.2 -0.1,0.3 -0.3,0.3c0,0 -0.1,0 -0.1,0c-0.1,0 -0.3,-0.1 -0.3,-0.3l-1.6,-5.7l0.5,0.1c-2.5,2.1 -4.3,4.9 -5.3,8c-0.5,1.5 -0.8,3.2 -0.7,4.8c0,1.6 0.4,3.2 1.2,4.7v0.1L54.1,93.6L54.1,93.6z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="145"/>
+            line="145"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1242 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1242 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M143.6,55c-0.3,0 -0.3,-0.1 -0.5,-0.2c-0.1,-0.1 -0.3,-0.2 -0.5,-0.3c-0.3,-0.1 -0.6,-0.2 -0.9,-0.3c-0.3,-0.1 -0.6,-0.1 -0.9,0.1c-0.3,0.1 -0.7,0.2 -1,0.3c-0.1,0 -0.1,-0.1 -0.1,-0.1v-0.1c0.2,-0.4 0.5,-0.7 0.9,-0.7c0.4,-0.1 0.8,-0.2 1.2,-0.1c0.4,0.1 0.8,0.2 1.1,0.4c0.2,0.1 0.3,0.2 0.5,0.3c0.1,0.1 0.3,0.2 0.4,0.4C143.9,54.9 143.8,55 143.6,55L143.6,55zM149.9,57.9c-0.3,-0.1 -0.3,-0.3 -0.4,-0.5l-0.3,-0.5c-0.2,-0.3 -0.4,-0.7 -0.6,-1.1c-0.2,-0.4 -0.4,-0.8 -0.5,-1.2c-0.2,-0.4 -0.3,-0.8 -0.3,-1.2c0,-0.1 0.1,-0.1 0.1,-0.1h0.1c0.3,0.3 0.5,0.6 0.7,1l0.5,1.1l0.5,1.1l0.3,0.5c0.1,0.2 0.3,0.3 0.2,0.5C150.2,57.8 150.1,57.9 149.9,57.9L149.9,57.9zM128.1,56.6c-0.1,0.8 -0.2,1.6 -0.4,2.4c-0.1,0.8 -0.3,1.6 -0.5,2.4c-0.3,1.6 -0.4,3.3 -0.4,4.9c0,1.6 0.2,3.3 0.5,4.9c0.3,1.6 0.7,3.3 0.9,4.9c0,0.1 0,0.1 -0.1,0.1c-0.1,0 -0.1,0 -0.1,-0.1c-0.6,-1.6 -1.1,-3.2 -1.3,-4.8c-0.3,-1.7 -0.5,-3.3 -0.6,-5c0,-1.7 0.1,-3.4 0.5,-5c0.1,-0.8 0.3,-1.6 0.5,-2.4c0.2,-0.8 0.4,-1.6 0.7,-2.4c0.1,-0.1 0.2,-0.2 0.3,-0.1C128,56.4 128.1,56.5 128.1,56.6L128.1,56.6zM129.7,62.7c0,0.3 0,0.6 -0.1,0.9c-0.1,0.3 -0.2,0.6 -0.3,0.8c0,0.1 -0.1,0.1 -0.2,0c0,0 0,0 0,0c-0.2,-0.3 -0.2,-0.6 -0.1,-0.9c0.1,-0.3 0.2,-0.6 0.3,-0.9c0.1,-0.1 0.2,-0.1 0.3,-0.1C129.6,62.5 129.7,62.6 129.7,62.7L129.7,62.7z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="205"/>
+            line="205"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (849 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (849 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M149.7,102.8c0.1,0.7 0.1,1.5 0,2.2l-0.1,2.2c-0.1,1.5 -0.1,3 -0.2,4.5l-0.2,4.5c0,1.5 -0.2,3 -0.4,4.5c0,0.1 -0.1,0.1 -0.1,0.1c-0.1,-0.1 -0.1,-0.1 -0.1,-0.1c-0.1,-1.5 -0.1,-3 -0.1,-4.5l0.1,-4.5l0.2,-4.5l0.1,-2.2c0,-0.8 0.1,-1.5 0.2,-2.2c0,-0.1 0.1,-0.2 0.3,-0.1S149.7,102.7 149.7,102.8L149.7,102.8zM142.7,102.8c0.2,0.7 0.2,1.5 0.3,2.2l0.2,2.2c0.1,1.5 0.3,3.1 0.4,4.5l0.3,4.5c0.1,1.5 0.2,3 0.1,4.5c0,0.1 -0.1,0.1 -0.1,0.1c-0.1,0 -0.1,-0.1 -0.1,-0.1c-0.3,-1.5 -0.5,-3 -0.6,-4.5l-0.4,-4.5c-0.1,-1.5 -0.3,-3.1 -0.3,-4.5l-0.2,-2.2c-0.1,-0.8 -0.1,-1.5 -0.1,-2.3c0,-0.1 0.1,-0.2 0.3,-0.2S142.7,102.7 142.7,102.8L142.7,102.8zM153.2,91.3c-0.3,0.1 -0.5,0.1 -0.8,0.1h-4.1c-0.5,0 -1.1,0 -1.6,-0.2c-0.1,0 -0.1,-0.1 -0.1,-0.1c0,0 0,-0.1 0.1,-0.1c0.5,-0.2 1.1,-0.2 1.6,-0.2h4.1c0.3,-0.1 0.6,0 0.8,0.1C153.3,91.1 153.3,91.2 153.2,91.3C153.3,91.3 153.3,91.3 153.2,91.3z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="215"/>
+            line="215"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (949 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (949 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M153.7,88.6L153.7,88.6c1.8,-1 3.5,-1.8 5.2,-2.6l5.1,-2.4l-0.2,0.4c-1.1,-3.7 -3,-7 -5.1,-10.2c-1.1,-1.6 -2.2,-3.1 -3.4,-4.6l-0.5,-0.5c-0.1,-0.2 -0.2,-0.3 -0.4,-0.4c-0.3,-0.2 -0.7,-0.3 -1.1,-0.1c-0.1,0 -0.2,0.1 -0.3,0.1l-0.3,0.1l-0.6,0.3l-1.3,0.7l-2.6,1.4c-0.4,0.1 -0.6,0.4 -0.7,0.8c-0.1,0.2 -0.1,0.4 -0.1,0.5c0,0.2 0.1,0.4 0.1,0.6c0.5,1.8 1.1,3.7 1.8,5.5c0.7,1.8 1.3,3.6 2,5.4c0.3,0.9 0.7,1.8 1.1,2.6c0.2,0.4 0.4,0.9 0.6,1.3C153.3,87.9 153.5,88.3 153.7,88.6L153.7,88.6zM153.7,89L153.7,89c-0.4,-0.5 -0.6,-0.9 -0.9,-1.4c-0.3,-0.4 -0.5,-0.8 -0.7,-1.3c-0.5,-0.8 -0.9,-1.7 -1.3,-2.6c-0.8,-1.8 -1.5,-3.6 -2.2,-5.4c-0.7,-1.8 -1.2,-3.7 -1.8,-5.5c-0.1,-0.2 -0.1,-0.5 -0.2,-0.7c0,-0.3 0,-0.6 0.1,-0.9c0.2,-0.6 0.6,-1 1.1,-1.2l2.6,-1.4l1.3,-0.7l0.6,-0.3l0.3,-0.1c0.1,-0.1 0.3,-0.1 0.4,-0.1c0.6,-0.2 1.2,-0.1 1.7,0.3c0.2,0.1 0.4,0.3 0.6,0.5l0.5,0.5c1.2,1.5 2.4,3.1 3.4,4.7c2.2,3.2 4,6.7 5.2,10.4c0.1,0.1 -0.1,0.3 -0.2,0.4l-5.3,2.4C157.2,87.5 155.4,88.3 153.7,89z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="255"/>
+            line="255"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1628 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1628 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M155.8,55.4c0.6,1 1.1,2 1.6,3c0.5,1 0.9,2.1 1.3,3.2c0.5,1.1 0.6,2.3 0.5,3.5c-0.1,0.7 -0.4,1.3 -0.9,1.7c-0.2,0.2 -0.5,0.4 -0.8,0.5l-0.4,0.2c-0.2,0.1 -0.3,0.1 -0.5,0.1c-0.6,0 -1.3,-0.1 -1.8,-0.3c-0.5,-0.2 -1.1,-0.5 -1.6,-0.8c-1,-0.6 -1.9,-1.3 -2.8,-2.1c-1.8,-1.5 -3.4,-3.1 -4.9,-4.9l0.3,0.1c-0.7,0 -1.4,-0.4 -2,-0.9c-0.5,-0.5 -0.9,-1.1 -1,-1.8c-0.1,-0.6 -0.3,-1.2 -0.9,-1.3c-0.6,-0.1 -1.2,0.1 -1.7,0.4c-0.1,0 -0.1,0 -0.1,-0.1v-0.1c0.3,-0.2 0.6,-0.4 0.9,-0.5c0.3,-0.1 0.7,-0.2 1.1,-0.1c0.4,0.1 0.7,0.3 0.9,0.6c0.2,0.3 0.3,0.6 0.4,0.9c0.1,0.6 0.4,1.1 0.9,1.5c0.4,0.4 1,0.6 1.6,0.7c0.1,0 0.2,0.1 0.3,0.1c1.5,1.7 3.1,3.3 4.9,4.7c0.9,0.7 1.8,1.4 2.7,2c0.5,0.3 1,0.5 1.5,0.7c0.5,0.2 1,0.3 1.5,0.3c0.2,0 0.5,-0.1 0.7,-0.2c0.3,-0.1 0.4,-0.3 0.6,-0.4c0.4,-0.3 0.6,-0.8 0.7,-1.3c0.1,-1.1 -0.1,-2.2 -0.5,-3.2c-0.4,-1.1 -0.8,-2.1 -1.3,-3.2c-0.5,-1 -0.9,-2 -1.4,-3.1c-0.1,-0.1 0,-0.3 0.1,-0.3C155.6,55.3 155.7,55.3 155.8,55.4L155.8,55.4zM143.9,122c0.1,0.3 0.3,0.6 0.7,0.6c8.6,0.1 10.8,1.1 11.3,-0.5c0.4,-1.4 -8.6,-3.3 -11.5,-3.7c-0.4,0 -0.7,0.2 -0.7,0.6c0,0 0,0.1 0,0.1L143.9,122L143.9,122zM131.6,102.5c0.2,0.7 0.2,1.3 0.2,2l0.1,2l0.3,4l0.2,4c0.1,1.4 0.1,2.7 0,4.1c0,0.1 -0.1,0.1 -0.1,0.1c-0.1,0 -0.1,-0.1 -0.1,-0.1c-0.3,-1.3 -0.4,-2.7 -0.5,-4l-0.3,-4l-0.2,-4l-0.1,-2c-0.1,-0.7 -0.1,-1.4 0,-2c0,-0.1 0.1,-0.2 0.3,-0.2S131.6,102.5 131.6,102.5L131.6,102.5zM141,87.8c0,1.4 -0.2,2.7 -0.3,4.1l-0.5,4.1c-0.3,2.7 -0.6,5.4 -0.9,8.1l-1,8.1c-0.3,2.7 -0.7,5.4 -1.2,8.1c0,0.1 -0.1,0.1 -0.1,0.1c-0.1,-0.1 -0.1,-0.1 -0.1,-0.1c0.1,-2.7 0.4,-5.5 0.7,-8.2l0.9,-8.1l1,-8.1l0.5,-4.1c0.2,-1.4 0.3,-2.7 0.6,-4.1c0,-0.1 0.1,-0.2 0.3,-0.1C141,87.6 141,87.7 141,87.8z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="260"/>
+            line="260"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1630 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1630 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M179.3,101.6c0.2,-0.2 0.3,-0.5 0.3,-0.7c0,-0.1 -0.1,-0.2 -0.1,-0.3l-0.3,-0.3c-0.5,-0.4 -1,-0.6 -1.6,-0.7c-0.6,-0.1 -1.2,0.1 -1.7,0.3c-0.5,0.2 -1,0.6 -1.4,1v-0.5c0.2,0.4 0.5,0.7 0.9,0.9c0.4,0.3 0.8,0.5 1.2,0.5C177.5,102.2 178.5,102 179.3,101.6L179.3,101.6zM179.5,101.8c-0.8,0.7 -1.9,1 -3,0.9c-0.6,-0.1 -1.1,-0.3 -1.6,-0.6c-0.4,-0.3 -0.8,-0.7 -1.1,-1.2c-0.1,-0.2 -0.1,-0.3 0,-0.5c0.9,-1.2 2.4,-1.9 3.8,-1.7c0.7,0.1 1.4,0.4 1.9,0.9c0.1,0.1 0.3,0.3 0.3,0.5c0.1,0.2 0.1,0.4 0.1,0.6C180,101.2 179.8,101.6 179.5,101.8L179.5,101.8zM180.1,97.6c0.2,-0.2 0.3,-0.5 0.3,-0.7c0,-0.1 -0.1,-0.2 -0.1,-0.3c-0.1,-0.1 -0.1,-0.2 -0.3,-0.3c-0.4,-0.4 -1,-0.7 -1.6,-0.8c-0.6,-0.1 -1.1,0 -1.7,0.2c-0.6,0.2 -1.1,0.5 -1.5,0.9l0.1,-0.5c0.2,0.4 0.5,0.7 0.8,1c0.3,0.3 0.7,0.5 1.1,0.7C178.3,98 179.3,97.9 180.1,97.6L180.1,97.6zM180.2,97.8c-0.9,0.6 -2,0.9 -3,0.6c-0.5,-0.1 -1.1,-0.4 -1.5,-0.7c-0.4,-0.3 -0.8,-0.8 -1.1,-1.2c-0.1,-0.2 -0.1,-0.3 0.1,-0.5c0.5,-0.5 1.1,-1 1.8,-1.2c0.7,-0.2 1.4,-0.3 2.2,-0.1c0.7,0.2 1.4,0.6 1.8,1.2c0.1,0.1 0.3,0.3 0.3,0.5c0.1,0.2 0.1,0.4 0.1,0.6C180.8,97.2 180.6,97.6 180.2,97.8zM182,94.1c0.3,-0.1 0.5,-0.4 0.5,-0.7v-0.3c-0.1,-0.1 -0.1,-0.2 -0.2,-0.3c-0.3,-0.5 -0.8,-0.9 -1.3,-1.2c-0.5,-0.2 -1.1,-0.3 -1.7,-0.3c-0.6,0.1 -1.1,0.3 -1.6,0.5l0.1,-0.5c0.1,0.4 0.3,0.8 0.5,1.2c0.3,0.3 0.6,0.6 0.9,0.9c0.8,0.5 1.8,0.7 2.7,0.5L182,94.1L182,94.1zM182.1,94.3c-1,0.4 -2.1,0.3 -3.1,-0.1c-0.5,-0.3 -0.9,-0.6 -1.3,-1c-0.4,-0.4 -0.6,-0.9 -0.7,-1.5c-0.1,-0.2 0,-0.3 0.1,-0.4c0.6,-0.4 1.3,-0.7 2,-0.7c0.7,-0.1 1.5,0.1 2.2,0.4c0.7,0.3 1.2,0.9 1.5,1.6c0.1,0.2 0.2,0.3 0.2,0.5c0,0.2 0,0.4 -0.1,0.6C182.8,94 182.4,94.3 182.1,94.3L182.1,94.3L182.1,94.3z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="285"/>
+            line="285"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1330 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1330 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M174.8,95.9L174.8,95.9l-0.1,-0.3c-0.1,-0.1 -0.1,-0.3 -0.1,-0.4c-0.1,-0.3 -0.2,-0.5 -0.3,-0.7c-0.3,-0.5 -0.6,-0.8 -1.1,-1.1c-0.4,-0.3 -0.9,-0.4 -1.4,-0.5H171c-0.2,0 -0.3,0.1 -0.4,0.2c-0.1,0.1 -0.1,0.3 -0.1,0.5c0.1,0.2 0.2,0.5 0.3,0.7c0.3,0.5 0.6,0.8 1.1,1.1c0.5,0.3 1,0.5 1.5,0.5c0.3,0.1 0.5,0.1 0.8,0.1c0.1,0 0.3,0 0.4,-0.1H174.8L174.8,95.9L174.8,95.9zM174.9,96.2l-0.2,0.1l-0.2,0.1c-0.1,0.1 -0.3,0.1 -0.4,0.1c-0.3,0.1 -0.6,0.1 -0.9,0.1c-0.6,0 -1.3,-0.2 -1.8,-0.5c-0.8,-0.5 -1.5,-1.2 -1.8,-2.2c-0.1,-0.4 -0.1,-0.8 0.2,-1.2c0.2,-0.3 0.6,-0.5 1,-0.6h0.9c0.6,0.1 1.2,0.3 1.8,0.7c0.5,0.3 0.9,0.9 1.1,1.5c0.1,0.3 0.2,0.6 0.3,0.9L174.9,96.2L174.9,96.2zM177.2,91.4v-0.3c0,-0.1 -0.1,-0.3 -0.1,-0.4c0,-0.3 -0.1,-0.5 -0.3,-0.7c-0.2,-0.5 -0.5,-0.9 -0.9,-1.2c-0.4,-0.3 -0.9,-0.5 -1.4,-0.7c-0.1,0 -0.3,-0.1 -0.4,-0.1h-0.3c-0.4,0 -0.7,0.3 -0.7,0.7c0,0 0,0 0,0c0,0.2 0.1,0.5 0.2,0.7c0.2,0.5 0.5,0.9 0.9,1.2c0.4,0.3 0.9,0.6 1.4,0.7c0.3,0.1 0.5,0.1 0.8,0.1h0.6L177.2,91.4L177.2,91.4zM177.3,91.7l-0.2,0.1l-0.2,0.1c-0.1,0 -0.3,0.1 -0.5,0.1c-0.3,0 -0.6,0 -0.9,-0.1c-0.6,-0.1 -1.2,-0.3 -1.7,-0.7c-0.5,-0.3 -0.9,-0.9 -1.1,-1.5c-0.2,-0.3 -0.3,-0.7 -0.3,-1c0,-0.4 0.1,-0.8 0.4,-1.1c0.3,-0.3 0.6,-0.4 1,-0.5h0.5c0.1,0 0.3,0.1 0.5,0.1c0.6,0.2 1.2,0.5 1.6,0.9c0.5,0.4 0.8,1 0.9,1.6c0.1,0.3 0.1,0.6 0.1,0.9c0,0.2 0,0.3 -0.1,0.5l-0.1,0.2L177.3,91.7L177.3,91.7z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="290"/>
+            line="290"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (918 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (918 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M172.6,104.8l6.9,-0.2c0.1,0 0.3,0.1 0.3,0.3v0.1c-0.6,1.4 -1.3,2.7 -2,4v-0.3c0.7,1.3 1.3,2.8 1.6,4.3c0.4,1.5 0.5,3 0.4,4.5c-0.2,1.6 -0.9,3.1 -2.1,4.1c-1.3,1 -2.9,1.5 -4.5,1.4v-0.9h0.1c0.2,0 0.4,0.2 0.4,0.4s-0.2,0.4 -0.4,0.4c-1.6,0 -3.2,-0.5 -4.5,-1.4c-1.2,-1 -2,-2.5 -2.1,-4.1c-0.1,-1.5 0,-3.1 0.4,-4.5c0.4,-1.5 0.9,-2.9 1.6,-4.3v0.3l-2,-4c-0.1,-0.2 0,-0.3 0.1,-0.4h0.1l6.9,0.1v0.3h-1.5L172.6,104.8L172.6,104.8zM172.6,104.8h1.5c0.1,0 0.2,0.1 0.2,0.2c0,0.1 -0.1,0.2 -0.2,0.2c0,0 0,0 0,0l-6.9,0.1l0.3,-0.4l2.1,3.9c0.1,0.1 0.1,0.2 0,0.3c-0.7,1.3 -1.2,2.7 -1.5,4.1c-0.4,1.4 -0.5,2.8 -0.3,4.3c0.1,1.4 0.8,2.7 1.8,3.6c1.1,0.8 2.5,1.3 3.9,1.2v0.9h-0.1c-0.2,0 -0.4,-0.2 -0.4,-0.4c0,0 0,0 0,0c0,-0.2 0.2,-0.4 0.4,-0.4c1.4,0.1 2.8,-0.4 3.9,-1.2c1.1,-0.9 1.7,-2.2 1.8,-3.6c0.2,-1.4 0,-2.9 -0.3,-4.3c-0.4,-1.4 -0.9,-2.8 -1.5,-4.1c-0.1,-0.1 -0.1,-0.2 0,-0.3c0.7,-1.3 1.4,-2.6 2.1,-3.9l0.3,0.4l-6.9,-0.2v-0.4L172.6,104.8L172.6,104.8z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="300"/>
+            line="300"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (958 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (958 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="    &lt;path android:fillColor=&quot;#C8D7E2&quot; android:pathData=&quot;M43.628 0.623c-8.762-0.35-21.694 4.811-29.24 12.697-3.804 3.916-6.896 8.542-8.915 13.643-2.02 5.1-3.098 10.442-3.098 15.898 0 5.456 1.073 10.917 3.207 15.898 2.134 4.98 5.232 9.612 9.035 13.408 3.804 3.796 8.44 6.881 13.436 8.896a42.779 42.779 0 0 0 15.93 3.086c5.468 0 10.82-1.07 15.931-3.086 4.991-2.015 9.632-5.1 13.436-8.896 3.803-3.796 6.895-8.422 9.035-13.408 2.14-4.986 3.207-10.442 3.207-15.898 0.12-10.917-4.28-21.709-12.007-29.54-3.803-3.916-8.439-7.117-13.55-9.252C53.643 0.765 45.718 0.705 43.628 0.623zm31.27 11.392c4.045 4.036 7.372 8.782 9.632 14.118 2.26 5.22 3.448 11.032 3.448 16.728 0.12 11.507-4.635 22.9-12.839 31.086-4.044 4.036-8.915 7.357-14.267 9.612C55.52 85.815 49.817 86.88 43.99 87c-11.53 0-23.062-4.746-31.15-12.933-4.044-4.036-7.372-9.016-9.512-14.237C1.193 54.494 0 48.798 0 42.98c0-11.507 4.876-22.9 13.08-30.846 4.159-3.916 9.035-7.116 14.267-9.251C32.584 0.907 38.05-0.158 43.633 0.022 43.83 0.027 62.935-0.563 74.9 12.015z&quot;/>"
+        errorLine2="                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_info_outline_88dp.xml"
-            line="8"/>
+            line="8"
+            column="57"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (2734 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (2734 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="    &lt;path android:fillColor=&quot;#A8BECE&quot; android:fillType=&quot;evenOdd&quot; android:pathData=&quot;M27.243,87.158a62.555,62.555 0,0 0,-3.294 -0.184c-1.097,-0.055 -2.194,-0.04 -3.292,-0.063a72.81,72.81 0,0 0,-3.294 0.038c-0.923,0.04 -1.848,0.088 -2.771,0.167 0.076,-3.53 0.143,-7.06 0.172,-10.59 0.056,-3.714 0.04,-7.428 0.064,-11.142 0.015,-3.714 -0.02,-7.428 -0.037,-11.142l-0.078,-5.57 -0.132,-5.571a0.51,0.51 0,1 0,-1.02 0l-0.134,5.57 -0.077,5.571c-0.016,3.714 -0.053,7.428 -0.037,11.142 0.024,3.714 0.008,7.428 0.063,11.142 0.03,3.714 0.102,7.428 0.184,11.141a0.505,0.505 0,0 0,0.418 0.481c0.03,0.01 0.059,0.025 0.092,0.029 1.098,0.115 2.196,0.162 3.293,0.21a72.81,72.81 0,0 0,3.294 0.037c1.098,-0.023 2.195,-0.008 3.292,-0.064a62.553,62.553 0,0 0,3.294 -0.183,0.512 0.512,0 0,0 0,-1.019M78.854,18.864l0.013,2.74 0.03,5.482 0.075,5.483 0.132,5.48a0.511,0.511 0,0 0,1.02 0l0.131,-5.48 0.076,-5.483 0.03,-5.482 0.013,-2.74c-0.01,-0.931 0.048,-1.776 -0.064,-2.832 -0.247,-2.02 -1.365,-3.905 -2.998,-5.105a7.512,7.512 0,0 0,-2.734 -1.274,6.728 6.728,0 0,0 -1.502,-0.196c-0.51,-0.022 -0.93,0.004 -1.398,0.003 -3.66,0.033 -7.318,0.102 -10.978,0.191a0.509,0.509 0,1 0,0 1.019c3.66,0.09 7.319,0.158 10.978,0.19 0.445,0.011 0.942,0 1.346,0.029 0.409,0.018 0.815,0.077 1.21,0.177a6.057,6.057 0,0 1,2.194 1.043,6.055 6.055,0 0,1 2.375,4.11c0.082,0.762 0.031,1.75 0.051,2.645M14.07,10.67c2.535,0.095 5.071,0.147 7.607,0.183 2.535,0.056 5.071,0.04 7.607,0.064 2.535,0.015 5.071,-0.02 7.607,-0.038 2.535,-0.048 5.071,-0.094 7.607,-0.21a0.51,0.51 0,0 0,0 -1.019c-2.536,-0.115 -5.072,-0.16 -7.607,-0.208 -2.536,-0.017 -5.072,-0.054 -7.607,-0.038 -2.536,0.023 -5.072,0.007 -7.607,0.063a332.3,332.3 0,0 0,-7.607 0.184,0.51 0.51,0 0,0 0,1.019M71.45,28.012c-1.323,-0.116 -2.647,-0.162 -3.97,-0.21a105.919,105.919 0,0 0,-3.973 -0.037c-1.324,0.024 -2.647,0.007 -3.971,0.063a92.07,92.07 0,0 0,-3.972 0.184,0.51 0.51,0 0,0 0,1.018c1.324,0.096 2.647,0.147 3.972,0.185 1.324,0.055 2.647,0.04 3.971,0.063a105.92,105.92 0,0 0,3.973 -0.038c1.323,-0.048 2.647,-0.093 3.97,-0.21a0.51,0.51 0,0 0,0 -1.018M67.288,38.56a0.51,0.51 0,0 0,0 -1.018c-1.323,-0.116 -2.648,-0.162 -3.97,-0.21a105.919,105.919 0,0 0,-3.973 -0.037c-1.324,0.024 -2.648,0.008 -3.971,0.063a92.07,92.07 0,0 0,-3.973 0.184,0.51 0.51,0 0,0 0,1.018c1.325,0.096 2.648,0.147 3.973,0.185 1.323,0.055 2.647,0.04 3.971,0.062 1.324,0.017 2.648,-0.003 3.972,-0.037 1.323,-0.048 2.648,-0.093 3.97,-0.21M44.432,57.25a0.511,0.511 0,0 0,-0.473 -0.546c-1.634,-0.115 -3.269,-0.162 -4.902,-0.21 -1.634,-0.016 -3.268,-0.053 -4.902,-0.037 -1.634,0.024 -3.268,0.008 -4.902,0.064a140.05,140.05 0,0 0,-4.902 0.183,0.512 0.512,0 0,0 0,1.02c1.635,0.094 3.268,0.146 4.902,0.183 1.634,0.056 3.268,0.04 4.902,0.063 1.634,0.016 3.268,-0.021 4.902,-0.037 1.633,-0.048 3.268,-0.094 4.902,-0.21a0.511,0.511 0,0 0,0.473 -0.473&quot;/>"
+        errorLine2="                                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_insights_94dp.xml"
-            line="3"/>
+            line="3"
+            column="84"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (2834 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (2834 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="    &lt;path android:fillColor=&quot;#A8BECE&quot; android:fillType=&quot;evenOdd&quot; android:pathData=&quot;M38.275,66.786a0.511,0.511 0,0 0,-0.468 -0.552c-1.386,-0.116 -2.773,-0.162 -4.16,-0.209a116.134,116.134 0,0 0,-4.159 -0.037c-1.387,0.022 -2.773,0.007 -4.16,0.062a99.586,99.586 0,0 0,-4.16 0.184,0.511 0.511,0 0,0 0,1.02c1.386,0.094 2.773,0.147 4.16,0.183 1.387,0.056 2.773,0.04 4.16,0.064 1.387,0.016 2.773,-0.005 4.16,-0.038 1.386,-0.048 2.773,-0.094 4.16,-0.21a0.51,0.51 0,0 0,0.467 -0.467M24.206,77.034c1.012,0.008 2.024,-0.03 3.037,-0.25a0.52,0.52 0,0 0,0 -1.02c-1.013,-0.22 -2.025,-0.259 -3.037,-0.25 -1.013,0.014 -2.025,0.067 -3.038,0.25a0.518,0.518 0,0 0,0 1.019c1.013,0.184 2.025,0.237 3.038,0.25M47.702,80.733a0.383,0.383 0,0 0,-0.382 0.382v3.82a0.383,0.383 0,0 0,0.765 0v-3.82a0.383,0.383 0,0 0,-0.383 -0.382M47.702,75.99h-2.904a0.383,0.383 0,1 0,0 0.765h2.522v0.538a0.383,0.383 0,0 0,0.765 0v-0.92a0.383,0.383 0,0 0,-0.383 -0.383M47.702,88.375a0.383,0.383 0,0 0,-0.382 0.382v3.821a0.383,0.383 0,0 0,0.765 0v-3.821a0.383,0.383 0,0 0,-0.383 -0.382M37.146,75.99a0.383,0.383 0,1 0,0 0.765h3.826a0.383,0.383 0,1 0,0 -0.765h-3.826zM34.94,76.373a0.383,0.383 0,0 0,-0.765 0v3.82a0.383,0.383 0,0 0,0.765 0v-3.82zM34.558,83.633a0.383,0.383 0,0 0,-0.383 0.382v3.821a0.383,0.383 0,0 0,0.765 0v-3.821a0.383,0.383 0,0 0,-0.382 -0.382M36.843,92.814H34.94v-1.157a0.383,0.383 0,0 0,-0.766 0v1.539c0,0.211 0.17,0.382 0.383,0.382h2.285a0.383,0.383 0,1 0,0 -0.764M44.495,92.814h-3.826a0.383,0.383 0,1 0,0 0.764h3.826a0.383,0.383 0,1 0,0 -0.764M53.976,81.185a0.383,0.383 0,0 0,0.765 0v-3.821a0.383,0.383 0,0 0,-0.765 0v3.82zM53.976,88.827a0.383,0.383 0,0 0,0.765 0v-3.821a0.383,0.383 0,0 0,-0.765 0v3.821zM57.636,92.814h-2.895v-0.166a0.383,0.383 0,0 0,-0.765 0v0.548c0,0.211 0.17,0.382 0.383,0.382h3.277a0.383,0.383 0,1 0,0 -0.764M53.976,73.543a0.383,0.383 0,0 0,0.765 0V69.72a0.383,0.383 0,0 0,-0.765 0v3.822zM54.358,66.282a0.383,0.383 0,0 0,0.383 -0.382v-3.82a0.383,0.383 0,0 0,-0.765 0v3.82c0,0.211 0.171,0.382 0.382,0.382M58.788,54.055h-3.826a0.384,0.384 0,0 0,-0.302 0.146,0.383 0.383,0 0,0 -0.684,0.235v3.822a0.383,0.383 0,0 0,0.765 0v-3.51c0.063,0.045 0.14,0.071 0.221,0.071h3.826a0.383,0.383 0,1 0,0 -0.764M67.503,64.457a0.383,0.383 0,0 0,-0.382 0.382v3.821a0.383,0.383 0,0 0,0.765 0V64.84a0.383,0.383 0,0 0,-0.383 -0.382M67.503,72.1a0.383,0.383 0,0 0,-0.382 0.381v3.821a0.383,0.383 0,0 0,0.765 0v-3.82a0.383,0.383 0,0 0,-0.383 -0.383M65.288,92.814h-3.826a0.383,0.383 0,1 0,0 0.764h3.826a0.383,0.383 0,1 0,0 -0.764M67.503,56.815a0.383,0.383 0,0 0,-0.382 0.382v3.82a0.383,0.383 0,0 0,0.765 0v-3.82a0.383,0.383 0,0 0,-0.383 -0.382M67.503,79.741a0.383,0.383 0,0 0,-0.382 0.383v3.82a0.383,0.383 0,0 0,0.765 0v-3.82a0.383,0.383 0,0 0,-0.383 -0.383M66.44,54.055h-3.826a0.383,0.383 0,1 0,0 0.764h3.827a0.383,0.383 0,1 0,0 -0.764M67.503,87.384a0.383,0.383 0,0 0,-0.382 0.382v3.821a0.383,0.383 0,0 0,0.765 0v-3.821a0.383,0.383 0,0 0,-0.383 -0.382&quot;/>"
+        errorLine2="                                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_insights_94dp.xml"
-            line="4"/>
+            line="4"
+            column="84"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1334 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1334 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="    &lt;path android:fillColor=&quot;#A8BECE&quot; android:fillType=&quot;evenOdd&quot; android:pathData=&quot;M73.777,79.81a0.383,0.383 0,0 0,0.766 0v-3.822a0.383,0.383 0,0 0,-0.766 0v3.821zM73.777,64.525a0.383,0.383 0,0 0,0.766 0v-3.821a0.383,0.383 0,0 0,-0.766 0v3.82zM73.777,72.167a0.383,0.383 0,0 0,0.766 0v-3.821a0.383,0.383 0,0 0,-0.766 0v3.821zM40.481,29.316l2.092,-3.2 0.007,-0.01a0.323,0.323 0,0 0,-0.553 -0.333l-1.977,3.272a0.255,0.255 0,0 0,0.431 0.27M44.148,23a0.35,0.35 0,0 0,0.483 -0.106l2.056,-3.222 0.003,-0.004a0.376,0.376 0,0 0,-0.639 -0.395l-2.012,3.25a0.35,0.35 0,0 0,0.11 0.478M50.618,12.722a0.334,0.334 0,0 0,-0.462 0.101l-2.065,3.217 -0.004,0.006a0.37,0.37 0,0 0,0.631 0.387l2.004,-3.255a0.335,0.335 0,0 0,-0.104 -0.456M25.471,27.857a0.37,0.37 0,1 0,0.427 -0.605,78.013 78.013,0 0,0 -3.185,-2.12 0.256,0.256 0,0 0,-0.296 0.416c1,0.794 2.016,1.564 3.051,2.308l0.003,0.001zM30.46,30.967a0.255,0.255 0,0 0,-0.034 -0.36A43.408,43.408 0,0 0,29 29.489l-0.015,-0.011a0.342,0.342 0,0 0,-0.381 0.567c0.502,0.336 1.009,0.663 1.525,0.978a0.257,0.257 0,0 0,0.33 -0.056M9.56,31.98a0.366,0.366 0,0 0,-0.505 0.115,104.97 104.97,0 0,0 -1.988,3.267 0.256,0.256 0,0 0,0.429 0.277,101.286 101.286,0 0,0 2.174,-3.146l0.005,-0.008a0.365,0.365 0,0 0,-0.115 -0.504M13.3,26.255a0.256,0.256 0,0 0,-0.358 0.054c-0.624,0.846 -1.22,1.71 -1.806,2.58l-0.006,0.01a0.366,0.366 0,1 0,0.62 0.387,70.574 70.574,0 0,0 1.62,-2.7 0.255,0.255 0,0 0,-0.07 -0.33&quot;/>"
+        errorLine2="                                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_insights_94dp.xml"
-            line="14"/>
+            line="14"
+            column="84"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (939 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (939 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="    &lt;path android:fillColor=&quot;#A8BECE&quot; android:fillType=&quot;evenOdd&quot; android:pathData=&quot;M38.607,36.683a3.351,3.351 0,0 1,-2.251 1.26,3.348 3.348,0 0,1 -2.484,-0.699 3.343,3.343 0,0 1,-1.262 -2.248,3.341 3.341,0 0,1 0.7,-2.48 3.35,3.35 0,0 1,2.655 -1.285,3.368 3.368,0 0,1 2.642,5.452m-0.089,-5.33a4.145,4.145 0,0 0,-5.81 0.69,4.1 4.1,0 0,0 -0.858,3.043 4.107,4.107 0,0 0,1.548 2.758,4.107 4.107,0 0,0 3.048,0.858 4.133,4.133 0,0 0,2.072 -7.349M14.838,18.883a3.351,3.351 0,0 1,2.655 -1.285c0.753,0 1.48,0.25 2.08,0.723a3.343,3.343 0,0 1,1.262 2.248,3.341 3.341,0 0,1 -0.7,2.481 3.38,3.38 0,0 1,-4.735 0.562,3.368 3.368,0 0,1 -0.562,-4.73m0.089,5.33a4.112,4.112 0,0 0,3.048 0.858,4.11 4.11,0 0,0 2.761,-1.547 4.1,4.1 0,0 0,0.86 -3.044,4.107 4.107,0 0,0 -1.55,-2.758A4.108,4.108 0,0 0,17 16.864a4.133,4.133 0,0 0,-2.072 7.349M6.785,42.56a3.38,3.38 0,0 1,-4.736 0.562,3.368 3.368,0 0,1 2.093,-6.014 3.368,3.368 0,0 1,2.642 5.452m-0.088,-5.33a4.12,4.12 0,0 0,-3.048 -0.857,4.133 4.133,0 1,0 0.976,8.207 4.133,4.133 0,0 0,2.072 -7.35&quot;/>"
+        errorLine2="                                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_insights_94dp.xml"
-            line="16"/>
+            line="16"
+            column="84"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (3386 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (3386 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M95.6,70.7H91c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S95.8,70.7,95.6,70.7z M86.4,70.7h-4.6c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S86.6,70.7,86.4,70.7z M77.2,70.7h-4.6c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S77.4,70.7,77.2,70.7z M67.9,70.7h-4.6c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S68.2,70.7,67.9,70.7z M58.7,70.7h-4.6c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S59,70.7,58.7,70.7z M49.5,70.7h-4.6c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S49.8,70.7,49.5,70.7z M40.3,70.7h-4.6c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S40.6,70.7,40.3,70.7z M31.1,70.7h-4.6c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S31.3,70.7,31.1,70.7z M21.9,70.7h-4.6c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S22.1,70.7,21.9,70.7z M12.7,70.7H8.1c-0.1,0-0.1,0-0.2,0c-0.4-0.2-0.4-0.2,0.6-2.9c0.1-0.2,0.4-0.4,0.6-0.3c0.2,0.1,0.4,0.4,0.3,0.6c-0.3,0.7-0.5,1.3-0.6,1.6h4c0.3,0,0.5,0.2,0.5,0.5S12.9,70.7,12.7,70.7z M94.8,66.3c-0.2,0-0.4-0.1-0.4-0.3c-0.4-1.5-0.8-3-1.3-4.4c-0.1-0.2,0-0.5,0.3-0.6c0.2-0.1,0.5,0,0.6,0.3c0.5,1.4,0.9,2.9,1.3,4.5c0.1,0.2-0.1,0.5-0.3,0.6C94.9,66.3,94.9,66.3,94.8,66.3z M10.6,64.1c-0.1,0-0.1,0-0.2,0c-0.2-0.1-0.3-0.4-0.2-0.6c0.6-1.4,1.3-2.8,2-4.2c0.1-0.2,0.4-0.3,0.6-0.2c0.2,0.1,0.3,0.4,0.2,0.6c-0.7,1.4-1.3,2.7-2,4.2C11,64,10.8,64.1,10.6,64.1z M91.8,57.6c-0.2,0-0.3-0.1-0.4-0.3c-0.7-1.5-1.4-2.8-2.2-4c-0.1-0.2-0.1-0.5,0.1-0.6c0.2-0.1,0.5-0.1,0.6,0.1c0.8,1.2,1.5,2.6,2.2,4.1c0.1,0.2,0,0.5-0.2,0.6C91.9,57.6,91.9,57.6,91.8,57.6z M14.8,55.9c-0.1,0-0.2,0-0.2-0.1c-0.2-0.1-0.3-0.4-0.2-0.6c0.8-1.4,1.6-2.7,2.5-3.9c0.1-0.2,0.4-0.3,0.6-0.1c0.2,0.1,0.3,0.4,0.1,0.6c-0.8,1.2-1.6,2.5-2.4,3.9C15.1,55.8,15,55.9,14.8,55.9z M60.6,50.2c0,0-0.1,0-0.1,0c-1.2-0.3-2.4-1.2-3.8-2.9c-0.2-0.2-0.1-0.5,0.1-0.6c0.2-0.2,0.5-0.1,0.6,0.1c1.3,1.5,2.3,2.3,3.4,2.6c0.2,0.1,0.4,0.3,0.3,0.6C60.9,50.1,60.8,50.2,60.6,50.2z M86.7,50c-0.1,0-0.2,0-0.3-0.1c-1.2-1.1-2.4-1.9-3.7-2.4c-0.2-0.1-0.4-0.4-0.3-0.6s0.4-0.4,0.6-0.3c1.4,0.5,2.7,1.4,4,2.6c0.2,0.2,0.2,0.5,0,0.7C87,50,86.8,50,86.7,50z M65.1,50c-0.2,0-0.4-0.1-0.4-0.4c-0.1-0.2,0.1-0.5,0.3-0.6c1.6-0.4,3-0.9,4.3-1.4c0.2-0.1,0.5,0,0.6,0.3c0.1,0.2,0,0.5-0.3,0.6c-1.3,0.5-2.8,1.1-4.4,1.5C65.2,50,65.1,50,65.1,50z M19.9,48.2c-0.1,0-0.2,0-0.3-0.1c-0.2-0.2-0.2-0.4-0.1-0.6c1-1.3,2-2.4,3-3.5c0.2-0.2,0.5-0.2,0.7,0c0.2,0.2,0.2,0.5,0,0.7c-1,1.1-2,2.2-3,3.5C20.2,48.2,20.1,48.2,19.9,48.2z M73.8,47c-0.2,0-0.4-0.1-0.4-0.4c-0.1-0.2,0.1-0.5,0.3-0.6c1.6-0.4,3.1-0.5,4.7-0.4c0.3,0,0.4,0.2,0.4,0.5c0,0.3-0.2,0.5-0.5,0.4c-1.5-0.1-2.9,0-4.4,0.4C73.9,47,73.9,47,73.8,47z M54.1,43.8c-0.1,0-0.3-0.1-0.4-0.2c-0.8-1.1-1.8-2.4-2.9-3.5c-0.2-0.2-0.2-0.5,0-0.7c0.2-0.2,0.5-0.2,0.7,0c1.1,1.2,2.1,2.5,3,3.6c0.2,0.2,0.1,0.5-0.1,0.6C54.3,43.8,54.2,43.8,54.1,43.8z M26.3,41.6c-0.1,0-0.3-0.1-0.4-0.2c-0.2-0.2-0.1-0.5,0.1-0.6c1.2-1,2.5-1.9,3.8-2.7c0.2-0.1,0.5-0.1,0.6,0.2c0.1,0.2,0.1,0.5-0.2,0.6c-1.2,0.7-2.5,1.6-3.7,2.6C26.5,41.6,26.4,41.6,26.3,41.6z M47.6,37.4c-0.1,0-0.2,0-0.2-0.1c-1.3-0.8-2.7-1.2-4.2-1.4c-0.3,0-0.4-0.3-0.4-0.5c0-0.3,0.3-0.4,0.5-0.4c1.6,0.2,3.1,0.8,4.5,1.6c0.2,0.1,0.3,0.4,0.2,0.6C47.9,37.3,47.8,37.4,47.6,37.4z M34.3,37c-0.2,0-0.4-0.1-0.4-0.3c-0.1-0.2,0-0.5,0.3-0.6c1.5-0.5,3-0.9,4.6-1.1c0.3,0,0.5,0.1,0.5,0.4c0,0.3-0.1,0.5-0.4,0.5c-1.5,0.2-2.9,0.5-4.4,1C34.4,37,34.3,37,34.3,37z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_media_105dp.xml"
-            line="15"/>
+            line="15"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (971 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (971 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M79.7,33.2c-1.3,0-2.5-0.3-3.6-0.9c-0.2-0.1-0.3-0.4-0.2-0.6c0.1-0.2,0.4-0.3,0.6-0.2c2.3,1.1,5.2,1,7.3-0.5c0.2-0.1,0.5-0.1,0.6,0.1c0.1,0.2,0.1,0.5-0.1,0.6C82.9,32.7,81.3,33.2,79.7,33.2z M72.9,29.2c-0.2,0-0.3-0.1-0.4-0.2c-0.8-1.3-1.1-2.8-1.1-4.3c0-0.1,0-0.3,0-0.4c0-0.3,0.2-0.5,0.5-0.4c0.3,0,0.5,0.2,0.4,0.5c0,0.1,0,0.2,0,0.3c0,1.3,0.4,2.7,1,3.8c0.1,0.2,0.1,0.5-0.2,0.6C73.1,29.2,73,29.2,72.9,29.2z M86.9,28.3c-0.1,0-0.1,0-0.2,0c-0.2-0.1-0.3-0.4-0.2-0.6c0.4-0.9,0.6-1.9,0.6-2.9c0-0.4,0-0.9-0.1-1.3c0-0.3,0.1-0.5,0.4-0.5c0.3,0,0.5,0.1,0.5,0.4c0.1,0.5,0.1,1,0.1,1.5c0,1.1-0.2,2.2-0.7,3.3C87.3,28.2,87.1,28.3,86.9,28.3z M73.3,20.5c-0.1,0-0.2,0-0.3-0.1c-0.2-0.1-0.3-0.4-0.1-0.6c1-1.3,2.3-2.4,3.8-2.9c0.2-0.1,0.5,0,0.6,0.3c0.1,0.2,0,0.5-0.3,0.6c-1.4,0.5-2.5,1.4-3.4,2.6C73.6,20.5,73.5,20.5,73.3,20.5z M85.4,19.7c-0.1,0-0.2,0-0.3-0.1c-1-1.1-2.3-1.8-3.7-2.1c-0.2-0.1-0.4-0.3-0.3-0.6c0.1-0.2,0.3-0.4,0.6-0.3c1.6,0.4,3,1.2,4.2,2.4c0.2,0.2,0.2,0.5,0,0.7C85.6,19.7,85.5,19.7,85.4,19.7z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_media_105dp.xml"
-            line="20"/>
+            line="20"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (994 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (994 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M0.9,23.9l4.5-0.1c0.2,0,0.4,0.1,0.4,0.4c0,0.2-0.1,0.4-0.4,0.4l-4.5-0.1c-0.1,0-0.3-0.1-0.3-0.3C0.6,24,0.7,23.9,0.9,23.9z M7.8,21.7c0.4-1.5,1.2-2.9,2-4.2c0.1-0.2,0.4-0.2,0.6-0.1c0.2,0.1,0.2,0.4,0.1,0.6C9.6,19.2,9,20.6,8.6,22c-0.1,0.1-0.3,0.3-0.4,0.3C7.8,22,7.8,21.9,7.8,21.7z M13.5,14.4c0.7-0.3,1.6-0.4,2.4-0.4c0.8,0,1.6,0.1,2.4,0.4c0.2,0.1,0.4,0.4,0.3,0.6s-0.4,0.4-0.6,0.3c-1.3-0.5-2.8-0.6-4.1-0.1c-0.2,0.1-0.4,0-0.5-0.2V15C13.2,14.7,13.3,14.4,13.5,14.4z M21.4,17.8c0.2,0.1,0.4,0.1,0.6,0.1c0.4-0.2,0.7-0.4,1.1-0.4c0.8-0.2,1.6-0.3,2.4-0.3c0.3,0,0.4,0.2,0.4,0.4c0,0.3-0.2,0.4-0.4,0.4c-0.7,0-1.4,0.1-2.1,0.3c-0.4,0.1-0.7,0.3-1,0.4c-0.5,0.2-1.1,0.2-1.6-0.1c-0.2-0.2-0.2-0.6,0-0.8C20.9,17.8,21.1,17.7,21.4,17.8z M29.7,19.3c0.4,0.7,0.7,1.5,0.8,2.3c0.1,0.8,0.1,1.6,0.1,2.4c0,0.2-0.2,0.4-0.4,0.4s-0.4-0.1-0.4-0.4c0.1-1.5-0.2-3-0.9-4.2c-0.1-0.2-0.1-0.4,0.1-0.6C29.2,19,29.6,19,29.7,19.3z M34.6,23.9H38c0.1,0,0.3,0.1,0.3,0.3c0,0.1-0.1,0.3-0.2,0.3h-3.5c-0.2,0-0.4-0.1-0.4-0.4C34.3,24.1,34.4,23.9,34.6,23.9z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_media_105dp.xml"
-            line="25"/>
+            line="25"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1324 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1324 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M139.48 44.4l-6.77-2.25c0.07-2.23 0.37-4.43 0.9-6.54 2.36 1.75 6.67 1.22 6.67 1.22l-0.8 7.57zm-8.74-2.91l-3.49-1.17c-0.12-0.03-0.23-0.04-0.35-0.04 0.45-1.92 1.61-3.08 2.55-3.5 0.52-0.23 0.86-0.19 0.93-0.15 0.2 0.31 0.53 0.47 0.88 0.46-0.27 1.44-0.45 2.92-0.52 4.4zm-0.06 5.41c-1.01 0.67-1.83 0.83-2.42 0.46-1.03-0.64-1.64-2.72-1.57-5.11l4.01 1.33c0.01 1.08 0.08 2.16 0.19 3.23-0.07 0.03-0.14 0.04-0.21 0.09zm44.48-1.76c-0.59 0.32-1.23 0.63-1.91 0.91-0.05 0.02-0.09 0.05-0.14 0.07-4.42 1.82-8.68 1.94-12.57 0.89-8.58-2.32-15.42-10.31-18.51-18.28-0.63-1.65-1.11-3.3-1.41-4.89-0.15-0.78-0.25-1.55-0.31-2.3-0.11-1.43-0.06-2.79 0.17-4.05-3.2 2.52-5.93 6.57-7.95 12.73-0.42 1.28-0.5 2.31-0.34 3.14-0.18 0.58-0.36 1.17-0.51 1.76-0.53-0.46-1.31-0.63-2.18-0.45-1.96 0.42-4.26 2.48-4.71 6.05-0.39 3.16 0.2 6.97 2.42 8.34 0.44 0.27 1.02 0.5 1.75 0.5 0.63 0 1.38-0.19 2.22-0.64 0.07 0.39 0.14 0.78 0.23 1.17 1.63 7.8 3.89 14.95 13.26 16.78L145.6 73c0.06 0.41 0.36 0.71 0.74 0.81 0.08 0.02 0.16 0.04 0.25 0.04 0.05 0 0.1 0 0.15-0.01 0.55-0.08 0.92-0.59 0.84-1.14l-1.04-6.84c-0.06-0.43-0.4-0.76-0.83-0.83-8.74-1.41-10.76-7.79-12.35-15.35-0.37-1.78-0.58-3.6-0.65-5.43l6.55 2.19-0.52 4.98c0.07 3.43 1.9 6.6 4.88 8.28 4.35 2.45 10.94 6.47 19.33 4.53 0.81-0.19 1.57-0.47 2.3-0.81 5.96-2.77 9.31-10.31 10.37-18.55-0.15 0.09-0.3 0.18-0.46 0.27z&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="16"/>
+            line="16"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (885 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (885 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M190.34 153.76c-0.03-1.67-0.07-3.35-0.12-5.02l-0.37-14.71-0.51-14.7c-0.16-4.9-0.31-9.8-0.83-14.69-0.01-0.06-0.06-0.11-0.12-0.11-0.07-0.01-0.13 0.05-0.13 0.11-0.24 4.92-0.09 9.82 0.04 14.72l0.37 14.71 0.51 14.7c0.16 4.9 0.31 9.81 0.83 14.7 0.01 0.06 0.06 0.11 0.12 0.11h0.01c0.06 0 0.12-0.05 0.12-0.12 0.04-0.83 0.06-1.65 0.08-2.48 0.05-2.41 0.04-4.82 0-7.22m-59.76-28.77c-0.04-0.06-0.12-0.08-0.17-0.04-1.1 0.69-2.17 1.41-3.24 2.12-1.05 0.73-2.11 1.46-3.19 2.15-0.18 0.12-0.38 0.22-0.56 0.34-1.99 1.24-4.03 2.39-6.14 3.41-2.28 1.15-4.66 2.1-7.09 2.87-1.23 0.35-2.45 0.7-3.7 0.94-1.24 0.34-2.5 0.48-3.77 0.82l-0.01 0.01c-0.05 0.01-0.09 0.05-0.09 0.11v0.01c0 0.06 0.05 0.12 0.12 0.12 2.61 0.19 5.24-0.27 7.75-1 2.5-0.76 4.96-1.68 7.31-2.82 1.25-0.63 2.47-1.31 3.68-2.01 0.67-0.4 1.33-0.82 1.99-1.24 0.36-0.23 0.73-0.45 1.08-0.68 2.17-1.44 4.29-2.98 6.02-4.96 0.04-0.04 0.04-0.11 0.01-0.15&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="81"/>
+            line="81"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1934 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1934 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M79.79 78.6v-0.02c-0.03-0.69-0.12-1.59-0.27-2.82l-0.01 0.01c-0.02-0.17-0.03-0.32-0.06-0.5-0.2-1.52-0.47-3.89-0.87-6.12-0.07-0.39-0.15-0.79-0.23-1.17v-0.01c-0.03-0.16-0.07-0.32-0.1-0.48-0.03-0.13-0.06-0.25-0.09-0.37-0.05-0.19-0.09-0.37-0.14-0.55l-0.12-0.45-0.09-0.27c-0.06-0.21-0.13-0.4-0.2-0.59-0.02-0.07-0.05-0.14-0.07-0.2-0.08-0.19-0.15-0.38-0.23-0.54-0.02-0.04-0.04-0.07-0.06-0.11-0.08-0.15-0.16-0.3-0.25-0.42-0.01-0.02-0.02-0.04-0.04-0.06-0.09-0.13-0.19-0.24-0.29-0.33-0.02-0.02-0.04-0.04-0.06-0.05-0.1-0.08-0.21-0.14-0.32-0.18-0.02 0-0.04-0.01-0.06-0.01-0.11-0.03-0.23-0.04-0.36-0.01-0.07 0.02-0.13 0.04-0.19 0.08-0.02 0.01-0.04 0.03-0.06 0.04-0.04 0.03-0.08 0.06-0.11 0.09-0.02 0.03-0.04 0.05-0.06 0.08-0.03 0.03-0.05 0.07-0.08 0.11-0.02 0.03-0.03 0.06-0.05 0.1-0.02 0.04-0.04 0.08-0.06 0.13-0.02 0.04-0.03 0.08-0.05 0.12-0.01 0.05-0.03 0.09-0.04 0.15-0.02 0.04-0.03 0.09-0.04 0.14-0.01 0.05-0.03 0.1-0.04 0.16-0.01 0.05-0.02 0.11-0.03 0.17-0.01 0.05-0.01 0.1-0.02 0.16l-0.03 0.2c0 0.05-0.01 0.1-0.01 0.15-0.01 0.08-0.02 0.15-0.02 0.23 0 0.05-0.01 0.09-0.01 0.14-0.01 0.09-0.01 0.18-0.02 0.28v0.05l-0.03 1.01c0 0.33-0.01 0.66-0.02 0.99-0.02 0.72-0.05 1.41-0.16 2v0.01h-0.01c0 0.05-0.02 0.1-0.03 0.14-0.01 0.05-0.02 0.1-0.03 0.14v0.01c-0.03 0.14-0.07 0.27-0.12 0.4-0.01 0.02-0.01 0.03-0.02 0.05-0.01 0.02-0.02 0.04-0.03 0.07-0.03 0.07-0.07 0.15-0.11 0.22l-0.03 0.06c-0.06 0.1-0.13 0.19-0.2 0.26 0 0.01-0.01 0.01-0.01 0.01-0.07 0.07-0.15 0.13-0.23 0.17-0.03 0.02-0.05 0.03-0.07 0.04-0.08 0.04-0.17 0.06-0.26 0.08-0.01 0-0.03 0.01-0.05 0.01-0.11 0.02-0.23 0.02-0.36 0-0.03 0-0.06-0.01-0.09-0.01-0.11-0.02-0.22-0.05-0.34-0.08-0.04-0.02-0.08-0.03-0.12-0.05-0.16-0.05-0.32-0.12-0.5-0.21l-0.38-1.09-2.95-8.39-0.35-1.01-0.3-0.84-0.33-0.94c-0.92 5.8-0.77 13.5 2.33 19.81 0.83 1.68 1.86 3.25 3.14 4.67 0.1 0.11 0.19 0.23 0.3 0.34 0.19 0.2 0.18 0.52-0.02 0.71-0.04 0.04-0.09 0.06-0.14 0.09l1.31 1.93 5.97-3.54c-0.2-0.85-0.92-3.78-0.92-4.39&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="96"/>
+            line="96"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1028 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1028 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M94.1 65.96L83.95 37.07c-0.81-2.29-3.33-3.5-5.63-2.69l-12.88 4.53c-2.3 0.8-3.51 3.32-2.7 5.62l4.44 12.63 0.32 0.91 0.32 0.91 0.33 0.94 0.3 0.84 0.35 1.01 2.95 8.39 0.38 1.09c0.18 0.09 0.34 0.16 0.5 0.21 0.04 0.02 0.08 0.03 0.12 0.04 0.12 0.04 0.23 0.07 0.34 0.09 0.03 0 0.06 0.01 0.09 0.01 0.13 0.02 0.25 0.02 0.36 0 0.02 0 0.04-0.01 0.05-0.01 0.09-0.02 0.18-0.05 0.26-0.08 0.02-0.01 0.04-0.02 0.07-0.04 0.08-0.04 0.16-0.1 0.23-0.17 0 0 0.01 0 0.01-0.01 0.07-0.07 0.14-0.16 0.2-0.26l0.03-0.06c0.05-0.07 0.08-0.15 0.11-0.24 0.01-0.01 0.02-0.03 0.03-0.05 0.01-0.02 0.01-0.03 0.02-0.05 0.05-0.13 0.09-0.26 0.12-0.4v-0.01c0.01-0.04 0.02-0.09 0.03-0.14 0.01-0.04 0.03-0.09 0.03-0.14h0.01v-0.01l-0.13-0.34-0.03-0.11-0.17-0.47-0.31-0.88-0.18-0.5-0.19-0.55-1.01-2.88-0.21-0.61-0.33-0.92-0.31-0.89-0.19-0.52-0.35-1.01-1.24-3.53-0.25-0.7-0.23-0.66-0.54-1.55-0.25-0.69-0.24-0.69-1.84-5.25-1.32-3.74 15.75-5.54 1.32 3.74 8.18 23.26-12.09 4.25c0.4 2.23 0.67 4.6 0.87 6.12 0.03 0.17 0.05 0.33 0.07 0.49l11.89-4.18c2.29-0.81 3.5-3.32 2.69-5.62&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="106"/>
+            line="106"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (2794 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (2794 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M82.51 63.01c-0.52 0.22-1.05 0.42-1.58 0.62-0.53 0.19-1.07 0.37-1.61 0.54-0.54 0.17-1.06 0.39-1.68 0.34l-0.06-0.16c0.44-0.43 0.98-0.61 1.51-0.82 0.52-0.22 1.05-0.42 1.58-0.62 0.54-0.18 1.07-0.37 1.61-0.54 0.54-0.17 1.06-0.39 1.68-0.33l0.06 0.15c-0.44 0.44-0.98 0.61-1.51 0.82zm-5.49-0.34l-0.05-0.16c0.44-0.43 0.98-0.61 1.5-0.82 0.53-0.22 1.06-0.42 1.59-0.62 0.53-0.18 1.06-0.37 1.61-0.54 0.54-0.17 1.06-0.39 1.68-0.33l0.06 0.15c-0.45 0.44-0.99 0.61-1.51 0.82-0.52 0.22-1.05 0.42-1.58 0.62-0.54 0.18-1.07 0.37-1.61 0.54-0.54 0.17-1.07 0.39-1.69 0.34zm-0.56-1.68l-0.02-0.06-0.02-0.06c0.6-0.44 1.29-0.66 1.96-0.92l2.01-0.75 2.04-0.7c0.68-0.22 1.35-0.48 2.1-0.52l0.04 0.12c-0.6 0.43-1.28 0.66-1.96 0.92l-2.01 0.75-2.04 0.7c-0.68 0.22-1.35 0.48-2.1 0.52zm-0.54-4.47c-0.53 0.17-1.09-0.11-1.27-0.63-0.09-0.26-0.06-0.53 0.05-0.76l1.79 0.88c-0.11 0.23-0.31 0.42-0.57 0.51zm-3.55-3.04l-0.14-0.07c-0.2-0.09-0.28-0.34-0.18-0.54l0.21-0.45c0.02-0.04 0.05-0.07 0.08-0.1 0.06-0.06 0.13-0.11 0.21-0.12l0.01-0.01 0.55-0.1c0.13-0.03 0.27-0.09 0.38-0.17 0.13-0.08 0.2-0.14 0.23-0.23l0.25-0.51c0.34-0.69 0.64-1.35 1-2.07 0.43-0.76 1.16-1.34 1.99-1.59 0.82-0.26 1.75-0.18 2.52 0.21 0.77 0.38 1.38 1.07 1.67 1.88 0.29 0.81 0.26 1.73-0.08 2.51-0.35 0.71-0.7 1.35-1.08 2.02l-0.28 0.49c-0.08 0.11-0.1 0.25-0.1 0.42-0.01 0.16 0.02 0.34 0.07 0.49 0.08 0.2 0.15 0.4 0.21 0.58-0.06 0.16-0.11 0.34-0.18 0.52-0.03 0.07-0.11 0.11-0.18 0.08l-0.03-0.01c-1.25-0.46-2.48-0.99-3.68-1.56l-3.45-1.67zm10.12-11.84l-15.75 5.54 1.84 5.25 0.24 0.69 0.25 0.69 0.54 1.55 0.23 0.66 0.25 0.7 1.24 3.53 0.35 1.01 0.19 0.52 0.31 0.89 0.32 0.92 0.22 0.61 1.01 2.88 0.2 0.55 0.17 0.5 0.31 0.88 0.17 0.47 0.03 0.11 0.13 0.34c0.03-0.17 0.05-0.35 0.07-0.54 0.02-0.16 0.04-0.32 0.05-0.49 0.02-0.32 0.03-0.64 0.04-0.97 0.01-0.33 0.02-0.66 0.02-0.99l0.03-1.01v-0.05c0.01-0.1 0.01-0.19 0.02-0.28 0-0.05 0-0.09 0.01-0.14 0-0.08 0.01-0.15 0.02-0.23 0-0.05 0.01-0.1 0.01-0.15l0.03-0.2c0-0.05 0.01-0.11 0.02-0.16 0.01-0.06 0.02-0.12 0.03-0.17 0.01-0.06 0.02-0.11 0.04-0.16 0.01-0.05 0.02-0.1 0.04-0.14 0.01-0.06 0.02-0.1 0.04-0.15 0.02-0.04 0.03-0.08 0.05-0.12 0.02-0.05 0.04-0.09 0.06-0.13 0.01-0.04 0.03-0.07 0.05-0.1 0.02-0.04 0.05-0.08 0.08-0.11 0.02-0.03 0.04-0.05 0.06-0.08 0.03-0.03 0.07-0.06 0.11-0.09 0.02-0.01 0.04-0.03 0.06-0.04 0.06-0.04 0.12-0.06 0.19-0.08 0.13-0.03 0.25-0.02 0.36 0.01 0.02 0 0.04 0.01 0.06 0.01 0.11 0.04 0.21 0.1 0.32 0.18 0.02 0.01 0.04 0.03 0.06 0.05 0.1 0.09 0.2 0.2 0.29 0.33 0.02 0.02 0.03 0.04 0.04 0.06 0.09 0.12 0.17 0.27 0.25 0.42 0.02 0.04 0.04 0.07 0.06 0.11 0.08 0.16 0.15 0.35 0.23 0.54 0.02 0.06 0.05 0.13 0.07 0.2 0.07 0.19 0.14 0.38 0.2 0.59l0.09 0.27 0.12 0.45c0.05 0.18 0.09 0.36 0.14 0.55 0.03 0.12 0.06 0.24 0.09 0.37 0.03 0.16 0.07 0.32 0.1 0.48v0.01c0.08 0.38 0.16 0.78 0.23 1.17l12.09-4.25-8.18-23.26z&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="116"/>
+            line="116"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1209 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1209 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M76.29 63.37c-0.02 0-0.04-0.01-0.06-0.01 0.02 0 0.04 0.01 0.06 0.01m-0.84 0.27c-0.03 0.03-0.06 0.07-0.08 0.11 0.02-0.04 0.05-0.08 0.08-0.11m0.42-0.29c-0.07 0.02-0.13 0.04-0.19 0.08 0.06-0.04 0.12-0.06 0.19-0.08m2.48 4.62c-0.03-0.16-0.07-0.32-0.1-0.48 0.03 0.16 0.07 0.32 0.1 0.48m-0.19-0.85c-0.05-0.19-0.09-0.37-0.14-0.55 0.05 0.18 0.09 0.36 0.14 0.55m-0.26-1l-0.09-0.27 0.09 0.27m-0.29-0.86c-0.02-0.07-0.05-0.14-0.07-0.2 0.02 0.06 0.05 0.13 0.07 0.2M77 63.99c-0.01-0.02-0.02-0.04-0.04-0.06 0.02 0.02 0.03 0.04 0.04 0.06m1.58 5.16c-0.07-0.39-0.15-0.79-0.23-1.17 0.08 0.38 0.16 0.78 0.23 1.17m-1.27-4.63c-0.02-0.04-0.04-0.07-0.06-0.11 0.02 0.04 0.04 0.07 0.06 0.11m-2.3 0.56c0 0.05-0.01 0.1-0.01 0.15 0-0.05 0.01-0.1 0.01-0.15m1.6-1.53c0.02 0.01 0.04 0.03 0.06 0.05-0.02-0.02-0.04-0.04-0.06-0.05m-1.63 1.91c-0.01 0.05-0.01 0.09-0.01 0.13 0-0.04 0-0.08 0.01-0.13m0.53-1.9c0.03-0.03 0.07-0.06 0.11-0.09-0.04 0.03-0.08 0.06-0.11 0.09m-0.45 1.16c-0.01 0.05-0.02 0.1-0.02 0.16 0-0.06 0.01-0.11 0.02-0.16m0.07-0.33c-0.01 0.05-0.03 0.1-0.04 0.16 0.01-0.06 0.03-0.11 0.04-0.16m0.08-0.29c-0.02 0.05-0.03 0.09-0.05 0.14 0.02-0.05 0.03-0.09 0.05-0.14m0.11-0.25c-0.02 0.04-0.04 0.08-0.06 0.13 0.02-0.05 0.04-0.09 0.06-0.13&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="121"/>
+            line="121"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1004 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1004 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M80.37 51.81c-0.3 0.66-0.64 1.37-0.92 2.06l-0.22 0.53c-0.1 0.23-0.1 0.49-0.07 0.69 0.04 0.21 0.11 0.41 0.23 0.6 0.09 0.14 0.19 0.28 0.31 0.43-0.07 0.09-0.12 0.16-0.17 0.24-1.1-0.68-2.22-1.31-3.37-1.89l-3.06-1.54 0.17-0.03c0.25-0.05 0.47-0.14 0.67-0.26 0.19-0.12 0.42-0.31 0.54-0.58l0.26-0.5 1.01-2.01c0.31-0.57 0.84-1.01 1.46-1.21 0.62-0.2 1.31-0.15 1.9 0.13 0.59 0.28 1.06 0.8 1.3 1.42 0.23 0.61 0.22 1.32-0.04 1.92m0.78-2.2c-0.29-0.81-0.9-1.5-1.67-1.88-0.77-0.39-1.7-0.47-2.53-0.21-0.82 0.25-1.55 0.83-1.98 1.59-0.36 0.72-0.66 1.38-1 2.07l-0.25 0.51c-0.03 0.09-0.1 0.15-0.23 0.23-0.12 0.08-0.26 0.14-0.38 0.17l-0.55 0.1-0.01 0.01c-0.08 0.01-0.15 0.06-0.21 0.12-0.03 0.03-0.06 0.06-0.08 0.1l-0.21 0.45c-0.1 0.2-0.02 0.45 0.18 0.54l0.14 0.07 3.45 1.67c1.2 0.57 2.43 1.1 3.68 1.56l0.03 0.01c0.07 0.03 0.15-0.01 0.18-0.08 0.07-0.18 0.12-0.36 0.17-0.52-0.05-0.18-0.12-0.38-0.2-0.58-0.06-0.15-0.08-0.33-0.07-0.49 0-0.17 0.02-0.31 0.09-0.42l0.29-0.49c0.38-0.67 0.73-1.31 1.07-2.02 0.35-0.78 0.38-1.7 0.09-2.51&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="141"/>
+            line="141"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (923 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (923 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M205.99 100.68c-4.67-18.66-19.25-20.76-30.55-23.25-11.29-2.49-29.89-2.83-37.87 0.32-5.19 2.06-8.73 3.62-11.1 5.71-14.8 11.57-24.19 21.48-24.19 21.48L83.41 81.39l-2.7 1.6-5.97 3.54-2.22 1.32s9.38 50.93 30.1 49.88v-0.01c0-0.06 0.04-0.1 0.09-0.11l0.01-0.01c1.27-0.34 2.53-0.48 3.77-0.82 1.25-0.24 2.47-0.59 3.7-0.94 2.43-0.77 4.81-1.72 7.09-2.87 2.11-1.02 4.15-2.16 6.14-3.41 0.18-0.12 0.38-0.22 0.56-0.34 1.08-0.69 2.14-1.42 3.19-2.15 1.07-0.71 2.14-1.43 3.24-2.12 0.05-0.04 0.13-0.02 0.17 0.03 0.03 0.05 0.03 0.12-0.01 0.16-1.73 1.98-3.85 3.52-6.02 4.96-0.35 0.23-0.72 0.45-1.08 0.68l1.73 40.62 14.25 0.02c8.83 0 30.69 0.03 50.69 0.13v-7.97h-0.01c-0.06 0-0.11-0.05-0.12-0.11-0.52-4.89-0.66-9.8-0.83-14.7l-0.51-14.7-0.37-14.71c-0.13-4.9-0.27-9.8-0.04-14.72 0-0.06 0.06-0.12 0.13-0.11 0.06 0 0.11 0.05 0.12 0.11 0.52 4.89 0.67 9.79 0.84 14.69l0.5 14.7 0.37 14.71c0.05 1.67 0.09 3.35 0.12 5.02 14.25-0.81 27.02-7.66 15.65-53.08&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="151"/>
+            line="151"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (7633 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (7633 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M65.94 170.71h-0.18 0.09c-1.51-0.02-3.02-0.39-4.15-1.31-1.17-0.93-1.83-2.38-2.01-3.9-0.2-1.52 0.02-3.14 0.38-4.68 0.4-1.53 0.93-3.08 1.64-4.49l0.01-0.02c0.06-0.12 0.06-0.27-0.01-0.4l-2-3.8 6.97-0.13v-0.07h0.15c1.73 0.07 3.46 0.13 5.19 0.17-0.69 1.27-1.36 2.56-2.03 3.83-0.07 0.12-0.07 0.27-0.01 0.4l0.01 0.02c0.71 1.41 1.24 2.96 1.63 4.49 0.37 1.54 0.59 3.16 0.39 4.68-0.18 1.52-0.84 2.97-2.01 3.9-1.14 0.92-2.65 1.29-4.15 1.31h0.09zm0.66-28.94c-0.63 0.08-1.48 0.03-2.35-0.48-0.71-0.41-1.21-1.02-1.5-1.84-0.06-0.17-0.04-0.35 0.06-0.5 0.09-0.15 0.24-0.25 0.42-0.27 0.17-0.02 0.33-0.03 0.5-0.03 0.65 0 1.26 0.16 1.81 0.48 0.25 0.14 0.46 0.33 0.66 0.54 0.19 0.22 0.36 0.47 0.5 0.72 0.17 0.28 0.3 0.56 0.39 0.81-0.12 0.32-0.26 0.52-0.49 0.57zM38.98 171.4h-1.07c-3.41-0.42-6.5-2.36-8.48-5.07-1.1-1.49-1.91-3.2-2.37-4.99-0.45-1.78-0.56-3.64-0.36-5.47l-0.01 0.05 0.02-0.08c0 0.01 0 0.02-0.01 0.03l1.48-4.94c1.54 0.11 3.09 0.16 4.64 0.21l6.6 0.06c3.46-0.05 6.92-0.04 10.39-0.2l1.45 4.87c0-0.01 0-0.02-0.01-0.04l0.02 0.09-0.01-0.05c0.45 3.66-0.49 7.51-2.72 10.47-1.12 1.49-2.55 2.75-4.19 3.64-1.63 0.89-3.49 1.39-5.37 1.41v0.01zm-9.45-25.02l9.45 0.02 9.45-0.03 1.16 3.89c-3.39-0.15-6.78-0.14-10.17-0.19l-6.6 0.06c-1.49 0.05-2.98 0.1-4.47 0.21l1.18-3.96zm36.3 0.57c-0.48 0.33-1.47 0.84-2.81 0.59-0.8-0.14-1.48-0.55-2.02-1.23-0.12-0.13-0.16-0.31-0.12-0.49 0.04-0.17 0.15-0.31 0.31-0.39 0.56-0.28 1.13-0.42 1.7-0.42 0.21 0 0.42 0.02 0.62 0.06 1.31 0.23 2.03 1.29 2.32 1.84v0.04zm3.49-0.92c0.05-0.02 0.1-0.02 0.15-0.03 0.22-0.04 0.44-0.07 0.65-0.07 0.98 0 1.73 0.5 2.18 0.93 0.13 0.12 0.2 0.29 0.19 0.47-0.02 0.18-0.11 0.34-0.26 0.45-0.64 0.44-1.37 0.67-2.16 0.67h-0.01c-1.08 0-1.87-0.51-2.37-1-0.14-0.14-0.44-0.28-0.43-0.47 0.4-0.34 1.23-0.77 2.06-0.95zm-2.33-10.23c-0.56-0.44-0.94-1.03-1.14-1.74-0.07-0.25-0.01-0.51 0.16-0.71 0.14-0.17 0.35-0.27 0.58-0.27 0.03 0 0.06 0.01 0.08 0.01 0.73 0.08 1.38 0.34 1.91 0.76 0.43 0.34 0.7 0.75 0.88 1.17 0.21 0.46 0.31 0.92 0.34 1.31-0.12 0.14-0.19 0.3-0.42 0.3-0.64-0.01-1.54-0.15-2.39-0.83zm4.43 1.35c0.62-0.24 1.53-0.42 2.52-0.1 0.93 0.31 1.49 1.03 1.78 1.58 0.09 0.16 0.1 0.33 0.03 0.5-0.07 0.17-0.21 0.29-0.39 0.35-0.75 0.22-1.51 0.2-2.25-0.05-1.15-0.38-1.75-1.26-2.04-1.88 0.11-0.14 0.23-0.27 0.35-0.4zm-2.98 5.08c0.51-0.43 1.49-1.04 2.75-0.94 0.79 0.07 1.49 0.44 2.1 1.11 0.12 0.13 0.18 0.3 0.15 0.48s-0.14 0.34-0.3 0.43c-0.67 0.39-1.41 0.56-2.2 0.49-1.34-0.1-2.16-0.97-2.53-1.48l0.03-0.09zm157.26 29.71c-6.55-0.19-20.26-0.31-35.07-0.39h-0.49c-20-0.1-41.86-0.13-50.69-0.13l-14.25-0.02-31.07-0.05-25.48 0.02c0.73-0.25 1.43-0.62 2.04-1.13 1.42-1.14 2.18-2.9 2.37-4.61 0.2-1.73-0.06-3.42-0.45-5.05-0.4-1.56-0.98-3.03-1.72-4.46 0.68-1.41 1.38-2.8 2.04-4.22l0.01-0.02c0.02-0.04-0.13-0.45-0.13-0.51-0.01-0.19 0 0-0.2 0.01-1.83 0.04-3.66 0.1-5.49 0.17 0-1.17 0.01-2.23 0.04-3.23 0.65 0.58 1.61 1.13 2.9 1.13h0.01c0.98 0 1.93-0.3 2.73-0.85 0.4-0.28 0.65-0.72 0.68-1.2 0.04-0.48-0.14-0.94-0.49-1.27-0.59-0.55-1.56-1.2-2.87-1.2h-0.01c-1.21 0-2.16 0.48-2.82 0.99 0.08-1.03 0.22-1.98 0.42-2.87 0.52 0.66 1.53 1.62 3.15 1.75 0.13 0.01 0.26 0.02 0.39 0.02 0.84 0 1.66-0.22 2.39-0.65 0.43-0.24 0.71-0.66 0.79-1.13 0.07-0.48-0.07-0.96-0.4-1.31-0.54-0.6-1.45-1.33-2.76-1.43-1.25-0.1-2.26 0.33-2.96 0.78 0.43-1.1 1.03-2.14 1.83-3.17 0.33 0.73 1.09 1.96 2.65 2.47 0.5 0.17 1 0.25 1.51 0.25 0.45 0 0.91-0.07 1.35-0.2 0.46-0.13 0.84-0.47 1.03-0.92 0.18-0.44 0.15-0.94-0.08-1.36-0.38-0.71-1.1-1.64-2.35-2.05-0.88-0.29-1.7-0.26-2.38-0.12l0.04-0.04-0.61-0.63c-0.21 0.2-0.39 0.4-0.58 0.6-0.11-0.82-0.45-1.99-1.51-2.84-0.69-0.55-1.51-0.88-2.43-0.97-0.59-0.07-1.16 0.16-1.54 0.61-0.38 0.44-0.51 1.05-0.35 1.62 0.26 0.92 0.75 1.68 1.47 2.25 1.02 0.81 2.07 1.03 2.88 1.05-0.63 0.84-1.14 1.7-1.53 2.58-0.37-0.85-0.93-1.52-1.68-1.95-0.86-0.5-1.87-0.69-2.92-0.57-0.48 0.05-0.9 0.32-1.15 0.73-0.26 0.41-0.31 0.91-0.15 1.36 0.25 0.72 0.8 1.72 1.94 2.38 0.85 0.49 1.68 0.64 2.38 0.64 0.27 0 0.51-0.03 0.74-0.06-0.23 0.99-0.38 2.04-0.47 3.19-0.48-0.71-1.35-1.6-2.71-1.85-0.98-0.17-2-0.02-2.95 0.46-0.43 0.21-0.73 0.6-0.84 1.07-0.1 0.47 0.02 0.96 0.32 1.33 0.48 0.6 1.33 1.35 2.62 1.59 0.31 0.05 0.6 0.08 0.88 0.08 1.17 0 2.05-0.43 2.58-0.77-0.04 1.12-0.06 2.33-0.06 3.65l-7.15-0.13c-0.06 0-0.12 0.01-0.17 0.04-0.19 0.09-0.27 0.31-0.17 0.5v0.01l2.06 4.21c-0.74 1.43-1.32 2.9-1.72 4.46-0.4 1.63-0.65 3.32-0.45 5.05 0.19 1.71 0.95 3.47 2.37 4.61 0.61 0.52 1.31 0.88 2.05 1.13l-15.26 0.01-5.59 0.01c0.83-0.21 1.65-0.5 2.42-0.89 1.75-0.87 3.29-2.16 4.49-3.71 2.44-3.08 3.54-7.15 3.12-11.07 0-0.03 0-0.05-0.01-0.08l-1.37-4.7c0.59-0.03 1.18-0.06 1.77-0.1 0.09-0.01 0.17-0.09 0.18-0.19 0.01-0.11-0.07-0.2-0.18-0.21-0.65-0.05-1.3-0.08-1.95-0.12l-1.34-4.63c-0.07-0.22-0.27-0.39-0.52-0.39l-6.63-0.02c0.58-1.53 1.19-3.02 1.92-4.44 0.18-0.34 0.36-0.68 0.55-1.02 0.71-1.22 1.51-2.39 2.38-3.52 2.19-2.88 4.97-5.29 7.55-7.93 0.06-0.07 0.08-0.17 0.02-0.25-0.07-0.1-0.19-0.12-0.28-0.05-3.02 2.12-5.81 4.62-8.18 7.54-0.85 1.07-1.61 2.22-2.27 3.43-0.67-1.4-1-2.94-1.01-4.48-0.03-1.77 0.29-3.55 0.86-5.23 1.04-3.09 2.88-5.9 5.26-8.13l0.02-0.02 0.06 0.21 1.46 5.23c0.05 0.19 0.22 0.35 0.43 0.37 0.28 0.04 0.54-0.16 0.57-0.44l0.91-6.74c2.82-0.78 6.29-0.36 7.96 2.12 0.95 1.21 1.56 2.67 1.69 4.2 0.14 1.52-0.17 3.08-0.76 4.54-1.2 2.91-3.33 5.44-5.88 7.35-1.28 0.95-2.67 1.78-4.17 2.29-1.48 0.5-3.14 0.74-4.61 0.16-0.1-0.04-0.21 0-0.26 0.1-0.01 0.02 0 0.04 0 0.07-0.01 0.08 0.02 0.16 0.1 0.19 1.57 0.73 3.38 0.6 4.98 0.13 1.61-0.49 3.11-1.28 4.47-2.24 2.7-1.94 5.02-4.52 6.33-7.66 0.65-1.57 1.02-3.29 0.87-5.03-0.12-1.73-0.81-3.42-1.86-4.79-0.51-0.67-1.14-1.35-1.93-1.8-0.77-0.47-1.61-0.76-2.47-0.92-1.71-0.31-3.46-0.19-5.11 0.36-0.19 0.06-0.33 0.22-0.36 0.43l-0.6 4.62-1.08-3.8v-0.02c-0.02-0.07-0.06-0.13-0.11-0.19-0.18-0.2-0.5-0.22-0.7-0.04-2.75 2.49-4.87 5.68-5.92 9.23-0.52 1.77-0.79 3.63-0.67 5.47 0.11 1.66 0.57 3.29 1.4 4.72-0.19 0.36-0.38 0.73-0.55 1.1-0.7 1.55-1.17 3.2-1.36 4.88l-2.86-0.01-2.04 0.01c0.23-3.41 0.09-6.85-0.38-10.25-0.01-0.13-0.04-0.25-0.06-0.38 1.52-1.16 2.66-2.81 3.28-4.64 0.64-1.92 0.8-3.97 0.65-5.97-0.3-4.03-1.74-7.86-3.6-11.4-1.97-3.52-4.71-6.56-7.94-8.98-1.63-1.19-3.4-2.22-5.35-2.88-1.92-0.66-4.11-0.93-6.16-0.29-2.07 0.63-3.71 2.17-4.78 3.96-1.08 1.89-1.2 4.07-1.01 6.08 0.46 4.06 2.04 7.82 3.93 11.32 1.95 3.49 4.28 6.76 7.07 9.63 1.4 1.42 2.91 2.76 4.65 3.79 0.88 0.5 1.81 0.93 2.82 1.14 1 0.22 2.12 0.17 3.04-0.36 0.06-0.03 0.08-0.09 0.09-0.16 0-0.03 0-0.07-0.01-0.1-0.05-0.1-0.17-0.14-0.27-0.09-0.84 0.43-1.82 0.44-2.74 0.21-0.92-0.23-1.78-0.67-2.6-1.18-1.64-1.03-3.1-2.35-4.44-3.77-2.67-2.86-4.91-6.13-6.75-9.57-1.81-3.45-3.33-7.14-3.73-10.96-0.17-1.89-0.02-3.86 0.91-5.43 0.96-1.58 2.41-2.9 4.15-3.42 1.75-0.56 3.69-0.36 5.48 0.25 1.81 0.59 3.5 1.56 5.07 2.69 3.11 2.29 5.78 5.25 7.72 8.6 1.89 3.39 3.3 7.12 3.74 10.98 0.2 1.93 0.11 3.9-0.43 5.76-0.32 1.14-0.87 2.2-1.58 3.15-0.38 0.5-0.78 0.98-1.26 1.39l-0.03-0.16c-0.55-3.31-1.44-6.58-2.74-9.7-1.44-3.34-3.32-6.51-5.73-9.26-2.4-2.73-5.26-5.06-8.42-6.82-0.09-0.04-0.21-0.02-0.27 0.07-0.06 0.09-0.04 0.21 0.06 0.28 2.93 2.03 5.62 4.38 7.89 7.11 2.28 2.7 4.08 5.8 5.43 9.06 1.33 3.15 2.29 6.48 2.87 9.87l0.06 0.33c0.59 3.33 0.85 6.7 1.1 10.1l-7.54 0.02c-0.23 0-0.45 0.15-0.52 0.38l-1.38 4.75c-0.34 0.04-0.68 0.06-1.02 0.11-0.04 0-0.08 0.04-0.08 0.09-0.01 0.05 0.03 0.1 0.08 0.11l0.9 0.09-1.39 4.8c-0.01 0.03-0.02 0.06-0.02 0.09-0.45 3.92 0.67 8 3.11 11.09 1.23 1.53 2.77 2.81 4.53 3.68 0.83 0.41 1.72 0.7 2.62 0.91l-12.32 0.02c-7.72 0.04-15.44-0.09-23.16 0.26-0.26 0.02-0.47 0.22-0.48 0.48-0.01 0.28 0.2 0.52 0.48 0.53 7.72 0.35 15.44 0.23 23.16 0.27l23.16 0.03 46.33 0.03 46.32-0.06c15.44 0 70.81-0.09 86.25-0.52 0.13 0 0.24-0.11 0.24-0.25 0.01-0.14-0.1-0.25-0.24-0.25z&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="156"/>
+            line="156"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1098 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1098 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M103.4,15.5c-1.2,-0.1 -2.5,-0.1 -3.7,-0.1V7.2c0,-0.7 -0.1,-1.5 -0.3,-2.1c-0.2,-0.7 -0.6,-1.4 -1,-2c-1,-1.2 -2.2,-2 -3.7,-2.3c-0.7,-0.1 -1.5,-0.1 -2.1,-0.1H83L52.1,0.7L21.3,0.8h-9.6c-0.6,0 -1.3,0 -2.1,0.1C8.2,1.3 7,2.1 6.1,3.3c-0.4,0.6 -0.7,1.2 -1,1.9C4.9,5.9 4.8,6.6 4.8,7.3v3.9l0,4.2c-1.3,0 -2.7,0.1 -4,0.1c-0.1,0 -0.3,0.1 -0.3,0.3s0.1,0.3 0.3,0.3c1.3,0 2.7,0.1 4,0.1l0,2.7C5,39.3 5.2,59.8 5.5,80.2c0,0.1 0.1,0.1 0.2,0.1c0.1,0 0.1,-0.1 0.1,-0.1c0.2,-20.4 0.4,-40.9 0.4,-61.4v-2.5c6.8,0.2 13.5,0.2 20.3,0.3l25.6,0.1H65l12.8,-0.1c6.8,-0.1 13.5,-0.1 20.3,-0.4v2.7l0.1,60.6l-42.3,0.1l-21.5,0.1L13,79.9c-0.1,0 -0.3,0.1 -0.3,0.3c0,0.1 0.1,0.3 0.3,0.3l21.5,0.1l21.5,0.1l43,0.1c0.4,0 0.7,-0.4 0.7,-0.7l0.1,-61.4v-2.6c1.2,0 2.5,-0.1 3.7,-0.2c0.1,0 0.1,-0.1 0.1,-0.3C103.6,15.6 103.5,15.5 103.4,15.5zM77.8,15L65,14.9H52.1L26.5,15c-6.8,0.1 -13.5,0.1 -20.3,0.3V7.2c0,-0.6 0.1,-1.1 0.2,-1.7c0.2,-0.5 0.4,-1 0.8,-1.5C8,3.2 8.9,2.6 10,2.3c0.6,-0.1 1.1,-0.1 1.8,-0.1h9.6l30.8,0.1l30.8,0.1h9.6c0.7,0 1.2,0 1.8,0.1c1.1,0.2 2.1,0.9 2.7,1.8c0.3,0.4 0.6,0.9 0.7,1.5c0.1,0.6 0.2,1.1 0.2,1.7v8C91.3,15.1 84.6,15 77.8,15z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_pages_104dp.xml"
-            line="10"/>
+            line="10"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1870 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1870 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M35.1,55.5c0,0.1 -0.2,0.4 -0.4,0.4c-0.2,0 -0.4,-0.1 -0.4,-0.4v-3.6c0,-0.2 0.1,-0.4 0.4,-0.4s0.4,0.1 0.4,0.4V55.5zM34.1,26.6h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4c0,0.2 0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4C34.4,26.7 34.3,26.6 34.1,26.6zM35.1,30c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4v3.6c0,0.2 0.1,0.4 0.4,0.4c0.1,0 0.4,-0.2 0.4,-0.4V30zM35.1,44.6c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4v3.6c0,0.2 0.1,0.4 0.4,0.4c0.1,0 0.4,-0.2 0.4,-0.4V44.6zM35.1,37.3c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4v3.6c0,0.2 0.1,0.4 0.4,0.4c0.1,0 0.4,-0.2 0.4,-0.4V37.3zM17.6,29.1c0.2,0 0.4,-0.1 0.4,-0.4v-1.5h1.5c0.2,0 0.4,-0.1 0.4,-0.4c0,-0.2 -0.1,-0.4 -0.4,-0.4h-1.8c-0.2,0 -0.4,0.1 -0.4,0.4v1.8C17.2,29 17.4,29.1 17.6,29.1zM17.2,36c0,0.2 0.1,0.4 0.4,0.4s0.4,-0.1 0.4,-0.4v-3.6c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4V36zM17.2,43.3c0,0.2 0.1,0.4 0.4,0.4s0.4,-0.1 0.4,-0.4v-3.6c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4V43.3zM17.2,50.6c0,0.2 0.1,0.4 0.4,0.4s0.4,-0.1 0.4,-0.4V47c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4V50.6zM35.1,59.2c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4v3.6c0,0.2 0.1,0.4 0.4,0.4c0.1,0 0.4,-0.2 0.4,-0.4V59.2zM23.4,70.1c0,0.2 0.1,0.4 0.4,0.4h3.7c0.1,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7C23.5,69.8 23.4,69.9 23.4,70.1zM17.2,57.9c0,0.2 0.1,0.4 0.4,0.4s0.4,-0.1 0.4,-0.4v-3.6c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4V57.9zM34.3,66.5v3.3h-3.3c-0.2,0 -0.4,0.1 -0.4,0.4s0.1,0.4 0.4,0.4h3.7c0.1,0 0.4,-0.2 0.4,-0.4v-3.6c0,-0.2 -0.1,-0.4 -0.4,-0.4S34.3,66.3 34.3,66.5zM26.7,26.6h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4c0,0.2 0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4C27.1,26.7 27,26.6 26.7,26.6zM17.2,70.1c0,0.2 0.1,0.4 0.4,0.4h2.5c0.1,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-2.1V69c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4V70.1zM17.2,65.2c0,0.2 0.1,0.4 0.4,0.4s0.4,-0.1 0.4,-0.4v-3.6c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4V65.2z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_pages_104dp.xml"
-            line="15"/>
+            line="15"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1552 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1552 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M44.2,32.5v-3.6c0,-0.2 0.1,-0.4 0.4,-0.4c0.2,0 0.4,0.1 0.4,0.4v3.6c0,0.2 -0.1,0.4 -0.4,0.4C44.4,32.9 44.2,32.8 44.2,32.5zM75.5,35h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4S75.3,35 75.5,35zM75.6,27.3h3.7c0.2,0 0.4,-0.1 0.4,-0.4c0,-0.2 -0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4C75.2,27.1 75.4,27.3 75.6,27.3zM46.2,35h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4S46,35 46.2,35zM46.3,27.3h3.7c0.2,0 0.4,-0.1 0.4,-0.4c0,-0.2 -0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4C45.9,27.1 46.1,27.3 46.3,27.3zM82.8,35h3.7c0.2,0 0.4,-0.2 0.4,-0.4v-3.9c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4v3.6h-3.3c-0.2,0 -0.4,0.1 -0.4,0.4S82.6,35 82.8,35zM82.9,27.3h3.4c0.1,0.1 0.1,0.1 0.2,0.1c0.2,0 0.4,-0.1 0.4,-0.4v-0.1c0,-0.2 -0.1,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.1 -0.4,0.4C82.5,27.1 82.7,27.3 82.9,27.3zM68.2,35h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4S68,35 68.2,35zM60.9,35h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4S60.6,35 60.9,35zM60.9,27.3h3.7c0.2,0 0.4,-0.1 0.4,-0.4c0,-0.2 -0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4C60.6,27.1 60.7,27.3 60.9,27.3zM68.3,27.3h3.7c0.2,0 0.4,-0.1 0.4,-0.4c0,-0.2 -0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4C67.9,27.1 68,27.3 68.3,27.3zM53.6,27.3h3.7c0.2,0 0.4,-0.1 0.4,-0.4c0,-0.2 -0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4C53.2,27.1 53.4,27.3 53.6,27.3zM53.5,35h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4S53.3,35 53.5,35z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_pages_104dp.xml"
-            line="20"/>
+            line="20"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (3366 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (3366 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M44.2,45.5c0,-0.2 0.1,-0.4 0.4,-0.4h2.9c0.2,0 0.4,0.1 0.4,0.4s-0.1,0.4 -0.4,0.4H45v0.4c0,0.2 -0.1,0.4 -0.4,0.4c-0.2,0 -0.4,-0.1 -0.4,-0.4V45.5zM72.8,45.5c0,0.2 0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7C72.9,45.1 72.8,45.2 72.8,45.5zM69.8,62.8h-0.3c-0.2,0 -0.4,0.1 -0.4,0.4c0,0.2 0.1,0.4 0.4,0.4h0.2c1.1,0 2.3,-0.3 3.4,-0.9c0.2,-0.1 0.2,-0.4 0.1,-0.5c-0.1,-0.2 -0.4,-0.2 -0.5,-0.1C71.8,62.5 70.8,62.8 69.8,62.8zM75.9,60.3c0.1,0 0.1,-0.1 0.2,-0.1l0.4,-0.4c0.8,-0.7 1.5,-1.3 2.4,-2c0.1,-0.1 0.2,-0.4 0.1,-0.5c-0.1,-0.1 -0.4,-0.2 -0.5,-0.1l-2.4,2l-0.4,0.4c-0.2,0.1 -0.2,0.4 -0.1,0.5C75.7,60.3 75.8,60.3 75.9,60.3zM75.1,70.1c0,0.2 0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7C75.3,69.8 75.1,69.9 75.1,70.1zM68.2,69.8c-0.2,0 -0.4,0.1 -0.4,0.4s0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4H68.2zM80.1,45.5c0,0.2 0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7C80.3,45.1 80.1,45.2 80.1,45.5zM44.2,60.8c0,0.2 0.1,0.4 0.4,0.4c0.2,0 0.4,-0.1 0.4,-0.4v-3.6c0,-0.2 -0.1,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.1 -0.4,0.4V60.8zM44.2,66.9c-0.2,0.3 -0.3,0.5 -0.4,0.8c-0.1,0.2 0,0.4 0.1,0.5c0,0.1 0.1,0.1 0.1,0.1c0,0 0.1,0 0.2,-0.1c0,0.2 0.1,0.3 0.3,0.3c0.2,0 0.4,-0.1 0.4,-0.4v-0.9c0.5,-0.8 0.9,-1.5 1.5,-2.1c0.1,-0.1 0.1,-0.4 -0.1,-0.5c-0.1,-0.1 -0.4,-0.1 -0.5,0.1c-0.3,0.4 -0.6,0.8 -0.9,1.2v-1.3c0,-0.2 -0.1,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.1 -0.4,0.4V66.9zM44.2,53.5c0,0.2 0.1,0.4 0.4,0.4c0.2,0 0.4,-0.1 0.4,-0.4v-3.6c0,-0.2 -0.1,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.1 -0.4,0.4V53.5zM86.9,61.4c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4V65c0,0.2 0.1,0.4 0.4,0.4s0.4,-0.2 0.4,-0.4V61.4zM46.2,69.8c-0.2,0 -0.4,0.1 -0.4,0.4s0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4H46.2zM86.9,54.1c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4v3.6c0,0.2 0.1,0.4 0.4,0.4s0.4,-0.2 0.4,-0.4V54.1zM86.9,46.8c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4v3.6c0,0.2 0.1,0.4 0.4,0.4s0.4,-0.2 0.4,-0.4V46.8zM82.8,70.5h3.7c0.2,0 0.4,-0.2 0.4,-0.4v-1.5c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4v1.1h-3.3c-0.2,0 -0.4,0.1 -0.4,0.4S82.6,70.5 82.8,70.5zM85.7,54.7c0,-0.1 -0.1,-0.3 -0.4,-0.3c-1.3,0.1 -2.5,0.4 -3.7,0.9c-0.2,0.1 -0.3,0.3 -0.2,0.5c0.1,0.1 0.2,0.2 0.4,0.2c0.1,0 0.1,0 0.1,-0.1c1.2,-0.4 2.3,-0.7 3.4,-0.9C85.5,55.1 85.7,54.9 85.7,54.7zM62.6,60.9c-0.2,-0.1 -0.4,0 -0.5,0.2s0,0.4 0.2,0.5l0.7,0.3c0.9,0.4 1.8,0.7 2.7,1h0.1c0.1,0 0.3,-0.1 0.3,-0.3c0.1,-0.1 0,-0.4 -0.2,-0.4c-0.9,-0.3 -1.8,-0.7 -2.6,-1L62.6,60.9zM60.9,69.8c-0.2,0 -0.4,0.1 -0.4,0.4s0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4H60.9zM65.5,45.5c0,0.2 0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7C65.6,45.1 65.5,45.2 65.5,45.5zM50.8,45.5c0,0.2 0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7C51,45.1 50.8,45.2 50.8,45.5zM58.2,45.5c0,0.2 0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7C58.3,45.1 58.2,45.2 58.2,45.5zM48.4,62.5c0.1,0.1 0.2,0.1 0.3,0.1h0.2c1,-0.8 2.1,-1.4 3.1,-1.8c0.2,-0.1 0.3,-0.3 0.2,-0.5c-0.1,-0.2 -0.3,-0.3 -0.5,-0.2c-1.1,0.4 -2.2,1.1 -3.2,1.9C48.3,62.1 48.3,62.3 48.4,62.5zM55.1,59.6c0,0.2 0.1,0.4 0.4,0.4c1.2,0 2.3,0.1 3.6,0.4c0.1,0 0.3,-0.1 0.4,-0.2c0,-0.2 -0.1,-0.4 -0.3,-0.4c-1.2,-0.3 -2.4,-0.4 -3.7,-0.4C55.2,59.3 55.1,59.4 55.1,59.6zM53.5,69.8c-0.2,0 -0.4,0.1 -0.4,0.4s0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4H53.5z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_pages_104dp.xml"
-            line="25"/>
+            line="25"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (2168 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (2168 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M60.6,27.1h1.8c0.2,0 0.4,-0.2 0.4,-0.4V25c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v1.5h-1.5c-0.2,0 -0.4,0.2 -0.4,0.4C60.2,27 60.4,27.1 60.6,27.1M17.5,27.1h3.6c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4C17.1,27 17.3,27.1 17.5,27.1M53.4,27.1H57c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4C53,27 53.2,27.1 53.4,27.1M39,27.1h3.6c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4H39c-0.2,0 -0.4,0.2 -0.4,0.4C38.6,27 38.8,27.1 39,27.1M31.8,27.1h3.6c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4C31.5,27 31.6,27.1 31.8,27.1M24.6,27.1h3.6c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4C24.3,27 24.4,27.1 24.6,27.1M46.2,27.1h3.6c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4C45.8,27 46,27.1 46.2,27.1M11.7,26.8c0,0.2 0.2,0.4 0.4,0.4h1.8c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-1.5V25c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4V26.8zM11.7,22.1c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4v-2.8c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4V22.1zM12.1,16.8c0.2,0 0.4,-0.2 0.4,-0.4V15h1.5c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4h-1.8c-0.2,0 -0.4,0.2 -0.4,0.4v1.8C11.7,16.7 11.8,16.8 12.1,16.8M24.6,15h3.6c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4S24.4,15 24.6,15M53.4,15H57c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4S53.2,15 53.4,15M39,15h3.6c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4H39c-0.2,0 -0.4,0.2 -0.4,0.4S38.8,15 39,15M17.5,15h3.6c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4S17.3,15 17.5,15M31.8,15h3.6c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4S31.6,15 31.8,15M46.2,15h3.6c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4S46,15 46.2,15M62.7,14.6c0,-0.2 -0.2,-0.4 -0.4,-0.4h-1.8c-0.2,0 -0.4,0.2 -0.4,0.4s0.2,0.4 0.4,0.4H62v1.5c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V14.6zM62.4,18.9c-0.2,0 -0.4,0.2 -0.4,0.4v2.8c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4v-2.8C62.7,19.1 62.6,18.9 62.4,18.9&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_posts_75dp.xml"
-            line="15"/>
+            line="15"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1998 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1998 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M28.9,74.3c-0.2,0 -0.4,0.2 -0.4,0.4v1.5h-1.5c-0.2,0 -0.4,0.2 -0.4,0.4c0,0.2 0.2,0.4 0.4,0.4h1.8c0.2,0 0.4,-0.2 0.4,-0.4v-1.8C29.3,74.4 29.1,74.3 28.9,74.3M18.3,76.1c-0.2,0 -0.4,0.2 -0.4,0.4c0,0.2 0.2,0.4 0.4,0.4h4.4c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4H18.3zM11.7,76.5c0,0.2 0.2,0.4 0.4,0.4h1.8c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-1.5v-1.5c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4V76.5zM11.7,71.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V68c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4V71.3zM11.7,57.9c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4v-3.3c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4V57.9zM11.7,64.6c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4v-3.3c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4V64.6zM11.7,44.6c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4v-3.3c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4V44.6zM11.7,51.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4v-3.3c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4V51.3zM11.7,37.9c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4v-1.5h1.5c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4h-1.8c-0.2,0 -0.4,0.2 -0.4,0.4V37.9zM22.7,35.7h-4.4c-0.2,0 -0.4,0.2 -0.4,0.4s0.2,0.4 0.4,0.4h4.4c0.2,0 0.4,-0.2 0.4,-0.4S22.9,35.7 22.7,35.7M29.3,36.1c0,-0.2 -0.2,-0.4 -0.4,-0.4h-1.8c-0.2,0 -0.4,0.2 -0.4,0.4s0.2,0.4 0.4,0.4h1.5v1.5c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V36.1zM29.3,41.3c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V41.3zM29.3,68c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V68zM29.3,47.9c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V47.9zM29.3,61.3c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V61.3zM29.3,54.6c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V54.6z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_posts_75dp.xml"
-            line="20"/>
+            line="20"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (3317 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (3317 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M60.6,76.8h1.8c0.2,0 0.4,-0.2 0.4,-0.4v-1.8c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v1.5h-1.5c-0.2,0 -0.4,0.2 -0.4,0.4C60.2,76.7 60.4,76.8 60.6,76.8M44.6,76.5c0,0.2 0.2,0.4 0.4,0.4h3.9c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4H45C44.8,76.1 44.6,76.3 44.6,76.5M52.8,76.8h3.9c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-3.9c-0.2,0 -0.4,0.2 -0.4,0.4C52.4,76.7 52.6,76.8 52.8,76.8M38.9,76.5C38.9,76.5 38.9,76.5 38.9,76.5c0,0.1 0,0.1 0,0.1c0,0 0,0 0,0.1c0,0 0,0 0,0.1c0,0 0,0 0.1,0.1c0,0 0,0 0,0c0,0 0,0 0,0c0.1,0 0.1,0 0.2,0h1.8c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-1.2l1.1,-1.9c0.1,-0.2 0,-0.4 -0.1,-0.5c-0.2,-0.1 -0.4,0 -0.5,0.1l-0.7,1.2v-0.5c0,-0.2 -0.2,-0.4 -0.4,-0.4s-0.4,0.2 -0.4,0.4V76.5zM38.9,64.6c0,0.2 0.2,0.4 0.4,0.4s0.4,-0.2 0.4,-0.4v-3.3c0,-0.2 -0.2,-0.4 -0.4,-0.4s-0.4,0.2 -0.4,0.4V64.6zM38.9,71.3c0,0.2 0.2,0.4 0.4,0.4s0.4,-0.2 0.4,-0.4V68c0,-0.2 -0.2,-0.4 -0.4,-0.4s-0.4,0.2 -0.4,0.4V71.3zM39.2,45c0.2,0 0.4,-0.2 0.4,-0.4v-3.3c0,-0.2 -0.2,-0.4 -0.4,-0.4s-0.4,0.2 -0.4,0.4v3.3C38.9,44.8 39,45 39.2,45M38.9,51.3c0,0.2 0.2,0.4 0.4,0.4s0.4,-0.2 0.4,-0.4v-3.3c0,-0.2 -0.2,-0.4 -0.4,-0.4s-0.4,0.2 -0.4,0.4V51.3zM38.9,57.9c0,0.2 0.2,0.4 0.4,0.4s0.4,-0.2 0.4,-0.4v-3.3c0,-0.2 -0.2,-0.4 -0.4,-0.4s-0.4,0.2 -0.4,0.4V57.9zM41.1,35.7h-1.8c-0.2,0 -0.4,0.2 -0.4,0.4v1.8c0,0.2 0.2,0.4 0.4,0.4s0.4,-0.2 0.4,-0.4v-1.5h1.5c0.2,0 0.4,-0.2 0.4,-0.4S41.3,35.7 41.1,35.7M44.6,36.1c0,0.2 0.2,0.4 0.4,0.4h3.9c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4H45C44.8,35.7 44.6,35.9 44.6,36.1M52.4,36.1c0,0.2 0.2,0.4 0.4,0.4h3.9c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4h-3.9C52.6,35.7 52.4,35.9 52.4,36.1M60.6,36.5h1.2l-1.5,2.6c-0.1,0.2 0,0.4 0.1,0.5c0.1,0 0.1,0 0.2,0c0.1,0 0.2,-0.1 0.3,-0.2l1.1,-2v0.5c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4v-1.8c0,0 0,0 0,0c0,0 0,0 0,-0.1c0,0 0,0 0,-0.1c0,0 0,0 0,-0.1c0,0 0,0 -0.1,-0.1c0,0 0,0 0,0c0,0 0,0 0,0c0,0 0,0 -0.1,0c0,0 0,0 -0.1,0c0,0 0,0 0,0h-1.8c-0.2,0 -0.4,0.2 -0.4,0.4S60.4,36.5 60.6,36.5M62.7,61.3c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V61.3zM62.7,41.3c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V41.3zM62.7,47.9c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V47.9zM62.7,54.6c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V54.6zM62.4,67.6c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V68C62.7,67.8 62.6,67.6 62.4,67.6M54.8,48.6L53,51.7c-0.1,0.2 0,0.4 0.1,0.5c0.1,0 0.1,0 0.2,0c0.1,0 0.2,-0.1 0.3,-0.2l1.8,-3.2c0.1,-0.2 0,-0.4 -0.1,-0.5C55.1,48.3 54.9,48.4 54.8,48.6M56.8,45.9c0.1,0 0.1,0 0.2,0c0.1,0 0.2,-0.1 0.3,-0.2l1.8,-3.2c0.1,-0.2 0,-0.4 -0.1,-0.5c-0.2,-0.1 -0.4,0 -0.5,0.1l-1.8,3.2C56.5,45.6 56.6,45.8 56.8,45.9M44.4,67.4c-0.2,-0.1 -0.4,0 -0.5,0.1l-1.8,3.2c-0.1,0.2 0,0.4 0.1,0.5c0.1,0 0.1,0 0.2,0c0.1,0 0.2,-0.1 0.3,-0.2l1.8,-3.2C44.7,67.7 44.6,67.5 44.4,67.4M46.1,64.9c0.1,0 0.2,-0.1 0.3,-0.2l1.8,-3.2c0.1,-0.2 0,-0.4 -0.1,-0.5c-0.2,-0.1 -0.4,0 -0.5,0.1l-1.8,3.2c-0.1,0.2 0,0.4 0.1,0.5C45.9,64.9 46,64.9 46.1,64.9M49.5,58.5c0.1,0 0.1,0 0.2,0c0.1,0 0.2,-0.1 0.3,-0.2l1.8,-3.2c0.1,-0.2 0,-0.4 -0.1,-0.5c-0.2,-0.1 -0.4,0 -0.5,0.1L49.4,58C49.3,58.2 49.3,58.4 49.5,58.5&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_posts_75dp.xml"
-            line="25"/>
+            line="25"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (845 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (845 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M116.91 34.44c-1.46 2.43-2.89 4.9-4.26 7.39-0.26 0.43-0.14 0.99 0.29 1.25s0.99 0.14 1.25-0.3c1.66-2.32 3.25-4.68 4.82-7.05 1.6-2.35 3.09-4.77 4.63-7.16 1.54-2.38 3.03-4.8 4.48-7.25 1.45-2.44 2.88-4.89 4.22-7.42 0.24-0.41 0.12-0.95-0.28-1.23-0.41-0.28-0.98-0.15-1.26 0.26-1.68 2.3-3.3 4.65-4.85 7.02-1.56 2.37-3.11 4.76-4.59 7.19-1.48 2.44-3.02 4.84-4.45 7.3m-22.54 4.59c-1.92-1.37-3.92-2.6-6-3.73-0.37-0.18-0.8-0.11-1.09 0.19-0.34 0.37-0.33 0.94 0.03 1.29 1.72 1.6 3.55 3.08 5.48 4.45 1.91 1.37 3.86 2.68 6 3.73 0.34 0.15 0.74 0.09 1.02-0.17 0.37-0.36 0.38-0.94 0.04-1.31-1.69-1.68-3.55-3.11-5.48-4.45m-29.8 12.78c0.38 0.32 0.97 0.27 1.29-0.11 1.71-2.08 3.3-4.25 4.74-6.51 1.48-2.25 2.88-4.53 4.01-6.99 0.17-0.37 0.07-0.8-0.23-1.07-0.39-0.33-0.96-0.29-1.3 0.08-1.78 2.03-3.29 4.25-4.74 6.5-1.46 2.25-2.8 4.59-4 6.99-0.19 0.38-0.09 0.83 0.23 1.11&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_stats_226dp.xml"
-            line="46"/>
+            line="46"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1277 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1277 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M223.67 109.62c-1.55 0.13-3.07 0.21-4.63 0.21-2.15 0-4.55-0.14-6.71-0.57l-0.54 42.04h-6.74c0.11 4.81 0.35 9.44 0.6 13.51 0.01 0.37 0.05 0.74 0.06 1.09 0.26 4.45 0.49 8.14 0.46 10.54-1.41 0.16-2.51 0.31-2.92 0.47-1.46 0.52-1.56 1.35 0.21 1.77 1.77 0.41 14.26 0 14.26 0v-3.02c0-31.76 5.93-46.26 6.4-63.49 0.02-0.82 0.03-1.77 0.03-2.61m-11.79-1.39c0.37 0.07 0.77 0.17 1.16 0.23 3.12 0.49 7.01 0.38 9.37 0.24h0.02c0.05 0 0.1 0 0.16-0.01h0.03c0.41-0.02 0.76-0.05 1.07-0.08 0.2-1.32 2-12.65 0.82-23.83-0.31-2.83-1.93-5.17-4.18-6.53-0.27 0.08-0.57 0.13-0.89 0.13-0.66-0.02-1.31-0.14-1.92-0.36-0.39-0.14-0.65-0.31-0.8-0.49-0.05 0.03-0.11 0.05-0.17 0.06-0.03 0-3.28 0.46-4.84 2.03-0.11 0.11-0.24 0.17-0.4 0.16l-2.49 2.57-1.5 1.57 1.74-1.66c0.24-0.2 0.57-0.19 0.77 0.04 0.2 0.22 0.19 0.56-0.01 0.76l-3.82 3.63 0.11 0.2 7.53 4.97c0.04-0.03 0.07-0.06 0.12-0.11 0.18 0.01 0.21 0.1 0.4 0.33 0.2 0.23 0.4 0.32 0.17 0.51-0.83 0.72-1.53 1.3-2.38 1.92M105.7 123.44h19.57v-11.32H105.7zm29.49-17.23h19.57V79.42h-19.57zm29.48-12.07h19.57V65.98h-19.57zM9.69 154.91l-0.65-0.05-2.2-0.15-0.54-0.03H6.19c-0.17-0.02-0.32-0.02-0.46-0.02-1.37 0.06-1.73 1.12-2.14 2.66-0.59 2.24-2.26 6.75-1.65 7.76 0.06 0.11 0.16 0.17 0.26 0.2 0.23 0.05 0.51-0.04 0.82-0.23 2.52-1.57 7.36-10.08 7.36-10.08h-0.06l-0.63-0.06z&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_stats_226dp.xml"
-            line="51"/>
+            line="51"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (2504 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (2504 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M94.82 128.06c-1.63-0.17-3.26-0.25-4.91-0.33-1.65-0.07-3.26-0.1-4.91-0.12-2.96-0.01-5.91 0.05-8.87 0.34 0.15-5.2 0.23-10.39 0.29-15.59 0.1-5.55 0.08-11.07 0.11-16.62 0.03-5.54-0.03-11.07-0.06-16.61-0.08-5.54-0.17-11.07-0.37-16.61-0.02-0.48-0.4-0.85-0.86-0.86-0.51-0.02-0.93 0.37-0.94 0.86-0.2 5.54-0.29 11.07-0.37 16.61-0.03 5.54-0.11 11.07-0.06 16.61 0.04 5.55 0.01 11.07 0.11 16.62 0.06 5.54 0.15 11.06 0.32 16.61 0.01 0.38 0.28 0.7 0.63 0.83 0.09 0.04 0.17 0.06 0.28 0.07 3.26 0.39 6.54 0.47 9.8 0.45 1.64-0.01 3.27-0.05 4.91-0.12 1.65-0.08 3.27-0.16 4.92-0.33 0.43-0.04 0.75-0.38 0.8-0.8 0.04-0.5-0.33-0.95-0.82-1.01m79.22-105.9c-0.61-4.73-4.06-8.58-8.7-9.69-0.73-0.18-1.5-0.28-2.27-0.29-0.77-0.03-1.39 0.01-2.1 0.01-5.45 0.07-10.9 0.16-16.35 0.34-0.47 0.02-0.84 0.4-0.86 0.87-0.01 0.5 0.37 0.92 0.86 0.93 5.45 0.19 10.9 0.28 16.35 0.34 0.66 0.02 1.42 0 2 0.05 0.6 0.03 1.19 0.11 1.76 0.26 3.56 0.89 6.19 3.87 6.63 7.51 0.13 1.1 0.05 2.59 0.08 3.91l0.02 4.08 0.06 8.18c0.08 5.45 0.17 10.9 0.37 16.35 0.01 0.48 0.4 0.84 0.86 0.86 0.51 0.02 0.92-0.37 0.94-0.86 0.2-5.45 0.29-10.9 0.37-16.35l0.06-8.18 0.02-4.08c-0.02-1.38 0.07-2.63-0.1-4.24m-53.54-9.64c-3.79-0.2-7.54-0.29-11.33-0.37-3.79-0.03-7.55-0.11-11.33-0.06-3.79 0.04-7.56 0.01-11.33 0.1-3.79 0.07-7.55 0.16-11.33 0.33-0.48 0.01-0.85 0.4-0.87 0.86-0.01 0.51 0.37 0.92 0.87 0.94 3.78 0.17 7.54 0.26 11.33 0.32 3.78 0.09 7.54 0.09 11.33 0.11 3.78 0.02 7.54-0.03 11.33-0.06 3.79-0.09 7.54-0.17 11.33-0.37 0.48-0.02 0.85-0.4 0.86-0.86 0.03-0.5-0.35-0.91-0.86-0.94m40.13 27.37c-3.94-0.4-7.88-0.46-11.82-0.45-1.97 0.02-3.94 0.05-5.91 0.13-1.97 0.07-3.94 0.15-5.91 0.32-0.43 0.05-0.79 0.39-0.82 0.82-0.04 0.5 0.32 0.94 0.82 0.98 1.97 0.17 3.94 0.23 5.91 0.32 1.97 0.1 3.94 0.11 5.91 0.13 3.94 0.01 7.88-0.06 11.82-0.45 0.44-0.04 0.79-0.38 0.82-0.81 0.05-0.5-0.31-0.94-0.82-0.99m-6.2 14.19c-3.94-0.38-7.88-0.46-11.82-0.44-1.97 0.01-3.94 0.04-5.92 0.12-1.97 0.08-3.94 0.16-5.91 0.32-0.43 0.05-0.78 0.39-0.81 0.82-0.05 0.51 0.32 0.94 0.81 0.99 1.97 0.17 3.94 0.23 5.91 0.32 1.98 0.09 3.95 0.11 5.92 0.12 3.94 0.02 7.88-0.06 11.82-0.44 0.43-0.05 0.79-0.39 0.82-0.82 0.06-0.49-0.31-0.94-0.82-0.99M119.7 82.66c-2.43-0.2-4.87-0.29-7.3-0.37-2.43-0.06-4.86-0.11-7.3-0.06-2.43 0.04-4.86 0.01-7.29 0.1-2.44 0.07-4.87 0.16-7.3 0.33-0.45 0.03-0.82 0.38-0.85 0.84-0.03 0.51 0.34 0.94 0.85 0.97 2.43 0.17 4.86 0.27 7.3 0.33 2.43 0.09 4.86 0.07 7.29 0.11 2.44 0.03 4.87-0.02 7.3-0.07 2.43-0.09 4.87-0.17 7.3-0.37 0.43-0.04 0.78-0.38 0.81-0.81 0.07-0.51-0.3-0.96-0.81-1&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_stats_226dp.xml"
-            line="56"/>
+            line="56"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (2272 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (2272 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M110.54 96.87c-4.13-0.4-8.25-0.46-12.39-0.45-2.07 0.02-4.13 0.05-6.19 0.12-2.07 0.08-4.13 0.16-6.19 0.33-0.45 0.03-0.82 0.38-0.85 0.84-0.03 0.51 0.34 0.94 0.85 0.97 2.06 0.17 4.12 0.24 6.19 0.33 2.06 0.09 4.12 0.11 6.19 0.12 4.12 0.02 8.25-0.06 12.39-0.45 0.43-0.04 0.78-0.38 0.81-0.81 0.07-0.51-0.3-0.96-0.81-1m-20.25 16.47c1.51 0.02 3.02-0.06 4.53-0.45 0.32-0.09 0.59-0.33 0.68-0.67 0.12-0.5-0.17-1.02-0.68-1.14-1.51-0.39-3.02-0.46-4.53-0.45-1.52 0-3.03 0.15-4.52 0.45-0.37 0.07-0.65 0.35-0.73 0.72-0.09 0.49 0.24 0.99 0.73 1.09 1.49 0.3 3 0.45 4.52 0.45M41.61 61.72c0-0.28 0.22-0.49 0.5-0.49 0.27 0 0.49 0.21 0.49 0.49v0.83c0 0.28-0.22 0.49-0.49 0.49-0.28 0-0.5-0.21-0.5-0.49v-0.83zm-5.2 13.35h0.2c0.23 0.01 0.46 0.04 0.69 0.09v-0.11l-2.95-3.14 0.06-0.37c0.02-0.03 0.02-0.06 0.03-0.07 0-0.04 0-0.07 0.02-0.11 0.06-0.26 0.3-0.43 0.57-0.4 0.03 0 0.06 0 0.09 0.01h0.01c0.76 0.2 1.1 0.19 1.96 0.16 0.17-0.02 0.34-0.02 0.49-0.05 2.06-0.23 3.76-1.28 4.84-2.92-0.44-0.28-1.01-0.77-1.33-1.5-0.12-0.27 0.02-0.6 0.29-0.72 0.28-0.12 0.6 0.01 0.73 0.29 0.2 0.45 0.55 0.77 0.84 0.97 0.23-0.49 0.42-1.01 0.54-1.58 0.16-0.67 0.73-1.01 1.22-1.31 0.45-0.28 0.72-0.46 0.72-0.68-0.01-0.35-0.32-0.68-0.81-1.17-0.7-0.69-1.64-1.63-1.91-3.34-0.19-1.09-0.74-1.94-1.5-2.57-0.09 2.98-1.49 5.85-4.26 6.03 0.12 0.6 0.15 1.25 0.06 1.9-0.17 1.4-0.8 2.84-1.8 3.88-0.6 0.61-1.32 1.09-2.17 1.34 0.22 1.41 0.05 3-0.54 4.57 1.2 0.12 2.49 0.4 3.91 0.8zm-24.51 57.5c-1.2 2.49-5.69 12.58-5.06 22.14l2.2 0.15 13.73-18.94c-0.12-1.12-0.23-2.23-0.32-3.37H11.9v0.02zm14 0h-2.36c0.06 0.68 0.12 1.35 0.19 2.03l0.09 0.82 0.09 0.81c0.43 3.73 1 7.39 1.56 10.99 0.78 5.09 1.53 9.9 1.77 14.25 0.01 0.23 0.03 0.46 0.03 0.69l4.98 0.14c0.05-0.2 0.11-0.43 0.16-0.68 1.12-5.44 2.14-22.19 2.51-29.05H25.9zm28.46-59.5c-1.52 0.12-5.66 4.89-7.65 8.39-0.85 1.51-1.99 2.85-3.32 3.94 0.24 1.43 0.4 2.89 0.46 4.34 0 0.31-0.25 0.55-0.56 0.54-0.29 0-0.52-0.23-0.54-0.51 0-0.12-0.44-11.45-5.03-13.33-0.15-0.06-0.32-0.12-0.49-0.16-0.22-0.04-0.43-0.09-0.66-0.09h-0.1c-1.4 0-2.06 1.79-2.38 3.44-0.02 0.12-0.05 0.23-0.07 0.35-1.09 6.74 1.78 19.35 4.58 20.14 0.03 0.01 0.06 0.01 0.09 0.01 3.86 0.82 11.16-13.82 12.76-18.93 0.05-0.14 0.14-0.27 0.28-0.33 1.06-0.54 2.43-2.95 2.92-5.19 0.27-1.17 0.24-2.11-0.09-2.51-0.03-0.07-0.06-0.12-0.2-0.1&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_stats_226dp.xml"
-            line="61"/>
+            line="61"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1094 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1094 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M38.9 101.2v-0.13l-0.13-0.01c-0.16-0.02-0.28-0.03-0.41-0.08-1.67-0.46-3.32-3.66-4.42-8.55-1.01-4.53-1.34-9.49-0.83-12.63 0.01-0.03 0.02-0.07 0.02-0.1 0-0.02 0-0.04 0.01-0.06l0.01-0.02c0.49-2.9 1.6-4.38 3.28-4.4l1.06-0.01-1.02-0.29c-1.35-0.38-2.66-0.66-3.9-0.82l-0.12-0.02-0.05 0.12c-0.25 0.65-0.56 1.28-0.92 1.86-0.38 0.61-0.8 1.17-1.26 1.67-2.21 2.38-5.12 3.35-7.41 2.49-0.26-0.1-0.53-0.22-0.8-0.39-0.23-0.14-0.41-0.27-0.55-0.4l-0.13-0.12-0.38 0.57c-3.6 5.47-3.65 8.37-3.71 11.73-0.03 1.95-0.06 3.97-0.76 6.73-0.02 0.06-0.03 0.12-0.04 0.18-0.01 0.05-0.02 0.09-0.04 0.15l-0.03 0.1c-0.01 0.04-0.02 0.09-0.03 0.12-0.04 0.17-0.09 0.34-0.15 0.52-0.5 1.67-1.11 3.16-1.75 4.73-2.23 5.41-4.75 11.54-4.05 28.44l0.01 0.14h26.64l0.02-0.14c0.02-0.22 2.1-22.02 1.84-31.38m1.19 62.19c-1.18-0.39-4.83-1.11-6.57-1.6-0.11 0.49-0.2 0.91-0.31 1.23-0.08 0.23-0.29 0.39-0.52 0.37h-0.02l-5.93-0.15c-0.29-0.02-0.52-0.25-0.54-0.54-0.01-0.42-0.03-0.83-0.06-1.27H25.9l-0.19 1.34c-0.01 0.11-0.03 0.22-0.03 0.34 0 0.54 0.19 1.02 0.51 1.4 0.41 0.51 1.05 0.83 1.74 0.83h11.84c0.63 0 0.98-0.49 1-1 0.01-0.4-0.2-0.8-0.68-0.95&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_stats_226dp.xml"
-            line="71"/>
+            line="71"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (2093 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (2093 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M222.52 67.72l0.46 0.33 0.48 0.32c1.56-4.76-1.01-9.88-5.77-11.47-3.39-1.14-6.62-0.32-8.18 1.97l0.45 0.31 0.46 0.31c1.45-2.16 4.51-2.34 6.93-1.54 4.08 1.35 6.33 5.68 5.17 9.77m2.13 41.8c-0.13 0.01-0.26 0.03-0.4 0.03-0.03 0-0.07 0-0.1 0.01 0 0.84 0 1.67-0.04 2.48-0.47 17.23-6.4 31.73-6.4 63.49v2.96c3.37-0.05 6.62-0.16 6.88-0.16l0.39-0.01v-1.74c0.1-1.89 2.21-45.57-0.33-67.06m-11.07-34.36l-0.13-0.37 0.22-0.01-0.09 0.38zm0.64 16.55c-0.04 0.03-0.07 0.08-0.12 0.11-1.21 1.04-2.42 1.94-3.57 2.69-5.47 3.59-10.05 4.11-11.98 2.5-3.02-2.51 0.96-11.74 2.88-16.17 0.54-1.26 0.94-2.17 1.05-2.63 1.08-4.45 2.97-5.68 4-6.02 0.83-0.28 1.46-0.11 1.66 0.06 0.3 0.35-0.21 2.51-1.09 4.51-0.02 0.03-0.03 0.08-0.03 0.12l-1.71 9.33-2.19 2.08c-0.1 0.11-0.16 0.25-0.16 0.4 0 0.31 0.24 0.56 0.55 0.56 0.14 0 0.28-0.05 0.38-0.16l2.51-2.38 0.08-0.08L210.3 83c0.2-0.2 0.21-0.54 0.01-0.76-0.2-0.23-0.55-0.24-0.77-0.04l-1.74 1.66-1.12 1.06 1.43-7.77c0.43-1.04 1.19-2.99 1.2-4.39 0.74 0.6 1.62 1.08 2.62 1.42 0.09 0.03 0.17 0.06 0.25 0.07 0 0.06 0 0.13 0.03 0.19l0.94 2.86c0.03 0.08 0.07 0.15 0.12 0.2 0.32-0.15 0.65-0.29 0.97-0.4l0.69-2.8c0.05-0.17 0-0.36-0.11-0.48-0.03-0.05-0.07-0.08-0.1-0.11-0.06-0.04-0.14-0.07-0.22-0.09-0.08-0.06-0.18-0.11-0.29-0.11-0.77-0.01-1.09-0.1-1.93-0.38-2.01-0.68-3.46-2.06-4.18-3.9 0.26 0.05 0.52 0.08 0.8 0.1 0.09 0 0.2-0.02 0.31-0.02 0.29-0.03 0.49-0.29 0.47-0.57-0.01-0.31-0.27-0.54-0.58-0.52-0.39 0.03-0.79-0.03-1.16-0.16-0.06-0.01-0.14-0.03-0.2-0.03-0.12-0.61-0.17-1.28-0.14-1.95 0.04-0.68-0.43-1.16-0.81-1.6-0.36-0.4-0.57-0.65-0.51-0.87 0.11-0.33 0.49-0.57 1.09-0.9 0.77-0.44 1.8-1.02 2.54-2.31l-0.46-0.31-0.46-0.31c-0.59 1.08-1.42 1.54-2.17 1.97-0.69 0.39-1.36 0.76-1.6 1.51-0.28 0.85 0.31 1.49 0.74 1.96 0.26 0.29 0.54 0.58 0.52 0.8-0.08 1.87 0.35 3.55 1.23 4.92-0.46-0.06-1-0.01-1.57 0.17-1.24 0.42-3.51 1.83-4.72 6.81-0.1 0.37-0.51 1.34-0.99 2.44-2.17 5.04-6.22 14.41-2.57 17.45 0.92 0.77 2.15 1.14 3.62 1.14 1.21 0 2.6-0.27 4.06-0.76 0.45-0.15 0.89-0.32 1.36-0.51 1.78-0.75 3.66-1.81 5.54-3.18 0.85-0.62 1.69-1.28 2.52-2 0.23-0.2 0.27-0.54 0.07-0.77-0.22-0.19-0.57-0.2-0.81-0.02z&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_stats_226dp.xml"
-            line="76"/>
+            line="76"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (2254 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (2254 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M51.45 81.15c-1.58 5.11-8.9 19.75-12.76 18.94-0.03 0-0.06-0.02-0.09-0.02-2.8-0.79-5.67-13.39-4.58-20.14 0.02-0.12 0.05-0.23 0.07-0.35 0.3-1.65 0.97-3.43 2.38-3.43h0.09c0.24 0.01 0.45 0.04 0.67 0.09 0.17 0.04 0.34 0.09 0.49 0.15 4.59 1.88 5.03 13.21 5.03 13.33 0.02 0.3 0.27 0.51 0.54 0.51 0.31 0 0.56-0.24 0.56-0.54-0.06-1.46-0.22-2.91-0.46-4.34 1.35-1.09 2.47-2.42 3.32-3.94 1.99-3.49 6.13-8.27 7.65-8.39 0.14-0.01 0.17 0.03 0.2 0.06 0.33 0.4 0.36 1.34 0.09 2.51-0.49 2.23-1.86 4.65-2.92 5.19-0.12 0.11-0.23 0.23-0.28 0.37m-30.14-1.62c0.18 0.16 0.37 0.3 0.57 0.42 0.26 0.17 0.55 0.31 0.83 0.4 2.37 0.88 5.37-0.14 7.57-2.53 0.47-0.5 0.91-1.07 1.28-1.69 0.39-0.62 0.69-1.26 0.94-1.89 0.59-1.57 0.77-3.16 0.54-4.58 0.85-0.24 1.57-0.72 2.17-1.33 1.02-1.05 1.63-2.48 1.8-3.88 0.08-0.65 0.06-1.3-0.06-1.9 2.77-0.18 4.17-3.05 4.26-6.03 0.77 0.63 1.33 1.47 1.5 2.57 0.27 1.71 1.21 2.65 1.91 3.34 0.49 0.49 0.8 0.81 0.81 1.17 0.02 0.21-0.26 0.4-0.72 0.68-0.49 0.3-1.06 0.66-1.22 1.3-0.14 0.57-0.32 1.1-0.54 1.59-0.29-0.2-0.64-0.52-0.84-0.97-0.13-0.28-0.45-0.4-0.73-0.29-0.27 0.12-0.4 0.44-0.29 0.72 0.31 0.74 0.89 1.22 1.33 1.49-1.1 1.67-2.78 2.7-4.84 2.93-0.17 0.02-0.32 0.03-0.49 0.05-0.88 0.03-1.22 0.04-1.96-0.16h-0.01c-0.03 0-0.06-0.01-0.09-0.01-0.27-0.03-0.51 0.14-0.57 0.4-0.02 0.03-0.02 0.06-0.02 0.1-0.01 0.04-0.03 0.05-0.03 0.08l-0.06 0.37 2.95 3.14 0.13 0.14c-0.05-0.01-0.1-0.01-0.14-0.03-0.22-0.05-0.45-0.08-0.69-0.09h-0.2c-1.28 0.01-2.81 0.86-3.44 4.52-0.01 0.07-0.01 0.13-0.03 0.17-1.05 6.45 1.48 20.29 5.36 21.37 0.14 0.05 0.29 0.06 0.43 0.08 0.06 0 0.14 0.01 0.22 0.01 5.03 0 12-14.98 13.48-19.52 1.45-0.91 2.82-3.66 3.3-5.82 0.24-1.09 0.38-2.55-0.31-3.43-0.26-0.31-0.69-0.49-1.13-0.45-2.32 0.19-6.85 6.01-8.52 8.95-0.7 1.2-1.57 2.29-2.61 3.23-0.73-3.65-2.27-7.91-5.43-8.88l0.74-3.2c2.25-0.47 4.08-1.82 5.2-3.82 0.02-0.02 0.02-0.03 0.03-0.05 0.39-0.71 0.7-1.48 0.9-2.34 0.04-0.21 0.4-0.43 0.72-0.63 0.54-0.34 1.28-0.78 1.23-1.68-0.03-0.8-0.57-1.32-1.12-1.89-0.65-0.65-1.39-1.39-1.6-2.74-0.27-1.6-1.24-2.91-2.64-3.79 0-0.04-0.01-0.11-0.01-0.15 0 0-2.91-1.77-6.04-0.83-1.89 0.57-3.26 0.95-4.77 3.63-1.66 0.43-3.25 1.46-4.19 2.82-0.66 0.97-1.15 2.34-1.37 3.74-0.15 1.01-0.69 1.92-1.49 2.55-0.92 0.76-1.72 1.67-2.36 2.68-1.83 2.97-2.03 6.38-0.75 8.62&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_stats_226dp.xml"
-            line="86"/>
+            line="86"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (2144 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (2144 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M225.14 108.44c-0.02 0-0.39 0.05-0.99 0.1-0.33 0.03-0.77 0.06-1.26 0.09-0.04 0-0.09 0-0.14 0.01-2.34 0.16-6.02 0.25-9.23-0.26h-0.02c-0.38-0.06-0.77-0.12-1.14-0.21l0.19-13.72-0.14 0.06c-1.88 1.36-3.77 2.43-5.54 3.19-0.47 0.2-0.91 0.37-1.36 0.51L205 123.3c0.28 0.02 0.56 0.03 0.85 0.03 1.06 0 2.25-0.09 3.57-0.29 0.29-0.05 0.57 0.17 0.62 0.46 0.04 0.29-0.17 0.57-0.47 0.62-1.21 0.18-2.46 0.29-3.69 0.29h-0.09c-0.28 0-0.54-0.02-0.82-0.03l-0.55 26.86h7.34l0.57-41.98c2.16 0.43 4.56 0.57 6.71 0.57 1.56 0 3.11-0.06 4.67-0.2 0.03 0 0.06 0 0.09-0.02 0.09-0.01 0.2-0.01 0.29-0.03 0.03 0 0.08 0 0.11-0.01 0.14-0.02 0.26-0.03 0.4-0.03 0.22-0.02 0.42-0.05 0.63-0.06 0.28-0.05 0.48-0.3 0.46-0.59 0.02-0.23-0.26-0.46-0.55-0.45m-4.23-31.49c-0.45 0.38-1.42 0.37-2.58-0.02-0.13-0.03-0.24-0.09-0.35-0.18 0-0.34 1.32-1.31 2.51-1.44 0.65-0.07 0.69 0.17 0.71 0.27 0.12 0.64 0.01 1.1-0.29 1.37m-0.22-2.76c-1.42 0-3.48 1.11-3.77 2.26h-0.08c-0.09 0.02-1.28 0.19-2.63 0.68-0.32 0.12-0.65 0.25-0.97 0.4-0.68 0.32-1.34 0.74-1.86 1.26-0.11 0.11-0.16 0.25-0.16 0.39 0 0.31 0.25 0.55 0.54 0.55 0.16 0 0.29-0.06 0.4-0.15 1.56-1.57 4.8-2.03 4.84-2.03 0.06-0.02 0.12-0.03 0.16-0.06 0.17 0.18 0.42 0.35 0.81 0.49 0.61 0.21 1.26 0.34 1.92 0.35 0.32 0 0.63-0.04 0.89-0.12 0.31-0.09 0.59-0.23 0.82-0.43 0.43-0.37 0.89-1.08 0.66-2.4-0.09-0.74-0.69-1.19-1.57-1.19M206 57.79l2.97 2.04 0.47 0.3 0.46 0.31 5.03 3.44 7.21 4.91 0.43 0.29 0.61 0.42c0.1 0.06 0.2 0.09 0.31 0.09 0.19 0 0.36-0.09 0.45-0.23 0.17-0.25 0.11-0.59-0.14-0.77l-0.32-0.22-0.48-0.32-0.46-0.33-12.1-8.25-0.46-0.31-0.45-0.3-2.9-1.97c-0.23-0.14-0.53-0.08-0.7 0.13-0.2 0.24-0.16 0.59 0.07 0.77M131.41 2.13c1.91-2.42 5.43-2.84 7.85-0.93 2.43 1.91 2.84 5.42 0.93 7.85-1.91 2.42-5.42 2.84-7.85 0.93-2.42-1.91-2.84-5.42-0.93-7.85M103.4 46.41c1.91-2.43 5.43-2.85 7.85-0.94 2.43 1.91 2.84 5.43 0.93 7.85-1.91 2.43-5.42 2.84-7.84 0.93-2.43-1.91-2.85-5.42-0.94-7.84M75.9 26.09c1.91-2.42 5.42-2.84 7.85-0.93 2.42 1.91 2.84 5.42 0.93 7.85-1.91 2.42-5.42 2.84-7.85 0.93-2.42-1.91-2.84-5.42-0.93-7.85M56.02 55.17c1.91-2.42 5.42-2.84 7.85-0.93 2.42 1.91 2.84 5.42 0.93 7.85-1.91 2.42-5.42 2.84-7.85 0.93-2.42-1.91-2.84-5.43-0.93-7.85&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_illustration_stats_226dp.xml"
-            line="91"/>
+            line="91"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1051 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1051 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M157.1 96.3c0.4-1.1 0.3-2.3-0.4-3.3-0.7-1.1-1.6-2-2.7-2.7-2.2-1.5-4.7-2.6-7.3-3.3-0.6-0.2-1.3-0.3-2-0.5l-1-0.2c-0.3-0.1-0.6-0.1-0.9-0.1-1.2 0-2.3 0.4-3.3 1-2.3 1.5-4.3 3.3-6.1 5.4-1 1-1.9 2-3 3.1-0.5 0.5-1.1 1-1.7 1.5-0.7 0.5-1.4 1-2.2 1.2-0.5 0.2-1.1 0.2-1.6 0.1-0.6-0.1-1.1-0.4-1.5-0.8-0.7-0.7-1.1-1.5-1.3-2.5-0.2-1.6 0-3.2 0.6-4.8 1.1-2.8 2.7-5.3 4.7-7.5 1.9-2.2 4.1-4.1 6.5-5.8 4.8-3.4 10.4-5.4 16.3-5.9 5.9-0.3 11.7 1 16.8 3.9 5 2.8 9.7 6.1 14 9.8 4.4 3.6 8.6 7.4 12.7 11.3 0.3 0.3 0.3 0.8 0 1.1s-0.8 0.3-1.1 0c-4.1-3.8-8.3-7.5-12.7-11-2.2-1.8-4.4-3.4-6.7-5-2.3-1.7-4.6-3.2-7.1-4.5-4.8-2.7-10.3-3.9-15.7-3.5-5.5 0.5-10.7 2.4-15.2 5.6-2.2 1.6-4.3 3.4-6.1 5.4-1.8 2-3.2 4.3-4.2 6.8-0.5 1.1-0.6 2.3-0.5 3.5 0.1 0.5 0.3 0.9 0.6 1.2 0.3 0.2 0.4 0.2 0.8 0.1 1.1-0.5 2.1-1.3 2.9-2.2 1-1 1.9-2 2.9-3 1.9-2.2 4.2-4.1 6.6-5.7 1.4-0.9 3-1.4 4.6-1.4 0.4 0 0.8 0 1.2 0.1l1.1 0.2c0.7 0.2 1.4 0.3 2.1 0.6 2.8 0.8 5.5 2.1 7.9 3.9 1.3 0.9 2.3 2.1 3.1 3.4 0.4 0.7 0.6 1.5 0.7 2.4 0 0.8-0.1 1.7-0.5 2.4-0.1 0.3-0.3 0.4-0.6 0.5s-0.5-0.1-0.7-0.3c-0.1 0-0.1-0.3 0-0.5z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_promo_editor.xml"
-            line="28"/>
+            line="28"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (857 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (857 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M92.034,111.91c-0.233,-2.972 0.447,-5.875 1.378,-8.583 0.919,-2.73 2.146,-5.31 3.298,-7.863 0.57,-1.274 1.133,-2.556 1.533,-3.81 0.198,-0.615 0.35,-1.257 0.329,-1.737 -0.034,-0.485 -0.152,-0.571 -0.432,-0.66 -0.301,-0.073 -0.93,0.1 -1.47,0.36 -0.56,0.269 -1.117,0.616 -1.65,1.009 -1.07,0.787 -2.064,1.724 -2.988,2.724a33.808,33.808 0,0 0,-7.728 14.369c-1.372,5.325 -1.293,11.018 0.34,16.304a0.64,0.64 0,0 1,-1.22 0.386,31.193 31.193,0 0,1 -0.703,-17.078c1.362,-5.616 4.084,-10.888 7.965,-15.215 0.984,-1.072 2.044,-2.085 3.242,-2.975 0.6,-0.444 1.239,-0.853 1.95,-1.197 0.725,-0.311 1.489,-0.675 2.6,-0.516a2.384,2.384 0,0 1,1.46 0.88c0.369,0.487 0.494,1.05 0.516,1.507 0.038,0.935 -0.173,1.682 -0.383,2.409 -0.457,1.434 -1.064,2.726 -1.653,4.019 -1.192,2.57 -2.408,5.082 -3.401,7.662 -0.955,2.577 -1.757,5.244 -1.706,7.933v0.01a0.64,0.64 0,0 1,-1.277 0.062&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_promo_quick_start.xml"
-            line="20"/>
+            line="20"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1929 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1929 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M105.194,97.932c4.367,-0.527 8.734,-0.715 13.1,-0.808l6.55,-0.105 6.55,-0.019 13.101,0.155c4.367,0.103 8.734,0.218 13.1,0.577 0.244,0.019 0.425,0.216 0.403,0.436 -0.02,0.197 -0.193,0.347 -0.403,0.364 -4.366,0.358 -8.733,0.473 -13.1,0.577l-13.1,0.154 -6.551,-0.019 -6.55,-0.105c-4.366,-0.094 -8.733,-0.28 -13.1,-0.808 -0.123,-0.014 -0.209,-0.116 -0.192,-0.226 0.013,-0.092 0.094,-0.161 0.192,-0.173M105.174,77.932c3.85,-0.528 7.7,-0.715 11.55,-0.808l5.777,-0.105 5.775,-0.019 11.55,0.155c3.852,0.103 7.702,0.218 11.553,0.577a0.4,0.4 0,0 1,0 0.8c-3.851,0.358 -7.701,0.473 -11.552,0.577l-11.551,0.154 -5.775,-0.019 -5.776,-0.105c-3.85,-0.094 -7.7,-0.28 -11.551,-0.808a0.201,0.201 0,0 1,0 -0.399M105.125,83.938c1.068,-0.527 2.136,-0.713 3.204,-0.808a31.17,31.17 0,0 1,3.203 -0.126c1.068,0.023 2.135,0.079 3.203,0.153 1.068,0.087 2.136,0.227 3.204,0.582a0.421,0.421 0,0 1,0 0.8c-1.068,0.353 -2.136,0.494 -3.204,0.581 -1.068,0.074 -2.135,0.13 -3.203,0.152a30.889,30.889 0,0 1,-3.203 -0.125c-1.068,-0.095 -2.136,-0.281 -3.204,-0.809a0.222,0.222 0,0 1,0 -0.4M105.193,117.932c4.285,-0.528 8.568,-0.715 12.85,-0.808l6.426,-0.105 6.425,-0.019 12.85,0.155c4.284,0.103 8.567,0.218 12.851,0.577 0.245,0.02 0.426,0.216 0.403,0.437 -0.02,0.196 -0.194,0.345 -0.403,0.363 -4.284,0.358 -8.567,0.473 -12.851,0.577l-12.85,0.154 -6.425,-0.019 -6.425,-0.105c-4.283,-0.094 -8.566,-0.28 -12.85,-0.808 -0.123,-0.014 -0.209,-0.117 -0.192,-0.227 0.013,-0.092 0.095,-0.16 0.191,-0.172M105.398,123.938c3.403,-0.527 6.806,-0.713 10.209,-0.808 3.4,-0.09 6.803,-0.146 10.206,-0.126 3.403,0.023 6.803,0.079 10.206,0.153 3.403,0.087 6.807,0.227 10.21,0.582 0.704,0.073 1.086,0.311 0.854,0.532 -0.14,0.131 -0.469,0.227 -0.854,0.268 -3.403,0.353 -6.807,0.494 -10.21,0.581 -3.403,0.074 -6.803,0.13 -10.206,0.152 -3.403,0.02 -6.806,-0.034 -10.206,-0.125 -3.403,-0.095 -6.806,-0.281 -10.21,-0.809 -0.353,-0.054 -0.496,-0.188 -0.324,-0.298a0.918,0.918 0,0 1,0.325 -0.102&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_promo_quick_start.xml"
-            line="50"/>
+            line="50"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1396 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1396 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M93.31,111.838c0.128,1.723 0.326,3.438 0.666,5.106 0.35,1.648 0.83,3.32 1.703,4.589 0.43,0.633 0.973,1.103 1.579,1.279 0.303,0.09 0.628,0.112 0.969,0.073 0.17,-0.018 0.133,-0.024 0.198,-0.06a0.728,0.728 0,0 0,0.174 -0.225c0.266,-0.505 0.375,-1.376 0.42,-2.186 0.048,-0.831 0.043,-1.69 0.029,-2.555 -0.032,-1.732 -0.093,-3.492 -0.02,-5.29 0.04,-0.9 0.11,-1.811 0.29,-2.742 0.19,-0.922 0.447,-1.906 1.167,-2.817 0.367,-0.45 0.857,-0.84 1.483,-1.05 0.742,-0.247 1.489,-0.047 1.986,0.224 1.026,0.56 1.639,1.327 2.209,2.086 1.097,1.544 1.845,3.212 2.46,4.913 1.19,3.414 1.78,6.987 1.89,10.567 0.105,3.58 -0.285,7.185 -1.258,10.639a33.844,33.844 0,0 1,-4.447 9.738c-2,2.968 -4.456,5.606 -7.207,7.85a0.64,0.64 0,0 1,-0.825 -0.978c5.205,-4.491 9.074,-10.464 10.77,-17.07 1.707,-6.575 1.5,-13.713 -0.731,-20.104 -0.563,-1.583 -1.264,-3.135 -2.191,-4.447 -0.457,-0.64 -1.011,-1.246 -1.533,-1.52 -0.264,-0.143 -0.44,-0.147 -0.54,-0.112 -0.204,0.065 -0.44,0.225 -0.621,0.452 -0.385,0.46 -0.64,1.21 -0.792,1.988 -0.156,0.785 -0.23,1.62 -0.272,2.466 -0.082,1.695 -0.02,3.43 -0.027,5.193a37.55,37.55 0,0 1,-0.077 2.686c-0.094,0.917 -0.136,1.842 -0.681,2.9a2.352,2.352 0,0 1,-0.667 0.764c-0.288,0.226 -0.76,0.353 -1.023,0.359a4.065,4.065 0,0 1,-1.623 -0.163c-1.082,-0.341 -1.888,-1.143 -2.417,-1.955 -1.066,-1.664 -1.464,-3.464 -1.796,-5.222 -0.302,-1.77 -0.447,-3.54 -0.521,-5.304a0.639,0.639 0,0 1,1.277 -0.072&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_promo_quick_start.xml"
-            line="80"/>
+            line="80"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (2499 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (2499 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M169.98,155.734c-4.134,-8.105 -5.986,-17.31 -5.617,-26.392a53.787,53.787 0,0 1,2.236 -13.441c0.669,-2.183 1.482,-4.33 2.532,-6.387 0.53,-1.027 1.109,-2.035 1.8,-2.993 0.692,-0.956 1.468,-1.884 2.534,-2.637 0.536,-0.365 1.17,-0.705 1.97,-0.785 0.409,-0.04 0.804,0.003 1.168,0.112a3.15,3.15 0,0 1,1.056 0.529c0.626,0.492 0.999,1.137 1.245,1.743a8.66,8.66 0,0 1,0.484 1.817c0.358,2.383 0.223,4.653 0.132,6.906 -0.102,2.244 -0.267,4.477 -0.184,6.63 0.047,1.057 0.163,2.149 0.509,2.937 0.175,0.396 0.388,0.62 0.604,0.7 0.402,0.14 0.919,0.289 1.36,0.32 0.916,0.095 1.747,-0.125 2.424,-0.704 0.689,-0.557 1.22,-1.426 1.623,-2.363 0.8,-1.902 1.166,-4.075 1.369,-6.24 0.197,-2.173 0.22,-4.381 0.13,-6.582 -0.072,-2.115 -0.57,-4.262 -1.095,-6.411 -1.066,-4.308 -2.494,-8.566 -3.383,-13.062 -0.214,-1.13 -0.394,-2.275 -0.46,-3.47 -0.033,-1.19 -0.072,-2.464 0.624,-3.828a3.167,3.167 0,0 1,1.859 -1.543c0.518,-0.15 1.044,-0.073 1.435,0.068 0.397,0.144 0.715,0.339 0.993,0.543 1.085,0.83 1.775,1.788 2.452,2.749 2.567,3.89 4.304,8.076 5.924,12.3a109.227,109.227 0,0 1,3.956 12.964c1.019,4.406 1.834,8.89 1.845,13.505 -0.006,1.154 -0.071,2.316 -0.255,3.484 -0.09,0.576 -0.22,1.186 -0.382,1.734l-0.472,1.636c-0.65,2.174 -1.392,4.307 -2.178,6.419 -3.202,8.429 -6.982,16.574 -10.99,24.62a0.692,0.692 0,0 1,-1.241 -0.607l0.005,-0.011c3.877,-8.045 7.513,-16.244 10.595,-24.605 0.767,-2.09 1.487,-4.196 2.11,-6.32 0.293,-1.076 0.649,-2.113 0.786,-3.141 0.16,-1.047 0.218,-2.128 0.22,-3.214 -0.03,-4.36 -0.838,-8.76 -1.86,-13.065a107.6,107.6 0,0 0,-3.947 -12.717c-1.595,-4.122 -3.363,-8.263 -5.762,-11.85 -0.602,-0.868 -1.283,-1.73 -1.992,-2.255 -0.351,-0.271 -0.677,-0.331 -0.688,-0.293 -0.222,0.08 -0.482,0.263 -0.636,0.577 -0.352,0.647 -0.42,1.717 -0.36,2.74 0.063,1.043 0.233,2.115 0.443,3.186 0.879,4.296 2.249,8.575 3.333,12.967 0.525,2.197 1.048,4.448 1.126,6.82 0.084,2.277 0.055,4.56 -0.162,6.848 -0.23,2.284 -0.601,4.592 -1.545,6.83 -0.486,1.103 -1.133,2.229 -2.19,3.092 -1.026,0.896 -2.544,1.289 -3.845,1.12 -0.677,-0.064 -1.247,-0.223 -1.897,-0.46 -0.844,-0.336 -1.362,-1.076 -1.627,-1.697 -0.536,-1.284 -0.598,-2.475 -0.662,-3.643 -0.078,-2.328 0.104,-4.573 0.212,-6.802 0.105,-2.215 0.224,-4.454 -0.083,-6.513 -0.153,-1.005 -0.491,-2 -1.027,-2.406 -0.547,-0.407 -1.248,-0.371 -2.038,0.197 -0.773,0.535 -1.48,1.335 -2.096,2.19 -0.624,0.857 -1.17,1.794 -1.67,2.756 -0.996,1.93 -1.786,3.987 -2.437,6.085 -1.298,4.202 -2.003,8.594 -2.238,12.998 -0.46,8.81 1.234,17.766 5.162,25.695a0.693,0.693 0,0 1,-1.237 0.62&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_promo_quick_start.xml"
-            line="110"/>
+            line="110"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (3064 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (3064 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M209.9 68c-0.7 0-1.3-0.6-1.3-1.3v-8.9c0-0.7 0.6-1.3 1.3-1.3 0.7 0 1.3 0.6 1.3 1.3v8.9c-0.1 0.7-0.6 1.3-1.3 1.3zm0-17.9c-0.7 0-1.3-0.6-1.3-1.3v-8.9c0-0.7 0.6-1.3 1.3-1.3 0.7 0 1.3 0.6 1.3 1.3v8.9c-0.1 0.8-0.6 1.3-1.3 1.3zm0-17.8c-0.7 0-1.3-0.6-1.3-1.3v-0.9c0-3.5 2.9-6.4 6.4-6.4 0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3-2.1 0-3.8 1.7-3.8 3.8V31c-0.1 0.7-0.6 1.3-1.3 1.3zm58.6-6h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3h8.9c0.7 0 1.3 0.6 1.3 1.3-0.1 0.7-0.6 1.3-1.3 1.3zm-17.9 0h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3h8.9c0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3zm-17.8 0h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3h8.9c0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3zm84.3 40.4v-8.9c0-0.7 0.6-1.3 1.3-1.3 0.7 0 1.3 0.6 1.3 1.3v8.9c0 0.7-0.6 1.3-1.3 1.3-0.7 0-1.3-0.6-1.3-1.3zm0 17.9v-8.9c0-0.7 0.6-1.3 1.3-1.3 0.7 0 1.3 0.6 1.3 1.3v8.9c0 0.7-0.6 1.3-1.3 1.3-0.7 0-1.3-0.6-1.3-1.3zm0-35.7V40c0-0.7 0.6-1.3 1.3-1.3 0.7 0 1.3 0.6 1.3 1.3v8.9c0 0.7-0.6 1.3-1.3 1.3-0.7-0.1-1.3-0.6-1.3-1.3zm0-17.9v-0.9c0-2.1-1.7-3.8-3.8-3.8-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3 3.5 0 6.4 2.9 6.4 6.4V31c0 0.7-0.6 1.3-1.3 1.3-0.7 0-1.3-0.6-1.3-1.3zm-58.6-6c0-0.7 0.6-1.3 1.3-1.3h8.9c0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3zm17.8 0c0-0.7 0.6-1.3 1.3-1.3h8.9c0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3zm17.8 0c0-0.7 0.6-1.3 1.3-1.3h8.9c0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3zm-83 66.5v8.9c0 0.7-0.6 1.3-1.3 1.3-0.7 0-1.3-0.6-1.3-1.3v-8.9c0-0.7 0.6-1.3 1.3-1.3 0.7 0 1.3 0.6 1.3 1.3zm0 17.9v8.9c0 0.7-0.6 1.3-1.3 1.3-0.7 0-1.3-0.6-1.3-1.3v-8.9c0-0.7 0.6-1.3 1.3-1.3 0.7 0 1.3 0.6 1.3 1.3zm0 17.8v0.9c0 2.1 1.7 3.8 3.8 3.8 0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3-3.5 0-6.4-2.9-6.4-6.4v-0.9c0-0.7 0.6-1.3 1.3-1.3 0.7 0 1.3 0.6 1.3 1.3zm58.6 6c0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3h8.9c0.8 0 1.3 0.6 1.3 1.3zm-17.8 0c0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3h8.9c0.7 0 1.3 0.6 1.3 1.3zm-17.8 0c0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3h8.9c0.7 0 1.3 0.6 1.3 1.3zm84.3-41c0.7 0 1.3 0.6 1.3 1.3v8.9c0 0.7-0.6 1.3-1.3 1.3-0.7 0-1.3-0.6-1.3-1.3v-8.9c0-0.7 0.6-1.3 1.3-1.3zm0 15.9c0.7 0 1.3 0.6 1.3 1.3v8.9c0 0.7-0.6 1.3-1.3 1.3-0.7 0-1.3-0.6-1.3-1.3v-8.9c0-0.7 0.6-1.3 1.3-1.3zm0 17.8c0.7 0 1.3 0.6 1.3 1.3v0.9c0 3.5-2.9 6.4-6.4 6.4-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3 2.1 0 3.8-1.7 3.8-3.8v-0.9c0-0.7 0.6-1.3 1.3-1.3zm-58.6 6h8.9c0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3zm17.8 0h8.9c0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3zm17.8 0h8.9c0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3zm-26.5-55.5h-5.6v-5.6c0-0.8-0.6-1.4-1.4-1.4-0.8 0-1.4 0.6-1.4 1.4v5.6h-5.6c-0.8 0-1.4 0.6-1.4 1.4 0 0.8 0.6 1.4 1.4 1.4h5.6v4.9c0 0.8 0.6 1.4 1.4 1.4 0.8 0 1.4-0.6 1.4-1.4v-4.9h5.6c0.8 0 1.4-0.6 1.4-1.4 0-0.8-0.7-1.4-1.4-1.4z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_promo_stats_widget.xml"
-            line="13"/>
+            line="13"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (3302 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (3302 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M94.567 57.807c-6.79 1.23-13.268 3.98-18.914 7.896-2.82 1.96-5.466 4.176-7.835 6.654-2.363 2.473-4.502 5.192-6.104 8.164-0.772 1.47-1.485 3.076-1.595 4.564-0.022 0.36 0.018 0.7 0.11 0.918 0.11 0.208 0.172 0.27 0.409 0.327 0.48 0.12 1.214-0.157 1.88-0.565 1.362-0.836 2.63-2.038 3.877-3.214l3.736-3.642c2.513-2.432 5.13-4.814 8.05-6.857 2.907-2.035 6.158-3.746 9.731-4.538 0.887-0.2 1.802-0.335 2.701-0.415 0.89-0.08 1.787-0.129 2.694-0.131 0.908 0.005 1.827 0.044 2.768 0.216 0.925 0.2 1.938 0.405 2.851 1.309 0.45 0.454 0.725 1.221 0.643 1.873-0.07 0.652-0.333 1.169-0.62 1.602-0.59 0.867-1.323 1.484-2.077 2.04-0.76 0.545-1.56 1.002-2.381 1.4l-2.387 1.09c-1.544 0.738-3.054 1.546-4.438 2.496-1.366 0.944-2.673 2.047-3.405 3.363-0.355 0.654-0.53 1.343-0.43 1.997 0.048 0.329 0.156 0.65 0.32 0.96 0.027 0.046 0.007 0.034 0.117 0.1 0.096 0.05 0.244 0.096 0.406 0.131 0.684 0.132 1.536 0.093 2.355 0.006 0.83-0.09 1.668-0.237 2.502-0.412 3.344-0.72 6.635-1.834 9.84-3.114 3.203-1.293 6.33-2.787 9.314-4.51 2.974-1.744 5.905-3.591 8.148-6.113 2.247-2.503 4.023-5.544 5.02-8.714l0.013-0.042c0.098-0.313 0.434-0.488 0.75-0.39 0.309 0.096 0.485 0.421 0.397 0.73-0.502 1.767-1.229 3.367-2.093 4.934-0.866 1.555-1.89 3.03-3.07 4.375-1.172 1.35-2.54 2.552-3.97 3.61-1.43 1.043-2.909 2.013-4.433 2.902-3.047 1.78-6.224 3.318-9.484 4.654-3.266 1.324-6.606 2.479-10.089 3.25-0.872 0.188-1.755 0.35-2.662 0.452-0.91 0.093-1.825 0.17-2.864-0.016-0.264-0.057-0.539-0.13-0.834-0.277-0.28-0.128-0.648-0.435-0.816-0.781-0.245-0.456-0.427-0.966-0.504-1.497-0.17-1.073 0.128-2.15 0.598-3.016 0.975-1.744 2.44-2.924 3.909-3.964 1.488-1.031 3.06-1.88 4.658-2.654l2.369-1.096c0.746-0.366 1.462-0.782 2.116-1.258 0.646-0.473 1.251-1.017 1.635-1.598 0.193-0.286 0.31-0.581 0.329-0.797 0.01-0.215-0.031-0.337-0.186-0.512-0.329-0.356-1.103-0.628-1.867-0.756-0.78-0.137-1.612-0.188-2.448-0.192-1.686 0.01-3.4 0.126-5.01 0.48-3.27 0.708-6.333 2.285-9.13 4.224-2.807 1.945-5.374 4.253-7.872 6.65l-3.761 3.633c-1.29 1.196-2.561 2.422-4.179 3.414-0.41 0.243-0.849 0.468-1.353 0.629-0.499 0.156-1.091 0.257-1.708 0.116-0.63-0.093-1.313-0.658-1.533-1.254-0.243-0.59-0.26-1.137-0.235-1.64 0.067-1.006 0.344-1.895 0.66-2.754 0.323-0.856 0.714-1.669 1.138-2.458 1.715-3.146 3.94-5.933 6.389-8.48 2.46-2.54 5.179-4.829 8.114-6.8 5.858-3.956 12.554-6.698 19.533-7.872 0.326-0.055 0.636 0.162 0.69 0.487 0.056 0.321-0.162 0.627-0.483 0.686m-1.997-5.609c-2.599 0.586-5.14 1.379-7.598 2.372-2.449 1.013-4.841 2.167-7.09 3.563-2.25 1.388-4.41 2.925-6.356 4.697-1.964 1.747-3.736 3.709-5.146 5.9l-0.009 0.014c-0.179 0.277-0.549 0.358-0.828 0.18-0.26-0.165-0.348-0.5-0.211-0.77 1.263-2.487 3.062-4.641 5.043-6.555 2.012-1.887 4.218-3.563 6.58-4.976 2.365-1.403 4.838-2.637 7.43-3.566 2.58-0.948 5.254-1.65 7.976-2.033 0.327-0.046 0.63 0.18 0.677 0.505 0.043 0.309-0.159 0.596-0.459 0.664l-0.008 0.002zm-26.758 9.171c1.169-2.21 2.848-4.025 4.626-5.655 1.78-1.642 3.736-3.059 5.725-4.405 2-1.335 4.098-2.51 6.229-3.612 2.149-1.067 4.343-2.043 6.607-2.835 0.313-0.11 0.656 0.054 0.765 0.364 0.102 0.288-0.036 0.604-0.306 0.736-2.122 1.026-4.224 2.077-6.275 3.22-2.068 1.112-4.071 2.331-6.038 3.6-1.967 1.266-3.839 2.669-5.628 4.146-1.765 1.498-3.424 3.137-4.658 5.016l-0.018 0.027c-0.18 0.275-0.55 0.353-0.827 0.173-0.26-0.169-0.344-0.507-0.203-0.775&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_publish_button_124dp.xml"
-            line="51"/>
+            line="51"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (806 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (806 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M200.9 40c-0.4 0.4-0.9 0.6-1.4 0.6-0.6 0.1-1.1 0-1.6-0.3s-0.8-0.5-1.2-0.7c-0.4-0.2-0.8-0.2-1.2-0.4-0.1 0-0.2-0.1-0.1-0.2v-0.1c0-0.1 0-0.1 0.1-0.1 0.5-0.2 1.1-0.3 1.6-0.2 0.5 0.1 1 0.3 1.4 0.6 0.3 0.2 0.7 0.3 1.1 0.3 0.5 0 1 0 1.4 0.2-0.1 0.2 0 0.2-0.1 0.3zm10.5 28.1C211 77 210.5 86 210 94.9l-0.4 6.7-0.2 3.4c-0.1 1.2-0.6 2.3-1.3 3.3-1.5 1.9-3.9 2.9-6.3 2.7h-13.4c-2.4 0.2-4.8-0.8-6.4-2.7-0.8-1-1.3-2.1-1.4-3.4-0.1-1.2-0.1-2.3-0.1-3.4l-0.2-6.7-0.9-26.8c0-0.2 0.2-0.4 0.4-0.5l12.8 0.1c4.3 0 8.5 0.1 12.8 0.1 0.1 0 0.2 0.1 0.2 0.2s-0.1 0.2-0.2 0.2c-4.3 0.1-8.5 0.1-12.8 0.1l-12.8 0.1 0.4-0.5 1.1 26.8 0.3 6.7c0.1 1.1 0.1 2.3 0.2 3.3s0.5 2 1.2 2.8c0.6 0.8 1.5 1.4 2.4 1.8 1 0.4 2 0.5 3.1 0.5h13.4c2.1 0.1 4.1-0.7 5.5-2.3 0.6-0.8 1-1.8 1.1-2.8l0.2-3.3 0.5-6.7c0.6-8.9 1.3-17.8 2.1-26.8 0-0.1 0-0.1 0.1-0.1v0.4z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_site_error_camera_pencils_226dp.xml"
-            line="25"/>
+            line="25"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1377 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1377 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M48.8 64.6c-0.1-0.2-0.2-0.5-0.3-0.7 0-0.1 0-0.1-0.1-0.2l-0.1-0.1c-0.1-0.1-0.1-0.1-0.2-0.1h-0.7c-0.2 0-0.3 0.1-0.4 0.3s0 0.5 0.5 0.6c0.1 0 0.2 0.1 0.1 0.2v0.1c0 0.1 0 0.1-0.1 0.1-0.3 0.1-0.6 0.1-0.9-0.1-0.3-0.2-0.5-0.5-0.6-0.9 0-0.4 0.1-0.7 0.3-1 0.3-0.3 0.6-0.4 1-0.4H48c0.4 0 0.8 0.2 1 0.5 0.1 0.2 0.2 0.3 0.2 0.5v0.5c-0.1 0.2-0.2 0.5-0.4 0.7 0 0.2 0.1 0.1 0 0zm7.3 0c-0.1-0.2-0.2-0.5-0.3-0.7 0-0.1 0-0.1-0.1-0.2l-0.1-0.1c-0.1-0.1-0.1-0.1-0.2-0.1h-0.7c-0.2 0-0.3 0.1-0.4 0.3-0.1 0.2 0 0.5 0.5 0.6 0.1 0 0.2 0.1 0.1 0.2v0.1c0 0.1 0 0.1-0.1 0.1-0.3 0.1-0.6 0.1-0.9-0.1-0.3-0.2-0.5-0.5-0.6-0.9 0-0.4 0.1-0.7 0.3-1 0.3-0.3 0.6-0.4 1-0.4h0.7c0.4 0 0.8 0.2 1 0.5 0.1 0.2 0.2 0.3 0.2 0.5v0.5c-0.1 0.2-0.2 0.5-0.4 0.7 0.2 0.1 0.1 0.1 0 0zM70.5 106l-11.3 0.2-11.3 0.1-22.5 0.2h-2.8c-1 0-2-0.2-2.9-0.6-1.8-0.9-3.1-2.7-3.5-4.7-0.1-1-0.1-1.9-0.1-2.9V77.2c0-0.5 0-1 0.1-1.5 0.1-1 0.5-2 1.1-2.8 1.2-1.7 3.1-2.7 5.2-2.7h47.9c1 0 2 0.2 2.9 0.6 1.8 0.9 3.1 2.7 3.5 4.7 0.1 1 0.1 1.9 0.1 2.9v8.4L76.6 98c0 0.9 0 1.9-0.1 2.8-0.1 1-0.5 1.9-1.1 2.7-1.1 1.6-3 2.6-4.9 2.5zm0-0.3c1.8 0 3.6-0.9 4.6-2.4 0.5-0.7 0.8-1.6 0.9-2.5 0.1-0.9 0.1-1.9 0-2.8l-0.1-11.3v-8.4c0-0.9 0-1.8-0.1-2.7-0.3-1.7-1.4-3.2-3-4-0.8-0.4-1.6-0.5-2.5-0.5H22.4c-1.7 0-3.4 0.9-4.4 2.3-0.5 0.7-0.8 1.5-0.9 2.4-0.1 0.4-0.1 0.9-0.1 1.3v21.1c0 0.9 0 1.8 0.1 2.7 0.3 1.7 1.4 3.2 3 4 0.8 0.4 1.6 0.6 2.5 0.5h2.8l22.5 0.2 11.3 0.1h11.3z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_site_error_camera_pencils_226dp.xml"
-            line="43"/>
+            line="43"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1613 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1613 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M63.6 91.9c-1.4 4.8-6.4 7.6-11.2 6.2-2.1-0.6-3.9-1.9-5.1-3.8-2.8-4.1-1.9-9.6 2-12.6 1.8-1.5 4.2-2.1 6.5-1.9 2.3 0.2 4.5 1.3 6.1 3 1.5 1.7 2.4 4 2.3 6.3 0 0.1-0.1 0.2-0.2 0.2s-0.2-0.1-0.2-0.2c-0.1-2.1-1-4.1-2.4-5.7-1.5-1.5-3.5-2.5-5.6-2.6-2.1-0.2-4.2 0.5-5.8 1.8-1.6 1.3-2.7 3.2-3 5.2s0.1 4.1 1.2 5.9c1.2 1.8 2.9 3 5 3.5s4.2 0.3 6.1-0.7c1.9-1 3.4-2.7 4.3-4.6-0.1-0.2-0.1-0.2 0-0.2v0.2zM32.5 106l-13 0.3c-0.6 0-1.2-0.1-1.8-0.3-0.5-0.3-1-0.8-1.3-1.3-0.2-0.6-0.3-1.2-0.3-1.8v-1.6L16 94.8V78.5c-0.1-1.1 0-2.2 0.1-3.3 0.3-2.3 1.5-4.4 3.3-5.9 1.8-1.5 4-2.3 6.3-2.4 1.1-0.1 2.3 0.1 3.4 0.4 1.1 0.3 2.2 0.9 3.1 1.6 1.8 1.5 3 3.6 3.3 5.9 0.1 1.2 0.1 2.2 0.1 3.3v3.3l-0.1 13-0.1 6.5v1.6c0 0.6 0 1.1-0.1 1.7-0.5 1.2-1.6 1.9-2.8 1.8zm0-0.3c1 0 1.9-0.7 2.2-1.7 0.1-0.5 0-1 0.1-1.6v-1.6l-0.1-6.5-0.1-13V78c0-1.1 0-2.2-0.1-3.2-0.2-2-1.3-3.9-2.9-5.2-0.8-0.6-1.7-1.1-2.7-1.4-1-0.3-2.1-0.4-3.1-0.3-4.2 0-7.8 3.1-8.5 7.3-0.1 1.1-0.2 2.1-0.1 3.2v16.3l-0.1 6.5v1.6c0 0.5 0 1 0.2 1.4 0.2 0.4 0.5 0.8 0.9 1 0.4 0.2 0.9 0.3 1.4 0.3 4.2 0.1 8.6 0.2 12.9 0.2zm36.7-5.5c0.5-0.2 1 0 1.3 0.4v0.1c0.3 0.5 0.2 1.2-0.3 1.6-0.4 0.4-1.1 0.5-1.6 0.3s-0.8-0.8-0.6-1.3c0-0.1 0.1-0.2 0.2-0.1h0.1c0.1 0 0.1 0 0.1 0.1 0.4 0.5 0.8 0.5 1 0.3 0.2-0.2 0.2-0.3 0.1-0.4-0.1-0.1-0.1-0.4-0.4-0.7 0-0.2 0-0.2 0.1-0.3zM44.3 77.4c-1.3 0.3-2.7 0.4-4 0.4h-1.6c-0.3 0-0.6-0.2-0.8-0.5-0.1-0.2-0.2-0.5-0.2-0.8v-1.6c0-0.3 0.2-0.6 0.5-0.8 0.2-0.1 0.5-0.2 0.8-0.2h4.5c0.2 0 0.5 0.1 0.7 0.2 0.2 0.2 0.4 0.4 0.4 0.7v0.6c0 0.3-0.1 0.7-0.1 1 0 0.1-0.1 0.2-0.2 0.2s-0.2-0.1-0.2-0.2c0-0.3-0.1-0.7-0.1-1V75c0-0.1 0-0.1-0.1-0.1h-5v1.6h1.5c1.3 0 2.7 0.1 4 0.4-0.1 0.3 0 0.3-0.1 0.5z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_site_error_camera_pencils_226dp.xml"
-            line="49"/>
+            line="49"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1361 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1361 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M18.4 70.1c0.9-0.1 1.7 0 2.5 0.4 0.7 0.4 1.3 1 1.8 1.7 0.4 0.6 1 1 1.6 1.4 0.7 0.3 1.4 0.4 2.1 0.4 0.7 0 1.4-0.1 2.1-0.4 0.7-0.3 1.3-0.8 1.8-1.3 0.6-0.6 1.3-1.1 2-1.6 0.8-0.4 1.6-0.6 2.5-0.5 0.1 0 0.2 0.1 0.2 0.2s-0.1 0.2-0.2 0.2c-0.7 0.1-1.5 0.3-2.1 0.7-0.6 0.5-1.2 1-1.7 1.6-0.6 0.6-1.3 1.2-2 1.6-1.6 0.8-3.5 0.8-5.1 0.1-0.8-0.4-1.4-1.1-1.9-1.8-0.4-0.6-0.9-1.2-1.5-1.7-0.7-0.5-1.4-0.8-2.1-1-0.1 0.2-0.1 0.2 0 0-0.1 0.1 0 0.1 0 0zm58 5.8c0.2 1.9-0.2 3.8-0.9 5.5-0.7 1.6-1.1 3.4-1.1 5.2-0.1 1.8 0.3 3.5 1 5.1 0.4 0.9 0.7 1.8 0.9 2.7 0.2 0.9 0.3 1.9 0.2 2.8 0 0.1-0.1 0.2-0.2 0.2s-0.2-0.1-0.2-0.2c-0.1-0.9-0.3-1.8-0.6-2.6-0.3-0.9-0.7-1.7-1.1-2.5-0.8-1.7-1.3-3.6-1.3-5.5 0-1 0.1-2 0.4-2.9 0.2-0.9 0.6-1.8 0.9-2.7 0.3-0.9 0.7-1.7 1-2.5 0.3-0.8 0.5-1.7 0.6-2.6 0.2-0.1 0.3-0.1 0.4 0zM16.6 82c0.1 2.2-0.2 4.4-0.9 6.5s-1.9 4-3.5 5.6c-1.6 1.5-3.3 2.8-5.2 4-1.8 1-3.4 2.6-4.4 4.4-0.8 1.9-0.9 4-0.1 5.9s2.3 3.4 4.2 4.2c1.9 0.9 4 1.4 6.1 1.7 2.1 0.3 4.3 0.4 6.4 0.4 8.6-0.2 17.2-1.1 25.7-2.9 8.5-1.6 16.9-3.7 25.3-6 0.1 0 0.2 0 0.2 0.1s0 0.2-0.1 0.2c-4.1 1.3-8.3 2.5-12.5 3.6-4.2 1.1-8.4 2.1-12.7 3-4.3 0.9-8.6 1.6-12.9 2.2s-8.7 0.9-13.1 0.9c-2.2 0-4.4-0.1-6.6-0.4-2.2-0.2-4.4-0.9-6.4-1.8-2.1-0.9-3.8-2.7-4.7-4.8-0.4-1.1-0.6-2.2-0.6-3.4 0-1.2 0.2-2.3 0.7-3.4 1-2.1 3-3.5 4.8-4.7 1.8-1.2 3.6-2.4 5.2-3.8 1.5-1.4 2.7-3.2 3.5-5.2 0.7-2 1.1-4.1 1.2-6.3 0.2-0.1 0.3-0.1 0.4 0z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_site_error_camera_pencils_226dp.xml"
-            line="52"/>
+            line="52"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (822 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (822 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M112.3,32.8C97.2,32.8,85,45,85,60.1s12.2,27.3,27.3,27.3s27.3-12.2,27.3-27.3C139.5,45,127.3,32.8,112.3,32.8z M87.8,60c0-3.4,0.7-6.8,2.1-10l11.7,32C93.1,77.9,87.7,69.4,87.8,60z M112.3,84.6c-2.3,0-4.7-0.4-6.9-1l7.4-21.4l7.5,20.6 c0,0.1,0.1,0.2,0.2,0.3C117.8,84.1,115.1,84.6,112.3,84.6z M115.7,48.5l2.8-0.2c0.6-0.1,1-0.5,0.9-1.1c-0.1-0.6-0.5-1-1.1-0.9 c0,0-4,0.3-6.5,0.3s-6.5-0.3-6.5-0.3c-0.6-0.1-1,0.3-1.1,0.9c-0.1,0.6,0.3,1,0.9,1.1c0.9,0.1,1.7,0.2,2.6,0.2l3.9,10.5l-5.4,16.1 l-8.9-26.6l2.8-0.2c0.6-0.1,1-0.5,0.9-1.1c-0.1-0.6-0.5-1-1.1-0.9c0,0-4,0.3-6.5,0.3h-1.6c7.4-11.4,22.7-14.5,34-7.1 c1.1,0.7,2.1,1.5,3.1,2.4h-0.3c-2.3,0.1-4.2,2-4.1,4.4c0,2,1.2,3.7,2.4,5.7c1.3,2,2,4.4,2,6.8c-0.1,2.7-0.8,5.4-1.9,7.9l-2.4,8.2 L115.7,48.5z M124.6,81.2l7.5-21.7c1.2-2.8,1.8-5.8,1.9-8.8c0-0.8-0.1-1.7-0.2-2.5C140.1,59.9,136,74.5,124.6,81.2z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_site_wordpress_camera_pencils_226dp.xml"
-            line="10"/>
+            line="10"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (835 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (835 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M200.9,40c-0.4,0.4-0.9,0.6-1.4,0.6c-0.6,0.1-1.1,0-1.6-0.3s-0.8-0.5-1.2-0.7c-0.4-0.2-0.8-0.2-1.2-0.4 c-0.1,0-0.2-0.1-0.1-0.2v-0.1c0-0.1,0-0.1,0.1-0.1c0.5-0.2,1.1-0.3,1.6-0.2c0.5,0.1,1,0.3,1.4,0.6c0.3,0.2,0.7,0.3,1.1,0.3 c0.5,0,1,0,1.4,0.2C200.9,39.9,201,39.9,200.9,40z M211.4,68.1C211,77,210.5,86,210,94.9l-0.4,6.7l-0.2,3.4 c-0.1,1.2-0.6,2.3-1.3,3.3c-1.5,1.9-3.9,2.9-6.3,2.7h-13.4c-2.4,0.2-4.8-0.8-6.4-2.7c-0.8-1-1.3-2.1-1.4-3.4 c-0.1-1.2-0.1-2.3-0.1-3.4l-0.2-6.7L179.4,68c0-0.2,0.2-0.4,0.4-0.5l12.8,0.1c4.3,0,8.5,0.1,12.8,0.1c0.1,0,0.2,0.1,0.2,0.2 s-0.1,0.2-0.2,0.2c-4.3,0.1-8.5,0.1-12.8,0.1l-12.8,0.1l0.4-0.5l1.1,26.8l0.3,6.7c0.1,1.1,0.1,2.3,0.2,3.3c0.1,1,0.5,2,1.2,2.8 c0.6,0.8,1.5,1.4,2.4,1.8c1,0.4,2,0.5,3.1,0.5h13.4c2.1,0.1,4.1-0.7,5.5-2.3c0.6-0.8,1-1.8,1.1-2.8l0.2-3.3l0.5-6.7 c0.6-8.9,1.3-17.8,2.1-26.8c0-0.1,0-0.1,0.1-0.1V68.1z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_site_wordpress_camera_pencils_226dp.xml"
-            line="35"/>
+            line="35"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1453 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1453 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M48.8,64.6c-0.1-0.2-0.2-0.5-0.3-0.7c0-0.1,0-0.1-0.1-0.2l-0.1-0.1c-0.1-0.1-0.1-0.1-0.2-0.1h-0.7 c-0.2,0-0.3,0.1-0.4,0.3s0,0.5,0.5,0.6c0.1,0,0.2,0.1,0.1,0.2v0.1c0,0.1,0,0.1-0.1,0.1c-0.3,0.1-0.6,0.1-0.9-0.1 c-0.3-0.2-0.5-0.5-0.6-0.9c0-0.4,0.1-0.7,0.3-1c0.3-0.3,0.6-0.4,1-0.4H48c0.4,0,0.8,0.2,1,0.5c0.1,0.2,0.2,0.3,0.2,0.5v0.5 C49.1,64.1,49,64.4,48.8,64.6C48.8,64.8,48.9,64.7,48.8,64.6z M56.1,64.6c-0.1-0.2-0.2-0.5-0.3-0.7c0-0.1,0-0.1-0.1-0.2l-0.1-0.1 c-0.1-0.1-0.1-0.1-0.2-0.1h-0.7c-0.2,0-0.3,0.1-0.4,0.3c-0.1,0.2,0,0.5,0.5,0.6c0.1,0,0.2,0.1,0.1,0.2v0.1c0,0.1,0,0.1-0.1,0.1 c-0.3,0.1-0.6,0.1-0.9-0.1c-0.3-0.2-0.5-0.5-0.6-0.9c0-0.4,0.1-0.7,0.3-1c0.3-0.3,0.6-0.4,1-0.4h0.7c0.4,0,0.8,0.2,1,0.5 c0.1,0.2,0.2,0.3,0.2,0.5v0.5C56.4,64.1,56.3,64.4,56.1,64.6C56.3,64.7,56.2,64.7,56.1,64.6z M70.5,106l-11.3,0.2l-11.3,0.1 l-22.5,0.2h-2.8c-1,0-2-0.2-2.9-0.6c-1.8-0.9-3.1-2.7-3.5-4.7c-0.1-1-0.1-1.9-0.1-2.9V77.2c0-0.5,0-1,0.1-1.5c0.1-1,0.5-2,1.1-2.8 c1.2-1.7,3.1-2.7,5.2-2.7h47.9c1,0,2,0.2,2.9,0.6c1.8,0.9,3.1,2.7,3.5,4.7c0.1,1,0.1,1.9,0.1,2.9v8.4L76.6,98c0,0.9,0,1.9-0.1,2.8 c-0.1,1-0.5,1.9-1.1,2.7C74.3,105.1,72.4,106.1,70.5,106z M70.5,105.7c1.8,0,3.6-0.9,4.6-2.4c0.5-0.7,0.8-1.6,0.9-2.5 c0.1-0.9,0.1-1.9,0-2.8l-0.1-11.3v-8.4c0-0.9,0-1.8-0.1-2.7c-0.3-1.7-1.4-3.2-3-4c-0.8-0.4-1.6-0.5-2.5-0.5H22.4 c-1.7,0-3.4,0.9-4.4,2.3c-0.5,0.7-0.8,1.5-0.9,2.4C17,76.2,17,76.7,17,77.1v21.1c0,0.9,0,1.8,0.1,2.7c0.3,1.7,1.4,3.2,3,4 c0.8,0.4,1.6,0.6,2.5,0.5h2.8l22.5,0.2l11.3,0.1H70.5z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_site_wordpress_camera_pencils_226dp.xml"
-            line="65"/>
+            line="65"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1724 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1724 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M63.6,91.9c-1.4,4.8-6.4,7.6-11.2,6.2c-2.1-0.6-3.9-1.9-5.1-3.8c-2.8-4.1-1.9-9.6,2-12.6 c1.8-1.5,4.2-2.1,6.5-1.9c2.3,0.2,4.5,1.3,6.1,3c1.5,1.7,2.4,4,2.3,6.3c0,0.1-0.1,0.2-0.2,0.2s-0.2-0.1-0.2-0.2 c-0.1-2.1-1-4.1-2.4-5.7c-1.5-1.5-3.5-2.5-5.6-2.6c-2.1-0.2-4.2,0.5-5.8,1.8c-1.6,1.3-2.7,3.2-3,5.2s0.1,4.1,1.2,5.9 c1.2,1.8,2.9,3,5,3.5c2.1,0.5,4.2,0.3,6.1-0.7C61.2,95.5,62.7,93.8,63.6,91.9c-0.1-0.2-0.1-0.2,0-0.2V91.9z M32.5,106l-13,0.3 c-0.6,0-1.2-0.1-1.8-0.3c-0.5-0.3-1-0.8-1.3-1.3c-0.2-0.6-0.3-1.2-0.3-1.8v-1.6L16,94.8V78.5c-0.1-1.1,0-2.2,0.1-3.3 c0.3-2.3,1.5-4.4,3.3-5.9c1.8-1.5,4-2.3,6.3-2.4c1.1-0.1,2.3,0.1,3.4,0.4c1.1,0.3,2.2,0.9,3.1,1.6c1.8,1.5,3,3.6,3.3,5.9 c0.1,1.2,0.1,2.2,0.1,3.3v3.3l-0.1,13l-0.1,6.5v1.6c0,0.6,0,1.1-0.1,1.7C34.8,105.4,33.7,106.1,32.5,106z M32.5,105.7 c1,0,1.9-0.7,2.2-1.7c0.1-0.5,0-1,0.1-1.6v-1.6l-0.1-6.5l-0.1-13V78c0-1.1,0-2.2-0.1-3.2c-0.2-2-1.3-3.9-2.9-5.2 c-0.8-0.6-1.7-1.1-2.7-1.4c-1-0.3-2.1-0.4-3.1-0.3c-4.2,0-7.8,3.1-8.5,7.3c-0.1,1.1-0.2,2.1-0.1,3.2v16.3l-0.1,6.5v1.6 c0,0.5,0,1,0.2,1.4c0.2,0.4,0.5,0.8,0.9,1c0.4,0.2,0.9,0.3,1.4,0.3C23.8,105.6,28.2,105.7,32.5,105.7z M69.2,100.2 c0.5-0.2,1,0,1.3,0.4v0.1c0.3,0.5,0.2,1.2-0.3,1.6c-0.4,0.4-1.1,0.5-1.6,0.3c-0.5-0.2-0.8-0.8-0.6-1.3c0-0.1,0.1-0.2,0.2-0.1h0.1 c0.1,0,0.1,0,0.1,0.1c0.4,0.5,0.8,0.5,1,0.3c0.2-0.2,0.2-0.3,0.1-0.4c-0.1-0.1-0.1-0.4-0.4-0.7C69.1,100.3,69.1,100.3,69.2,100.2z  M44.3,77.4c-1.3,0.3-2.7,0.4-4,0.4h-1.6c-0.3,0-0.6-0.2-0.8-0.5c-0.1-0.2-0.2-0.5-0.2-0.8v-1.6c0-0.3,0.2-0.6,0.5-0.8 c0.2-0.1,0.5-0.2,0.8-0.2h4.5c0.2,0,0.5,0.1,0.7,0.2c0.2,0.2,0.4,0.4,0.4,0.7v0.6c0,0.3-0.1,0.7-0.1,1c0,0.1-0.1,0.2-0.2,0.2 c-0.1,0-0.2-0.1-0.2-0.2c0-0.3-0.1-0.7-0.1-1V75c0-0.1,0-0.1-0.1-0.1h-5v1.6h1.5c1.3,0,2.7,0.1,4,0.4C44.3,77.2,44.4,77.2,44.3,77.4 z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_site_wordpress_camera_pencils_226dp.xml"
-            line="75"/>
+            line="75"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1444 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1444 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M18.4,70.1c0.9-0.1,1.7,0,2.5,0.4c0.7,0.4,1.3,1,1.8,1.7c0.4,0.6,1,1,1.6,1.4c0.7,0.3,1.4,0.4,2.1,0.4 c0.7,0,1.4-0.1,2.1-0.4c0.7-0.3,1.3-0.8,1.8-1.3c0.6-0.6,1.3-1.1,2-1.6c0.8-0.4,1.6-0.6,2.5-0.5c0.1,0,0.2,0.1,0.2,0.2 s-0.1,0.2-0.2,0.2c-0.7,0.1-1.5,0.3-2.1,0.7c-0.6,0.5-1.2,1-1.7,1.6c-0.6,0.6-1.3,1.2-2,1.6c-1.6,0.8-3.5,0.8-5.1,0.1 c-0.8-0.4-1.4-1.1-1.9-1.8c-0.4-0.6-0.9-1.2-1.5-1.7C19.8,70.6,19.1,70.3,18.4,70.1C18.3,70.3,18.3,70.3,18.4,70.1 C18.3,70.2,18.4,70.2,18.4,70.1z M76.4,75.9c0.2,1.9-0.2,3.8-0.9,5.5c-0.7,1.6-1.1,3.4-1.1,5.2c-0.1,1.8,0.3,3.5,1,5.1 c0.4,0.9,0.7,1.8,0.9,2.7c0.2,0.9,0.3,1.9,0.2,2.8c0,0.1-0.1,0.2-0.2,0.2c-0.1,0-0.2-0.1-0.2-0.2c-0.1-0.9-0.3-1.8-0.6-2.6 c-0.3-0.9-0.7-1.7-1.1-2.5c-0.8-1.7-1.3-3.6-1.3-5.5c0-1,0.1-2,0.4-2.9c0.2-0.9,0.6-1.8,0.9-2.7c0.3-0.9,0.7-1.7,1-2.5 c0.3-0.8,0.5-1.7,0.6-2.6C76.2,75.8,76.3,75.8,76.4,75.9z M16.6,82c0.1,2.2-0.2,4.4-0.9,6.5s-1.9,4-3.5,5.6c-1.6,1.5-3.3,2.8-5.2,4 c-1.8,1-3.4,2.6-4.4,4.4c-0.8,1.9-0.9,4-0.1,5.9s2.3,3.4,4.2,4.2c1.9,0.9,4,1.4,6.1,1.7c2.1,0.3,4.3,0.4,6.4,0.4 c8.6-0.2,17.2-1.1,25.7-2.9c8.5-1.6,16.9-3.7,25.3-6c0.1,0,0.2,0,0.2,0.1s0,0.2-0.1,0.2c-4.1,1.3-8.3,2.5-12.5,3.6 c-4.2,1.1-8.4,2.1-12.7,3c-4.3,0.9-8.6,1.6-12.9,2.2s-8.7,0.9-13.1,0.9c-2.2,0-4.4-0.1-6.6-0.4c-2.2-0.2-4.4-0.9-6.4-1.8 c-2.1-0.9-3.8-2.7-4.7-4.8c-0.4-1.1-0.6-2.2-0.6-3.4c0-1.2,0.2-2.3,0.7-3.4c1-2.1,3-3.5,4.8-4.7c1.8-1.2,3.6-2.4,5.2-3.8 c1.5-1.4,2.7-3.2,3.5-5.2c0.7-2,1.1-4.1,1.2-6.3C16.4,81.9,16.5,81.9,16.6,82z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_site_wordpress_camera_pencils_226dp.xml"
-            line="80"/>
+            line="80"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1149 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1149 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M1232.9 937l-24.2 0.3c-4 0-8.1 0.1-12.1 0.2l-6.1 0.2h-2.7v-2.9h0.3l3-0.1v3.1c-9.4 0.3-18.7-3.1-26.2-8.6s-13.6-12.7-18.7-20.3c-10-15.4-16.5-32.5-21.9-49.7a450.9 450.9 0 0 1-12.6-52.5c-3.2-17.7-5.8-35.5-7.4-53.5a3.3 3.3 0 0 1 3-3.5h0.3l107.9-0.1 107.9 0.3a3.2 3.2 0 0 1 3.2 3.2 3.5 3.5 0 0 1 0 0.5c-2.9 17.9-6.7 35.4-11 53a498.4 498.4 0 0 1-15.5 51.8c-6.3 16.9-13.8 33.6-24 48.6a95.6 95.6 0 0 1-18.1 20.3c-7 5.8-15.8 10-25.1 9.9zm0-1.5c8.8-0.2 17.1-4.3 23.7-10s11.9-13.1 16.5-20.6a178.5 178.5 0 0 0 11.9-23.8q5.3-12.2 9.6-24.9c5.8-16.8 10.8-34 15-51.3s7.8-34.9 10.6-52.5l3.2 3.7-107.9 0.3-107.9-0.1 3.3-3.6c1.5 17.6 3.9 35.4 7 52.9a444.8 444.8 0 0 0 12.3 51.8c5.1 17 11.8 33.5 20.8 48.5a80.6 80.6 0 0 0 16.8 19.6 38.8 38.8 0 0 0 23.4 9.2h0.1a1.6 1.6 0 0 1-0.1 3.1l-3-0.1h-0.3v-2.9h2.7l6.1 0.2c4 0.1 8.1 0.2 12.1 0.2zm91.2-124.1c5.9 6 8.4 14 10 22a50.9 50.9 0 0 1-1.1 24.8 42.4 42.4 0 0 1-14.2 20.5l-2.4 2c-0.8 0.6-1.7 1.1-2.6 1.6-1.7 1.1-3.5 2.1-5.3 3.1a44.8 44.8 0 0 1-11.7 3.3 0.8 0.8 0 0 1-0.6-1.3l0.1-0.1a69.9 69.9 0 0 1 9.5-6.7c2.9-2.4 6.4-4 8.9-6.7a38.5 38.5 0 0 0 11.7-17.9c2.3-6.8 2.5-14.3 1.6-21.7s-3.6-14.5-5-22.3v-0.1a0.8 0.8 0 0 1 1.3-0.7z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_type_blog_80dp.xml"
-            line="34"/>
+            line="34"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1453 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1453 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M303.1 333.9l88.8-1.3 88.8-0.8c59.2-0.6 118.5-0.5 177.7-0.7s118.5 0.2 177.7 0.4c59.2 0.6 118.5 1.1 177.7 2.4a5.9 5.9 0 0 1 0 11.9c-59.2 1.4-118.5 1.9-177.7 2.4-59.2 0.2-118.5 0.6-177.7 0.4s-118.5-0.1-177.7-0.7l-88.8-0.8-88.8-1.3a5.9 5.9 0 0 1 0-11.9zM386 475.6c46.4-0.6 92.8-1.2 139.2-1.4l139.2-0.5 139.2 0.3 69.6 0.6 69.6 1a4 4 0 0 1 0 7.9l-69.6 1-69.6 0.6-139.2 0.3-139.2-0.5c-46.4-0.2-92.8-0.8-139.2-1.4a4 4 0 0 1 0-7.9zm0 68.4c46.4-0.6 92.8-1.2 139.2-1.4l139.2-0.5 139.2 0.3 69.6 0.6 69.6 1a4 4 0 0 1 0 7.9l-69.6 1-69.6 0.6-139.2 0.3-139.2-0.5c-46.4-0.2-92.8-0.8-139.2-1.4a4 4 0 0 1 0-7.9zm-71.2 68.5q87.4-1 174.8-1.4l174.8-0.5 174.8 0.3 87.4 0.6 87.4 1a4 4 0 0 1 0 7.9l-87.4 1-87.4 0.6-174.8 0.4-174.8-0.5q-87.4-0.3-174.8-1.4a4 4 0 0 1 0-7.9zm39.3 68.4q77.6-1 155.1-1.4l155.1-0.5 155.1 0.3 77.6 0.6 77.6 1a4 4 0 0 1 0 7.9l-77.6 1-77.6 0.6-155.1 0.3-155.1-0.5q-77.6-0.3-155.1-1.4a4 4 0 0 1 0-7.9zm-14.6 68.4q81.2-1 162.4-1.4l162.4-0.5 162.4 0.3 81.2 0.6 81.2 1a4 4 0 0 1 0 7.9l-81.2 1-81.2 0.6-162.4 0.3-162.4-0.5q-81.2-0.3-162.4-1.4a4 4 0 0 1 0-7.9zm-31.8 68.5q89.2-1 178.3-1.4l178.3-0.5 178.3 0.3 89.2 0.6 89.2 1a4 4 0 0 1 0 7.9l-89.2 1-89.2 0.6-178.3 0.3-178.3-0.5q-89.2-0.3-178.3-1.4a4 4 0 0 1 0-7.9zm196.5 68.4c26.7-0.6 53.4-1.2 80.1-1.4 26.7-0.4 53.4-0.3 80.1-0.5s53.4 0.2 80.1 0.3c26.7 0.4 53.4 0.7 80.1 1.6a4 4 0 0 1 0 7.9c-26.7 0.9-53.4 1.3-80.1 1.6-26.7 0.1-53.4 0.4-80.1 0.3s-53.4-0.1-80.1-0.5c-26.7-0.2-53.4-0.8-80.1-1.4a4 4 0 0 1 0-7.9z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_type_blog_80dp.xml"
-            line="37"/>
+            line="37"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (944 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (944 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M1137.7 455.4c-17.2-0.3-34.3-0.9-51.5-1.1 0.2-9.8-1-19.4-5.3-29a34.2 34.2 0 0 0-12.5-14.5c-1.5-0.8-2.9-1.6-4.4-2.3l-4.7-1.5a59.4 59.4 0 0 0-8.7-1.7 63.2 63.2 0 0 0-17.8 0.2 51.7 51.7 0 0 0-8.9 2.2 45.3 45.3 0 0 0-4.3 1.7l-2.1 1a4.4 4.4 0 0 1-0.7 0.3 2.1 2.1 0 0 1-1.9-0.5 2.3 2.3 0 0 1-0.6-0.9l-1.8-4.2a43.1 43.1 0 0 0-11.6-14.7 41.2 41.2 0 0 0-17-8 50.7 50.7 0 0 0-18.1-0.6c-12.1 1.3-23.5 7.5-31.8 15.9s-14.2 18.4-18.8 28.7a144.6 144.6 0 0 0-9 28.1l-45.8 0.9a4.1 4.1 0 0 0 0 8.1l50 1a4.9 4.9 0 0 0 4.9-3.9l0.1-0.3c4.4-19.9 12.7-40.5 26.8-54.3 7-6.9 15.7-11.4 25.1-12.4 9.4-1.3 19.4 0.7 26.2 6.3a30.9 30.9 0 0 1 8.2 10.6c0.5 1 0.9 2.1 1.4 3.2a14.5 14.5 0 0 0 4 5.7 14.2 14.2 0 0 0 13.3 2.9 17.2 17.2 0 0 0 3-1.3l1.5-0.8a33 33 0 0 1 3.2-1.3 39.7 39.7 0 0 1 6.8-1.8 51.3 51.3 0 0 1 14.4-0.2 48.3 48.3 0 0 1 7.2 1.3l3.1 0.9 2.8 1.5a23.8 23.8 0 0 1 8.4 9.6c4.2 8.2 5.3 19 4.8 28.6v0.6a5.2 5.2 0 0 0 5.3 5.2c19-0.2 38-0.8 57-1.2a4.1 4.1 0 0 0 0-8.1z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_type_portfolio_80dp.xml"
-            line="46"/>
+            line="46"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1334 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1334 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M395.8 808.1a0.6 0.6 0 0 0-0.8-0.3 174.2 174.2 0 0 0-23.2 11.7c-7.4 4.4-14.9 8.8-22.1 13.5-10.9 7.2-22 14.1-32.6 21.7 9.7-11.3 18.6-23.1 27.8-34.8 5.8-7.6 11.4-15.3 17-23a211.7 211.7 0 0 0 15.3-24.4 0.6 0.6 0 0 0-1-0.7 211.5 211.5 0 0 0-19.2 21.3c-6 7.4-11.9 15-17.6 22.6-9 12.3-18.2 24.5-26.6 37.2 5-14.3 9-28.9 13.3-43.4 2.6-9.1 4.9-18.3 7.2-27.5a209.3 209.3 0 0 0 5.2-28.1 0.6 0.6 0 0 0-1.2-0.3 209.3 209.3 0 0 0-9.9 26.8c-2.8 9.1-5.5 18.2-7.9 27.3-3.6 14.2-7.6 28.4-10.6 42.8 0.1-6-0.1-11.9-0.3-17.8-0.5-10.2-1-20.4-1.8-30.6-1.8-20.3-3.1-40.7-6.6-61a1.2 1.2 0 0 0-2.4 0.2c-0.6 20.5 1.1 40.9 2.2 61.3 0.7 10.2 1.6 20.4 2.6 30.5 0.7 7 1.5 13.9 2.8 20.9-1.9-5-4-9.8-6.2-14.5-3.6-7.7-7.2-15.3-11.1-22.8-7.9-14.9-15.4-30.1-24.8-44.3a1.2 1.2 0 0 0-2.2 1.1c5.8 16 13.6 31 20.8 46.3 3.8 7.6 7.7 15 11.8 22.5 1.9 3.4 3.8 6.7 5.8 10-4-4.6-8.1-9-12.4-13.4-7.5-7.7-15-15.3-22.6-22.8-15.5-14.7-30.6-29.9-47.4-43.4a1.2 1.2 0 0 0-1.7 1.7c13.8 16.5 29.2 31.3 44.3 46.6 7.6 7.5 15.4 14.9 23.2 22.2 5.4 5 10.8 9.9 16.5 14.5-3.9-2.1-7.8-4-11.8-5.8-7.1-3.2-14.2-6.2-21.4-9.1-14.5-5.5-28.8-11.5-43.9-15.4a1.2 1.2 0 0 0-0.9 2.3c13.6 7.8 28 13.4 42.2 19.6 7.2 3 14.4 5.7 21.7 8.4a143.3 143.3 0 0 0 21.6 6.3 1.2 1.2 0 0 0 0.6 0.6 1.2 1.2 0 0 0 1 0c15.7-7.4 30.2-16.8 45.1-25.7 7.3-4.6 14.6-9.3 21.7-14.1a174.1 174.1 0 0 0 20.6-15.9 0.6 0.6 0 0 0 0.2-0.6z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_type_portfolio_80dp.xml"
-            line="55"/>
+            line="55"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1391 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1391 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M1297.3 817l-10.4-99-10.7-99.1a3.7 3.7 0 0 0-0.9-2l-31.9-38a3.9 3.9 0 0 0-1.3-1 3.8 3.8 0 0 0-5 1.9l-20 43.7a3.8 3.8 0 0 0-0.3 2l22.1 196.7 1.1 9.2c2.3 0.2 4.5 0.4 6.7 0.7l-1.1-10.7-21.2-195.8 10.3-22.4a36.5 36.5 0 0 0 16.5-3.4l17.7 21 10.9 96.6 11.3 97.8 2.1 17.5h5.6zm90-132a25 25 0 0 0-4.6-11 25.6 25.6 0 0 0-18.3-10.5c0.6-0.2 1.1-0.5 1.7-0.7a28.5 28.5 0 0 0 11.5-10.8c5.3-9.2 6.9-19.9 6.1-30.1-1.7-20.6-11.5-39.7-25-54.6l-0.1-0.1a3.7 3.7 0 0 0-6.2 1c-6 13.1-12.6 26.1-17.1 40.2-2.2 7-4.1 14.3-4.2 22a35.9 35.9 0 0 0 1.5 11.4 23.2 23.2 0 0 0 6.1 9.7 1 1 0 0 0 1.5-1.3c-4.2-5.6-5-12.6-4.2-19.4a89.7 89.7 0 0 1 5.4-20.2l0.1-0.3a49.7 49.7 0 0 1 7.2 2.1c2.9 1 5.4 3 9 5.1a21.2 21.2 0 0 0 12.4 2.3 19.4 19.4 0 0 0 6.2-1.6c0.3 1.5 0.5 3 0.6 4.5 0.9 9.2 0.2 18.8-3.9 26.9a22.5 22.5 0 0 1-21.9 13.5 0.7 0.7 0 0 0-0.7 0.5 0.7 0.7 0 0 0 0 0.2 25 25 0 0 0-10.3 3.5 25.6 25.6 0 0 0-12.3 19.7c-0.2 14.3 0 27.6 0 41.4l0.3 82.2 0.2 22.3q3 0.2 6.1 0.4l0.2-22.8 0.3-82.2 0.2-40.8a18.1 18.1 0 0 1 8.8-13.9 17.4 17.4 0 0 1 8-2.5c2.9-0.1 6.7 0 10 0a18.3 18.3 0 0 1 14.6 7.4 17.4 17.4 0 0 1 3.3 7.7c0.4 2.5 0.2 6.3 0.3 9.7l0.1 41.1 0.2 82.2 0.1 13.2a53.6 53.6 0 0 1 6.5-0.1l0.1-13.1 0.2-82.2 0.1-41.1c0-3.6 0.3-6.7-0.3-11zm-17.4-72.2a20.8 20.8 0 0 1-8.8-2.3c-2.8-1.4-6.4-3.7-10.6-4.6a20.3 20.3 0 0 0-7.3-0.3c4-9.8 8.7-19.3 13.4-28.9a104.4 104.4 0 0 1 12.3 19 81.5 81.5 0 0 1 6.3 17.4c-1.9-0.1-3.7-0.1-5.4-0.3z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_type_portfolio_80dp.xml"
-            line="73"/>
+            line="73"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1855 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1855 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M1264.1 886.7a306.2 306.2 0 0 1 5.2 36c1.1 12 2.1 24.1 2.9 36.1 1.3 24.1 3.2 48.2 2.5 72.5a1.4 1.4 0 0 1-2.7 0.2c-4-23.9-5.4-48-7.4-72.1-0.9-12-1.5-24.1-2.1-36.2a305.8 305.8 0 0 1 0.2-36.3 0.7 0.7 0 0 1 1.4-0.1zm-200 14.8c-4.8-7.4-9.7-14.8-14.8-22-2.6-3.7-4.7-7.2-7.9-11a39 39 0 0 0-11.1-8.9 38 38 0 0 0-13.7-4.3l-1.8-0.1c0.2-0.6 0.4-1.3 0.5-2a8.1 8.1 0 0 0 0.2-3.3 8.7 8.7 0 0 0-1.5-3.5 9.4 9.4 0 0 0-6.8-3.7l-5.3-0.1a9.7 9.7 0 0 0-7.1 3 9.3 9.3 0 0 0-2.5 7.3 8.5 8.5 0 0 0 0.5 2.1l-16.4-0.1-16.1 0.1c0.2-0.5 0.3-1.1 0.4-1.6a8.1 8.1 0 0 0 0.2-3.3 8.7 8.7 0 0 0-1.5-3.5 9.4 9.4 0 0 0-6.8-3.7l-5.3-0.1a9.7 9.7 0 0 0-7.1 3 9.3 9.3 0 0 0-2.5 7.3 8.5 8.5 0 0 0 0.6 2.3c-0.7 0-1.4 0.1-2.1 0.2a39.4 39.4 0 0 0-13.7 4.4 37.8 37.8 0 0 0-11 9.1c-2.9 3.8-5.3 7.2-7.9 10.9-5 7.3-10 14.6-14.6 22.1a0.6 0.6 0 0 0 1 0.8c6.1-6.5 11.8-13.2 17.5-20 2.9-3.3 5.6-7 8.3-10.1a34.2 34.2 0 0 1 9.7-7.2 32.9 32.9 0 0 1 11.5-3.5c3.8-0.4 8.5-0.1 12.9-0.1l26.5 0.2 26.5-0.2c4.3 0 9.1-0.2 12.9 0.1a34.3 34.3 0 0 1 11.6 3.3 33 33 0 0 1 9.7 7.2c2.6 2.9 5.4 6.8 8.1 10.1 5.5 6.9 11.1 13.8 16.7 20.6a1.3 1.3 0 0 0 2-1.5zM944.8 855a4.1 4.1 0 0 1-0.6-2.5 2.9 2.9 0 0 1 3.3-2.7l5-0.1a2.7 2.7 0 0 1 2.1 0.7 3.5 3.5 0 0 1 0.8 1 4.3 4.3 0 0 1 0.6 1.8c0.1 0.6 0.3 1.1 0.4 1.7L950 855h-5.3zm53.9-2.5a2.9 2.9 0 0 1 3.3-2.7l5-0.1a2.7 2.7 0 0 1 2.1 0.7 3.5 3.5 0 0 1 0.8 1 4.3 4.3 0 0 1 0.6 1.8c0.1 0.6 0.3 1.2 0.5 1.8-2.7 0-5.2 0-7.9-0.1h-3.8a4.1 4.1 0 0 1-0.7-2.5zm100.9 208.8a97.4 97.4 0 0 1-41.5 61.6 99.6 99.6 0 0 1-73.8 14.6 100.3 100.3 0 0 1 34.2-197.6 99.8 99.8 0 0 1 64.6 38.4 98 98 0 0 1 16.7 34.2 102 102 0 0 1 2.4 37.8 1.3 1.3 0 0 1-1.4 1.1 1.3 1.3 0 0 1-1.1-1.4 97.9 97.9 0 0 0-20.3-68.8 94.3 94.3 0 0 0-61.7-35.2c-24-3.3-49.1 2.8-68.5 17.2a94 94 0 0 0 36.4 168 95.6 95.6 0 0 0 36.1 0.6 97.6 97.6 0 0 0 33.8-13 93.2 93.2 0 0 0 26.8-24.7 97.2 97.2 0 0 0 16.1-33.1 0.6 0.6 0 0 1 1.2 0.3z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_type_portfolio_80dp.xml"
-            line="79"/>
+            line="79"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1231 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1231 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M1162.9 932.9a40.2 40.2 0 0 0-28.2-31.9 42.6 42.6 0 0 0-11.1-1.6l-10.5-0.1-20.9-0.1-243.8-0.1a56.1 56.1 0 0 0-38-22.7c-8.8-1-16.5-0.4-24.7-0.6-7.8-0.2-17 0-25.1 2.6a61.2 61.2 0 0 0-22.4 12.4 61.8 61.8 0 0 0-21.5 45.2v48.7l0.2 97.2 0.3 48.6 0.1 12.1c0.1 2.1-0.1 3.8 0.1 6.3a18.5 18.5 0 0 0 12.7 15.6 19.8 19.8 0 0 0 6.8 0.8l6.1-0.1 6-0.1c-8.8 0.3-14.7 0.5-15.8 0.6l222.9-0.7 83.7-0.5 83.7-0.4a38.9 38.9 0 0 0 34.9-21.7c3.4-6.4 4.2-14.1 4-21l0.1-20.9 0.4-83.7 0.2-41.8 0.1-20.9 0.1-10.5c0-3.3 0.2-7.1-0.5-10.8zm-419.8 227.7l-6.1-0.1a15.6 15.6 0 0 1-5.2-0.7 13.2 13.2 0 0 1-7.5-6.4c-1.7-3-1.5-6.3-1.4-10.6l0.1-12.1 0.3-48.6 0.2-97.2 0.2-48.5a55.3 55.3 0 0 1 19.1-40 54 54 0 0 1 19.8-11c7.4-2.3 14.7-2.6 23-2.4 8 0.1 16.5-0.4 23.8 0.5a50.8 50.8 0 0 1 21.1 7.9c12.6 8.5 21.3 22.8 22.1 38 0.4 15.7 0.1 32.3 0.4 48.4l0.8 97.2 0.5 48.6 0.3 24.3c0.1 6.3-4.8 12-10.8 13.6-3 0.3-6.9 0.6-11.6 0.9q-44.5-1-89-1.6zm412.7-19.4a36.1 36.1 0 0 1-32.2 20.5l-83.7-0.4-83.7-0.5-104.7-0.6a16.9 16.9 0 0 0 6.1-12.4l0.3-24.4 0.5-48.6 0.8-97.2c0.1-16.3 0.3-32.2 0-48.8a54.4 54.4 0 0 0-6.8-23.3l239.8-0.1 20.9-0.1 10.5-0.1a36.8 36.8 0 0 1 9.5 1.3 34.8 34.8 0 0 1 24.7 27.3c1 6.2 0.4 13.6 0.6 20.4l0.1 20.9 0.2 41.8 0.4 83.7 0.1 20.9c0.2 7-0.5 13.6-3.5 19.7z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_type_portfolio_80dp.xml"
-            line="85"/>
+            line="85"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (2379 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (2379 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M1108.4 1120.8c3-1.8 7.7 0 9.4 3.7a9.9 9.9 0 0 1-1.9 11.4 10.1 10.1 0 0 1-11.3 1.8c-3.6-1.7-5.6-6-4.4-9.3a1.4 1.4 0 0 1 2.5-0.2l0.1 0.2c2.3 4.3 6.3 4.4 8 2.4a4.3 4.3 0 0 0 1.1-3.8 7.9 7.9 0 0 0-3.5-4.9h-0.1a0.7 0.7 0 0 1-0.2-1 0.8 0.8 0 0 1 0.3-0.3zM924.6 952.2a218 218 0 0 1-29.7 2.6l-7.4 0.2h-1.9a13.6 13.6 0 0 1-2.4-0.1 7.9 7.9 0 0 1-5.4-3.5c-1.3-1.7-1.3-4.7-1.3-5.5v-9.3a17.1 17.1 0 0 1 0.1-2.4 8 8 0 0 1 6.6-6.7 13.5 13.5 0 0 1 2.5-0.1l7.4 0.1 14.8 0.3 7.4 0.3 3.7 0.1c0.9 0 3.5 0.1 4.9 1.3a6.8 6.8 0 0 1 2.8 4.8 28.5 28.5 0 0 1-0.2 4.1c-0.2 2.5-0.4 4.9-0.7 7.4a1.3 1.3 0 0 1-2.5 0c-0.3-2.5-0.5-4.9-0.7-7.4-0.1-1.1-0.1-2.8-0.3-3.3a2 2 0 0 0-1.1-1.3c-0.4-0.4-3.6 0.1-5.9 0l-7.4 0.3-14.8 0.3-7.4 0.1c-1.7 0-1.2 0-1.6 0.2a0.9 0.9 0 0 0-0.3 0.6v6.9c0 2.3-0.1 5.8 0.1 5.4a0.9 0.9 0 0 0 0.6 0.5 8.2 8.2 0 0 0 1.3 0.1h1.9l7.4 0.2a217.9 217.9 0 0 1 29.7 2.6 0.6 0.6 0 0 1 0 1.3zm-190.8-52.9a27.3 27.3 0 0 1 18.1 3.4c5.6 3.3 9.5 8.4 13.3 12.8s7.6 8.2 12.3 10.4 10 3 15.5 3a37.9 37.9 0 0 0 15.8-3.1c4.9-2.2 9.1-5.8 13.3-9.7s8.5-8.5 14.2-11.5a31.5 31.5 0 0 1 18.2-3.6 1.3 1.3 0 0 1 0 2.5 33.1 33.1 0 0 0-15.6 5.3c-4.5 3.1-8.3 7.3-12.4 11.6s-9 8.6-14.8 11.4a44.8 44.8 0 0 1-18.6 4.2 39.4 39.4 0 0 1-18.8-3.9c-6-3-10.5-8-14.1-12.7s-6.8-9.4-11-12.8-9.6-5.2-15.4-6.1a0.6 0.6 0 0 1 0-1.3zm427.7 42a62.4 62.4 0 0 1-1.1 20.7c-1.5 6.8-3.9 13.3-6.2 19.7-5 12.5-8.4 25.2-8.3 38.3a84.3 84.3 0 0 0 1.7 19.4 114.7 114.7 0 0 0 6.1 18.8c2.4 6.3 5.2 12.6 6.8 19.5a67.2 67.2 0 0 1 1.6 20.8 1.3 1.3 0 0 1-1.4 1.2 1.3 1.3 0 0 1-1.2-1.2 84.3 84.3 0 0 0-3.9-19.4 190.6 190.6 0 0 0-7.7-18.5 109.3 109.3 0 0 1-7-19.7 91.3 91.3 0 0 1-2.3-21c0-14.1 4.3-28 9.5-40.5 5.6-12.4 10.4-24.5 12-38a0.6 0.6 0 0 1 0.7-0.6 0.6 0.6 0 0 1 0.6 0.6zm-440.7-21.4c0.3 16-1.3 32.3-6.4 47.8a104.8 104.8 0 0 1-25.8 41.1c-11.5 11.6-25.3 20.4-38.4 29.5s-26 18.7-32.5 32.3c-6.5 13.4-5.7 30.2-1 44.3 5.2 14.2 17.5 24.7 31.4 31.2s29.5 10.2 45.1 12.4a357.7 357.7 0 0 0 47.4 3c63.7 0.1 127.2 0.1 189.9-11.8s125 29.6 186.6 12.6a1.3 1.3 0 0 1 1.6 0.9 1.3 1.3 0 0 1-0.8 1.6c-30.6 9.7-58.7 7.1-92.5-0.7-37.9-9.7-62.3-14.8-93.7-8.3s-63.1 10.8-94.9 15-63.9-2-96.2-2a347.7 347.7 0 0 1-48.4-3.3c-16-2.4-32.1-6.1-47.1-13.2a79.2 79.2 0 0 1-20.7-14 56.2 56.2 0 0 1-14-21.1 73.3 73.3 0 0 1-4-24.7 56 56 0 0 1 5.4-24.6c7.7-15.6 21.9-25.4 35.1-34.3 13.4-8.9 26.8-17.4 38.2-28.2a100.8 100.8 0 0 0 26-38.8c6.1-15.8 7.9-30.7 8.3-46.7a0.6 0.6 0 0 1 1.3 0z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_type_portfolio_80dp.xml"
-            line="88"/>
+            line="88"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (1572 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (1572 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M158.2 433.9c17.5-0.8 35-1.2 52.5-1.5s35-0.3 52.5-0.5 35 0.2 52.5 0.3c17.5 0.4 35 0.7 52.5 1.7a4 4 0 0 1 0 8.1c-17.5 0.9-35 1.3-52.5 1.7-17.5 0.1-35 0.4-52.5 0.3s-35-0.1-52.5-0.5-35-0.7-52.5-1.5a4 4 0 0 1 0-8.1zm0 64.2c17.5-0.8 35-1.2 52.5-1.5s35-0.3 52.5-0.5 35 0.2 52.5 0.3c17.5 0.4 35 0.7 52.5 1.7a4 4 0 0 1 0 8.1c-17.5 0.9-35 1.3-52.5 1.7-17.5 0.1-35 0.4-52.5 0.3s-35-0.1-52.5-0.5-35-0.7-52.5-1.5a4 4 0 0 1 0-8.1zm0 67.6c17.5-0.8 35-1.2 52.5-1.5s35-0.3 52.5-0.5 35 0.2 52.5 0.3c17.5 0.4 35 0.7 52.5 1.7a4 4 0 0 1 0 8.1c-17.5 0.9-35 1.3-52.5 1.7-17.5 0.1-35 0.4-52.5 0.3s-35-0.1-52.5-0.5-35-0.7-52.5-1.5a4 4 0 0 1 0-8.1zm0 61.6c17.5-0.8 35-1.2 52.5-1.5s35-0.3 52.5-0.5 35 0.2 52.5 0.3c17.5 0.4 35 0.7 52.5 1.7a4 4 0 0 1 0 8.1c-17.5 0.9-35 1.3-52.5 1.7-17.5 0.1-35 0.4-52.5 0.3s-35-0.1-52.5-0.5-35-0.7-52.5-1.5a4 4 0 0 1 0-8.1zm0 64.2c17.5-0.8 35-1.2 52.5-1.5s35-0.3 52.5-0.5 35 0.2 52.5 0.3c17.5 0.4 35 0.7 52.5 1.7a4 4 0 0 1 0 8.1c-17.5 0.9-35 1.3-52.5 1.7-17.5 0.1-35 0.4-52.5 0.3s-35-0.1-52.5-0.5-35-0.7-52.5-1.5a4 4 0 0 1 0-8.1zm0 67.5c17.5-0.8 35-1.2 52.5-1.5s35-0.3 52.5-0.5 35 0.2 52.5 0.3c17.5 0.4 35 0.7 52.5 1.7a4 4 0 0 1 0 8.1c-17.5 0.9-35 1.3-52.5 1.7-17.5 0.1-35 0.4-52.5 0.3s-35-0.1-52.5-0.5-35-0.7-52.5-1.5a4 4 0 0 1 0-8.1zm60.4 159.6c12.4-0.8 24.9-1.2 37.4-1.5s24.9-0.3 37.4-0.5 24.9 0 37.4 0.3 24.9 0.7 37.4 1.7a4 4 0 0 1 0 8.1c-12.4 0.9-24.9 1.3-37.4 1.7s-24.9 0.4-37.4 0.3-24.9-0.1-37.4-0.5-24.9-0.7-37.4-1.5a4 4 0 0 1 0-8.1zm603-277.2H1150s-12.4-75.7-51.5-86.5c-34.3-9.5-48.1 11.5-76.7 11.5-22.9 0-31.9-53.9-75.4-53.9-82.4 0-124.9 128.9-124.9 128.9z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_type_website_80dp.xml"
-            line="34"/>
+            line="34"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (821 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (821 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M1084.1 945.7a288.9 288.9 0 0 1 33.3-2.4c11.1-0.3 22.2-0.4 33.3-0.4 22.2 0.4 44.4 0.2 66.7 2.2a1.2 1.2 0 0 1 0 2.4c-22.2 2-44.4 1.9-66.7 2.2-11.1 0.1-22.2-0.1-33.3-0.4a289 289 0 0 1-33.3-2.4 0.6 0.6 0 0 1 0-1.2zm0 30.2a288.9 288.9 0 0 1 33.3-2.4c11.1-0.3 22.2-0.4 33.3-0.4 22.2 0.4 44.4 0.2 66.7 2.2a1.2 1.2 0 0 1 0 2.4c-22.2 2-44.4 1.9-66.7 2.2-11.1 0.1-22.2-0.1-33.3-0.4a289 289 0 0 1-33.3-2.4 0.6 0.6 0 0 1 0-1.2zm0 36.3a288.9 288.9 0 0 1 33.3-2.4c11.1-0.3 22.2-0.4 33.3-0.4 22.2 0.4 44.4 0.2 66.7 2.2a1.2 1.2 0 0 1 0 2.4c-22.2 2-44.4 1.9-66.7 2.2-11.1 0.1-22.2-0.1-33.3-0.4a289 289 0 0 1-33.3-2.4 0.6 0.6 0 0 1 0-1.2zm-36.3 15.8c-3.1 11.4-41.2 15.1-62.7 15.2h-0.3c-21.5 0-59.6-3.8-62.7-15.2-3.6-13.3 23.3-41.7 62.7-41.9h0.3c39.4 0.1 66.3 28.5 62.7 41.9zm-62.7-49.1a31.3 31.3 0 1 0-31.3-31.3 31.3 31.3 0 0 0 31.3 31.3z&quot;/>"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/img_type_website_80dp.xml"
-            line="52"/>
+            line="52"
+            column="27"/>
     </issue>
 
     <issue
         id="VectorPath"
-        message="Very long vector path (847 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        message="Very long vector path (847 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M16,2.7C8.6,2.7 2.7,8.6 2.7,16s6,13.3 13.3,13.3s13.3,-6 13.3,-13.3S23.4,2.7 16,2.7zM4.7,16c0,-1.6 0.4,-3.2 1,-4.6l5.4,14.8C7.3,24.4 4.7,20.5 4.7,16zM16,27.3c-1.1,0 -2.2,-0.2 -3.2,-0.5l3.4,-9.9l3.5,9.5c0,0.1 0.1,0.1 0.1,0.2C18.6,27.1 17.3,27.3 16,27.3L16,27.3zM17.6,10.7c0.7,0 1.3,-0.1 1.3,-0.1c0.6,-0.1 0.5,-1 -0.1,-0.9c0,0 -1.8,0.1 -3,0.1c-1.1,0 -3,-0.1 -3,-0.1c-0.6,0 -0.7,0.9 -0.1,0.9c0,0 0.6,0.1 1.2,0.1l1.8,4.8L13.2,23L9.1,10.7c0.7,0 1.3,-0.1 1.3,-0.1c0.6,-0.1 0.5,-1 -0.1,-0.9c0,0 -1.8,0.1 -3,0.1c-0.2,0 -0.5,0 -0.7,0c2,-3.1 5.5,-5.1 9.5,-5.1c3,0 5.6,1.1 7.7,3c0,0 -0.1,0 -0.1,0c-1.1,0 -1.9,1 -1.9,2c0,0.9 0.5,1.7 1.1,2.7c0.4,0.8 0.9,1.7 0.9,3.1c0,1 -0.4,2.1 -0.9,3.7l-1.1,3.8C21.7,22.9 17.6,10.7 17.6,10.7zM21.7,25.8l3.5,-10c0.6,-1.6 0.9,-2.9 0.9,-4.1c0,-0.4 0,-0.8 -0.1,-1.2c0.9,1.6 1.4,3.5 1.4,5.4C27.3,20.2 25.1,23.8 21.7,25.8L21.7,25.8z&quot; >"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/drawable/login_toolbar_icon.xml"
-            line="10"/>
+            line="10"
+            column="27"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="    &lt;LinearLayout"
+        errorLine2="    ^">
         <location
             file="src/main/res/layout/comment_action_footer.xml"
-            line="10"/>
+            line="10"
+            column="5"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                        &lt;LinearLayout"
+        errorLine2="                        ^">
         <location
             file="src/main/res/layout-sw720dp/stats_activity.xml"
-            line="109"/>
+            line="109"
+            column="25"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                        &lt;LinearLayout"
+        errorLine2="                        ^">
         <location
             file="src/main/res/layout-sw720dp/stats_activity.xml"
-            line="170"/>
+            line="170"
+            column="25"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="    &lt;LinearLayout"
+        errorLine2="    ^">
         <location
             file="src/main/res/layout/stats_insights_all_time_item.xml"
-            line="12"/>
+            line="12"
+            column="5"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="    &lt;LinearLayout"
+        errorLine2="    ^">
         <location
             file="src/main/res/layout/stats_insights_all_time_item.xml"
-            line="111"/>
+            line="111"
+            column="5"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="    &lt;LinearLayout"
+        errorLine2="    ^">
         <location
             file="src/main/res/layout/stats_insights_latest_post_item.xml"
-            line="31"/>
+            line="31"
+            column="5"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="    &lt;LinearLayout"
+        errorLine2="    ^">
         <location
             file="src/main/res/layout/stats_insights_today_item.xml"
-            line="9"/>
+            line="9"
+            column="5"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="        &lt;LinearLayout"
+        errorLine2="        ^">
         <location
             file="src/main/res/layout/stats_visitors_and_views_fragment.xml"
-            line="16"/>
+            line="16"
+            column="9"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="        &lt;LinearLayout"
+        errorLine2="        ^">
         <location
             file="src/main/res/layout/stats_visitors_and_views_fragment.xml"
-            line="102"/>
+            line="102"
+            column="9"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="    &lt;LinearLayout"
+        errorLine2="    ^">
         <location
             file="src/main/res/layout/stats_widget_layout.xml"
-            line="45"/>
+            line="45"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/nux_background` with a theme that also paints a background (inferred theme is `@style/WordPress_TransparentToolbarTheme`)">
+        message="Possible overdraw: Root element paints background `@color/nux_background` with a theme that also paints a background (inferred theme is `@style/WordPress_TransparentToolbarTheme`)"
+        errorLine1="    android:background=&quot;@color/nux_background&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/about_activity.xml"
-            line="8"/>
+            line="8"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `#FFEEEEEE` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `#FFEEEEEE` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="  android:background=&quot;#FFEEEEEE&quot;>"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/add_quickpress_shortcut.xml"
-            line="6"/>
+            line="6"
+            column="3"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="              android:background=&quot;@color/white&quot;"
+        errorLine2="              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/comment_action_footer.xml"
-            line="7"/>
+            line="7"
+            column="15"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/grey_light` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/grey_light` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/grey_light&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/comment_detail_fragment.xml"
-            line="11"/>
+            line="11"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme`)"
+        errorLine1="    android:background=&quot;@color/white&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/comment_edit_activity.xml"
-            line="9"/>
+            line="9"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/comment_listitem.xml"
-            line="6"/>
+            line="6"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@android:color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@android:color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@android:color/white&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/res/layout/dialog_image_options.xml"
-            line="6"/>
+            file="../libs/editor/WordPressEditor/src/main/res/layout/dialog_image_options.xml"
+            line="6"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/grey_3` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/grey_3` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/grey_3&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/dialog_snackbar.xml"
-            line="8"/>
+            line="8"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/edit_post_preview_fragment.xml"
-            line="7"/>
+            line="7"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/background_grey` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/background_grey` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/background_grey&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/edit_post_settings_fragment.xml"
-            line="8"/>
+            line="8"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/format_bar_background` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/format_bar_background` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/format_bar_background&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/res/layout-w360dp/format_bar.xml"
-            line="8"/>
+            file="../libs/editor/WordPressEditor/src/main/res/layout-w360dp/format_bar.xml"
+            line="8"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/format_bar_background` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/format_bar_background` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/format_bar_background&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/res/layout-w380dp/format_bar.xml"
-            line="8"/>
+            file="../libs/editor/WordPressEditor/src/main/res/layout-w380dp/format_bar.xml"
+            line="8"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/format_bar_background` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/format_bar_background` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/format_bar_background&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/res/layout-w600dp/format_bar.xml"
-            line="8"/>
+            file="../libs/editor/WordPressEditor/src/main/res/layout-w600dp/format_bar.xml"
+            line="8"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/format_bar_background` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/format_bar_background` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/format_bar_background&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/res/layout/format_bar.xml"
-            line="9"/>
+            file="../libs/editor/WordPressEditor/src/main/res/layout/format_bar.xml"
+            line="9"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml"
-            line="5"/>
+            file="../libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml"
+            line="5"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@android:color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@android:color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@android:color/white&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/res/layout/fragment_edit_post_content.xml"
-            line="6"/>
+            file="../libs/editor/WordPressEditor/src/main/res/layout/fragment_edit_post_content.xml"
+            line="6"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml"
-            line="5"/>
+            file="../libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml"
+            line="5"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/gutenberg_warning_dialog.xml"
-            line="5"/>
+            line="5"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/background_grey` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme_NoActionBarShadow`)">
+        message="Possible overdraw: Root element paints background `@color/background_grey` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme_NoActionBarShadow`)"
+        errorLine1="    android:background=&quot;@color/background_grey&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/help_activity.xml"
-            line="6"/>
+            line="6"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/history_detail_fragment.xml"
-            line="5"/>
+            line="5"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/home_row.xml"
-            line="5"/>
+            line="5"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/transparent` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/transparent` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/transparent&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/learn_more_pref_screen.xml"
-            line="8"/>
+            line="8"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/blue_medium` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/blue_medium` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/blue_medium&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/login_intro_template_view.xml"
-            line="5"/>
+            line="5"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/blue_medium` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/blue_medium` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/blue_medium&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-sw600dp-land/login_intro_template_view.xml"
-            line="5"/>
+            line="5"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/black` with a theme that also paints a background (inferred theme is `@style/Theme_AppCompat_NoActionBar`)">
+        message="Possible overdraw: Root element paints background `@color/black` with a theme that also paints a background (inferred theme is `@style/Theme_AppCompat_NoActionBar`)"
+        errorLine1="    android:background=&quot;@color/black&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/media_preview_activity.xml"
-            line="7"/>
+            line="7"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/news_card.xml"
-            line="8"/>
+            line="8"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/note_block_footer.xml"
-            line="5"/>
+            line="5"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/note_block_user.xml"
-            line="6"/>
+            line="6"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/default_background` with a theme that also paints a background (inferred theme is `@style/Calypso_NoActionBar_Preferences`)">
+        message="Possible overdraw: Root element paints background `@color/default_background` with a theme that also paints a background (inferred theme is `@style/Calypso_NoActionBar_Preferences`)"
+        errorLine1="    android:background=&quot;@color/default_background&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/notifications_settings_activity.xml"
-            line="7"/>
+            line="7"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/people_invite_fragment.xml"
-            line="7"/>
+            line="7"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/person_detail_fragment.xml"
-            line="7"/>
+            line="7"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="                android:background=&quot;@color/white&quot;>"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/photo_picker_fragment.xml"
-            line="8"/>
+            line="8"
+            column="17"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/Calypso_NoActionBar`)">
+        message="Possible overdraw: Root element paints background `?android:attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/Calypso_NoActionBar`)"
+        errorLine1="    android:background=&quot;?android:attr/selectableItemBackground&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/plugin_browser_row.xml"
-            line="6"/>
+            line="6"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/Calypso_NoActionBar`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/Calypso_NoActionBar`)"
+        errorLine1="    android:background=&quot;@color/white&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/post_preview_activity.xml"
-            line="6"/>
+            line="6"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/promo_dialog.xml"
-            line="6"/>
+            line="6"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/publicize_connect_button.xml"
-            line="6"/>
+            line="6"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/publicize_listitem_connection.xml"
-            line="7"/>
+            line="7"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/publicize_listitem_service.xml"
-            line="7"/>
+            line="7"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/quick_start_fragment.xml"
-            line="9"/>
+            line="9"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/black` with a theme that also paints a background (inferred theme is `@style/ReaderMediaViewerTheme`)">
+        message="Possible overdraw: Root element paints background `@color/black` with a theme that also paints a background (inferred theme is `@style/ReaderMediaViewerTheme`)"
+        errorLine1="                android:background=&quot;@color/black&quot;>"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_activity_photo_viewer.xml"
-            line="8"/>
+            line="8"
+            column="17"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/Calypso_NoActionBar`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/Calypso_NoActionBar`)"
+        errorLine1="    android:background=&quot;@color/white&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_activity_subs.xml"
-            line="7"/>
+            line="7"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/grey_dark` with a theme that also paints a background (inferred theme is `@style/ReaderMediaViewerTheme`)">
+        message="Possible overdraw: Root element paints background `@color/grey_dark` with a theme that also paints a background (inferred theme is `@style/ReaderMediaViewerTheme`)"
+        errorLine1="    android:background=&quot;@color/grey_dark&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_activity_video_player.xml"
-            line="7"/>
+            line="7"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;?attr/selectableItemBackground&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_bookmark_button.xml"
-            line="5"/>
+            line="5"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_comments_post_header_view.xml"
-            line="11"/>
+            line="11"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;?attr/selectableItemBackground&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_icon_count_view.xml"
-            line="6"/>
+            line="6"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_include_comment_box.xml"
-            line="12"/>
+            line="12"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_include_post_detail_footer.xml"
-            line="11"/>
+            line="11"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_listitem_blog.xml"
-            line="10"/>
+            line="10"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_listitem_comment.xml"
-            line="8"/>
+            line="8"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_listitem_tag.xml"
-            line="12"/>
+            line="12"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_listitem_user.xml"
-            line="7"/>
+            line="7"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_simple_post_view.xml"
-            line="9"/>
+            line="9"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="             android:background=&quot;@color/white&quot;"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_site_search_result.xml"
-            line="7"/>
+            line="7"
+            column="14"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_tag_strip_label.xml"
-            line="9"/>
+            line="9"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/related_posts_dialog.xml"
-            line="10"/>
+            line="10"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme`)"
+        errorLine1="    android:background=&quot;@color/white&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/select_categories.xml"
-            line="6"/>
+            line="6"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="/Users/mariozorz/proyectos/WordPress-Android/libs/login/WordPressLoginFlow/src/main/res/layout-land/signup_bottom_sheet_dialog.xml"
-            line="5"/>
+            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/signup_bottom_sheet_dialog.xml"
+            line="5"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="/Users/mariozorz/proyectos/WordPress-Android/libs/login/WordPressLoginFlow/src/main/res/layout/signup_bottom_sheet_dialog.xml"
-            line="5"/>
+            file="../libs/login/WordPressLoginFlow/src/main/res/layout/signup_bottom_sheet_dialog.xml"
+            line="5"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/site_creation_domain_header.xml"
-            line="6"/>
+            line="6"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/site_creation_domain_input.xml"
-            line="8"/>
+            line="8"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/white&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/site_creation_domain_screen.xml"
-            line="7"/>
+            line="7"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/site_creation_form_screen.xml"
-            line="7"/>
+            line="7"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme`)">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme`)"
+        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/site_picker_listitem.xml"
-            line="8"/>
+            line="8"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/site_settings_tag_detail_fragment.xml"
-            line="7"/>
+            line="7"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `?android:attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;?android:attr/selectableItemBackground&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/start_over_preference.xml"
-            line="10"/>
+            line="10"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme`)">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme`)"
+        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/stats_activity_view_all.xml"
-            line="8"/>
+            line="8"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot; />"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/stats_insights_header_line.xml"
-            line="5"/>
+            line="5"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot; />"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/stats_vertical_line.xml"
-            line="4"/>
+            line="4"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?attr/colorPrimary` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `?attr/colorPrimary` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;?attr/colorPrimary&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/toolbar.xml"
-            line="8"/>
+            line="8"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/blue_wordpress` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/blue_wordpress` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/blue_wordpress&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/toolbar_login.xml"
-            line="8"/>
+            line="8"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/login_toolbar_color` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/login_toolbar_color` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/login_toolbar_color&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="/Users/mariozorz/proyectos/WordPress-Android/libs/login/WordPressLoginFlow/src/main/res/layout/toolbar_login.xml"
-            line="9"/>
+            file="../libs/login/WordPressLoginFlow/src/main/res/layout/toolbar_login.xml"
+            line="9"
+            column="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/color_primary` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        message="Possible overdraw: Root element paints background `@color/color_primary` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
+        errorLine1="    android:background=&quot;@color/color_primary&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/toolbar_main.xml"
-            line="8"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.fragment_tag_reader_post_list` appears to be unused">
-        <location
-            file="src/main/res/values/key_strings.xml"
-            line="6"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.error_refresh_pages` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1395"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="1562"/>
-        <location
-            file="src/main/res/values-az/strings.xml"
-            line="199"/>
-        <location
-            file="src/main/res/values-bg/strings.xml"
-            line="875"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="1562"/>
-        <location
-            file="src/main/res/values-cy/strings.xml"
-            line="612"/>
-        <location
-            file="src/main/res/values-da/strings.xml"
-            line="244"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1617"/>
-        <location
-            file="src/main/res/values-el/strings.xml"
-            line="1012"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1617"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1617"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1620"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1617"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1617"/>
-        <location
-            file="src/main/res/values-es-rCO/strings.xml"
-            line="915"/>
-        <location
-            file="src/main/res/values-es-rVE/strings.xml"
-            line="587"/>
-        <location
-            file="src/main/res/values-eu/strings.xml"
-            line="370"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1617"/>
-        <location
-            file="src/main/res/values-gd/strings.xml"
-            line="216"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="655"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1616"/>
-        <location
-            file="src/main/res/values-hi/strings.xml"
-            line="266"/>
-        <location
-            file="src/main/res/values-hr/strings.xml"
-            line="407"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="1578"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="1578"/>
-        <location
-            file="src/main/res/values-is/strings.xml"
-            line="650"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1617"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1616"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1616"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1616"/>
-        <location
-            file="src/main/res/values-mk/strings.xml"
-            line="128"/>
-        <location
-            file="src/main/res/values-ms/strings.xml"
-            line="951"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="1530"/>
-        <location
-            file="src/main/res/values-nl/strings.xml"
-            line="1551"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1613"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1617"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1617"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1617"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1617"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1617"/>
-        <location
-            file="src/main/res/values-sr/strings.xml"
-            line="213"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1617"/>
-        <location
-            file="src/main/res/values-th/strings.xml"
-            line="356"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1617"/>
-        <location
-            file="src/main/res/values-vi/strings.xml"
-            line="593"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="1606"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="1606"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1602"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1602"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.reader_title_blog_preview` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1484"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="1547"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="1547"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1602"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1602"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1602"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1596"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1602"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1602"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1602"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="640"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-hr/strings.xml"
-            line="389"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="1563"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="1563"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1602"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="1515"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1602"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1602"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1602"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1602"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1602"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1602"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1602"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="1591"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="1591"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1584"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1584"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.reader_title_tag_preview` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1485"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="1546"/>
-        <location
-            file="src/main/res/values-bg/strings.xml"
-            line="868"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="1546"/>
-        <location
-            file="src/main/res/values-cy/strings.xml"
-            line="594"/>
-        <location
-            file="src/main/res/values-da/strings.xml"
-            line="229"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-el/strings.xml"
-            line="981"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1592"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-es-rCO/strings.xml"
-            line="900"/>
-        <location
-            file="src/main/res/values-es-rVE/strings.xml"
-            line="569"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-gd/strings.xml"
-            line="197"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="639"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1600"/>
-        <location
-            file="src/main/res/values-hi/strings.xml"
-            line="242"/>
-        <location
-            file="src/main/res/values-hr/strings.xml"
-            line="380"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="1562"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="1562"/>
-        <location
-            file="src/main/res/values-is/strings.xml"
-            line="632"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1600"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1600"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1600"/>
-        <location
-            file="src/main/res/values-ms/strings.xml"
-            line="936"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="1514"/>
-        <location
-            file="src/main/res/values-nl/strings.xml"
-            line="1536"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1597"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-sr/strings.xml"
-            line="194"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-th/strings.xml"
-            line="329"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1601"/>
-        <location
-            file="src/main/res/values-vi/strings.xml"
-            line="568"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="1590"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="1590"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1574"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1574"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.reader_title_post_detail_wpcom` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1487"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="953"/>
-        <location
-            file="src/main/res/values-bg/strings.xml"
-            line="305"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="952"/>
-        <location
-            file="src/main/res/values-cy/strings.xml"
-            line="44"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-el/strings.xml"
-            line="397"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-es-rCO/strings.xml"
-            line="337"/>
-        <location
-            file="src/main/res/values-es-rVE/strings.xml"
-            line="17"/>
-        <location
-            file="src/main/res/values-eu/strings.xml"
-            line="17"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="45"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-hi/strings.xml"
-            line="89"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="973"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="973"/>
-        <location
-            file="src/main/res/values-is/strings.xml"
-            line="79"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-ms/strings.xml"
-            line="373"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="920"/>
-        <location
-            file="src/main/res/values-nl/strings.xml"
-            line="957"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1003"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1007"/>
-        <location
-            file="src/main/res/values-vi/strings.xml"
-            line="23"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="997"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="997"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1002"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1002"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.reader_title_related_post_detail` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1488"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="1048"/>
-        <location
-            file="src/main/res/values-bg/strings.xml"
-            line="398"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="1047"/>
-        <location
-            file="src/main/res/values-cy/strings.xml"
-            line="132"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-el/strings.xml"
-            line="492"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-es-rCO/strings.xml"
-            line="430"/>
-        <location
-            file="src/main/res/values-es-rVE/strings.xml"
-            line="105"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="140"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="1068"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="1068"/>
-        <location
-            file="src/main/res/values-is/strings.xml"
-            line="167"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-ms/strings.xml"
-            line="466"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="1015"/>
-        <location
-            file="src/main/res/values-nl/strings.xml"
-            line="1051"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1098"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1102"/>
-        <location
-            file="src/main/res/values-vi/strings.xml"
-            line="88"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="1092"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="1092"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1094"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1094"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.reader_page_followed_tags` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1494"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="1544"/>
-        <location
-            file="src/main/res/values-az/strings.xml"
-            line="179"/>
-        <location
-            file="src/main/res/values-bg/strings.xml"
-            line="865"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="1544"/>
-        <location
-            file="src/main/res/values-cy/strings.xml"
-            line="593"/>
-        <location
-            file="src/main/res/values-da/strings.xml"
-            line="228"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1599"/>
-        <location
-            file="src/main/res/values-el/strings.xml"
-            line="982"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1599"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1599"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1591"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1599"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1599"/>
-        <location
-            file="src/main/res/values-es-rCO/strings.xml"
-            line="899"/>
-        <location
-            file="src/main/res/values-es-rVE/strings.xml"
-            line="566"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1599"/>
-        <location
-            file="src/main/res/values-gd/strings.xml"
-            line="196"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="637"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-hi/strings.xml"
-            line="245"/>
-        <location
-            file="src/main/res/values-hr/strings.xml"
-            line="378"/>
-        <location
-            file="src/main/res/values-hu/strings.xml"
-            line="48"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="1560"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="1560"/>
-        <location
-            file="src/main/res/values-is/strings.xml"
-            line="630"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1599"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-mk/strings.xml"
-            line="102"/>
-        <location
-            file="src/main/res/values-ms/strings.xml"
-            line="935"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="1512"/>
-        <location
-            file="src/main/res/values-nl/strings.xml"
-            line="1535"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1595"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1599"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1599"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1599"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1599"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1599"/>
-        <location
-            file="src/main/res/values-sr/strings.xml"
-            line="193"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1599"/>
-        <location
-            file="src/main/res/values-th/strings.xml"
-            line="328"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1599"/>
-        <location
-            file="src/main/res/values-vi/strings.xml"
-            line="569"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="1588"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="1588"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1573"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1573"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.reader_page_followed_blogs` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1495"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="1543"/>
-        <location
-            file="src/main/res/values-az/strings.xml"
-            line="181"/>
-        <location
-            file="src/main/res/values-bg/strings.xml"
-            line="866"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="1543"/>
-        <location
-            file="src/main/res/values-cy/strings.xml"
-            line="595"/>
-        <location
-            file="src/main/res/values-da/strings.xml"
-            line="227"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-el/strings.xml"
-            line="983"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1593"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-es-rCO/strings.xml"
-            line="898"/>
-        <location
-            file="src/main/res/values-es-rVE/strings.xml"
-            line="567"/>
-        <location
-            file="src/main/res/values-eu/strings.xml"
-            line="363"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-gd/strings.xml"
-            line="198"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="636"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1597"/>
-        <location
-            file="src/main/res/values-hi/strings.xml"
-            line="244"/>
-        <location
-            file="src/main/res/values-hr/strings.xml"
-            line="381"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="1559"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="1559"/>
-        <location
-            file="src/main/res/values-is/strings.xml"
-            line="629"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1597"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1597"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1597"/>
-        <location
-            file="src/main/res/values-ms/strings.xml"
-            line="934"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="1511"/>
-        <location
-            file="src/main/res/values-nl/strings.xml"
-            line="1534"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-sr/strings.xml"
-            line="195"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-th/strings.xml"
-            line="330"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1598"/>
-        <location
-            file="src/main/res/values-vi/strings.xml"
-            line="570"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="1587"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="1587"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1575"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1575"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.reader_page_recommended_blogs` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1496"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="1435"/>
-        <location
-            file="src/main/res/values-bg/strings.xml"
-            line="767"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="1435"/>
-        <location
-            file="src/main/res/values-cy/strings.xml"
-            line="505"/>
-        <location
-            file="src/main/res/values-da/strings.xml"
-            line="130"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1490"/>
-        <location
-            file="src/main/res/values-el/strings.xml"
-            line="880"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1490"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1490"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1498"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1490"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1490"/>
-        <location
-            file="src/main/res/values-es-rCO/strings.xml"
-            line="800"/>
-        <location
-            file="src/main/res/values-es-rVE/strings.xml"
-            line="470"/>
-        <location
-            file="src/main/res/values-eu/strings.xml"
-            line="311"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1490"/>
-        <location
-            file="src/main/res/values-gd/strings.xml"
-            line="110"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="528"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1489"/>
-        <location
-            file="src/main/res/values-hr/strings.xml"
-            line="286"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="1453"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="1453"/>
-        <location
-            file="src/main/res/values-is/strings.xml"
-            line="539"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1490"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1489"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1489"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1489"/>
-        <location
-            file="src/main/res/values-ms/strings.xml"
-            line="836"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="1403"/>
-        <location
-            file="src/main/res/values-nl/strings.xml"
-            line="1436"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1486"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1490"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1490"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1490"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1490"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1490"/>
-        <location
-            file="src/main/res/values-sr/strings.xml"
-            line="107"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1490"/>
-        <location
-            file="src/main/res/values-th/strings.xml"
-            line="240"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1490"/>
-        <location
-            file="src/main/res/values-vi/strings.xml"
-            line="474"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="1479"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="1479"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1480"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1480"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.reader_label_added_tag` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1529"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="1661"/>
-        <location
-            file="src/main/res/values-az/strings.xml"
-            line="282"/>
-        <location
-            file="src/main/res/values-bg/strings.xml"
-            line="978"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="1661"/>
-        <location
-            file="src/main/res/values-cy/strings.xml"
-            line="704"/>
-        <location
-            file="src/main/res/values-da/strings.xml"
-            line="329"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1716"/>
-        <location
-            file="src/main/res/values-el/strings.xml"
-            line="1105"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1716"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1716"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1718"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1716"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1716"/>
-        <location
-            file="src/main/res/values-es-rCO/strings.xml"
-            line="1013"/>
-        <location
-            file="src/main/res/values-es-rVE/strings.xml"
-            line="672"/>
-        <location
-            file="src/main/res/values-eu/strings.xml"
-            line="464"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1716"/>
-        <location
-            file="src/main/res/values-gd/strings.xml"
-            line="302"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="752"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-hi/strings.xml"
-            line="344"/>
-        <location
-            file="src/main/res/values-hr/strings.xml"
-            line="497"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="1677"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="1677"/>
-        <location
-            file="src/main/res/values-is/strings.xml"
-            line="735"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1716"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-mk/strings.xml"
-            line="210"/>
-        <location
-            file="src/main/res/values-ms/strings.xml"
-            line="1047"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="1628"/>
-        <location
-            file="src/main/res/values-nl/strings.xml"
-            line="1650"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1712"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1716"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1716"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1716"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1716"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1716"/>
-        <location
-            file="src/main/res/values-sr/strings.xml"
-            line="304"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1716"/>
-        <location
-            file="src/main/res/values-th/strings.xml"
-            line="437"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1716"/>
-        <location
-            file="src/main/res/values-uz/strings.xml"
-            line="31"/>
-        <location
-            file="src/main/res/values-vi/strings.xml"
-            line="678"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="1705"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="1705"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1692"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1692"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.reader_label_removed_tag` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1530"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="1660"/>
-        <location
-            file="src/main/res/values-az/strings.xml"
-            line="283"/>
-        <location
-            file="src/main/res/values-bg/strings.xml"
-            line="979"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="1660"/>
-        <location
-            file="src/main/res/values-cy/strings.xml"
-            line="703"/>
-        <location
-            file="src/main/res/values-da/strings.xml"
-            line="328"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-el/strings.xml"
-            line="1111"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1719"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-es-rCO/strings.xml"
-            line="1004"/>
-        <location
-            file="src/main/res/values-es-rVE/strings.xml"
-            line="673"/>
-        <location
-            file="src/main/res/values-eu/strings.xml"
-            line="475"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-gd/strings.xml"
-            line="303"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="751"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1714"/>
-        <location
-            file="src/main/res/values-hi/strings.xml"
-            line="351"/>
-        <location
-            file="src/main/res/values-hr/strings.xml"
-            line="498"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="1676"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="1676"/>
-        <location
-            file="src/main/res/values-is/strings.xml"
-            line="745"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1714"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1714"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1714"/>
-        <location
-            file="src/main/res/values-mk/strings.xml"
-            line="198"/>
-        <location
-            file="src/main/res/values-ms/strings.xml"
-            line="1046"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="1627"/>
-        <location
-            file="src/main/res/values-nl/strings.xml"
-            line="1649"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1711"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-sr/strings.xml"
-            line="303"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-th/strings.xml"
-            line="438"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1715"/>
-        <location
-            file="src/main/res/values-uz/strings.xml"
-            line="32"/>
-        <location
-            file="src/main/res/values-vi/strings.xml"
-            line="671"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="1704"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="1704"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1693"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1693"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.reader_label_followed_blog` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1532"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="1541"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="1541"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1596"/>
-        <location
-            file="src/main/res/values-el/strings.xml"
-            line="986"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1596"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1596"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1597"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1596"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1596"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1596"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="634"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1595"/>
-        <location
-            file="src/main/res/values-hr/strings.xml"
-            line="388"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="1557"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="1557"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1596"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1595"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1595"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1595"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="1509"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1592"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1596"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1596"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1596"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1596"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1596"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1596"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1596"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="1585"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="1585"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1578"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1578"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.reader_toast_err_tag_exists` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1565"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="1656"/>
-        <location
-            file="src/main/res/values-az/strings.xml"
-            line="289"/>
-        <location
-            file="src/main/res/values-bg/strings.xml"
-            line="981"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="1656"/>
-        <location
-            file="src/main/res/values-cy/strings.xml"
-            line="699"/>
-        <location
-            file="src/main/res/values-da/strings.xml"
-            line="324"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1711"/>
-        <location
-            file="src/main/res/values-el/strings.xml"
-            line="1106"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1711"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1711"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1711"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1711"/>
-        <location
-            file="src/main/res/values-es-rCO/strings.xml"
-            line="1006"/>
-        <location
-            file="src/main/res/values-es-rVE/strings.xml"
-            line="677"/>
-        <location
-            file="src/main/res/values-eu/strings.xml"
-            line="478"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1711"/>
-        <location
-            file="src/main/res/values-gd/strings.xml"
-            line="307"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="747"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-hi/strings.xml"
-            line="355"/>
-        <location
-            file="src/main/res/values-hr/strings.xml"
-            line="502"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="1672"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="1672"/>
-        <location
-            file="src/main/res/values-is/strings.xml"
-            line="741"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1711"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-mk/strings.xml"
-            line="204"/>
-        <location
-            file="src/main/res/values-ms/strings.xml"
-            line="1042"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="1623"/>
-        <location
-            file="src/main/res/values-nl/strings.xml"
-            line="1645"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1707"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1711"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1711"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1711"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1711"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1711"/>
-        <location
-            file="src/main/res/values-sr/strings.xml"
-            line="299"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1711"/>
-        <location
-            file="src/main/res/values-th/strings.xml"
-            line="434"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1711"/>
-        <location
-            file="src/main/res/values-uz/strings.xml"
-            line="26"/>
-        <location
-            file="src/main/res/values-vi/strings.xml"
-            line="684"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="1700"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="1700"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1700"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1700"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.reader_toast_err_tag_invalid` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1566"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="1655"/>
-        <location
-            file="src/main/res/values-az/strings.xml"
-            line="290"/>
-        <location
-            file="src/main/res/values-bg/strings.xml"
-            line="972"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="1655"/>
-        <location
-            file="src/main/res/values-cy/strings.xml"
-            line="698"/>
-        <location
-            file="src/main/res/values-da/strings.xml"
-            line="323"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-el/strings.xml"
-            line="1107"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1711"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-es-rCO/strings.xml"
-            line="1011"/>
-        <location
-            file="src/main/res/values-es-rVE/strings.xml"
-            line="678"/>
-        <location
-            file="src/main/res/values-eu/strings.xml"
-            line="465"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-gd/strings.xml"
-            line="308"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="746"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1709"/>
-        <location
-            file="src/main/res/values-hi/strings.xml"
-            line="357"/>
-        <location
-            file="src/main/res/values-hr/strings.xml"
-            line="503"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="1671"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="1671"/>
-        <location
-            file="src/main/res/values-is/strings.xml"
-            line="742"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1709"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1709"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1709"/>
-        <location
-            file="src/main/res/values-mk/strings.xml"
-            line="205"/>
-        <location
-            file="src/main/res/values-ms/strings.xml"
-            line="1041"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="1622"/>
-        <location
-            file="src/main/res/values-nl/strings.xml"
-            line="1644"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1706"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-sr/strings.xml"
-            line="298"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-th/strings.xml"
-            line="435"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1710"/>
-        <location
-            file="src/main/res/values-uz/strings.xml"
-            line="27"/>
-        <location
-            file="src/main/res/values-vi/strings.xml"
-            line="682"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="1699"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="1699"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1701"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1701"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.reader_toast_err_add_tag` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1567"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="1578"/>
-        <location
-            file="src/main/res/values-az/strings.xml"
-            line="216"/>
-        <location
-            file="src/main/res/values-bg/strings.xml"
-            line="952"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="1578"/>
-        <location
-            file="src/main/res/values-cy/strings.xml"
-            line="626"/>
-        <location
-            file="src/main/res/values-da/strings.xml"
-            line="258"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1633"/>
-        <location
-            file="src/main/res/values-el/strings.xml"
-            line="1076"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1633"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1633"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1682"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1633"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1633"/>
-        <location
-            file="src/main/res/values-es-rCO/strings.xml"
-            line="931"/>
-        <location
-            file="src/main/res/values-es-rVE/strings.xml"
-            line="651"/>
-        <location
-            file="src/main/res/values-eu/strings.xml"
-            line="418"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1633"/>
-        <location
-            file="src/main/res/values-gd/strings.xml"
-            line="228"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="671"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1632"/>
-        <location
-            file="src/main/res/values-hi/strings.xml"
-            line="304"/>
-        <location
-            file="src/main/res/values-hr/strings.xml"
-            line="468"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-is/strings.xml"
-            line="713"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1633"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1632"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1632"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1632"/>
-        <location
-            file="src/main/res/values-mk/strings.xml"
-            line="157"/>
-        <location
-            file="src/main/res/values-ms/strings.xml"
-            line="967"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="1546"/>
-        <location
-            file="src/main/res/values-nl/strings.xml"
-            line="1567"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1629"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1633"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1633"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1633"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1633"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1633"/>
-        <location
-            file="src/main/res/values-sr/strings.xml"
-            line="236"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1633"/>
-        <location
-            file="src/main/res/values-th/strings.xml"
-            line="360"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1633"/>
-        <location
-            file="src/main/res/values-vi/strings.xml"
-            line="629"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="1622"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="1622"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1668"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1668"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.reader_toast_err_already_follow_blog` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1572"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="1539"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="1539"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-el/strings.xml"
-            line="988"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1602"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="632"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1593"/>
-        <location
-            file="src/main/res/values-hr/strings.xml"
-            line="384"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="1555"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="1555"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1593"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1593"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1593"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="1507"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1590"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1594"/>
-        <location
-            file="src/main/res/values-vi/strings.xml"
-            line="572"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="1583"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="1583"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1580"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1580"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.reader_toast_err_follow_blog_not_found` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1574"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="1374"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="1374"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1429"/>
-        <location
-            file="src/main/res/values-el/strings.xml"
-            line="819"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1429"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1429"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1429"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1429"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1429"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1429"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="467"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-hr/strings.xml"
-            line="217"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="1393"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="1393"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1429"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="1342"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1425"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1429"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1429"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1429"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1429"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1429"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1429"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1429"/>
-        <location
-            file="src/main/res/values-vi/strings.xml"
-            line="410"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="1418"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="1418"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1413"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1413"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.reader_toast_err_follow_blog_not_authorized` appears to be unused">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1575"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="1373"/>
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="1373"/>
-        <location
-            file="src/main/res/values-de/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-el/strings.xml"
-            line="818"/>
-        <location
-            file="src/main/res/values-en-rAU/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-en-rCA/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-en-rGB/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-es/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-es-rCL/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-fr/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-gl/strings.xml"
-            line="466"/>
-        <location
-            file="src/main/res/values-he/strings.xml"
-            line="1427"/>
-        <location
-            file="src/main/res/values-hr/strings.xml"
-            line="216"/>
-        <location
-            file="src/main/res/values-id/strings.xml"
-            line="1392"/>
-        <location
-            file="src/main/res/values-in/strings.xml"
-            line="1392"/>
-        <location
-            file="src/main/res/values-it/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-iw/strings.xml"
-            line="1427"/>
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="1427"/>
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="1427"/>
-        <location
-            file="src/main/res/values-nb/strings.xml"
-            line="1341"/>
-        <location
-            file="src/main/res/values-pl/strings.xml"
-            line="1424"/>
-        <location
-            file="src/main/res/values-pt-rBR/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-ro/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-sk/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-sq/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-sv/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-tr/strings.xml"
-            line="1428"/>
-        <location
-            file="src/main/res/values-vi/strings.xml"
-            line="409"/>
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="1417"/>
-        <location
-            file="src/main/res/values-zh-rCN/strings.xml"
-            line="1417"/>
-        <location
-            file="src/main/res/values-zh-rHK/strings.xml"
-            line="1412"/>
-        <location
-            file="src/main/res/values-zh-rTW/strings.xml"
-            line="1412"/>
+            line="8"
+            column="5"/>
     </issue>
 
     <issue
         id="TypographyFractions"
-        message="Use fraction character ¾ (&amp;#190;) instead of 3/4 ?">
+        message="Use fraction character ¾ (&amp;#190;) instead of 3/4 ?"
+        errorLine1="    &lt;string name=&quot;site_creation_label_site_details_title&quot;>Adım 3/4&lt;/string>"
+        errorLine2="                                                          ^">
         <location
             file="src/main/res/values-tr/strings.xml"
-            line="488"/>
+            line="488"
+            column="59"/>
     </issue>
 
     <issue
         id="TypographyFractions"
-        message="Use fraction character ¼ (&amp;#188;) instead of 1/4 ?">
+        message="Use fraction character ¼ (&amp;#188;) instead of 1/4 ?"
+        errorLine1="    &lt;string name=&quot;site_creation_label_category_title&quot;>Adım 1/4&lt;/string>"
+        errorLine2="                                                      ^">
         <location
             file="src/main/res/values-tr/strings.xml"
-            line="499"/>
+            line="499"
+            column="55"/>
     </issue>
 
     <issue
         id="TypographyFractions"
-        message="Use fraction character ¾ (&amp;#190;) instead of 3/4 ?">
+        message="Use fraction character ¾ (&amp;#190;) instead of 3/4 ?"
+        errorLine1="    &lt;string name=&quot;notification_site_creation_step_tagline&quot;>Adım 3/4&lt;/string>"
+        errorLine2="                                                           ^">
         <location
             file="src/main/res/values-tr/strings.xml"
-            line="504"/>
+            line="504"
+            column="60"/>
     </issue>
 
     <issue
         id="TypographyFractions"
-        message="Use fraction character ¼ (&amp;#188;) instead of 1/4 ?">
+        message="Use fraction character ¼ (&amp;#188;) instead of 1/4 ?"
+        errorLine1="    &lt;string name=&quot;notification_site_creation_step_creating&quot;>Adım 1/4&lt;/string>"
+        errorLine2="                                                            ^">
         <location
             file="src/main/res/values-tr/strings.xml"
-            line="506"/>
+            line="506"
+            column="61"/>
     </issue>
 
     <issue
@@ -4674,947 +2927,1103 @@
 
     <issue
         id="GoogleAppIndexingWarning"
-        message="App is not indexable by Google Search; consider adding at least one Activity with an ACTION-VIEW intent filter. See issue explanation for more details.">
+        message="App is not indexable by Google Search; consider adding at least one Activity with an ACTION-VIEW intent filter. See issue explanation for more details."
+        errorLine1="    &lt;application"
+        errorLine2="    ^">
         <location
             file="src/debug/AndroidManifest.xml"
-            line="7"/>
-    </issue>
-
-    <issue
-        id="TextFields"
-        message="This text field does not specify an `inputType`">
-        <location
-            file="src/main/res/layout/site_creation_domain_input.xml"
-            line="10"/>
+            line="7"
+            column="5"/>
     </issue>
 
     <issue
         id="AlwaysShowAction"
-        message="Prefer &quot;`ifRoom`&quot; instead of &quot;`always`&quot;">
+        message="Prefer &quot;`ifRoom`&quot; instead of &quot;`always`&quot;"
+        errorLine1="        app:showAsAction=&quot;always&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/menu/edit_post_legacy.xml"
-            line="7"/>
+            line="7"
+            column="9"/>
         <location
             file="src/main/res/menu/edit_post_legacy.xml"
-            line="11"/>
+            line="11"
+            column="9"/>
     </issue>
 
     <issue
         id="AlwaysShowAction"
-        message="Prefer &quot;`ifRoom`&quot; instead of &quot;`always`&quot;">
+        message="Prefer &quot;`ifRoom`&quot; instead of &quot;`always`&quot;"
+        errorLine1="        app:showAsAction=&quot;always&quot; />"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/menu/reader_detail.xml"
-            line="9"/>
+            line="9"
+            column="9"/>
         <location
             file="src/main/res/menu/reader_detail.xml"
-            line="15"/>
+            line="15"
+            column="9"/>
     </issue>
 
     <issue
         id="AlwaysShowAction"
-        message="Prefer &quot;`ifRoom`&quot; instead of &quot;`always`&quot;">
+        message="Prefer &quot;`ifRoom`&quot; instead of &quot;`always`&quot;"
+        errorLine1="        app:showAsAction=&quot;always&quot; />"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/menu/reader_list.xml"
-            line="9"/>
+            line="9"
+            column="9"/>
         <location
             file="src/main/res/menu/reader_list.xml"
-            line="16"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/add_category.xml"
-            line="26"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/alert_create_link.xml"
-            line="9"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/alert_create_link.xml"
-            line="17"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/alert_image_options.xml"
-            line="15"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/alert_image_options.xml"
-            line="23"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/alert_image_options.xml"
-            line="57"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/comment_edit_activity.xml"
-            line="25"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/delete_site_dialog.xml"
-            line="7"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/dialog_image_options.xml"
-            line="61"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/dialog_image_options.xml"
-            line="76"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/dialog_image_options.xml"
-            line="90"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/dialog_image_options.xml"
-            line="122"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/dialog_image_options.xml"
-            line="156"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/dialog_link.xml"
-            line="16"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/dialog_link.xml"
-            line="34"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/fragment_edit_post_content.xml"
-            line="22"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/my_profile_dialog.xml"
-            line="29"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/people_invite_fragment.xml"
-            line="159"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/post_settings_tags_activity.xml"
-            line="18"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/reader_activity_subs.xml"
-            line="54"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/site_creation_domain_input.xml"
-            line="10"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/site_settings_format_dialog.xml"
-            line="28"/>
-    </issue>
-
-    <issue
-        id="Autofill"
-        message="Missing `autofillHints` attribute">
-        <location
-            file="src/main/res/layout/wppref_text_dialog.xml"
-            line="19"/>
+            line="16"
+            column="9"/>
     </issue>
 
     <issue
         id="ViewConstructor"
-        message="Custom view `ReactAztecText` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`">
+        message="Custom view `ReactAztecText` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="public class ReactAztecText extends AztecText {"
+        errorLine2="             ~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java"
-            line="30"/>
+            line="30"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `RecyclableWrapperViewGroup` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="    static class RecyclableWrapperViewGroup extends ViewGroup {"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollView.java"
+            line="78"
+            column="18"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`">
+        message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`"
+        errorLine1="        mTitle.setOnTouchListener(this);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/editor/AztecEditorFragment.java"
-            line="233"/>
+            line="233"
+            column="9"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        message="`AztecEditorFragment#onTouch` should call `View#performClick` when a click is detected">
+        message="Custom view ``AztecText`` has `setOnTouchListener` called on it but does not override `performClick`"
+        errorLine1="        mContent.setOnTouchListener(this);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/editor/AztecEditorFragment.java"
-            line="1361"/>
+            line="234"
+            column="9"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        message="Custom view `CustomSwipeRefreshLayout` overrides `onTouchEvent` but not `performClick`">
+        message="Custom view ``SourceViewEditText`` has `setOnTouchListener` called on it but does not override `performClick`"
+        errorLine1="        mSource.setOnTouchListener(this);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/wordpress/android/editor/AztecEditorFragment.java"
+            line="235"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="`AztecEditorFragment#onTouch` should call `View#performClick` when a click is detected"
+        errorLine1="    public boolean onTouch(View view, MotionEvent event) {"
+        errorLine2="                   ~~~~~~~">
+        <location
+            file="src/main/java/org/wordpress/android/editor/AztecEditorFragment.java"
+            line="1361"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="Custom view `CustomSwipeRefreshLayout` overrides `onTouchEvent` but not `performClick`"
+        errorLine1="    public boolean onTouchEvent(MotionEvent event) {"
+        errorLine2="                   ~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/util/widgets/CustomSwipeRefreshLayout.java"
-            line="21"/>
+            line="21"
+            column="20"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`">
+        message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`"
+        errorLine1="        mSourceViewTitle.setOnTouchListener(this);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/editor/EditorFragment.java"
-            line="359"/>
+            line="359"
+            column="9"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`">
+        message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`"
+        errorLine1="        mSourceViewContent.setOnTouchListener(this);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/editor/EditorFragment.java"
-            line="360"/>
+            line="360"
+            column="9"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        message="`EditorFragment#onTouch` should call `View#performClick` when a click is detected">
+        message="`EditorFragment#onTouch` should call `View#performClick` when a click is detected"
+        errorLine1="    public boolean onTouch(View view, MotionEvent event) {"
+        errorLine2="                   ~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/editor/EditorFragment.java"
-            line="797"/>
+            line="797"
+            column="20"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`">
+        message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`"
+        errorLine1="        mTitle.setOnTouchListener(this);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java"
-            line="118"/>
+            line="118"
+            column="9"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        message="`GutenbergEditorFragment#onTouch` should call `View#performClick` when a click is detected">
+        message="Custom view ``SourceViewEditText`` has `setOnTouchListener` called on it but does not override `performClick`"
+        errorLine1="        mSource.setOnTouchListener(this);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java"
-            line="487"/>
+            line="119"
+            column="9"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        message="Custom view ``WPEditText`` has `setOnTouchListener` called on it but does not override `performClick`">
+        message="`GutenbergEditorFragment#onTouch` should call `View#performClick` when a click is detected"
+        errorLine1="    public boolean onTouch(View view, MotionEvent event) {"
+        errorLine2="                   ~~~~~~~">
+        <location
+            file="src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java"
+            line="487"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="Custom view ``WPEditText`` has `setOnTouchListener` called on it but does not override `performClick`"
+        errorLine1="        mContentEditText.setOnTouchListener(this);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java"
-            line="218"/>
+            line="218"
+            column="9"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        message="`LegacyEditorFragment#onTouch` should call `View#performClick` when a click is detected">
+        message="`LegacyEditorFragment#onTouch` should call `View#performClick` when a click is detected"
+        errorLine1="    public boolean onTouch(View v, MotionEvent event) {"
+        errorLine2="                   ~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java"
-            line="674"/>
+            line="674"
+            column="20"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        message="Custom view `RippleToggleButton` overrides `onTouchEvent` but not `performClick`">
+        message="Custom view `RecyclableWrapperViewGroup` overrides `onTouchEvent` but not `performClick`"
+        errorLine1="        public boolean onTouchEvent(MotionEvent event) {"
+        errorLine2="                       ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollView.java"
+            line="146"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="Custom view `RecyclerViewBackedScrollView` overrides `onTouchEvent` but not `performClick`"
+        errorLine1="    public boolean onTouchEvent(MotionEvent ev) {"
+        errorLine2="                   ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollView.java"
+            line="330"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="Custom view `RippleToggleButton` overrides `onTouchEvent` but not `performClick`"
+        errorLine1="    public boolean onTouchEvent(@NonNull MotionEvent event) {"
+        errorLine2="                   ~~~~~~~~~~~~">
         <location
             file="src/main/java/org/wordpress/android/editor/RippleToggleButton.java"
-            line="83"/>
+            line="83"
+            column="20"/>
     </issue>
 
     <issue
         id="ContentDescription"
-        message="Missing `contentDescription` attribute on image">
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="            &lt;ImageView"
+        errorLine2="            ^">
         <location
             file="src/main/res/layout/dialog_image_options.xml"
-            line="142"/>
+            line="142"
+            column="13"/>
     </issue>
 
     <issue
         id="ContentDescription"
-        message="Missing `contentDescription` attribute on image">
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="        ^">
         <location
             file="src/main/res/layout/format_bar.xml"
-            line="104"/>
+            line="104"
+            column="9"/>
     </issue>
 
     <issue
         id="ContentDescription"
-        message="Missing `contentDescription` attribute on image">
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="            &lt;ImageView"
+        errorLine2="            ^">
         <location
             file="src/main/res/layout-land/login_magic_link_request_screen.xml"
-            line="21"/>
+            line="21"
+            column="13"/>
     </issue>
 
     <issue
         id="ContentDescription"
-        message="Missing `contentDescription` attribute on image">
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="                &lt;ImageView"
+        errorLine2="                ^">
         <location
             file="src/main/res/layout/login_magic_link_request_screen.xml"
-            line="28"/>
+            line="28"
+            column="17"/>
     </issue>
 
     <issue
         id="ContentDescription"
-        message="Missing `contentDescription` attribute on image">
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="            &lt;ImageView"
+        errorLine2="            ^">
         <location
             file="src/main/res/layout/login_username_password_screen.xml"
-            line="29"/>
+            line="29"
+            column="13"/>
     </issue>
 
     <issue
         id="ContentDescription"
-        message="Missing `contentDescription` attribute on image">
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="            &lt;ImageView"
+        errorLine2="            ^">
         <location
             file="src/main/res/layout/login_username_password_screen.xml"
-            line="37"/>
+            line="37"
+            column="13"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        message="`@id/read_reviews_container` can overlap `@id/rating_bar` if @id/read_reviews_container grows due to localized text expansion">
+        message="`@id/read_reviews_container` can overlap `@id/rating_bar` if @id/read_reviews_container grows due to localized text expansion"
+        errorLine1="        &lt;LinearLayout"
+        errorLine2="        ^">
         <location
             file="src/main/res/layout/plugin_ratings_cardview.xml"
-            line="27"/>
+            line="27"
+            column="9"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        message="`@id/text_num_downloads` can overlap `@id/text_num_ratings` if @id/text_num_ratings, @id/text_num_downloads grow due to localized text expansion">
+        message="`@id/text_num_downloads` can overlap `@id/text_num_ratings` if @id/text_num_ratings, @id/text_num_downloads grow due to localized text expansion"
+        errorLine1="            &lt;TextView"
+        errorLine2="            ^">
         <location
             file="src/main/res/layout/plugin_ratings_cardview.xml"
-            line="212"/>
+            line="212"
+            column="13"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        message="`@id/reply_container` can overlap `@id/text_comment_date` if @id/text_comment_date, @id/reply_container grow due to localized text expansion">
+        message="`@id/reply_container` can overlap `@id/text_comment_date` if @id/text_comment_date, @id/reply_container grow due to localized text expansion"
+        errorLine1="            &lt;LinearLayout"
+        errorLine2="            ^">
         <location
             file="src/main/res/layout/reader_listitem_comment.xml"
-            line="86"/>
+            line="86"
+            column="13"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        message="`@id/stats_views_totals` can overlap `@id/stats_views_label` if @string/stats_default_number_zero, @string/stats_default_number_zero grow due to localized text expansion">
+        message="`@id/stats_views_totals` can overlap `@id/stats_views_label` if @string/stats_default_number_zero, @string/stats_default_number_zero grow due to localized text expansion"
+        errorLine1="                    &lt;org.wordpress.android.widgets.WPTextView"
+        errorLine2="                    ^">
         <location
             file="src/main/res/layout/stats_activity_single_post_details.xml"
-            line="73"/>
+            line="73"
+            column="21"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        message="`org.wordpress.android.widgets.WPTextView-3` can overlap `org.wordpress.android.widgets.WPTextView-1` if @string/stats_period, @string/stats_total grow due to localized text expansion">
+        message="`org.wordpress.android.widgets.WPTextView-3` can overlap `org.wordpress.android.widgets.WPTextView-1` if @string/stats_period, @string/stats_total grow due to localized text expansion"
+        errorLine1="                    &lt;org.wordpress.android.widgets.WPTextView"
+        errorLine2="                    ^">
         <location
             file="src/main/res/layout/stats_activity_single_post_details.xml"
-            line="129"/>
+            line="129"
+            column="21"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        message="`org.wordpress.android.widgets.WPTextView-3` can overlap `org.wordpress.android.widgets.WPTextView-1` if @string/stats_period, @string/stats_overall grow due to localized text expansion">
+        message="`org.wordpress.android.widgets.WPTextView-3` can overlap `org.wordpress.android.widgets.WPTextView-1` if @string/stats_period, @string/stats_overall grow due to localized text expansion"
+        errorLine1="                    &lt;org.wordpress.android.widgets.WPTextView"
+        errorLine2="                    ^">
         <location
             file="src/main/res/layout/stats_activity_single_post_details.xml"
-            line="191"/>
+            line="191"
+            column="21"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        message="`org.wordpress.android.widgets.WPTextView-3` can overlap `org.wordpress.android.widgets.WPTextView-1` if @string/stats_period, @string/stats_total grow due to localized text expansion">
+        message="`org.wordpress.android.widgets.WPTextView-3` can overlap `org.wordpress.android.widgets.WPTextView-1` if @string/stats_period, @string/stats_total grow due to localized text expansion"
+        errorLine1="                    &lt;org.wordpress.android.widgets.WPTextView"
+        errorLine2="                    ^">
         <location
             file="src/main/res/layout/stats_activity_single_post_details.xml"
-            line="253"/>
+            line="253"
+            column="21"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        message="`@id/stats_list_totals_label` can overlap `@id/stats_list_entry_label` if @id/stats_list_entry_label, @id/stats_list_totals_label grow due to localized text expansion">
+        message="`@id/stats_list_totals_label` can overlap `@id/stats_list_entry_label` if @id/stats_list_entry_label, @id/stats_list_totals_label grow due to localized text expansion"
+        errorLine1="                    &lt;org.wordpress.android.widgets.WPTextView"
+        errorLine2="                    ^">
         <location
             file="src/main/res/layout/stats_expandable_list_fragment.xml"
-            line="94"/>
+            line="94"
+            column="21"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        message="`LinearLayout-1` can overlap `LinearLayout-3` if LinearLayout-1 grows due to localized text expansion">
+        message="`LinearLayout-1` can overlap `LinearLayout-3` if LinearLayout-1 grows due to localized text expansion"
+        errorLine1="            &lt;LinearLayout"
+        errorLine2="            ^">
         <location
             file="src/main/res/layout-sw600dp/theme_grid_cardview_header.xml"
-            line="21"/>
+            line="21"
+            column="13"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        message="`LinearLayout-1` can overlap `LinearLayout-3` if LinearLayout-1 grows due to localized text expansion">
+        message="`LinearLayout-1` can overlap `LinearLayout-3` if LinearLayout-1 grows due to localized text expansion"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                ^">
         <location
             file="src/main/res/layout/theme_grid_item.xml"
-            line="46"/>
+            line="46"
+            column="17"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry">
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
+        errorLine1="            android:paddingEnd=&quot;@dimen/margin_large&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/comment_listitem.xml"
-            line="101"/>
+            line="101"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry">
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="        android:paddingStart=&quot;@dimen/start_over_preference_margin_small&quot;/>"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/domain_removal_preference.xml"
-            line="15"/>
+            line="15"
+            column="9"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        message="When you define `paddingLeft` you should probably also define `paddingRight` for right-to-left symmetry">
+        message="When you define `paddingLeft` you should probably also define `paddingRight` for right-to-left symmetry"
+        errorLine1="            android:paddingLeft=&quot;16dp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/fragment_edit_post_content.xml"
-            line="69"/>
+            line="69"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry">
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;16dp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/fragment_edit_post_content.xml"
-            line="70"/>
+            line="70"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry">
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
+        errorLine1="            android:paddingEnd=&quot;8dip&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/home_row.xml"
-            line="44"/>
+            line="44"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        message="When you define `paddingRight` you should probably also define `paddingLeft` for right-to-left symmetry">
+        message="When you define `paddingRight` you should probably also define `paddingLeft` for right-to-left symmetry"
+        errorLine1="            android:paddingRight=&quot;@dimen/textinputlayout_correction_padding_right&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_input_row.xml"
-            line="39"/>
+            line="39"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry">
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
+        errorLine1="            android:paddingEnd=&quot;@dimen/textinputlayout_correction_padding_right&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_input_row.xml"
-            line="40"/>
+            line="40"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry">
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
+        errorLine1="    android:paddingEnd=&quot;@dimen/margin_extra_extra_large&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-sw600dp-land/login_intro_template_view.xml"
-            line="7"/>
+            line="7"
+            column="5"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry">
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
+        errorLine1="                android:paddingEnd=&quot;@dimen/margin_medium&quot; >"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_cardview_post.xml"
-            line="220"/>
+            line="220"
+            column="17"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry">
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;@dimen/margin_small&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/reader_include_comment_box.xml"
-            line="55"/>
+            line="55"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry">
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;@dimen/margin_small&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/site_settings_format_dialog.xml"
-            line="37"/>
+            line="37"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry">
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;@dimen/margin_small&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/site_settings_format_dialog.xml"
-            line="55"/>
+            line="55"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry">
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;@dimen/start_over_title_margin&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/start_over_preference.xml"
-            line="39"/>
+            line="39"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry">
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="        android:paddingStart=&quot;@dimen/start_over_preference_margin_small&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/start_over_preference.xml"
-            line="51"/>
+            line="51"
+            column="9"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry">
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
+        errorLine1="                    android:paddingEnd=&quot;@dimen/margin_medium&quot;/>"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/stats_visitors_and_views_fragment.xml"
-            line="91"/>
+            line="91"
+            column="21"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26"
+        errorLine1="    android:layout_alignParentRight=&quot;true&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/alert_create_link.xml"
-            line="31"/>
+            line="31"
+            column="5"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26"
+        errorLine1="    android:layout_marginLeft=&quot;@dimen/margin_medium&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/alert_create_link.xml"
-            line="32"/>
+            line="32"
+            column="5"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 26"
+        errorLine1="    android:layout_toLeftOf=&quot;@id/ok&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/alert_create_link.xml"
-            line="41"/>
+            line="41"
+            column="5"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26"
+        errorLine1="                android:layout_marginLeft=&quot;@dimen/image_settings_dialog_thumbnail_left_margin&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/dialog_image_options.xml"
-            line="26"/>
+            line="26"
+            column="17"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
+        errorLine1="                android:layout_marginRight=&quot;@dimen/image_settings_dialog_thumbnail_right_margin&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/dialog_image_options.xml"
-            line="28"/>
+            line="28"
+            column="17"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26"
+        errorLine1="                android:layout_marginLeft=&quot;@dimen/image_settings_dialog_filename_margin_left&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/dialog_image_options.xml"
-            line="50"/>
+            line="50"
+            column="17"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_marginLeft=&quot;@dimen/image_settings_dialog_input_field_start_margin&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/dialog_image_options.xml"
-            line="111"/>
+            line="111"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_toRightOf`; already defining `layout_toEndOf` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_toRightOf`; already defining `layout_toEndOf` with `targetSdkVersion` 26"
+        errorLine1="                android:layout_toRightOf=&quot;@+id/image_icon&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/dialog_image_options.xml"
-            line="152"/>
+            line="152"
+            column="17"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_marginLeft=&quot;@dimen/image_settings_dialog_input_field_start_margin&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/dialog_image_options.xml"
-            line="172"/>
+            line="172"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26"
+        errorLine1="            android:paddingLeft=&quot;16dp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/fragment_edit_post_content.xml"
-            line="69"/>
+            line="69"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `drawableLeft`; already defining `drawableStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `drawableLeft`; already defining `drawableStart` with `targetSdkVersion` 26"
+        errorLine1="            android:drawableLeft=&quot;@drawable/ic_post_settings&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/fragment_edit_post_content.xml"
-            line="72"/>
+            line="72"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_marginLeft=&quot;@dimen/margin_extra_large&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_email_password_screen.xml"
-            line="42"/>
+            line="42"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26"
+        errorLine1="        android:paddingRight=&quot;@dimen/margin_medium&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_email_screen.xml"
-            line="60"/>
+            line="60"
+            column="9"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_marginRight=&quot;@dimen/margin_medium&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_email_screen.xml"
-            line="69"/>
+            line="69"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26"
+        errorLine1="        android:paddingRight=&quot;@dimen/margin_medium&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_email_screen.xml"
-            line="95"/>
+            line="95"
+            column="9"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_marginRight=&quot;@dimen/margin_medium&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_email_screen.xml"
-            line="105"/>
+            line="105"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26"
+        errorLine1="        android:paddingLeft=&quot;@dimen/margin_small_medium&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_form_screen.xml"
-            line="31"/>
+            line="31"
+            column="9"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26"
+        errorLine1="        android:paddingRight=&quot;@dimen/margin_medium_large&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_form_screen.xml"
-            line="33"/>
+            line="33"
+            column="9"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_alignParentLeft=&quot;true&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_form_screen.xml"
-            line="45"/>
+            line="45"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_toLeftOf=&quot;@+id/primary_button&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_form_screen.xml"
-            line="47"/>
+            line="47"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_marginRight=&quot;@dimen/margin_extra_large&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_form_screen.xml"
-            line="53"/>
+            line="53"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_alignParentRight=&quot;true&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_form_screen.xml"
-            line="63"/>
+            line="63"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
+        errorLine1="        android:layout_marginRight=&quot;@dimen/margin_extra_large&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_input_row.xml"
-            line="15"/>
+            line="15"
+            column="9"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_toRightOf`; already defining `layout_toEndOf` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_toRightOf`; already defining `layout_toEndOf` with `targetSdkVersion` 26"
+        errorLine1="        android:layout_toRightOf=&quot;@+id/icon&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_input_row.xml"
-            line="27"/>
+            line="27"
+            column="9"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_marginRight=&quot;@dimen/textinputlayout_correction_margin_right&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_input_row.xml"
-            line="37"/>
+            line="37"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26"
+        errorLine1="            android:paddingRight=&quot;@dimen/textinputlayout_correction_padding_right&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_input_row.xml"
-            line="39"/>
+            line="39"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26"
+        errorLine1="        android:paddingLeft=&quot;@dimen/margin_small_medium&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/login_magic_link_request_screen.xml"
-            line="52"/>
+            line="52"
+            column="9"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26"
+        errorLine1="        android:paddingRight=&quot;@dimen/margin_medium_large&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/login_magic_link_request_screen.xml"
-            line="54"/>
+            line="54"
+            column="9"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_alignParentLeft=&quot;true&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/login_magic_link_request_screen.xml"
-            line="67"/>
+            line="67"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_toLeftOf=&quot;@+id/login_request_magic_link&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/login_magic_link_request_screen.xml"
-            line="69"/>
+            line="69"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
+        errorLine1="                android:layout_marginRight=&quot;@dimen/margin_extra_large&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_magic_link_request_screen.xml"
-            line="73"/>
+            line="73"
+            column="17"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_marginRight=&quot;@dimen/margin_extra_large&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/login_magic_link_request_screen.xml"
-            line="75"/>
+            line="75"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_alignParentRight=&quot;true&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/login_magic_link_request_screen.xml"
-            line="85"/>
+            line="85"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26"
+        errorLine1="        android:paddingLeft=&quot;@dimen/margin_small_medium&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/login_magic_link_sent_screen.xml"
-            line="42"/>
+            line="42"
+            column="9"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26"
+        errorLine1="        android:paddingRight=&quot;@dimen/margin_medium_large&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/login_magic_link_sent_screen.xml"
-            line="44"/>
+            line="44"
+            column="9"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_alignParentLeft=&quot;true&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/login_magic_link_sent_screen.xml"
-            line="57"/>
+            line="57"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_toLeftOf=&quot;@+id/login_open_email_client&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/login_magic_link_sent_screen.xml"
-            line="59"/>
+            line="59"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_marginRight=&quot;@dimen/margin_extra_large&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/login_magic_link_sent_screen.xml"
-            line="65"/>
+            line="65"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_alignParentRight=&quot;true&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/login_magic_link_sent_screen.xml"
-            line="75"/>
+            line="75"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_marginRight=&quot;@dimen/textinputlayout_correction_padding&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_username_password_screen.xml"
-            line="25"/>
+            line="25"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_marginLeft=&quot;@dimen/margin_extra_large&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/login_username_password_screen.xml"
-            line="50"/>
+            line="50"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_marginRight=&quot;@dimen/margin_medium&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/signup_bottom_sheet_dialog.xml"
-            line="37"/>
+            line="37"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_marginLeft=&quot;@dimen/margin_medium&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/signup_bottom_sheet_dialog.xml"
-            line="48"/>
+            line="48"
+            column="13"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26">
+        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26"
+        errorLine1="        android:paddingLeft=&quot;@dimen/margin_small_medium&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/signup_magic_link.xml"
-            line="56"/>
+            line="56"
+            column="9"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26"
+        errorLine1="        android:paddingRight=&quot;@dimen/margin_medium_large&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/signup_magic_link.xml"
-            line="57"/>
+            line="57"
+            column="9"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26">
+        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26"
+        errorLine1="            android:layout_alignParentRight=&quot;true&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout-land/signup_magic_link.xml"
-            line="65"/>
+            line="65"
+            column="13"/>
     </issue>
 
 </issues>

--- a/WordPress/lint-baseline.xml
+++ b/WordPress/lint-baseline.xml
@@ -1,5695 +1,5620 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="4" by="lint 3.1.3">
+<issues format="4" by="lint 3.2.1">
 
     <issue
-        id="DefaultLocale"
-        message="Implicitly using the default locale is a common source of bugs: Use `toUpperCase(Locale)` instead. For strings meant to be internal use `Locale.ROOT`, otherwise `Locale.getDefault()`."
-        errorLine1="            matched.appendReplacement(sb, matched.group(1).toUpperCase());"
-        errorLine2="                                                           ~~~~~~~~~~~">
+        id="WrongViewCast"
+        message="Unexpected cast to `EditorWebViewAbstract`: layout tag was `WebView`">
         <location
-            file="src/main/java/com/horcrux/svg/RenderableShadowNode.java"
-            line="400"
-            column="60"/>
-    </issue>
-
-    <issue
-        id="WrongCall"
-        message="Suspicious method call; should probably call &quot;`layout`&quot; rather than &quot;`onLayout`&quot;"
-        errorLine1="                    onLayout(false, getLeft(), getTop(), getRight(), getBottom());"
-        errorLine2="                    ~~~~~~~~">
+            file="src/main/java/org/wordpress/android/editor/EditorFragment.java"
+            line="294"/>
         <location
-            file="src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollView.java"
-            line="364"
-            column="21"/>
-    </issue>
-
-    <issue
-        id="ClickableViewAccessibility"
-        message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`"
-        errorLine1="        mTitle.setOnTouchListener(this);"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java"
-            line="282"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="ClickableViewAccessibility"
-        message="Custom view ``SourceViewEditText`` has `setOnTouchListener` called on it but does not override `performClick`"
-        errorLine1="        mSource.setOnTouchListener(this);"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java"
-            line="284"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="ClickableViewAccessibility"
-        message="`GutenbergEditorFragment#onTouch` should call `View#performClick` when a click is detected"
-        errorLine1="    public boolean onTouch(View view, MotionEvent event) {"
-        errorLine2="                   ~~~~~~~">
-        <location
-            file="src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java"
-            line="1478"
-            column="20"/>
-    </issue>
-
-    <issue
-        id="ClickableViewAccessibility"
-        message="Custom view `RecyclableWrapperViewGroup` overrides `onTouchEvent` but not `performClick`"
-        errorLine1="        public boolean onTouchEvent(MotionEvent event) {"
-        errorLine2="                       ~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollView.java"
-            line="146"
-            column="24"/>
-    </issue>
-
-    <issue
-        id="ClickableViewAccessibility"
-        message="Custom view `RecyclerViewBackedScrollView` overrides `onTouchEvent` but not `performClick`"
-        errorLine1="    public boolean onTouchEvent(MotionEvent ev) {"
-        errorLine2="                   ~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollView.java"
-            line="330"
-            column="20"/>
+            file="src/main/java/org/wordpress/android/editor/EditorFragment.java"
+            line="294"/>
     </issue>
 
     <issue
         id="ExifInterface"
-        severity="Warning"
-        message="Avoid using `android.media.ExifInterface`; use `android.support.media.ExifInterface` from the support library instead"
-        category="Correctness"
-        priority="6"
-        summary="Using `android.media.ExifInterface`"
-        explanation="The `android.media.ExifInterface` implementation has some known security bugs in older versions of Android. There is a new implementation available of this library in the support library, which is preferable."
-        errorLine1="import android.media.ExifInterface;"
-        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Avoid using `android.media.ExifInterface`; use `android.support.media.ExifInterface` from the support library instead">
         <location
-            file="../libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java"
-            line="17"
-            column="8"/>
+            file="src/main/java/org/wordpress/android/util/ImageUtils.java"
+            line="17"/>
     </issue>
 
     <issue
         id="LocaleFolder"
-        severity="Warning"
-        message="The locale folder &quot;`he`&quot; should be called &quot;`iw`&quot; instead; see the `java.util.Locale` documentation"
-        category="Correctness"
-        priority="6"
-        summary="Wrong locale name"
-        explanation="From the `java.util.Locale` documentation:&#xA;&quot;Note that Java uses several deprecated two-letter codes. The Hebrew (&quot;he&quot;) language code is rewritten as &quot;iw&quot;, Indonesian (&quot;id&quot;) as &quot;in&quot;, and Yiddish (&quot;yi&quot;) as &quot;ji&quot;. This rewriting happens even if you construct your own Locale object, not just for instances returned by the various lookup methods.&#xA;&#xA;Because of this, if you add your localized resources in for example `values-he` they will not be used, since the system will look for `values-iw` instead.&#xA;&#xA;To work around this, place your resources in a `values` folder using the deprecated language code instead."
-        url="http://developer.android.com/reference/java/util/Locale.html"
-        urls="http://developer.android.com/reference/java/util/Locale.html">
+        message="The locale folder &quot;`he`&quot; should be called &quot;`iw`&quot; instead; see the `java.util.Locale` documentation">
         <location
-            file="../WordPress/src/main/res/values-he"/>
+            file="src/main/res/values-he"/>
     </issue>
 
     <issue
         id="LocaleFolder"
-        severity="Warning"
-        message="The locale folder &quot;`id`&quot; should be called &quot;`in`&quot; instead; see the `java.util.Locale` documentation"
-        category="Correctness"
-        priority="6"
-        summary="Wrong locale name"
-        explanation="From the `java.util.Locale` documentation:&#xA;&quot;Note that Java uses several deprecated two-letter codes. The Hebrew (&quot;he&quot;) language code is rewritten as &quot;iw&quot;, Indonesian (&quot;id&quot;) as &quot;in&quot;, and Yiddish (&quot;yi&quot;) as &quot;ji&quot;. This rewriting happens even if you construct your own Locale object, not just for instances returned by the various lookup methods.&#xA;&#xA;Because of this, if you add your localized resources in for example `values-he` they will not be used, since the system will look for `values-iw` instead.&#xA;&#xA;To work around this, place your resources in a `values` folder using the deprecated language code instead."
-        url="http://developer.android.com/reference/java/util/Locale.html"
-        urls="http://developer.android.com/reference/java/util/Locale.html">
+        message="The locale folder &quot;`id`&quot; should be called &quot;`in`&quot; instead; see the `java.util.Locale` documentation">
         <location
-            file="../WordPress/src/main/res/values-id"/>
+            file="src/main/res/values-id"/>
+    </issue>
+
+    <issue
+        id="OldTargetApi"
+        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the android.os.Build.VERSION_CODES javadoc for details.">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="OldTargetApi"
+        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the android.os.Build.VERSION_CODES javadoc for details.">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="OldTargetApi"
+        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the android.os.Build.VERSION_CODES javadoc for details.">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="OldTargetApi"
+        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the android.os.Build.VERSION_CODES javadoc for details.">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="OldTargetApi"
+        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the android.os.Build.VERSION_CODES javadoc for details.">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="OldTargetApi"
+        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the android.os.Build.VERSION_CODES javadoc for details.">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="OldTargetApi"
+        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the android.os.Build.VERSION_CODES javadoc for details.">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="Registered"
+        message="The `&lt;application> org.wordpress.android.WordPress` is not registered in the manifest">
+        <location
+            file="src/main/java/org/wordpress/android/WordPress.java"
+            line="111"/>
     </issue>
 
     <issue
         id="UnusedAttribute"
-        severity="Error"
-        message="Attribute `drawableTint` is only used in API level 23 and higher (current min is 21)"
-        category="Correctness"
-        priority="6"
-        summary="Attribute unused on older versions"
-        explanation="This check finds attributes set in XML files that were introduced in a version newer than the oldest version targeted by your application (with the `minSdkVersion` attribute).&#xA;&#xA;This is not an error; the application will simply ignore the attribute. However, if the attribute is important to the appearance or functionality of your application, you should consider finding an alternative way to achieve the same result with only available attributes, and then you can optionally create a copy of the layout in a layout-vNN folder which will be used on API NN or higher where you can take advantage of the newer attribute.&#xA;&#xA;Note: This check does not only apply to attributes. For example, some tags can be unused too, such as the new `&lt;tag>` element in layouts introduced in API 21."
-        errorLine1="                android:drawableTint=&quot;@color/blue_wordpress&quot;"
-        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Attribute `drawableTint` is only used in API level 23 and higher (current min is 21)">
         <location
-            file="../WordPress/src/main/res/layout/people_invite_fragment.xml"
-            line="133"
-            column="17"/>
+            file="src/main/res/layout/people_invite_fragment.xml"
+            line="133"/>
     </issue>
 
     <issue
         id="UnusedAttribute"
-        severity="Error"
-        message="Attribute `drawableTint` is only used in API level 23 and higher (current min is 21)"
-        category="Correctness"
-        priority="6"
-        summary="Attribute unused on older versions"
-        explanation="This check finds attributes set in XML files that were introduced in a version newer than the oldest version targeted by your application (with the `minSdkVersion` attribute).&#xA;&#xA;This is not an error; the application will simply ignore the attribute. However, if the attribute is important to the appearance or functionality of your application, you should consider finding an alternative way to achieve the same result with only available attributes, and then you can optionally create a copy of the layout in a layout-vNN folder which will be used on API NN or higher where you can take advantage of the newer attribute.&#xA;&#xA;Note: This check does not only apply to attributes. For example, some tags can be unused too, such as the new `&lt;tag>` element in layouts introduced in API 21."
-        errorLine1="        android:drawableTint=&quot;@color/grey_text_min&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Attribute `drawableTint` is only used in API level 23 and higher (current min is 21)">
         <location
-            file="../WordPress/src/main/res/layout/site_creation_domain_input.xml"
-            line="16"
-            column="9"/>
+            file="src/main/res/layout/site_creation_domain_input.xml"
+            line="16"/>
     </issue>
 
     <issue
         id="InflateParams"
-        severity="Warning"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
-        category="Correctness"
-        priority="5"
-        summary="Layout Inflation without a Parent"
-        explanation="When inflating a layout, avoid passing in null as the parent view, since otherwise any layout parameters on the root of the inflated layout will be ignored."
-        url="http://www.doubleencore.com/2013/05/layout-inflation-as-intended"
-        urls="http://www.doubleencore.com/2013/05/layout-inflation-as-intended"
-        errorLine1="    val layout = LayoutInflater.from(context).inflate(R.layout.support_email_and_name_dialog, null)"
-        errorLine2="                                                                                              ~~~~">
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/support/SupportHelper.kt"
-            line="96"
-            column="95"/>
+            file="src/main/java/org/wordpress/android/ui/posts/AddCategoryFragment.java"
+            line="56"/>
     </issue>
 
     <issue
         id="InflateParams"
-        severity="Warning"
-        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
-        category="Correctness"
-        priority="5"
-        summary="Layout Inflation without a Parent"
-        explanation="When inflating a layout, avoid passing in null as the parent view, since otherwise any layout parameters on the root of the inflated layout will be ignored."
-        url="http://www.doubleencore.com/2013/05/layout-inflation-as-intended"
-        urls="http://www.doubleencore.com/2013/05/layout-inflation-as-intended"
-        errorLine1="        mContentView = LayoutInflater.from(view.getContext()).inflate(R.layout.dialog_snackbar, null);"
-        errorLine2="                                                                                                ~~~~">
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/widgets/WPDialogSnackbar.java"
-            line="34"
-            column="97"/>
+            file="src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java"
+            line="167"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        <location
+            file="src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java"
+            line="249"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        <location
+            file="src/main/java/org/wordpress/android/ui/prefs/DeleteSiteDialogFragment.java"
+            line="111"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        <location
+            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java"
+            line="723"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        <location
+            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LinkDialogFragment.java"
+            line="29"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        <location
+            file="/Users/mariozorz/proyectos/WordPress-Android/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginHttpAuthDialogFragment.java"
+            line="55"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        <location
+            file="/Users/mariozorz/proyectos/WordPress-Android/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressHelpDialogFragment.java"
+            line="47"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        <location
+            file="src/main/java/org/wordpress/android/ui/posts/PostSettingsInputDialogFragment.java"
+            line="85"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        <location
+            file="src/main/java/org/wordpress/android/ui/prefs/ProfileInputDialogFragment.java"
+            line="49"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        <location
+            file="src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserDialogFragment.java"
+            line="51"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        <location
+            file="src/main/java/org/wordpress/android/ui/prefs/RelatedPostsDialog.java"
+            line="65"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        <location
+            file="src/main/java/org/wordpress/android/ui/prefs/RelatedPostsDialog.java"
+            line="98"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        <location
+            file="/Users/mariozorz/proyectos/WordPress-Android/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupBottomSheetDialog.java"
+            line="19"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        <location
+            file="src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTimezoneDialog.java"
+            line="88"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        <location
+            file="src/main/java/org/wordpress/android/support/SupportHelper.kt"
+            line="96"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        <location
+            file="src/main/java/org/wordpress/android/widgets/WPDialogSnackbar.java"
+            line="34"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)">
+        <location
+            file="src/main/java/org/wordpress/android/widgets/WPPrefView.java"
+            line="396"/>
     </issue>
 
     <issue
         id="ManifestOrder"
-        severity="Warning"
-        message="`&lt;uses-permission>` tag appears after `&lt;application>` tag"
-        category="Correctness"
-        priority="5"
-        summary="Incorrect order of elements in manifest"
-        explanation="The &lt;application> tag should appear after the elements which declare which version you need, which features you need, which libraries you need, and so on. In the past there have been subtle bugs (such as themes not getting applied correctly) when the `&lt;application>` tag appears before some of these other elements, so it&apos;s best to order your manifest in the logical dependency order."
-        errorLine1="    &lt;uses-permission android:name=&quot;android.permission.DISABLE_KEYGUARD&quot;/>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="`&lt;uses-permission>` tag appears after `&lt;application>` tag">
         <location
-            file="../WordPress/src/debug/AndroidManifest.xml"
-            line="18"
-            column="5"/>
+            file="src/debug/AndroidManifest.xml"
+            line="18"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        severity="Warning"
-        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1"
-        category="Correctness"
-        priority="4"
-        summary="Obsolete Gradle Dependency"
-        explanation="This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find."
-        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.1.2&apos;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="A newer version of com.android.support.constraint:constraint-layout than 1.1.2 is available: 1.1.3">
         <location
-            file="../libs/analytics/WordPressAnalytics/build.gradle"
-            line="7"
-            column="9"/>
+            file="build.gradle"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        severity="Warning"
-        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1"
-        category="Correctness"
-        priority="4"
-        summary="Obsolete Gradle Dependency"
-        explanation="This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find."
-        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.1.2&apos;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="A newer version of com.android.support:multidex than 1.0.2 is available: 1.0.3">
         <location
-            file="../libs/networking/WordPressNetworking/build.gradle"
-            line="7"
-            column="9"/>
+            file="build.gradle"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        severity="Warning"
-        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1"
-        category="Correctness"
-        priority="4"
-        summary="Obsolete Gradle Dependency"
-        explanation="This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find."
-        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.1.2&apos;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1">
         <location
-            file="../libs/utils/WordPressUtils/build.gradle"
-            line="7"
-            column="9"/>
+            file="build.gradle"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        severity="Warning"
-        message="A newer version of com.android.tools.build:gradle than 3.1.3 is available: 3.2.1"
-        category="Correctness"
-        priority="4"
-        summary="Obsolete Gradle Dependency"
-        explanation="This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find."
-        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.1.3&apos;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1">
         <location
-            file="../libs/login/WordPressLoginFlow/build.gradle"
-            line="7"
-            column="9"/>
+            file="build.gradle"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        severity="Warning"
-        message="A newer version of com.android.support:design than 27.1.1 is available: 28.0.0"
-        category="Correctness"
-        priority="4"
-        summary="Obsolete Gradle Dependency"
-        explanation="This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find."
-        errorLine1="    implementation &apos;com.android.support:design:27.1.1&apos;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1">
         <location
-            file="../libs/utils/WordPressUtils/build.gradle"
-            line="23"
-            column="5"/>
+            file="build.gradle"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        severity="Warning"
-        message="A newer version of org.wordpress:utils than 1.19.0 is available: 1.22"
-        category="Correctness"
-        priority="4"
-        summary="Obsolete Gradle Dependency"
-        explanation="This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find."
-        errorLine1="    implementation &apos;org.wordpress:utils:1.19.0&apos;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1">
         <location
-            file="../libs/analytics/WordPressAnalytics/build.gradle"
-            line="23"
-            column="5"/>
+            file="build.gradle"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        severity="Warning"
-        message="A newer version of com.android.support:recyclerview-v7 than 27.1.1 is available: 28.0.0"
-        category="Correctness"
-        priority="4"
-        summary="Obsolete Gradle Dependency"
-        explanation="This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find."
-        errorLine1="    implementation &apos;com.android.support:recyclerview-v7:27.1.1&apos;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="A newer version of com.android.tools.build:gradle than 3.1.3 is available: 3.2.1">
         <location
-            file="../libs/utils/WordPressUtils/build.gradle"
-            line="24"
-            column="5"/>
+            file="build.gradle"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        severity="Warning"
-        message="A newer version of org.wordpress:utils than 1.18.1 is available: 1.22"
-        category="Correctness"
-        priority="4"
-        summary="Obsolete Gradle Dependency"
-        explanation="This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find."
-        errorLine1="    implementation &apos;org.wordpress:utils:1.18.1&apos;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="A newer version of com.android.tools.build:gradle than 3.1.4 is available: 3.2.1">
         <location
-            file="../libs/networking/WordPressNetworking/build.gradle"
-            line="32"
-            column="5"/>
+            file="build.gradle"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        severity="Warning"
-        message="A newer version of org.wordpress:utils than 1.20.3 is available: 1.22"
-        category="Correctness"
-        priority="4"
-        summary="Obsolete Gradle Dependency"
-        explanation="This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find."
-        errorLine1="    implementation (&apos;org.wordpress:utils:1.20.3&apos;) {"
-        errorLine2="    ^"
-        quickfix="studio">
+        message="A newer version of com.android.tools.build:gradle than 3.1.4 is available: 3.2.1">
         <location
-            file="../libs/login/WordPressLoginFlow/build.gradle"
-            line="34"
-            column="5"/>
+            file="build.gradle"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        severity="Warning"
-        message="A newer version of com.google.android.gms:play-services-auth than 15.0.1 is available: 16.0.1"
-        category="Correctness"
-        priority="4"
-        summary="Obsolete Gradle Dependency"
-        explanation="This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find."
-        errorLine1="    api &apos;com.google.android.gms:play-services-auth:15.0.1&apos;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="A newer version of com.google.android.gms:play-services-auth than 15.0.1 is available: 16.0.1">
         <location
-            file="../libs/login/WordPressLoginFlow/build.gradle"
-            line="41"
-            column="5"/>
+            file="build.gradle"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        severity="Warning"
-        message="A newer version of com.github.bumptech.glide:glide than 4.6.1 is available: 4.8.0"
-        category="Correctness"
-        priority="4"
-        summary="Obsolete Gradle Dependency"
-        explanation="This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find."
-        errorLine1="    implementation &apos;com.github.bumptech.glide:glide:4.6.1&apos;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="A newer version of com.google.android.gms:play-services-auth than 15.0.1 is available: 16.0.1">
         <location
-            file="../libs/login/WordPressLoginFlow/build.gradle"
-            line="56"
-            column="5"/>
+            file="build.gradle"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        severity="Warning"
-        message="A newer version of com.github.bumptech.glide:compiler than 4.6.1 is available: 4.8.0"
-        category="Correctness"
-        priority="4"
-        summary="Obsolete Gradle Dependency"
-        explanation="This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find."
-        errorLine1="    annotationProcessor &apos;com.github.bumptech.glide:compiler:4.6.1&apos;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="A newer version of com.google.android.gms:play-services-places than 15.0.1 is available: 16.0.0">
         <location
-            file="../libs/login/WordPressLoginFlow/build.gradle"
-            line="57"
-            column="5"/>
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.code.gson:gson than 2.6.2 is available: 2.8.5">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.code.gson:gson than 2.6.2 is available: 2.8.5">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.dexmaker:dexmaker-mockito than 1.0 is available: 1.2">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.firebase:firebase-messaging than 17.0.0 is available: 17.3.4">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.gms:google-services than 3.2.0 is available: 4.2.0">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.squareup.okio:okio than 1.13.0 is available: 1.14.0">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.squareup.okio:okio than 1.13.0 is available: 1.14.0">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of org.jetbrains.kotlin:kotlin-stdlib than 1.1.4 is available: 1.2.71">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of org.mockito:mockito-core than 1.10.19 is available: 2.20.1">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of org.objenesis:objenesis than 2.1 is available: 2.6">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of org.wordpress:utils than 1.18.1 is available: 1.22">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of org.wordpress:utils than 1.19.0 is available: 1.22">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="GradleDynamicVersion"
+        message="Avoid using + in version numbers; can lead to unpredictable and unrepeatable builds (io.fabric.tools:gradle:1.+)">
+        <location
+            file="build.gradle"/>
     </issue>
 
     <issue
         id="PrivateResource"
-        severity="Error"
-        message="The resource `@dimen/design_fab_size_normal` is marked as private in com.android.support:design"
-        category="Correctness"
-        priority="3"
-        summary="Using private resources"
-        explanation="Private resources should not be referenced; the may not be present everywhere, and even where they are they may disappear without notice.&#xA;&#xA;To fix this, copy the resource into your own project instead."
-        errorLine1="                context.getResources().getDimensionPixelSize(android.support.design.R.dimen.design_fab_size_normal);"
-        errorLine2="                                                                                            ~~~~~~~~~~~~~~~~~~~~~~">
+        message="The resource `@dimen/design_fab_size_normal` is marked as private in com.android.support:design">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/util/AniUtils.java"
-            line="86"
-            column="93"/>
+            file="src/main/java/org/wordpress/android/util/AniUtils.java"
+            line="86"/>
     </issue>
 
     <issue
         id="SetJavaScriptEnabled"
-        severity="Warning"
-        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully."
-        category="Security"
-        priority="6"
-        summary="Using `setJavaScriptEnabled`"
-        explanation="Your code should not invoke `setJavaScriptEnabled` if you are not sure that your app really requires JavaScript support."
-        url="http://developer.android.com/guide/practices/security.html"
-        urls="http://developer.android.com/guide/practices/security.html"
-        errorLine1="        mWebView.getSettings().setJavaScriptEnabled(true);"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully.">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java"
-            line="102"
-            column="9"/>
+            file="src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItemViewHolder.kt"
+            line="502"/>
     </issue>
 
     <issue
         id="SetJavaScriptEnabled"
-        severity="Warning"
-        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully."
-        category="Security"
-        priority="6"
-        summary="Using `setJavaScriptEnabled`"
-        explanation="Your code should not invoke `setJavaScriptEnabled` if you are not sure that your app really requires JavaScript support."
-        url="http://developer.android.com/guide/practices/security.html"
-        urls="http://developer.android.com/guide/practices/security.html"
-        errorLine1="        mWebView.getSettings().setJavaScriptEnabled(true);"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully.">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderVideoViewerActivity.java"
-            line="39"
-            column="9"/>
+            file="src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java"
+            line="102"/>
     </issue>
 
     <issue
         id="SetJavaScriptEnabled"
-        severity="Warning"
-        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully."
-        category="Security"
-        priority="6"
-        summary="Using `setJavaScriptEnabled`"
-        explanation="Your code should not invoke `setJavaScriptEnabled` if you are not sure that your app really requires JavaScript support."
-        url="http://developer.android.com/guide/practices/security.html"
-        urls="http://developer.android.com/guide/practices/security.html"
-        errorLine1="                webView.getSettings().setJavaScriptEnabled(true);"
-        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully.">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java"
-            line="163"
-            column="17"/>
+            file="src/main/java/org/wordpress/android/ui/reader/ReaderVideoViewerActivity.java"
+            line="39"/>
     </issue>
 
     <issue
-        id="TrustAllX509TrustManager"
-        severity="Warning"
-        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers"
-        category="Security"
-        priority="6"
-        summary="Insecure TLS/SSL trust manager"
-        explanation="This check looks for X509TrustManager implementations whose `checkServerTrusted` or `checkClientTrusted` methods do nothing (thus trusting any certificate chain) which could result in insecure network traffic caused by trusting arbitrary TLS/SSL certificates presented by peers.">
+        id="SetJavaScriptEnabled"
+        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully.">
         <location
-            file="../org/jsoup/helper/HttpConnection$Response$2.class"/>
-    </issue>
-
-    <issue
-        id="TrustAllX509TrustManager"
-        severity="Warning"
-        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers"
-        category="Security"
-        priority="6"
-        summary="Insecure TLS/SSL trust manager"
-        explanation="This check looks for X509TrustManager implementations whose `checkServerTrusted` or `checkClientTrusted` methods do nothing (thus trusting any certificate chain) which could result in insecure network traffic caused by trusting arbitrary TLS/SSL certificates presented by peers.">
-        <location
-            file="../org/jsoup/helper/HttpConnection$Response$2.class"/>
-    </issue>
-
-    <issue
-        id="TrustAllX509TrustManager"
-        severity="Warning"
-        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers"
-        category="Security"
-        priority="6"
-        summary="Insecure TLS/SSL trust manager"
-        explanation="This check looks for X509TrustManager implementations whose `checkServerTrusted` or `checkClientTrusted` methods do nothing (thus trusting any certificate chain) which could result in insecure network traffic caused by trusting arbitrary TLS/SSL certificates presented by peers.">
-        <location
-            file="../org/jsoup/helper/HttpConnection$Response$2.class"/>
-    </issue>
-
-    <issue
-        id="TrustAllX509TrustManager"
-        severity="Warning"
-        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers"
-        category="Security"
-        priority="6"
-        summary="Insecure TLS/SSL trust manager"
-        explanation="This check looks for X509TrustManager implementations whose `checkServerTrusted` or `checkClientTrusted` methods do nothing (thus trusting any certificate chain) which could result in insecure network traffic caused by trusting arbitrary TLS/SSL certificates presented by peers.">
-        <location
-            file="../org/jsoup/helper/HttpConnection$Response$2.class"/>
+            file="src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java"
+            line="163"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        severity="Error"
-        message="Unnecessary; SDK_INT is never &lt; 21"
-        category="Performance"
-        priority="6"
-        summary="Obsolete SDK_INT Version Check"
-        explanation="This check flags version checks that are not necessary, because the `minSdkVersion` (or surrounding known API level) is already at least as high as the version checked for.&#xA;&#xA;Similarly, it also looks for resources in `-vNN` folders, such as `values-v14` where the version qualifier is less than or equal to the `minSdkVersion`, where the contents should be merged into the best folder."
-        errorLine1="        if (Build.VERSION.SDK_INT &lt; Build.VERSION_CODES.JELLY_BEAN_MR1) {"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Unnecessary; SDK_INT is never &lt; 21">
         <location
-            file="../libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DeviceUtils.java"
-            line="52"
-            column="13"/>
+            file="src/main/java/org/wordpress/android/util/DeviceUtils.java"
+            line="52"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        severity="Error"
-        message="Unnecessary; SDK_INT is always >= 21"
-        category="Performance"
-        priority="6"
-        summary="Obsolete SDK_INT Version Check"
-        explanation="This check flags version checks that are not necessary, because the `minSdkVersion` (or surrounding known API level) is already at least as high as the version checked for.&#xA;&#xA;Similarly, it also looks for resources in `-vNN` folders, such as `values-v14` where the version qualifier is less than or equal to the `minSdkVersion`, where the contents should be merged into the best folder."
-        errorLine1="        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Unnecessary; SDK_INT is always >= 21">
         <location
-            file="../libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DeviceUtils.java"
-            line="144"
-            column="13"/>
+            file="src/main/java/org/wordpress/android/util/DeviceUtils.java"
+            line="144"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        severity="Error"
-        message="Unnecessary; SDK_INT is never &lt; 21"
-        category="Performance"
-        priority="6"
-        summary="Obsolete SDK_INT Version Check"
-        explanation="This check flags version checks that are not necessary, because the `minSdkVersion` (or surrounding known API level) is already at least as high as the version checked for.&#xA;&#xA;Similarly, it also looks for resources in `-vNN` folders, such as `values-v14` where the version qualifier is less than or equal to the `minSdkVersion`, where the contents should be merged into the best folder."
-        errorLine1="        if (Build.VERSION.SDK_INT &lt; 17) {"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Unnecessary; SDK_INT is never &lt; 21">
         <location
-            file="../libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java"
-            line="571"
-            column="13"/>
+            file="src/main/java/org/wordpress/android/editor/EditorFragment.java"
+            line="571"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        severity="Error"
-        message="Unnecessary; SDK_INT is always >= 21"
-        category="Performance"
-        priority="6"
-        summary="Obsolete SDK_INT Version Check"
-        explanation="This check flags version checks that are not necessary, because the `minSdkVersion` (or surrounding known API level) is already at least as high as the version checked for.&#xA;&#xA;Similarly, it also looks for resources in `-vNN` folders, such as `values-v14` where the version qualifier is less than or equal to the `minSdkVersion`, where the contents should be merged into the best folder."
-        errorLine1="        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Unnecessary; SDK_INT is always >= 21">
         <location
-            file="../libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java"
-            line="913"
-            column="13"/>
+            file="src/main/java/org/wordpress/android/editor/EditorFragment.java"
+            line="913"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        severity="Error"
-        message="Unnecessary; SDK_INT is never &lt; 21"
-        category="Performance"
-        priority="6"
-        summary="Obsolete SDK_INT Version Check"
-        explanation="This check flags version checks that are not necessary, because the `minSdkVersion` (or surrounding known API level) is already at least as high as the version checked for.&#xA;&#xA;Similarly, it also looks for resources in `-vNN` folders, such as `values-v14` where the version qualifier is less than or equal to the `minSdkVersion`, where the contents should be merged into the best folder."
-        errorLine1="        if (Build.VERSION.SDK_INT &lt;= 19) {"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Unnecessary; SDK_INT is never &lt; 21">
         <location
-            file="../libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebView.java"
-            line="23"
-            column="13"/>
+            file="src/main/java/org/wordpress/android/editor/EditorWebView.java"
+            line="23"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        severity="Error"
-        message="Unnecessary; SDK_INT is always >= 21"
-        category="Performance"
-        priority="6"
-        summary="Obsolete SDK_INT Version Check"
-        explanation="This check flags version checks that are not necessary, because the `minSdkVersion` (or surrounding known API level) is already at least as high as the version checked for.&#xA;&#xA;Similarly, it also looks for resources in `-vNN` folders, such as `values-v14` where the version qualifier is less than or equal to the `minSdkVersion`, where the contents should be merged into the best folder."
-        errorLine1="    private static final boolean HAS_EMOJI = SDK_INT >= VERSION_CODES.JELLY_BEAN;"
-        errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Unnecessary; SDK_INT is always >= 21">
         <location
-            file="../libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/EmoticonsUtils.java"
-            line="19"
-            column="46"/>
+            file="src/main/java/org/wordpress/android/util/EmoticonsUtils.java"
+            line="19"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        severity="Error"
-        message="Unnecessary; SDK_INT is always >= 21"
-        category="Performance"
-        priority="6"
-        summary="Obsolete SDK_INT Version Check"
-        explanation="This check flags version checks that are not necessary, because the `minSdkVersion` (or surrounding known API level) is already at least as high as the version checked for.&#xA;&#xA;Similarly, it also looks for resources in `-vNN` folders, such as `values-v14` where the version qualifier is less than or equal to the `minSdkVersion`, where the contents should be merged into the best folder."
-        errorLine1="        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;"
-        errorLine2="                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Unnecessary; SDK_INT is always >= 21">
         <location
-            file="../libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java"
-            line="440"
-            column="34"/>
+            file="src/main/java/org/wordpress/android/util/MediaUtils.java"
+            line="440"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        severity="Error"
-        message="Unnecessary; SDK_INT is never &lt; 21"
-        category="Performance"
-        priority="6"
-        summary="Obsolete SDK_INT Version Check"
-        explanation="This check flags version checks that are not necessary, because the `minSdkVersion` (or surrounding known API level) is already at least as high as the version checked for.&#xA;&#xA;Similarly, it also looks for resources in `-vNN` folders, such as `values-v14` where the version qualifier is less than or equal to the `minSdkVersion`, where the contents should be merged into the best folder."
-        errorLine1="        if (Build.VERSION.SDK_INT &lt; Build.VERSION_CODES.JELLY_BEAN_MR1) {"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Unnecessary; SDK_INT is never &lt; 21">
         <location
-            file="../libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/NetworkUtils.java"
-            line="79"
-            column="13"/>
+            file="src/main/java/org/wordpress/android/util/NetworkUtils.java"
+            line="79"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        severity="Error"
-        message="Unnecessary; SDK_INT is always >= 21"
-        category="Performance"
-        priority="6"
-        summary="Obsolete SDK_INT Version Check"
-        explanation="This check flags version checks that are not necessary, because the `minSdkVersion` (or surrounding known API level) is already at least as high as the version checked for.&#xA;&#xA;Similarly, it also looks for resources in `-vNN` folders, such as `values-v14` where the version qualifier is less than or equal to the `minSdkVersion`, where the contents should be merged into the best folder."
-        errorLine1="        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Unnecessary; SDK_INT is always >= 21">
         <location
-            file="../libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ViewUtils.java"
-            line="27"
-            column="13"/>
+            file="src/main/java/org/wordpress/android/util/ViewUtils.java"
+            line="27"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        severity="Error"
-        message="Unnecessary; SDK_INT is always >= 21"
-        category="Performance"
-        priority="6"
-        summary="Obsolete SDK_INT Version Check"
-        explanation="This check flags version checks that are not necessary, because the `minSdkVersion` (or surrounding known API level) is already at least as high as the version checked for.&#xA;&#xA;Similarly, it also looks for resources in `-vNN` folders, such as `values-v14` where the version qualifier is less than or equal to the `minSdkVersion`, where the contents should be merged into the best folder."
-        errorLine1="                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {"
-        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Unnecessary; SDK_INT is always >= 21">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java"
-            line="104"
-            column="21"/>
+            file="src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java"
+            line="104"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        severity="Error"
-        message="This folder configuration (`v18`) is unnecessary; `minSdkVersion` is 21. Merge all the resources in this folder into `drawable-ldrtl`."
-        category="Performance"
-        priority="6"
-        summary="Obsolete SDK_INT Version Check"
-        explanation="This check flags version checks that are not necessary, because the `minSdkVersion` (or surrounding known API level) is already at least as high as the version checked for.&#xA;&#xA;Similarly, it also looks for resources in `-vNN` folders, such as `values-v14` where the version qualifier is less than or equal to the `minSdkVersion`, where the contents should be merged into the best folder."
-        quickfix="studio">
+        message="This folder configuration (`v21`) is unnecessary; `minSdkVersion` is 21. Merge all the resources in this folder into `drawable-anydpi`.">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/drawable-ldrtl-v18"/>
+            file="src/main/res/drawable-anydpi-v21"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        severity="Error"
-        message="This folder configuration (`v18`) is unnecessary; `minSdkVersion` is 21. Merge all the resources in this folder into `drawable-ldrtl`."
-        category="Performance"
-        priority="6"
-        summary="Obsolete SDK_INT Version Check"
-        explanation="This check flags version checks that are not necessary, because the `minSdkVersion` (or surrounding known API level) is already at least as high as the version checked for.&#xA;&#xA;Similarly, it also looks for resources in `-vNN` folders, such as `values-v14` where the version qualifier is less than or equal to the `minSdkVersion`, where the contents should be merged into the best folder."
-        quickfix="studio">
+        message="This folder configuration (`v18`) is unnecessary; `minSdkVersion` is 21. Merge all the resources in this folder into `drawable-ldrtl`.">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/drawable-ldrtl-v18"/>
+            file="src/main/res/drawable-ldrtl-v18"/>
     </issue>
 
     <issue
         id="ObsoleteSdkInt"
-        severity="Error"
-        message="This folder configuration (`v19`) is unnecessary; `minSdkVersion` is 21. Merge all the resources in this folder into `layout`."
-        category="Performance"
-        priority="6"
-        summary="Obsolete SDK_INT Version Check"
-        explanation="This check flags version checks that are not necessary, because the `minSdkVersion` (or surrounding known API level) is already at least as high as the version checked for.&#xA;&#xA;Similarly, it also looks for resources in `-vNN` folders, such as `values-v14` where the version qualifier is less than or equal to the `minSdkVersion`, where the contents should be merged into the best folder."
-        quickfix="studio">
+        message="This folder configuration (`v18`) is unnecessary; `minSdkVersion` is 21. Merge all the resources in this folder into `drawable-ldrtl`.">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout-v19"/>
+            file="src/main/res/drawable-ldrtl-v18"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="This folder configuration (`v19`) is unnecessary; `minSdkVersion` is 21. Merge all the resources in this folder into `layout`.">
+        <location
+            file="src/main/res/layout-v19"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.prefs.AccountSettingsFragment.LoadSitesTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class LoadSitesTask extends AsyncTask&lt;Void, Void, Void> {"
-        errorLine2="                  ~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.prefs.AccountSettingsFragment.LoadSitesTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java"
-            line="339"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java"
+            line="339"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (anonymous android.os.AsyncTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="        new AsyncTask&lt;Void, Void, Bitmap>() {"
-        errorLine2="        ^">
+        message="This AsyncTask class should be static or leaks might occur (anonymous android.os.AsyncTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java"
-            line="41"
-            column="9"/>
+            file="src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java"
+            line="41"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.comments.CommentAdapter.LoadCommentsTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class LoadCommentsTask extends AsyncTask&lt;Void, Void, Boolean> {"
-        errorLine2="                  ~~~~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.comments.CommentAdapter.LoadCommentsTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java"
-            line="407"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java"
+            line="407"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostActivity.SavePostOnlineAndFinishTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class SavePostOnlineAndFinishTask extends AsyncTask&lt;Void, Void, Void> {"
-        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostActivity.SavePostOnlineAndFinishTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java"
-            line="1636"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java"
+            line="1630"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostActivity.SavePostLocallyAndFinishTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class SavePostLocallyAndFinishTask extends AsyncTask&lt;Void, Void, Boolean> {"
-        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostActivity.SavePostLocallyAndFinishTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java"
-            line="1680"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java"
+            line="1674"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostActivity.LoadPostContentTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class LoadPostContentTask extends AsyncTask&lt;String, Spanned, Spanned> {"
-        errorLine2="                  ~~~~~~~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostActivity.LoadPostContentTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java"
-            line="2075"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java"
+            line="2069"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostPreviewFragment.LoadPostPreviewTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class LoadPostPreviewTask extends AsyncTask&lt;Void, Void, Spanned> {"
-        errorLine2="                  ~~~~~~~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostPreviewFragment.LoadPostPreviewTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPreviewFragment.java"
-            line="104"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/posts/EditPostPreviewFragment.java"
+            line="104"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostSettingsFragment.FetchAndSetAddressAsyncTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class FetchAndSetAddressAsyncTask extends AsyncTask&lt;Double, Void, Address> {"
-        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.EditPostSettingsFragment.FetchAndSetAddressAsyncTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java"
-            line="928"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java"
+            line="928"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.editor.LegacyEditorFragment.AddMediaFileTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class AddMediaFileTask extends AsyncTask&lt;Void, Void, WPEditImageSpan> {"
-        errorLine2="                  ~~~~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.GutenbergEditPostActivity.SavePostOnlineAndFinishTask)">
         <location
-            file="../libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java"
-            line="1059"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java"
+            line="1503"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.main.MeFragment.SignOutWordPressComAsync)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class SignOutWordPressComAsync extends AsyncTask&lt;Void, Void, Void> {"
-        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.posts.GutenbergEditPostActivity.SavePostLocallyAndFinishTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java"
-            line="514"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java"
+            line="1547"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.notifications.adapters.NotesAdapter.ReloadNotesFromDBTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class ReloadNotesFromDBTask extends AsyncTask&lt;Void, Void, ArrayList&lt;Note>> {"
-        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.editor.LegacyEditorFragment.AddMediaFileTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java"
-            line="341"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java"
+            line="1059"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.notifications.NotificationsDetailListFragment.LoadNoteBlocksTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class LoadNoteBlocksTask extends AsyncTask&lt;Void, Boolean, List&lt;NoteBlock>> {"
-        errorLine2="                  ~~~~~~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.main.MeFragment.SignOutWordPressComAsync)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java"
-            line="322"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/main/MeFragment.java"
+            line="514"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.photopicker.PhotoPickerAdapter.BuildDeviceMediaListTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class BuildDeviceMediaListTask extends AsyncTask&lt;Void, Void, Boolean> {"
-        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.notifications.adapters.NotesAdapter.ReloadNotesFromDBTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java"
-            line="411"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java"
+            line="335"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.uploads.PostUploadHandler.UploadPostTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class UploadPostTask extends AsyncTask&lt;PostModel, Boolean, Boolean> {"
-        errorLine2="                  ~~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.notifications.NotificationsDetailListFragment.LoadNoteBlocksTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java"
-            line="188"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java"
+            line="322"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter.LoadServicesTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class LoadServicesTask extends AsyncTask&lt;Void, Void, Boolean> {"
-        errorLine2="                  ~~~~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.photopicker.PhotoPickerAdapter.BuildDeviceMediaListTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java"
-            line="174"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java"
+            line="411"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.adapters.ReaderBlogAdapter.LoadBlogsTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class LoadBlogsTask extends AsyncTask&lt;Void, Void, Boolean> {"
-        errorLine2="                  ~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.uploads.PostUploadHandler.UploadPostTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java"
-            line="206"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java"
+            line="188"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.adapters.ReaderCommentAdapter.LoadCommentsTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class LoadCommentsTask extends AsyncTask&lt;Void, Void, Boolean> {"
-        errorLine2="                  ~~~~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter.LoadServicesTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java"
-            line="512"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java"
+            line="174"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.adapters.ReaderPostAdapter.LoadPostsTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class LoadPostsTask extends AsyncTask&lt;Void, Void, Boolean> {"
-        errorLine2="                  ~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.adapters.ReaderBlogAdapter.LoadBlogsTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java"
-            line="1155"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java"
+            line="206"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.ReaderPostDetailFragment.ShowPostTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class ShowPostTask extends AsyncTask&lt;Void, Void, Boolean> {"
-        errorLine2="                  ~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.adapters.ReaderCommentAdapter.LoadCommentsTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java"
-            line="1098"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java"
+            line="512"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.ReaderPostListFragment.LoadTagsTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class LoadTagsTask extends AsyncTask&lt;Void, Void, ReaderTagList> {"
-        errorLine2="                  ~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.adapters.ReaderPostAdapter.LoadPostsTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java"
-            line="2287"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java"
+            line="1155"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.adapters.ReaderTagAdapter.LoadTagsTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class LoadTagsTask extends AsyncTask&lt;Void, Void, ReaderTagList> {"
-        errorLine2="                  ~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.ReaderPostDetailFragment.ShowPostTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java"
-            line="146"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java"
+            line="1098"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.main.SitePickerAdapter.LoadSitesTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class LoadSitesTask extends AsyncTask&lt;Void, Void, SiteList[]&gt; {"
-        errorLine2="                  ~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.ReaderPostListFragment.LoadTagsTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java"
-            line="561"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java"
+            line="2290"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="Do not place Android context classes in static fields (static reference to `StatsDatabaseHelper` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private static StatsDatabaseHelper mDatabaseHelper;"
-        errorLine2="            ~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.reader.adapters.ReaderTagAdapter.LoadTagsTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/stats/datasets/StatsDatabaseHelper.java"
-            line="25"
-            column="13"/>
+            file="src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java"
+            line="146"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.stats.StatsWidgetConfigureAdapter.LoadSitesTask)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private class LoadSitesTask extends AsyncTask&lt;Void, Void, Void> {"
-        errorLine2="                  ~~~~~~~~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.main.SitePickerAdapter.LoadSitesTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureAdapter.java"
-            line="169"
-            column="19"/>
+            file="src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java"
+            line="561"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private static RestClientUtils sRestClientUtils;"
-        errorLine2="            ~~~~~~">
+        message="Do not place Android context classes in static fields (static reference to `StatsDatabaseHelper` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/WordPress.java"
-            line="117"
-            column="13"/>
+            file="src/main/java/org/wordpress/android/ui/stats/datasets/StatsDatabaseHelper.java"
+            line="25"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private static RestClientUtils sRestClientUtilsVersion1p1;"
-        errorLine2="            ~~~~~~">
+        message="This AsyncTask class should be static or leaks might occur (org.wordpress.android.ui.stats.StatsWidgetConfigureAdapter.LoadSitesTask)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/WordPress.java"
-            line="118"
-            column="13"/>
+            file="src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureAdapter.java"
+            line="169"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private static RestClientUtils sRestClientUtilsVersion1p2;"
-        errorLine2="            ~~~~~~">
+        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/WordPress.java"
-            line="119"
-            column="13"/>
+            file="src/main/java/org/wordpress/android/WordPress.java"
+            line="117"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private static RestClientUtils sRestClientUtilsVersion1p3;"
-        errorLine2="            ~~~~~~">
+        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/WordPress.java"
-            line="120"
-            column="13"/>
+            file="src/main/java/org/wordpress/android/WordPress.java"
+            line="118"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private static RestClientUtils sRestClientUtilsVersion0;"
-        errorLine2="            ~~~~~~">
+        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/WordPress.java"
-            line="121"
-            column="13"/>
+            file="src/main/java/org/wordpress/android/WordPress.java"
+            line="119"/>
     </issue>
 
     <issue
         id="StaticFieldLeak"
-        severity="Error"
-        message="Do not place Android context classes in static fields; this is a memory leak (and also breaks Instant Run)"
-        category="Performance"
-        priority="6"
-        summary="Static Field Leaks"
-        explanation="A static field will leak contexts.&#xA;&#xA;Non-static inner classes have an implicit reference to their outer class. If that outer class is for example a `Fragment` or `Activity`, then this reference means that the long-running handler/loader/task will hold a reference to the activity which prevents it from getting garbage collected.&#xA;&#xA;Similarly, direct field references to activities and fragments from these longer running instances can cause leaks.&#xA;&#xA;ViewModel classes should never point to Views or non-application Contexts."
-        errorLine1="    private static Context mContext;"
-        errorLine2="            ~~~~~~">
+        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)">
         <location
-            file="../WordPress/src/main/java/org/wordpress/android/WordPress.java"
-            line="127"
-            column="13"/>
+            file="src/main/java/org/wordpress/android/WordPress.java"
+            line="120"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="Do not place Android context classes in static fields (static reference to `RestClientUtils` which has field `mContext` pointing to `Context`); this is a memory leak (and also breaks Instant Run)">
+        <location
+            file="src/main/java/org/wordpress/android/WordPress.java"
+            line="121"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="Do not place Android context classes in static fields; this is a memory leak (and also breaks Instant Run)">
+        <location
+            file="src/main/java/org/wordpress/android/WordPress.java"
+            line="127"/>
     </issue>
 
     <issue
         id="UseCompoundDrawables"
-        severity="Warning"
-        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable"
-        category="Performance"
-        priority="6"
-        summary="Node can be replaced by a `TextView` with compound drawables"
-        explanation="A `LinearLayout` which contains an `ImageView` and a `TextView` can be more efficiently handled as a compound drawable (a single TextView, using the `drawableTop`, `drawableLeft`, `drawableRight` and/or `drawableBottom` attributes to draw one or more images adjacent to the text).&#xA;&#xA;If the two widgets are offset from each other with margins, this can be replaced with a `drawablePadding` attribute.&#xA;&#xA;There&apos;s a lint quickfix to perform this conversion in the Eclipse plugin."
-        errorLine1="        &lt;LinearLayout"
-        errorLine2="        ^">
+        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable">
         <location
-            file="../WordPress/src/main/res/layout/plugin_browser_row.xml"
-            line="51"
-            column="9"/>
+            file="src/main/res/layout/plugin_browser_row.xml"
+            line="51"/>
     </issue>
 
     <issue
         id="UseCompoundDrawables"
-        severity="Warning"
-        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable"
-        category="Performance"
-        priority="6"
-        summary="Node can be replaced by a `TextView` with compound drawables"
-        explanation="A `LinearLayout` which contains an `ImageView` and a `TextView` can be more efficiently handled as a compound drawable (a single TextView, using the `drawableTop`, `drawableLeft`, `drawableRight` and/or `drawableBottom` attributes to draw one or more images adjacent to the text).&#xA;&#xA;If the two widgets are offset from each other with margins, this can be replaced with a `drawablePadding` attribute.&#xA;&#xA;There&apos;s a lint quickfix to perform this conversion in the Eclipse plugin."
-        errorLine1="    &lt;LinearLayout"
-        errorLine2="    ^">
+        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable">
         <location
-            file="../WordPress/src/main/res/layout/start_over_preference.xml"
-            line="15"
-            column="5"/>
+            file="src/main/res/layout/start_over_preference.xml"
+            line="15"/>
     </issue>
 
     <issue
         id="UseCompoundDrawables"
-        severity="Warning"
-        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable"
-        category="Performance"
-        priority="6"
-        summary="Node can be replaced by a `TextView` with compound drawables"
-        explanation="A `LinearLayout` which contains an `ImageView` and a `TextView` can be more efficiently handled as a compound drawable (a single TextView, using the `drawableTop`, `drawableLeft`, `drawableRight` and/or `drawableBottom` attributes to draw one or more images adjacent to the text).&#xA;&#xA;If the two widgets are offset from each other with margins, this can be replaced with a `drawablePadding` attribute.&#xA;&#xA;There&apos;s a lint quickfix to perform this conversion in the Eclipse plugin."
-        errorLine1="            &lt;LinearLayout"
-        errorLine2="            ^">
+        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable">
         <location
-            file="../WordPress/src/main/res/layout/stats_widget_layout.xml"
-            line="63"
-            column="13"/>
+            file="src/main/res/layout/stats_widget_layout.xml"
+            line="63"/>
     </issue>
 
     <issue
         id="UseCompoundDrawables"
-        severity="Warning"
-        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable"
-        category="Performance"
-        priority="6"
-        summary="Node can be replaced by a `TextView` with compound drawables"
-        explanation="A `LinearLayout` which contains an `ImageView` and a `TextView` can be more efficiently handled as a compound drawable (a single TextView, using the `drawableTop`, `drawableLeft`, `drawableRight` and/or `drawableBottom` attributes to draw one or more images adjacent to the text).&#xA;&#xA;If the two widgets are offset from each other with margins, this can be replaced with a `drawablePadding` attribute.&#xA;&#xA;There&apos;s a lint quickfix to perform this conversion in the Eclipse plugin."
-        errorLine1="            &lt;LinearLayout"
-        errorLine2="            ^">
+        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable">
         <location
-            file="../WordPress/src/main/res/layout/stats_widget_layout.xml"
-            line="109"
-            column="13"/>
+            file="src/main/res/layout/stats_widget_layout.xml"
+            line="109"/>
     </issue>
 
     <issue
         id="UseCompoundDrawables"
-        severity="Warning"
-        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable"
-        category="Performance"
-        priority="6"
-        summary="Node can be replaced by a `TextView` with compound drawables"
-        explanation="A `LinearLayout` which contains an `ImageView` and a `TextView` can be more efficiently handled as a compound drawable (a single TextView, using the `drawableTop`, `drawableLeft`, `drawableRight` and/or `drawableBottom` attributes to draw one or more images adjacent to the text).&#xA;&#xA;If the two widgets are offset from each other with margins, this can be replaced with a `drawablePadding` attribute.&#xA;&#xA;There&apos;s a lint quickfix to perform this conversion in the Eclipse plugin."
-        errorLine1="            &lt;LinearLayout"
-        errorLine2="            ^">
+        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable">
         <location
-            file="../WordPress/src/main/res/layout/stats_widget_layout.xml"
-            line="155"
-            column="13"/>
+            file="src/main/res/layout/stats_widget_layout.xml"
+            line="155"/>
     </issue>
 
     <issue
         id="UseCompoundDrawables"
-        severity="Warning"
-        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable"
-        category="Performance"
-        priority="6"
-        summary="Node can be replaced by a `TextView` with compound drawables"
-        explanation="A `LinearLayout` which contains an `ImageView` and a `TextView` can be more efficiently handled as a compound drawable (a single TextView, using the `drawableTop`, `drawableLeft`, `drawableRight` and/or `drawableBottom` attributes to draw one or more images adjacent to the text).&#xA;&#xA;If the two widgets are offset from each other with margins, this can be replaced with a `drawablePadding` attribute.&#xA;&#xA;There&apos;s a lint quickfix to perform this conversion in the Eclipse plugin."
-        errorLine1="            &lt;LinearLayout"
-        errorLine2="            ^">
+        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable">
         <location
-            file="../WordPress/src/main/res/layout/stats_widget_layout.xml"
-            line="201"
-            column="13"/>
+            file="src/main/res/layout/stats_widget_layout.xml"
+            line="201"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (811 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M26.3,26.4c0.4,0.3,0.8,0.6,1.3,0.8c0.5,0.2,1,0.3,1.5,0.3c0.5,0,1.1-0.1,1.5-0.3c0.4-0.2,0.6-0.5,0.6-0.9 c0-0.2-0.1-0.4-0.2-0.6c-0.1-0.2-0.3-0.4-0.6-0.5c-0.3-0.1-0.7-0.2-1.1-0.3c-0.5-0.1-1.1-0.1-1.7-0.1V23c0.8,0.1,1.6-0.1,2.4-0.4 c0.4-0.2,0.7-0.6,0.7-1c0-0.3-0.1-0.7-0.4-0.9c-0.4-0.2-0.8-0.3-1.2-0.3c-0.4,0-0.9,0.1-1.2,0.3c-0.4,0.2-0.8,0.4-1.2,0.7l-1.3-1.5 c0.5-0.4,1.1-0.7,1.8-1c0.7-0.2,1.4-0.4,2.1-0.4c0.6,0,1.1,0.1,1.7,0.2c0.5,0.1,0.9,0.3,1.3,0.6c0.4,0.2,0.6,0.5,0.9,0.9 c0.2,0.4,0.3,0.8,0.3,1.2c0,0.5-0.2,1-0.6,1.4c-0.5,0.4-1,0.7-1.6,0.9v0.1c0.7,0.2,1.3,0.5,1.8,0.9c0.5,0.4,0.7,1,0.7,1.7 c0,0.5-0.1,0.9-0.4,1.3c-0.3,0.4-0.6,0.7-1,1c-0.4,0.3-0.9,0.5-1.4,0.6c-0.6,0.1-1.1,0.2-1.7,0.2c-0.9,0-1.7-0.1-2.5-0.4 c-0.6-0.2-1.2-0.6-1.7-1.1L26.3,26.4z M20.7,22.9h-4.4v-4.4h-2.2v10.9h2.2v-4.4h4.4v4.4h2.2V18.5h-2.2V22.9z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (811 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_3.xml"
-            line="13"
-            column="27"/>
+            file="src/main/res/drawable/format_bar_button_heading_3.xml"
+            line="13"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (811 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M26.3,26.4c0.4,0.3,0.8,0.6,1.3,0.8c0.5,0.2,1,0.3,1.5,0.3c0.5,0,1.1-0.1,1.5-0.3c0.4-0.2,0.6-0.5,0.6-0.9 c0-0.2-0.1-0.4-0.2-0.6c-0.1-0.2-0.3-0.4-0.6-0.5c-0.3-0.1-0.7-0.2-1.1-0.3c-0.5-0.1-1.1-0.1-1.7-0.1V23c0.8,0.1,1.6-0.1,2.4-0.4 c0.4-0.2,0.7-0.6,0.7-1c0-0.3-0.1-0.7-0.4-0.9c-0.4-0.2-0.8-0.3-1.2-0.3c-0.4,0-0.9,0.1-1.2,0.3c-0.4,0.2-0.8,0.4-1.2,0.7l-1.3-1.5 c0.5-0.4,1.1-0.7,1.8-1c0.7-0.2,1.4-0.4,2.1-0.4c0.6,0,1.1,0.1,1.7,0.2c0.5,0.1,0.9,0.3,1.3,0.6c0.4,0.2,0.6,0.5,0.9,0.9 c0.2,0.4,0.3,0.8,0.3,1.2c0,0.5-0.2,1-0.6,1.4c-0.5,0.4-1,0.7-1.6,0.9v0.1c0.7,0.2,1.3,0.5,1.8,0.9c0.5,0.4,0.7,1,0.7,1.7 c0,0.5-0.1,0.9-0.4,1.3c-0.3,0.4-0.6,0.7-1,1c-0.4,0.3-0.9,0.5-1.4,0.6c-0.6,0.1-1.1,0.2-1.7,0.2c-0.9,0-1.7-0.1-2.5-0.4 c-0.6-0.2-1.2-0.6-1.7-1.1L26.3,26.4z M20.7,22.9h-4.4v-4.4h-2.2v10.9h2.2v-4.4h4.4v4.4h2.2V18.5h-2.2V22.9z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (811 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_3_disabled.xml"
-            line="13"
-            column="27"/>
+            file="src/main/res/drawable/format_bar_button_heading_3_disabled.xml"
+            line="13"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (811 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M26.3,26.4c0.4,0.3,0.8,0.6,1.3,0.8c0.5,0.2,1,0.3,1.5,0.3c0.5,0,1.1-0.1,1.5-0.3c0.4-0.2,0.6-0.5,0.6-0.9 c0-0.2-0.1-0.4-0.2-0.6c-0.1-0.2-0.3-0.4-0.6-0.5c-0.3-0.1-0.7-0.2-1.1-0.3c-0.5-0.1-1.1-0.1-1.7-0.1V23c0.8,0.1,1.6-0.1,2.4-0.4 c0.4-0.2,0.7-0.6,0.7-1c0-0.3-0.1-0.7-0.4-0.9c-0.4-0.2-0.8-0.3-1.2-0.3c-0.4,0-0.9,0.1-1.2,0.3c-0.4,0.2-0.8,0.4-1.2,0.7l-1.3-1.5 c0.5-0.4,1.1-0.7,1.8-1c0.7-0.2,1.4-0.4,2.1-0.4c0.6,0,1.1,0.1,1.7,0.2c0.5,0.1,0.9,0.3,1.3,0.6c0.4,0.2,0.6,0.5,0.9,0.9 c0.2,0.4,0.3,0.8,0.3,1.2c0,0.5-0.2,1-0.6,1.4c-0.5,0.4-1,0.7-1.6,0.9v0.1c0.7,0.2,1.3,0.5,1.8,0.9c0.5,0.4,0.7,1,0.7,1.7 c0,0.5-0.1,0.9-0.4,1.3c-0.3,0.4-0.6,0.7-1,1c-0.4,0.3-0.9,0.5-1.4,0.6c-0.6,0.1-1.1,0.2-1.7,0.2c-0.9,0-1.7-0.1-2.5-0.4 c-0.6-0.2-1.2-0.6-1.7-1.1L26.3,26.4z M20.7,22.9h-4.4v-4.4h-2.2v10.9h2.2v-4.4h4.4v4.4h2.2V18.5h-2.2V22.9z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (811 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_3_highlighted.xml"
-            line="13"
-            column="27"/>
+            file="src/main/res/drawable/format_bar_button_heading_3_highlighted.xml"
+            line="13"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (960 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M22.9,29.5h-2.2v-4.4h-4.4v4.4h-2.2V18.5h2.2v4.4h4.4v-4.4h2.2V29.5z M32.3,21.3c-0.3-0.2-0.6-0.4-0.9-0.5 c-0.7-0.3-1.4-0.3-2.1,0c-0.3,0.1-0.6,0.3-0.9,0.6c-0.3,0.3-0.5,0.6-0.6,1c-0.2,0.5-0.3,1-0.3,1.6c0.4-0.4,0.9-0.6,1.4-0.8 c0.4-0.2,0.9-0.3,1.4-0.3c0.5,0,0.9,0.1,1.3,0.2c0.4,0.1,0.8,0.3,1.1,0.6c0.3,0.3,0.6,0.6,0.7,1c0.2,0.4,0.3,0.9,0.3,1.4 c0,0.5-0.1,1-0.3,1.5c-0.2,0.4-0.5,0.8-0.9,1.1c-0.4,0.3-0.8,0.5-1.3,0.7c-1.1,0.3-2.2,0.3-3.3-0.1c-0.6-0.2-1.1-0.5-1.5-0.9 c-0.5-0.5-0.8-1-1.1-1.6c-0.3-0.8-0.4-1.6-0.3-2.4c0-0.9,0.1-1.7,0.4-2.6c0.2-0.7,0.6-1.3,1.1-1.8c0.4-0.5,1-0.8,1.6-1 c0.6-0.2,1.2-0.3,1.9-0.3c0.7,0,1.5,0.1,2.2,0.4c0.5,0.2,1.1,0.5,1.5,0.9L32.3,21.3z M29.7,27.6c0.2,0,0.4,0,0.7-0.1 c0.2-0.1,0.4-0.1,0.6-0.3c0.2-0.1,0.3-0.3,0.4-0.5c0.1-0.2,0.1-0.5,0.1-0.8c0-0.4-0.1-0.9-0.5-1.2c-0.4-0.3-0.8-0.4-1.2-0.4 c-0.4,0-0.7,0.1-1.1,0.2c-0.4,0.2-0.8,0.5-1.1,0.8c0.1,0.4,0.2,0.7,0.3,1.1c0.1,0.3,0.3,0.5,0.5,0.7c0.2,0.2,0.4,0.3,0.6,0.4 C29.2,27.7,29.4,27.7,29.7,27.6z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (960 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_6.xml"
-            line="13"
-            column="27"/>
+            file="src/main/res/drawable/format_bar_button_heading_6.xml"
+            line="13"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (960 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M22.9,29.5h-2.2v-4.4h-4.4v4.4h-2.2V18.5h2.2v4.4h4.4v-4.4h2.2V29.5z M32.3,21.3c-0.3-0.2-0.6-0.4-0.9-0.5 c-0.7-0.3-1.4-0.3-2.1,0c-0.3,0.1-0.6,0.3-0.9,0.6c-0.3,0.3-0.5,0.6-0.6,1c-0.2,0.5-0.3,1-0.3,1.6c0.4-0.4,0.9-0.6,1.4-0.8 c0.4-0.2,0.9-0.3,1.4-0.3c0.5,0,0.9,0.1,1.3,0.2c0.4,0.1,0.8,0.3,1.1,0.6c0.3,0.3,0.6,0.6,0.7,1c0.2,0.4,0.3,0.9,0.3,1.4 c0,0.5-0.1,1-0.3,1.5c-0.2,0.4-0.5,0.8-0.9,1.1c-0.4,0.3-0.8,0.5-1.3,0.7c-1.1,0.3-2.2,0.3-3.3-0.1c-0.6-0.2-1.1-0.5-1.5-0.9 c-0.5-0.5-0.8-1-1.1-1.6c-0.3-0.8-0.4-1.6-0.3-2.4c0-0.9,0.1-1.7,0.4-2.6c0.2-0.7,0.6-1.3,1.1-1.8c0.4-0.5,1-0.8,1.6-1 c0.6-0.2,1.2-0.3,1.9-0.3c0.7,0,1.5,0.1,2.2,0.4c0.5,0.2,1.1,0.5,1.5,0.9L32.3,21.3z M29.7,27.6c0.2,0,0.4,0,0.7-0.1 c0.2-0.1,0.4-0.1,0.6-0.3c0.2-0.1,0.3-0.3,0.4-0.5c0.1-0.2,0.1-0.5,0.1-0.8c0-0.4-0.1-0.9-0.5-1.2c-0.4-0.3-0.8-0.4-1.2-0.4 c-0.4,0-0.7,0.1-1.1,0.2c-0.4,0.2-0.8,0.5-1.1,0.8c0.1,0.4,0.2,0.7,0.3,1.1c0.1,0.3,0.3,0.5,0.5,0.7c0.2,0.2,0.4,0.3,0.6,0.4 C29.2,27.7,29.4,27.7,29.7,27.6z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (960 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_6_disabled.xml"
-            line="13"
-            column="27"/>
+            file="src/main/res/drawable/format_bar_button_heading_6_disabled.xml"
+            line="13"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (960 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M22.9,29.5h-2.2v-4.4h-4.4v4.4h-2.2V18.5h2.2v4.4h4.4v-4.4h2.2V29.5z M32.3,21.3c-0.3-0.2-0.6-0.4-0.9-0.5 c-0.7-0.3-1.4-0.3-2.1,0c-0.3,0.1-0.6,0.3-0.9,0.6c-0.3,0.3-0.5,0.6-0.6,1c-0.2,0.5-0.3,1-0.3,1.6c0.4-0.4,0.9-0.6,1.4-0.8 c0.4-0.2,0.9-0.3,1.4-0.3c0.5,0,0.9,0.1,1.3,0.2c0.4,0.1,0.8,0.3,1.1,0.6c0.3,0.3,0.6,0.6,0.7,1c0.2,0.4,0.3,0.9,0.3,1.4 c0,0.5-0.1,1-0.3,1.5c-0.2,0.4-0.5,0.8-0.9,1.1c-0.4,0.3-0.8,0.5-1.3,0.7c-1.1,0.3-2.2,0.3-3.3-0.1c-0.6-0.2-1.1-0.5-1.5-0.9 c-0.5-0.5-0.8-1-1.1-1.6c-0.3-0.8-0.4-1.6-0.3-2.4c0-0.9,0.1-1.7,0.4-2.6c0.2-0.7,0.6-1.3,1.1-1.8c0.4-0.5,1-0.8,1.6-1 c0.6-0.2,1.2-0.3,1.9-0.3c0.7,0,1.5,0.1,2.2,0.4c0.5,0.2,1.1,0.5,1.5,0.9L32.3,21.3z M29.7,27.6c0.2,0,0.4,0,0.7-0.1 c0.2-0.1,0.4-0.1,0.6-0.3c0.2-0.1,0.3-0.3,0.4-0.5c0.1-0.2,0.1-0.5,0.1-0.8c0-0.4-0.1-0.9-0.5-1.2c-0.4-0.3-0.8-0.4-1.2-0.4 c-0.4,0-0.7,0.1-1.1,0.2c-0.4,0.2-0.8,0.5-1.1,0.8c0.1,0.4,0.2,0.7,0.3,1.1c0.1,0.3,0.3,0.5,0.5,0.7c0.2,0.2,0.4,0.3,0.6,0.4 C29.2,27.7,29.4,27.7,29.7,27.6z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (960 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_6_highlighted.xml"
-            line="13"
-            column="27"/>
+            file="src/main/res/drawable/format_bar_button_heading_6_highlighted.xml"
+            line="13"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1201 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M19.6,31.6h14.2v-2.2H19.6V31.6z M19.6,25.1h14.2v-2.2H19.6V25.1z M19.6,16.4v2.2h14.2v-2.2H19.6z M14.8,16.6 c0.1-0.1,0.2-0.2,0.3-0.3c0,0.2,0,0.5,0,0.8v2.5h1.3V15h-1.1l-1.6,1.3l0.7,0.8L14.8,16.6z M15.2,25.1c0.5-0.5,0.9-0.8,1-0.9 c0.2-0.2,0.3-0.3,0.4-0.5c0.1-0.2,0.2-0.3,0.2-0.5c0-0.2,0.1-0.3,0.1-0.5c0-0.2-0.1-0.5-0.2-0.7s-0.3-0.3-0.6-0.5 c-0.2-0.1-0.5-0.2-0.8-0.2c-0.2,0-0.5,0-0.7,0.1c-0.2,0-0.4,0.1-0.5,0.2c-0.2,0.1-0.4,0.2-0.6,0.5l0.7,0.8c0.2-0.2,0.4-0.3,0.5-0.4 c0.2-0.1,0.3-0.1,0.4-0.1c0.1,0,0.3,0,0.3,0.1c0.1,0.1,0.1,0.2,0.1,0.3c0,0.1,0,0.2-0.1,0.3s-0.1,0.2-0.2,0.3 c-0.1,0.1-0.3,0.4-0.6,0.7l-1.1,1.2v0.8h3.4v-1L15.2,25.1L15.2,25.1L15.2,25.1z M15.8,30.3L15.8,30.3c0.3-0.1,0.6-0.3,0.8-0.5 c0.2-0.2,0.3-0.5,0.3-0.7c0-0.3-0.1-0.6-0.4-0.8c-0.3-0.2-0.7-0.3-1.1-0.3c-0.3,0-0.6,0-0.9,0.1c-0.3,0.1-0.5,0.2-0.8,0.4l0.5,0.8 c0.3-0.2,0.6-0.3,0.9-0.3c0.2,0,0.3,0,0.4,0.1c0.1,0.1,0.1,0.2,0.1,0.3c0,0.3-0.3,0.5-1,0.5h-0.3v0.9h0.3c0.2,0,0.4,0,0.6,0.1 c0.1,0,0.3,0.1,0.3,0.2c0.1,0.1,0.1,0.2,0.1,0.3c0,0.2-0.1,0.3-0.2,0.4c-0.1,0.1-0.3,0.1-0.6,0.1c-0.2,0-0.4,0-0.6-0.1 c-0.2,0-0.4-0.1-0.6-0.2v1c0.2,0.1,0.5,0.2,0.7,0.2c0.2,0,0.4,0.1,0.7,0.1c0.6,0,1.1-0.1,1.4-0.4c0.3-0.2,0.5-0.6,0.5-1 C16.9,30.8,16.5,30.4,15.8,30.3z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1201 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ol.xml"
-            line="13"
-            column="27"/>
+            file="src/main/res/drawable/format_bar_button_ol.xml"
+            line="13"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1201 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M19.6,31.6h14.2v-2.2H19.6V31.6z M19.6,25.1h14.2v-2.2H19.6V25.1z M19.6,16.4v2.2h14.2v-2.2H19.6z M14.8,16.6 c0.1-0.1,0.2-0.2,0.3-0.3c0,0.2,0,0.5,0,0.8v2.5h1.3V15h-1.1l-1.6,1.3l0.7,0.8L14.8,16.6z M15.2,25.1c0.5-0.5,0.9-0.8,1-0.9 c0.2-0.2,0.3-0.3,0.4-0.5c0.1-0.2,0.2-0.3,0.2-0.5c0-0.2,0.1-0.3,0.1-0.5c0-0.2-0.1-0.5-0.2-0.7s-0.3-0.3-0.6-0.5 c-0.2-0.1-0.5-0.2-0.8-0.2c-0.2,0-0.5,0-0.7,0.1c-0.2,0-0.4,0.1-0.5,0.2c-0.2,0.1-0.4,0.2-0.6,0.5l0.7,0.8c0.2-0.2,0.4-0.3,0.5-0.4 c0.2-0.1,0.3-0.1,0.4-0.1c0.1,0,0.3,0,0.3,0.1c0.1,0.1,0.1,0.2,0.1,0.3c0,0.1,0,0.2-0.1,0.3s-0.1,0.2-0.2,0.3 c-0.1,0.1-0.3,0.4-0.6,0.7l-1.1,1.2v0.8h3.4v-1L15.2,25.1L15.2,25.1L15.2,25.1z M15.8,30.3L15.8,30.3c0.3-0.1,0.6-0.3,0.8-0.5 c0.2-0.2,0.3-0.5,0.3-0.7c0-0.3-0.1-0.6-0.4-0.8c-0.3-0.2-0.7-0.3-1.1-0.3c-0.3,0-0.6,0-0.9,0.1c-0.3,0.1-0.5,0.2-0.8,0.4l0.5,0.8 c0.3-0.2,0.6-0.3,0.9-0.3c0.2,0,0.3,0,0.4,0.1c0.1,0.1,0.1,0.2,0.1,0.3c0,0.3-0.3,0.5-1,0.5h-0.3v0.9h0.3c0.2,0,0.4,0,0.6,0.1 c0.1,0,0.3,0.1,0.3,0.2c0.1,0.1,0.1,0.2,0.1,0.3c0,0.2-0.1,0.3-0.2,0.4c-0.1,0.1-0.3,0.1-0.6,0.1c-0.2,0-0.4,0-0.6-0.1 c-0.2,0-0.4-0.1-0.6-0.2v1c0.2,0.1,0.5,0.2,0.7,0.2c0.2,0,0.4,0.1,0.7,0.1c0.6,0,1.1-0.1,1.4-0.4c0.3-0.2,0.5-0.6,0.5-1 C16.9,30.8,16.5,30.4,15.8,30.3z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1201 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ol_disabled.xml"
-            line="13"
-            column="27"/>
+            file="src/main/res/drawable/format_bar_button_ol_disabled.xml"
+            line="13"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1201 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M19.6,31.6h14.2v-2.2H19.6V31.6z M19.6,25.1h14.2v-2.2H19.6V25.1z M19.6,16.4v2.2h14.2v-2.2H19.6z M14.8,16.6 c0.1-0.1,0.2-0.2,0.3-0.3c0,0.2,0,0.5,0,0.8v2.5h1.3V15h-1.1l-1.6,1.3l0.7,0.8L14.8,16.6z M15.2,25.1c0.5-0.5,0.9-0.8,1-0.9 c0.2-0.2,0.3-0.3,0.4-0.5c0.1-0.2,0.2-0.3,0.2-0.5c0-0.2,0.1-0.3,0.1-0.5c0-0.2-0.1-0.5-0.2-0.7s-0.3-0.3-0.6-0.5 c-0.2-0.1-0.5-0.2-0.8-0.2c-0.2,0-0.5,0-0.7,0.1c-0.2,0-0.4,0.1-0.5,0.2c-0.2,0.1-0.4,0.2-0.6,0.5l0.7,0.8c0.2-0.2,0.4-0.3,0.5-0.4 c0.2-0.1,0.3-0.1,0.4-0.1c0.1,0,0.3,0,0.3,0.1c0.1,0.1,0.1,0.2,0.1,0.3c0,0.1,0,0.2-0.1,0.3s-0.1,0.2-0.2,0.3 c-0.1,0.1-0.3,0.4-0.6,0.7l-1.1,1.2v0.8h3.4v-1L15.2,25.1L15.2,25.1L15.2,25.1z M15.8,30.3L15.8,30.3c0.3-0.1,0.6-0.3,0.8-0.5 c0.2-0.2,0.3-0.5,0.3-0.7c0-0.3-0.1-0.6-0.4-0.8c-0.3-0.2-0.7-0.3-1.1-0.3c-0.3,0-0.6,0-0.9,0.1c-0.3,0.1-0.5,0.2-0.8,0.4l0.5,0.8 c0.3-0.2,0.6-0.3,0.9-0.3c0.2,0,0.3,0,0.4,0.1c0.1,0.1,0.1,0.2,0.1,0.3c0,0.3-0.3,0.5-1,0.5h-0.3v0.9h0.3c0.2,0,0.4,0,0.6,0.1 c0.1,0,0.3,0.1,0.3,0.2c0.1,0.1,0.1,0.2,0.1,0.3c0,0.2-0.1,0.3-0.2,0.4c-0.1,0.1-0.3,0.1-0.6,0.1c-0.2,0-0.4,0-0.6-0.1 c-0.2,0-0.4-0.1-0.6-0.2v1c0.2,0.1,0.5,0.2,0.7,0.2c0.2,0,0.4,0.1,0.7,0.1c0.6,0,1.1-0.1,1.4-0.4c0.3-0.2,0.5-0.6,0.5-1 C16.9,30.8,16.5,30.4,15.8,30.3z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1201 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ol_highlighted.xml"
-            line="13"
-            column="27"/>
+            file="src/main/res/drawable/format_bar_button_ol_highlighted.xml"
+            line="13"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1068 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm6.918 6h-3.215c-0.188-1.424-0.42-2.65-0.565-3.357 1.593 0.682 2.916 1.87 3.78 3.357zm-5.904-3.928c0.068 0.352 0.387 2.038 0.645 3.928h-3.32c0.26-1.89 0.578-3.576 0.646-3.928C11.32 4.03 11.656 4 12 4s0.68 0.03 1.014 0.072zM14 12c0 0.598-0.043 1.286-0.11 2h-3.78c-0.067-0.714-0.11-1.402-0.11-2s0.043-1.286 0.11-2h3.78c0.067 0.714 0.11 1.402 0.11 2zM8.862 4.643C8.717 5.35 8.485 6.576 8.297 8H5.082c0.864-1.487 2.187-2.675 3.78-3.357zM4.262 10h3.822c-0.05 0.668-0.084 1.344-0.084 2s0.033 1.332 0.085 2H4.263C4.097 13.36 4 12.692 4 12s0.098-1.36 0.263-2zm0.82 6h3.215c0.188 1.424 0.42 2.65 0.565 3.357-1.593-0.682-2.916-1.87-3.78-3.357zm5.904 3.928c-0.068-0.353-0.388-2.038-0.645-3.928h3.32c-0.26 1.89-0.578 3.576-0.646 3.928-0.333 0.043-0.67 0.072-1.014 0.072s-0.68-0.03-1.014-0.072zm4.152-0.57c0.145-0.708 0.377-1.934 0.565-3.358h3.215c-0.864 1.487-2.187 2.675-3.78 3.357zm4.6-5.358h-3.822c0.05-0.668 0.084-1.344 0.084-2s-0.033-1.332-0.085-2h3.82c0.167 0.64 0.265 1.308 0.265 2s-0.097 1.36-0.263 2z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1068 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/drawable/ic_domains_grey_24dp.xml"
-            line="10"
-            column="27"/>
+            file="src/main/res/drawable/ic_domains_grey_24dp.xml"
+            line="10"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1068 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm6.918 6h-3.215c-0.188-1.424-0.42-2.65-0.565-3.357 1.593 0.682 2.916 1.87 3.78 3.357zm-5.904-3.928c0.068 0.352 0.387 2.038 0.645 3.928h-3.32c0.26-1.89 0.578-3.576 0.646-3.928C11.32 4.03 11.656 4 12 4s0.68 0.03 1.014 0.072zM14 12c0 0.598-0.043 1.286-0.11 2h-3.78c-0.067-0.714-0.11-1.402-0.11-2s0.043-1.286 0.11-2h3.78c0.067 0.714 0.11 1.402 0.11 2zM8.862 4.643C8.717 5.35 8.485 6.576 8.297 8H5.082c0.864-1.487 2.187-2.675 3.78-3.357zM4.262 10h3.822c-0.05 0.668-0.084 1.344-0.084 2s0.033 1.332 0.085 2H4.263C4.097 13.36 4 12.692 4 12s0.098-1.36 0.263-2zm0.82 6h3.215c0.188 1.424 0.42 2.65 0.565 3.357-1.593-0.682-2.916-1.87-3.78-3.357zm5.904 3.928c-0.068-0.353-0.388-2.038-0.645-3.928h3.32c-0.26 1.89-0.578 3.576-0.646 3.928-0.333 0.043-0.67 0.072-1.014 0.072s-0.68-0.03-1.014-0.072zm4.152-0.57c0.145-0.708 0.377-1.934 0.565-3.358h3.215c-0.864 1.487-2.187 2.675-3.78 3.357zm4.6-5.358h-3.822c0.05-0.668 0.084-1.344 0.084-2s-0.033-1.332-0.085-2h3.82c0.167 0.64 0.265 1.308 0.265 2s-0.097 1.36-0.263 2z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1068 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/ic_domains_white_24dp.xml"
-            line="12"
-            column="27"/>
+            file="src/main/res/drawable/ic_domains_white_24dp.xml"
+            line="12"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1040 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zM3.5 12c0-1.232 0.264-2.402 0.736-3.46L8.29 19.65C5.456 18.272 3.5 15.365 3.5 12zm8.5 8.5c-0.834 0-1.64-0.12-2.4-0.345l2.55-7.41 2.613 7.157c0.017 0.042 0.038 0.08 0.06 0.117-0.884 0.31-1.833 0.48-2.823 0.48zm1.172-12.485c0.512-0.027 0.973-0.08 0.973-0.08 0.458-0.055 0.404-0.728-0.054-0.702 0 0-1.376 0.108-2.265 0.108-0.835 0-2.24-0.107-2.24-0.107-0.458-0.026-0.51 0.674-0.053 0.7 0 0 0.434 0.055 0.892 0.082l1.324 3.63-1.86 5.578-3.096-9.208c0.512-0.027 0.973-0.08 0.973-0.08 0.458-0.055 0.403-0.728-0.055-0.702 0 0-1.376 0.108-2.265 0.108-0.16 0-0.347-0.003-0.547-0.01C6.418 5.025 9.03 3.5 12 3.5c2.213 0 4.228 0.846 5.74 2.232-0.037-0.002-0.072-0.007-0.11-0.007-0.835 0-1.427 0.727-1.427 1.51 0 0.7 0.404 1.292 0.835 1.993 0.323 0.566 0.7 1.293 0.7 2.344 0 0.727-0.28 1.572-0.646 2.748l-0.848 2.833-3.072-9.138zm3.1 11.332l2.597-7.506c0.484-1.212 0.645-2.18 0.645-3.044 0-0.313-0.02-0.603-0.057-0.874 0.664 1.21 1.042 2.6 1.042 4.078 0 3.136-1.7 5.874-4.227 7.347z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1040 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/ic_wordpress_grey_20dp.xml"
-            line="10"
-            column="27"/>
+            file="src/main/res/drawable/ic_wordpress_grey_20dp.xml"
+            line="10"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1087 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="    &lt;path android:fillColor=&quot;#004F81&quot; android:pathData=&quot;M82.1,113.1c0.7,-0.4 1.5,-0.8 2.3,-1c0.8,-0.3 1.6,-0.4 2.4,-0.5c0.8,-0.1 1.7,0 2.5,0.1c0.8,0.1 1.6,0.3 2.5,0.6c0.4,0.1 0.6,0.4 0.6,0.8l0,0.1c0.1,1 0.5,2.2 1,3.1c0.5,1 1.2,1.8 2,2.3c1,0.6 2,1.2 3.1,1.6c1.1,0.4 2.2,0.8 3.3,1c0.4,0.1 0.8,0.4 0.9,0.8l0,0c1.7,6.7 4.3,13.4 8,19.3c1.9,2.9 4,5.7 6.6,7.8c2.6,2.2 5.7,3.7 9,4.1c1.7,0.2 3.3,0.1 4.9,-0.2c1.6,-0.4 3.1,-1.1 4.4,-2.1c2.6,-2 4.3,-5.1 5.3,-8.4c1.1,-3.3 1.7,-6.7 2,-10.2c0.2,-1.7 0.3,-3.5 0.4,-5.3c0.1,-1.8 0.1,-3.5 0,-5.3l0,0c0,-0.2 0.1,-0.3 0.3,-0.3c0.2,0 0.3,0.1 0.3,0.3c0.6,3.6 0.7,7.1 0.6,10.7c-0.2,3.6 -0.7,7.2 -1.8,10.7c-1.1,3.5 -2.9,6.9 -6,9.4c-1.5,1.2 -3.3,2 -5.2,2.5c-1.9,0.4 -3.8,0.5 -5.7,0.3c-3.8,-0.4 -7.3,-2.2 -10.2,-4.5c-2.9,-2.4 -5.2,-5.3 -7.1,-8.3c-1.9,-3.1 -3.5,-6.3 -4.9,-9.7c-1.3,-3.4 -2.5,-6.7 -3.3,-10.3l0.9,0.8c-1.4,-0.3 -2.5,-0.7 -3.7,-1.2c-1.2,-0.5 -2.3,-1.1 -3.4,-1.8c-1.2,-0.8 -2.1,-1.9 -2.7,-3.1c-0.6,-1.2 -1,-2.5 -1.2,-3.9l0.6,0.9c-0.6,-0.2 -1.3,-0.4 -2,-0.5c-0.7,-0.1 -1.4,-0.1 -2.1,-0.1c-0.7,0 -1.4,0.1 -2.1,0.2c-0.7,0.1 -1.4,0.3 -2.1,0.6l0,0c-0.4,0.1 -0.7,-0.1 -0.8,-0.4C81.7,113.6 81.8,113.2 82.1,113.1z&quot;/>"
-        errorLine2="                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1087 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/drawable/img_email_alert_120dp.xml"
-            line="29"
-            column="57"/>
+            file="src/main/res/drawable/img_email_alert_120dp.xml"
+            line="29"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (3673 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M32.8 35.8c-1.5 0-2.7-1.2-2.7-2.7V22.6c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7V33c0.1 1.5-1.1 2.8-2.7 2.8zm0-23.5c-1.5 0-2.7-1.2-2.7-2.7V2.7c0-1.5 1.2-2.7 2.7-2.7h6.8c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.7-2.7 2.7h-4.1v4.1c0.1 1.6-1.1 2.8-2.7 2.8zm247.5-6.8h-13.4c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.7-2.7 2.7zm26.1 0H293c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.7-2.7 2.7zm-52.8 0h-13.4c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.7-2.7 2.7zm-26.8 0h-13.4c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.7-2.7 2.7zm-26.7 0h-13.4c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.7-2.7 2.7zm-26.8 0H160c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.8 2.7-2.8h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.8-2.8 2.8zm-26.7 0h-13.4c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.7-2.7 2.7zm-26.7 0h-13.4c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.8 2.7-2.8h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.8-2.7 2.8zm-26.8 0H79.8c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.8 2.7-2.8h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.8-2.8 2.8zm-26.7 0H53c-1.5 0-2.7-1.2-2.7-2.7C50.3 1.3 51.5 0 53 0h13.4c1.5 0 2.7 1.2 2.7 2.7 0 1.5-1.2 2.8-2.7 2.8zm259 6.8c-1.5 0-2.7-1.2-2.7-2.7V5.5h-4.1c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h6.8c1.5 0 2.7 1.2 2.7 2.7v6.8c0.1 1.5-1.1 2.7-2.7 2.7zm0 185.1c-1.5 0-2.7-1.2-2.7-2.7v-13.4c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v13.4c0.1 1.5-1.1 2.7-2.7 2.7zm0-50.7c-1.5 0-2.7-1.2-2.7-2.7v-13.4c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7V144c0.1 1.5-1.1 2.7-2.7 2.7zm0 25c-1.5 0-2.7-1.2-2.7-2.7v-13.4c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7V169c0.1 1.5-1.1 2.7-2.7 2.7zm0-51.9c-1.5 0-2.7-1.2-2.7-2.7v-13.4c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v13.4c0.1 1.5-1.1 2.7-2.7 2.7zm0-26.9c-1.5 0-2.7-1.2-2.7-2.7V76.8c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v13.4c0.1 1.5-1.1 2.7-2.7 2.7zm0-26.8c-1.5 0-2.7-1.2-2.7-2.7V49.9c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v13.4c0.1 1.5-1.1 2.8-2.7 2.8zm0-26.9c-1.5 0-2.7-1.2-2.7-2.7V23c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v13.4c0.1 1.6-1.1 2.8-2.7 2.8zm0 179.6c-1.5 0-2.7-1.2-2.7-2.7v-6.8c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v6.8c0.1 1.5-1.1 2.7-2.7 2.7zm-42.9 39.6h-6.8c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h6.8c1.5 0 2.7 1.2 2.7 2.7 0 1.4-1.2 2.7-2.7 2.7zm-21.8 0H247c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.7c1.5 0 2.7 1.2 2.7 2.7 0 1.4-1.2 2.7-2.7 2.7zm-56 0h-13.8c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.8c1.5 0 2.7 1.2 2.7 2.7 0 1.4-1.2 2.7-2.7 2.7zm27.3 0h-13.8c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7H232c1.5 0 2.7 1.2 2.7 2.7 0 1.4-1.2 2.7-2.7 2.7zm-54.8 0h-13.7c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.7c1.5 0 2.7 1.2 2.7 2.7 0 1.4-1.2 2.7-2.7 2.7zm-27.5 0h-13.8c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.8c1.5 0 2.7 1.2 2.7 2.7 0 1.4-1.2 2.7-2.7 2.7zm-27.5 0h-13.8c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.8c1.5 0 2.7 1.2 2.7 2.7 0 1.4-1.2 2.7-2.7 2.7zm-27.5 0H80.9c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.7c1.5 0 2.7 1.2 2.7 2.7 0.1 1.4-1.1 2.7-2.6 2.7zm-27.5 0H53.4c-1.5 0-2.7-1.2-2.7-2.7 0-1.5 1.2-2.7 2.7-2.7h13.7c1.5 0 2.7 1.2 2.7 2.7 0.1 1.4-1.1 2.7-2.6 2.7zm-27.5 0h-6.8c-1.5 0-2.7-1.2-2.7-2.7v-6.8c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v4.1h4.1c1.5 0 2.7 1.2 2.7 2.7 0 1.4-1.2 2.7-2.7 2.7zm7.4-35.1c-1.5 0-2.7-1.2-2.7-2.7v-15.2c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v15.2c0 1.5-1.2 2.7-2.7 2.7zm0-30.4c-1.5 0-2.7-1.2-2.7-2.7V175c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7v15.2c0 1.5-1.2 2.7-2.7 2.7z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (3673 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_add_media_150dp.xml"
-            line="14"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_add_media_150dp.xml"
+            line="14"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1011 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M213.2 98.2l15.6-0.3-1.6 1.3c0.6-3.5 1.6-6.8 3.1-10 1.4-3.2 3.3-6.3 5.9-8.9 2.6-2.6 6.1-4.5 9.9-4.9 1.9-0.3 3.7-0.2 5.6 0.2 1.9 0.4 3.7 1.2 5.3 2.5 1.6 1.2 2.8 2.9 3.6 4.6 0.2 0.4 0.4 0.9 0.6 1.3 0 0.1 0.1 0.2 0.2 0.3 0.2 0.2 0.4 0.2 0.6 0.2 0.1 0 0 0 0.2-0.1l0.7-0.3c0.4-0.2 0.9-0.4 1.3-0.5 0.9-0.3 1.8-0.5 2.8-0.7 1.9-0.3 3.7-0.3 5.6-0.1 0.9 0.1 1.8 0.2 2.7 0.5l1.5 0.5c0.5 0.2 0.9 0.5 1.4 0.7 1.8 1.1 3.1 2.8 3.9 4.5 1.6 3.6 1.9 7.2 1.6 10.8l-1.6-1.8c5.9 0 11.8 0.3 17.8 0.4 0.7 0 1.3 0.6 1.2 1.3 0 0.7-0.6 1.2-1.2 1.2-5.9 0.1-11.8 0.3-17.8 0.4-0.9 0-1.6-0.7-1.6-1.6v-0.2c0.2-3-0.2-6.4-1.5-8.9-0.7-1.3-1.5-2.3-2.6-3l-0.9-0.5-1-0.3c-0.7-0.2-1.5-0.3-2.2-0.4-1.5-0.2-3.1-0.2-4.5 0.1-0.7 0.1-1.4 0.3-2.1 0.5-0.3 0.1-0.7 0.3-1 0.4l-0.5 0.2c-0.2 0.1-0.6 0.3-0.9 0.4-1.4 0.4-3 0.1-4.1-0.9-0.6-0.5-1-1.1-1.2-1.8-0.1-0.3-0.3-0.7-0.4-1-0.6-1.3-1.5-2.4-2.6-3.3-2.1-1.7-5.2-2.4-8.2-1.9-2.9 0.3-5.6 1.7-7.8 3.9-4.4 4.3-7 10.7-8.3 16.9v0.1c-0.2 0.7-0.8 1.2-1.5 1.2l-15.6-0.3c-0.7 0-1.3-0.6-1.2-1.3-0.4-0.8 0.1-1.3 0.8-1.4z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1011 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_add_media_150dp.xml"
-            line="69"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_add_media_150dp.xml"
+            line="69"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (817 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M92.4,29.9c0.4,0.3 0.8,0.6 1.2,1l1.1,1.1l2.2,2.2h-0.5c0.7,-0.7 1.5,-1.4 2.2,-2.2c0.7,-0.7 1.5,-1.4 2.4,-2c0,0 0.1,0 0.1,0c0,0 0,0 0,0v0.1c-0.6,0.9 -1.3,1.6 -2,2.4c-0.7,0.7 -1.4,1.5 -2.2,2.2c-0.2,0.1 -0.4,0.1 -0.5,0l-2.2,-2.2l-1.1,-1.2c-0.4,-0.4 -0.7,-0.8 -1,-1.2c-0.1,-0.1 0,-0.3 0.1,-0.3C92.3,29.9 92.3,29.9 92.4,29.9zM104.1,51.2c1.3,1 2.3,2.3 3.2,3.7c0.4,0.7 0.8,1.4 1.1,2.1c0.2,0.3 0.3,0.7 0.5,1.1l0.5,1.2c1.1,3 1.8,6.2 2.2,9.4c0.3,3.2 0.4,6.4 0.3,9.6l-0.1,2.4l-0.3,2.4c-0.1,0.8 -0.2,1.6 -0.3,2.4s-0.3,1.6 -0.4,2.4c0,0.1 -0.1,0.1 -0.1,0.1c-0.1,0 -0.1,-0.1 -0.1,-0.1c0.2,-3.2 0.6,-6.3 0.7,-9.5c0.1,-3.2 0.1,-6.3 -0.3,-9.5c-0.3,-3.1 -1,-6.2 -2.1,-9.2l-0.4,-1.1c-0.1,-0.3 -0.3,-0.7 -0.5,-1.1c-0.3,-0.7 -0.7,-1.4 -1.1,-2c-0.8,-1.3 -1.8,-2.5 -2.9,-3.7c-0.1,-0.1 -0.1,-0.2 0,-0.3C104,51.1 104,51.1 104.1,51.2L104.1,51.2z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (817 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="75"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
+            line="75"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (846 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M95.1,25.1c0.2,0.1 0.5,0.2 0.8,0.2c0.3,0 0.5,-0.1 0.7,-0.3c0.1,-0.1 0.2,-0.1 0.3,0c0.1,0.1 0.1,0.1 0.1,0.2c-0.1,0.2 -0.3,0.4 -0.5,0.5c-0.2,0.1 -0.4,0.2 -0.7,0.1c-0.2,0 -0.5,-0.1 -0.7,-0.1c-0.2,-0.1 -0.4,-0.3 -0.5,-0.5c-0.1,-0.1 0,-0.3 0.1,-0.3S95,25 95.1,25.1L95.1,25.1zM93.6,19.2c-0.3,0 -0.5,0 -0.8,0.1c-0.3,0.1 -0.6,0.1 -0.8,0.2h-0.1c-0.1,0.1 -0.3,0 -0.3,-0.1v-0.2c0.3,-0.3 0.6,-0.5 1,-0.5c0.2,0 0.4,0 0.6,0c0.2,0 0.4,0.1 0.6,0.3c0.1,0.1 0.1,0.2 0,0.3c-0.1,0.1 -0.1,0.1 -0.1,0.1C93.8,19.2 93.6,19.2 93.6,19.2zM97.1,18.7c0.2,-0.2 0.5,-0.4 0.7,-0.4c0.2,-0.1 0.5,-0.1 0.7,0c0.5,0.1 0.9,0.3 1.1,0.7c0.1,0.2 0.1,0.4 -0.1,0.5c0,0 -0.1,0 -0.1,0c-0.1,0 -0.1,0.1 -0.2,0.1H99c-0.2,0 -0.5,0 -0.7,-0.1c-0.1,0 -0.3,-0.1 -0.4,-0.1c-0.1,0 -0.2,-0.1 -0.3,-0.1c-0.2,0.1 -0.5,0.1 -0.6,-0.1c0,0 0,0 0,0C96.9,19.1 96.9,18.8 97.1,18.7C97.1,18.7 97.1,18.7 97.1,18.7z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (846 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="110"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
+            line="110"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1003 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M98.8,38.1c-0.1,0.8 -0.5,1.6 -1.1,2.2c-0.5,0.6 -1.2,1.2 -1.8,1.6c-0.1,0.1 -0.3,0.1 -0.5,0c0,0 0,0 0,0c-0.1,-0.1 -0.1,-0.2 0,-0.3c0.2,-0.4 0.4,-0.8 0.5,-1.2c0.1,-0.2 0.1,-0.4 0.1,-0.6c0.1,-0.2 0,-0.4 0,-0.3c0,0.1 -0.1,0 -0.2,0.1c-0.2,0.1 -0.3,0.2 -0.4,0.3c-0.3,0.3 -0.5,0.7 -0.7,1c-0.3,0.3 -0.4,0.7 -0.6,1.2l-0.3,0.6c-0.1,0.2 -0.3,0.4 -0.5,0.6c-0.4,0.3 -0.8,0.6 -1.3,0.7c-0.4,0.2 -0.8,0.4 -1.2,0.5c-1.6,0.7 -3.2,1.5 -4.7,2.4c-1.5,0.9 -2.8,2.2 -3.6,3.7c0,0.1 -0.1,0.1 -0.1,0.1c-0.1,0 -0.1,-0.1 -0.1,-0.1c0.7,-1.8 1.9,-3.2 3.5,-4.2c1.5,-1 3.1,-1.8 4.8,-2.5c0.4,-0.2 0.8,-0.3 1.2,-0.5c0.4,-0.2 0.7,-0.4 1.1,-0.6c0.1,-0.2 0.2,-0.3 0.3,-0.5l0.3,-0.6c0.2,-0.4 0.4,-0.8 0.7,-1.2c0.2,-0.4 0.5,-0.8 0.8,-1.2c0.2,-0.2 0.4,-0.4 0.6,-0.5c0.1,-0.1 0.3,-0.1 0.5,-0.1h0.3c0.1,0 0.2,0.1 0.3,0.1c0.1,0.1 0.1,0.2 0.2,0.3c0.1,0.1 0.1,0.2 0.1,0.3v0.4c-0.1,0.2 -0.1,0.5 -0.2,0.7c-0.1,0.5 -0.3,0.9 -0.6,1.3l-0.5,-0.5c0.6,-0.4 1.2,-0.9 1.7,-1.5c0.5,-0.5 0.9,-1.2 1.2,-1.8c0.1,-0.1 0.2,-0.2 0.3,-0.1C98.8,37.9 98.9,38 98.8,38.1z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1003 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="130"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
+            line="130"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1304 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M111.2,49.3c-0.3,0.3 -0.6,0.7 -0.7,1.2l-0.6,1.2c-0.4,0.8 -0.7,1.7 -1.1,2.6c-0.3,0.9 -0.7,1.8 -0.9,2.6l-0.2,0.7l-0.1,0.1c0,0.1 0,0.1 -0.1,0.2c-0.1,0.2 -0.2,0.3 -0.3,0.4c-0.4,0.3 -0.9,0.6 -1.4,0.7c-0.2,0.1 -0.4,0.1 -0.6,0.2l0.1,-0.1c0.1,-0.1 0.1,-0.1 0.1,-0.2v-0.1c0,0.1 0,0.1 0.1,0.1c0,0 0,0.1 0.1,0.1c0.1,0.1 0.3,0.1 0.5,0.1c0.2,0 0.5,0 0.7,0c0.1,0 0.2,0 0.3,0.1c0.1,0 0.1,0.1 0.2,0.1c0.1,0.1 0.2,0.2 0.2,0.3c0,0.3 -0.1,0.3 -0.1,0.4l-0.2,0.2c-0.2,0.2 -0.4,0.3 -0.6,0.4l-1.2,0.7c-0.4,0.3 -0.8,0.5 -1.1,0.7c-0.3,0.2 -0.6,0.5 -0.7,0.9c0,0.5 0,0.9 0.3,1.1c0.4,0.2 0.8,0.3 1.2,0.3c0.1,0 0.1,0.1 0.1,0.1c0,0.1 -0.1,0.1 -0.1,0.1c-0.5,0.1 -1,0 -1.5,-0.2c-0.2,-0.1 -0.4,-0.4 -0.5,-0.7c-0.1,-0.2 -0.1,-0.5 -0.1,-0.7c0,-0.3 0.1,-0.6 0.3,-0.8c0.2,-0.2 0.3,-0.4 0.5,-0.5c0.4,-0.3 0.8,-0.6 1.1,-0.9c0.4,-0.3 0.8,-0.5 1.2,-0.7c0.2,-0.1 0.4,-0.3 0.5,-0.4c0.1,-0.1 0.1,0 0.1,-0.1v0.1c0.1,0.1 0.1,0.1 0.1,0.1h-0.1c-0.3,-0.1 -0.9,0.2 -1.6,-0.1c-0.2,-0.1 -0.3,-0.2 -0.4,-0.4c-0.1,-0.1 -0.1,-0.1 -0.1,-0.2V59c0,-0.1 0,-0.2 0.1,-0.3c0.1,-0.1 0.1,-0.1 0.2,-0.1c0.3,-0.1 0.5,-0.2 0.7,-0.3c0.4,-0.1 0.8,-0.3 1.1,-0.5l0.1,-0.1c0,-0.1 0,-0.1 0.1,-0.1l0.1,-0.2l0.2,-0.7c0.3,-0.9 0.6,-1.8 1,-2.6c0.4,-0.9 0.7,-1.8 1.2,-2.6C109.8,50.6 110.4,49.9 111.2,49.3L111.2,49.3C111.2,49.3 111.2,49.3 111.2,49.3C111.2,49.3 111.2,49.3 111.2,49.3z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1304 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="140"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
+            line="140"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1692 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M46.9,89c1.4,-1.1 2.4,-2.7 2.9,-4.4c0.5,-1.7 0.6,-3.5 0.4,-5.3c-0.5,-3.5 -1.6,-6.9 -3.4,-10c-1.8,-3.1 -4.2,-5.7 -7,-7.9c-1.4,-1 -3,-1.9 -4.6,-2.5c-1.6,-0.6 -3.4,-0.7 -5.1,-0.2c-1.6,0.5 -3,1.7 -3.8,3.2c-0.8,1.5 -1.1,3.3 -0.8,5c0.3,3.5 1.8,6.8 3.4,10c1.7,3.2 3.7,6.1 6.1,8.7c1.2,1.3 2.6,2.5 4.1,3.5c0.7,0.5 1.5,0.8 2.4,1.1c0.8,0.2 1.7,0.2 2.5,-0.2c0.1,-0.1 0.1,0 0.2,0.1c0.1,0.1 0,0.1 -0.1,0.2c-0.8,0.4 -1.8,0.5 -2.7,0.3c-0.9,-0.2 -1.8,-0.6 -2.6,-1c-1.5,-1 -2.9,-2.1 -4.2,-3.5c-2.5,-2.6 -4.6,-5.6 -6.3,-8.7c-0.9,-1.6 -1.6,-3.2 -2.2,-4.9c-0.6,-1.7 -1.1,-3.5 -1.3,-5.3c-0.3,-1.9 0,-3.8 0.9,-5.5c0.9,-1.7 2.4,-2.9 4.3,-3.5c1.8,-0.5 3.8,-0.4 5.5,0.3c1.7,0.6 3.3,1.5 4.8,2.6c2.9,2.2 5.4,4.9 7.2,8.1c0.9,1.6 1.6,3.3 2.2,5c0.6,1.7 1,3.5 1.1,5.4c0.2,1.8 0,3.7 -0.5,5.4c-0.6,1.8 -1.6,3.3 -3.1,4.4H47C46.9,89.2 46.9,89.1 46.9,89zM54.1,93.6c-0.9,-1.4 -1.4,-3.1 -1.5,-4.7c-0.1,-1.7 0.1,-3.3 0.6,-4.9c1,-3.2 2.9,-6.1 5.4,-8.3c0.1,-0.1 0.3,-0.1 0.5,0c0,0 0,0 0,0c0.1,0.1 0.1,0.1 0.1,0.1l1.6,5.7l-0.7,0.1l0.8,-6.4c0,-0.1 0.1,-0.3 0.3,-0.3c1.5,-0.5 3.1,-0.6 4.6,-0.3c0.8,0.2 1.5,0.4 2.2,0.8c0.7,0.4 1.2,1 1.7,1.6c1,1.2 1.5,2.7 1.7,4.3c0.1,1.5 -0.2,3.1 -0.7,4.5c-1.2,2.8 -3.2,5.2 -5.7,6.9c-1.2,0.9 -2.5,1.6 -4,2c-1.5,0.5 -3,0.5 -4.5,-0.1c-0.1,0 -0.1,-0.1 -0.1,-0.2c0,-0.1 0.1,-0.1 0.2,-0.1c1.4,0.5 2.9,0.4 4.3,-0.1c1.4,-0.5 2.7,-1.2 3.8,-2c2.4,-1.8 4.2,-4.1 5.4,-6.8c0.6,-1.3 0.8,-2.8 0.7,-4.2c-0.1,-1.4 -0.7,-2.8 -1.6,-3.9c-0.4,-0.5 -0.9,-1 -1.5,-1.4c-0.6,-0.3 -1.3,-0.6 -2,-0.7c-1.4,-0.2 -2.8,-0.2 -4.2,0.3l0.3,-0.3L61,81.5c0,0.2 -0.1,0.3 -0.3,0.3c0,0 -0.1,0 -0.1,0c-0.1,0 -0.3,-0.1 -0.3,-0.3l-1.6,-5.7l0.5,0.1c-2.5,2.1 -4.3,4.9 -5.3,8c-0.5,1.5 -0.8,3.2 -0.7,4.8c0,1.6 0.4,3.2 1.2,4.7v0.1L54.1,93.6L54.1,93.6z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1692 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="145"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
+            line="145"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1242 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M143.6,55c-0.3,0 -0.3,-0.1 -0.5,-0.2c-0.1,-0.1 -0.3,-0.2 -0.5,-0.3c-0.3,-0.1 -0.6,-0.2 -0.9,-0.3c-0.3,-0.1 -0.6,-0.1 -0.9,0.1c-0.3,0.1 -0.7,0.2 -1,0.3c-0.1,0 -0.1,-0.1 -0.1,-0.1v-0.1c0.2,-0.4 0.5,-0.7 0.9,-0.7c0.4,-0.1 0.8,-0.2 1.2,-0.1c0.4,0.1 0.8,0.2 1.1,0.4c0.2,0.1 0.3,0.2 0.5,0.3c0.1,0.1 0.3,0.2 0.4,0.4C143.9,54.9 143.8,55 143.6,55L143.6,55zM149.9,57.9c-0.3,-0.1 -0.3,-0.3 -0.4,-0.5l-0.3,-0.5c-0.2,-0.3 -0.4,-0.7 -0.6,-1.1c-0.2,-0.4 -0.4,-0.8 -0.5,-1.2c-0.2,-0.4 -0.3,-0.8 -0.3,-1.2c0,-0.1 0.1,-0.1 0.1,-0.1h0.1c0.3,0.3 0.5,0.6 0.7,1l0.5,1.1l0.5,1.1l0.3,0.5c0.1,0.2 0.3,0.3 0.2,0.5C150.2,57.8 150.1,57.9 149.9,57.9L149.9,57.9zM128.1,56.6c-0.1,0.8 -0.2,1.6 -0.4,2.4c-0.1,0.8 -0.3,1.6 -0.5,2.4c-0.3,1.6 -0.4,3.3 -0.4,4.9c0,1.6 0.2,3.3 0.5,4.9c0.3,1.6 0.7,3.3 0.9,4.9c0,0.1 0,0.1 -0.1,0.1c-0.1,0 -0.1,0 -0.1,-0.1c-0.6,-1.6 -1.1,-3.2 -1.3,-4.8c-0.3,-1.7 -0.5,-3.3 -0.6,-5c0,-1.7 0.1,-3.4 0.5,-5c0.1,-0.8 0.3,-1.6 0.5,-2.4c0.2,-0.8 0.4,-1.6 0.7,-2.4c0.1,-0.1 0.2,-0.2 0.3,-0.1C128,56.4 128.1,56.5 128.1,56.6L128.1,56.6zM129.7,62.7c0,0.3 0,0.6 -0.1,0.9c-0.1,0.3 -0.2,0.6 -0.3,0.8c0,0.1 -0.1,0.1 -0.2,0c0,0 0,0 0,0c-0.2,-0.3 -0.2,-0.6 -0.1,-0.9c0.1,-0.3 0.2,-0.6 0.3,-0.9c0.1,-0.1 0.2,-0.1 0.3,-0.1C129.6,62.5 129.7,62.6 129.7,62.7L129.7,62.7z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1242 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="205"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
+            line="205"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (849 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M149.7,102.8c0.1,0.7 0.1,1.5 0,2.2l-0.1,2.2c-0.1,1.5 -0.1,3 -0.2,4.5l-0.2,4.5c0,1.5 -0.2,3 -0.4,4.5c0,0.1 -0.1,0.1 -0.1,0.1c-0.1,-0.1 -0.1,-0.1 -0.1,-0.1c-0.1,-1.5 -0.1,-3 -0.1,-4.5l0.1,-4.5l0.2,-4.5l0.1,-2.2c0,-0.8 0.1,-1.5 0.2,-2.2c0,-0.1 0.1,-0.2 0.3,-0.1S149.7,102.7 149.7,102.8L149.7,102.8zM142.7,102.8c0.2,0.7 0.2,1.5 0.3,2.2l0.2,2.2c0.1,1.5 0.3,3.1 0.4,4.5l0.3,4.5c0.1,1.5 0.2,3 0.1,4.5c0,0.1 -0.1,0.1 -0.1,0.1c-0.1,0 -0.1,-0.1 -0.1,-0.1c-0.3,-1.5 -0.5,-3 -0.6,-4.5l-0.4,-4.5c-0.1,-1.5 -0.3,-3.1 -0.3,-4.5l-0.2,-2.2c-0.1,-0.8 -0.1,-1.5 -0.1,-2.3c0,-0.1 0.1,-0.2 0.3,-0.2S142.7,102.7 142.7,102.8L142.7,102.8zM153.2,91.3c-0.3,0.1 -0.5,0.1 -0.8,0.1h-4.1c-0.5,0 -1.1,0 -1.6,-0.2c-0.1,0 -0.1,-0.1 -0.1,-0.1c0,0 0,-0.1 0.1,-0.1c0.5,-0.2 1.1,-0.2 1.6,-0.2h4.1c0.3,-0.1 0.6,0 0.8,0.1C153.3,91.1 153.3,91.2 153.2,91.3C153.3,91.3 153.3,91.3 153.2,91.3z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (849 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="215"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
+            line="215"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (949 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M153.7,88.6L153.7,88.6c1.8,-1 3.5,-1.8 5.2,-2.6l5.1,-2.4l-0.2,0.4c-1.1,-3.7 -3,-7 -5.1,-10.2c-1.1,-1.6 -2.2,-3.1 -3.4,-4.6l-0.5,-0.5c-0.1,-0.2 -0.2,-0.3 -0.4,-0.4c-0.3,-0.2 -0.7,-0.3 -1.1,-0.1c-0.1,0 -0.2,0.1 -0.3,0.1l-0.3,0.1l-0.6,0.3l-1.3,0.7l-2.6,1.4c-0.4,0.1 -0.6,0.4 -0.7,0.8c-0.1,0.2 -0.1,0.4 -0.1,0.5c0,0.2 0.1,0.4 0.1,0.6c0.5,1.8 1.1,3.7 1.8,5.5c0.7,1.8 1.3,3.6 2,5.4c0.3,0.9 0.7,1.8 1.1,2.6c0.2,0.4 0.4,0.9 0.6,1.3C153.3,87.9 153.5,88.3 153.7,88.6L153.7,88.6zM153.7,89L153.7,89c-0.4,-0.5 -0.6,-0.9 -0.9,-1.4c-0.3,-0.4 -0.5,-0.8 -0.7,-1.3c-0.5,-0.8 -0.9,-1.7 -1.3,-2.6c-0.8,-1.8 -1.5,-3.6 -2.2,-5.4c-0.7,-1.8 -1.2,-3.7 -1.8,-5.5c-0.1,-0.2 -0.1,-0.5 -0.2,-0.7c0,-0.3 0,-0.6 0.1,-0.9c0.2,-0.6 0.6,-1 1.1,-1.2l2.6,-1.4l1.3,-0.7l0.6,-0.3l0.3,-0.1c0.1,-0.1 0.3,-0.1 0.4,-0.1c0.6,-0.2 1.2,-0.1 1.7,0.3c0.2,0.1 0.4,0.3 0.6,0.5l0.5,0.5c1.2,1.5 2.4,3.1 3.4,4.7c2.2,3.2 4,6.7 5.2,10.4c0.1,0.1 -0.1,0.3 -0.2,0.4l-5.3,2.4C157.2,87.5 155.4,88.3 153.7,89z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (949 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="255"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
+            line="255"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1628 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M155.8,55.4c0.6,1 1.1,2 1.6,3c0.5,1 0.9,2.1 1.3,3.2c0.5,1.1 0.6,2.3 0.5,3.5c-0.1,0.7 -0.4,1.3 -0.9,1.7c-0.2,0.2 -0.5,0.4 -0.8,0.5l-0.4,0.2c-0.2,0.1 -0.3,0.1 -0.5,0.1c-0.6,0 -1.3,-0.1 -1.8,-0.3c-0.5,-0.2 -1.1,-0.5 -1.6,-0.8c-1,-0.6 -1.9,-1.3 -2.8,-2.1c-1.8,-1.5 -3.4,-3.1 -4.9,-4.9l0.3,0.1c-0.7,0 -1.4,-0.4 -2,-0.9c-0.5,-0.5 -0.9,-1.1 -1,-1.8c-0.1,-0.6 -0.3,-1.2 -0.9,-1.3c-0.6,-0.1 -1.2,0.1 -1.7,0.4c-0.1,0 -0.1,0 -0.1,-0.1v-0.1c0.3,-0.2 0.6,-0.4 0.9,-0.5c0.3,-0.1 0.7,-0.2 1.1,-0.1c0.4,0.1 0.7,0.3 0.9,0.6c0.2,0.3 0.3,0.6 0.4,0.9c0.1,0.6 0.4,1.1 0.9,1.5c0.4,0.4 1,0.6 1.6,0.7c0.1,0 0.2,0.1 0.3,0.1c1.5,1.7 3.1,3.3 4.9,4.7c0.9,0.7 1.8,1.4 2.7,2c0.5,0.3 1,0.5 1.5,0.7c0.5,0.2 1,0.3 1.5,0.3c0.2,0 0.5,-0.1 0.7,-0.2c0.3,-0.1 0.4,-0.3 0.6,-0.4c0.4,-0.3 0.6,-0.8 0.7,-1.3c0.1,-1.1 -0.1,-2.2 -0.5,-3.2c-0.4,-1.1 -0.8,-2.1 -1.3,-3.2c-0.5,-1 -0.9,-2 -1.4,-3.1c-0.1,-0.1 0,-0.3 0.1,-0.3C155.6,55.3 155.7,55.3 155.8,55.4L155.8,55.4zM143.9,122c0.1,0.3 0.3,0.6 0.7,0.6c8.6,0.1 10.8,1.1 11.3,-0.5c0.4,-1.4 -8.6,-3.3 -11.5,-3.7c-0.4,0 -0.7,0.2 -0.7,0.6c0,0 0,0.1 0,0.1L143.9,122L143.9,122zM131.6,102.5c0.2,0.7 0.2,1.3 0.2,2l0.1,2l0.3,4l0.2,4c0.1,1.4 0.1,2.7 0,4.1c0,0.1 -0.1,0.1 -0.1,0.1c-0.1,0 -0.1,-0.1 -0.1,-0.1c-0.3,-1.3 -0.4,-2.7 -0.5,-4l-0.3,-4l-0.2,-4l-0.1,-2c-0.1,-0.7 -0.1,-1.4 0,-2c0,-0.1 0.1,-0.2 0.3,-0.2S131.6,102.5 131.6,102.5L131.6,102.5zM141,87.8c0,1.4 -0.2,2.7 -0.3,4.1l-0.5,4.1c-0.3,2.7 -0.6,5.4 -0.9,8.1l-1,8.1c-0.3,2.7 -0.7,5.4 -1.2,8.1c0,0.1 -0.1,0.1 -0.1,0.1c-0.1,-0.1 -0.1,-0.1 -0.1,-0.1c0.1,-2.7 0.4,-5.5 0.7,-8.2l0.9,-8.1l1,-8.1l0.5,-4.1c0.2,-1.4 0.3,-2.7 0.6,-4.1c0,-0.1 0.1,-0.2 0.3,-0.1C141,87.6 141,87.7 141,87.8z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1628 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="260"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
+            line="260"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1630 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M179.3,101.6c0.2,-0.2 0.3,-0.5 0.3,-0.7c0,-0.1 -0.1,-0.2 -0.1,-0.3l-0.3,-0.3c-0.5,-0.4 -1,-0.6 -1.6,-0.7c-0.6,-0.1 -1.2,0.1 -1.7,0.3c-0.5,0.2 -1,0.6 -1.4,1v-0.5c0.2,0.4 0.5,0.7 0.9,0.9c0.4,0.3 0.8,0.5 1.2,0.5C177.5,102.2 178.5,102 179.3,101.6L179.3,101.6zM179.5,101.8c-0.8,0.7 -1.9,1 -3,0.9c-0.6,-0.1 -1.1,-0.3 -1.6,-0.6c-0.4,-0.3 -0.8,-0.7 -1.1,-1.2c-0.1,-0.2 -0.1,-0.3 0,-0.5c0.9,-1.2 2.4,-1.9 3.8,-1.7c0.7,0.1 1.4,0.4 1.9,0.9c0.1,0.1 0.3,0.3 0.3,0.5c0.1,0.2 0.1,0.4 0.1,0.6C180,101.2 179.8,101.6 179.5,101.8L179.5,101.8zM180.1,97.6c0.2,-0.2 0.3,-0.5 0.3,-0.7c0,-0.1 -0.1,-0.2 -0.1,-0.3c-0.1,-0.1 -0.1,-0.2 -0.3,-0.3c-0.4,-0.4 -1,-0.7 -1.6,-0.8c-0.6,-0.1 -1.1,0 -1.7,0.2c-0.6,0.2 -1.1,0.5 -1.5,0.9l0.1,-0.5c0.2,0.4 0.5,0.7 0.8,1c0.3,0.3 0.7,0.5 1.1,0.7C178.3,98 179.3,97.9 180.1,97.6L180.1,97.6zM180.2,97.8c-0.9,0.6 -2,0.9 -3,0.6c-0.5,-0.1 -1.1,-0.4 -1.5,-0.7c-0.4,-0.3 -0.8,-0.8 -1.1,-1.2c-0.1,-0.2 -0.1,-0.3 0.1,-0.5c0.5,-0.5 1.1,-1 1.8,-1.2c0.7,-0.2 1.4,-0.3 2.2,-0.1c0.7,0.2 1.4,0.6 1.8,1.2c0.1,0.1 0.3,0.3 0.3,0.5c0.1,0.2 0.1,0.4 0.1,0.6C180.8,97.2 180.6,97.6 180.2,97.8zM182,94.1c0.3,-0.1 0.5,-0.4 0.5,-0.7v-0.3c-0.1,-0.1 -0.1,-0.2 -0.2,-0.3c-0.3,-0.5 -0.8,-0.9 -1.3,-1.2c-0.5,-0.2 -1.1,-0.3 -1.7,-0.3c-0.6,0.1 -1.1,0.3 -1.6,0.5l0.1,-0.5c0.1,0.4 0.3,0.8 0.5,1.2c0.3,0.3 0.6,0.6 0.9,0.9c0.8,0.5 1.8,0.7 2.7,0.5L182,94.1L182,94.1zM182.1,94.3c-1,0.4 -2.1,0.3 -3.1,-0.1c-0.5,-0.3 -0.9,-0.6 -1.3,-1c-0.4,-0.4 -0.6,-0.9 -0.7,-1.5c-0.1,-0.2 0,-0.3 0.1,-0.4c0.6,-0.4 1.3,-0.7 2,-0.7c0.7,-0.1 1.5,0.1 2.2,0.4c0.7,0.3 1.2,0.9 1.5,1.6c0.1,0.2 0.2,0.3 0.2,0.5c0,0.2 0,0.4 -0.1,0.6C182.8,94 182.4,94.3 182.1,94.3L182.1,94.3L182.1,94.3z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1630 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="285"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
+            line="285"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1330 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M174.8,95.9L174.8,95.9l-0.1,-0.3c-0.1,-0.1 -0.1,-0.3 -0.1,-0.4c-0.1,-0.3 -0.2,-0.5 -0.3,-0.7c-0.3,-0.5 -0.6,-0.8 -1.1,-1.1c-0.4,-0.3 -0.9,-0.4 -1.4,-0.5H171c-0.2,0 -0.3,0.1 -0.4,0.2c-0.1,0.1 -0.1,0.3 -0.1,0.5c0.1,0.2 0.2,0.5 0.3,0.7c0.3,0.5 0.6,0.8 1.1,1.1c0.5,0.3 1,0.5 1.5,0.5c0.3,0.1 0.5,0.1 0.8,0.1c0.1,0 0.3,0 0.4,-0.1H174.8L174.8,95.9L174.8,95.9zM174.9,96.2l-0.2,0.1l-0.2,0.1c-0.1,0.1 -0.3,0.1 -0.4,0.1c-0.3,0.1 -0.6,0.1 -0.9,0.1c-0.6,0 -1.3,-0.2 -1.8,-0.5c-0.8,-0.5 -1.5,-1.2 -1.8,-2.2c-0.1,-0.4 -0.1,-0.8 0.2,-1.2c0.2,-0.3 0.6,-0.5 1,-0.6h0.9c0.6,0.1 1.2,0.3 1.8,0.7c0.5,0.3 0.9,0.9 1.1,1.5c0.1,0.3 0.2,0.6 0.3,0.9L174.9,96.2L174.9,96.2zM177.2,91.4v-0.3c0,-0.1 -0.1,-0.3 -0.1,-0.4c0,-0.3 -0.1,-0.5 -0.3,-0.7c-0.2,-0.5 -0.5,-0.9 -0.9,-1.2c-0.4,-0.3 -0.9,-0.5 -1.4,-0.7c-0.1,0 -0.3,-0.1 -0.4,-0.1h-0.3c-0.4,0 -0.7,0.3 -0.7,0.7c0,0 0,0 0,0c0,0.2 0.1,0.5 0.2,0.7c0.2,0.5 0.5,0.9 0.9,1.2c0.4,0.3 0.9,0.6 1.4,0.7c0.3,0.1 0.5,0.1 0.8,0.1h0.6L177.2,91.4L177.2,91.4zM177.3,91.7l-0.2,0.1l-0.2,0.1c-0.1,0 -0.3,0.1 -0.5,0.1c-0.3,0 -0.6,0 -0.9,-0.1c-0.6,-0.1 -1.2,-0.3 -1.7,-0.7c-0.5,-0.3 -0.9,-0.9 -1.1,-1.5c-0.2,-0.3 -0.3,-0.7 -0.3,-1c0,-0.4 0.1,-0.8 0.4,-1.1c0.3,-0.3 0.6,-0.4 1,-0.5h0.5c0.1,0 0.3,0.1 0.5,0.1c0.6,0.2 1.2,0.5 1.6,0.9c0.5,0.4 0.8,1 0.9,1.6c0.1,0.3 0.1,0.6 0.1,0.9c0,0.2 0,0.3 -0.1,0.5l-0.1,0.2L177.3,91.7L177.3,91.7z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1330 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="290"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
+            line="290"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (918 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M172.6,104.8l6.9,-0.2c0.1,0 0.3,0.1 0.3,0.3v0.1c-0.6,1.4 -1.3,2.7 -2,4v-0.3c0.7,1.3 1.3,2.8 1.6,4.3c0.4,1.5 0.5,3 0.4,4.5c-0.2,1.6 -0.9,3.1 -2.1,4.1c-1.3,1 -2.9,1.5 -4.5,1.4v-0.9h0.1c0.2,0 0.4,0.2 0.4,0.4s-0.2,0.4 -0.4,0.4c-1.6,0 -3.2,-0.5 -4.5,-1.4c-1.2,-1 -2,-2.5 -2.1,-4.1c-0.1,-1.5 0,-3.1 0.4,-4.5c0.4,-1.5 0.9,-2.9 1.6,-4.3v0.3l-2,-4c-0.1,-0.2 0,-0.3 0.1,-0.4h0.1l6.9,0.1v0.3h-1.5L172.6,104.8L172.6,104.8zM172.6,104.8h1.5c0.1,0 0.2,0.1 0.2,0.2c0,0.1 -0.1,0.2 -0.2,0.2c0,0 0,0 0,0l-6.9,0.1l0.3,-0.4l2.1,3.9c0.1,0.1 0.1,0.2 0,0.3c-0.7,1.3 -1.2,2.7 -1.5,4.1c-0.4,1.4 -0.5,2.8 -0.3,4.3c0.1,1.4 0.8,2.7 1.8,3.6c1.1,0.8 2.5,1.3 3.9,1.2v0.9h-0.1c-0.2,0 -0.4,-0.2 -0.4,-0.4c0,0 0,0 0,0c0,-0.2 0.2,-0.4 0.4,-0.4c1.4,0.1 2.8,-0.4 3.9,-1.2c1.1,-0.9 1.7,-2.2 1.8,-3.6c0.2,-1.4 0,-2.9 -0.3,-4.3c-0.4,-1.4 -0.9,-2.8 -1.5,-4.1c-0.1,-0.1 -0.1,-0.2 0,-0.3c0.7,-1.3 1.4,-2.6 2.1,-3.9l0.3,0.4l-6.9,-0.2v-0.4L172.6,104.8L172.6,104.8z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (918 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_empty_results_216dp.xml"
-            line="300"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_empty_results_216dp.xml"
+            line="300"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (958 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="    &lt;path android:fillColor=&quot;#C8D7E2&quot; android:pathData=&quot;M43.628 0.623c-8.762-0.35-21.694 4.811-29.24 12.697-3.804 3.916-6.896 8.542-8.915 13.643-2.02 5.1-3.098 10.442-3.098 15.898 0 5.456 1.073 10.917 3.207 15.898 2.134 4.98 5.232 9.612 9.035 13.408 3.804 3.796 8.44 6.881 13.436 8.896a42.779 42.779 0 0 0 15.93 3.086c5.468 0 10.82-1.07 15.931-3.086 4.991-2.015 9.632-5.1 13.436-8.896 3.803-3.796 6.895-8.422 9.035-13.408 2.14-4.986 3.207-10.442 3.207-15.898 0.12-10.917-4.28-21.709-12.007-29.54-3.803-3.916-8.439-7.117-13.55-9.252C53.643 0.765 45.718 0.705 43.628 0.623zm31.27 11.392c4.045 4.036 7.372 8.782 9.632 14.118 2.26 5.22 3.448 11.032 3.448 16.728 0.12 11.507-4.635 22.9-12.839 31.086-4.044 4.036-8.915 7.357-14.267 9.612C55.52 85.815 49.817 86.88 43.99 87c-11.53 0-23.062-4.746-31.15-12.933-4.044-4.036-7.372-9.016-9.512-14.237C1.193 54.494 0 48.798 0 42.98c0-11.507 4.876-22.9 13.08-30.846 4.159-3.916 9.035-7.116 14.267-9.251C32.584 0.907 38.05-0.158 43.633 0.022 43.83 0.027 62.935-0.563 74.9 12.015z&quot;/>"
-        errorLine2="                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (958 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_info_outline_88dp.xml"
-            line="8"
-            column="57"/>
+            file="src/main/res/drawable/img_illustration_info_outline_88dp.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (3386 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M95.6,70.7H91c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S95.8,70.7,95.6,70.7z M86.4,70.7h-4.6c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S86.6,70.7,86.4,70.7z M77.2,70.7h-4.6c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S77.4,70.7,77.2,70.7z M67.9,70.7h-4.6c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S68.2,70.7,67.9,70.7z M58.7,70.7h-4.6c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S59,70.7,58.7,70.7z M49.5,70.7h-4.6c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S49.8,70.7,49.5,70.7z M40.3,70.7h-4.6c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S40.6,70.7,40.3,70.7z M31.1,70.7h-4.6c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S31.3,70.7,31.1,70.7z M21.9,70.7h-4.6c-0.3,0-0.5-0.2-0.5-0.5s0.2-0.5,0.5-0.5h4.6c0.3,0,0.5,0.2,0.5,0.5S22.1,70.7,21.9,70.7z M12.7,70.7H8.1c-0.1,0-0.1,0-0.2,0c-0.4-0.2-0.4-0.2,0.6-2.9c0.1-0.2,0.4-0.4,0.6-0.3c0.2,0.1,0.4,0.4,0.3,0.6c-0.3,0.7-0.5,1.3-0.6,1.6h4c0.3,0,0.5,0.2,0.5,0.5S12.9,70.7,12.7,70.7z M94.8,66.3c-0.2,0-0.4-0.1-0.4-0.3c-0.4-1.5-0.8-3-1.3-4.4c-0.1-0.2,0-0.5,0.3-0.6c0.2-0.1,0.5,0,0.6,0.3c0.5,1.4,0.9,2.9,1.3,4.5c0.1,0.2-0.1,0.5-0.3,0.6C94.9,66.3,94.9,66.3,94.8,66.3z M10.6,64.1c-0.1,0-0.1,0-0.2,0c-0.2-0.1-0.3-0.4-0.2-0.6c0.6-1.4,1.3-2.8,2-4.2c0.1-0.2,0.4-0.3,0.6-0.2c0.2,0.1,0.3,0.4,0.2,0.6c-0.7,1.4-1.3,2.7-2,4.2C11,64,10.8,64.1,10.6,64.1z M91.8,57.6c-0.2,0-0.3-0.1-0.4-0.3c-0.7-1.5-1.4-2.8-2.2-4c-0.1-0.2-0.1-0.5,0.1-0.6c0.2-0.1,0.5-0.1,0.6,0.1c0.8,1.2,1.5,2.6,2.2,4.1c0.1,0.2,0,0.5-0.2,0.6C91.9,57.6,91.9,57.6,91.8,57.6z M14.8,55.9c-0.1,0-0.2,0-0.2-0.1c-0.2-0.1-0.3-0.4-0.2-0.6c0.8-1.4,1.6-2.7,2.5-3.9c0.1-0.2,0.4-0.3,0.6-0.1c0.2,0.1,0.3,0.4,0.1,0.6c-0.8,1.2-1.6,2.5-2.4,3.9C15.1,55.8,15,55.9,14.8,55.9z M60.6,50.2c0,0-0.1,0-0.1,0c-1.2-0.3-2.4-1.2-3.8-2.9c-0.2-0.2-0.1-0.5,0.1-0.6c0.2-0.2,0.5-0.1,0.6,0.1c1.3,1.5,2.3,2.3,3.4,2.6c0.2,0.1,0.4,0.3,0.3,0.6C60.9,50.1,60.8,50.2,60.6,50.2z M86.7,50c-0.1,0-0.2,0-0.3-0.1c-1.2-1.1-2.4-1.9-3.7-2.4c-0.2-0.1-0.4-0.4-0.3-0.6s0.4-0.4,0.6-0.3c1.4,0.5,2.7,1.4,4,2.6c0.2,0.2,0.2,0.5,0,0.7C87,50,86.8,50,86.7,50z M65.1,50c-0.2,0-0.4-0.1-0.4-0.4c-0.1-0.2,0.1-0.5,0.3-0.6c1.6-0.4,3-0.9,4.3-1.4c0.2-0.1,0.5,0,0.6,0.3c0.1,0.2,0,0.5-0.3,0.6c-1.3,0.5-2.8,1.1-4.4,1.5C65.2,50,65.1,50,65.1,50z M19.9,48.2c-0.1,0-0.2,0-0.3-0.1c-0.2-0.2-0.2-0.4-0.1-0.6c1-1.3,2-2.4,3-3.5c0.2-0.2,0.5-0.2,0.7,0c0.2,0.2,0.2,0.5,0,0.7c-1,1.1-2,2.2-3,3.5C20.2,48.2,20.1,48.2,19.9,48.2z M73.8,47c-0.2,0-0.4-0.1-0.4-0.4c-0.1-0.2,0.1-0.5,0.3-0.6c1.6-0.4,3.1-0.5,4.7-0.4c0.3,0,0.4,0.2,0.4,0.5c0,0.3-0.2,0.5-0.5,0.4c-1.5-0.1-2.9,0-4.4,0.4C73.9,47,73.9,47,73.8,47z M54.1,43.8c-0.1,0-0.3-0.1-0.4-0.2c-0.8-1.1-1.8-2.4-2.9-3.5c-0.2-0.2-0.2-0.5,0-0.7c0.2-0.2,0.5-0.2,0.7,0c1.1,1.2,2.1,2.5,3,3.6c0.2,0.2,0.1,0.5-0.1,0.6C54.3,43.8,54.2,43.8,54.1,43.8z M26.3,41.6c-0.1,0-0.3-0.1-0.4-0.2c-0.2-0.2-0.1-0.5,0.1-0.6c1.2-1,2.5-1.9,3.8-2.7c0.2-0.1,0.5-0.1,0.6,0.2c0.1,0.2,0.1,0.5-0.2,0.6c-1.2,0.7-2.5,1.6-3.7,2.6C26.5,41.6,26.4,41.6,26.3,41.6z M47.6,37.4c-0.1,0-0.2,0-0.2-0.1c-1.3-0.8-2.7-1.2-4.2-1.4c-0.3,0-0.4-0.3-0.4-0.5c0-0.3,0.3-0.4,0.5-0.4c1.6,0.2,3.1,0.8,4.5,1.6c0.2,0.1,0.3,0.4,0.2,0.6C47.9,37.3,47.8,37.4,47.6,37.4z M34.3,37c-0.2,0-0.4-0.1-0.4-0.3c-0.1-0.2,0-0.5,0.3-0.6c1.5-0.5,3-0.9,4.6-1.1c0.3,0,0.5,0.1,0.5,0.4c0,0.3-0.1,0.5-0.4,0.5c-1.5,0.2-2.9,0.5-4.4,1C34.4,37,34.3,37,34.3,37z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (2734 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_media_105dp.xml"
-            line="15"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_insights_94dp.xml"
+            line="3"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (971 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M79.7,33.2c-1.3,0-2.5-0.3-3.6-0.9c-0.2-0.1-0.3-0.4-0.2-0.6c0.1-0.2,0.4-0.3,0.6-0.2c2.3,1.1,5.2,1,7.3-0.5c0.2-0.1,0.5-0.1,0.6,0.1c0.1,0.2,0.1,0.5-0.1,0.6C82.9,32.7,81.3,33.2,79.7,33.2z M72.9,29.2c-0.2,0-0.3-0.1-0.4-0.2c-0.8-1.3-1.1-2.8-1.1-4.3c0-0.1,0-0.3,0-0.4c0-0.3,0.2-0.5,0.5-0.4c0.3,0,0.5,0.2,0.4,0.5c0,0.1,0,0.2,0,0.3c0,1.3,0.4,2.7,1,3.8c0.1,0.2,0.1,0.5-0.2,0.6C73.1,29.2,73,29.2,72.9,29.2z M86.9,28.3c-0.1,0-0.1,0-0.2,0c-0.2-0.1-0.3-0.4-0.2-0.6c0.4-0.9,0.6-1.9,0.6-2.9c0-0.4,0-0.9-0.1-1.3c0-0.3,0.1-0.5,0.4-0.5c0.3,0,0.5,0.1,0.5,0.4c0.1,0.5,0.1,1,0.1,1.5c0,1.1-0.2,2.2-0.7,3.3C87.3,28.2,87.1,28.3,86.9,28.3z M73.3,20.5c-0.1,0-0.2,0-0.3-0.1c-0.2-0.1-0.3-0.4-0.1-0.6c1-1.3,2.3-2.4,3.8-2.9c0.2-0.1,0.5,0,0.6,0.3c0.1,0.2,0,0.5-0.3,0.6c-1.4,0.5-2.5,1.4-3.4,2.6C73.6,20.5,73.5,20.5,73.3,20.5z M85.4,19.7c-0.1,0-0.2,0-0.3-0.1c-1-1.1-2.3-1.8-3.7-2.1c-0.2-0.1-0.4-0.3-0.3-0.6c0.1-0.2,0.3-0.4,0.6-0.3c1.6,0.4,3,1.2,4.2,2.4c0.2,0.2,0.2,0.5,0,0.7C85.6,19.7,85.5,19.7,85.4,19.7z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (2834 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_media_105dp.xml"
-            line="20"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_insights_94dp.xml"
+            line="4"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (994 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M0.9,23.9l4.5-0.1c0.2,0,0.4,0.1,0.4,0.4c0,0.2-0.1,0.4-0.4,0.4l-4.5-0.1c-0.1,0-0.3-0.1-0.3-0.3C0.6,24,0.7,23.9,0.9,23.9z M7.8,21.7c0.4-1.5,1.2-2.9,2-4.2c0.1-0.2,0.4-0.2,0.6-0.1c0.2,0.1,0.2,0.4,0.1,0.6C9.6,19.2,9,20.6,8.6,22c-0.1,0.1-0.3,0.3-0.4,0.3C7.8,22,7.8,21.9,7.8,21.7z M13.5,14.4c0.7-0.3,1.6-0.4,2.4-0.4c0.8,0,1.6,0.1,2.4,0.4c0.2,0.1,0.4,0.4,0.3,0.6s-0.4,0.4-0.6,0.3c-1.3-0.5-2.8-0.6-4.1-0.1c-0.2,0.1-0.4,0-0.5-0.2V15C13.2,14.7,13.3,14.4,13.5,14.4z M21.4,17.8c0.2,0.1,0.4,0.1,0.6,0.1c0.4-0.2,0.7-0.4,1.1-0.4c0.8-0.2,1.6-0.3,2.4-0.3c0.3,0,0.4,0.2,0.4,0.4c0,0.3-0.2,0.4-0.4,0.4c-0.7,0-1.4,0.1-2.1,0.3c-0.4,0.1-0.7,0.3-1,0.4c-0.5,0.2-1.1,0.2-1.6-0.1c-0.2-0.2-0.2-0.6,0-0.8C20.9,17.8,21.1,17.7,21.4,17.8z M29.7,19.3c0.4,0.7,0.7,1.5,0.8,2.3c0.1,0.8,0.1,1.6,0.1,2.4c0,0.2-0.2,0.4-0.4,0.4s-0.4-0.1-0.4-0.4c0.1-1.5-0.2-3-0.9-4.2c-0.1-0.2-0.1-0.4,0.1-0.6C29.2,19,29.6,19,29.7,19.3z M34.6,23.9H38c0.1,0,0.3,0.1,0.3,0.3c0,0.1-0.1,0.3-0.2,0.3h-3.5c-0.2,0-0.4-0.1-0.4-0.4C34.3,24.1,34.4,23.9,34.6,23.9z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1334 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_media_105dp.xml"
-            line="25"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_insights_94dp.xml"
+            line="14"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1324 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M139.48 44.4l-6.77-2.25c0.07-2.23 0.37-4.43 0.9-6.54 2.36 1.75 6.67 1.22 6.67 1.22l-0.8 7.57zm-8.74-2.91l-3.49-1.17c-0.12-0.03-0.23-0.04-0.35-0.04 0.45-1.92 1.61-3.08 2.55-3.5 0.52-0.23 0.86-0.19 0.93-0.15 0.2 0.31 0.53 0.47 0.88 0.46-0.27 1.44-0.45 2.92-0.52 4.4zm-0.06 5.41c-1.01 0.67-1.83 0.83-2.42 0.46-1.03-0.64-1.64-2.72-1.57-5.11l4.01 1.33c0.01 1.08 0.08 2.16 0.19 3.23-0.07 0.03-0.14 0.04-0.21 0.09zm44.48-1.76c-0.59 0.32-1.23 0.63-1.91 0.91-0.05 0.02-0.09 0.05-0.14 0.07-4.42 1.82-8.68 1.94-12.57 0.89-8.58-2.32-15.42-10.31-18.51-18.28-0.63-1.65-1.11-3.3-1.41-4.89-0.15-0.78-0.25-1.55-0.31-2.3-0.11-1.43-0.06-2.79 0.17-4.05-3.2 2.52-5.93 6.57-7.95 12.73-0.42 1.28-0.5 2.31-0.34 3.14-0.18 0.58-0.36 1.17-0.51 1.76-0.53-0.46-1.31-0.63-2.18-0.45-1.96 0.42-4.26 2.48-4.71 6.05-0.39 3.16 0.2 6.97 2.42 8.34 0.44 0.27 1.02 0.5 1.75 0.5 0.63 0 1.38-0.19 2.22-0.64 0.07 0.39 0.14 0.78 0.23 1.17 1.63 7.8 3.89 14.95 13.26 16.78L145.6 73c0.06 0.41 0.36 0.71 0.74 0.81 0.08 0.02 0.16 0.04 0.25 0.04 0.05 0 0.1 0 0.15-0.01 0.55-0.08 0.92-0.59 0.84-1.14l-1.04-6.84c-0.06-0.43-0.4-0.76-0.83-0.83-8.74-1.41-10.76-7.79-12.35-15.35-0.37-1.78-0.58-3.6-0.65-5.43l6.55 2.19-0.52 4.98c0.07 3.43 1.9 6.6 4.88 8.28 4.35 2.45 10.94 6.47 19.33 4.53 0.81-0.19 1.57-0.47 2.3-0.81 5.96-2.77 9.31-10.31 10.37-18.55-0.15 0.09-0.3 0.18-0.46 0.27z&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (939 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="16"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_insights_94dp.xml"
+            line="16"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (885 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M190.34 153.76c-0.03-1.67-0.07-3.35-0.12-5.02l-0.37-14.71-0.51-14.7c-0.16-4.9-0.31-9.8-0.83-14.69-0.01-0.06-0.06-0.11-0.12-0.11-0.07-0.01-0.13 0.05-0.13 0.11-0.24 4.92-0.09 9.82 0.04 14.72l0.37 14.71 0.51 14.7c0.16 4.9 0.31 9.81 0.83 14.7 0.01 0.06 0.06 0.11 0.12 0.11h0.01c0.06 0 0.12-0.05 0.12-0.12 0.04-0.83 0.06-1.65 0.08-2.48 0.05-2.41 0.04-4.82 0-7.22m-59.76-28.77c-0.04-0.06-0.12-0.08-0.17-0.04-1.1 0.69-2.17 1.41-3.24 2.12-1.05 0.73-2.11 1.46-3.19 2.15-0.18 0.12-0.38 0.22-0.56 0.34-1.99 1.24-4.03 2.39-6.14 3.41-2.28 1.15-4.66 2.1-7.09 2.87-1.23 0.35-2.45 0.7-3.7 0.94-1.24 0.34-2.5 0.48-3.77 0.82l-0.01 0.01c-0.05 0.01-0.09 0.05-0.09 0.11v0.01c0 0.06 0.05 0.12 0.12 0.12 2.61 0.19 5.24-0.27 7.75-1 2.5-0.76 4.96-1.68 7.31-2.82 1.25-0.63 2.47-1.31 3.68-2.01 0.67-0.4 1.33-0.82 1.99-1.24 0.36-0.23 0.73-0.45 1.08-0.68 2.17-1.44 4.29-2.98 6.02-4.96 0.04-0.04 0.04-0.11 0.01-0.15&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (3386 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="81"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_media_105dp.xml"
+            line="15"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1934 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M79.79 78.6v-0.02c-0.03-0.69-0.12-1.59-0.27-2.82l-0.01 0.01c-0.02-0.17-0.03-0.32-0.06-0.5-0.2-1.52-0.47-3.89-0.87-6.12-0.07-0.39-0.15-0.79-0.23-1.17v-0.01c-0.03-0.16-0.07-0.32-0.1-0.48-0.03-0.13-0.06-0.25-0.09-0.37-0.05-0.19-0.09-0.37-0.14-0.55l-0.12-0.45-0.09-0.27c-0.06-0.21-0.13-0.4-0.2-0.59-0.02-0.07-0.05-0.14-0.07-0.2-0.08-0.19-0.15-0.38-0.23-0.54-0.02-0.04-0.04-0.07-0.06-0.11-0.08-0.15-0.16-0.3-0.25-0.42-0.01-0.02-0.02-0.04-0.04-0.06-0.09-0.13-0.19-0.24-0.29-0.33-0.02-0.02-0.04-0.04-0.06-0.05-0.1-0.08-0.21-0.14-0.32-0.18-0.02 0-0.04-0.01-0.06-0.01-0.11-0.03-0.23-0.04-0.36-0.01-0.07 0.02-0.13 0.04-0.19 0.08-0.02 0.01-0.04 0.03-0.06 0.04-0.04 0.03-0.08 0.06-0.11 0.09-0.02 0.03-0.04 0.05-0.06 0.08-0.03 0.03-0.05 0.07-0.08 0.11-0.02 0.03-0.03 0.06-0.05 0.1-0.02 0.04-0.04 0.08-0.06 0.13-0.02 0.04-0.03 0.08-0.05 0.12-0.01 0.05-0.03 0.09-0.04 0.15-0.02 0.04-0.03 0.09-0.04 0.14-0.01 0.05-0.03 0.1-0.04 0.16-0.01 0.05-0.02 0.11-0.03 0.17-0.01 0.05-0.01 0.1-0.02 0.16l-0.03 0.2c0 0.05-0.01 0.1-0.01 0.15-0.01 0.08-0.02 0.15-0.02 0.23 0 0.05-0.01 0.09-0.01 0.14-0.01 0.09-0.01 0.18-0.02 0.28v0.05l-0.03 1.01c0 0.33-0.01 0.66-0.02 0.99-0.02 0.72-0.05 1.41-0.16 2v0.01h-0.01c0 0.05-0.02 0.1-0.03 0.14-0.01 0.05-0.02 0.1-0.03 0.14v0.01c-0.03 0.14-0.07 0.27-0.12 0.4-0.01 0.02-0.01 0.03-0.02 0.05-0.01 0.02-0.02 0.04-0.03 0.07-0.03 0.07-0.07 0.15-0.11 0.22l-0.03 0.06c-0.06 0.1-0.13 0.19-0.2 0.26 0 0.01-0.01 0.01-0.01 0.01-0.07 0.07-0.15 0.13-0.23 0.17-0.03 0.02-0.05 0.03-0.07 0.04-0.08 0.04-0.17 0.06-0.26 0.08-0.01 0-0.03 0.01-0.05 0.01-0.11 0.02-0.23 0.02-0.36 0-0.03 0-0.06-0.01-0.09-0.01-0.11-0.02-0.22-0.05-0.34-0.08-0.04-0.02-0.08-0.03-0.12-0.05-0.16-0.05-0.32-0.12-0.5-0.21l-0.38-1.09-2.95-8.39-0.35-1.01-0.3-0.84-0.33-0.94c-0.92 5.8-0.77 13.5 2.33 19.81 0.83 1.68 1.86 3.25 3.14 4.67 0.1 0.11 0.19 0.23 0.3 0.34 0.19 0.2 0.18 0.52-0.02 0.71-0.04 0.04-0.09 0.06-0.14 0.09l1.31 1.93 5.97-3.54c-0.2-0.85-0.92-3.78-0.92-4.39&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (971 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="96"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_media_105dp.xml"
+            line="20"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1028 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M94.1 65.96L83.95 37.07c-0.81-2.29-3.33-3.5-5.63-2.69l-12.88 4.53c-2.3 0.8-3.51 3.32-2.7 5.62l4.44 12.63 0.32 0.91 0.32 0.91 0.33 0.94 0.3 0.84 0.35 1.01 2.95 8.39 0.38 1.09c0.18 0.09 0.34 0.16 0.5 0.21 0.04 0.02 0.08 0.03 0.12 0.04 0.12 0.04 0.23 0.07 0.34 0.09 0.03 0 0.06 0.01 0.09 0.01 0.13 0.02 0.25 0.02 0.36 0 0.02 0 0.04-0.01 0.05-0.01 0.09-0.02 0.18-0.05 0.26-0.08 0.02-0.01 0.04-0.02 0.07-0.04 0.08-0.04 0.16-0.1 0.23-0.17 0 0 0.01 0 0.01-0.01 0.07-0.07 0.14-0.16 0.2-0.26l0.03-0.06c0.05-0.07 0.08-0.15 0.11-0.24 0.01-0.01 0.02-0.03 0.03-0.05 0.01-0.02 0.01-0.03 0.02-0.05 0.05-0.13 0.09-0.26 0.12-0.4v-0.01c0.01-0.04 0.02-0.09 0.03-0.14 0.01-0.04 0.03-0.09 0.03-0.14h0.01v-0.01l-0.13-0.34-0.03-0.11-0.17-0.47-0.31-0.88-0.18-0.5-0.19-0.55-1.01-2.88-0.21-0.61-0.33-0.92-0.31-0.89-0.19-0.52-0.35-1.01-1.24-3.53-0.25-0.7-0.23-0.66-0.54-1.55-0.25-0.69-0.24-0.69-1.84-5.25-1.32-3.74 15.75-5.54 1.32 3.74 8.18 23.26-12.09 4.25c0.4 2.23 0.67 4.6 0.87 6.12 0.03 0.17 0.05 0.33 0.07 0.49l11.89-4.18c2.29-0.81 3.5-3.32 2.69-5.62&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (994 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="106"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_media_105dp.xml"
+            line="25"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (2794 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M82.51 63.01c-0.52 0.22-1.05 0.42-1.58 0.62-0.53 0.19-1.07 0.37-1.61 0.54-0.54 0.17-1.06 0.39-1.68 0.34l-0.06-0.16c0.44-0.43 0.98-0.61 1.51-0.82 0.52-0.22 1.05-0.42 1.58-0.62 0.54-0.18 1.07-0.37 1.61-0.54 0.54-0.17 1.06-0.39 1.68-0.33l0.06 0.15c-0.44 0.44-0.98 0.61-1.51 0.82zm-5.49-0.34l-0.05-0.16c0.44-0.43 0.98-0.61 1.5-0.82 0.53-0.22 1.06-0.42 1.59-0.62 0.53-0.18 1.06-0.37 1.61-0.54 0.54-0.17 1.06-0.39 1.68-0.33l0.06 0.15c-0.45 0.44-0.99 0.61-1.51 0.82-0.52 0.22-1.05 0.42-1.58 0.62-0.54 0.18-1.07 0.37-1.61 0.54-0.54 0.17-1.07 0.39-1.69 0.34zm-0.56-1.68l-0.02-0.06-0.02-0.06c0.6-0.44 1.29-0.66 1.96-0.92l2.01-0.75 2.04-0.7c0.68-0.22 1.35-0.48 2.1-0.52l0.04 0.12c-0.6 0.43-1.28 0.66-1.96 0.92l-2.01 0.75-2.04 0.7c-0.68 0.22-1.35 0.48-2.1 0.52zm-0.54-4.47c-0.53 0.17-1.09-0.11-1.27-0.63-0.09-0.26-0.06-0.53 0.05-0.76l1.79 0.88c-0.11 0.23-0.31 0.42-0.57 0.51zm-3.55-3.04l-0.14-0.07c-0.2-0.09-0.28-0.34-0.18-0.54l0.21-0.45c0.02-0.04 0.05-0.07 0.08-0.1 0.06-0.06 0.13-0.11 0.21-0.12l0.01-0.01 0.55-0.1c0.13-0.03 0.27-0.09 0.38-0.17 0.13-0.08 0.2-0.14 0.23-0.23l0.25-0.51c0.34-0.69 0.64-1.35 1-2.07 0.43-0.76 1.16-1.34 1.99-1.59 0.82-0.26 1.75-0.18 2.52 0.21 0.77 0.38 1.38 1.07 1.67 1.88 0.29 0.81 0.26 1.73-0.08 2.51-0.35 0.71-0.7 1.35-1.08 2.02l-0.28 0.49c-0.08 0.11-0.1 0.25-0.1 0.42-0.01 0.16 0.02 0.34 0.07 0.49 0.08 0.2 0.15 0.4 0.21 0.58-0.06 0.16-0.11 0.34-0.18 0.52-0.03 0.07-0.11 0.11-0.18 0.08l-0.03-0.01c-1.25-0.46-2.48-0.99-3.68-1.56l-3.45-1.67zm10.12-11.84l-15.75 5.54 1.84 5.25 0.24 0.69 0.25 0.69 0.54 1.55 0.23 0.66 0.25 0.7 1.24 3.53 0.35 1.01 0.19 0.52 0.31 0.89 0.32 0.92 0.22 0.61 1.01 2.88 0.2 0.55 0.17 0.5 0.31 0.88 0.17 0.47 0.03 0.11 0.13 0.34c0.03-0.17 0.05-0.35 0.07-0.54 0.02-0.16 0.04-0.32 0.05-0.49 0.02-0.32 0.03-0.64 0.04-0.97 0.01-0.33 0.02-0.66 0.02-0.99l0.03-1.01v-0.05c0.01-0.1 0.01-0.19 0.02-0.28 0-0.05 0-0.09 0.01-0.14 0-0.08 0.01-0.15 0.02-0.23 0-0.05 0.01-0.1 0.01-0.15l0.03-0.2c0-0.05 0.01-0.11 0.02-0.16 0.01-0.06 0.02-0.12 0.03-0.17 0.01-0.06 0.02-0.11 0.04-0.16 0.01-0.05 0.02-0.1 0.04-0.14 0.01-0.06 0.02-0.1 0.04-0.15 0.02-0.04 0.03-0.08 0.05-0.12 0.02-0.05 0.04-0.09 0.06-0.13 0.01-0.04 0.03-0.07 0.05-0.1 0.02-0.04 0.05-0.08 0.08-0.11 0.02-0.03 0.04-0.05 0.06-0.08 0.03-0.03 0.07-0.06 0.11-0.09 0.02-0.01 0.04-0.03 0.06-0.04 0.06-0.04 0.12-0.06 0.19-0.08 0.13-0.03 0.25-0.02 0.36 0.01 0.02 0 0.04 0.01 0.06 0.01 0.11 0.04 0.21 0.1 0.32 0.18 0.02 0.01 0.04 0.03 0.06 0.05 0.1 0.09 0.2 0.2 0.29 0.33 0.02 0.02 0.03 0.04 0.04 0.06 0.09 0.12 0.17 0.27 0.25 0.42 0.02 0.04 0.04 0.07 0.06 0.11 0.08 0.16 0.15 0.35 0.23 0.54 0.02 0.06 0.05 0.13 0.07 0.2 0.07 0.19 0.14 0.38 0.2 0.59l0.09 0.27 0.12 0.45c0.05 0.18 0.09 0.36 0.14 0.55 0.03 0.12 0.06 0.24 0.09 0.37 0.03 0.16 0.07 0.32 0.1 0.48v0.01c0.08 0.38 0.16 0.78 0.23 1.17l12.09-4.25-8.18-23.26z&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1324 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="116"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
+            line="16"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1209 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M76.29 63.37c-0.02 0-0.04-0.01-0.06-0.01 0.02 0 0.04 0.01 0.06 0.01m-0.84 0.27c-0.03 0.03-0.06 0.07-0.08 0.11 0.02-0.04 0.05-0.08 0.08-0.11m0.42-0.29c-0.07 0.02-0.13 0.04-0.19 0.08 0.06-0.04 0.12-0.06 0.19-0.08m2.48 4.62c-0.03-0.16-0.07-0.32-0.1-0.48 0.03 0.16 0.07 0.32 0.1 0.48m-0.19-0.85c-0.05-0.19-0.09-0.37-0.14-0.55 0.05 0.18 0.09 0.36 0.14 0.55m-0.26-1l-0.09-0.27 0.09 0.27m-0.29-0.86c-0.02-0.07-0.05-0.14-0.07-0.2 0.02 0.06 0.05 0.13 0.07 0.2M77 63.99c-0.01-0.02-0.02-0.04-0.04-0.06 0.02 0.02 0.03 0.04 0.04 0.06m1.58 5.16c-0.07-0.39-0.15-0.79-0.23-1.17 0.08 0.38 0.16 0.78 0.23 1.17m-1.27-4.63c-0.02-0.04-0.04-0.07-0.06-0.11 0.02 0.04 0.04 0.07 0.06 0.11m-2.3 0.56c0 0.05-0.01 0.1-0.01 0.15 0-0.05 0.01-0.1 0.01-0.15m1.6-1.53c0.02 0.01 0.04 0.03 0.06 0.05-0.02-0.02-0.04-0.04-0.06-0.05m-1.63 1.91c-0.01 0.05-0.01 0.09-0.01 0.13 0-0.04 0-0.08 0.01-0.13m0.53-1.9c0.03-0.03 0.07-0.06 0.11-0.09-0.04 0.03-0.08 0.06-0.11 0.09m-0.45 1.16c-0.01 0.05-0.02 0.1-0.02 0.16 0-0.06 0.01-0.11 0.02-0.16m0.07-0.33c-0.01 0.05-0.03 0.1-0.04 0.16 0.01-0.06 0.03-0.11 0.04-0.16m0.08-0.29c-0.02 0.05-0.03 0.09-0.05 0.14 0.02-0.05 0.03-0.09 0.05-0.14m0.11-0.25c-0.02 0.04-0.04 0.08-0.06 0.13 0.02-0.05 0.04-0.09 0.06-0.13&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (885 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="121"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
+            line="81"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1004 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M80.37 51.81c-0.3 0.66-0.64 1.37-0.92 2.06l-0.22 0.53c-0.1 0.23-0.1 0.49-0.07 0.69 0.04 0.21 0.11 0.41 0.23 0.6 0.09 0.14 0.19 0.28 0.31 0.43-0.07 0.09-0.12 0.16-0.17 0.24-1.1-0.68-2.22-1.31-3.37-1.89l-3.06-1.54 0.17-0.03c0.25-0.05 0.47-0.14 0.67-0.26 0.19-0.12 0.42-0.31 0.54-0.58l0.26-0.5 1.01-2.01c0.31-0.57 0.84-1.01 1.46-1.21 0.62-0.2 1.31-0.15 1.9 0.13 0.59 0.28 1.06 0.8 1.3 1.42 0.23 0.61 0.22 1.32-0.04 1.92m0.78-2.2c-0.29-0.81-0.9-1.5-1.67-1.88-0.77-0.39-1.7-0.47-2.53-0.21-0.82 0.25-1.55 0.83-1.98 1.59-0.36 0.72-0.66 1.38-1 2.07l-0.25 0.51c-0.03 0.09-0.1 0.15-0.23 0.23-0.12 0.08-0.26 0.14-0.38 0.17l-0.55 0.1-0.01 0.01c-0.08 0.01-0.15 0.06-0.21 0.12-0.03 0.03-0.06 0.06-0.08 0.1l-0.21 0.45c-0.1 0.2-0.02 0.45 0.18 0.54l0.14 0.07 3.45 1.67c1.2 0.57 2.43 1.1 3.68 1.56l0.03 0.01c0.07 0.03 0.15-0.01 0.18-0.08 0.07-0.18 0.12-0.36 0.17-0.52-0.05-0.18-0.12-0.38-0.2-0.58-0.06-0.15-0.08-0.33-0.07-0.49 0-0.17 0.02-0.31 0.09-0.42l0.29-0.49c0.38-0.67 0.73-1.31 1.07-2.02 0.35-0.78 0.38-1.7 0.09-2.51&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1934 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="141"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
+            line="96"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (923 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M205.99 100.68c-4.67-18.66-19.25-20.76-30.55-23.25-11.29-2.49-29.89-2.83-37.87 0.32-5.19 2.06-8.73 3.62-11.1 5.71-14.8 11.57-24.19 21.48-24.19 21.48L83.41 81.39l-2.7 1.6-5.97 3.54-2.22 1.32s9.38 50.93 30.1 49.88v-0.01c0-0.06 0.04-0.1 0.09-0.11l0.01-0.01c1.27-0.34 2.53-0.48 3.77-0.82 1.25-0.24 2.47-0.59 3.7-0.94 2.43-0.77 4.81-1.72 7.09-2.87 2.11-1.02 4.15-2.16 6.14-3.41 0.18-0.12 0.38-0.22 0.56-0.34 1.08-0.69 2.14-1.42 3.19-2.15 1.07-0.71 2.14-1.43 3.24-2.12 0.05-0.04 0.13-0.02 0.17 0.03 0.03 0.05 0.03 0.12-0.01 0.16-1.73 1.98-3.85 3.52-6.02 4.96-0.35 0.23-0.72 0.45-1.08 0.68l1.73 40.62 14.25 0.02c8.83 0 30.69 0.03 50.69 0.13v-7.97h-0.01c-0.06 0-0.11-0.05-0.12-0.11-0.52-4.89-0.66-9.8-0.83-14.7l-0.51-14.7-0.37-14.71c-0.13-4.9-0.27-9.8-0.04-14.72 0-0.06 0.06-0.12 0.13-0.11 0.06 0 0.11 0.05 0.12 0.11 0.52 4.89 0.67 9.79 0.84 14.69l0.5 14.7 0.37 14.71c0.05 1.67 0.09 3.35 0.12 5.02 14.25-0.81 27.02-7.66 15.65-53.08&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1028 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="151"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
+            line="106"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (7633 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M65.94 170.71h-0.18 0.09c-1.51-0.02-3.02-0.39-4.15-1.31-1.17-0.93-1.83-2.38-2.01-3.9-0.2-1.52 0.02-3.14 0.38-4.68 0.4-1.53 0.93-3.08 1.64-4.49l0.01-0.02c0.06-0.12 0.06-0.27-0.01-0.4l-2-3.8 6.97-0.13v-0.07h0.15c1.73 0.07 3.46 0.13 5.19 0.17-0.69 1.27-1.36 2.56-2.03 3.83-0.07 0.12-0.07 0.27-0.01 0.4l0.01 0.02c0.71 1.41 1.24 2.96 1.63 4.49 0.37 1.54 0.59 3.16 0.39 4.68-0.18 1.52-0.84 2.97-2.01 3.9-1.14 0.92-2.65 1.29-4.15 1.31h0.09zm0.66-28.94c-0.63 0.08-1.48 0.03-2.35-0.48-0.71-0.41-1.21-1.02-1.5-1.84-0.06-0.17-0.04-0.35 0.06-0.5 0.09-0.15 0.24-0.25 0.42-0.27 0.17-0.02 0.33-0.03 0.5-0.03 0.65 0 1.26 0.16 1.81 0.48 0.25 0.14 0.46 0.33 0.66 0.54 0.19 0.22 0.36 0.47 0.5 0.72 0.17 0.28 0.3 0.56 0.39 0.81-0.12 0.32-0.26 0.52-0.49 0.57zM38.98 171.4h-1.07c-3.41-0.42-6.5-2.36-8.48-5.07-1.1-1.49-1.91-3.2-2.37-4.99-0.45-1.78-0.56-3.64-0.36-5.47l-0.01 0.05 0.02-0.08c0 0.01 0 0.02-0.01 0.03l1.48-4.94c1.54 0.11 3.09 0.16 4.64 0.21l6.6 0.06c3.46-0.05 6.92-0.04 10.39-0.2l1.45 4.87c0-0.01 0-0.02-0.01-0.04l0.02 0.09-0.01-0.05c0.45 3.66-0.49 7.51-2.72 10.47-1.12 1.49-2.55 2.75-4.19 3.64-1.63 0.89-3.49 1.39-5.37 1.41v0.01zm-9.45-25.02l9.45 0.02 9.45-0.03 1.16 3.89c-3.39-0.15-6.78-0.14-10.17-0.19l-6.6 0.06c-1.49 0.05-2.98 0.1-4.47 0.21l1.18-3.96zm36.3 0.57c-0.48 0.33-1.47 0.84-2.81 0.59-0.8-0.14-1.48-0.55-2.02-1.23-0.12-0.13-0.16-0.31-0.12-0.49 0.04-0.17 0.15-0.31 0.31-0.39 0.56-0.28 1.13-0.42 1.7-0.42 0.21 0 0.42 0.02 0.62 0.06 1.31 0.23 2.03 1.29 2.32 1.84v0.04zm3.49-0.92c0.05-0.02 0.1-0.02 0.15-0.03 0.22-0.04 0.44-0.07 0.65-0.07 0.98 0 1.73 0.5 2.18 0.93 0.13 0.12 0.2 0.29 0.19 0.47-0.02 0.18-0.11 0.34-0.26 0.45-0.64 0.44-1.37 0.67-2.16 0.67h-0.01c-1.08 0-1.87-0.51-2.37-1-0.14-0.14-0.44-0.28-0.43-0.47 0.4-0.34 1.23-0.77 2.06-0.95zm-2.33-10.23c-0.56-0.44-0.94-1.03-1.14-1.74-0.07-0.25-0.01-0.51 0.16-0.71 0.14-0.17 0.35-0.27 0.58-0.27 0.03 0 0.06 0.01 0.08 0.01 0.73 0.08 1.38 0.34 1.91 0.76 0.43 0.34 0.7 0.75 0.88 1.17 0.21 0.46 0.31 0.92 0.34 1.31-0.12 0.14-0.19 0.3-0.42 0.3-0.64-0.01-1.54-0.15-2.39-0.83zm4.43 1.35c0.62-0.24 1.53-0.42 2.52-0.1 0.93 0.31 1.49 1.03 1.78 1.58 0.09 0.16 0.1 0.33 0.03 0.5-0.07 0.17-0.21 0.29-0.39 0.35-0.75 0.22-1.51 0.2-2.25-0.05-1.15-0.38-1.75-1.26-2.04-1.88 0.11-0.14 0.23-0.27 0.35-0.4zm-2.98 5.08c0.51-0.43 1.49-1.04 2.75-0.94 0.79 0.07 1.49 0.44 2.1 1.11 0.12 0.13 0.18 0.3 0.15 0.48s-0.14 0.34-0.3 0.43c-0.67 0.39-1.41 0.56-2.2 0.49-1.34-0.1-2.16-0.97-2.53-1.48l0.03-0.09zm157.26 29.71c-6.55-0.19-20.26-0.31-35.07-0.39h-0.49c-20-0.1-41.86-0.13-50.69-0.13l-14.25-0.02-31.07-0.05-25.48 0.02c0.73-0.25 1.43-0.62 2.04-1.13 1.42-1.14 2.18-2.9 2.37-4.61 0.2-1.73-0.06-3.42-0.45-5.05-0.4-1.56-0.98-3.03-1.72-4.46 0.68-1.41 1.38-2.8 2.04-4.22l0.01-0.02c0.02-0.04-0.13-0.45-0.13-0.51-0.01-0.19 0 0-0.2 0.01-1.83 0.04-3.66 0.1-5.49 0.17 0-1.17 0.01-2.23 0.04-3.23 0.65 0.58 1.61 1.13 2.9 1.13h0.01c0.98 0 1.93-0.3 2.73-0.85 0.4-0.28 0.65-0.72 0.68-1.2 0.04-0.48-0.14-0.94-0.49-1.27-0.59-0.55-1.56-1.2-2.87-1.2h-0.01c-1.21 0-2.16 0.48-2.82 0.99 0.08-1.03 0.22-1.98 0.42-2.87 0.52 0.66 1.53 1.62 3.15 1.75 0.13 0.01 0.26 0.02 0.39 0.02 0.84 0 1.66-0.22 2.39-0.65 0.43-0.24 0.71-0.66 0.79-1.13 0.07-0.48-0.07-0.96-0.4-1.31-0.54-0.6-1.45-1.33-2.76-1.43-1.25-0.1-2.26 0.33-2.96 0.78 0.43-1.1 1.03-2.14 1.83-3.17 0.33 0.73 1.09 1.96 2.65 2.47 0.5 0.17 1 0.25 1.51 0.25 0.45 0 0.91-0.07 1.35-0.2 0.46-0.13 0.84-0.47 1.03-0.92 0.18-0.44 0.15-0.94-0.08-1.36-0.38-0.71-1.1-1.64-2.35-2.05-0.88-0.29-1.7-0.26-2.38-0.12l0.04-0.04-0.61-0.63c-0.21 0.2-0.39 0.4-0.58 0.6-0.11-0.82-0.45-1.99-1.51-2.84-0.69-0.55-1.51-0.88-2.43-0.97-0.59-0.07-1.16 0.16-1.54 0.61-0.38 0.44-0.51 1.05-0.35 1.62 0.26 0.92 0.75 1.68 1.47 2.25 1.02 0.81 2.07 1.03 2.88 1.05-0.63 0.84-1.14 1.7-1.53 2.58-0.37-0.85-0.93-1.52-1.68-1.95-0.86-0.5-1.87-0.69-2.92-0.57-0.48 0.05-0.9 0.32-1.15 0.73-0.26 0.41-0.31 0.91-0.15 1.36 0.25 0.72 0.8 1.72 1.94 2.38 0.85 0.49 1.68 0.64 2.38 0.64 0.27 0 0.51-0.03 0.74-0.06-0.23 0.99-0.38 2.04-0.47 3.19-0.48-0.71-1.35-1.6-2.71-1.85-0.98-0.17-2-0.02-2.95 0.46-0.43 0.21-0.73 0.6-0.84 1.07-0.1 0.47 0.02 0.96 0.32 1.33 0.48 0.6 1.33 1.35 2.62 1.59 0.31 0.05 0.6 0.08 0.88 0.08 1.17 0 2.05-0.43 2.58-0.77-0.04 1.12-0.06 2.33-0.06 3.65l-7.15-0.13c-0.06 0-0.12 0.01-0.17 0.04-0.19 0.09-0.27 0.31-0.17 0.5v0.01l2.06 4.21c-0.74 1.43-1.32 2.9-1.72 4.46-0.4 1.63-0.65 3.32-0.45 5.05 0.19 1.71 0.95 3.47 2.37 4.61 0.61 0.52 1.31 0.88 2.05 1.13l-15.26 0.01-5.59 0.01c0.83-0.21 1.65-0.5 2.42-0.89 1.75-0.87 3.29-2.16 4.49-3.71 2.44-3.08 3.54-7.15 3.12-11.07 0-0.03 0-0.05-0.01-0.08l-1.37-4.7c0.59-0.03 1.18-0.06 1.77-0.1 0.09-0.01 0.17-0.09 0.18-0.19 0.01-0.11-0.07-0.2-0.18-0.21-0.65-0.05-1.3-0.08-1.95-0.12l-1.34-4.63c-0.07-0.22-0.27-0.39-0.52-0.39l-6.63-0.02c0.58-1.53 1.19-3.02 1.92-4.44 0.18-0.34 0.36-0.68 0.55-1.02 0.71-1.22 1.51-2.39 2.38-3.52 2.19-2.88 4.97-5.29 7.55-7.93 0.06-0.07 0.08-0.17 0.02-0.25-0.07-0.1-0.19-0.12-0.28-0.05-3.02 2.12-5.81 4.62-8.18 7.54-0.85 1.07-1.61 2.22-2.27 3.43-0.67-1.4-1-2.94-1.01-4.48-0.03-1.77 0.29-3.55 0.86-5.23 1.04-3.09 2.88-5.9 5.26-8.13l0.02-0.02 0.06 0.21 1.46 5.23c0.05 0.19 0.22 0.35 0.43 0.37 0.28 0.04 0.54-0.16 0.57-0.44l0.91-6.74c2.82-0.78 6.29-0.36 7.96 2.12 0.95 1.21 1.56 2.67 1.69 4.2 0.14 1.52-0.17 3.08-0.76 4.54-1.2 2.91-3.33 5.44-5.88 7.35-1.28 0.95-2.67 1.78-4.17 2.29-1.48 0.5-3.14 0.74-4.61 0.16-0.1-0.04-0.21 0-0.26 0.1-0.01 0.02 0 0.04 0 0.07-0.01 0.08 0.02 0.16 0.1 0.19 1.57 0.73 3.38 0.6 4.98 0.13 1.61-0.49 3.11-1.28 4.47-2.24 2.7-1.94 5.02-4.52 6.33-7.66 0.65-1.57 1.02-3.29 0.87-5.03-0.12-1.73-0.81-3.42-1.86-4.79-0.51-0.67-1.14-1.35-1.93-1.8-0.77-0.47-1.61-0.76-2.47-0.92-1.71-0.31-3.46-0.19-5.11 0.36-0.19 0.06-0.33 0.22-0.36 0.43l-0.6 4.62-1.08-3.8v-0.02c-0.02-0.07-0.06-0.13-0.11-0.19-0.18-0.2-0.5-0.22-0.7-0.04-2.75 2.49-4.87 5.68-5.92 9.23-0.52 1.77-0.79 3.63-0.67 5.47 0.11 1.66 0.57 3.29 1.4 4.72-0.19 0.36-0.38 0.73-0.55 1.1-0.7 1.55-1.17 3.2-1.36 4.88l-2.86-0.01-2.04 0.01c0.23-3.41 0.09-6.85-0.38-10.25-0.01-0.13-0.04-0.25-0.06-0.38 1.52-1.16 2.66-2.81 3.28-4.64 0.64-1.92 0.8-3.97 0.65-5.97-0.3-4.03-1.74-7.86-3.6-11.4-1.97-3.52-4.71-6.56-7.94-8.98-1.63-1.19-3.4-2.22-5.35-2.88-1.92-0.66-4.11-0.93-6.16-0.29-2.07 0.63-3.71 2.17-4.78 3.96-1.08 1.89-1.2 4.07-1.01 6.08 0.46 4.06 2.04 7.82 3.93 11.32 1.95 3.49 4.28 6.76 7.07 9.63 1.4 1.42 2.91 2.76 4.65 3.79 0.88 0.5 1.81 0.93 2.82 1.14 1 0.22 2.12 0.17 3.04-0.36 0.06-0.03 0.08-0.09 0.09-0.16 0-0.03 0-0.07-0.01-0.1-0.05-0.1-0.17-0.14-0.27-0.09-0.84 0.43-1.82 0.44-2.74 0.21-0.92-0.23-1.78-0.67-2.6-1.18-1.64-1.03-3.1-2.35-4.44-3.77-2.67-2.86-4.91-6.13-6.75-9.57-1.81-3.45-3.33-7.14-3.73-10.96-0.17-1.89-0.02-3.86 0.91-5.43 0.96-1.58 2.41-2.9 4.15-3.42 1.75-0.56 3.69-0.36 5.48 0.25 1.81 0.59 3.5 1.56 5.07 2.69 3.11 2.29 5.78 5.25 7.72 8.6 1.89 3.39 3.3 7.12 3.74 10.98 0.2 1.93 0.11 3.9-0.43 5.76-0.32 1.14-0.87 2.2-1.58 3.15-0.38 0.5-0.78 0.98-1.26 1.39l-0.03-0.16c-0.55-3.31-1.44-6.58-2.74-9.7-1.44-3.34-3.32-6.51-5.73-9.26-2.4-2.73-5.26-5.06-8.42-6.82-0.09-0.04-0.21-0.02-0.27 0.07-0.06 0.09-0.04 0.21 0.06 0.28 2.93 2.03 5.62 4.38 7.89 7.11 2.28 2.7 4.08 5.8 5.43 9.06 1.33 3.15 2.29 6.48 2.87 9.87l0.06 0.33c0.59 3.33 0.85 6.7 1.1 10.1l-7.54 0.02c-0.23 0-0.45 0.15-0.52 0.38l-1.38 4.75c-0.34 0.04-0.68 0.06-1.02 0.11-0.04 0-0.08 0.04-0.08 0.09-0.01 0.05 0.03 0.1 0.08 0.11l0.9 0.09-1.39 4.8c-0.01 0.03-0.02 0.06-0.02 0.09-0.45 3.92 0.67 8 3.11 11.09 1.23 1.53 2.77 2.81 4.53 3.68 0.83 0.41 1.72 0.7 2.62 0.91l-12.32 0.02c-7.72 0.04-15.44-0.09-23.16 0.26-0.26 0.02-0.47 0.22-0.48 0.48-0.01 0.28 0.2 0.52 0.48 0.53 7.72 0.35 15.44 0.23 23.16 0.27l23.16 0.03 46.33 0.03 46.32-0.06c15.44 0 70.81-0.09 86.25-0.52 0.13 0 0.24-0.11 0.24-0.25 0.01-0.14-0.1-0.25-0.24-0.25z&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (2794 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_notifications_152dp.xml"
-            line="156"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
+            line="116"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1098 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M103.4,15.5c-1.2,-0.1 -2.5,-0.1 -3.7,-0.1V7.2c0,-0.7 -0.1,-1.5 -0.3,-2.1c-0.2,-0.7 -0.6,-1.4 -1,-2c-1,-1.2 -2.2,-2 -3.7,-2.3c-0.7,-0.1 -1.5,-0.1 -2.1,-0.1H83L52.1,0.7L21.3,0.8h-9.6c-0.6,0 -1.3,0 -2.1,0.1C8.2,1.3 7,2.1 6.1,3.3c-0.4,0.6 -0.7,1.2 -1,1.9C4.9,5.9 4.8,6.6 4.8,7.3v3.9l0,4.2c-1.3,0 -2.7,0.1 -4,0.1c-0.1,0 -0.3,0.1 -0.3,0.3s0.1,0.3 0.3,0.3c1.3,0 2.7,0.1 4,0.1l0,2.7C5,39.3 5.2,59.8 5.5,80.2c0,0.1 0.1,0.1 0.2,0.1c0.1,0 0.1,-0.1 0.1,-0.1c0.2,-20.4 0.4,-40.9 0.4,-61.4v-2.5c6.8,0.2 13.5,0.2 20.3,0.3l25.6,0.1H65l12.8,-0.1c6.8,-0.1 13.5,-0.1 20.3,-0.4v2.7l0.1,60.6l-42.3,0.1l-21.5,0.1L13,79.9c-0.1,0 -0.3,0.1 -0.3,0.3c0,0.1 0.1,0.3 0.3,0.3l21.5,0.1l21.5,0.1l43,0.1c0.4,0 0.7,-0.4 0.7,-0.7l0.1,-61.4v-2.6c1.2,0 2.5,-0.1 3.7,-0.2c0.1,0 0.1,-0.1 0.1,-0.3C103.6,15.6 103.5,15.5 103.4,15.5zM77.8,15L65,14.9H52.1L26.5,15c-6.8,0.1 -13.5,0.1 -20.3,0.3V7.2c0,-0.6 0.1,-1.1 0.2,-1.7c0.2,-0.5 0.4,-1 0.8,-1.5C8,3.2 8.9,2.6 10,2.3c0.6,-0.1 1.1,-0.1 1.8,-0.1h9.6l30.8,0.1l30.8,0.1h9.6c0.7,0 1.2,0 1.8,0.1c1.1,0.2 2.1,0.9 2.7,1.8c0.3,0.4 0.6,0.9 0.7,1.5c0.1,0.6 0.2,1.1 0.2,1.7v8C91.3,15.1 84.6,15 77.8,15z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1209 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_pages_104dp.xml"
-            line="10"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
+            line="121"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1870 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M35.1,55.5c0,0.1 -0.2,0.4 -0.4,0.4c-0.2,0 -0.4,-0.1 -0.4,-0.4v-3.6c0,-0.2 0.1,-0.4 0.4,-0.4s0.4,0.1 0.4,0.4V55.5zM34.1,26.6h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4c0,0.2 0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4C34.4,26.7 34.3,26.6 34.1,26.6zM35.1,30c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4v3.6c0,0.2 0.1,0.4 0.4,0.4c0.1,0 0.4,-0.2 0.4,-0.4V30zM35.1,44.6c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4v3.6c0,0.2 0.1,0.4 0.4,0.4c0.1,0 0.4,-0.2 0.4,-0.4V44.6zM35.1,37.3c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4v3.6c0,0.2 0.1,0.4 0.4,0.4c0.1,0 0.4,-0.2 0.4,-0.4V37.3zM17.6,29.1c0.2,0 0.4,-0.1 0.4,-0.4v-1.5h1.5c0.2,0 0.4,-0.1 0.4,-0.4c0,-0.2 -0.1,-0.4 -0.4,-0.4h-1.8c-0.2,0 -0.4,0.1 -0.4,0.4v1.8C17.2,29 17.4,29.1 17.6,29.1zM17.2,36c0,0.2 0.1,0.4 0.4,0.4s0.4,-0.1 0.4,-0.4v-3.6c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4V36zM17.2,43.3c0,0.2 0.1,0.4 0.4,0.4s0.4,-0.1 0.4,-0.4v-3.6c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4V43.3zM17.2,50.6c0,0.2 0.1,0.4 0.4,0.4s0.4,-0.1 0.4,-0.4V47c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4V50.6zM35.1,59.2c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4v3.6c0,0.2 0.1,0.4 0.4,0.4c0.1,0 0.4,-0.2 0.4,-0.4V59.2zM23.4,70.1c0,0.2 0.1,0.4 0.4,0.4h3.7c0.1,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7C23.5,69.8 23.4,69.9 23.4,70.1zM17.2,57.9c0,0.2 0.1,0.4 0.4,0.4s0.4,-0.1 0.4,-0.4v-3.6c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4V57.9zM34.3,66.5v3.3h-3.3c-0.2,0 -0.4,0.1 -0.4,0.4s0.1,0.4 0.4,0.4h3.7c0.1,0 0.4,-0.2 0.4,-0.4v-3.6c0,-0.2 -0.1,-0.4 -0.4,-0.4S34.3,66.3 34.3,66.5zM26.7,26.6h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4c0,0.2 0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4C27.1,26.7 27,26.6 26.7,26.6zM17.2,70.1c0,0.2 0.1,0.4 0.4,0.4h2.5c0.1,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-2.1V69c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4V70.1zM17.2,65.2c0,0.2 0.1,0.4 0.4,0.4s0.4,-0.1 0.4,-0.4v-3.6c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4V65.2z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1004 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_pages_104dp.xml"
-            line="15"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
+            line="141"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1552 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M44.2,32.5v-3.6c0,-0.2 0.1,-0.4 0.4,-0.4c0.2,0 0.4,0.1 0.4,0.4v3.6c0,0.2 -0.1,0.4 -0.4,0.4C44.4,32.9 44.2,32.8 44.2,32.5zM75.5,35h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4S75.3,35 75.5,35zM75.6,27.3h3.7c0.2,0 0.4,-0.1 0.4,-0.4c0,-0.2 -0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4C75.2,27.1 75.4,27.3 75.6,27.3zM46.2,35h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4S46,35 46.2,35zM46.3,27.3h3.7c0.2,0 0.4,-0.1 0.4,-0.4c0,-0.2 -0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4C45.9,27.1 46.1,27.3 46.3,27.3zM82.8,35h3.7c0.2,0 0.4,-0.2 0.4,-0.4v-3.9c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4v3.6h-3.3c-0.2,0 -0.4,0.1 -0.4,0.4S82.6,35 82.8,35zM82.9,27.3h3.4c0.1,0.1 0.1,0.1 0.2,0.1c0.2,0 0.4,-0.1 0.4,-0.4v-0.1c0,-0.2 -0.1,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.1 -0.4,0.4C82.5,27.1 82.7,27.3 82.9,27.3zM68.2,35h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4S68,35 68.2,35zM60.9,35h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4S60.6,35 60.9,35zM60.9,27.3h3.7c0.2,0 0.4,-0.1 0.4,-0.4c0,-0.2 -0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4C60.6,27.1 60.7,27.3 60.9,27.3zM68.3,27.3h3.7c0.2,0 0.4,-0.1 0.4,-0.4c0,-0.2 -0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4C67.9,27.1 68,27.3 68.3,27.3zM53.6,27.3h3.7c0.2,0 0.4,-0.1 0.4,-0.4c0,-0.2 -0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4C53.2,27.1 53.4,27.3 53.6,27.3zM53.5,35h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7c-0.2,0 -0.4,0.1 -0.4,0.4S53.3,35 53.5,35z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (923 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_pages_104dp.xml"
-            line="20"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
+            line="151"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (3366 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M44.2,45.5c0,-0.2 0.1,-0.4 0.4,-0.4h2.9c0.2,0 0.4,0.1 0.4,0.4s-0.1,0.4 -0.4,0.4H45v0.4c0,0.2 -0.1,0.4 -0.4,0.4c-0.2,0 -0.4,-0.1 -0.4,-0.4V45.5zM72.8,45.5c0,0.2 0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7C72.9,45.1 72.8,45.2 72.8,45.5zM69.8,62.8h-0.3c-0.2,0 -0.4,0.1 -0.4,0.4c0,0.2 0.1,0.4 0.4,0.4h0.2c1.1,0 2.3,-0.3 3.4,-0.9c0.2,-0.1 0.2,-0.4 0.1,-0.5c-0.1,-0.2 -0.4,-0.2 -0.5,-0.1C71.8,62.5 70.8,62.8 69.8,62.8zM75.9,60.3c0.1,0 0.1,-0.1 0.2,-0.1l0.4,-0.4c0.8,-0.7 1.5,-1.3 2.4,-2c0.1,-0.1 0.2,-0.4 0.1,-0.5c-0.1,-0.1 -0.4,-0.2 -0.5,-0.1l-2.4,2l-0.4,0.4c-0.2,0.1 -0.2,0.4 -0.1,0.5C75.7,60.3 75.8,60.3 75.9,60.3zM75.1,70.1c0,0.2 0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7C75.3,69.8 75.1,69.9 75.1,70.1zM68.2,69.8c-0.2,0 -0.4,0.1 -0.4,0.4s0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4H68.2zM80.1,45.5c0,0.2 0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7C80.3,45.1 80.1,45.2 80.1,45.5zM44.2,60.8c0,0.2 0.1,0.4 0.4,0.4c0.2,0 0.4,-0.1 0.4,-0.4v-3.6c0,-0.2 -0.1,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.1 -0.4,0.4V60.8zM44.2,66.9c-0.2,0.3 -0.3,0.5 -0.4,0.8c-0.1,0.2 0,0.4 0.1,0.5c0,0.1 0.1,0.1 0.1,0.1c0,0 0.1,0 0.2,-0.1c0,0.2 0.1,0.3 0.3,0.3c0.2,0 0.4,-0.1 0.4,-0.4v-0.9c0.5,-0.8 0.9,-1.5 1.5,-2.1c0.1,-0.1 0.1,-0.4 -0.1,-0.5c-0.1,-0.1 -0.4,-0.1 -0.5,0.1c-0.3,0.4 -0.6,0.8 -0.9,1.2v-1.3c0,-0.2 -0.1,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.1 -0.4,0.4V66.9zM44.2,53.5c0,0.2 0.1,0.4 0.4,0.4c0.2,0 0.4,-0.1 0.4,-0.4v-3.6c0,-0.2 -0.1,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.1 -0.4,0.4V53.5zM86.9,61.4c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4V65c0,0.2 0.1,0.4 0.4,0.4s0.4,-0.2 0.4,-0.4V61.4zM46.2,69.8c-0.2,0 -0.4,0.1 -0.4,0.4s0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4H46.2zM86.9,54.1c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4v3.6c0,0.2 0.1,0.4 0.4,0.4s0.4,-0.2 0.4,-0.4V54.1zM86.9,46.8c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4v3.6c0,0.2 0.1,0.4 0.4,0.4s0.4,-0.2 0.4,-0.4V46.8zM82.8,70.5h3.7c0.2,0 0.4,-0.2 0.4,-0.4v-1.5c0,-0.2 -0.1,-0.4 -0.4,-0.4s-0.4,0.1 -0.4,0.4v1.1h-3.3c-0.2,0 -0.4,0.1 -0.4,0.4S82.6,70.5 82.8,70.5zM85.7,54.7c0,-0.1 -0.1,-0.3 -0.4,-0.3c-1.3,0.1 -2.5,0.4 -3.7,0.9c-0.2,0.1 -0.3,0.3 -0.2,0.5c0.1,0.1 0.2,0.2 0.4,0.2c0.1,0 0.1,0 0.1,-0.1c1.2,-0.4 2.3,-0.7 3.4,-0.9C85.5,55.1 85.7,54.9 85.7,54.7zM62.6,60.9c-0.2,-0.1 -0.4,0 -0.5,0.2s0,0.4 0.2,0.5l0.7,0.3c0.9,0.4 1.8,0.7 2.7,1h0.1c0.1,0 0.3,-0.1 0.3,-0.3c0.1,-0.1 0,-0.4 -0.2,-0.4c-0.9,-0.3 -1.8,-0.7 -2.6,-1L62.6,60.9zM60.9,69.8c-0.2,0 -0.4,0.1 -0.4,0.4s0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4H60.9zM65.5,45.5c0,0.2 0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7C65.6,45.1 65.5,45.2 65.5,45.5zM50.8,45.5c0,0.2 0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7C51,45.1 50.8,45.2 50.8,45.5zM58.2,45.5c0,0.2 0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4h-3.7C58.3,45.1 58.2,45.2 58.2,45.5zM48.4,62.5c0.1,0.1 0.2,0.1 0.3,0.1h0.2c1,-0.8 2.1,-1.4 3.1,-1.8c0.2,-0.1 0.3,-0.3 0.2,-0.5c-0.1,-0.2 -0.3,-0.3 -0.5,-0.2c-1.1,0.4 -2.2,1.1 -3.2,1.9C48.3,62.1 48.3,62.3 48.4,62.5zM55.1,59.6c0,0.2 0.1,0.4 0.4,0.4c1.2,0 2.3,0.1 3.6,0.4c0.1,0 0.3,-0.1 0.4,-0.2c0,-0.2 -0.1,-0.4 -0.3,-0.4c-1.2,-0.3 -2.4,-0.4 -3.7,-0.4C55.2,59.3 55.1,59.4 55.1,59.6zM53.5,69.8c-0.2,0 -0.4,0.1 -0.4,0.4s0.1,0.4 0.4,0.4h3.7c0.2,0 0.4,-0.1 0.4,-0.4s-0.1,-0.4 -0.4,-0.4H53.5z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (7633 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_pages_104dp.xml"
-            line="25"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_notifications_152dp.xml"
+            line="156"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (2168 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M60.6,27.1h1.8c0.2,0 0.4,-0.2 0.4,-0.4V25c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v1.5h-1.5c-0.2,0 -0.4,0.2 -0.4,0.4C60.2,27 60.4,27.1 60.6,27.1M17.5,27.1h3.6c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4C17.1,27 17.3,27.1 17.5,27.1M53.4,27.1H57c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4C53,27 53.2,27.1 53.4,27.1M39,27.1h3.6c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4H39c-0.2,0 -0.4,0.2 -0.4,0.4C38.6,27 38.8,27.1 39,27.1M31.8,27.1h3.6c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4C31.5,27 31.6,27.1 31.8,27.1M24.6,27.1h3.6c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4C24.3,27 24.4,27.1 24.6,27.1M46.2,27.1h3.6c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4C45.8,27 46,27.1 46.2,27.1M11.7,26.8c0,0.2 0.2,0.4 0.4,0.4h1.8c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-1.5V25c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4V26.8zM11.7,22.1c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4v-2.8c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4V22.1zM12.1,16.8c0.2,0 0.4,-0.2 0.4,-0.4V15h1.5c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4h-1.8c-0.2,0 -0.4,0.2 -0.4,0.4v1.8C11.7,16.7 11.8,16.8 12.1,16.8M24.6,15h3.6c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4S24.4,15 24.6,15M53.4,15H57c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4S53.2,15 53.4,15M39,15h3.6c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4H39c-0.2,0 -0.4,0.2 -0.4,0.4S38.8,15 39,15M17.5,15h3.6c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4S17.3,15 17.5,15M31.8,15h3.6c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4S31.6,15 31.8,15M46.2,15h3.6c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4h-3.6c-0.2,0 -0.4,0.2 -0.4,0.4S46,15 46.2,15M62.7,14.6c0,-0.2 -0.2,-0.4 -0.4,-0.4h-1.8c-0.2,0 -0.4,0.2 -0.4,0.4s0.2,0.4 0.4,0.4H62v1.5c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V14.6zM62.4,18.9c-0.2,0 -0.4,0.2 -0.4,0.4v2.8c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4v-2.8C62.7,19.1 62.6,18.9 62.4,18.9&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1098 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_posts_75dp.xml"
-            line="15"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_pages_104dp.xml"
+            line="10"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1998 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M28.9,74.3c-0.2,0 -0.4,0.2 -0.4,0.4v1.5h-1.5c-0.2,0 -0.4,0.2 -0.4,0.4c0,0.2 0.2,0.4 0.4,0.4h1.8c0.2,0 0.4,-0.2 0.4,-0.4v-1.8C29.3,74.4 29.1,74.3 28.9,74.3M18.3,76.1c-0.2,0 -0.4,0.2 -0.4,0.4c0,0.2 0.2,0.4 0.4,0.4h4.4c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4H18.3zM11.7,76.5c0,0.2 0.2,0.4 0.4,0.4h1.8c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-1.5v-1.5c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4V76.5zM11.7,71.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V68c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4V71.3zM11.7,57.9c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4v-3.3c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4V57.9zM11.7,64.6c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4v-3.3c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4V64.6zM11.7,44.6c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4v-3.3c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4V44.6zM11.7,51.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4v-3.3c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4V51.3zM11.7,37.9c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4v-1.5h1.5c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4h-1.8c-0.2,0 -0.4,0.2 -0.4,0.4V37.9zM22.7,35.7h-4.4c-0.2,0 -0.4,0.2 -0.4,0.4s0.2,0.4 0.4,0.4h4.4c0.2,0 0.4,-0.2 0.4,-0.4S22.9,35.7 22.7,35.7M29.3,36.1c0,-0.2 -0.2,-0.4 -0.4,-0.4h-1.8c-0.2,0 -0.4,0.2 -0.4,0.4s0.2,0.4 0.4,0.4h1.5v1.5c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V36.1zM29.3,41.3c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V41.3zM29.3,68c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V68zM29.3,47.9c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V47.9zM29.3,61.3c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V61.3zM29.3,54.6c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V54.6z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1870 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_posts_75dp.xml"
-            line="20"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_pages_104dp.xml"
+            line="15"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (3317 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M60.6,76.8h1.8c0.2,0 0.4,-0.2 0.4,-0.4v-1.8c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v1.5h-1.5c-0.2,0 -0.4,0.2 -0.4,0.4C60.2,76.7 60.4,76.8 60.6,76.8M44.6,76.5c0,0.2 0.2,0.4 0.4,0.4h3.9c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4H45C44.8,76.1 44.6,76.3 44.6,76.5M52.8,76.8h3.9c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-3.9c-0.2,0 -0.4,0.2 -0.4,0.4C52.4,76.7 52.6,76.8 52.8,76.8M38.9,76.5C38.9,76.5 38.9,76.5 38.9,76.5c0,0.1 0,0.1 0,0.1c0,0 0,0 0,0.1c0,0 0,0 0,0.1c0,0 0,0 0.1,0.1c0,0 0,0 0,0c0,0 0,0 0,0c0.1,0 0.1,0 0.2,0h1.8c0.2,0 0.4,-0.2 0.4,-0.4c0,-0.2 -0.2,-0.4 -0.4,-0.4h-1.2l1.1,-1.9c0.1,-0.2 0,-0.4 -0.1,-0.5c-0.2,-0.1 -0.4,0 -0.5,0.1l-0.7,1.2v-0.5c0,-0.2 -0.2,-0.4 -0.4,-0.4s-0.4,0.2 -0.4,0.4V76.5zM38.9,64.6c0,0.2 0.2,0.4 0.4,0.4s0.4,-0.2 0.4,-0.4v-3.3c0,-0.2 -0.2,-0.4 -0.4,-0.4s-0.4,0.2 -0.4,0.4V64.6zM38.9,71.3c0,0.2 0.2,0.4 0.4,0.4s0.4,-0.2 0.4,-0.4V68c0,-0.2 -0.2,-0.4 -0.4,-0.4s-0.4,0.2 -0.4,0.4V71.3zM39.2,45c0.2,0 0.4,-0.2 0.4,-0.4v-3.3c0,-0.2 -0.2,-0.4 -0.4,-0.4s-0.4,0.2 -0.4,0.4v3.3C38.9,44.8 39,45 39.2,45M38.9,51.3c0,0.2 0.2,0.4 0.4,0.4s0.4,-0.2 0.4,-0.4v-3.3c0,-0.2 -0.2,-0.4 -0.4,-0.4s-0.4,0.2 -0.4,0.4V51.3zM38.9,57.9c0,0.2 0.2,0.4 0.4,0.4s0.4,-0.2 0.4,-0.4v-3.3c0,-0.2 -0.2,-0.4 -0.4,-0.4s-0.4,0.2 -0.4,0.4V57.9zM41.1,35.7h-1.8c-0.2,0 -0.4,0.2 -0.4,0.4v1.8c0,0.2 0.2,0.4 0.4,0.4s0.4,-0.2 0.4,-0.4v-1.5h1.5c0.2,0 0.4,-0.2 0.4,-0.4S41.3,35.7 41.1,35.7M44.6,36.1c0,0.2 0.2,0.4 0.4,0.4h3.9c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4H45C44.8,35.7 44.6,35.9 44.6,36.1M52.4,36.1c0,0.2 0.2,0.4 0.4,0.4h3.9c0.2,0 0.4,-0.2 0.4,-0.4s-0.2,-0.4 -0.4,-0.4h-3.9C52.6,35.7 52.4,35.9 52.4,36.1M60.6,36.5h1.2l-1.5,2.6c-0.1,0.2 0,0.4 0.1,0.5c0.1,0 0.1,0 0.2,0c0.1,0 0.2,-0.1 0.3,-0.2l1.1,-2v0.5c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4v-1.8c0,0 0,0 0,0c0,0 0,0 0,-0.1c0,0 0,0 0,-0.1c0,0 0,0 0,-0.1c0,0 0,0 -0.1,-0.1c0,0 0,0 0,0c0,0 0,0 0,0c0,0 0,0 -0.1,0c0,0 0,0 -0.1,0c0,0 0,0 0,0h-1.8c-0.2,0 -0.4,0.2 -0.4,0.4S60.4,36.5 60.6,36.5M62.7,61.3c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V61.3zM62.7,41.3c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V41.3zM62.7,47.9c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V47.9zM62.7,54.6c0,-0.2 -0.2,-0.4 -0.4,-0.4c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V54.6zM62.4,67.6c-0.2,0 -0.4,0.2 -0.4,0.4v3.3c0,0.2 0.2,0.4 0.4,0.4c0.2,0 0.4,-0.2 0.4,-0.4V68C62.7,67.8 62.6,67.6 62.4,67.6M54.8,48.6L53,51.7c-0.1,0.2 0,0.4 0.1,0.5c0.1,0 0.1,0 0.2,0c0.1,0 0.2,-0.1 0.3,-0.2l1.8,-3.2c0.1,-0.2 0,-0.4 -0.1,-0.5C55.1,48.3 54.9,48.4 54.8,48.6M56.8,45.9c0.1,0 0.1,0 0.2,0c0.1,0 0.2,-0.1 0.3,-0.2l1.8,-3.2c0.1,-0.2 0,-0.4 -0.1,-0.5c-0.2,-0.1 -0.4,0 -0.5,0.1l-1.8,3.2C56.5,45.6 56.6,45.8 56.8,45.9M44.4,67.4c-0.2,-0.1 -0.4,0 -0.5,0.1l-1.8,3.2c-0.1,0.2 0,0.4 0.1,0.5c0.1,0 0.1,0 0.2,0c0.1,0 0.2,-0.1 0.3,-0.2l1.8,-3.2C44.7,67.7 44.6,67.5 44.4,67.4M46.1,64.9c0.1,0 0.2,-0.1 0.3,-0.2l1.8,-3.2c0.1,-0.2 0,-0.4 -0.1,-0.5c-0.2,-0.1 -0.4,0 -0.5,0.1l-1.8,3.2c-0.1,0.2 0,0.4 0.1,0.5C45.9,64.9 46,64.9 46.1,64.9M49.5,58.5c0.1,0 0.1,0 0.2,0c0.1,0 0.2,-0.1 0.3,-0.2l1.8,-3.2c0.1,-0.2 0,-0.4 -0.1,-0.5c-0.2,-0.1 -0.4,0 -0.5,0.1L49.4,58C49.3,58.2 49.3,58.4 49.5,58.5&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1552 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_posts_75dp.xml"
-            line="25"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_pages_104dp.xml"
+            line="20"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (845 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M116.91 34.44c-1.46 2.43-2.89 4.9-4.26 7.39-0.26 0.43-0.14 0.99 0.29 1.25s0.99 0.14 1.25-0.3c1.66-2.32 3.25-4.68 4.82-7.05 1.6-2.35 3.09-4.77 4.63-7.16 1.54-2.38 3.03-4.8 4.48-7.25 1.45-2.44 2.88-4.89 4.22-7.42 0.24-0.41 0.12-0.95-0.28-1.23-0.41-0.28-0.98-0.15-1.26 0.26-1.68 2.3-3.3 4.65-4.85 7.02-1.56 2.37-3.11 4.76-4.59 7.19-1.48 2.44-3.02 4.84-4.45 7.3m-22.54 4.59c-1.92-1.37-3.92-2.6-6-3.73-0.37-0.18-0.8-0.11-1.09 0.19-0.34 0.37-0.33 0.94 0.03 1.29 1.72 1.6 3.55 3.08 5.48 4.45 1.91 1.37 3.86 2.68 6 3.73 0.34 0.15 0.74 0.09 1.02-0.17 0.37-0.36 0.38-0.94 0.04-1.31-1.69-1.68-3.55-3.11-5.48-4.45m-29.8 12.78c0.38 0.32 0.97 0.27 1.29-0.11 1.71-2.08 3.3-4.25 4.74-6.51 1.48-2.25 2.88-4.53 4.01-6.99 0.17-0.37 0.07-0.8-0.23-1.07-0.39-0.33-0.96-0.29-1.3 0.08-1.78 2.03-3.29 4.25-4.74 6.5-1.46 2.25-2.8 4.59-4 6.99-0.19 0.38-0.09 0.83 0.23 1.11&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (3366 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_stats_226dp.xml"
-            line="46"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_pages_104dp.xml"
+            line="25"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1277 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M223.67 109.62c-1.55 0.13-3.07 0.21-4.63 0.21-2.15 0-4.55-0.14-6.71-0.57l-0.54 42.04h-6.74c0.11 4.81 0.35 9.44 0.6 13.51 0.01 0.37 0.05 0.74 0.06 1.09 0.26 4.45 0.49 8.14 0.46 10.54-1.41 0.16-2.51 0.31-2.92 0.47-1.46 0.52-1.56 1.35 0.21 1.77 1.77 0.41 14.26 0 14.26 0v-3.02c0-31.76 5.93-46.26 6.4-63.49 0.02-0.82 0.03-1.77 0.03-2.61m-11.79-1.39c0.37 0.07 0.77 0.17 1.16 0.23 3.12 0.49 7.01 0.38 9.37 0.24h0.02c0.05 0 0.1 0 0.16-0.01h0.03c0.41-0.02 0.76-0.05 1.07-0.08 0.2-1.32 2-12.65 0.82-23.83-0.31-2.83-1.93-5.17-4.18-6.53-0.27 0.08-0.57 0.13-0.89 0.13-0.66-0.02-1.31-0.14-1.92-0.36-0.39-0.14-0.65-0.31-0.8-0.49-0.05 0.03-0.11 0.05-0.17 0.06-0.03 0-3.28 0.46-4.84 2.03-0.11 0.11-0.24 0.17-0.4 0.16l-2.49 2.57-1.5 1.57 1.74-1.66c0.24-0.2 0.57-0.19 0.77 0.04 0.2 0.22 0.19 0.56-0.01 0.76l-3.82 3.63 0.11 0.2 7.53 4.97c0.04-0.03 0.07-0.06 0.12-0.11 0.18 0.01 0.21 0.1 0.4 0.33 0.2 0.23 0.4 0.32 0.17 0.51-0.83 0.72-1.53 1.3-2.38 1.92M105.7 123.44h19.57v-11.32H105.7zm29.49-17.23h19.57V79.42h-19.57zm29.48-12.07h19.57V65.98h-19.57zM9.69 154.91l-0.65-0.05-2.2-0.15-0.54-0.03H6.19c-0.17-0.02-0.32-0.02-0.46-0.02-1.37 0.06-1.73 1.12-2.14 2.66-0.59 2.24-2.26 6.75-1.65 7.76 0.06 0.11 0.16 0.17 0.26 0.2 0.23 0.05 0.51-0.04 0.82-0.23 2.52-1.57 7.36-10.08 7.36-10.08h-0.06l-0.63-0.06z&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (2168 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_stats_226dp.xml"
-            line="51"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_posts_75dp.xml"
+            line="15"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (2504 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M94.82 128.06c-1.63-0.17-3.26-0.25-4.91-0.33-1.65-0.07-3.26-0.1-4.91-0.12-2.96-0.01-5.91 0.05-8.87 0.34 0.15-5.2 0.23-10.39 0.29-15.59 0.1-5.55 0.08-11.07 0.11-16.62 0.03-5.54-0.03-11.07-0.06-16.61-0.08-5.54-0.17-11.07-0.37-16.61-0.02-0.48-0.4-0.85-0.86-0.86-0.51-0.02-0.93 0.37-0.94 0.86-0.2 5.54-0.29 11.07-0.37 16.61-0.03 5.54-0.11 11.07-0.06 16.61 0.04 5.55 0.01 11.07 0.11 16.62 0.06 5.54 0.15 11.06 0.32 16.61 0.01 0.38 0.28 0.7 0.63 0.83 0.09 0.04 0.17 0.06 0.28 0.07 3.26 0.39 6.54 0.47 9.8 0.45 1.64-0.01 3.27-0.05 4.91-0.12 1.65-0.08 3.27-0.16 4.92-0.33 0.43-0.04 0.75-0.38 0.8-0.8 0.04-0.5-0.33-0.95-0.82-1.01m79.22-105.9c-0.61-4.73-4.06-8.58-8.7-9.69-0.73-0.18-1.5-0.28-2.27-0.29-0.77-0.03-1.39 0.01-2.1 0.01-5.45 0.07-10.9 0.16-16.35 0.34-0.47 0.02-0.84 0.4-0.86 0.87-0.01 0.5 0.37 0.92 0.86 0.93 5.45 0.19 10.9 0.28 16.35 0.34 0.66 0.02 1.42 0 2 0.05 0.6 0.03 1.19 0.11 1.76 0.26 3.56 0.89 6.19 3.87 6.63 7.51 0.13 1.1 0.05 2.59 0.08 3.91l0.02 4.08 0.06 8.18c0.08 5.45 0.17 10.9 0.37 16.35 0.01 0.48 0.4 0.84 0.86 0.86 0.51 0.02 0.92-0.37 0.94-0.86 0.2-5.45 0.29-10.9 0.37-16.35l0.06-8.18 0.02-4.08c-0.02-1.38 0.07-2.63-0.1-4.24m-53.54-9.64c-3.79-0.2-7.54-0.29-11.33-0.37-3.79-0.03-7.55-0.11-11.33-0.06-3.79 0.04-7.56 0.01-11.33 0.1-3.79 0.07-7.55 0.16-11.33 0.33-0.48 0.01-0.85 0.4-0.87 0.86-0.01 0.51 0.37 0.92 0.87 0.94 3.78 0.17 7.54 0.26 11.33 0.32 3.78 0.09 7.54 0.09 11.33 0.11 3.78 0.02 7.54-0.03 11.33-0.06 3.79-0.09 7.54-0.17 11.33-0.37 0.48-0.02 0.85-0.4 0.86-0.86 0.03-0.5-0.35-0.91-0.86-0.94m40.13 27.37c-3.94-0.4-7.88-0.46-11.82-0.45-1.97 0.02-3.94 0.05-5.91 0.13-1.97 0.07-3.94 0.15-5.91 0.32-0.43 0.05-0.79 0.39-0.82 0.82-0.04 0.5 0.32 0.94 0.82 0.98 1.97 0.17 3.94 0.23 5.91 0.32 1.97 0.1 3.94 0.11 5.91 0.13 3.94 0.01 7.88-0.06 11.82-0.45 0.44-0.04 0.79-0.38 0.82-0.81 0.05-0.5-0.31-0.94-0.82-0.99m-6.2 14.19c-3.94-0.38-7.88-0.46-11.82-0.44-1.97 0.01-3.94 0.04-5.92 0.12-1.97 0.08-3.94 0.16-5.91 0.32-0.43 0.05-0.78 0.39-0.81 0.82-0.05 0.51 0.32 0.94 0.81 0.99 1.97 0.17 3.94 0.23 5.91 0.32 1.98 0.09 3.95 0.11 5.92 0.12 3.94 0.02 7.88-0.06 11.82-0.44 0.43-0.05 0.79-0.39 0.82-0.82 0.06-0.49-0.31-0.94-0.82-0.99M119.7 82.66c-2.43-0.2-4.87-0.29-7.3-0.37-2.43-0.06-4.86-0.11-7.3-0.06-2.43 0.04-4.86 0.01-7.29 0.1-2.44 0.07-4.87 0.16-7.3 0.33-0.45 0.03-0.82 0.38-0.85 0.84-0.03 0.51 0.34 0.94 0.85 0.97 2.43 0.17 4.86 0.27 7.3 0.33 2.43 0.09 4.86 0.07 7.29 0.11 2.44 0.03 4.87-0.02 7.3-0.07 2.43-0.09 4.87-0.17 7.3-0.37 0.43-0.04 0.78-0.38 0.81-0.81 0.07-0.51-0.3-0.96-0.81-1&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1998 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_stats_226dp.xml"
-            line="56"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_posts_75dp.xml"
+            line="20"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (2272 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M110.54 96.87c-4.13-0.4-8.25-0.46-12.39-0.45-2.07 0.02-4.13 0.05-6.19 0.12-2.07 0.08-4.13 0.16-6.19 0.33-0.45 0.03-0.82 0.38-0.85 0.84-0.03 0.51 0.34 0.94 0.85 0.97 2.06 0.17 4.12 0.24 6.19 0.33 2.06 0.09 4.12 0.11 6.19 0.12 4.12 0.02 8.25-0.06 12.39-0.45 0.43-0.04 0.78-0.38 0.81-0.81 0.07-0.51-0.3-0.96-0.81-1m-20.25 16.47c1.51 0.02 3.02-0.06 4.53-0.45 0.32-0.09 0.59-0.33 0.68-0.67 0.12-0.5-0.17-1.02-0.68-1.14-1.51-0.39-3.02-0.46-4.53-0.45-1.52 0-3.03 0.15-4.52 0.45-0.37 0.07-0.65 0.35-0.73 0.72-0.09 0.49 0.24 0.99 0.73 1.09 1.49 0.3 3 0.45 4.52 0.45M41.61 61.72c0-0.28 0.22-0.49 0.5-0.49 0.27 0 0.49 0.21 0.49 0.49v0.83c0 0.28-0.22 0.49-0.49 0.49-0.28 0-0.5-0.21-0.5-0.49v-0.83zm-5.2 13.35h0.2c0.23 0.01 0.46 0.04 0.69 0.09v-0.11l-2.95-3.14 0.06-0.37c0.02-0.03 0.02-0.06 0.03-0.07 0-0.04 0-0.07 0.02-0.11 0.06-0.26 0.3-0.43 0.57-0.4 0.03 0 0.06 0 0.09 0.01h0.01c0.76 0.2 1.1 0.19 1.96 0.16 0.17-0.02 0.34-0.02 0.49-0.05 2.06-0.23 3.76-1.28 4.84-2.92-0.44-0.28-1.01-0.77-1.33-1.5-0.12-0.27 0.02-0.6 0.29-0.72 0.28-0.12 0.6 0.01 0.73 0.29 0.2 0.45 0.55 0.77 0.84 0.97 0.23-0.49 0.42-1.01 0.54-1.58 0.16-0.67 0.73-1.01 1.22-1.31 0.45-0.28 0.72-0.46 0.72-0.68-0.01-0.35-0.32-0.68-0.81-1.17-0.7-0.69-1.64-1.63-1.91-3.34-0.19-1.09-0.74-1.94-1.5-2.57-0.09 2.98-1.49 5.85-4.26 6.03 0.12 0.6 0.15 1.25 0.06 1.9-0.17 1.4-0.8 2.84-1.8 3.88-0.6 0.61-1.32 1.09-2.17 1.34 0.22 1.41 0.05 3-0.54 4.57 1.2 0.12 2.49 0.4 3.91 0.8zm-24.51 57.5c-1.2 2.49-5.69 12.58-5.06 22.14l2.2 0.15 13.73-18.94c-0.12-1.12-0.23-2.23-0.32-3.37H11.9v0.02zm14 0h-2.36c0.06 0.68 0.12 1.35 0.19 2.03l0.09 0.82 0.09 0.81c0.43 3.73 1 7.39 1.56 10.99 0.78 5.09 1.53 9.9 1.77 14.25 0.01 0.23 0.03 0.46 0.03 0.69l4.98 0.14c0.05-0.2 0.11-0.43 0.16-0.68 1.12-5.44 2.14-22.19 2.51-29.05H25.9zm28.46-59.5c-1.52 0.12-5.66 4.89-7.65 8.39-0.85 1.51-1.99 2.85-3.32 3.94 0.24 1.43 0.4 2.89 0.46 4.34 0 0.31-0.25 0.55-0.56 0.54-0.29 0-0.52-0.23-0.54-0.51 0-0.12-0.44-11.45-5.03-13.33-0.15-0.06-0.32-0.12-0.49-0.16-0.22-0.04-0.43-0.09-0.66-0.09h-0.1c-1.4 0-2.06 1.79-2.38 3.44-0.02 0.12-0.05 0.23-0.07 0.35-1.09 6.74 1.78 19.35 4.58 20.14 0.03 0.01 0.06 0.01 0.09 0.01 3.86 0.82 11.16-13.82 12.76-18.93 0.05-0.14 0.14-0.27 0.28-0.33 1.06-0.54 2.43-2.95 2.92-5.19 0.27-1.17 0.24-2.11-0.09-2.51-0.03-0.07-0.06-0.12-0.2-0.1&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (3317 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_stats_226dp.xml"
-            line="61"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_posts_75dp.xml"
+            line="25"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1094 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M38.9 101.2v-0.13l-0.13-0.01c-0.16-0.02-0.28-0.03-0.41-0.08-1.67-0.46-3.32-3.66-4.42-8.55-1.01-4.53-1.34-9.49-0.83-12.63 0.01-0.03 0.02-0.07 0.02-0.1 0-0.02 0-0.04 0.01-0.06l0.01-0.02c0.49-2.9 1.6-4.38 3.28-4.4l1.06-0.01-1.02-0.29c-1.35-0.38-2.66-0.66-3.9-0.82l-0.12-0.02-0.05 0.12c-0.25 0.65-0.56 1.28-0.92 1.86-0.38 0.61-0.8 1.17-1.26 1.67-2.21 2.38-5.12 3.35-7.41 2.49-0.26-0.1-0.53-0.22-0.8-0.39-0.23-0.14-0.41-0.27-0.55-0.4l-0.13-0.12-0.38 0.57c-3.6 5.47-3.65 8.37-3.71 11.73-0.03 1.95-0.06 3.97-0.76 6.73-0.02 0.06-0.03 0.12-0.04 0.18-0.01 0.05-0.02 0.09-0.04 0.15l-0.03 0.1c-0.01 0.04-0.02 0.09-0.03 0.12-0.04 0.17-0.09 0.34-0.15 0.52-0.5 1.67-1.11 3.16-1.75 4.73-2.23 5.41-4.75 11.54-4.05 28.44l0.01 0.14h26.64l0.02-0.14c0.02-0.22 2.1-22.02 1.84-31.38m1.19 62.19c-1.18-0.39-4.83-1.11-6.57-1.6-0.11 0.49-0.2 0.91-0.31 1.23-0.08 0.23-0.29 0.39-0.52 0.37h-0.02l-5.93-0.15c-0.29-0.02-0.52-0.25-0.54-0.54-0.01-0.42-0.03-0.83-0.06-1.27H25.9l-0.19 1.34c-0.01 0.11-0.03 0.22-0.03 0.34 0 0.54 0.19 1.02 0.51 1.4 0.41 0.51 1.05 0.83 1.74 0.83h11.84c0.63 0 0.98-0.49 1-1 0.01-0.4-0.2-0.8-0.68-0.95&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (845 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_stats_226dp.xml"
-            line="71"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_stats_226dp.xml"
+            line="46"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (2093 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M222.52 67.72l0.46 0.33 0.48 0.32c1.56-4.76-1.01-9.88-5.77-11.47-3.39-1.14-6.62-0.32-8.18 1.97l0.45 0.31 0.46 0.31c1.45-2.16 4.51-2.34 6.93-1.54 4.08 1.35 6.33 5.68 5.17 9.77m2.13 41.8c-0.13 0.01-0.26 0.03-0.4 0.03-0.03 0-0.07 0-0.1 0.01 0 0.84 0 1.67-0.04 2.48-0.47 17.23-6.4 31.73-6.4 63.49v2.96c3.37-0.05 6.62-0.16 6.88-0.16l0.39-0.01v-1.74c0.1-1.89 2.21-45.57-0.33-67.06m-11.07-34.36l-0.13-0.37 0.22-0.01-0.09 0.38zm0.64 16.55c-0.04 0.03-0.07 0.08-0.12 0.11-1.21 1.04-2.42 1.94-3.57 2.69-5.47 3.59-10.05 4.11-11.98 2.5-3.02-2.51 0.96-11.74 2.88-16.17 0.54-1.26 0.94-2.17 1.05-2.63 1.08-4.45 2.97-5.68 4-6.02 0.83-0.28 1.46-0.11 1.66 0.06 0.3 0.35-0.21 2.51-1.09 4.51-0.02 0.03-0.03 0.08-0.03 0.12l-1.71 9.33-2.19 2.08c-0.1 0.11-0.16 0.25-0.16 0.4 0 0.31 0.24 0.56 0.55 0.56 0.14 0 0.28-0.05 0.38-0.16l2.51-2.38 0.08-0.08L210.3 83c0.2-0.2 0.21-0.54 0.01-0.76-0.2-0.23-0.55-0.24-0.77-0.04l-1.74 1.66-1.12 1.06 1.43-7.77c0.43-1.04 1.19-2.99 1.2-4.39 0.74 0.6 1.62 1.08 2.62 1.42 0.09 0.03 0.17 0.06 0.25 0.07 0 0.06 0 0.13 0.03 0.19l0.94 2.86c0.03 0.08 0.07 0.15 0.12 0.2 0.32-0.15 0.65-0.29 0.97-0.4l0.69-2.8c0.05-0.17 0-0.36-0.11-0.48-0.03-0.05-0.07-0.08-0.1-0.11-0.06-0.04-0.14-0.07-0.22-0.09-0.08-0.06-0.18-0.11-0.29-0.11-0.77-0.01-1.09-0.1-1.93-0.38-2.01-0.68-3.46-2.06-4.18-3.9 0.26 0.05 0.52 0.08 0.8 0.1 0.09 0 0.2-0.02 0.31-0.02 0.29-0.03 0.49-0.29 0.47-0.57-0.01-0.31-0.27-0.54-0.58-0.52-0.39 0.03-0.79-0.03-1.16-0.16-0.06-0.01-0.14-0.03-0.2-0.03-0.12-0.61-0.17-1.28-0.14-1.95 0.04-0.68-0.43-1.16-0.81-1.6-0.36-0.4-0.57-0.65-0.51-0.87 0.11-0.33 0.49-0.57 1.09-0.9 0.77-0.44 1.8-1.02 2.54-2.31l-0.46-0.31-0.46-0.31c-0.59 1.08-1.42 1.54-2.17 1.97-0.69 0.39-1.36 0.76-1.6 1.51-0.28 0.85 0.31 1.49 0.74 1.96 0.26 0.29 0.54 0.58 0.52 0.8-0.08 1.87 0.35 3.55 1.23 4.92-0.46-0.06-1-0.01-1.57 0.17-1.24 0.42-3.51 1.83-4.72 6.81-0.1 0.37-0.51 1.34-0.99 2.44-2.17 5.04-6.22 14.41-2.57 17.45 0.92 0.77 2.15 1.14 3.62 1.14 1.21 0 2.6-0.27 4.06-0.76 0.45-0.15 0.89-0.32 1.36-0.51 1.78-0.75 3.66-1.81 5.54-3.18 0.85-0.62 1.69-1.28 2.52-2 0.23-0.2 0.27-0.54 0.07-0.77-0.22-0.19-0.57-0.2-0.81-0.02z&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1277 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_stats_226dp.xml"
-            line="76"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_stats_226dp.xml"
+            line="51"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (2254 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M51.45 81.15c-1.58 5.11-8.9 19.75-12.76 18.94-0.03 0-0.06-0.02-0.09-0.02-2.8-0.79-5.67-13.39-4.58-20.14 0.02-0.12 0.05-0.23 0.07-0.35 0.3-1.65 0.97-3.43 2.38-3.43h0.09c0.24 0.01 0.45 0.04 0.67 0.09 0.17 0.04 0.34 0.09 0.49 0.15 4.59 1.88 5.03 13.21 5.03 13.33 0.02 0.3 0.27 0.51 0.54 0.51 0.31 0 0.56-0.24 0.56-0.54-0.06-1.46-0.22-2.91-0.46-4.34 1.35-1.09 2.47-2.42 3.32-3.94 1.99-3.49 6.13-8.27 7.65-8.39 0.14-0.01 0.17 0.03 0.2 0.06 0.33 0.4 0.36 1.34 0.09 2.51-0.49 2.23-1.86 4.65-2.92 5.19-0.12 0.11-0.23 0.23-0.28 0.37m-30.14-1.62c0.18 0.16 0.37 0.3 0.57 0.42 0.26 0.17 0.55 0.31 0.83 0.4 2.37 0.88 5.37-0.14 7.57-2.53 0.47-0.5 0.91-1.07 1.28-1.69 0.39-0.62 0.69-1.26 0.94-1.89 0.59-1.57 0.77-3.16 0.54-4.58 0.85-0.24 1.57-0.72 2.17-1.33 1.02-1.05 1.63-2.48 1.8-3.88 0.08-0.65 0.06-1.3-0.06-1.9 2.77-0.18 4.17-3.05 4.26-6.03 0.77 0.63 1.33 1.47 1.5 2.57 0.27 1.71 1.21 2.65 1.91 3.34 0.49 0.49 0.8 0.81 0.81 1.17 0.02 0.21-0.26 0.4-0.72 0.68-0.49 0.3-1.06 0.66-1.22 1.3-0.14 0.57-0.32 1.1-0.54 1.59-0.29-0.2-0.64-0.52-0.84-0.97-0.13-0.28-0.45-0.4-0.73-0.29-0.27 0.12-0.4 0.44-0.29 0.72 0.31 0.74 0.89 1.22 1.33 1.49-1.1 1.67-2.78 2.7-4.84 2.93-0.17 0.02-0.32 0.03-0.49 0.05-0.88 0.03-1.22 0.04-1.96-0.16h-0.01c-0.03 0-0.06-0.01-0.09-0.01-0.27-0.03-0.51 0.14-0.57 0.4-0.02 0.03-0.02 0.06-0.02 0.1-0.01 0.04-0.03 0.05-0.03 0.08l-0.06 0.37 2.95 3.14 0.13 0.14c-0.05-0.01-0.1-0.01-0.14-0.03-0.22-0.05-0.45-0.08-0.69-0.09h-0.2c-1.28 0.01-2.81 0.86-3.44 4.52-0.01 0.07-0.01 0.13-0.03 0.17-1.05 6.45 1.48 20.29 5.36 21.37 0.14 0.05 0.29 0.06 0.43 0.08 0.06 0 0.14 0.01 0.22 0.01 5.03 0 12-14.98 13.48-19.52 1.45-0.91 2.82-3.66 3.3-5.82 0.24-1.09 0.38-2.55-0.31-3.43-0.26-0.31-0.69-0.49-1.13-0.45-2.32 0.19-6.85 6.01-8.52 8.95-0.7 1.2-1.57 2.29-2.61 3.23-0.73-3.65-2.27-7.91-5.43-8.88l0.74-3.2c2.25-0.47 4.08-1.82 5.2-3.82 0.02-0.02 0.02-0.03 0.03-0.05 0.39-0.71 0.7-1.48 0.9-2.34 0.04-0.21 0.4-0.43 0.72-0.63 0.54-0.34 1.28-0.78 1.23-1.68-0.03-0.8-0.57-1.32-1.12-1.89-0.65-0.65-1.39-1.39-1.6-2.74-0.27-1.6-1.24-2.91-2.64-3.79 0-0.04-0.01-0.11-0.01-0.15 0 0-2.91-1.77-6.04-0.83-1.89 0.57-3.26 0.95-4.77 3.63-1.66 0.43-3.25 1.46-4.19 2.82-0.66 0.97-1.15 2.34-1.37 3.74-0.15 1.01-0.69 1.92-1.49 2.55-0.92 0.76-1.72 1.67-2.36 2.68-1.83 2.97-2.03 6.38-0.75 8.62&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (2504 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_stats_226dp.xml"
-            line="86"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_stats_226dp.xml"
+            line="56"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (2144 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M225.14 108.44c-0.02 0-0.39 0.05-0.99 0.1-0.33 0.03-0.77 0.06-1.26 0.09-0.04 0-0.09 0-0.14 0.01-2.34 0.16-6.02 0.25-9.23-0.26h-0.02c-0.38-0.06-0.77-0.12-1.14-0.21l0.19-13.72-0.14 0.06c-1.88 1.36-3.77 2.43-5.54 3.19-0.47 0.2-0.91 0.37-1.36 0.51L205 123.3c0.28 0.02 0.56 0.03 0.85 0.03 1.06 0 2.25-0.09 3.57-0.29 0.29-0.05 0.57 0.17 0.62 0.46 0.04 0.29-0.17 0.57-0.47 0.62-1.21 0.18-2.46 0.29-3.69 0.29h-0.09c-0.28 0-0.54-0.02-0.82-0.03l-0.55 26.86h7.34l0.57-41.98c2.16 0.43 4.56 0.57 6.71 0.57 1.56 0 3.11-0.06 4.67-0.2 0.03 0 0.06 0 0.09-0.02 0.09-0.01 0.2-0.01 0.29-0.03 0.03 0 0.08 0 0.11-0.01 0.14-0.02 0.26-0.03 0.4-0.03 0.22-0.02 0.42-0.05 0.63-0.06 0.28-0.05 0.48-0.3 0.46-0.59 0.02-0.23-0.26-0.46-0.55-0.45m-4.23-31.49c-0.45 0.38-1.42 0.37-2.58-0.02-0.13-0.03-0.24-0.09-0.35-0.18 0-0.34 1.32-1.31 2.51-1.44 0.65-0.07 0.69 0.17 0.71 0.27 0.12 0.64 0.01 1.1-0.29 1.37m-0.22-2.76c-1.42 0-3.48 1.11-3.77 2.26h-0.08c-0.09 0.02-1.28 0.19-2.63 0.68-0.32 0.12-0.65 0.25-0.97 0.4-0.68 0.32-1.34 0.74-1.86 1.26-0.11 0.11-0.16 0.25-0.16 0.39 0 0.31 0.25 0.55 0.54 0.55 0.16 0 0.29-0.06 0.4-0.15 1.56-1.57 4.8-2.03 4.84-2.03 0.06-0.02 0.12-0.03 0.16-0.06 0.17 0.18 0.42 0.35 0.81 0.49 0.61 0.21 1.26 0.34 1.92 0.35 0.32 0 0.63-0.04 0.89-0.12 0.31-0.09 0.59-0.23 0.82-0.43 0.43-0.37 0.89-1.08 0.66-2.4-0.09-0.74-0.69-1.19-1.57-1.19M206 57.79l2.97 2.04 0.47 0.3 0.46 0.31 5.03 3.44 7.21 4.91 0.43 0.29 0.61 0.42c0.1 0.06 0.2 0.09 0.31 0.09 0.19 0 0.36-0.09 0.45-0.23 0.17-0.25 0.11-0.59-0.14-0.77l-0.32-0.22-0.48-0.32-0.46-0.33-12.1-8.25-0.46-0.31-0.45-0.3-2.9-1.97c-0.23-0.14-0.53-0.08-0.7 0.13-0.2 0.24-0.16 0.59 0.07 0.77M131.41 2.13c1.91-2.42 5.43-2.84 7.85-0.93 2.43 1.91 2.84 5.42 0.93 7.85-1.91 2.42-5.42 2.84-7.85 0.93-2.42-1.91-2.84-5.42-0.93-7.85M103.4 46.41c1.91-2.43 5.43-2.85 7.85-0.94 2.43 1.91 2.84 5.43 0.93 7.85-1.91 2.43-5.42 2.84-7.84 0.93-2.43-1.91-2.85-5.42-0.94-7.84M75.9 26.09c1.91-2.42 5.42-2.84 7.85-0.93 2.42 1.91 2.84 5.42 0.93 7.85-1.91 2.42-5.42 2.84-7.85 0.93-2.42-1.91-2.84-5.42-0.93-7.85M56.02 55.17c1.91-2.42 5.42-2.84 7.85-0.93 2.42 1.91 2.84 5.42 0.93 7.85-1.91 2.42-5.42 2.84-7.85 0.93-2.42-1.91-2.84-5.43-0.93-7.85&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (2272 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_illustration_stats_226dp.xml"
-            line="91"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_stats_226dp.xml"
+            line="61"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1051 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M157.1 96.3c0.4-1.1 0.3-2.3-0.4-3.3-0.7-1.1-1.6-2-2.7-2.7-2.2-1.5-4.7-2.6-7.3-3.3-0.6-0.2-1.3-0.3-2-0.5l-1-0.2c-0.3-0.1-0.6-0.1-0.9-0.1-1.2 0-2.3 0.4-3.3 1-2.3 1.5-4.3 3.3-6.1 5.4-1 1-1.9 2-3 3.1-0.5 0.5-1.1 1-1.7 1.5-0.7 0.5-1.4 1-2.2 1.2-0.5 0.2-1.1 0.2-1.6 0.1-0.6-0.1-1.1-0.4-1.5-0.8-0.7-0.7-1.1-1.5-1.3-2.5-0.2-1.6 0-3.2 0.6-4.8 1.1-2.8 2.7-5.3 4.7-7.5 1.9-2.2 4.1-4.1 6.5-5.8 4.8-3.4 10.4-5.4 16.3-5.9 5.9-0.3 11.7 1 16.8 3.9 5 2.8 9.7 6.1 14 9.8 4.4 3.6 8.6 7.4 12.7 11.3 0.3 0.3 0.3 0.8 0 1.1s-0.8 0.3-1.1 0c-4.1-3.8-8.3-7.5-12.7-11-2.2-1.8-4.4-3.4-6.7-5-2.3-1.7-4.6-3.2-7.1-4.5-4.8-2.7-10.3-3.9-15.7-3.5-5.5 0.5-10.7 2.4-15.2 5.6-2.2 1.6-4.3 3.4-6.1 5.4-1.8 2-3.2 4.3-4.2 6.8-0.5 1.1-0.6 2.3-0.5 3.5 0.1 0.5 0.3 0.9 0.6 1.2 0.3 0.2 0.4 0.2 0.8 0.1 1.1-0.5 2.1-1.3 2.9-2.2 1-1 1.9-2 2.9-3 1.9-2.2 4.2-4.1 6.6-5.7 1.4-0.9 3-1.4 4.6-1.4 0.4 0 0.8 0 1.2 0.1l1.1 0.2c0.7 0.2 1.4 0.3 2.1 0.6 2.8 0.8 5.5 2.1 7.9 3.9 1.3 0.9 2.3 2.1 3.1 3.4 0.4 0.7 0.6 1.5 0.7 2.4 0 0.8-0.1 1.7-0.5 2.4-0.1 0.3-0.3 0.4-0.6 0.5s-0.5-0.1-0.7-0.3c-0.1 0-0.1-0.3 0-0.5z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1094 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_promo_editor.xml"
-            line="28"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_stats_226dp.xml"
+            line="71"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (857 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M92.034,111.91c-0.233,-2.972 0.447,-5.875 1.378,-8.583 0.919,-2.73 2.146,-5.31 3.298,-7.863 0.57,-1.274 1.133,-2.556 1.533,-3.81 0.198,-0.615 0.35,-1.257 0.329,-1.737 -0.034,-0.485 -0.152,-0.571 -0.432,-0.66 -0.301,-0.073 -0.93,0.1 -1.47,0.36 -0.56,0.269 -1.117,0.616 -1.65,1.009 -1.07,0.787 -2.064,1.724 -2.988,2.724a33.808,33.808 0,0 0,-7.728 14.369c-1.372,5.325 -1.293,11.018 0.34,16.304a0.64,0.64 0,0 1,-1.22 0.386,31.193 31.193,0 0,1 -0.703,-17.078c1.362,-5.616 4.084,-10.888 7.965,-15.215 0.984,-1.072 2.044,-2.085 3.242,-2.975 0.6,-0.444 1.239,-0.853 1.95,-1.197 0.725,-0.311 1.489,-0.675 2.6,-0.516a2.384,2.384 0,0 1,1.46 0.88c0.369,0.487 0.494,1.05 0.516,1.507 0.038,0.935 -0.173,1.682 -0.383,2.409 -0.457,1.434 -1.064,2.726 -1.653,4.019 -1.192,2.57 -2.408,5.082 -3.401,7.662 -0.955,2.577 -1.757,5.244 -1.706,7.933v0.01a0.64,0.64 0,0 1,-1.277 0.062&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (2093 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_promo_quick_start.xml"
-            line="20"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_stats_226dp.xml"
+            line="76"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1929 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M105.194,97.932c4.367,-0.527 8.734,-0.715 13.1,-0.808l6.55,-0.105 6.55,-0.019 13.101,0.155c4.367,0.103 8.734,0.218 13.1,0.577 0.244,0.019 0.425,0.216 0.403,0.436 -0.02,0.197 -0.193,0.347 -0.403,0.364 -4.366,0.358 -8.733,0.473 -13.1,0.577l-13.1,0.154 -6.551,-0.019 -6.55,-0.105c-4.366,-0.094 -8.733,-0.28 -13.1,-0.808 -0.123,-0.014 -0.209,-0.116 -0.192,-0.226 0.013,-0.092 0.094,-0.161 0.192,-0.173M105.174,77.932c3.85,-0.528 7.7,-0.715 11.55,-0.808l5.777,-0.105 5.775,-0.019 11.55,0.155c3.852,0.103 7.702,0.218 11.553,0.577a0.4,0.4 0,0 1,0 0.8c-3.851,0.358 -7.701,0.473 -11.552,0.577l-11.551,0.154 -5.775,-0.019 -5.776,-0.105c-3.85,-0.094 -7.7,-0.28 -11.551,-0.808a0.201,0.201 0,0 1,0 -0.399M105.125,83.938c1.068,-0.527 2.136,-0.713 3.204,-0.808a31.17,31.17 0,0 1,3.203 -0.126c1.068,0.023 2.135,0.079 3.203,0.153 1.068,0.087 2.136,0.227 3.204,0.582a0.421,0.421 0,0 1,0 0.8c-1.068,0.353 -2.136,0.494 -3.204,0.581 -1.068,0.074 -2.135,0.13 -3.203,0.152a30.889,30.889 0,0 1,-3.203 -0.125c-1.068,-0.095 -2.136,-0.281 -3.204,-0.809a0.222,0.222 0,0 1,0 -0.4M105.193,117.932c4.285,-0.528 8.568,-0.715 12.85,-0.808l6.426,-0.105 6.425,-0.019 12.85,0.155c4.284,0.103 8.567,0.218 12.851,0.577 0.245,0.02 0.426,0.216 0.403,0.437 -0.02,0.196 -0.194,0.345 -0.403,0.363 -4.284,0.358 -8.567,0.473 -12.851,0.577l-12.85,0.154 -6.425,-0.019 -6.425,-0.105c-4.283,-0.094 -8.566,-0.28 -12.85,-0.808 -0.123,-0.014 -0.209,-0.117 -0.192,-0.227 0.013,-0.092 0.095,-0.16 0.191,-0.172M105.398,123.938c3.403,-0.527 6.806,-0.713 10.209,-0.808 3.4,-0.09 6.803,-0.146 10.206,-0.126 3.403,0.023 6.803,0.079 10.206,0.153 3.403,0.087 6.807,0.227 10.21,0.582 0.704,0.073 1.086,0.311 0.854,0.532 -0.14,0.131 -0.469,0.227 -0.854,0.268 -3.403,0.353 -6.807,0.494 -10.21,0.581 -3.403,0.074 -6.803,0.13 -10.206,0.152 -3.403,0.02 -6.806,-0.034 -10.206,-0.125 -3.403,-0.095 -6.806,-0.281 -10.21,-0.809 -0.353,-0.054 -0.496,-0.188 -0.324,-0.298a0.918,0.918 0,0 1,0.325 -0.102&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (2254 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_promo_quick_start.xml"
-            line="50"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_stats_226dp.xml"
+            line="86"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1396 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M93.31,111.838c0.128,1.723 0.326,3.438 0.666,5.106 0.35,1.648 0.83,3.32 1.703,4.589 0.43,0.633 0.973,1.103 1.579,1.279 0.303,0.09 0.628,0.112 0.969,0.073 0.17,-0.018 0.133,-0.024 0.198,-0.06a0.728,0.728 0,0 0,0.174 -0.225c0.266,-0.505 0.375,-1.376 0.42,-2.186 0.048,-0.831 0.043,-1.69 0.029,-2.555 -0.032,-1.732 -0.093,-3.492 -0.02,-5.29 0.04,-0.9 0.11,-1.811 0.29,-2.742 0.19,-0.922 0.447,-1.906 1.167,-2.817 0.367,-0.45 0.857,-0.84 1.483,-1.05 0.742,-0.247 1.489,-0.047 1.986,0.224 1.026,0.56 1.639,1.327 2.209,2.086 1.097,1.544 1.845,3.212 2.46,4.913 1.19,3.414 1.78,6.987 1.89,10.567 0.105,3.58 -0.285,7.185 -1.258,10.639a33.844,33.844 0,0 1,-4.447 9.738c-2,2.968 -4.456,5.606 -7.207,7.85a0.64,0.64 0,0 1,-0.825 -0.978c5.205,-4.491 9.074,-10.464 10.77,-17.07 1.707,-6.575 1.5,-13.713 -0.731,-20.104 -0.563,-1.583 -1.264,-3.135 -2.191,-4.447 -0.457,-0.64 -1.011,-1.246 -1.533,-1.52 -0.264,-0.143 -0.44,-0.147 -0.54,-0.112 -0.204,0.065 -0.44,0.225 -0.621,0.452 -0.385,0.46 -0.64,1.21 -0.792,1.988 -0.156,0.785 -0.23,1.62 -0.272,2.466 -0.082,1.695 -0.02,3.43 -0.027,5.193a37.55,37.55 0,0 1,-0.077 2.686c-0.094,0.917 -0.136,1.842 -0.681,2.9a2.352,2.352 0,0 1,-0.667 0.764c-0.288,0.226 -0.76,0.353 -1.023,0.359a4.065,4.065 0,0 1,-1.623 -0.163c-1.082,-0.341 -1.888,-1.143 -2.417,-1.955 -1.066,-1.664 -1.464,-3.464 -1.796,-5.222 -0.302,-1.77 -0.447,-3.54 -0.521,-5.304a0.639,0.639 0,0 1,1.277 -0.072&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (2144 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_promo_quick_start.xml"
-            line="80"
-            column="27"/>
+            file="src/main/res/drawable/img_illustration_stats_226dp.xml"
+            line="91"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (2499 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M169.98,155.734c-4.134,-8.105 -5.986,-17.31 -5.617,-26.392a53.787,53.787 0,0 1,2.236 -13.441c0.669,-2.183 1.482,-4.33 2.532,-6.387 0.53,-1.027 1.109,-2.035 1.8,-2.993 0.692,-0.956 1.468,-1.884 2.534,-2.637 0.536,-0.365 1.17,-0.705 1.97,-0.785 0.409,-0.04 0.804,0.003 1.168,0.112a3.15,3.15 0,0 1,1.056 0.529c0.626,0.492 0.999,1.137 1.245,1.743a8.66,8.66 0,0 1,0.484 1.817c0.358,2.383 0.223,4.653 0.132,6.906 -0.102,2.244 -0.267,4.477 -0.184,6.63 0.047,1.057 0.163,2.149 0.509,2.937 0.175,0.396 0.388,0.62 0.604,0.7 0.402,0.14 0.919,0.289 1.36,0.32 0.916,0.095 1.747,-0.125 2.424,-0.704 0.689,-0.557 1.22,-1.426 1.623,-2.363 0.8,-1.902 1.166,-4.075 1.369,-6.24 0.197,-2.173 0.22,-4.381 0.13,-6.582 -0.072,-2.115 -0.57,-4.262 -1.095,-6.411 -1.066,-4.308 -2.494,-8.566 -3.383,-13.062 -0.214,-1.13 -0.394,-2.275 -0.46,-3.47 -0.033,-1.19 -0.072,-2.464 0.624,-3.828a3.167,3.167 0,0 1,1.859 -1.543c0.518,-0.15 1.044,-0.073 1.435,0.068 0.397,0.144 0.715,0.339 0.993,0.543 1.085,0.83 1.775,1.788 2.452,2.749 2.567,3.89 4.304,8.076 5.924,12.3a109.227,109.227 0,0 1,3.956 12.964c1.019,4.406 1.834,8.89 1.845,13.505 -0.006,1.154 -0.071,2.316 -0.255,3.484 -0.09,0.576 -0.22,1.186 -0.382,1.734l-0.472,1.636c-0.65,2.174 -1.392,4.307 -2.178,6.419 -3.202,8.429 -6.982,16.574 -10.99,24.62a0.692,0.692 0,0 1,-1.241 -0.607l0.005,-0.011c3.877,-8.045 7.513,-16.244 10.595,-24.605 0.767,-2.09 1.487,-4.196 2.11,-6.32 0.293,-1.076 0.649,-2.113 0.786,-3.141 0.16,-1.047 0.218,-2.128 0.22,-3.214 -0.03,-4.36 -0.838,-8.76 -1.86,-13.065a107.6,107.6 0,0 0,-3.947 -12.717c-1.595,-4.122 -3.363,-8.263 -5.762,-11.85 -0.602,-0.868 -1.283,-1.73 -1.992,-2.255 -0.351,-0.271 -0.677,-0.331 -0.688,-0.293 -0.222,0.08 -0.482,0.263 -0.636,0.577 -0.352,0.647 -0.42,1.717 -0.36,2.74 0.063,1.043 0.233,2.115 0.443,3.186 0.879,4.296 2.249,8.575 3.333,12.967 0.525,2.197 1.048,4.448 1.126,6.82 0.084,2.277 0.055,4.56 -0.162,6.848 -0.23,2.284 -0.601,4.592 -1.545,6.83 -0.486,1.103 -1.133,2.229 -2.19,3.092 -1.026,0.896 -2.544,1.289 -3.845,1.12 -0.677,-0.064 -1.247,-0.223 -1.897,-0.46 -0.844,-0.336 -1.362,-1.076 -1.627,-1.697 -0.536,-1.284 -0.598,-2.475 -0.662,-3.643 -0.078,-2.328 0.104,-4.573 0.212,-6.802 0.105,-2.215 0.224,-4.454 -0.083,-6.513 -0.153,-1.005 -0.491,-2 -1.027,-2.406 -0.547,-0.407 -1.248,-0.371 -2.038,0.197 -0.773,0.535 -1.48,1.335 -2.096,2.19 -0.624,0.857 -1.17,1.794 -1.67,2.756 -0.996,1.93 -1.786,3.987 -2.437,6.085 -1.298,4.202 -2.003,8.594 -2.238,12.998 -0.46,8.81 1.234,17.766 5.162,25.695a0.693,0.693 0,0 1,-1.237 0.62&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1051 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_promo_quick_start.xml"
-            line="110"
-            column="27"/>
+            file="src/main/res/drawable/img_promo_editor.xml"
+            line="28"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (3064 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M209.9 68c-0.7 0-1.3-0.6-1.3-1.3v-8.9c0-0.7 0.6-1.3 1.3-1.3 0.7 0 1.3 0.6 1.3 1.3v8.9c-0.1 0.7-0.6 1.3-1.3 1.3zm0-17.9c-0.7 0-1.3-0.6-1.3-1.3v-8.9c0-0.7 0.6-1.3 1.3-1.3 0.7 0 1.3 0.6 1.3 1.3v8.9c-0.1 0.8-0.6 1.3-1.3 1.3zm0-17.8c-0.7 0-1.3-0.6-1.3-1.3v-0.9c0-3.5 2.9-6.4 6.4-6.4 0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3-2.1 0-3.8 1.7-3.8 3.8V31c-0.1 0.7-0.6 1.3-1.3 1.3zm58.6-6h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3h8.9c0.7 0 1.3 0.6 1.3 1.3-0.1 0.7-0.6 1.3-1.3 1.3zm-17.9 0h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3h8.9c0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3zm-17.8 0h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3h8.9c0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3zm84.3 40.4v-8.9c0-0.7 0.6-1.3 1.3-1.3 0.7 0 1.3 0.6 1.3 1.3v8.9c0 0.7-0.6 1.3-1.3 1.3-0.7 0-1.3-0.6-1.3-1.3zm0 17.9v-8.9c0-0.7 0.6-1.3 1.3-1.3 0.7 0 1.3 0.6 1.3 1.3v8.9c0 0.7-0.6 1.3-1.3 1.3-0.7 0-1.3-0.6-1.3-1.3zm0-35.7V40c0-0.7 0.6-1.3 1.3-1.3 0.7 0 1.3 0.6 1.3 1.3v8.9c0 0.7-0.6 1.3-1.3 1.3-0.7-0.1-1.3-0.6-1.3-1.3zm0-17.9v-0.9c0-2.1-1.7-3.8-3.8-3.8-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3 3.5 0 6.4 2.9 6.4 6.4V31c0 0.7-0.6 1.3-1.3 1.3-0.7 0-1.3-0.6-1.3-1.3zm-58.6-6c0-0.7 0.6-1.3 1.3-1.3h8.9c0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3zm17.8 0c0-0.7 0.6-1.3 1.3-1.3h8.9c0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3zm17.8 0c0-0.7 0.6-1.3 1.3-1.3h8.9c0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3zm-83 66.5v8.9c0 0.7-0.6 1.3-1.3 1.3-0.7 0-1.3-0.6-1.3-1.3v-8.9c0-0.7 0.6-1.3 1.3-1.3 0.7 0 1.3 0.6 1.3 1.3zm0 17.9v8.9c0 0.7-0.6 1.3-1.3 1.3-0.7 0-1.3-0.6-1.3-1.3v-8.9c0-0.7 0.6-1.3 1.3-1.3 0.7 0 1.3 0.6 1.3 1.3zm0 17.8v0.9c0 2.1 1.7 3.8 3.8 3.8 0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3-3.5 0-6.4-2.9-6.4-6.4v-0.9c0-0.7 0.6-1.3 1.3-1.3 0.7 0 1.3 0.6 1.3 1.3zm58.6 6c0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3h8.9c0.8 0 1.3 0.6 1.3 1.3zm-17.8 0c0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3h8.9c0.7 0 1.3 0.6 1.3 1.3zm-17.8 0c0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3h8.9c0.7 0 1.3 0.6 1.3 1.3zm84.3-41c0.7 0 1.3 0.6 1.3 1.3v8.9c0 0.7-0.6 1.3-1.3 1.3-0.7 0-1.3-0.6-1.3-1.3v-8.9c0-0.7 0.6-1.3 1.3-1.3zm0 15.9c0.7 0 1.3 0.6 1.3 1.3v8.9c0 0.7-0.6 1.3-1.3 1.3-0.7 0-1.3-0.6-1.3-1.3v-8.9c0-0.7 0.6-1.3 1.3-1.3zm0 17.8c0.7 0 1.3 0.6 1.3 1.3v0.9c0 3.5-2.9 6.4-6.4 6.4-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3 2.1 0 3.8-1.7 3.8-3.8v-0.9c0-0.7 0.6-1.3 1.3-1.3zm-58.6 6h8.9c0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3zm17.8 0h8.9c0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3zm17.8 0h8.9c0.7 0 1.3 0.6 1.3 1.3 0 0.7-0.6 1.3-1.3 1.3h-8.9c-0.7 0-1.3-0.6-1.3-1.3 0-0.7 0.6-1.3 1.3-1.3zm-26.5-55.5h-5.6v-5.6c0-0.8-0.6-1.4-1.4-1.4-0.8 0-1.4 0.6-1.4 1.4v5.6h-5.6c-0.8 0-1.4 0.6-1.4 1.4 0 0.8 0.6 1.4 1.4 1.4h5.6v4.9c0 0.8 0.6 1.4 1.4 1.4 0.8 0 1.4-0.6 1.4-1.4v-4.9h5.6c0.8 0 1.4-0.6 1.4-1.4 0-0.8-0.7-1.4-1.4-1.4z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (857 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_promo_stats_widget.xml"
-            line="13"
-            column="27"/>
+            file="src/main/res/drawable/img_promo_quick_start.xml"
+            line="20"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (3302 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M94.567 57.807c-6.79 1.23-13.268 3.98-18.914 7.896-2.82 1.96-5.466 4.176-7.835 6.654-2.363 2.473-4.502 5.192-6.104 8.164-0.772 1.47-1.485 3.076-1.595 4.564-0.022 0.36 0.018 0.7 0.11 0.918 0.11 0.208 0.172 0.27 0.409 0.327 0.48 0.12 1.214-0.157 1.88-0.565 1.362-0.836 2.63-2.038 3.877-3.214l3.736-3.642c2.513-2.432 5.13-4.814 8.05-6.857 2.907-2.035 6.158-3.746 9.731-4.538 0.887-0.2 1.802-0.335 2.701-0.415 0.89-0.08 1.787-0.129 2.694-0.131 0.908 0.005 1.827 0.044 2.768 0.216 0.925 0.2 1.938 0.405 2.851 1.309 0.45 0.454 0.725 1.221 0.643 1.873-0.07 0.652-0.333 1.169-0.62 1.602-0.59 0.867-1.323 1.484-2.077 2.04-0.76 0.545-1.56 1.002-2.381 1.4l-2.387 1.09c-1.544 0.738-3.054 1.546-4.438 2.496-1.366 0.944-2.673 2.047-3.405 3.363-0.355 0.654-0.53 1.343-0.43 1.997 0.048 0.329 0.156 0.65 0.32 0.96 0.027 0.046 0.007 0.034 0.117 0.1 0.096 0.05 0.244 0.096 0.406 0.131 0.684 0.132 1.536 0.093 2.355 0.006 0.83-0.09 1.668-0.237 2.502-0.412 3.344-0.72 6.635-1.834 9.84-3.114 3.203-1.293 6.33-2.787 9.314-4.51 2.974-1.744 5.905-3.591 8.148-6.113 2.247-2.503 4.023-5.544 5.02-8.714l0.013-0.042c0.098-0.313 0.434-0.488 0.75-0.39 0.309 0.096 0.485 0.421 0.397 0.73-0.502 1.767-1.229 3.367-2.093 4.934-0.866 1.555-1.89 3.03-3.07 4.375-1.172 1.35-2.54 2.552-3.97 3.61-1.43 1.043-2.909 2.013-4.433 2.902-3.047 1.78-6.224 3.318-9.484 4.654-3.266 1.324-6.606 2.479-10.089 3.25-0.872 0.188-1.755 0.35-2.662 0.452-0.91 0.093-1.825 0.17-2.864-0.016-0.264-0.057-0.539-0.13-0.834-0.277-0.28-0.128-0.648-0.435-0.816-0.781-0.245-0.456-0.427-0.966-0.504-1.497-0.17-1.073 0.128-2.15 0.598-3.016 0.975-1.744 2.44-2.924 3.909-3.964 1.488-1.031 3.06-1.88 4.658-2.654l2.369-1.096c0.746-0.366 1.462-0.782 2.116-1.258 0.646-0.473 1.251-1.017 1.635-1.598 0.193-0.286 0.31-0.581 0.329-0.797 0.01-0.215-0.031-0.337-0.186-0.512-0.329-0.356-1.103-0.628-1.867-0.756-0.78-0.137-1.612-0.188-2.448-0.192-1.686 0.01-3.4 0.126-5.01 0.48-3.27 0.708-6.333 2.285-9.13 4.224-2.807 1.945-5.374 4.253-7.872 6.65l-3.761 3.633c-1.29 1.196-2.561 2.422-4.179 3.414-0.41 0.243-0.849 0.468-1.353 0.629-0.499 0.156-1.091 0.257-1.708 0.116-0.63-0.093-1.313-0.658-1.533-1.254-0.243-0.59-0.26-1.137-0.235-1.64 0.067-1.006 0.344-1.895 0.66-2.754 0.323-0.856 0.714-1.669 1.138-2.458 1.715-3.146 3.94-5.933 6.389-8.48 2.46-2.54 5.179-4.829 8.114-6.8 5.858-3.956 12.554-6.698 19.533-7.872 0.326-0.055 0.636 0.162 0.69 0.487 0.056 0.321-0.162 0.627-0.483 0.686m-1.997-5.609c-2.599 0.586-5.14 1.379-7.598 2.372-2.449 1.013-4.841 2.167-7.09 3.563-2.25 1.388-4.41 2.925-6.356 4.697-1.964 1.747-3.736 3.709-5.146 5.9l-0.009 0.014c-0.179 0.277-0.549 0.358-0.828 0.18-0.26-0.165-0.348-0.5-0.211-0.77 1.263-2.487 3.062-4.641 5.043-6.555 2.012-1.887 4.218-3.563 6.58-4.976 2.365-1.403 4.838-2.637 7.43-3.566 2.58-0.948 5.254-1.65 7.976-2.033 0.327-0.046 0.63 0.18 0.677 0.505 0.043 0.309-0.159 0.596-0.459 0.664l-0.008 0.002zm-26.758 9.171c1.169-2.21 2.848-4.025 4.626-5.655 1.78-1.642 3.736-3.059 5.725-4.405 2-1.335 4.098-2.51 6.229-3.612 2.149-1.067 4.343-2.043 6.607-2.835 0.313-0.11 0.656 0.054 0.765 0.364 0.102 0.288-0.036 0.604-0.306 0.736-2.122 1.026-4.224 2.077-6.275 3.22-2.068 1.112-4.071 2.331-6.038 3.6-1.967 1.266-3.839 2.669-5.628 4.146-1.765 1.498-3.424 3.137-4.658 5.016l-0.018 0.027c-0.18 0.275-0.55 0.353-0.827 0.173-0.26-0.169-0.344-0.507-0.203-0.775&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1929 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_publish_button_124dp.xml"
-            line="51"
-            column="27"/>
+            file="src/main/res/drawable/img_promo_quick_start.xml"
+            line="50"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (806 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M200.9 40c-0.4 0.4-0.9 0.6-1.4 0.6-0.6 0.1-1.1 0-1.6-0.3s-0.8-0.5-1.2-0.7c-0.4-0.2-0.8-0.2-1.2-0.4-0.1 0-0.2-0.1-0.1-0.2v-0.1c0-0.1 0-0.1 0.1-0.1 0.5-0.2 1.1-0.3 1.6-0.2 0.5 0.1 1 0.3 1.4 0.6 0.3 0.2 0.7 0.3 1.1 0.3 0.5 0 1 0 1.4 0.2-0.1 0.2 0 0.2-0.1 0.3zm10.5 28.1C211 77 210.5 86 210 94.9l-0.4 6.7-0.2 3.4c-0.1 1.2-0.6 2.3-1.3 3.3-1.5 1.9-3.9 2.9-6.3 2.7h-13.4c-2.4 0.2-4.8-0.8-6.4-2.7-0.8-1-1.3-2.1-1.4-3.4-0.1-1.2-0.1-2.3-0.1-3.4l-0.2-6.7-0.9-26.8c0-0.2 0.2-0.4 0.4-0.5l12.8 0.1c4.3 0 8.5 0.1 12.8 0.1 0.1 0 0.2 0.1 0.2 0.2s-0.1 0.2-0.2 0.2c-4.3 0.1-8.5 0.1-12.8 0.1l-12.8 0.1 0.4-0.5 1.1 26.8 0.3 6.7c0.1 1.1 0.1 2.3 0.2 3.3s0.5 2 1.2 2.8c0.6 0.8 1.5 1.4 2.4 1.8 1 0.4 2 0.5 3.1 0.5h13.4c2.1 0.1 4.1-0.7 5.5-2.3 0.6-0.8 1-1.8 1.1-2.8l0.2-3.3 0.5-6.7c0.6-8.9 1.3-17.8 2.1-26.8 0-0.1 0-0.1 0.1-0.1v0.4z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1396 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_site_error_camera_pencils_226dp.xml"
-            line="25"
-            column="27"/>
+            file="src/main/res/drawable/img_promo_quick_start.xml"
+            line="80"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1377 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M48.8 64.6c-0.1-0.2-0.2-0.5-0.3-0.7 0-0.1 0-0.1-0.1-0.2l-0.1-0.1c-0.1-0.1-0.1-0.1-0.2-0.1h-0.7c-0.2 0-0.3 0.1-0.4 0.3s0 0.5 0.5 0.6c0.1 0 0.2 0.1 0.1 0.2v0.1c0 0.1 0 0.1-0.1 0.1-0.3 0.1-0.6 0.1-0.9-0.1-0.3-0.2-0.5-0.5-0.6-0.9 0-0.4 0.1-0.7 0.3-1 0.3-0.3 0.6-0.4 1-0.4H48c0.4 0 0.8 0.2 1 0.5 0.1 0.2 0.2 0.3 0.2 0.5v0.5c-0.1 0.2-0.2 0.5-0.4 0.7 0 0.2 0.1 0.1 0 0zm7.3 0c-0.1-0.2-0.2-0.5-0.3-0.7 0-0.1 0-0.1-0.1-0.2l-0.1-0.1c-0.1-0.1-0.1-0.1-0.2-0.1h-0.7c-0.2 0-0.3 0.1-0.4 0.3-0.1 0.2 0 0.5 0.5 0.6 0.1 0 0.2 0.1 0.1 0.2v0.1c0 0.1 0 0.1-0.1 0.1-0.3 0.1-0.6 0.1-0.9-0.1-0.3-0.2-0.5-0.5-0.6-0.9 0-0.4 0.1-0.7 0.3-1 0.3-0.3 0.6-0.4 1-0.4h0.7c0.4 0 0.8 0.2 1 0.5 0.1 0.2 0.2 0.3 0.2 0.5v0.5c-0.1 0.2-0.2 0.5-0.4 0.7 0.2 0.1 0.1 0.1 0 0zM70.5 106l-11.3 0.2-11.3 0.1-22.5 0.2h-2.8c-1 0-2-0.2-2.9-0.6-1.8-0.9-3.1-2.7-3.5-4.7-0.1-1-0.1-1.9-0.1-2.9V77.2c0-0.5 0-1 0.1-1.5 0.1-1 0.5-2 1.1-2.8 1.2-1.7 3.1-2.7 5.2-2.7h47.9c1 0 2 0.2 2.9 0.6 1.8 0.9 3.1 2.7 3.5 4.7 0.1 1 0.1 1.9 0.1 2.9v8.4L76.6 98c0 0.9 0 1.9-0.1 2.8-0.1 1-0.5 1.9-1.1 2.7-1.1 1.6-3 2.6-4.9 2.5zm0-0.3c1.8 0 3.6-0.9 4.6-2.4 0.5-0.7 0.8-1.6 0.9-2.5 0.1-0.9 0.1-1.9 0-2.8l-0.1-11.3v-8.4c0-0.9 0-1.8-0.1-2.7-0.3-1.7-1.4-3.2-3-4-0.8-0.4-1.6-0.5-2.5-0.5H22.4c-1.7 0-3.4 0.9-4.4 2.3-0.5 0.7-0.8 1.5-0.9 2.4-0.1 0.4-0.1 0.9-0.1 1.3v21.1c0 0.9 0 1.8 0.1 2.7 0.3 1.7 1.4 3.2 3 4 0.8 0.4 1.6 0.6 2.5 0.5h2.8l22.5 0.2 11.3 0.1h11.3z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (2499 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_site_error_camera_pencils_226dp.xml"
-            line="43"
-            column="27"/>
+            file="src/main/res/drawable/img_promo_quick_start.xml"
+            line="110"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1613 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M63.6 91.9c-1.4 4.8-6.4 7.6-11.2 6.2-2.1-0.6-3.9-1.9-5.1-3.8-2.8-4.1-1.9-9.6 2-12.6 1.8-1.5 4.2-2.1 6.5-1.9 2.3 0.2 4.5 1.3 6.1 3 1.5 1.7 2.4 4 2.3 6.3 0 0.1-0.1 0.2-0.2 0.2s-0.2-0.1-0.2-0.2c-0.1-2.1-1-4.1-2.4-5.7-1.5-1.5-3.5-2.5-5.6-2.6-2.1-0.2-4.2 0.5-5.8 1.8-1.6 1.3-2.7 3.2-3 5.2s0.1 4.1 1.2 5.9c1.2 1.8 2.9 3 5 3.5s4.2 0.3 6.1-0.7c1.9-1 3.4-2.7 4.3-4.6-0.1-0.2-0.1-0.2 0-0.2v0.2zM32.5 106l-13 0.3c-0.6 0-1.2-0.1-1.8-0.3-0.5-0.3-1-0.8-1.3-1.3-0.2-0.6-0.3-1.2-0.3-1.8v-1.6L16 94.8V78.5c-0.1-1.1 0-2.2 0.1-3.3 0.3-2.3 1.5-4.4 3.3-5.9 1.8-1.5 4-2.3 6.3-2.4 1.1-0.1 2.3 0.1 3.4 0.4 1.1 0.3 2.2 0.9 3.1 1.6 1.8 1.5 3 3.6 3.3 5.9 0.1 1.2 0.1 2.2 0.1 3.3v3.3l-0.1 13-0.1 6.5v1.6c0 0.6 0 1.1-0.1 1.7-0.5 1.2-1.6 1.9-2.8 1.8zm0-0.3c1 0 1.9-0.7 2.2-1.7 0.1-0.5 0-1 0.1-1.6v-1.6l-0.1-6.5-0.1-13V78c0-1.1 0-2.2-0.1-3.2-0.2-2-1.3-3.9-2.9-5.2-0.8-0.6-1.7-1.1-2.7-1.4-1-0.3-2.1-0.4-3.1-0.3-4.2 0-7.8 3.1-8.5 7.3-0.1 1.1-0.2 2.1-0.1 3.2v16.3l-0.1 6.5v1.6c0 0.5 0 1 0.2 1.4 0.2 0.4 0.5 0.8 0.9 1 0.4 0.2 0.9 0.3 1.4 0.3 4.2 0.1 8.6 0.2 12.9 0.2zm36.7-5.5c0.5-0.2 1 0 1.3 0.4v0.1c0.3 0.5 0.2 1.2-0.3 1.6-0.4 0.4-1.1 0.5-1.6 0.3s-0.8-0.8-0.6-1.3c0-0.1 0.1-0.2 0.2-0.1h0.1c0.1 0 0.1 0 0.1 0.1 0.4 0.5 0.8 0.5 1 0.3 0.2-0.2 0.2-0.3 0.1-0.4-0.1-0.1-0.1-0.4-0.4-0.7 0-0.2 0-0.2 0.1-0.3zM44.3 77.4c-1.3 0.3-2.7 0.4-4 0.4h-1.6c-0.3 0-0.6-0.2-0.8-0.5-0.1-0.2-0.2-0.5-0.2-0.8v-1.6c0-0.3 0.2-0.6 0.5-0.8 0.2-0.1 0.5-0.2 0.8-0.2h4.5c0.2 0 0.5 0.1 0.7 0.2 0.2 0.2 0.4 0.4 0.4 0.7v0.6c0 0.3-0.1 0.7-0.1 1 0 0.1-0.1 0.2-0.2 0.2s-0.2-0.1-0.2-0.2c0-0.3-0.1-0.7-0.1-1V75c0-0.1 0-0.1-0.1-0.1h-5v1.6h1.5c1.3 0 2.7 0.1 4 0.4-0.1 0.3 0 0.3-0.1 0.5z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (3064 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_site_error_camera_pencils_226dp.xml"
-            line="49"
-            column="27"/>
+            file="src/main/res/drawable/img_promo_stats_widget.xml"
+            line="13"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1361 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M18.4 70.1c0.9-0.1 1.7 0 2.5 0.4 0.7 0.4 1.3 1 1.8 1.7 0.4 0.6 1 1 1.6 1.4 0.7 0.3 1.4 0.4 2.1 0.4 0.7 0 1.4-0.1 2.1-0.4 0.7-0.3 1.3-0.8 1.8-1.3 0.6-0.6 1.3-1.1 2-1.6 0.8-0.4 1.6-0.6 2.5-0.5 0.1 0 0.2 0.1 0.2 0.2s-0.1 0.2-0.2 0.2c-0.7 0.1-1.5 0.3-2.1 0.7-0.6 0.5-1.2 1-1.7 1.6-0.6 0.6-1.3 1.2-2 1.6-1.6 0.8-3.5 0.8-5.1 0.1-0.8-0.4-1.4-1.1-1.9-1.8-0.4-0.6-0.9-1.2-1.5-1.7-0.7-0.5-1.4-0.8-2.1-1-0.1 0.2-0.1 0.2 0 0-0.1 0.1 0 0.1 0 0zm58 5.8c0.2 1.9-0.2 3.8-0.9 5.5-0.7 1.6-1.1 3.4-1.1 5.2-0.1 1.8 0.3 3.5 1 5.1 0.4 0.9 0.7 1.8 0.9 2.7 0.2 0.9 0.3 1.9 0.2 2.8 0 0.1-0.1 0.2-0.2 0.2s-0.2-0.1-0.2-0.2c-0.1-0.9-0.3-1.8-0.6-2.6-0.3-0.9-0.7-1.7-1.1-2.5-0.8-1.7-1.3-3.6-1.3-5.5 0-1 0.1-2 0.4-2.9 0.2-0.9 0.6-1.8 0.9-2.7 0.3-0.9 0.7-1.7 1-2.5 0.3-0.8 0.5-1.7 0.6-2.6 0.2-0.1 0.3-0.1 0.4 0zM16.6 82c0.1 2.2-0.2 4.4-0.9 6.5s-1.9 4-3.5 5.6c-1.6 1.5-3.3 2.8-5.2 4-1.8 1-3.4 2.6-4.4 4.4-0.8 1.9-0.9 4-0.1 5.9s2.3 3.4 4.2 4.2c1.9 0.9 4 1.4 6.1 1.7 2.1 0.3 4.3 0.4 6.4 0.4 8.6-0.2 17.2-1.1 25.7-2.9 8.5-1.6 16.9-3.7 25.3-6 0.1 0 0.2 0 0.2 0.1s0 0.2-0.1 0.2c-4.1 1.3-8.3 2.5-12.5 3.6-4.2 1.1-8.4 2.1-12.7 3-4.3 0.9-8.6 1.6-12.9 2.2s-8.7 0.9-13.1 0.9c-2.2 0-4.4-0.1-6.6-0.4-2.2-0.2-4.4-0.9-6.4-1.8-2.1-0.9-3.8-2.7-4.7-4.8-0.4-1.1-0.6-2.2-0.6-3.4 0-1.2 0.2-2.3 0.7-3.4 1-2.1 3-3.5 4.8-4.7 1.8-1.2 3.6-2.4 5.2-3.8 1.5-1.4 2.7-3.2 3.5-5.2 0.7-2 1.1-4.1 1.2-6.3 0.2-0.1 0.3-0.1 0.4 0z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (3302 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_site_error_camera_pencils_226dp.xml"
-            line="52"
-            column="27"/>
+            file="src/main/res/drawable/img_publish_button_124dp.xml"
+            line="51"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (822 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M112.3,32.8C97.2,32.8,85,45,85,60.1s12.2,27.3,27.3,27.3s27.3-12.2,27.3-27.3C139.5,45,127.3,32.8,112.3,32.8z M87.8,60c0-3.4,0.7-6.8,2.1-10l11.7,32C93.1,77.9,87.7,69.4,87.8,60z M112.3,84.6c-2.3,0-4.7-0.4-6.9-1l7.4-21.4l7.5,20.6 c0,0.1,0.1,0.2,0.2,0.3C117.8,84.1,115.1,84.6,112.3,84.6z M115.7,48.5l2.8-0.2c0.6-0.1,1-0.5,0.9-1.1c-0.1-0.6-0.5-1-1.1-0.9 c0,0-4,0.3-6.5,0.3s-6.5-0.3-6.5-0.3c-0.6-0.1-1,0.3-1.1,0.9c-0.1,0.6,0.3,1,0.9,1.1c0.9,0.1,1.7,0.2,2.6,0.2l3.9,10.5l-5.4,16.1 l-8.9-26.6l2.8-0.2c0.6-0.1,1-0.5,0.9-1.1c-0.1-0.6-0.5-1-1.1-0.9c0,0-4,0.3-6.5,0.3h-1.6c7.4-11.4,22.7-14.5,34-7.1 c1.1,0.7,2.1,1.5,3.1,2.4h-0.3c-2.3,0.1-4.2,2-4.1,4.4c0,2,1.2,3.7,2.4,5.7c1.3,2,2,4.4,2,6.8c-0.1,2.7-0.8,5.4-1.9,7.9l-2.4,8.2 L115.7,48.5z M124.6,81.2l7.5-21.7c1.2-2.8,1.8-5.8,1.9-8.8c0-0.8-0.1-1.7-0.2-2.5C140.1,59.9,136,74.5,124.6,81.2z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (806 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_site_wordpress_camera_pencils_226dp.xml"
-            line="10"
-            column="27"/>
+            file="src/main/res/drawable/img_site_error_camera_pencils_226dp.xml"
+            line="25"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (835 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M200.9,40c-0.4,0.4-0.9,0.6-1.4,0.6c-0.6,0.1-1.1,0-1.6-0.3s-0.8-0.5-1.2-0.7c-0.4-0.2-0.8-0.2-1.2-0.4 c-0.1,0-0.2-0.1-0.1-0.2v-0.1c0-0.1,0-0.1,0.1-0.1c0.5-0.2,1.1-0.3,1.6-0.2c0.5,0.1,1,0.3,1.4,0.6c0.3,0.2,0.7,0.3,1.1,0.3 c0.5,0,1,0,1.4,0.2C200.9,39.9,201,39.9,200.9,40z M211.4,68.1C211,77,210.5,86,210,94.9l-0.4,6.7l-0.2,3.4 c-0.1,1.2-0.6,2.3-1.3,3.3c-1.5,1.9-3.9,2.9-6.3,2.7h-13.4c-2.4,0.2-4.8-0.8-6.4-2.7c-0.8-1-1.3-2.1-1.4-3.4 c-0.1-1.2-0.1-2.3-0.1-3.4l-0.2-6.7L179.4,68c0-0.2,0.2-0.4,0.4-0.5l12.8,0.1c4.3,0,8.5,0.1,12.8,0.1c0.1,0,0.2,0.1,0.2,0.2 s-0.1,0.2-0.2,0.2c-4.3,0.1-8.5,0.1-12.8,0.1l-12.8,0.1l0.4-0.5l1.1,26.8l0.3,6.7c0.1,1.1,0.1,2.3,0.2,3.3c0.1,1,0.5,2,1.2,2.8 c0.6,0.8,1.5,1.4,2.4,1.8c1,0.4,2,0.5,3.1,0.5h13.4c2.1,0.1,4.1-0.7,5.5-2.3c0.6-0.8,1-1.8,1.1-2.8l0.2-3.3l0.5-6.7 c0.6-8.9,1.3-17.8,2.1-26.8c0-0.1,0-0.1,0.1-0.1V68.1z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1377 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_site_wordpress_camera_pencils_226dp.xml"
-            line="35"
-            column="27"/>
+            file="src/main/res/drawable/img_site_error_camera_pencils_226dp.xml"
+            line="43"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1453 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M48.8,64.6c-0.1-0.2-0.2-0.5-0.3-0.7c0-0.1,0-0.1-0.1-0.2l-0.1-0.1c-0.1-0.1-0.1-0.1-0.2-0.1h-0.7 c-0.2,0-0.3,0.1-0.4,0.3s0,0.5,0.5,0.6c0.1,0,0.2,0.1,0.1,0.2v0.1c0,0.1,0,0.1-0.1,0.1c-0.3,0.1-0.6,0.1-0.9-0.1 c-0.3-0.2-0.5-0.5-0.6-0.9c0-0.4,0.1-0.7,0.3-1c0.3-0.3,0.6-0.4,1-0.4H48c0.4,0,0.8,0.2,1,0.5c0.1,0.2,0.2,0.3,0.2,0.5v0.5 C49.1,64.1,49,64.4,48.8,64.6C48.8,64.8,48.9,64.7,48.8,64.6z M56.1,64.6c-0.1-0.2-0.2-0.5-0.3-0.7c0-0.1,0-0.1-0.1-0.2l-0.1-0.1 c-0.1-0.1-0.1-0.1-0.2-0.1h-0.7c-0.2,0-0.3,0.1-0.4,0.3c-0.1,0.2,0,0.5,0.5,0.6c0.1,0,0.2,0.1,0.1,0.2v0.1c0,0.1,0,0.1-0.1,0.1 c-0.3,0.1-0.6,0.1-0.9-0.1c-0.3-0.2-0.5-0.5-0.6-0.9c0-0.4,0.1-0.7,0.3-1c0.3-0.3,0.6-0.4,1-0.4h0.7c0.4,0,0.8,0.2,1,0.5 c0.1,0.2,0.2,0.3,0.2,0.5v0.5C56.4,64.1,56.3,64.4,56.1,64.6C56.3,64.7,56.2,64.7,56.1,64.6z M70.5,106l-11.3,0.2l-11.3,0.1 l-22.5,0.2h-2.8c-1,0-2-0.2-2.9-0.6c-1.8-0.9-3.1-2.7-3.5-4.7c-0.1-1-0.1-1.9-0.1-2.9V77.2c0-0.5,0-1,0.1-1.5c0.1-1,0.5-2,1.1-2.8 c1.2-1.7,3.1-2.7,5.2-2.7h47.9c1,0,2,0.2,2.9,0.6c1.8,0.9,3.1,2.7,3.5,4.7c0.1,1,0.1,1.9,0.1,2.9v8.4L76.6,98c0,0.9,0,1.9-0.1,2.8 c-0.1,1-0.5,1.9-1.1,2.7C74.3,105.1,72.4,106.1,70.5,106z M70.5,105.7c1.8,0,3.6-0.9,4.6-2.4c0.5-0.7,0.8-1.6,0.9-2.5 c0.1-0.9,0.1-1.9,0-2.8l-0.1-11.3v-8.4c0-0.9,0-1.8-0.1-2.7c-0.3-1.7-1.4-3.2-3-4c-0.8-0.4-1.6-0.5-2.5-0.5H22.4 c-1.7,0-3.4,0.9-4.4,2.3c-0.5,0.7-0.8,1.5-0.9,2.4C17,76.2,17,76.7,17,77.1v21.1c0,0.9,0,1.8,0.1,2.7c0.3,1.7,1.4,3.2,3,4 c0.8,0.4,1.6,0.6,2.5,0.5h2.8l22.5,0.2l11.3,0.1H70.5z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1613 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_site_wordpress_camera_pencils_226dp.xml"
-            line="65"
-            column="27"/>
+            file="src/main/res/drawable/img_site_error_camera_pencils_226dp.xml"
+            line="49"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1724 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M63.6,91.9c-1.4,4.8-6.4,7.6-11.2,6.2c-2.1-0.6-3.9-1.9-5.1-3.8c-2.8-4.1-1.9-9.6,2-12.6 c1.8-1.5,4.2-2.1,6.5-1.9c2.3,0.2,4.5,1.3,6.1,3c1.5,1.7,2.4,4,2.3,6.3c0,0.1-0.1,0.2-0.2,0.2s-0.2-0.1-0.2-0.2 c-0.1-2.1-1-4.1-2.4-5.7c-1.5-1.5-3.5-2.5-5.6-2.6c-2.1-0.2-4.2,0.5-5.8,1.8c-1.6,1.3-2.7,3.2-3,5.2s0.1,4.1,1.2,5.9 c1.2,1.8,2.9,3,5,3.5c2.1,0.5,4.2,0.3,6.1-0.7C61.2,95.5,62.7,93.8,63.6,91.9c-0.1-0.2-0.1-0.2,0-0.2V91.9z M32.5,106l-13,0.3 c-0.6,0-1.2-0.1-1.8-0.3c-0.5-0.3-1-0.8-1.3-1.3c-0.2-0.6-0.3-1.2-0.3-1.8v-1.6L16,94.8V78.5c-0.1-1.1,0-2.2,0.1-3.3 c0.3-2.3,1.5-4.4,3.3-5.9c1.8-1.5,4-2.3,6.3-2.4c1.1-0.1,2.3,0.1,3.4,0.4c1.1,0.3,2.2,0.9,3.1,1.6c1.8,1.5,3,3.6,3.3,5.9 c0.1,1.2,0.1,2.2,0.1,3.3v3.3l-0.1,13l-0.1,6.5v1.6c0,0.6,0,1.1-0.1,1.7C34.8,105.4,33.7,106.1,32.5,106z M32.5,105.7 c1,0,1.9-0.7,2.2-1.7c0.1-0.5,0-1,0.1-1.6v-1.6l-0.1-6.5l-0.1-13V78c0-1.1,0-2.2-0.1-3.2c-0.2-2-1.3-3.9-2.9-5.2 c-0.8-0.6-1.7-1.1-2.7-1.4c-1-0.3-2.1-0.4-3.1-0.3c-4.2,0-7.8,3.1-8.5,7.3c-0.1,1.1-0.2,2.1-0.1,3.2v16.3l-0.1,6.5v1.6 c0,0.5,0,1,0.2,1.4c0.2,0.4,0.5,0.8,0.9,1c0.4,0.2,0.9,0.3,1.4,0.3C23.8,105.6,28.2,105.7,32.5,105.7z M69.2,100.2 c0.5-0.2,1,0,1.3,0.4v0.1c0.3,0.5,0.2,1.2-0.3,1.6c-0.4,0.4-1.1,0.5-1.6,0.3c-0.5-0.2-0.8-0.8-0.6-1.3c0-0.1,0.1-0.2,0.2-0.1h0.1 c0.1,0,0.1,0,0.1,0.1c0.4,0.5,0.8,0.5,1,0.3c0.2-0.2,0.2-0.3,0.1-0.4c-0.1-0.1-0.1-0.4-0.4-0.7C69.1,100.3,69.1,100.3,69.2,100.2z  M44.3,77.4c-1.3,0.3-2.7,0.4-4,0.4h-1.6c-0.3,0-0.6-0.2-0.8-0.5c-0.1-0.2-0.2-0.5-0.2-0.8v-1.6c0-0.3,0.2-0.6,0.5-0.8 c0.2-0.1,0.5-0.2,0.8-0.2h4.5c0.2,0,0.5,0.1,0.7,0.2c0.2,0.2,0.4,0.4,0.4,0.7v0.6c0,0.3-0.1,0.7-0.1,1c0,0.1-0.1,0.2-0.2,0.2 c-0.1,0-0.2-0.1-0.2-0.2c0-0.3-0.1-0.7-0.1-1V75c0-0.1,0-0.1-0.1-0.1h-5v1.6h1.5c1.3,0,2.7,0.1,4,0.4C44.3,77.2,44.4,77.2,44.3,77.4 z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1361 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_site_wordpress_camera_pencils_226dp.xml"
-            line="75"
-            column="27"/>
+            file="src/main/res/drawable/img_site_error_camera_pencils_226dp.xml"
+            line="52"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1444 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M18.4,70.1c0.9-0.1,1.7,0,2.5,0.4c0.7,0.4,1.3,1,1.8,1.7c0.4,0.6,1,1,1.6,1.4c0.7,0.3,1.4,0.4,2.1,0.4 c0.7,0,1.4-0.1,2.1-0.4c0.7-0.3,1.3-0.8,1.8-1.3c0.6-0.6,1.3-1.1,2-1.6c0.8-0.4,1.6-0.6,2.5-0.5c0.1,0,0.2,0.1,0.2,0.2 s-0.1,0.2-0.2,0.2c-0.7,0.1-1.5,0.3-2.1,0.7c-0.6,0.5-1.2,1-1.7,1.6c-0.6,0.6-1.3,1.2-2,1.6c-1.6,0.8-3.5,0.8-5.1,0.1 c-0.8-0.4-1.4-1.1-1.9-1.8c-0.4-0.6-0.9-1.2-1.5-1.7C19.8,70.6,19.1,70.3,18.4,70.1C18.3,70.3,18.3,70.3,18.4,70.1 C18.3,70.2,18.4,70.2,18.4,70.1z M76.4,75.9c0.2,1.9-0.2,3.8-0.9,5.5c-0.7,1.6-1.1,3.4-1.1,5.2c-0.1,1.8,0.3,3.5,1,5.1 c0.4,0.9,0.7,1.8,0.9,2.7c0.2,0.9,0.3,1.9,0.2,2.8c0,0.1-0.1,0.2-0.2,0.2c-0.1,0-0.2-0.1-0.2-0.2c-0.1-0.9-0.3-1.8-0.6-2.6 c-0.3-0.9-0.7-1.7-1.1-2.5c-0.8-1.7-1.3-3.6-1.3-5.5c0-1,0.1-2,0.4-2.9c0.2-0.9,0.6-1.8,0.9-2.7c0.3-0.9,0.7-1.7,1-2.5 c0.3-0.8,0.5-1.7,0.6-2.6C76.2,75.8,76.3,75.8,76.4,75.9z M16.6,82c0.1,2.2-0.2,4.4-0.9,6.5s-1.9,4-3.5,5.6c-1.6,1.5-3.3,2.8-5.2,4 c-1.8,1-3.4,2.6-4.4,4.4c-0.8,1.9-0.9,4-0.1,5.9s2.3,3.4,4.2,4.2c1.9,0.9,4,1.4,6.1,1.7c2.1,0.3,4.3,0.4,6.4,0.4 c8.6-0.2,17.2-1.1,25.7-2.9c8.5-1.6,16.9-3.7,25.3-6c0.1,0,0.2,0,0.2,0.1s0,0.2-0.1,0.2c-4.1,1.3-8.3,2.5-12.5,3.6 c-4.2,1.1-8.4,2.1-12.7,3c-4.3,0.9-8.6,1.6-12.9,2.2s-8.7,0.9-13.1,0.9c-2.2,0-4.4-0.1-6.6-0.4c-2.2-0.2-4.4-0.9-6.4-1.8 c-2.1-0.9-3.8-2.7-4.7-4.8c-0.4-1.1-0.6-2.2-0.6-3.4c0-1.2,0.2-2.3,0.7-3.4c1-2.1,3-3.5,4.8-4.7c1.8-1.2,3.6-2.4,5.2-3.8 c1.5-1.4,2.7-3.2,3.5-5.2c0.7-2,1.1-4.1,1.2-6.3C16.4,81.9,16.5,81.9,16.6,82z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (822 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_site_wordpress_camera_pencils_226dp.xml"
-            line="80"
-            column="27"/>
+            file="src/main/res/drawable/img_site_wordpress_camera_pencils_226dp.xml"
+            line="10"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1149 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M1232.9 937l-24.2 0.3c-4 0-8.1 0.1-12.1 0.2l-6.1 0.2h-2.7v-2.9h0.3l3-0.1v3.1c-9.4 0.3-18.7-3.1-26.2-8.6s-13.6-12.7-18.7-20.3c-10-15.4-16.5-32.5-21.9-49.7a450.9 450.9 0 0 1-12.6-52.5c-3.2-17.7-5.8-35.5-7.4-53.5a3.3 3.3 0 0 1 3-3.5h0.3l107.9-0.1 107.9 0.3a3.2 3.2 0 0 1 3.2 3.2 3.5 3.5 0 0 1 0 0.5c-2.9 17.9-6.7 35.4-11 53a498.4 498.4 0 0 1-15.5 51.8c-6.3 16.9-13.8 33.6-24 48.6a95.6 95.6 0 0 1-18.1 20.3c-7 5.8-15.8 10-25.1 9.9zm0-1.5c8.8-0.2 17.1-4.3 23.7-10s11.9-13.1 16.5-20.6a178.5 178.5 0 0 0 11.9-23.8q5.3-12.2 9.6-24.9c5.8-16.8 10.8-34 15-51.3s7.8-34.9 10.6-52.5l3.2 3.7-107.9 0.3-107.9-0.1 3.3-3.6c1.5 17.6 3.9 35.4 7 52.9a444.8 444.8 0 0 0 12.3 51.8c5.1 17 11.8 33.5 20.8 48.5a80.6 80.6 0 0 0 16.8 19.6 38.8 38.8 0 0 0 23.4 9.2h0.1a1.6 1.6 0 0 1-0.1 3.1l-3-0.1h-0.3v-2.9h2.7l6.1 0.2c4 0.1 8.1 0.2 12.1 0.2zm91.2-124.1c5.9 6 8.4 14 10 22a50.9 50.9 0 0 1-1.1 24.8 42.4 42.4 0 0 1-14.2 20.5l-2.4 2c-0.8 0.6-1.7 1.1-2.6 1.6-1.7 1.1-3.5 2.1-5.3 3.1a44.8 44.8 0 0 1-11.7 3.3 0.8 0.8 0 0 1-0.6-1.3l0.1-0.1a69.9 69.9 0 0 1 9.5-6.7c2.9-2.4 6.4-4 8.9-6.7a38.5 38.5 0 0 0 11.7-17.9c2.3-6.8 2.5-14.3 1.6-21.7s-3.6-14.5-5-22.3v-0.1a0.8 0.8 0 0 1 1.3-0.7z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (835 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_type_blog_80dp.xml"
-            line="34"
-            column="27"/>
+            file="src/main/res/drawable/img_site_wordpress_camera_pencils_226dp.xml"
+            line="35"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1453 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M303.1 333.9l88.8-1.3 88.8-0.8c59.2-0.6 118.5-0.5 177.7-0.7s118.5 0.2 177.7 0.4c59.2 0.6 118.5 1.1 177.7 2.4a5.9 5.9 0 0 1 0 11.9c-59.2 1.4-118.5 1.9-177.7 2.4-59.2 0.2-118.5 0.6-177.7 0.4s-118.5-0.1-177.7-0.7l-88.8-0.8-88.8-1.3a5.9 5.9 0 0 1 0-11.9zM386 475.6c46.4-0.6 92.8-1.2 139.2-1.4l139.2-0.5 139.2 0.3 69.6 0.6 69.6 1a4 4 0 0 1 0 7.9l-69.6 1-69.6 0.6-139.2 0.3-139.2-0.5c-46.4-0.2-92.8-0.8-139.2-1.4a4 4 0 0 1 0-7.9zm0 68.4c46.4-0.6 92.8-1.2 139.2-1.4l139.2-0.5 139.2 0.3 69.6 0.6 69.6 1a4 4 0 0 1 0 7.9l-69.6 1-69.6 0.6-139.2 0.3-139.2-0.5c-46.4-0.2-92.8-0.8-139.2-1.4a4 4 0 0 1 0-7.9zm-71.2 68.5q87.4-1 174.8-1.4l174.8-0.5 174.8 0.3 87.4 0.6 87.4 1a4 4 0 0 1 0 7.9l-87.4 1-87.4 0.6-174.8 0.4-174.8-0.5q-87.4-0.3-174.8-1.4a4 4 0 0 1 0-7.9zm39.3 68.4q77.6-1 155.1-1.4l155.1-0.5 155.1 0.3 77.6 0.6 77.6 1a4 4 0 0 1 0 7.9l-77.6 1-77.6 0.6-155.1 0.3-155.1-0.5q-77.6-0.3-155.1-1.4a4 4 0 0 1 0-7.9zm-14.6 68.4q81.2-1 162.4-1.4l162.4-0.5 162.4 0.3 81.2 0.6 81.2 1a4 4 0 0 1 0 7.9l-81.2 1-81.2 0.6-162.4 0.3-162.4-0.5q-81.2-0.3-162.4-1.4a4 4 0 0 1 0-7.9zm-31.8 68.5q89.2-1 178.3-1.4l178.3-0.5 178.3 0.3 89.2 0.6 89.2 1a4 4 0 0 1 0 7.9l-89.2 1-89.2 0.6-178.3 0.3-178.3-0.5q-89.2-0.3-178.3-1.4a4 4 0 0 1 0-7.9zm196.5 68.4c26.7-0.6 53.4-1.2 80.1-1.4 26.7-0.4 53.4-0.3 80.1-0.5s53.4 0.2 80.1 0.3c26.7 0.4 53.4 0.7 80.1 1.6a4 4 0 0 1 0 7.9c-26.7 0.9-53.4 1.3-80.1 1.6-26.7 0.1-53.4 0.4-80.1 0.3s-53.4-0.1-80.1-0.5c-26.7-0.2-53.4-0.8-80.1-1.4a4 4 0 0 1 0-7.9z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1453 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_type_blog_80dp.xml"
-            line="37"
-            column="27"/>
+            file="src/main/res/drawable/img_site_wordpress_camera_pencils_226dp.xml"
+            line="65"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (944 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M1137.7 455.4c-17.2-0.3-34.3-0.9-51.5-1.1 0.2-9.8-1-19.4-5.3-29a34.2 34.2 0 0 0-12.5-14.5c-1.5-0.8-2.9-1.6-4.4-2.3l-4.7-1.5a59.4 59.4 0 0 0-8.7-1.7 63.2 63.2 0 0 0-17.8 0.2 51.7 51.7 0 0 0-8.9 2.2 45.3 45.3 0 0 0-4.3 1.7l-2.1 1a4.4 4.4 0 0 1-0.7 0.3 2.1 2.1 0 0 1-1.9-0.5 2.3 2.3 0 0 1-0.6-0.9l-1.8-4.2a43.1 43.1 0 0 0-11.6-14.7 41.2 41.2 0 0 0-17-8 50.7 50.7 0 0 0-18.1-0.6c-12.1 1.3-23.5 7.5-31.8 15.9s-14.2 18.4-18.8 28.7a144.6 144.6 0 0 0-9 28.1l-45.8 0.9a4.1 4.1 0 0 0 0 8.1l50 1a4.9 4.9 0 0 0 4.9-3.9l0.1-0.3c4.4-19.9 12.7-40.5 26.8-54.3 7-6.9 15.7-11.4 25.1-12.4 9.4-1.3 19.4 0.7 26.2 6.3a30.9 30.9 0 0 1 8.2 10.6c0.5 1 0.9 2.1 1.4 3.2a14.5 14.5 0 0 0 4 5.7 14.2 14.2 0 0 0 13.3 2.9 17.2 17.2 0 0 0 3-1.3l1.5-0.8a33 33 0 0 1 3.2-1.3 39.7 39.7 0 0 1 6.8-1.8 51.3 51.3 0 0 1 14.4-0.2 48.3 48.3 0 0 1 7.2 1.3l3.1 0.9 2.8 1.5a23.8 23.8 0 0 1 8.4 9.6c4.2 8.2 5.3 19 4.8 28.6v0.6a5.2 5.2 0 0 0 5.3 5.2c19-0.2 38-0.8 57-1.2a4.1 4.1 0 0 0 0-8.1z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1724 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_type_portfolio_80dp.xml"
-            line="46"
-            column="27"/>
+            file="src/main/res/drawable/img_site_wordpress_camera_pencils_226dp.xml"
+            line="75"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1334 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M395.8 808.1a0.6 0.6 0 0 0-0.8-0.3 174.2 174.2 0 0 0-23.2 11.7c-7.4 4.4-14.9 8.8-22.1 13.5-10.9 7.2-22 14.1-32.6 21.7 9.7-11.3 18.6-23.1 27.8-34.8 5.8-7.6 11.4-15.3 17-23a211.7 211.7 0 0 0 15.3-24.4 0.6 0.6 0 0 0-1-0.7 211.5 211.5 0 0 0-19.2 21.3c-6 7.4-11.9 15-17.6 22.6-9 12.3-18.2 24.5-26.6 37.2 5-14.3 9-28.9 13.3-43.4 2.6-9.1 4.9-18.3 7.2-27.5a209.3 209.3 0 0 0 5.2-28.1 0.6 0.6 0 0 0-1.2-0.3 209.3 209.3 0 0 0-9.9 26.8c-2.8 9.1-5.5 18.2-7.9 27.3-3.6 14.2-7.6 28.4-10.6 42.8 0.1-6-0.1-11.9-0.3-17.8-0.5-10.2-1-20.4-1.8-30.6-1.8-20.3-3.1-40.7-6.6-61a1.2 1.2 0 0 0-2.4 0.2c-0.6 20.5 1.1 40.9 2.2 61.3 0.7 10.2 1.6 20.4 2.6 30.5 0.7 7 1.5 13.9 2.8 20.9-1.9-5-4-9.8-6.2-14.5-3.6-7.7-7.2-15.3-11.1-22.8-7.9-14.9-15.4-30.1-24.8-44.3a1.2 1.2 0 0 0-2.2 1.1c5.8 16 13.6 31 20.8 46.3 3.8 7.6 7.7 15 11.8 22.5 1.9 3.4 3.8 6.7 5.8 10-4-4.6-8.1-9-12.4-13.4-7.5-7.7-15-15.3-22.6-22.8-15.5-14.7-30.6-29.9-47.4-43.4a1.2 1.2 0 0 0-1.7 1.7c13.8 16.5 29.2 31.3 44.3 46.6 7.6 7.5 15.4 14.9 23.2 22.2 5.4 5 10.8 9.9 16.5 14.5-3.9-2.1-7.8-4-11.8-5.8-7.1-3.2-14.2-6.2-21.4-9.1-14.5-5.5-28.8-11.5-43.9-15.4a1.2 1.2 0 0 0-0.9 2.3c13.6 7.8 28 13.4 42.2 19.6 7.2 3 14.4 5.7 21.7 8.4a143.3 143.3 0 0 0 21.6 6.3 1.2 1.2 0 0 0 0.6 0.6 1.2 1.2 0 0 0 1 0c15.7-7.4 30.2-16.8 45.1-25.7 7.3-4.6 14.6-9.3 21.7-14.1a174.1 174.1 0 0 0 20.6-15.9 0.6 0.6 0 0 0 0.2-0.6z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1444 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_type_portfolio_80dp.xml"
-            line="55"
-            column="27"/>
+            file="src/main/res/drawable/img_site_wordpress_camera_pencils_226dp.xml"
+            line="80"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1391 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M1297.3 817l-10.4-99-10.7-99.1a3.7 3.7 0 0 0-0.9-2l-31.9-38a3.9 3.9 0 0 0-1.3-1 3.8 3.8 0 0 0-5 1.9l-20 43.7a3.8 3.8 0 0 0-0.3 2l22.1 196.7 1.1 9.2c2.3 0.2 4.5 0.4 6.7 0.7l-1.1-10.7-21.2-195.8 10.3-22.4a36.5 36.5 0 0 0 16.5-3.4l17.7 21 10.9 96.6 11.3 97.8 2.1 17.5h5.6zm90-132a25 25 0 0 0-4.6-11 25.6 25.6 0 0 0-18.3-10.5c0.6-0.2 1.1-0.5 1.7-0.7a28.5 28.5 0 0 0 11.5-10.8c5.3-9.2 6.9-19.9 6.1-30.1-1.7-20.6-11.5-39.7-25-54.6l-0.1-0.1a3.7 3.7 0 0 0-6.2 1c-6 13.1-12.6 26.1-17.1 40.2-2.2 7-4.1 14.3-4.2 22a35.9 35.9 0 0 0 1.5 11.4 23.2 23.2 0 0 0 6.1 9.7 1 1 0 0 0 1.5-1.3c-4.2-5.6-5-12.6-4.2-19.4a89.7 89.7 0 0 1 5.4-20.2l0.1-0.3a49.7 49.7 0 0 1 7.2 2.1c2.9 1 5.4 3 9 5.1a21.2 21.2 0 0 0 12.4 2.3 19.4 19.4 0 0 0 6.2-1.6c0.3 1.5 0.5 3 0.6 4.5 0.9 9.2 0.2 18.8-3.9 26.9a22.5 22.5 0 0 1-21.9 13.5 0.7 0.7 0 0 0-0.7 0.5 0.7 0.7 0 0 0 0 0.2 25 25 0 0 0-10.3 3.5 25.6 25.6 0 0 0-12.3 19.7c-0.2 14.3 0 27.6 0 41.4l0.3 82.2 0.2 22.3q3 0.2 6.1 0.4l0.2-22.8 0.3-82.2 0.2-40.8a18.1 18.1 0 0 1 8.8-13.9 17.4 17.4 0 0 1 8-2.5c2.9-0.1 6.7 0 10 0a18.3 18.3 0 0 1 14.6 7.4 17.4 17.4 0 0 1 3.3 7.7c0.4 2.5 0.2 6.3 0.3 9.7l0.1 41.1 0.2 82.2 0.1 13.2a53.6 53.6 0 0 1 6.5-0.1l0.1-13.1 0.2-82.2 0.1-41.1c0-3.6 0.3-6.7-0.3-11zm-17.4-72.2a20.8 20.8 0 0 1-8.8-2.3c-2.8-1.4-6.4-3.7-10.6-4.6a20.3 20.3 0 0 0-7.3-0.3c4-9.8 8.7-19.3 13.4-28.9a104.4 104.4 0 0 1 12.3 19 81.5 81.5 0 0 1 6.3 17.4c-1.9-0.1-3.7-0.1-5.4-0.3z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1149 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_type_portfolio_80dp.xml"
-            line="73"
-            column="27"/>
+            file="src/main/res/drawable/img_type_blog_80dp.xml"
+            line="34"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1855 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M1264.1 886.7a306.2 306.2 0 0 1 5.2 36c1.1 12 2.1 24.1 2.9 36.1 1.3 24.1 3.2 48.2 2.5 72.5a1.4 1.4 0 0 1-2.7 0.2c-4-23.9-5.4-48-7.4-72.1-0.9-12-1.5-24.1-2.1-36.2a305.8 305.8 0 0 1 0.2-36.3 0.7 0.7 0 0 1 1.4-0.1zm-200 14.8c-4.8-7.4-9.7-14.8-14.8-22-2.6-3.7-4.7-7.2-7.9-11a39 39 0 0 0-11.1-8.9 38 38 0 0 0-13.7-4.3l-1.8-0.1c0.2-0.6 0.4-1.3 0.5-2a8.1 8.1 0 0 0 0.2-3.3 8.7 8.7 0 0 0-1.5-3.5 9.4 9.4 0 0 0-6.8-3.7l-5.3-0.1a9.7 9.7 0 0 0-7.1 3 9.3 9.3 0 0 0-2.5 7.3 8.5 8.5 0 0 0 0.5 2.1l-16.4-0.1-16.1 0.1c0.2-0.5 0.3-1.1 0.4-1.6a8.1 8.1 0 0 0 0.2-3.3 8.7 8.7 0 0 0-1.5-3.5 9.4 9.4 0 0 0-6.8-3.7l-5.3-0.1a9.7 9.7 0 0 0-7.1 3 9.3 9.3 0 0 0-2.5 7.3 8.5 8.5 0 0 0 0.6 2.3c-0.7 0-1.4 0.1-2.1 0.2a39.4 39.4 0 0 0-13.7 4.4 37.8 37.8 0 0 0-11 9.1c-2.9 3.8-5.3 7.2-7.9 10.9-5 7.3-10 14.6-14.6 22.1a0.6 0.6 0 0 0 1 0.8c6.1-6.5 11.8-13.2 17.5-20 2.9-3.3 5.6-7 8.3-10.1a34.2 34.2 0 0 1 9.7-7.2 32.9 32.9 0 0 1 11.5-3.5c3.8-0.4 8.5-0.1 12.9-0.1l26.5 0.2 26.5-0.2c4.3 0 9.1-0.2 12.9 0.1a34.3 34.3 0 0 1 11.6 3.3 33 33 0 0 1 9.7 7.2c2.6 2.9 5.4 6.8 8.1 10.1 5.5 6.9 11.1 13.8 16.7 20.6a1.3 1.3 0 0 0 2-1.5zM944.8 855a4.1 4.1 0 0 1-0.6-2.5 2.9 2.9 0 0 1 3.3-2.7l5-0.1a2.7 2.7 0 0 1 2.1 0.7 3.5 3.5 0 0 1 0.8 1 4.3 4.3 0 0 1 0.6 1.8c0.1 0.6 0.3 1.1 0.4 1.7L950 855h-5.3zm53.9-2.5a2.9 2.9 0 0 1 3.3-2.7l5-0.1a2.7 2.7 0 0 1 2.1 0.7 3.5 3.5 0 0 1 0.8 1 4.3 4.3 0 0 1 0.6 1.8c0.1 0.6 0.3 1.2 0.5 1.8-2.7 0-5.2 0-7.9-0.1h-3.8a4.1 4.1 0 0 1-0.7-2.5zm100.9 208.8a97.4 97.4 0 0 1-41.5 61.6 99.6 99.6 0 0 1-73.8 14.6 100.3 100.3 0 0 1 34.2-197.6 99.8 99.8 0 0 1 64.6 38.4 98 98 0 0 1 16.7 34.2 102 102 0 0 1 2.4 37.8 1.3 1.3 0 0 1-1.4 1.1 1.3 1.3 0 0 1-1.1-1.4 97.9 97.9 0 0 0-20.3-68.8 94.3 94.3 0 0 0-61.7-35.2c-24-3.3-49.1 2.8-68.5 17.2a94 94 0 0 0 36.4 168 95.6 95.6 0 0 0 36.1 0.6 97.6 97.6 0 0 0 33.8-13 93.2 93.2 0 0 0 26.8-24.7 97.2 97.2 0 0 0 16.1-33.1 0.6 0.6 0 0 1 1.2 0.3z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1453 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_type_portfolio_80dp.xml"
-            line="79"
-            column="27"/>
+            file="src/main/res/drawable/img_type_blog_80dp.xml"
+            line="37"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1231 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M1162.9 932.9a40.2 40.2 0 0 0-28.2-31.9 42.6 42.6 0 0 0-11.1-1.6l-10.5-0.1-20.9-0.1-243.8-0.1a56.1 56.1 0 0 0-38-22.7c-8.8-1-16.5-0.4-24.7-0.6-7.8-0.2-17 0-25.1 2.6a61.2 61.2 0 0 0-22.4 12.4 61.8 61.8 0 0 0-21.5 45.2v48.7l0.2 97.2 0.3 48.6 0.1 12.1c0.1 2.1-0.1 3.8 0.1 6.3a18.5 18.5 0 0 0 12.7 15.6 19.8 19.8 0 0 0 6.8 0.8l6.1-0.1 6-0.1c-8.8 0.3-14.7 0.5-15.8 0.6l222.9-0.7 83.7-0.5 83.7-0.4a38.9 38.9 0 0 0 34.9-21.7c3.4-6.4 4.2-14.1 4-21l0.1-20.9 0.4-83.7 0.2-41.8 0.1-20.9 0.1-10.5c0-3.3 0.2-7.1-0.5-10.8zm-419.8 227.7l-6.1-0.1a15.6 15.6 0 0 1-5.2-0.7 13.2 13.2 0 0 1-7.5-6.4c-1.7-3-1.5-6.3-1.4-10.6l0.1-12.1 0.3-48.6 0.2-97.2 0.2-48.5a55.3 55.3 0 0 1 19.1-40 54 54 0 0 1 19.8-11c7.4-2.3 14.7-2.6 23-2.4 8 0.1 16.5-0.4 23.8 0.5a50.8 50.8 0 0 1 21.1 7.9c12.6 8.5 21.3 22.8 22.1 38 0.4 15.7 0.1 32.3 0.4 48.4l0.8 97.2 0.5 48.6 0.3 24.3c0.1 6.3-4.8 12-10.8 13.6-3 0.3-6.9 0.6-11.6 0.9q-44.5-1-89-1.6zm412.7-19.4a36.1 36.1 0 0 1-32.2 20.5l-83.7-0.4-83.7-0.5-104.7-0.6a16.9 16.9 0 0 0 6.1-12.4l0.3-24.4 0.5-48.6 0.8-97.2c0.1-16.3 0.3-32.2 0-48.8a54.4 54.4 0 0 0-6.8-23.3l239.8-0.1 20.9-0.1 10.5-0.1a36.8 36.8 0 0 1 9.5 1.3 34.8 34.8 0 0 1 24.7 27.3c1 6.2 0.4 13.6 0.6 20.4l0.1 20.9 0.2 41.8 0.4 83.7 0.1 20.9c0.2 7-0.5 13.6-3.5 19.7z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (944 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_type_portfolio_80dp.xml"
-            line="85"
-            column="27"/>
+            file="src/main/res/drawable/img_type_portfolio_80dp.xml"
+            line="46"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (2379 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M1108.4 1120.8c3-1.8 7.7 0 9.4 3.7a9.9 9.9 0 0 1-1.9 11.4 10.1 10.1 0 0 1-11.3 1.8c-3.6-1.7-5.6-6-4.4-9.3a1.4 1.4 0 0 1 2.5-0.2l0.1 0.2c2.3 4.3 6.3 4.4 8 2.4a4.3 4.3 0 0 0 1.1-3.8 7.9 7.9 0 0 0-3.5-4.9h-0.1a0.7 0.7 0 0 1-0.2-1 0.8 0.8 0 0 1 0.3-0.3zM924.6 952.2a218 218 0 0 1-29.7 2.6l-7.4 0.2h-1.9a13.6 13.6 0 0 1-2.4-0.1 7.9 7.9 0 0 1-5.4-3.5c-1.3-1.7-1.3-4.7-1.3-5.5v-9.3a17.1 17.1 0 0 1 0.1-2.4 8 8 0 0 1 6.6-6.7 13.5 13.5 0 0 1 2.5-0.1l7.4 0.1 14.8 0.3 7.4 0.3 3.7 0.1c0.9 0 3.5 0.1 4.9 1.3a6.8 6.8 0 0 1 2.8 4.8 28.5 28.5 0 0 1-0.2 4.1c-0.2 2.5-0.4 4.9-0.7 7.4a1.3 1.3 0 0 1-2.5 0c-0.3-2.5-0.5-4.9-0.7-7.4-0.1-1.1-0.1-2.8-0.3-3.3a2 2 0 0 0-1.1-1.3c-0.4-0.4-3.6 0.1-5.9 0l-7.4 0.3-14.8 0.3-7.4 0.1c-1.7 0-1.2 0-1.6 0.2a0.9 0.9 0 0 0-0.3 0.6v6.9c0 2.3-0.1 5.8 0.1 5.4a0.9 0.9 0 0 0 0.6 0.5 8.2 8.2 0 0 0 1.3 0.1h1.9l7.4 0.2a217.9 217.9 0 0 1 29.7 2.6 0.6 0.6 0 0 1 0 1.3zm-190.8-52.9a27.3 27.3 0 0 1 18.1 3.4c5.6 3.3 9.5 8.4 13.3 12.8s7.6 8.2 12.3 10.4 10 3 15.5 3a37.9 37.9 0 0 0 15.8-3.1c4.9-2.2 9.1-5.8 13.3-9.7s8.5-8.5 14.2-11.5a31.5 31.5 0 0 1 18.2-3.6 1.3 1.3 0 0 1 0 2.5 33.1 33.1 0 0 0-15.6 5.3c-4.5 3.1-8.3 7.3-12.4 11.6s-9 8.6-14.8 11.4a44.8 44.8 0 0 1-18.6 4.2 39.4 39.4 0 0 1-18.8-3.9c-6-3-10.5-8-14.1-12.7s-6.8-9.4-11-12.8-9.6-5.2-15.4-6.1a0.6 0.6 0 0 1 0-1.3zm427.7 42a62.4 62.4 0 0 1-1.1 20.7c-1.5 6.8-3.9 13.3-6.2 19.7-5 12.5-8.4 25.2-8.3 38.3a84.3 84.3 0 0 0 1.7 19.4 114.7 114.7 0 0 0 6.1 18.8c2.4 6.3 5.2 12.6 6.8 19.5a67.2 67.2 0 0 1 1.6 20.8 1.3 1.3 0 0 1-1.4 1.2 1.3 1.3 0 0 1-1.2-1.2 84.3 84.3 0 0 0-3.9-19.4 190.6 190.6 0 0 0-7.7-18.5 109.3 109.3 0 0 1-7-19.7 91.3 91.3 0 0 1-2.3-21c0-14.1 4.3-28 9.5-40.5 5.6-12.4 10.4-24.5 12-38a0.6 0.6 0 0 1 0.7-0.6 0.6 0.6 0 0 1 0.6 0.6zm-440.7-21.4c0.3 16-1.3 32.3-6.4 47.8a104.8 104.8 0 0 1-25.8 41.1c-11.5 11.6-25.3 20.4-38.4 29.5s-26 18.7-32.5 32.3c-6.5 13.4-5.7 30.2-1 44.3 5.2 14.2 17.5 24.7 31.4 31.2s29.5 10.2 45.1 12.4a357.7 357.7 0 0 0 47.4 3c63.7 0.1 127.2 0.1 189.9-11.8s125 29.6 186.6 12.6a1.3 1.3 0 0 1 1.6 0.9 1.3 1.3 0 0 1-0.8 1.6c-30.6 9.7-58.7 7.1-92.5-0.7-37.9-9.7-62.3-14.8-93.7-8.3s-63.1 10.8-94.9 15-63.9-2-96.2-2a347.7 347.7 0 0 1-48.4-3.3c-16-2.4-32.1-6.1-47.1-13.2a79.2 79.2 0 0 1-20.7-14 56.2 56.2 0 0 1-14-21.1 73.3 73.3 0 0 1-4-24.7 56 56 0 0 1 5.4-24.6c7.7-15.6 21.9-25.4 35.1-34.3 13.4-8.9 26.8-17.4 38.2-28.2a100.8 100.8 0 0 0 26-38.8c6.1-15.8 7.9-30.7 8.3-46.7a0.6 0.6 0 0 1 1.3 0z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1334 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_type_portfolio_80dp.xml"
-            line="88"
-            column="27"/>
+            file="src/main/res/drawable/img_type_portfolio_80dp.xml"
+            line="55"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (1572 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M158.2 433.9c17.5-0.8 35-1.2 52.5-1.5s35-0.3 52.5-0.5 35 0.2 52.5 0.3c17.5 0.4 35 0.7 52.5 1.7a4 4 0 0 1 0 8.1c-17.5 0.9-35 1.3-52.5 1.7-17.5 0.1-35 0.4-52.5 0.3s-35-0.1-52.5-0.5-35-0.7-52.5-1.5a4 4 0 0 1 0-8.1zm0 64.2c17.5-0.8 35-1.2 52.5-1.5s35-0.3 52.5-0.5 35 0.2 52.5 0.3c17.5 0.4 35 0.7 52.5 1.7a4 4 0 0 1 0 8.1c-17.5 0.9-35 1.3-52.5 1.7-17.5 0.1-35 0.4-52.5 0.3s-35-0.1-52.5-0.5-35-0.7-52.5-1.5a4 4 0 0 1 0-8.1zm0 67.6c17.5-0.8 35-1.2 52.5-1.5s35-0.3 52.5-0.5 35 0.2 52.5 0.3c17.5 0.4 35 0.7 52.5 1.7a4 4 0 0 1 0 8.1c-17.5 0.9-35 1.3-52.5 1.7-17.5 0.1-35 0.4-52.5 0.3s-35-0.1-52.5-0.5-35-0.7-52.5-1.5a4 4 0 0 1 0-8.1zm0 61.6c17.5-0.8 35-1.2 52.5-1.5s35-0.3 52.5-0.5 35 0.2 52.5 0.3c17.5 0.4 35 0.7 52.5 1.7a4 4 0 0 1 0 8.1c-17.5 0.9-35 1.3-52.5 1.7-17.5 0.1-35 0.4-52.5 0.3s-35-0.1-52.5-0.5-35-0.7-52.5-1.5a4 4 0 0 1 0-8.1zm0 64.2c17.5-0.8 35-1.2 52.5-1.5s35-0.3 52.5-0.5 35 0.2 52.5 0.3c17.5 0.4 35 0.7 52.5 1.7a4 4 0 0 1 0 8.1c-17.5 0.9-35 1.3-52.5 1.7-17.5 0.1-35 0.4-52.5 0.3s-35-0.1-52.5-0.5-35-0.7-52.5-1.5a4 4 0 0 1 0-8.1zm0 67.5c17.5-0.8 35-1.2 52.5-1.5s35-0.3 52.5-0.5 35 0.2 52.5 0.3c17.5 0.4 35 0.7 52.5 1.7a4 4 0 0 1 0 8.1c-17.5 0.9-35 1.3-52.5 1.7-17.5 0.1-35 0.4-52.5 0.3s-35-0.1-52.5-0.5-35-0.7-52.5-1.5a4 4 0 0 1 0-8.1zm60.4 159.6c12.4-0.8 24.9-1.2 37.4-1.5s24.9-0.3 37.4-0.5 24.9 0 37.4 0.3 24.9 0.7 37.4 1.7a4 4 0 0 1 0 8.1c-12.4 0.9-24.9 1.3-37.4 1.7s-24.9 0.4-37.4 0.3-24.9-0.1-37.4-0.5-24.9-0.7-37.4-1.5a4 4 0 0 1 0-8.1zm603-277.2H1150s-12.4-75.7-51.5-86.5c-34.3-9.5-48.1 11.5-76.7 11.5-22.9 0-31.9-53.9-75.4-53.9-82.4 0-124.9 128.9-124.9 128.9z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1391 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_type_website_80dp.xml"
-            line="34"
-            column="27"/>
+            file="src/main/res/drawable/img_type_portfolio_80dp.xml"
+            line="73"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (821 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M1084.1 945.7a288.9 288.9 0 0 1 33.3-2.4c11.1-0.3 22.2-0.4 33.3-0.4 22.2 0.4 44.4 0.2 66.7 2.2a1.2 1.2 0 0 1 0 2.4c-22.2 2-44.4 1.9-66.7 2.2-11.1 0.1-22.2-0.1-33.3-0.4a289 289 0 0 1-33.3-2.4 0.6 0.6 0 0 1 0-1.2zm0 30.2a288.9 288.9 0 0 1 33.3-2.4c11.1-0.3 22.2-0.4 33.3-0.4 22.2 0.4 44.4 0.2 66.7 2.2a1.2 1.2 0 0 1 0 2.4c-22.2 2-44.4 1.9-66.7 2.2-11.1 0.1-22.2-0.1-33.3-0.4a289 289 0 0 1-33.3-2.4 0.6 0.6 0 0 1 0-1.2zm0 36.3a288.9 288.9 0 0 1 33.3-2.4c11.1-0.3 22.2-0.4 33.3-0.4 22.2 0.4 44.4 0.2 66.7 2.2a1.2 1.2 0 0 1 0 2.4c-22.2 2-44.4 1.9-66.7 2.2-11.1 0.1-22.2-0.1-33.3-0.4a289 289 0 0 1-33.3-2.4 0.6 0.6 0 0 1 0-1.2zm-36.3 15.8c-3.1 11.4-41.2 15.1-62.7 15.2h-0.3c-21.5 0-59.6-3.8-62.7-15.2-3.6-13.3 23.3-41.7 62.7-41.9h0.3c39.4 0.1 66.3 28.5 62.7 41.9zm-62.7-49.1a31.3 31.3 0 1 0-31.3-31.3 31.3 31.3 0 0 0 31.3 31.3z&quot;/>"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1855 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../WordPress/src/main/res/drawable/img_type_website_80dp.xml"
-            line="52"
-            column="27"/>
+            file="src/main/res/drawable/img_type_portfolio_80dp.xml"
+            line="79"/>
     </issue>
 
     <issue
         id="VectorPath"
-        severity="Error"
-        message="Very long vector path (847 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        category="Performance"
-        priority="5"
-        summary="Long vector paths"
-        explanation="Using long vector paths is bad for performance. There are several ways to make the `pathData` shorter:&#xA;* Using less precision&#xA;* Removing some minor details&#xA;* Using the Android Studio vector conversion tool&#xA;* Rasterizing the image (converting to PNG)"
-        errorLine1="        android:pathData=&quot;M16,2.7C8.6,2.7 2.7,8.6 2.7,16s6,13.3 13.3,13.3s13.3,-6 13.3,-13.3S23.4,2.7 16,2.7zM4.7,16c0,-1.6 0.4,-3.2 1,-4.6l5.4,14.8C7.3,24.4 4.7,20.5 4.7,16zM16,27.3c-1.1,0 -2.2,-0.2 -3.2,-0.5l3.4,-9.9l3.5,9.5c0,0.1 0.1,0.1 0.1,0.2C18.6,27.1 17.3,27.3 16,27.3L16,27.3zM17.6,10.7c0.7,0 1.3,-0.1 1.3,-0.1c0.6,-0.1 0.5,-1 -0.1,-0.9c0,0 -1.8,0.1 -3,0.1c-1.1,0 -3,-0.1 -3,-0.1c-0.6,0 -0.7,0.9 -0.1,0.9c0,0 0.6,0.1 1.2,0.1l1.8,4.8L13.2,23L9.1,10.7c0.7,0 1.3,-0.1 1.3,-0.1c0.6,-0.1 0.5,-1 -0.1,-0.9c0,0 -1.8,0.1 -3,0.1c-0.2,0 -0.5,0 -0.7,0c2,-3.1 5.5,-5.1 9.5,-5.1c3,0 5.6,1.1 7.7,3c0,0 -0.1,0 -0.1,0c-1.1,0 -1.9,1 -1.9,2c0,0.9 0.5,1.7 1.1,2.7c0.4,0.8 0.9,1.7 0.9,3.1c0,1 -0.4,2.1 -0.9,3.7l-1.1,3.8C21.7,22.9 17.6,10.7 17.6,10.7zM21.7,25.8l3.5,-10c0.6,-1.6 0.9,-2.9 0.9,-4.1c0,-0.4 0,-0.8 -0.1,-1.2c0.9,1.6 1.4,3.5 1.4,5.4C27.3,20.2 25.1,23.8 21.7,25.8L21.7,25.8z&quot; >"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Very long vector path (1231 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/drawable/login_toolbar_icon.xml"
-            line="10"
-            column="27"/>
+            file="src/main/res/drawable/img_type_portfolio_80dp.xml"
+            line="85"/>
+    </issue>
+
+    <issue
+        id="VectorPath"
+        message="Very long vector path (2379 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        <location
+            file="src/main/res/drawable/img_type_portfolio_80dp.xml"
+            line="88"/>
+    </issue>
+
+    <issue
+        id="VectorPath"
+        message="Very long vector path (1572 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        <location
+            file="src/main/res/drawable/img_type_website_80dp.xml"
+            line="34"/>
+    </issue>
+
+    <issue
+        id="VectorPath"
+        message="Very long vector path (821 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        <location
+            file="src/main/res/drawable/img_type_website_80dp.xml"
+            line="52"/>
+    </issue>
+
+    <issue
+        id="VectorPath"
+        message="Very long vector path (847 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        <location
+            file="src/main/res/drawable/login_toolbar_icon.xml"
+            line="10"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        severity="Warning"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
-        category="Performance"
-        priority="3"
-        summary="Missing `baselineAligned` attribute"
-        explanation="When a LinearLayout is used to distribute the space proportionally between nested layouts, the baseline alignment property should be turned off to make the layout computation faster."
-        errorLine1="    &lt;LinearLayout"
-        errorLine2="    ^"
-        quickfix="studio">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
         <location
-            file="../WordPress/src/main/res/layout/comment_action_footer.xml"
-            line="10"
-            column="5"/>
+            file="src/main/res/layout/comment_action_footer.xml"
+            line="10"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        severity="Warning"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
-        category="Performance"
-        priority="3"
-        summary="Missing `baselineAligned` attribute"
-        explanation="When a LinearLayout is used to distribute the space proportionally between nested layouts, the baseline alignment property should be turned off to make the layout computation faster."
-        errorLine1="                        &lt;LinearLayout"
-        errorLine2="                        ^"
-        quickfix="studio">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
         <location
-            file="../WordPress/src/main/res/layout-sw720dp/stats_activity.xml"
-            line="109"
-            column="25"/>
+            file="src/main/res/layout-sw720dp/stats_activity.xml"
+            line="109"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        severity="Warning"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
-        category="Performance"
-        priority="3"
-        summary="Missing `baselineAligned` attribute"
-        explanation="When a LinearLayout is used to distribute the space proportionally between nested layouts, the baseline alignment property should be turned off to make the layout computation faster."
-        errorLine1="                        &lt;LinearLayout"
-        errorLine2="                        ^"
-        quickfix="studio">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
         <location
-            file="../WordPress/src/main/res/layout-sw720dp/stats_activity.xml"
-            line="170"
-            column="25"/>
+            file="src/main/res/layout-sw720dp/stats_activity.xml"
+            line="170"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        severity="Warning"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
-        category="Performance"
-        priority="3"
-        summary="Missing `baselineAligned` attribute"
-        explanation="When a LinearLayout is used to distribute the space proportionally between nested layouts, the baseline alignment property should be turned off to make the layout computation faster."
-        errorLine1="    &lt;LinearLayout"
-        errorLine2="    ^"
-        quickfix="studio">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
         <location
-            file="../WordPress/src/main/res/layout/stats_insights_all_time_item.xml"
-            line="12"
-            column="5"/>
+            file="src/main/res/layout/stats_insights_all_time_item.xml"
+            line="12"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        severity="Warning"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
-        category="Performance"
-        priority="3"
-        summary="Missing `baselineAligned` attribute"
-        explanation="When a LinearLayout is used to distribute the space proportionally between nested layouts, the baseline alignment property should be turned off to make the layout computation faster."
-        errorLine1="    &lt;LinearLayout"
-        errorLine2="    ^"
-        quickfix="studio">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
         <location
-            file="../WordPress/src/main/res/layout/stats_insights_all_time_item.xml"
-            line="111"
-            column="5"/>
+            file="src/main/res/layout/stats_insights_all_time_item.xml"
+            line="111"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        severity="Warning"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
-        category="Performance"
-        priority="3"
-        summary="Missing `baselineAligned` attribute"
-        explanation="When a LinearLayout is used to distribute the space proportionally between nested layouts, the baseline alignment property should be turned off to make the layout computation faster."
-        errorLine1="    &lt;LinearLayout"
-        errorLine2="    ^"
-        quickfix="studio">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
         <location
-            file="../WordPress/src/main/res/layout/stats_insights_latest_post_item.xml"
-            line="31"
-            column="5"/>
+            file="src/main/res/layout/stats_insights_latest_post_item.xml"
+            line="31"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        severity="Warning"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
-        category="Performance"
-        priority="3"
-        summary="Missing `baselineAligned` attribute"
-        explanation="When a LinearLayout is used to distribute the space proportionally between nested layouts, the baseline alignment property should be turned off to make the layout computation faster."
-        errorLine1="    &lt;LinearLayout"
-        errorLine2="    ^"
-        quickfix="studio">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
         <location
-            file="../WordPress/src/main/res/layout/stats_insights_today_item.xml"
-            line="9"
-            column="5"/>
+            file="src/main/res/layout/stats_insights_today_item.xml"
+            line="9"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        severity="Warning"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
-        category="Performance"
-        priority="3"
-        summary="Missing `baselineAligned` attribute"
-        explanation="When a LinearLayout is used to distribute the space proportionally between nested layouts, the baseline alignment property should be turned off to make the layout computation faster."
-        errorLine1="        &lt;LinearLayout"
-        errorLine2="        ^"
-        quickfix="studio">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
         <location
-            file="../WordPress/src/main/res/layout/stats_visitors_and_views_fragment.xml"
-            line="16"
-            column="9"/>
+            file="src/main/res/layout/stats_visitors_and_views_fragment.xml"
+            line="16"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        severity="Warning"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
-        category="Performance"
-        priority="3"
-        summary="Missing `baselineAligned` attribute"
-        explanation="When a LinearLayout is used to distribute the space proportionally between nested layouts, the baseline alignment property should be turned off to make the layout computation faster."
-        errorLine1="        &lt;LinearLayout"
-        errorLine2="        ^"
-        quickfix="studio">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
         <location
-            file="../WordPress/src/main/res/layout/stats_visitors_and_views_fragment.xml"
-            line="102"
-            column="9"/>
+            file="src/main/res/layout/stats_visitors_and_views_fragment.xml"
+            line="102"/>
     </issue>
 
     <issue
         id="DisableBaselineAlignment"
-        severity="Warning"
-        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
-        category="Performance"
-        priority="3"
-        summary="Missing `baselineAligned` attribute"
-        explanation="When a LinearLayout is used to distribute the space proportionally between nested layouts, the baseline alignment property should be turned off to make the layout computation faster."
-        errorLine1="    &lt;LinearLayout"
-        errorLine2="    ^"
-        quickfix="studio">
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance">
         <location
-            file="../WordPress/src/main/res/layout/stats_widget_layout.xml"
-            line="45"
-            column="5"/>
+            file="src/main/res/layout/stats_widget_layout.xml"
+            line="45"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/nux_background` with a theme that also paints a background (inferred theme is `@style/WordPress_TransparentToolbarTheme`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/nux_background&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/nux_background` with a theme that also paints a background (inferred theme is `@style/WordPress_TransparentToolbarTheme`)">
         <location
-            file="../WordPress/src/main/res/layout/about_activity.xml"
-            line="8"
-            column="5"/>
+            file="src/main/res/layout/about_activity.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `#FFEEEEEE` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="  android:background=&quot;#FFEEEEEE&quot;>"
-        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `#FFEEEEEE` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/add_quickpress_shortcut.xml"
-            line="6"
-            column="3"/>
+            file="src/main/res/layout/add_quickpress_shortcut.xml"
+            line="6"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="              android:background=&quot;@color/white&quot;"
-        errorLine2="              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/comment_action_footer.xml"
-            line="7"
-            column="15"/>
+            file="src/main/res/layout/comment_action_footer.xml"
+            line="7"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/grey_light` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/grey_light&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/grey_light` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/comment_detail_fragment.xml"
-            line="11"
-            column="5"/>
+            file="src/main/res/layout/comment_detail_fragment.xml"
+            line="11"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme`)">
         <location
-            file="../WordPress/src/main/res/layout/comment_edit_activity.xml"
-            line="9"
-            column="5"/>
+            file="src/main/res/layout/comment_edit_activity.xml"
+            line="9"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/comment_listitem.xml"
-            line="6"
-            column="5"/>
+            file="src/main/res/layout/comment_listitem.xml"
+            line="6"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@android:color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@android:color/white&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@android:color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/dialog_image_options.xml"
-            line="6"
-            column="5"/>
+            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/res/layout/dialog_image_options.xml"
+            line="6"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/grey_3` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/grey_3&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/grey_3` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/dialog_snackbar.xml"
-            line="8"
-            column="5"/>
+            file="src/main/res/layout/dialog_snackbar.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/edit_post_preview_fragment.xml"
-            line="7"
-            column="5"/>
+            file="src/main/res/layout/edit_post_preview_fragment.xml"
+            line="7"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/background_grey` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/background_grey&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/background_grey` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/edit_post_settings_fragment.xml"
-            line="8"
-            column="5"/>
+            file="src/main/res/layout/edit_post_settings_fragment.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/format_bar_background` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/format_bar_background&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/format_bar_background` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout-w360dp/format_bar.xml"
-            line="8"
-            column="5"/>
+            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/res/layout-w360dp/format_bar.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/format_bar_background` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/format_bar_background&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/format_bar_background` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout-w380dp/format_bar.xml"
-            line="8"
-            column="5"/>
+            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/res/layout-w380dp/format_bar.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/format_bar_background` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/format_bar_background&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/format_bar_background` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout-w600dp/format_bar.xml"
-            line="8"
-            column="5"/>
+            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/res/layout-w600dp/format_bar.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/format_bar_background` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/format_bar_background&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/format_bar_background` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/format_bar.xml"
-            line="9"
-            column="5"/>
+            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/res/layout/format_bar.xml"
+            line="9"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml"
-            line="5"
-            column="5"/>
+            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml"
+            line="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@android:color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@android:color/white&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@android:color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/fragment_edit_post_content.xml"
-            line="6"
-            column="5"/>
+            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/res/layout/fragment_edit_post_content.xml"
+            line="6"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/gutenberg_warning_dialog.xml"
-            line="5"
-            column="5"/>
+            file="/Users/mariozorz/proyectos/WordPress-Android/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml"
+            line="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/background_grey` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme_NoActionBarShadow`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/background_grey&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/help_activity.xml"
-            line="6"
-            column="5"/>
+            file="src/main/res/layout/gutenberg_warning_dialog.xml"
+            line="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/background_grey` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme_NoActionBarShadow`)">
         <location
-            file="../WordPress/src/main/res/layout/history_detail_fragment.xml"
-            line="5"
-            column="5"/>
+            file="src/main/res/layout/help_activity.xml"
+            line="6"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/home_row.xml"
-            line="5"
-            column="5"/>
+            file="src/main/res/layout/history_detail_fragment.xml"
+            line="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/transparent` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/transparent&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/learn_more_pref_screen.xml"
-            line="8"
-            column="5"/>
+            file="src/main/res/layout/home_row.xml"
+            line="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/blue_medium` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/blue_medium&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/transparent` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout-land/login_intro_template_view.xml"
-            line="5"
-            column="5"/>
+            file="src/main/res/layout/learn_more_pref_screen.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/blue_medium` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/blue_medium&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/blue_medium` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout-sw600dp-land/login_intro_template_view.xml"
-            line="5"
-            column="5"/>
+            file="src/main/res/layout-land/login_intro_template_view.xml"
+            line="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/black` with a theme that also paints a background (inferred theme is `@style/Theme_AppCompat_NoActionBar`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/black&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/blue_medium` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/media_preview_activity.xml"
-            line="7"
-            column="5"/>
+            file="src/main/res/layout-sw600dp-land/login_intro_template_view.xml"
+            line="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/black` with a theme that also paints a background (inferred theme is `@style/Theme_AppCompat_NoActionBar`)">
         <location
-            file="../WordPress/src/main/res/layout/news_card.xml"
-            line="8"
-            column="5"/>
+            file="src/main/res/layout/media_preview_activity.xml"
+            line="7"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/note_block_footer.xml"
-            line="5"
-            column="5"/>
+            file="src/main/res/layout/news_card.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/note_block_user.xml"
-            line="6"
-            column="5"/>
+            file="src/main/res/layout/note_block_footer.xml"
+            line="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/default_background` with a theme that also paints a background (inferred theme is `@style/Calypso_NoActionBar_Preferences`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/default_background&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/notifications_settings_activity.xml"
-            line="7"
-            column="5"/>
+            file="src/main/res/layout/note_block_user.xml"
+            line="6"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/default_background` with a theme that also paints a background (inferred theme is `@style/Calypso_NoActionBar_Preferences`)">
         <location
-            file="../WordPress/src/main/res/layout/people_invite_fragment.xml"
-            line="7"
-            column="5"/>
+            file="src/main/res/layout/notifications_settings_activity.xml"
+            line="7"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/person_detail_fragment.xml"
-            line="7"
-            column="5"/>
+            file="src/main/res/layout/people_invite_fragment.xml"
+            line="7"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="                android:background=&quot;@color/white&quot;>"
-        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/photo_picker_fragment.xml"
-            line="8"
-            column="17"/>
+            file="src/main/res/layout/person_detail_fragment.xml"
+            line="7"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `?android:attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/Calypso_NoActionBar`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;?android:attr/selectableItemBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/plugin_browser_row.xml"
-            line="6"
-            column="5"/>
+            file="src/main/res/layout/photo_picker_fragment.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/Calypso_NoActionBar`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?android:attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/Calypso_NoActionBar`)">
         <location
-            file="../WordPress/src/main/res/layout/post_preview_activity.xml"
-            line="6"
-            column="5"/>
+            file="src/main/res/layout/plugin_browser_row.xml"
+            line="6"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/Calypso_NoActionBar`)">
         <location
-            file="../WordPress/src/main/res/layout/promo_dialog.xml"
-            line="6"
-            column="5"/>
+            file="src/main/res/layout/post_preview_activity.xml"
+            line="6"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/publicize_connect_button.xml"
-            line="6"
-            column="5"/>
+            file="src/main/res/layout/promo_dialog.xml"
+            line="6"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/publicize_listitem_connection.xml"
-            line="7"
-            column="5"/>
+            file="src/main/res/layout/publicize_connect_button.xml"
+            line="6"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/publicize_listitem_service.xml"
-            line="7"
-            column="5"/>
+            file="src/main/res/layout/publicize_listitem_connection.xml"
+            line="7"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/quick_start_fragment.xml"
-            line="9"
-            column="5"/>
+            file="src/main/res/layout/publicize_listitem_service.xml"
+            line="7"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/black` with a theme that also paints a background (inferred theme is `@style/ReaderMediaViewerTheme`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="                android:background=&quot;@color/black&quot;>"
-        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/reader_activity_photo_viewer.xml"
-            line="8"
-            column="17"/>
+            file="src/main/res/layout/quick_start_fragment.xml"
+            line="9"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/Calypso_NoActionBar`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/black` with a theme that also paints a background (inferred theme is `@style/ReaderMediaViewerTheme`)">
         <location
-            file="../WordPress/src/main/res/layout/reader_activity_subs.xml"
-            line="7"
-            column="5"/>
+            file="src/main/res/layout/reader_activity_photo_viewer.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/grey_dark` with a theme that also paints a background (inferred theme is `@style/ReaderMediaViewerTheme`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/grey_dark&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/Calypso_NoActionBar`)">
         <location
-            file="../WordPress/src/main/res/layout/reader_activity_video_player.xml"
-            line="7"
-            column="5"/>
+            file="src/main/res/layout/reader_activity_subs.xml"
+            line="7"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;?attr/selectableItemBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/grey_dark` with a theme that also paints a background (inferred theme is `@style/ReaderMediaViewerTheme`)">
         <location
-            file="../WordPress/src/main/res/layout/reader_bookmark_button.xml"
-            line="5"
-            column="5"/>
+            file="src/main/res/layout/reader_activity_video_player.xml"
+            line="7"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/reader_comments_post_header_view.xml"
-            line="11"
-            column="5"/>
+            file="src/main/res/layout/reader_bookmark_button.xml"
+            line="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;?attr/selectableItemBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/reader_icon_count_view.xml"
-            line="6"
-            column="5"/>
+            file="src/main/res/layout/reader_comments_post_header_view.xml"
+            line="11"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/reader_include_comment_box.xml"
-            line="12"
-            column="5"/>
+            file="src/main/res/layout/reader_icon_count_view.xml"
+            line="6"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/reader_include_post_detail_footer.xml"
-            line="11"
-            column="5"/>
+            file="src/main/res/layout/reader_include_comment_box.xml"
+            line="12"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/reader_listitem_blog.xml"
-            line="10"
-            column="5"/>
+            file="src/main/res/layout/reader_include_post_detail_footer.xml"
+            line="11"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/reader_listitem_comment.xml"
-            line="8"
-            column="5"/>
+            file="src/main/res/layout/reader_listitem_blog.xml"
+            line="10"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/reader_listitem_tag.xml"
-            line="12"
-            column="5"/>
+            file="src/main/res/layout/reader_listitem_comment.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/reader_listitem_user.xml"
-            line="7"
-            column="5"/>
+            file="src/main/res/layout/reader_listitem_tag.xml"
+            line="12"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/reader_simple_post_view.xml"
-            line="9"
-            column="5"/>
+            file="src/main/res/layout/reader_listitem_user.xml"
+            line="7"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="             android:background=&quot;@color/white&quot;"
-        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/reader_site_search_result.xml"
-            line="7"
-            column="14"/>
+            file="src/main/res/layout/reader_simple_post_view.xml"
+            line="9"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/reader_tag_strip_label.xml"
-            line="9"
-            column="5"/>
+            file="src/main/res/layout/reader_site_search_result.xml"
+            line="7"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/related_posts_dialog.xml"
-            line="10"
-            column="5"/>
+            file="src/main/res/layout/reader_tag_strip_label.xml"
+            line="9"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/select_categories.xml"
-            line="6"
-            column="5"/>
+            file="src/main/res/layout/related_posts_dialog.xml"
+            line="10"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme`)">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/signup_bottom_sheet_dialog.xml"
-            line="5"
-            column="5"/>
+            file="src/main/res/layout/select_categories.xml"
+            line="6"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/signup_bottom_sheet_dialog.xml"
-            line="5"
-            column="5"/>
+            file="/Users/mariozorz/proyectos/WordPress-Android/libs/login/WordPressLoginFlow/src/main/res/layout-land/signup_bottom_sheet_dialog.xml"
+            line="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/site_creation_domain_header.xml"
-            line="6"
-            column="5"/>
+            file="/Users/mariozorz/proyectos/WordPress-Android/libs/login/WordPressLoginFlow/src/main/res/layout/signup_bottom_sheet_dialog.xml"
+            line="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/site_creation_domain_input.xml"
-            line="8"
-            column="5"/>
+            file="src/main/res/layout/site_creation_domain_header.xml"
+            line="6"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/white&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/site_creation_domain_screen.xml"
-            line="7"
-            column="5"/>
+            file="src/main/res/layout/site_creation_domain_input.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/site_creation_form_screen.xml"
-            line="7"
-            column="5"/>
+            file="src/main/res/layout/site_creation_domain_screen.xml"
+            line="7"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;?android:selectableItemBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/site_picker_listitem.xml"
-            line="8"
-            column="5"/>
+            file="src/main/res/layout/site_creation_form_screen.xml"
+            line="7"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?android:selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme`)">
         <location
-            file="../WordPress/src/main/res/layout/site_settings_tag_detail_fragment.xml"
-            line="7"
-            column="5"/>
+            file="src/main/res/layout/site_picker_listitem.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `?android:attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;?android:attr/selectableItemBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/start_over_preference.xml"
-            line="10"
-            column="5"/>
+            file="src/main/res/layout/site_settings_tag_detail_fragment.xml"
+            line="7"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?android:attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/stats_activity_view_all.xml"
-            line="8"
-            column="5"/>
+            file="src/main/res/layout/start_over_preference.xml"
+            line="10"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot; />"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/CalypsoTheme`)">
         <location
-            file="../WordPress/src/main/res/layout/stats_insights_header_line.xml"
-            line="5"
-            column="5"/>
+            file="src/main/res/layout/stats_activity_view_all.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/grey_lighten_30&quot; />"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/stats_vertical_line.xml"
-            line="4"
-            column="5"/>
+            file="src/main/res/layout/stats_insights_header_line.xml"
+            line="5"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `?attr/colorPrimary` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;?attr/colorPrimary&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/grey_lighten_30` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/toolbar.xml"
-            line="8"
-            column="5"/>
+            file="src/main/res/layout/stats_vertical_line.xml"
+            line="4"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/blue_wordpress` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/blue_wordpress&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?attr/colorPrimary` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/toolbar_login.xml"
-            line="8"
-            column="5"/>
+            file="src/main/res/layout/toolbar.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/login_toolbar_color` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/login_toolbar_color&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/blue_wordpress` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/toolbar_login.xml"
-            line="9"
-            column="5"/>
+            file="src/main/res/layout/toolbar_login.xml"
+            line="8"/>
     </issue>
 
     <issue
         id="Overdraw"
-        severity="Warning"
-        message="Possible overdraw: Root element paints background `@color/color_primary` with a theme that also paints a background (inferred theme is `@style/WordPress`)"
-        category="Performance"
-        priority="3"
-        summary="Overdraw: Painting regions more than once"
-        explanation="If you set a background drawable on a root view, then you should use a custom theme where the theme background is null. Otherwise, the theme background will be painted first, only to have your custom background completely cover it; this is called &quot;overdraw&quot;.&#xA;&#xA;NOTE: This detector relies on figuring out which layouts are associated with which activities based on scanning the Java code, and it&apos;s currently doing that using an inexact pattern matching algorithm. Therefore, it can incorrectly conclude which activity the layout is associated with and then wrongly complain that a background-theme is hidden.&#xA;&#xA;If you want your custom background on multiple pages, then you should consider making a custom theme with your custom background and just using that theme instead of a root element background.&#xA;&#xA;Of course it&apos;s possible that your custom drawable is translucent and you want it to be mixed with the background. However, you will get better performance if you pre-mix the background with your drawable and use that resulting image or color as a custom theme background instead."
-        errorLine1="    android:background=&quot;@color/color_primary&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `@color/login_toolbar_color` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
         <location
-            file="../WordPress/src/main/res/layout/toolbar_main.xml"
-            line="8"
-            column="5"/>
+            file="/Users/mariozorz/proyectos/WordPress-Android/libs/login/WordPressLoginFlow/src/main/res/layout/toolbar_login.xml"
+            line="9"/>
+    </issue>
+
+    <issue
+        id="Overdraw"
+        message="Possible overdraw: Root element paints background `@color/color_primary` with a theme that also paints a background (inferred theme is `@style/WordPress`)">
+        <location
+            file="src/main/res/layout/toolbar_main.xml"
+            line="8"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.fragment_tag_reader_post_list` appears to be unused">
+        <location
+            file="src/main/res/values/key_strings.xml"
+            line="6"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_refresh_pages` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1395"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="1562"/>
+        <location
+            file="src/main/res/values-az/strings.xml"
+            line="199"/>
+        <location
+            file="src/main/res/values-bg/strings.xml"
+            line="875"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="1562"/>
+        <location
+            file="src/main/res/values-cy/strings.xml"
+            line="612"/>
+        <location
+            file="src/main/res/values-da/strings.xml"
+            line="244"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1617"/>
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="1012"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1617"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1617"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1620"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1617"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1617"/>
+        <location
+            file="src/main/res/values-es-rCO/strings.xml"
+            line="915"/>
+        <location
+            file="src/main/res/values-es-rVE/strings.xml"
+            line="587"/>
+        <location
+            file="src/main/res/values-eu/strings.xml"
+            line="370"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1617"/>
+        <location
+            file="src/main/res/values-gd/strings.xml"
+            line="216"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="655"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1616"/>
+        <location
+            file="src/main/res/values-hi/strings.xml"
+            line="266"/>
+        <location
+            file="src/main/res/values-hr/strings.xml"
+            line="407"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="1578"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="1578"/>
+        <location
+            file="src/main/res/values-is/strings.xml"
+            line="650"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1617"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1616"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1616"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1616"/>
+        <location
+            file="src/main/res/values-mk/strings.xml"
+            line="128"/>
+        <location
+            file="src/main/res/values-ms/strings.xml"
+            line="951"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="1530"/>
+        <location
+            file="src/main/res/values-nl/strings.xml"
+            line="1551"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1613"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1617"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1617"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1617"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1617"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1617"/>
+        <location
+            file="src/main/res/values-sr/strings.xml"
+            line="213"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1617"/>
+        <location
+            file="src/main/res/values-th/strings.xml"
+            line="356"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1617"/>
+        <location
+            file="src/main/res/values-vi/strings.xml"
+            line="593"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="1606"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1606"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1602"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1602"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.reader_title_blog_preview` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1484"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="1547"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="1547"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1602"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1602"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1602"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1596"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1602"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1602"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1602"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="640"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-hr/strings.xml"
+            line="389"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="1563"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="1563"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1602"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="1515"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1602"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1602"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1602"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1602"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1602"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1602"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1602"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="1591"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1591"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1584"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1584"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.reader_title_tag_preview` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1485"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="1546"/>
+        <location
+            file="src/main/res/values-bg/strings.xml"
+            line="868"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="1546"/>
+        <location
+            file="src/main/res/values-cy/strings.xml"
+            line="594"/>
+        <location
+            file="src/main/res/values-da/strings.xml"
+            line="229"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="981"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1592"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-es-rCO/strings.xml"
+            line="900"/>
+        <location
+            file="src/main/res/values-es-rVE/strings.xml"
+            line="569"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-gd/strings.xml"
+            line="197"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="639"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1600"/>
+        <location
+            file="src/main/res/values-hi/strings.xml"
+            line="242"/>
+        <location
+            file="src/main/res/values-hr/strings.xml"
+            line="380"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="1562"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="1562"/>
+        <location
+            file="src/main/res/values-is/strings.xml"
+            line="632"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1600"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1600"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1600"/>
+        <location
+            file="src/main/res/values-ms/strings.xml"
+            line="936"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="1514"/>
+        <location
+            file="src/main/res/values-nl/strings.xml"
+            line="1536"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1597"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-sr/strings.xml"
+            line="194"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-th/strings.xml"
+            line="329"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1601"/>
+        <location
+            file="src/main/res/values-vi/strings.xml"
+            line="568"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="1590"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1590"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1574"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1574"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.reader_title_post_detail_wpcom` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1487"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="953"/>
+        <location
+            file="src/main/res/values-bg/strings.xml"
+            line="305"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="952"/>
+        <location
+            file="src/main/res/values-cy/strings.xml"
+            line="44"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="397"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-es-rCO/strings.xml"
+            line="337"/>
+        <location
+            file="src/main/res/values-es-rVE/strings.xml"
+            line="17"/>
+        <location
+            file="src/main/res/values-eu/strings.xml"
+            line="17"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="45"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-hi/strings.xml"
+            line="89"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="973"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="973"/>
+        <location
+            file="src/main/res/values-is/strings.xml"
+            line="79"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-ms/strings.xml"
+            line="373"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="920"/>
+        <location
+            file="src/main/res/values-nl/strings.xml"
+            line="957"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1003"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1007"/>
+        <location
+            file="src/main/res/values-vi/strings.xml"
+            line="23"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="997"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="997"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1002"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1002"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.reader_title_related_post_detail` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1488"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="1048"/>
+        <location
+            file="src/main/res/values-bg/strings.xml"
+            line="398"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="1047"/>
+        <location
+            file="src/main/res/values-cy/strings.xml"
+            line="132"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="492"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-es-rCO/strings.xml"
+            line="430"/>
+        <location
+            file="src/main/res/values-es-rVE/strings.xml"
+            line="105"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="140"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="1068"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="1068"/>
+        <location
+            file="src/main/res/values-is/strings.xml"
+            line="167"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-ms/strings.xml"
+            line="466"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="1015"/>
+        <location
+            file="src/main/res/values-nl/strings.xml"
+            line="1051"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1098"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1102"/>
+        <location
+            file="src/main/res/values-vi/strings.xml"
+            line="88"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="1092"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1092"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1094"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1094"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.reader_page_followed_tags` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1494"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="1544"/>
+        <location
+            file="src/main/res/values-az/strings.xml"
+            line="179"/>
+        <location
+            file="src/main/res/values-bg/strings.xml"
+            line="865"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="1544"/>
+        <location
+            file="src/main/res/values-cy/strings.xml"
+            line="593"/>
+        <location
+            file="src/main/res/values-da/strings.xml"
+            line="228"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1599"/>
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="982"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1599"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1599"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1591"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1599"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1599"/>
+        <location
+            file="src/main/res/values-es-rCO/strings.xml"
+            line="899"/>
+        <location
+            file="src/main/res/values-es-rVE/strings.xml"
+            line="566"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1599"/>
+        <location
+            file="src/main/res/values-gd/strings.xml"
+            line="196"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="637"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-hi/strings.xml"
+            line="245"/>
+        <location
+            file="src/main/res/values-hr/strings.xml"
+            line="378"/>
+        <location
+            file="src/main/res/values-hu/strings.xml"
+            line="48"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="1560"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="1560"/>
+        <location
+            file="src/main/res/values-is/strings.xml"
+            line="630"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1599"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-mk/strings.xml"
+            line="102"/>
+        <location
+            file="src/main/res/values-ms/strings.xml"
+            line="935"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="1512"/>
+        <location
+            file="src/main/res/values-nl/strings.xml"
+            line="1535"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1595"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1599"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1599"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1599"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1599"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1599"/>
+        <location
+            file="src/main/res/values-sr/strings.xml"
+            line="193"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1599"/>
+        <location
+            file="src/main/res/values-th/strings.xml"
+            line="328"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1599"/>
+        <location
+            file="src/main/res/values-vi/strings.xml"
+            line="569"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="1588"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1588"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1573"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1573"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.reader_page_followed_blogs` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1495"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="1543"/>
+        <location
+            file="src/main/res/values-az/strings.xml"
+            line="181"/>
+        <location
+            file="src/main/res/values-bg/strings.xml"
+            line="866"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="1543"/>
+        <location
+            file="src/main/res/values-cy/strings.xml"
+            line="595"/>
+        <location
+            file="src/main/res/values-da/strings.xml"
+            line="227"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="983"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1593"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-es-rCO/strings.xml"
+            line="898"/>
+        <location
+            file="src/main/res/values-es-rVE/strings.xml"
+            line="567"/>
+        <location
+            file="src/main/res/values-eu/strings.xml"
+            line="363"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-gd/strings.xml"
+            line="198"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="636"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1597"/>
+        <location
+            file="src/main/res/values-hi/strings.xml"
+            line="244"/>
+        <location
+            file="src/main/res/values-hr/strings.xml"
+            line="381"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="1559"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="1559"/>
+        <location
+            file="src/main/res/values-is/strings.xml"
+            line="629"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1597"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1597"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1597"/>
+        <location
+            file="src/main/res/values-ms/strings.xml"
+            line="934"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="1511"/>
+        <location
+            file="src/main/res/values-nl/strings.xml"
+            line="1534"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-sr/strings.xml"
+            line="195"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-th/strings.xml"
+            line="330"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1598"/>
+        <location
+            file="src/main/res/values-vi/strings.xml"
+            line="570"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="1587"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1587"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1575"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1575"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.reader_page_recommended_blogs` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1496"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="1435"/>
+        <location
+            file="src/main/res/values-bg/strings.xml"
+            line="767"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="1435"/>
+        <location
+            file="src/main/res/values-cy/strings.xml"
+            line="505"/>
+        <location
+            file="src/main/res/values-da/strings.xml"
+            line="130"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1490"/>
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="880"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1490"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1490"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1498"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1490"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1490"/>
+        <location
+            file="src/main/res/values-es-rCO/strings.xml"
+            line="800"/>
+        <location
+            file="src/main/res/values-es-rVE/strings.xml"
+            line="470"/>
+        <location
+            file="src/main/res/values-eu/strings.xml"
+            line="311"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1490"/>
+        <location
+            file="src/main/res/values-gd/strings.xml"
+            line="110"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="528"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1489"/>
+        <location
+            file="src/main/res/values-hr/strings.xml"
+            line="286"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="1453"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="1453"/>
+        <location
+            file="src/main/res/values-is/strings.xml"
+            line="539"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1490"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1489"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1489"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1489"/>
+        <location
+            file="src/main/res/values-ms/strings.xml"
+            line="836"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="1403"/>
+        <location
+            file="src/main/res/values-nl/strings.xml"
+            line="1436"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1486"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1490"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1490"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1490"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1490"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1490"/>
+        <location
+            file="src/main/res/values-sr/strings.xml"
+            line="107"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1490"/>
+        <location
+            file="src/main/res/values-th/strings.xml"
+            line="240"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1490"/>
+        <location
+            file="src/main/res/values-vi/strings.xml"
+            line="474"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="1479"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1479"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1480"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1480"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.reader_label_added_tag` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1529"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="1661"/>
+        <location
+            file="src/main/res/values-az/strings.xml"
+            line="282"/>
+        <location
+            file="src/main/res/values-bg/strings.xml"
+            line="978"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="1661"/>
+        <location
+            file="src/main/res/values-cy/strings.xml"
+            line="704"/>
+        <location
+            file="src/main/res/values-da/strings.xml"
+            line="329"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1716"/>
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="1105"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1716"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1716"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1718"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1716"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1716"/>
+        <location
+            file="src/main/res/values-es-rCO/strings.xml"
+            line="1013"/>
+        <location
+            file="src/main/res/values-es-rVE/strings.xml"
+            line="672"/>
+        <location
+            file="src/main/res/values-eu/strings.xml"
+            line="464"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1716"/>
+        <location
+            file="src/main/res/values-gd/strings.xml"
+            line="302"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="752"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-hi/strings.xml"
+            line="344"/>
+        <location
+            file="src/main/res/values-hr/strings.xml"
+            line="497"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="1677"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="1677"/>
+        <location
+            file="src/main/res/values-is/strings.xml"
+            line="735"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1716"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-mk/strings.xml"
+            line="210"/>
+        <location
+            file="src/main/res/values-ms/strings.xml"
+            line="1047"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="1628"/>
+        <location
+            file="src/main/res/values-nl/strings.xml"
+            line="1650"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1712"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1716"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1716"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1716"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1716"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1716"/>
+        <location
+            file="src/main/res/values-sr/strings.xml"
+            line="304"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1716"/>
+        <location
+            file="src/main/res/values-th/strings.xml"
+            line="437"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1716"/>
+        <location
+            file="src/main/res/values-uz/strings.xml"
+            line="31"/>
+        <location
+            file="src/main/res/values-vi/strings.xml"
+            line="678"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="1705"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1705"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1692"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1692"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.reader_label_removed_tag` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1530"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="1660"/>
+        <location
+            file="src/main/res/values-az/strings.xml"
+            line="283"/>
+        <location
+            file="src/main/res/values-bg/strings.xml"
+            line="979"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="1660"/>
+        <location
+            file="src/main/res/values-cy/strings.xml"
+            line="703"/>
+        <location
+            file="src/main/res/values-da/strings.xml"
+            line="328"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="1111"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1719"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-es-rCO/strings.xml"
+            line="1004"/>
+        <location
+            file="src/main/res/values-es-rVE/strings.xml"
+            line="673"/>
+        <location
+            file="src/main/res/values-eu/strings.xml"
+            line="475"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-gd/strings.xml"
+            line="303"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="751"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1714"/>
+        <location
+            file="src/main/res/values-hi/strings.xml"
+            line="351"/>
+        <location
+            file="src/main/res/values-hr/strings.xml"
+            line="498"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="1676"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="1676"/>
+        <location
+            file="src/main/res/values-is/strings.xml"
+            line="745"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1714"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1714"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1714"/>
+        <location
+            file="src/main/res/values-mk/strings.xml"
+            line="198"/>
+        <location
+            file="src/main/res/values-ms/strings.xml"
+            line="1046"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="1627"/>
+        <location
+            file="src/main/res/values-nl/strings.xml"
+            line="1649"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1711"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-sr/strings.xml"
+            line="303"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-th/strings.xml"
+            line="438"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1715"/>
+        <location
+            file="src/main/res/values-uz/strings.xml"
+            line="32"/>
+        <location
+            file="src/main/res/values-vi/strings.xml"
+            line="671"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="1704"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1704"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1693"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1693"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.reader_label_followed_blog` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1532"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="1541"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="1541"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1596"/>
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="986"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1596"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1596"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1597"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1596"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1596"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1596"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="634"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1595"/>
+        <location
+            file="src/main/res/values-hr/strings.xml"
+            line="388"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="1557"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="1557"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1596"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1595"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1595"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1595"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="1509"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1592"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1596"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1596"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1596"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1596"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1596"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1596"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1596"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="1585"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1585"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1578"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1578"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.reader_toast_err_tag_exists` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1565"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="1656"/>
+        <location
+            file="src/main/res/values-az/strings.xml"
+            line="289"/>
+        <location
+            file="src/main/res/values-bg/strings.xml"
+            line="981"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="1656"/>
+        <location
+            file="src/main/res/values-cy/strings.xml"
+            line="699"/>
+        <location
+            file="src/main/res/values-da/strings.xml"
+            line="324"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1711"/>
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="1106"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1711"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1711"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1711"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1711"/>
+        <location
+            file="src/main/res/values-es-rCO/strings.xml"
+            line="1006"/>
+        <location
+            file="src/main/res/values-es-rVE/strings.xml"
+            line="677"/>
+        <location
+            file="src/main/res/values-eu/strings.xml"
+            line="478"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1711"/>
+        <location
+            file="src/main/res/values-gd/strings.xml"
+            line="307"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="747"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-hi/strings.xml"
+            line="355"/>
+        <location
+            file="src/main/res/values-hr/strings.xml"
+            line="502"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="1672"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="1672"/>
+        <location
+            file="src/main/res/values-is/strings.xml"
+            line="741"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1711"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-mk/strings.xml"
+            line="204"/>
+        <location
+            file="src/main/res/values-ms/strings.xml"
+            line="1042"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="1623"/>
+        <location
+            file="src/main/res/values-nl/strings.xml"
+            line="1645"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1707"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1711"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1711"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1711"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1711"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1711"/>
+        <location
+            file="src/main/res/values-sr/strings.xml"
+            line="299"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1711"/>
+        <location
+            file="src/main/res/values-th/strings.xml"
+            line="434"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1711"/>
+        <location
+            file="src/main/res/values-uz/strings.xml"
+            line="26"/>
+        <location
+            file="src/main/res/values-vi/strings.xml"
+            line="684"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="1700"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1700"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1700"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1700"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.reader_toast_err_tag_invalid` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1566"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="1655"/>
+        <location
+            file="src/main/res/values-az/strings.xml"
+            line="290"/>
+        <location
+            file="src/main/res/values-bg/strings.xml"
+            line="972"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="1655"/>
+        <location
+            file="src/main/res/values-cy/strings.xml"
+            line="698"/>
+        <location
+            file="src/main/res/values-da/strings.xml"
+            line="323"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="1107"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1711"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-es-rCO/strings.xml"
+            line="1011"/>
+        <location
+            file="src/main/res/values-es-rVE/strings.xml"
+            line="678"/>
+        <location
+            file="src/main/res/values-eu/strings.xml"
+            line="465"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-gd/strings.xml"
+            line="308"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="746"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1709"/>
+        <location
+            file="src/main/res/values-hi/strings.xml"
+            line="357"/>
+        <location
+            file="src/main/res/values-hr/strings.xml"
+            line="503"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="1671"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="1671"/>
+        <location
+            file="src/main/res/values-is/strings.xml"
+            line="742"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1709"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1709"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1709"/>
+        <location
+            file="src/main/res/values-mk/strings.xml"
+            line="205"/>
+        <location
+            file="src/main/res/values-ms/strings.xml"
+            line="1041"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="1622"/>
+        <location
+            file="src/main/res/values-nl/strings.xml"
+            line="1644"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1706"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-sr/strings.xml"
+            line="298"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-th/strings.xml"
+            line="435"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1710"/>
+        <location
+            file="src/main/res/values-uz/strings.xml"
+            line="27"/>
+        <location
+            file="src/main/res/values-vi/strings.xml"
+            line="682"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="1699"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1699"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1701"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1701"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.reader_toast_err_add_tag` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1567"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="1578"/>
+        <location
+            file="src/main/res/values-az/strings.xml"
+            line="216"/>
+        <location
+            file="src/main/res/values-bg/strings.xml"
+            line="952"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="1578"/>
+        <location
+            file="src/main/res/values-cy/strings.xml"
+            line="626"/>
+        <location
+            file="src/main/res/values-da/strings.xml"
+            line="258"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1633"/>
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="1076"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1633"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1633"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1682"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1633"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1633"/>
+        <location
+            file="src/main/res/values-es-rCO/strings.xml"
+            line="931"/>
+        <location
+            file="src/main/res/values-es-rVE/strings.xml"
+            line="651"/>
+        <location
+            file="src/main/res/values-eu/strings.xml"
+            line="418"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1633"/>
+        <location
+            file="src/main/res/values-gd/strings.xml"
+            line="228"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="671"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1632"/>
+        <location
+            file="src/main/res/values-hi/strings.xml"
+            line="304"/>
+        <location
+            file="src/main/res/values-hr/strings.xml"
+            line="468"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-is/strings.xml"
+            line="713"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1633"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1632"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1632"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1632"/>
+        <location
+            file="src/main/res/values-mk/strings.xml"
+            line="157"/>
+        <location
+            file="src/main/res/values-ms/strings.xml"
+            line="967"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="1546"/>
+        <location
+            file="src/main/res/values-nl/strings.xml"
+            line="1567"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1629"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1633"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1633"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1633"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1633"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1633"/>
+        <location
+            file="src/main/res/values-sr/strings.xml"
+            line="236"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1633"/>
+        <location
+            file="src/main/res/values-th/strings.xml"
+            line="360"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1633"/>
+        <location
+            file="src/main/res/values-vi/strings.xml"
+            line="629"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="1622"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1622"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1668"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1668"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.reader_toast_err_already_follow_blog` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1572"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="1539"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="1539"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="988"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1602"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="632"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1593"/>
+        <location
+            file="src/main/res/values-hr/strings.xml"
+            line="384"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="1555"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="1555"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1593"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1593"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1593"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="1507"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1590"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1594"/>
+        <location
+            file="src/main/res/values-vi/strings.xml"
+            line="572"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="1583"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1583"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1580"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1580"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.reader_toast_err_follow_blog_not_found` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1574"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="1374"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="1374"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1429"/>
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="819"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1429"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1429"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1429"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1429"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1429"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1429"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="467"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-hr/strings.xml"
+            line="217"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="1393"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="1393"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1429"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="1342"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1425"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1429"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1429"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1429"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1429"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1429"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1429"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1429"/>
+        <location
+            file="src/main/res/values-vi/strings.xml"
+            line="410"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="1418"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1418"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1413"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1413"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.reader_toast_err_follow_blog_not_authorized` appears to be unused">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1575"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="1373"/>
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="1373"/>
+        <location
+            file="src/main/res/values-de/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="818"/>
+        <location
+            file="src/main/res/values-en-rAU/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-en-rCA/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-en-rGB/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-es-rCL/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-gl/strings.xml"
+            line="466"/>
+        <location
+            file="src/main/res/values-he/strings.xml"
+            line="1427"/>
+        <location
+            file="src/main/res/values-hr/strings.xml"
+            line="216"/>
+        <location
+            file="src/main/res/values-id/strings.xml"
+            line="1392"/>
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="1392"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="1427"/>
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="1427"/>
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="1427"/>
+        <location
+            file="src/main/res/values-nb/strings.xml"
+            line="1341"/>
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="1424"/>
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-ro/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-sk/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-sq/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="1428"/>
+        <location
+            file="src/main/res/values-vi/strings.xml"
+            line="409"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="1417"/>
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1417"/>
+        <location
+            file="src/main/res/values-zh-rHK/strings.xml"
+            line="1412"/>
+        <location
+            file="src/main/res/values-zh-rTW/strings.xml"
+            line="1412"/>
     </issue>
 
     <issue
         id="TypographyFractions"
-        severity="Warning"
-        message="Use fraction character ¾ (&amp;#190;) instead of 3/4 ?"
-        category="Usability:Typography"
-        priority="5"
-        summary="Fraction string can be replaced with fraction character"
-        explanation="You can replace certain strings, such as 1/2, and 1/4, with dedicated characters for these, such as ½ (&amp;#189;) and ¼ (&amp;#188;). This can help make the text more readable."
-        url="http://en.wikipedia.org/wiki/Number_Forms"
-        urls="http://en.wikipedia.org/wiki/Number_Forms"
-        errorLine1="    &lt;string name=&quot;site_creation_label_site_details_title&quot;>Adım 3/4&lt;/string>"
-        errorLine2="                                                          ^"
-        quickfix="studio">
+        message="Use fraction character ¾ (&amp;#190;) instead of 3/4 ?">
         <location
-            file="../WordPress/src/main/res/values-tr/strings.xml"
-            line="476"
-            column="59"/>
+            file="src/main/res/values-tr/strings.xml"
+            line="488"/>
     </issue>
 
     <issue
         id="TypographyFractions"
-        severity="Warning"
-        message="Use fraction character ¼ (&amp;#188;) instead of 1/4 ?"
-        category="Usability:Typography"
-        priority="5"
-        summary="Fraction string can be replaced with fraction character"
-        explanation="You can replace certain strings, such as 1/2, and 1/4, with dedicated characters for these, such as ½ (&amp;#189;) and ¼ (&amp;#188;). This can help make the text more readable."
-        url="http://en.wikipedia.org/wiki/Number_Forms"
-        urls="http://en.wikipedia.org/wiki/Number_Forms"
-        errorLine1="    &lt;string name=&quot;site_creation_label_category_title&quot;>Adım 1/4&lt;/string>"
-        errorLine2="                                                      ^"
-        quickfix="studio">
+        message="Use fraction character ¼ (&amp;#188;) instead of 1/4 ?">
         <location
-            file="../WordPress/src/main/res/values-tr/strings.xml"
-            line="487"
-            column="55"/>
+            file="src/main/res/values-tr/strings.xml"
+            line="499"/>
     </issue>
 
     <issue
         id="TypographyFractions"
-        severity="Warning"
-        message="Use fraction character ¾ (&amp;#190;) instead of 3/4 ?"
-        category="Usability:Typography"
-        priority="5"
-        summary="Fraction string can be replaced with fraction character"
-        explanation="You can replace certain strings, such as 1/2, and 1/4, with dedicated characters for these, such as ½ (&amp;#189;) and ¼ (&amp;#188;). This can help make the text more readable."
-        url="http://en.wikipedia.org/wiki/Number_Forms"
-        urls="http://en.wikipedia.org/wiki/Number_Forms"
-        errorLine1="    &lt;string name=&quot;notification_site_creation_step_tagline&quot;>Adım 3/4&lt;/string>"
-        errorLine2="                                                           ^"
-        quickfix="studio">
+        message="Use fraction character ¾ (&amp;#190;) instead of 3/4 ?">
         <location
-            file="../WordPress/src/main/res/values-tr/strings.xml"
-            line="492"
-            column="60"/>
+            file="src/main/res/values-tr/strings.xml"
+            line="504"/>
     </issue>
 
     <issue
         id="TypographyFractions"
-        severity="Warning"
-        message="Use fraction character ¼ (&amp;#188;) instead of 1/4 ?"
-        category="Usability:Typography"
-        priority="5"
-        summary="Fraction string can be replaced with fraction character"
-        explanation="You can replace certain strings, such as 1/2, and 1/4, with dedicated characters for these, such as ½ (&amp;#189;) and ¼ (&amp;#188;). This can help make the text more readable."
-        url="http://en.wikipedia.org/wiki/Number_Forms"
-        urls="http://en.wikipedia.org/wiki/Number_Forms"
-        errorLine1="    &lt;string name=&quot;notification_site_creation_step_creating&quot;>Adım 1/4&lt;/string>"
-        errorLine2="                                                            ^"
-        quickfix="studio">
+        message="Use fraction character ¼ (&amp;#188;) instead of 1/4 ?">
         <location
-            file="../WordPress/src/main/res/values-tr/strings.xml"
-            line="494"
-            column="61"/>
+            file="src/main/res/values-tr/strings.xml"
+            line="506"/>
     </issue>
 
     <issue
         id="IconXmlAndPng"
-        severity="Error"
-        message="The following images appear both as density independent `.xml` files and as bitmap files: src/main/res/drawable-anydpi/ic_checkmark_grey_32dp.xml, src/main/res/drawable-hdpi/ic_checkmark_grey_32dp.png"
-        category="Usability:Icons"
-        priority="7"
-        summary="Icon is specified both as `.xml` file and as a bitmap"
-        explanation="If a drawable resource appears as an `.xml` file in the `drawable/` folder, it&apos;s usually not intentional for it to also appear as a bitmap using the same name; generally you expect the drawable XML file to define states and each state has a corresponding drawable bitmap.">
+        message="The following images appear both as density independent `.xml` files and as bitmap files: src/main/res/drawable-anydpi/ic_checkmark_grey_32dp.xml, src/main/res/drawable-hdpi/ic_checkmark_grey_32dp.png">
         <location
-            file="../WordPress/src/main/res/drawable-xxhdpi/ic_checkmark_grey_32dp.png"/>
+            file="src/main/res/drawable-xxhdpi/ic_checkmark_grey_32dp.png"/>
         <location
-            file="../WordPress/src/main/res/drawable-xhdpi/ic_checkmark_grey_32dp.png"/>
+            file="src/main/res/drawable-xhdpi/ic_checkmark_grey_32dp.png"/>
         <location
-            file="../WordPress/src/main/res/drawable-hdpi/ic_checkmark_grey_32dp.png"/>
+            file="src/main/res/drawable-hdpi/ic_checkmark_grey_32dp.png"/>
         <location
-            file="../WordPress/src/main/res/drawable-anydpi/ic_checkmark_grey_32dp.xml"/>
+            file="src/main/res/drawable-anydpi/ic_checkmark_grey_32dp.xml"/>
     </issue>
 
     <issue
         id="IconXmlAndPng"
-        severity="Error"
-        message="The following images appear both as density independent `.xml` files and as bitmap files: src/main/res/drawable-anydpi/ic_reply_grey_32dp.xml, src/main/res/drawable-hdpi/ic_reply_grey_32dp.png"
-        category="Usability:Icons"
-        priority="7"
-        summary="Icon is specified both as `.xml` file and as a bitmap"
-        explanation="If a drawable resource appears as an `.xml` file in the `drawable/` folder, it&apos;s usually not intentional for it to also appear as a bitmap using the same name; generally you expect the drawable XML file to define states and each state has a corresponding drawable bitmap.">
+        message="The following images appear both as density independent `.xml` files and as bitmap files: src/main/res/drawable-anydpi/ic_reply_grey_32dp.xml, src/main/res/drawable-hdpi/ic_reply_grey_32dp.png">
         <location
-            file="../WordPress/src/main/res/drawable-xxhdpi/ic_reply_grey_32dp.png"/>
+            file="src/main/res/drawable-xxhdpi/ic_reply_grey_32dp.png"/>
         <location
-            file="../WordPress/src/main/res/drawable-xhdpi/ic_reply_grey_32dp.png"/>
+            file="src/main/res/drawable-xhdpi/ic_reply_grey_32dp.png"/>
         <location
-            file="../WordPress/src/main/res/drawable-hdpi/ic_reply_grey_32dp.png"/>
+            file="src/main/res/drawable-hdpi/ic_reply_grey_32dp.png"/>
         <location
-            file="../WordPress/src/main/res/drawable-anydpi/ic_reply_grey_32dp.xml"/>
+            file="src/main/res/drawable-anydpi/ic_reply_grey_32dp.xml"/>
     </issue>
 
     <issue
         id="IconXmlAndPng"
-        severity="Error"
-        message="The following images appear both as density independent `.xml` files and as bitmap files: src/main/res/drawable-anydpi/ic_star_grey_32dp.xml, src/main/res/drawable-hdpi/ic_star_grey_32dp.png"
-        category="Usability:Icons"
-        priority="7"
-        summary="Icon is specified both as `.xml` file and as a bitmap"
-        explanation="If a drawable resource appears as an `.xml` file in the `drawable/` folder, it&apos;s usually not intentional for it to also appear as a bitmap using the same name; generally you expect the drawable XML file to define states and each state has a corresponding drawable bitmap.">
+        message="The following images appear both as density independent `.xml` files and as bitmap files: src/main/res/drawable-anydpi/ic_star_grey_32dp.xml, src/main/res/drawable-hdpi/ic_star_grey_32dp.png">
         <location
-            file="../WordPress/src/main/res/drawable-xxhdpi/ic_star_grey_32dp.png"/>
+            file="src/main/res/drawable-xxhdpi/ic_star_grey_32dp.png"/>
         <location
-            file="../WordPress/src/main/res/drawable-xhdpi/ic_star_grey_32dp.png"/>
+            file="src/main/res/drawable-xhdpi/ic_star_grey_32dp.png"/>
         <location
-            file="../WordPress/src/main/res/drawable-hdpi/ic_star_grey_32dp.png"/>
+            file="src/main/res/drawable-hdpi/ic_star_grey_32dp.png"/>
         <location
-            file="../WordPress/src/main/res/drawable-anydpi/ic_star_grey_32dp.xml"/>
+            file="src/main/res/drawable-anydpi/ic_star_grey_32dp.xml"/>
+    </issue>
+
+    <issue
+        id="IconColors"
+        message="Action Bar icons should use a single gray color (`#333333` for light themes (with 60%/30% opacity for enabled/disabled), and `#FFFFFF` with opacity 80%/30% for dark themes">
+        <location
+            file="src/main/res/drawable-hdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconColors"
+        message="Action Bar icons should use a single gray color (`#333333` for light themes (with 60%/30% opacity for enabled/disabled), and `#FFFFFF` with opacity 80%/30% for dark themes">
+        <location
+            file="src/main/res/drawable-mdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconColors"
+        message="Action Bar icons should use a single gray color (`#333333` for light themes (with 60%/30% opacity for enabled/disabled), and `#FFFFFF` with opacity 80%/30% for dark themes">
+        <location
+            file="src/main/res/drawable-xhdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconColors"
+        message="Action Bar icons should use a single gray color (`#333333` for light themes (with 60%/30% opacity for enabled/disabled), and `#FFFFFF` with opacity 80%/30% for dark themes">
+        <location
+            file="src/main/res/drawable-xxhdpi/ic_launcher.png"/>
     </issue>
 
     <issue
         id="IconDensities"
-        severity="Warning"
-        message="Missing the following drawables in `drawable-hdpi`: rppreview1.png, rppreview2.png, rppreview3.png"
-        category="Usability:Icons"
-        priority="4"
-        summary="Icon densities validation"
-        explanation="Icons will look best if a custom version is provided for each of the major screen density classes (low, medium, high, extra high). This lint check identifies icons which do not have complete coverage across the densities.&#xA;&#xA;Low density is not really used much anymore, so this check ignores the ldpi density. To force lint to include it, set the environment variable `ANDROID_LINT_INCLUDE_LDPI=true`. For more information on current density usage, see http://developer.android.com/resources/dashboard/screens.html"
-        url="http://developer.android.com/guide/practices/screens_support.html"
-        urls="http://developer.android.com/guide/practices/screens_support.html">
+        message="Missing the following drawables in `drawable-hdpi`: rppreview1.png, rppreview2.png, rppreview3.png">
         <location
-            file="../WordPress/src/main/res/drawable-hdpi"/>
+            file="src/main/res/drawable-hdpi"/>
     </issue>
 
     <issue
         id="IconDensities"
-        severity="Warning"
-        message="Missing the following drawables in `drawable-xxhdpi`: btn_cab_done_default_wordpress.9.png, btn_cab_done_focused_wordpress.9.png, btn_cab_done_pressed_wordpress.9.png, list_focused_wordpress.9.png, menu_dropdown_panel_wordpress.9.png... (4 more)"
-        category="Usability:Icons"
-        priority="4"
-        summary="Icon densities validation"
-        explanation="Icons will look best if a custom version is provided for each of the major screen density classes (low, medium, high, extra high). This lint check identifies icons which do not have complete coverage across the densities.&#xA;&#xA;Low density is not really used much anymore, so this check ignores the ldpi density. To force lint to include it, set the environment variable `ANDROID_LINT_INCLUDE_LDPI=true`. For more information on current density usage, see http://developer.android.com/resources/dashboard/screens.html"
-        url="http://developer.android.com/guide/practices/screens_support.html"
-        urls="http://developer.android.com/guide/practices/screens_support.html">
+        message="Missing the following drawables in `drawable-xxhdpi`: btn_cab_done_default_wordpress.9.png, btn_cab_done_focused_wordpress.9.png, btn_cab_done_pressed_wordpress.9.png, list_focused_wordpress.9.png, menu_dropdown_panel_wordpress.9.png... (4 more)">
         <location
-            file="../WordPress/src/main/res/drawable-xxhdpi"/>
+            file="src/main/res/drawable-xxhdpi"/>
     </issue>
 
     <issue
         id="IconDensities"
-        severity="Warning"
-        message="Missing the following drawables in `drawable-xxhdpi`: list_focused_wordpress.9.png (found in drawable-hdpi, drawable-xhdpi)"
-        category="Usability:Icons"
-        priority="4"
-        summary="Icon densities validation"
-        explanation="Icons will look best if a custom version is provided for each of the major screen density classes (low, medium, high, extra high). This lint check identifies icons which do not have complete coverage across the densities.&#xA;&#xA;Low density is not really used much anymore, so this check ignores the ldpi density. To force lint to include it, set the environment variable `ANDROID_LINT_INCLUDE_LDPI=true`. For more information on current density usage, see http://developer.android.com/resources/dashboard/screens.html"
-        url="http://developer.android.com/guide/practices/screens_support.html"
-        urls="http://developer.android.com/guide/practices/screens_support.html">
+        message="Missing the following drawables in `drawable-xxhdpi`: list_focused_wordpress.9.png (found in drawable-hdpi, drawable-xhdpi)">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/drawable-xxhdpi"/>
+            file="src/main/res/drawable-xxhdpi"/>
     </issue>
 
     <issue
         id="IconMissingDensityFolder"
-        severity="Warning"
-        message="Missing density variation folders in `src/main/res`: drawable-mdpi"
-        category="Usability:Icons"
-        priority="3"
-        summary="Missing density folder"
-        explanation="Icons will look best if a custom version is provided for each of the major screen density classes (low, medium, high, extra-high, extra-extra-high). This lint check identifies folders which are missing, such as `drawable-hdpi`.&#xA;&#xA;Low density is not really used much anymore, so this check ignores the ldpi density. To force lint to include it, set the environment variable `ANDROID_LINT_INCLUDE_LDPI=true`. For more information on current density usage, see http://developer.android.com/resources/dashboard/screens.html"
-        url="http://developer.android.com/guide/practices/screens_support.html"
-        urls="http://developer.android.com/guide/practices/screens_support.html">
+        message="Missing density variation folders in `src/main/res`: drawable-mdpi">
         <location
-            file="../WordPress/src/main/res"/>
+            file="src/main/res"/>
     </issue>
 
     <issue
         id="IconMissingDensityFolder"
-        severity="Warning"
-        message="Missing density variation folders in `src/main/res`: drawable-mdpi"
-        category="Usability:Icons"
-        priority="3"
-        summary="Missing density folder"
-        explanation="Icons will look best if a custom version is provided for each of the major screen density classes (low, medium, high, extra-high, extra-extra-high). This lint check identifies folders which are missing, such as `drawable-hdpi`.&#xA;&#xA;Low density is not really used much anymore, so this check ignores the ldpi density. To force lint to include it, set the environment variable `ANDROID_LINT_INCLUDE_LDPI=true`. For more information on current density usage, see http://developer.android.com/resources/dashboard/screens.html"
-        url="http://developer.android.com/guide/practices/screens_support.html"
-        urls="http://developer.android.com/guide/practices/screens_support.html">
+        message="Missing density variation folders in `src/main/res`: drawable-mdpi">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res"/>
+            file="src/main/res"/>
     </issue>
 
     <issue
         id="IconMissingDensityFolder"
-        severity="Warning"
-        message="Missing density variation folders in `src/main/res`: drawable-mdpi"
-        category="Usability:Icons"
-        priority="3"
-        summary="Missing density folder"
-        explanation="Icons will look best if a custom version is provided for each of the major screen density classes (low, medium, high, extra-high, extra-extra-high). This lint check identifies folders which are missing, such as `drawable-hdpi`.&#xA;&#xA;Low density is not really used much anymore, so this check ignores the ldpi density. To force lint to include it, set the environment variable `ANDROID_LINT_INCLUDE_LDPI=true`. For more information on current density usage, see http://developer.android.com/resources/dashboard/screens.html"
-        url="http://developer.android.com/guide/practices/screens_support.html"
-        urls="http://developer.android.com/guide/practices/screens_support.html">
+        message="Missing density variation folders in `src/main/res`: drawable-mdpi">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res"/>
+            file="src/main/res"/>
+    </issue>
+
+    <issue
+        id="GoogleAppIndexingWarning"
+        message="App is not indexable by Google Search; consider adding at least one Activity with an ACTION-VIEW intent filter. See issue explanation for more details.">
+        <location
+            file="src/debug/AndroidManifest.xml"
+            line="7"/>
+    </issue>
+
+    <issue
+        id="TextFields"
+        message="This text field does not specify an `inputType`">
+        <location
+            file="src/main/res/layout/site_creation_domain_input.xml"
+            line="10"/>
     </issue>
 
     <issue
         id="AlwaysShowAction"
-        severity="Warning"
-        message="Prefer &quot;`ifRoom`&quot; instead of &quot;`always`&quot;"
-        category="Usability"
-        priority="3"
-        summary="Usage of `showAsAction=always`"
-        explanation="Using `showAsAction=&quot;always&quot;` in menu XML, or `MenuItem.SHOW_AS_ACTION_ALWAYS` in Java code is usually a deviation from the user interface style guide.Use `ifRoom` or the corresponding `MenuItem.SHOW_AS_ACTION_IF_ROOM` instead.&#xA;&#xA;If `always` is used sparingly there are usually no problems and behavior is roughly equivalent to `ifRoom` but with preference over other `ifRoom` items. Using it more than twice in the same menu is a bad idea.&#xA;&#xA;This check looks for menu XML files that contain more than two `always` actions, or some `always` actions and no `ifRoom` actions. In Java code, it looks for projects that contain references to `MenuItem.SHOW_AS_ACTION_ALWAYS` and no references to `MenuItem.SHOW_AS_ACTION_IF_ROOM`."
-        url="http://developer.android.com/design/patterns/actionbar.html"
-        urls="http://developer.android.com/design/patterns/actionbar.html"
-        errorLine1="        app:showAsAction=&quot;always&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Prefer &quot;`ifRoom`&quot; instead of &quot;`always`&quot;">
         <location
-            file="../WordPress/src/main/res/menu/edit_post_legacy.xml"
-            line="7"
-            column="9"/>
+            file="src/main/res/menu/edit_post_legacy.xml"
+            line="7"/>
         <location
-            file="../WordPress/src/main/res/menu/edit_post_legacy.xml"
-            line="11"
-            column="9"/>
+            file="src/main/res/menu/edit_post_legacy.xml"
+            line="11"/>
     </issue>
 
     <issue
         id="AlwaysShowAction"
-        severity="Warning"
-        message="Prefer &quot;`ifRoom`&quot; instead of &quot;`always`&quot;"
-        category="Usability"
-        priority="3"
-        summary="Usage of `showAsAction=always`"
-        explanation="Using `showAsAction=&quot;always&quot;` in menu XML, or `MenuItem.SHOW_AS_ACTION_ALWAYS` in Java code is usually a deviation from the user interface style guide.Use `ifRoom` or the corresponding `MenuItem.SHOW_AS_ACTION_IF_ROOM` instead.&#xA;&#xA;If `always` is used sparingly there are usually no problems and behavior is roughly equivalent to `ifRoom` but with preference over other `ifRoom` items. Using it more than twice in the same menu is a bad idea.&#xA;&#xA;This check looks for menu XML files that contain more than two `always` actions, or some `always` actions and no `ifRoom` actions. In Java code, it looks for projects that contain references to `MenuItem.SHOW_AS_ACTION_ALWAYS` and no references to `MenuItem.SHOW_AS_ACTION_IF_ROOM`."
-        url="http://developer.android.com/design/patterns/actionbar.html"
-        urls="http://developer.android.com/design/patterns/actionbar.html"
-        errorLine1="        app:showAsAction=&quot;always&quot; />"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Prefer &quot;`ifRoom`&quot; instead of &quot;`always`&quot;">
         <location
-            file="../WordPress/src/main/res/menu/reader_detail.xml"
-            line="9"
-            column="9"/>
+            file="src/main/res/menu/reader_detail.xml"
+            line="9"/>
         <location
-            file="../WordPress/src/main/res/menu/reader_detail.xml"
-            line="15"
-            column="9"/>
+            file="src/main/res/menu/reader_detail.xml"
+            line="15"/>
     </issue>
 
     <issue
         id="AlwaysShowAction"
-        severity="Warning"
-        message="Prefer &quot;`ifRoom`&quot; instead of &quot;`always`&quot;"
-        category="Usability"
-        priority="3"
-        summary="Usage of `showAsAction=always`"
-        explanation="Using `showAsAction=&quot;always&quot;` in menu XML, or `MenuItem.SHOW_AS_ACTION_ALWAYS` in Java code is usually a deviation from the user interface style guide.Use `ifRoom` or the corresponding `MenuItem.SHOW_AS_ACTION_IF_ROOM` instead.&#xA;&#xA;If `always` is used sparingly there are usually no problems and behavior is roughly equivalent to `ifRoom` but with preference over other `ifRoom` items. Using it more than twice in the same menu is a bad idea.&#xA;&#xA;This check looks for menu XML files that contain more than two `always` actions, or some `always` actions and no `ifRoom` actions. In Java code, it looks for projects that contain references to `MenuItem.SHOW_AS_ACTION_ALWAYS` and no references to `MenuItem.SHOW_AS_ACTION_IF_ROOM`."
-        url="http://developer.android.com/design/patterns/actionbar.html"
-        urls="http://developer.android.com/design/patterns/actionbar.html"
-        errorLine1="        app:showAsAction=&quot;always&quot; />"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Prefer &quot;`ifRoom`&quot; instead of &quot;`always`&quot;">
         <location
-            file="../WordPress/src/main/res/menu/reader_list.xml"
-            line="9"
-            column="9"/>
+            file="src/main/res/menu/reader_list.xml"
+            line="9"/>
         <location
-            file="../WordPress/src/main/res/menu/reader_list.xml"
-            line="16"
-            column="9"/>
+            file="src/main/res/menu/reader_list.xml"
+            line="16"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/add_category.xml"
+            line="26"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/alert_create_link.xml"
+            line="9"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/alert_create_link.xml"
+            line="17"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/alert_image_options.xml"
+            line="15"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/alert_image_options.xml"
+            line="23"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/alert_image_options.xml"
+            line="57"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/comment_edit_activity.xml"
+            line="25"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/delete_site_dialog.xml"
+            line="7"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/dialog_image_options.xml"
+            line="61"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/dialog_image_options.xml"
+            line="76"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/dialog_image_options.xml"
+            line="90"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/dialog_image_options.xml"
+            line="122"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/dialog_image_options.xml"
+            line="156"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/dialog_link.xml"
+            line="16"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/dialog_link.xml"
+            line="34"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/fragment_edit_post_content.xml"
+            line="22"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/my_profile_dialog.xml"
+            line="29"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/people_invite_fragment.xml"
+            line="159"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/post_settings_tags_activity.xml"
+            line="18"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/reader_activity_subs.xml"
+            line="54"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/site_creation_domain_input.xml"
+            line="10"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/site_settings_format_dialog.xml"
+            line="28"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute">
+        <location
+            file="src/main/res/layout/wppref_text_dialog.xml"
+            line="19"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `ReactAztecText` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`">
+        <location
+            file="src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java"
+            line="30"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        severity="Error"
-        message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`"
-        category="Accessibility"
-        priority="6"
-        summary="Accessibility in Custom Views"
-        explanation="If a `View` that overrides `onTouchEvent` or uses an `OnTouchListener` does not also implement `performClick` and call it when clicks are detected, the `View` may not handle accessibility actions properly. Logic handling the click actions should ideally be placed in `View#performClick` as some accessibility services invoke `performClick` when a click action should occur."
-        errorLine1="        mTitle.setOnTouchListener(this);"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`">
         <location
-            file="../libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java"
-            line="233"
-            column="9"/>
+            file="src/main/java/org/wordpress/android/editor/AztecEditorFragment.java"
+            line="233"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        severity="Error"
-        message="Custom view ``AztecText`` has `setOnTouchListener` called on it but does not override `performClick`"
-        category="Accessibility"
-        priority="6"
-        summary="Accessibility in Custom Views"
-        explanation="If a `View` that overrides `onTouchEvent` or uses an `OnTouchListener` does not also implement `performClick` and call it when clicks are detected, the `View` may not handle accessibility actions properly. Logic handling the click actions should ideally be placed in `View#performClick` as some accessibility services invoke `performClick` when a click action should occur."
-        errorLine1="        mContent.setOnTouchListener(this);"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="`AztecEditorFragment#onTouch` should call `View#performClick` when a click is detected">
         <location
-            file="../libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java"
-            line="234"
-            column="9"/>
+            file="src/main/java/org/wordpress/android/editor/AztecEditorFragment.java"
+            line="1361"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        severity="Error"
-        message="Custom view ``SourceViewEditText`` has `setOnTouchListener` called on it but does not override `performClick`"
-        category="Accessibility"
-        priority="6"
-        summary="Accessibility in Custom Views"
-        explanation="If a `View` that overrides `onTouchEvent` or uses an `OnTouchListener` does not also implement `performClick` and call it when clicks are detected, the `View` may not handle accessibility actions properly. Logic handling the click actions should ideally be placed in `View#performClick` as some accessibility services invoke `performClick` when a click action should occur."
-        errorLine1="        mSource.setOnTouchListener(this);"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Custom view `CustomSwipeRefreshLayout` overrides `onTouchEvent` but not `performClick`">
         <location
-            file="../libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java"
-            line="235"
-            column="9"/>
+            file="src/main/java/org/wordpress/android/util/widgets/CustomSwipeRefreshLayout.java"
+            line="21"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        severity="Error"
-        message="`AztecEditorFragment#onTouch` should call `View#performClick` when a click is detected"
-        category="Accessibility"
-        priority="6"
-        summary="Accessibility in Custom Views"
-        explanation="If a `View` that overrides `onTouchEvent` or uses an `OnTouchListener` does not also implement `performClick` and call it when clicks are detected, the `View` may not handle accessibility actions properly. Logic handling the click actions should ideally be placed in `View#performClick` as some accessibility services invoke `performClick` when a click action should occur."
-        errorLine1="    public boolean onTouch(View view, MotionEvent event) {"
-        errorLine2="                   ~~~~~~~">
+        message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`">
         <location
-            file="../libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java"
-            line="1361"
-            column="20"/>
+            file="src/main/java/org/wordpress/android/editor/EditorFragment.java"
+            line="359"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        severity="Error"
-        message="Custom view `CustomSwipeRefreshLayout` overrides `onTouchEvent` but not `performClick`"
-        category="Accessibility"
-        priority="6"
-        summary="Accessibility in Custom Views"
-        explanation="If a `View` that overrides `onTouchEvent` or uses an `OnTouchListener` does not also implement `performClick` and call it when clicks are detected, the `View` may not handle accessibility actions properly. Logic handling the click actions should ideally be placed in `View#performClick` as some accessibility services invoke `performClick` when a click action should occur."
-        errorLine1="    public boolean onTouchEvent(MotionEvent event) {"
-        errorLine2="                   ~~~~~~~~~~~~">
+        message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`">
         <location
-            file="../libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/widgets/CustomSwipeRefreshLayout.java"
-            line="21"
-            column="20"/>
+            file="src/main/java/org/wordpress/android/editor/EditorFragment.java"
+            line="360"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        severity="Error"
-        message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`"
-        category="Accessibility"
-        priority="6"
-        summary="Accessibility in Custom Views"
-        explanation="If a `View` that overrides `onTouchEvent` or uses an `OnTouchListener` does not also implement `performClick` and call it when clicks are detected, the `View` may not handle accessibility actions properly. Logic handling the click actions should ideally be placed in `View#performClick` as some accessibility services invoke `performClick` when a click action should occur."
-        errorLine1="        mSourceViewTitle.setOnTouchListener(this);"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="`EditorFragment#onTouch` should call `View#performClick` when a click is detected">
         <location
-            file="../libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java"
-            line="359"
-            column="9"/>
+            file="src/main/java/org/wordpress/android/editor/EditorFragment.java"
+            line="797"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        severity="Error"
-        message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`"
-        category="Accessibility"
-        priority="6"
-        summary="Accessibility in Custom Views"
-        explanation="If a `View` that overrides `onTouchEvent` or uses an `OnTouchListener` does not also implement `performClick` and call it when clicks are detected, the `View` may not handle accessibility actions properly. Logic handling the click actions should ideally be placed in `View#performClick` as some accessibility services invoke `performClick` when a click action should occur."
-        errorLine1="        mSourceViewContent.setOnTouchListener(this);"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`">
         <location
-            file="../libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java"
-            line="360"
-            column="9"/>
+            file="src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java"
+            line="118"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        severity="Error"
-        message="`EditorFragment#onTouch` should call `View#performClick` when a click is detected"
-        category="Accessibility"
-        priority="6"
-        summary="Accessibility in Custom Views"
-        explanation="If a `View` that overrides `onTouchEvent` or uses an `OnTouchListener` does not also implement `performClick` and call it when clicks are detected, the `View` may not handle accessibility actions properly. Logic handling the click actions should ideally be placed in `View#performClick` as some accessibility services invoke `performClick` when a click action should occur."
-        errorLine1="    public boolean onTouch(View view, MotionEvent event) {"
-        errorLine2="                   ~~~~~~~">
+        message="`GutenbergEditorFragment#onTouch` should call `View#performClick` when a click is detected">
         <location
-            file="../libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java"
-            line="797"
-            column="20"/>
+            file="src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java"
+            line="487"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        severity="Error"
-        message="Custom view ``WPEditText`` has `setOnTouchListener` called on it but does not override `performClick`"
-        category="Accessibility"
-        priority="6"
-        summary="Accessibility in Custom Views"
-        explanation="If a `View` that overrides `onTouchEvent` or uses an `OnTouchListener` does not also implement `performClick` and call it when clicks are detected, the `View` may not handle accessibility actions properly. Logic handling the click actions should ideally be placed in `View#performClick` as some accessibility services invoke `performClick` when a click action should occur."
-        errorLine1="        mContentEditText.setOnTouchListener(this);"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Custom view ``WPEditText`` has `setOnTouchListener` called on it but does not override `performClick`">
         <location
-            file="../libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java"
-            line="218"
-            column="9"/>
+            file="src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java"
+            line="218"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        severity="Error"
-        message="`LegacyEditorFragment#onTouch` should call `View#performClick` when a click is detected"
-        category="Accessibility"
-        priority="6"
-        summary="Accessibility in Custom Views"
-        explanation="If a `View` that overrides `onTouchEvent` or uses an `OnTouchListener` does not also implement `performClick` and call it when clicks are detected, the `View` may not handle accessibility actions properly. Logic handling the click actions should ideally be placed in `View#performClick` as some accessibility services invoke `performClick` when a click action should occur."
-        errorLine1="    public boolean onTouch(View v, MotionEvent event) {"
-        errorLine2="                   ~~~~~~~">
+        message="`LegacyEditorFragment#onTouch` should call `View#performClick` when a click is detected">
         <location
-            file="../libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java"
-            line="674"
-            column="20"/>
+            file="src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java"
+            line="674"/>
     </issue>
 
     <issue
         id="ClickableViewAccessibility"
-        severity="Error"
-        message="Custom view `RippleToggleButton` overrides `onTouchEvent` but not `performClick`"
-        category="Accessibility"
-        priority="6"
-        summary="Accessibility in Custom Views"
-        explanation="If a `View` that overrides `onTouchEvent` or uses an `OnTouchListener` does not also implement `performClick` and call it when clicks are detected, the `View` may not handle accessibility actions properly. Logic handling the click actions should ideally be placed in `View#performClick` as some accessibility services invoke `performClick` when a click action should occur."
-        errorLine1="    public boolean onTouchEvent(@NonNull MotionEvent event) {"
-        errorLine2="                   ~~~~~~~~~~~~">
+        message="Custom view `RippleToggleButton` overrides `onTouchEvent` but not `performClick`">
         <location
-            file="../libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/RippleToggleButton.java"
-            line="83"
-            column="20"/>
+            file="src/main/java/org/wordpress/android/editor/RippleToggleButton.java"
+            line="83"/>
     </issue>
 
     <issue
         id="ContentDescription"
-        severity="Error"
-        message="Missing `contentDescription` attribute on image"
-        category="Accessibility"
-        priority="3"
-        summary="Image without `contentDescription`"
-        explanation="Non-textual widgets like ImageViews and ImageButtons should use the `contentDescription` attribute to specify a textual description of the widget such that screen readers and other accessibility tools can adequately describe the user interface.&#xA;&#xA;Note that elements in application screens that are purely decorative and do not provide any content or enable a user action should not have accessibility content descriptions. In this case, just suppress the lint warning with a tools:ignore=&quot;ContentDescription&quot; attribute.&#xA;&#xA;Note that for text fields, you should not set both the `hint` and the `contentDescription` attributes since the hint will never be shown. Just set the `hint`. See http://developer.android.com/guide/topics/ui/accessibility/checklist.html#special-cases."
-        errorLine1="            &lt;ImageView"
-        errorLine2="            ^"
-        quickfix="studio">
+        message="Missing `contentDescription` attribute on image">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/dialog_image_options.xml"
-            line="142"
-            column="13"/>
+            file="src/main/res/layout/dialog_image_options.xml"
+            line="142"/>
     </issue>
 
     <issue
         id="ContentDescription"
-        severity="Error"
-        message="Missing `contentDescription` attribute on image"
-        category="Accessibility"
-        priority="3"
-        summary="Image without `contentDescription`"
-        explanation="Non-textual widgets like ImageViews and ImageButtons should use the `contentDescription` attribute to specify a textual description of the widget such that screen readers and other accessibility tools can adequately describe the user interface.&#xA;&#xA;Note that elements in application screens that are purely decorative and do not provide any content or enable a user action should not have accessibility content descriptions. In this case, just suppress the lint warning with a tools:ignore=&quot;ContentDescription&quot; attribute.&#xA;&#xA;Note that for text fields, you should not set both the `hint` and the `contentDescription` attributes since the hint will never be shown. Just set the `hint`. See http://developer.android.com/guide/topics/ui/accessibility/checklist.html#special-cases."
-        errorLine1="        &lt;ImageView"
-        errorLine2="        ^"
-        quickfix="studio">
+        message="Missing `contentDescription` attribute on image">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/format_bar.xml"
-            line="104"
-            column="9"/>
+            file="src/main/res/layout/format_bar.xml"
+            line="104"/>
     </issue>
 
     <issue
         id="ContentDescription"
-        severity="Error"
-        message="Missing `contentDescription` attribute on image"
-        category="Accessibility"
-        priority="3"
-        summary="Image without `contentDescription`"
-        explanation="Non-textual widgets like ImageViews and ImageButtons should use the `contentDescription` attribute to specify a textual description of the widget such that screen readers and other accessibility tools can adequately describe the user interface.&#xA;&#xA;Note that elements in application screens that are purely decorative and do not provide any content or enable a user action should not have accessibility content descriptions. In this case, just suppress the lint warning with a tools:ignore=&quot;ContentDescription&quot; attribute.&#xA;&#xA;Note that for text fields, you should not set both the `hint` and the `contentDescription` attributes since the hint will never be shown. Just set the `hint`. See http://developer.android.com/guide/topics/ui/accessibility/checklist.html#special-cases."
-        errorLine1="            &lt;ImageView"
-        errorLine2="            ^"
-        quickfix="studio">
+        message="Missing `contentDescription` attribute on image">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/login_magic_link_request_screen.xml"
-            line="21"
-            column="13"/>
+            file="src/main/res/layout-land/login_magic_link_request_screen.xml"
+            line="21"/>
     </issue>
 
     <issue
         id="ContentDescription"
-        severity="Error"
-        message="Missing `contentDescription` attribute on image"
-        category="Accessibility"
-        priority="3"
-        summary="Image without `contentDescription`"
-        explanation="Non-textual widgets like ImageViews and ImageButtons should use the `contentDescription` attribute to specify a textual description of the widget such that screen readers and other accessibility tools can adequately describe the user interface.&#xA;&#xA;Note that elements in application screens that are purely decorative and do not provide any content or enable a user action should not have accessibility content descriptions. In this case, just suppress the lint warning with a tools:ignore=&quot;ContentDescription&quot; attribute.&#xA;&#xA;Note that for text fields, you should not set both the `hint` and the `contentDescription` attributes since the hint will never be shown. Just set the `hint`. See http://developer.android.com/guide/topics/ui/accessibility/checklist.html#special-cases."
-        errorLine1="                &lt;ImageView"
-        errorLine2="                ^"
-        quickfix="studio">
+        message="Missing `contentDescription` attribute on image">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_magic_link_request_screen.xml"
-            line="28"
-            column="17"/>
+            file="src/main/res/layout/login_magic_link_request_screen.xml"
+            line="28"/>
     </issue>
 
     <issue
         id="ContentDescription"
-        severity="Error"
-        message="Missing `contentDescription` attribute on image"
-        category="Accessibility"
-        priority="3"
-        summary="Image without `contentDescription`"
-        explanation="Non-textual widgets like ImageViews and ImageButtons should use the `contentDescription` attribute to specify a textual description of the widget such that screen readers and other accessibility tools can adequately describe the user interface.&#xA;&#xA;Note that elements in application screens that are purely decorative and do not provide any content or enable a user action should not have accessibility content descriptions. In this case, just suppress the lint warning with a tools:ignore=&quot;ContentDescription&quot; attribute.&#xA;&#xA;Note that for text fields, you should not set both the `hint` and the `contentDescription` attributes since the hint will never be shown. Just set the `hint`. See http://developer.android.com/guide/topics/ui/accessibility/checklist.html#special-cases."
-        errorLine1="            &lt;ImageView"
-        errorLine2="            ^"
-        quickfix="studio">
+        message="Missing `contentDescription` attribute on image">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_username_password_screen.xml"
-            line="29"
-            column="13"/>
+            file="src/main/res/layout/login_username_password_screen.xml"
+            line="29"/>
     </issue>
 
     <issue
         id="ContentDescription"
-        severity="Error"
-        message="Missing `contentDescription` attribute on image"
-        category="Accessibility"
-        priority="3"
-        summary="Image without `contentDescription`"
-        explanation="Non-textual widgets like ImageViews and ImageButtons should use the `contentDescription` attribute to specify a textual description of the widget such that screen readers and other accessibility tools can adequately describe the user interface.&#xA;&#xA;Note that elements in application screens that are purely decorative and do not provide any content or enable a user action should not have accessibility content descriptions. In this case, just suppress the lint warning with a tools:ignore=&quot;ContentDescription&quot; attribute.&#xA;&#xA;Note that for text fields, you should not set both the `hint` and the `contentDescription` attributes since the hint will never be shown. Just set the `hint`. See http://developer.android.com/guide/topics/ui/accessibility/checklist.html#special-cases."
-        errorLine1="            &lt;ImageView"
-        errorLine2="            ^"
-        quickfix="studio">
+        message="Missing `contentDescription` attribute on image">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_username_password_screen.xml"
-            line="37"
-            column="13"/>
+            file="src/main/res/layout/login_username_password_screen.xml"
+            line="37"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        severity="Error"
-        message="`@id/read_reviews_container` can overlap `@id/rating_bar` if @id/read_reviews_container grows due to localized text expansion"
-        category="Internationalization"
-        priority="3"
-        summary="Overlapping items in RelativeLayout"
-        explanation="If relative layout has text or button items aligned to left and right sides they can overlap each other due to localized text expansion unless they have mutual constraints like `toEndOf`/`toStartOf`."
-        errorLine1="        &lt;LinearLayout"
-        errorLine2="        ^">
+        message="`@id/read_reviews_container` can overlap `@id/rating_bar` if @id/read_reviews_container grows due to localized text expansion">
         <location
-            file="../WordPress/src/main/res/layout/plugin_ratings_cardview.xml"
-            line="27"
-            column="9"/>
+            file="src/main/res/layout/plugin_ratings_cardview.xml"
+            line="27"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        severity="Error"
-        message="`@id/text_num_downloads` can overlap `@id/text_num_ratings` if @id/text_num_ratings, @id/text_num_downloads grow due to localized text expansion"
-        category="Internationalization"
-        priority="3"
-        summary="Overlapping items in RelativeLayout"
-        explanation="If relative layout has text or button items aligned to left and right sides they can overlap each other due to localized text expansion unless they have mutual constraints like `toEndOf`/`toStartOf`."
-        errorLine1="            &lt;TextView"
-        errorLine2="            ^">
+        message="`@id/text_num_downloads` can overlap `@id/text_num_ratings` if @id/text_num_ratings, @id/text_num_downloads grow due to localized text expansion">
         <location
-            file="../WordPress/src/main/res/layout/plugin_ratings_cardview.xml"
-            line="212"
-            column="13"/>
+            file="src/main/res/layout/plugin_ratings_cardview.xml"
+            line="212"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        severity="Error"
-        message="`@id/reply_container` can overlap `@id/text_comment_date` if @id/text_comment_date, @id/reply_container grow due to localized text expansion"
-        category="Internationalization"
-        priority="3"
-        summary="Overlapping items in RelativeLayout"
-        explanation="If relative layout has text or button items aligned to left and right sides they can overlap each other due to localized text expansion unless they have mutual constraints like `toEndOf`/`toStartOf`."
-        errorLine1="            &lt;LinearLayout"
-        errorLine2="            ^">
+        message="`@id/reply_container` can overlap `@id/text_comment_date` if @id/text_comment_date, @id/reply_container grow due to localized text expansion">
         <location
-            file="../WordPress/src/main/res/layout/reader_listitem_comment.xml"
-            line="86"
-            column="13"/>
+            file="src/main/res/layout/reader_listitem_comment.xml"
+            line="86"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        severity="Error"
-        message="`@id/stats_views_totals` can overlap `@id/stats_views_label` if @string/stats_default_number_zero, @string/stats_default_number_zero grow due to localized text expansion"
-        category="Internationalization"
-        priority="3"
-        summary="Overlapping items in RelativeLayout"
-        explanation="If relative layout has text or button items aligned to left and right sides they can overlap each other due to localized text expansion unless they have mutual constraints like `toEndOf`/`toStartOf`."
-        errorLine1="                    &lt;org.wordpress.android.widgets.WPTextView"
-        errorLine2="                    ^">
+        message="`@id/stats_views_totals` can overlap `@id/stats_views_label` if @string/stats_default_number_zero, @string/stats_default_number_zero grow due to localized text expansion">
         <location
-            file="../WordPress/src/main/res/layout/stats_activity_single_post_details.xml"
-            line="73"
-            column="21"/>
+            file="src/main/res/layout/stats_activity_single_post_details.xml"
+            line="73"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        severity="Error"
-        message="`org.wordpress.android.widgets.WPTextView-3` can overlap `org.wordpress.android.widgets.WPTextView-1` if @string/stats_period, @string/stats_total grow due to localized text expansion"
-        category="Internationalization"
-        priority="3"
-        summary="Overlapping items in RelativeLayout"
-        explanation="If relative layout has text or button items aligned to left and right sides they can overlap each other due to localized text expansion unless they have mutual constraints like `toEndOf`/`toStartOf`."
-        errorLine1="                    &lt;org.wordpress.android.widgets.WPTextView"
-        errorLine2="                    ^">
+        message="`org.wordpress.android.widgets.WPTextView-3` can overlap `org.wordpress.android.widgets.WPTextView-1` if @string/stats_period, @string/stats_total grow due to localized text expansion">
         <location
-            file="../WordPress/src/main/res/layout/stats_activity_single_post_details.xml"
-            line="129"
-            column="21"/>
+            file="src/main/res/layout/stats_activity_single_post_details.xml"
+            line="129"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        severity="Error"
-        message="`org.wordpress.android.widgets.WPTextView-3` can overlap `org.wordpress.android.widgets.WPTextView-1` if @string/stats_period, @string/stats_overall grow due to localized text expansion"
-        category="Internationalization"
-        priority="3"
-        summary="Overlapping items in RelativeLayout"
-        explanation="If relative layout has text or button items aligned to left and right sides they can overlap each other due to localized text expansion unless they have mutual constraints like `toEndOf`/`toStartOf`."
-        errorLine1="                    &lt;org.wordpress.android.widgets.WPTextView"
-        errorLine2="                    ^">
+        message="`org.wordpress.android.widgets.WPTextView-3` can overlap `org.wordpress.android.widgets.WPTextView-1` if @string/stats_period, @string/stats_overall grow due to localized text expansion">
         <location
-            file="../WordPress/src/main/res/layout/stats_activity_single_post_details.xml"
-            line="191"
-            column="21"/>
+            file="src/main/res/layout/stats_activity_single_post_details.xml"
+            line="191"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        severity="Error"
-        message="`org.wordpress.android.widgets.WPTextView-3` can overlap `org.wordpress.android.widgets.WPTextView-1` if @string/stats_period, @string/stats_total grow due to localized text expansion"
-        category="Internationalization"
-        priority="3"
-        summary="Overlapping items in RelativeLayout"
-        explanation="If relative layout has text or button items aligned to left and right sides they can overlap each other due to localized text expansion unless they have mutual constraints like `toEndOf`/`toStartOf`."
-        errorLine1="                    &lt;org.wordpress.android.widgets.WPTextView"
-        errorLine2="                    ^">
+        message="`org.wordpress.android.widgets.WPTextView-3` can overlap `org.wordpress.android.widgets.WPTextView-1` if @string/stats_period, @string/stats_total grow due to localized text expansion">
         <location
-            file="../WordPress/src/main/res/layout/stats_activity_single_post_details.xml"
-            line="253"
-            column="21"/>
+            file="src/main/res/layout/stats_activity_single_post_details.xml"
+            line="253"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        severity="Error"
-        message="`@id/stats_list_totals_label` can overlap `@id/stats_list_entry_label` if @id/stats_list_entry_label, @id/stats_list_totals_label grow due to localized text expansion"
-        category="Internationalization"
-        priority="3"
-        summary="Overlapping items in RelativeLayout"
-        explanation="If relative layout has text or button items aligned to left and right sides they can overlap each other due to localized text expansion unless they have mutual constraints like `toEndOf`/`toStartOf`."
-        errorLine1="                    &lt;org.wordpress.android.widgets.WPTextView"
-        errorLine2="                    ^">
+        message="`@id/stats_list_totals_label` can overlap `@id/stats_list_entry_label` if @id/stats_list_entry_label, @id/stats_list_totals_label grow due to localized text expansion">
         <location
-            file="../WordPress/src/main/res/layout/stats_expandable_list_fragment.xml"
-            line="94"
-            column="21"/>
+            file="src/main/res/layout/stats_expandable_list_fragment.xml"
+            line="94"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        severity="Error"
-        message="`@id/stats_list_totals_label` can overlap `@id/stats_list_entry_label` if @id/stats_list_entry_label, @id/stats_list_totals_label grow due to localized text expansion"
-        category="Internationalization"
-        priority="3"
-        summary="Overlapping items in RelativeLayout"
-        explanation="If relative layout has text or button items aligned to left and right sides they can overlap each other due to localized text expansion unless they have mutual constraints like `toEndOf`/`toStartOf`."
-        errorLine1="                    &lt;org.wordpress.android.widgets.WPTextView"
-        errorLine2="                    ^">
+        message="`LinearLayout-1` can overlap `LinearLayout-3` if LinearLayout-1 grows due to localized text expansion">
         <location
-            file="../WordPress/src/main/res/layout/stats_list_fragment.xml"
-            line="92"
-            column="21"/>
+            file="src/main/res/layout-sw600dp/theme_grid_cardview_header.xml"
+            line="21"/>
     </issue>
 
     <issue
         id="RelativeOverlap"
-        severity="Error"
-        message="`LinearLayout-1` can overlap `LinearLayout-3` if LinearLayout-1 grows due to localized text expansion"
-        category="Internationalization"
-        priority="3"
-        summary="Overlapping items in RelativeLayout"
-        explanation="If relative layout has text or button items aligned to left and right sides they can overlap each other due to localized text expansion unless they have mutual constraints like `toEndOf`/`toStartOf`."
-        errorLine1="            &lt;LinearLayout"
-        errorLine2="            ^">
+        message="`LinearLayout-1` can overlap `LinearLayout-3` if LinearLayout-1 grows due to localized text expansion">
         <location
-            file="../WordPress/src/main/res/layout-sw600dp/theme_grid_cardview_header.xml"
-            line="21"
-            column="13"/>
-    </issue>
-
-    <issue
-        id="RelativeOverlap"
-        severity="Error"
-        message="`LinearLayout-1` can overlap `LinearLayout-3` if LinearLayout-1 grows due to localized text expansion"
-        category="Internationalization"
-        priority="3"
-        summary="Overlapping items in RelativeLayout"
-        explanation="If relative layout has text or button items aligned to left and right sides they can overlap each other due to localized text expansion unless they have mutual constraints like `toEndOf`/`toStartOf`."
-        errorLine1="                &lt;LinearLayout"
-        errorLine2="                ^">
-        <location
-            file="../WordPress/src/main/res/layout/theme_grid_item.xml"
-            line="46"
-            column="17"/>
+            file="src/main/res/layout/theme_grid_item.xml"
+            line="46"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        severity="Error"
-        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
-        category="Internationalization:Bidirectional Text"
-        priority="6"
-        summary="Padding and margin symmetry"
-        explanation="If you specify padding or margin on the left side of a layout, you should probably also specify padding on the right side (and vice versa) for right-to-left layout symmetry."
-        errorLine1="            android:paddingEnd=&quot;@dimen/margin_large&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry">
         <location
-            file="../WordPress/src/main/res/layout/comment_listitem.xml"
-            line="101"
-            column="13"/>
+            file="src/main/res/layout/comment_listitem.xml"
+            line="101"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        severity="Error"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
-        category="Internationalization:Bidirectional Text"
-        priority="6"
-        summary="Padding and margin symmetry"
-        explanation="If you specify padding or margin on the left side of a layout, you should probably also specify padding on the right side (and vice versa) for right-to-left layout symmetry."
-        errorLine1="        android:paddingStart=&quot;@dimen/start_over_preference_margin_small&quot;/>"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry">
         <location
-            file="../WordPress/src/main/res/layout/domain_removal_preference.xml"
-            line="15"
-            column="9"/>
+            file="src/main/res/layout/domain_removal_preference.xml"
+            line="15"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        severity="Error"
-        message="When you define `paddingLeft` you should probably also define `paddingRight` for right-to-left symmetry"
-        category="Internationalization:Bidirectional Text"
-        priority="6"
-        summary="Padding and margin symmetry"
-        explanation="If you specify padding or margin on the left side of a layout, you should probably also specify padding on the right side (and vice versa) for right-to-left layout symmetry."
-        errorLine1="            android:paddingLeft=&quot;16dp&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        message="When you define `paddingLeft` you should probably also define `paddingRight` for right-to-left symmetry">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/fragment_edit_post_content.xml"
-            line="69"
-            column="13"/>
+            file="src/main/res/layout/fragment_edit_post_content.xml"
+            line="69"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        severity="Error"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
-        category="Internationalization:Bidirectional Text"
-        priority="6"
-        summary="Padding and margin symmetry"
-        explanation="If you specify padding or margin on the left side of a layout, you should probably also specify padding on the right side (and vice versa) for right-to-left layout symmetry."
-        errorLine1="            android:paddingStart=&quot;16dp&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/fragment_edit_post_content.xml"
-            line="70"
-            column="13"/>
+            file="src/main/res/layout/fragment_edit_post_content.xml"
+            line="70"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        severity="Error"
-        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
-        category="Internationalization:Bidirectional Text"
-        priority="6"
-        summary="Padding and margin symmetry"
-        explanation="If you specify padding or margin on the left side of a layout, you should probably also specify padding on the right side (and vice versa) for right-to-left layout symmetry."
-        errorLine1="            android:paddingEnd=&quot;8dip&quot;/>"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry">
         <location
-            file="../WordPress/src/main/res/layout/home_row.xml"
-            line="44"
-            column="13"/>
+            file="src/main/res/layout/home_row.xml"
+            line="44"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        severity="Error"
-        message="When you define `paddingRight` you should probably also define `paddingLeft` for right-to-left symmetry"
-        category="Internationalization:Bidirectional Text"
-        priority="6"
-        summary="Padding and margin symmetry"
-        explanation="If you specify padding or margin on the left side of a layout, you should probably also specify padding on the right side (and vice versa) for right-to-left layout symmetry."
-        errorLine1="            android:paddingRight=&quot;@dimen/textinputlayout_correction_padding_right&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        message="When you define `paddingRight` you should probably also define `paddingLeft` for right-to-left symmetry">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_input_row.xml"
-            line="39"
-            column="13"/>
+            file="src/main/res/layout/login_input_row.xml"
+            line="39"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        severity="Error"
-        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
-        category="Internationalization:Bidirectional Text"
-        priority="6"
-        summary="Padding and margin symmetry"
-        explanation="If you specify padding or margin on the left side of a layout, you should probably also specify padding on the right side (and vice versa) for right-to-left layout symmetry."
-        errorLine1="            android:paddingEnd=&quot;@dimen/textinputlayout_correction_padding_right&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_input_row.xml"
-            line="40"
-            column="13"/>
+            file="src/main/res/layout/login_input_row.xml"
+            line="40"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        severity="Error"
-        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
-        category="Internationalization:Bidirectional Text"
-        priority="6"
-        summary="Padding and margin symmetry"
-        explanation="If you specify padding or margin on the left side of a layout, you should probably also specify padding on the right side (and vice versa) for right-to-left layout symmetry."
-        errorLine1="    android:paddingEnd=&quot;@dimen/margin_extra_extra_large&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~">
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry">
         <location
-            file="../WordPress/src/main/res/layout-sw600dp-land/login_intro_template_view.xml"
-            line="7"
-            column="5"/>
+            file="src/main/res/layout-sw600dp-land/login_intro_template_view.xml"
+            line="7"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        severity="Error"
-        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
-        category="Internationalization:Bidirectional Text"
-        priority="6"
-        summary="Padding and margin symmetry"
-        explanation="If you specify padding or margin on the left side of a layout, you should probably also specify padding on the right side (and vice versa) for right-to-left layout symmetry."
-        errorLine1="                android:paddingEnd=&quot;@dimen/margin_medium&quot; >"
-        errorLine2="                ~~~~~~~~~~~~~~~~~~">
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry">
         <location
-            file="../WordPress/src/main/res/layout/reader_cardview_post.xml"
-            line="220"
-            column="17"/>
+            file="src/main/res/layout/reader_cardview_post.xml"
+            line="220"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        severity="Error"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
-        category="Internationalization:Bidirectional Text"
-        priority="6"
-        summary="Padding and margin symmetry"
-        explanation="If you specify padding or margin on the left side of a layout, you should probably also specify padding on the right side (and vice versa) for right-to-left layout symmetry."
-        errorLine1="            android:paddingStart=&quot;@dimen/margin_small&quot;/>"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry">
         <location
-            file="../WordPress/src/main/res/layout/reader_include_comment_box.xml"
-            line="55"
-            column="13"/>
+            file="src/main/res/layout/reader_include_comment_box.xml"
+            line="55"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        severity="Error"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
-        category="Internationalization:Bidirectional Text"
-        priority="6"
-        summary="Padding and margin symmetry"
-        explanation="If you specify padding or margin on the left side of a layout, you should probably also specify padding on the right side (and vice versa) for right-to-left layout symmetry."
-        errorLine1="            android:paddingStart=&quot;@dimen/margin_small&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry">
         <location
-            file="../WordPress/src/main/res/layout/site_settings_format_dialog.xml"
-            line="37"
-            column="13"/>
+            file="src/main/res/layout/site_settings_format_dialog.xml"
+            line="37"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        severity="Error"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
-        category="Internationalization:Bidirectional Text"
-        priority="6"
-        summary="Padding and margin symmetry"
-        explanation="If you specify padding or margin on the left side of a layout, you should probably also specify padding on the right side (and vice versa) for right-to-left layout symmetry."
-        errorLine1="            android:paddingStart=&quot;@dimen/margin_small&quot;/>"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry">
         <location
-            file="../WordPress/src/main/res/layout/site_settings_format_dialog.xml"
-            line="55"
-            column="13"/>
+            file="src/main/res/layout/site_settings_format_dialog.xml"
+            line="55"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        severity="Error"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
-        category="Internationalization:Bidirectional Text"
-        priority="6"
-        summary="Padding and margin symmetry"
-        explanation="If you specify padding or margin on the left side of a layout, you should probably also specify padding on the right side (and vice versa) for right-to-left layout symmetry."
-        errorLine1="            android:paddingStart=&quot;@dimen/start_over_title_margin&quot;/>"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry">
         <location
-            file="../WordPress/src/main/res/layout/start_over_preference.xml"
-            line="39"
-            column="13"/>
+            file="src/main/res/layout/start_over_preference.xml"
+            line="39"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        severity="Error"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
-        category="Internationalization:Bidirectional Text"
-        priority="6"
-        summary="Padding and margin symmetry"
-        explanation="If you specify padding or margin on the left side of a layout, you should probably also specify padding on the right side (and vice versa) for right-to-left layout symmetry."
-        errorLine1="        android:paddingStart=&quot;@dimen/start_over_preference_margin_small&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry">
         <location
-            file="../WordPress/src/main/res/layout/start_over_preference.xml"
-            line="51"
-            column="9"/>
+            file="src/main/res/layout/start_over_preference.xml"
+            line="51"/>
     </issue>
 
     <issue
         id="RtlSymmetry"
-        severity="Error"
-        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
-        category="Internationalization:Bidirectional Text"
-        priority="6"
-        summary="Padding and margin symmetry"
-        explanation="If you specify padding or margin on the left side of a layout, you should probably also specify padding on the right side (and vice versa) for right-to-left layout symmetry."
-        errorLine1="                    android:paddingEnd=&quot;@dimen/margin_medium&quot;/>"
-        errorLine2="                    ~~~~~~~~~~~~~~~~~~">
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry">
         <location
-            file="../WordPress/src/main/res/layout/stats_visitors_and_views_fragment.xml"
-            line="91"
-            column="21"/>
+            file="src/main/res/layout/stats_visitors_and_views_fragment.xml"
+            line="91"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="    android:layout_alignParentRight=&quot;true&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/alert_create_link.xml"
-            line="31"
-            column="5"/>
+            file="src/main/res/layout/alert_create_link.xml"
+            line="31"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="    android:layout_marginLeft=&quot;@dimen/margin_medium&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/alert_create_link.xml"
-            line="32"
-            column="5"/>
+            file="src/main/res/layout/alert_create_link.xml"
+            line="32"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="    android:layout_toLeftOf=&quot;@id/ok&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 26">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/alert_create_link.xml"
-            line="41"
-            column="5"/>
+            file="src/main/res/layout/alert_create_link.xml"
+            line="41"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="                android:layout_marginLeft=&quot;@dimen/image_settings_dialog_thumbnail_left_margin&quot;"
-        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/dialog_image_options.xml"
-            line="26"
-            column="17"/>
+            file="src/main/res/layout/dialog_image_options.xml"
+            line="26"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="                android:layout_marginRight=&quot;@dimen/image_settings_dialog_thumbnail_right_margin&quot;"
-        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/dialog_image_options.xml"
-            line="28"
-            column="17"/>
+            file="src/main/res/layout/dialog_image_options.xml"
+            line="28"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="                android:layout_marginLeft=&quot;@dimen/image_settings_dialog_filename_margin_left&quot;"
-        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/dialog_image_options.xml"
-            line="50"
-            column="17"/>
+            file="src/main/res/layout/dialog_image_options.xml"
+            line="50"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_marginLeft=&quot;@dimen/image_settings_dialog_input_field_start_margin&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/dialog_image_options.xml"
-            line="111"
-            column="13"/>
+            file="src/main/res/layout/dialog_image_options.xml"
+            line="111"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_toRightOf`; already defining `layout_toEndOf` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="                android:layout_toRightOf=&quot;@+id/image_icon&quot;"
-        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_toRightOf`; already defining `layout_toEndOf` with `targetSdkVersion` 26">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/dialog_image_options.xml"
-            line="152"
-            column="17"/>
+            file="src/main/res/layout/dialog_image_options.xml"
+            line="152"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_marginLeft=&quot;@dimen/image_settings_dialog_input_field_start_margin&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/dialog_image_options.xml"
-            line="172"
-            column="13"/>
+            file="src/main/res/layout/dialog_image_options.xml"
+            line="172"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:paddingLeft=&quot;16dp&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/fragment_edit_post_content.xml"
-            line="69"
-            column="13"/>
+            file="src/main/res/layout/fragment_edit_post_content.xml"
+            line="69"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `drawableLeft`; already defining `drawableStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:drawableLeft=&quot;@drawable/ic_post_settings&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `drawableLeft`; already defining `drawableStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/editor/WordPressEditor/src/main/res/layout/fragment_edit_post_content.xml"
-            line="72"
-            column="13"/>
+            file="src/main/res/layout/fragment_edit_post_content.xml"
+            line="72"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_marginLeft=&quot;@dimen/margin_extra_large&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_email_password_screen.xml"
-            line="42"
-            column="13"/>
+            file="src/main/res/layout/login_email_password_screen.xml"
+            line="42"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="        android:paddingRight=&quot;@dimen/margin_medium&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_email_screen.xml"
-            line="60"
-            column="9"/>
+            file="src/main/res/layout/login_email_screen.xml"
+            line="60"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_marginRight=&quot;@dimen/margin_medium&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_email_screen.xml"
-            line="69"
-            column="13"/>
+            file="src/main/res/layout/login_email_screen.xml"
+            line="69"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="        android:paddingRight=&quot;@dimen/margin_medium&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_email_screen.xml"
-            line="95"
-            column="9"/>
+            file="src/main/res/layout/login_email_screen.xml"
+            line="95"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_marginRight=&quot;@dimen/margin_medium&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_email_screen.xml"
-            line="105"
-            column="13"/>
+            file="src/main/res/layout/login_email_screen.xml"
+            line="105"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="        android:paddingLeft=&quot;@dimen/margin_small_medium&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_form_screen.xml"
-            line="31"
-            column="9"/>
+            file="src/main/res/layout/login_form_screen.xml"
+            line="31"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="        android:paddingRight=&quot;@dimen/margin_medium_large&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_form_screen.xml"
-            line="33"
-            column="9"/>
+            file="src/main/res/layout/login_form_screen.xml"
+            line="33"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_alignParentLeft=&quot;true&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_form_screen.xml"
-            line="45"
-            column="13"/>
+            file="src/main/res/layout/login_form_screen.xml"
+            line="45"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_toLeftOf=&quot;@+id/primary_button&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_form_screen.xml"
-            line="47"
-            column="13"/>
+            file="src/main/res/layout/login_form_screen.xml"
+            line="47"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_marginRight=&quot;@dimen/margin_extra_large&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_form_screen.xml"
-            line="53"
-            column="13"/>
+            file="src/main/res/layout/login_form_screen.xml"
+            line="53"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_alignParentRight=&quot;true&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_form_screen.xml"
-            line="63"
-            column="13"/>
+            file="src/main/res/layout/login_form_screen.xml"
+            line="63"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="        android:layout_marginRight=&quot;@dimen/margin_extra_large&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_input_row.xml"
-            line="15"
-            column="9"/>
+            file="src/main/res/layout/login_input_row.xml"
+            line="15"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_toRightOf`; already defining `layout_toEndOf` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="        android:layout_toRightOf=&quot;@+id/icon&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_toRightOf`; already defining `layout_toEndOf` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_input_row.xml"
-            line="27"
-            column="9"/>
+            file="src/main/res/layout/login_input_row.xml"
+            line="27"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_marginRight=&quot;@dimen/textinputlayout_correction_margin_right&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_input_row.xml"
-            line="37"
-            column="13"/>
+            file="src/main/res/layout/login_input_row.xml"
+            line="37"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:paddingRight=&quot;@dimen/textinputlayout_correction_padding_right&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_input_row.xml"
-            line="39"
-            column="13"/>
+            file="src/main/res/layout/login_input_row.xml"
+            line="39"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="        android:paddingLeft=&quot;@dimen/margin_small_medium&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/login_magic_link_request_screen.xml"
-            line="52"
-            column="9"/>
+            file="src/main/res/layout-land/login_magic_link_request_screen.xml"
+            line="52"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="        android:paddingRight=&quot;@dimen/margin_medium_large&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/login_magic_link_request_screen.xml"
-            line="54"
-            column="9"/>
+            file="src/main/res/layout-land/login_magic_link_request_screen.xml"
+            line="54"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_alignParentLeft=&quot;true&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/login_magic_link_request_screen.xml"
-            line="67"
-            column="13"/>
+            file="src/main/res/layout-land/login_magic_link_request_screen.xml"
+            line="67"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_toLeftOf=&quot;@+id/login_request_magic_link&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/login_magic_link_request_screen.xml"
-            line="69"
-            column="13"/>
+            file="src/main/res/layout-land/login_magic_link_request_screen.xml"
+            line="69"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="                android:layout_marginRight=&quot;@dimen/margin_extra_large&quot;"
-        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_magic_link_request_screen.xml"
-            line="73"
-            column="17"/>
+            file="src/main/res/layout/login_magic_link_request_screen.xml"
+            line="73"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_marginRight=&quot;@dimen/margin_extra_large&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/login_magic_link_request_screen.xml"
-            line="75"
-            column="13"/>
+            file="src/main/res/layout-land/login_magic_link_request_screen.xml"
+            line="75"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_alignParentRight=&quot;true&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/login_magic_link_request_screen.xml"
-            line="85"
-            column="13"/>
+            file="src/main/res/layout-land/login_magic_link_request_screen.xml"
+            line="85"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="        android:paddingLeft=&quot;@dimen/margin_small_medium&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/login_magic_link_sent_screen.xml"
-            line="42"
-            column="9"/>
+            file="src/main/res/layout-land/login_magic_link_sent_screen.xml"
+            line="42"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="        android:paddingRight=&quot;@dimen/margin_medium_large&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/login_magic_link_sent_screen.xml"
-            line="44"
-            column="9"/>
+            file="src/main/res/layout-land/login_magic_link_sent_screen.xml"
+            line="44"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_alignParentLeft=&quot;true&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/login_magic_link_sent_screen.xml"
-            line="57"
-            column="13"/>
+            file="src/main/res/layout-land/login_magic_link_sent_screen.xml"
+            line="57"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_toLeftOf=&quot;@+id/login_open_email_client&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/login_magic_link_sent_screen.xml"
-            line="59"
-            column="13"/>
+            file="src/main/res/layout-land/login_magic_link_sent_screen.xml"
+            line="59"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_marginRight=&quot;@dimen/margin_extra_large&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/login_magic_link_sent_screen.xml"
-            line="65"
-            column="13"/>
+            file="src/main/res/layout-land/login_magic_link_sent_screen.xml"
+            line="65"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_alignParentRight=&quot;true&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/login_magic_link_sent_screen.xml"
-            line="75"
-            column="13"/>
+            file="src/main/res/layout-land/login_magic_link_sent_screen.xml"
+            line="75"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_marginRight=&quot;@dimen/textinputlayout_correction_padding&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_username_password_screen.xml"
-            line="25"
-            column="13"/>
+            file="src/main/res/layout/login_username_password_screen.xml"
+            line="25"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_marginLeft=&quot;@dimen/margin_extra_large&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout/login_username_password_screen.xml"
-            line="50"
-            column="13"/>
+            file="src/main/res/layout/login_username_password_screen.xml"
+            line="50"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_marginRight=&quot;@dimen/margin_medium&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/signup_bottom_sheet_dialog.xml"
-            line="37"
-            column="13"/>
+            file="src/main/res/layout-land/signup_bottom_sheet_dialog.xml"
+            line="37"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_marginLeft=&quot;@dimen/margin_medium&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_marginLeft`; already defining `layout_marginStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/signup_bottom_sheet_dialog.xml"
-            line="48"
-            column="13"/>
+            file="src/main/res/layout-land/signup_bottom_sheet_dialog.xml"
+            line="48"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="        android:paddingLeft=&quot;@dimen/margin_small_medium&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/signup_magic_link.xml"
-            line="56"
-            column="9"/>
+            file="src/main/res/layout-land/signup_magic_link.xml"
+            line="56"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="        android:paddingRight=&quot;@dimen/margin_medium_large&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/signup_magic_link.xml"
-            line="57"
-            column="9"/>
+            file="src/main/res/layout-land/signup_magic_link.xml"
+            line="57"/>
     </issue>
 
     <issue
         id="RtlHardcoded"
-        severity="Error"
-        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26"
-        category="Internationalization:Bidirectional Text"
-        priority="5"
-        summary="Using left/right instead of start/end attributes"
-        explanation="Using `Gravity#LEFT` and `Gravity#RIGHT` can lead to problems when a layout is rendered in locales where text flows from right to left. Use `Gravity#START` and `Gravity#END` instead. Similarly, in XML `gravity` and `layout_gravity` attributes, use `start` rather than `left`.&#xA;&#xA;For XML attributes such as paddingLeft and `layout_marginLeft`, use `paddingStart` and `layout_marginStart`. **NOTE**: If your `minSdkVersion` is less than 17, you should add **both** the older left/right attributes **as well as** the new start/right attributes. On older platforms, where RTL is not supported and the start/right attributes are unknown and therefore ignored, you need the older left/right attributes. There is a separate lint check which catches that type of error.&#xA;&#xA;(Note: For `Gravity#LEFT` and `Gravity#START`, you can use these constants even when targeting older platforms, because the `start` bitmask is a superset of the `left` bitmask. Therefore, you can use `gravity=&quot;start&quot;` rather than `gravity=&quot;left|start&quot;`.)"
-        errorLine1="            android:layout_alignParentRight=&quot;true&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        quickfix="studio">
+        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 26">
         <location
-            file="../libs/login/WordPressLoginFlow/src/main/res/layout-land/signup_magic_link.xml"
-            line="65"
-            column="13"/>
+            file="src/main/res/layout-land/signup_magic_link.xml"
+            line="65"/>
     </issue>
 
 </issues>

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -212,6 +212,19 @@
                 <action android:name="android.intent.action.MAIN" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".ui.posts.GutenbergEditPostActivity"
+            android:theme="@style/Calypso.ActionMode.Dark"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+            android:windowSoftInputMode="stateHidden|adjustResize">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".ui.posts.PostsListActivity" />
+
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+            </intent-filter>
+        </activity>
         <!-- Workaround for old launcher icon pointing to .ui.posts.PostsActivity -->
         <activity-alias
             android:name=".ui.posts.PostsActivity"

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -85,6 +85,7 @@ import org.wordpress.android.ui.posts.AddCategoryFragment;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.EditPostPreviewFragment;
 import org.wordpress.android.ui.posts.EditPostSettingsFragment;
+import org.wordpress.android.ui.posts.GutenbergEditPostActivity;
 import org.wordpress.android.ui.posts.HistoryListFragment;
 import org.wordpress.android.ui.posts.PostListFragment;
 import org.wordpress.android.ui.posts.PostPreviewActivity;
@@ -321,6 +322,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(PublicizeButtonPrefsFragment object);
 
     void inject(EditPostActivity object);
+
+    void inject(GutenbergEditPostActivity object);
 
     void inject(EditPostSettingsFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -618,6 +618,13 @@ public class ActivityLauncher {
         fragment.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 
+    public static void editPageForResultOnGutenberg(@NonNull Fragment fragment, @NonNull PageModel page) {
+        Intent intent = new Intent(fragment.getContext(), GutenbergEditPostActivity.class);
+        intent.putExtra(WordPress.SITE, page.getSite());
+        intent.putExtra(EditPostBaseActivity.EXTRA_POST_LOCAL_ID, page.getPageId());
+        fragment.startActivityForResult(intent, RequestCodes.EDIT_POST);
+    }
+
     public static void addNewPageForResult(@NonNull Fragment fragment, @NonNull SiteModel site) {
         Intent intent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(fragment.getContext(), true, null);
         intent.putExtra(WordPress.SITE, site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -52,6 +52,7 @@ import org.wordpress.android.ui.plugins.PluginBrowserActivity;
 import org.wordpress.android.ui.plugins.PluginDetailActivity;
 import org.wordpress.android.ui.plugins.PluginUtils;
 import org.wordpress.android.ui.posts.EditPostActivity;
+import org.wordpress.android.ui.posts.EditPostBaseActivity;
 import org.wordpress.android.ui.posts.PostPreviewActivity;
 import org.wordpress.android.ui.posts.PostsListActivity;
 import org.wordpress.android.ui.prefs.AccountSettingsActivity;
@@ -571,14 +572,14 @@ public class ActivityLauncher {
         }
 
         Intent intent = new Intent(activity, PostPreviewActivity.class);
-        intent.putExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, post.getId());
+        intent.putExtra(EditPostBaseActivity.EXTRA_POST_LOCAL_ID, post.getId());
         intent.putExtra(WordPress.SITE, site);
         activity.startActivityForResult(intent, RequestCodes.PREVIEW_POST);
     }
 
     public static void viewPagePreview(@NonNull Fragment fragment, @NonNull PageModel page) {
         Intent intent = new Intent(fragment.getContext(), PostPreviewActivity.class);
-        intent.putExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, page.getPageId());
+        intent.putExtra(EditPostBaseActivity.EXTRA_POST_LOCAL_ID, page.getPageId());
         intent.putExtra(WordPress.SITE, page.getSite());
         fragment.startActivity(intent);
     }
@@ -590,8 +591,8 @@ public class ActivityLauncher {
 
         Intent intent = new Intent(activity, EditPostActivity.class);
         intent.putExtra(WordPress.SITE, site);
-        intent.putExtra(EditPostActivity.EXTRA_IS_PAGE, false);
-        intent.putExtra(EditPostActivity.EXTRA_IS_PROMO, isPromo);
+        intent.putExtra(EditPostBaseActivity.EXTRA_IS_PAGE, false);
+        intent.putExtra(EditPostBaseActivity.EXTRA_IS_PROMO, isPromo);
         activity.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 
@@ -605,22 +606,22 @@ public class ActivityLauncher {
         // PostModel objects can be quite large, since content field is not size restricted,
         // in order to avoid issues like TransactionTooLargeException it's better to pass the id of the post.
         // However, we still want to keep passing the SiteModel to avoid confusion around local & remote ids.
-        intent.putExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, post.getId());
+        intent.putExtra(EditPostBaseActivity.EXTRA_POST_LOCAL_ID, post.getId());
         activity.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 
     public static void editPageForResult(@NonNull Fragment fragment, @NonNull PageModel page) {
         Intent intent = new Intent(fragment.getContext(), EditPostActivity.class);
         intent.putExtra(WordPress.SITE, page.getSite());
-        intent.putExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, page.getPageId());
+        intent.putExtra(EditPostBaseActivity.EXTRA_POST_LOCAL_ID, page.getPageId());
         fragment.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 
     public static void addNewPageForResult(@NonNull Fragment fragment, @NonNull SiteModel site) {
         Intent intent = new Intent(fragment.getContext(), EditPostActivity.class);
         intent.putExtra(WordPress.SITE, site);
-        intent.putExtra(EditPostActivity.EXTRA_IS_PAGE, true);
-        intent.putExtra(EditPostActivity.EXTRA_IS_PROMO, false);
+        intent.putExtra(EditPostBaseActivity.EXTRA_IS_PAGE, true);
+        intent.putExtra(EditPostBaseActivity.EXTRA_IS_PROMO, false);
         fragment.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -53,6 +53,7 @@ import org.wordpress.android.ui.plugins.PluginDetailActivity;
 import org.wordpress.android.ui.plugins.PluginUtils;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.EditPostBaseActivity;
+import org.wordpress.android.ui.posts.GutenbergEditPostActivity;
 import org.wordpress.android.ui.posts.PostPreviewActivity;
 import org.wordpress.android.ui.posts.PostsListActivity;
 import org.wordpress.android.ui.prefs.AccountSettingsActivity;
@@ -589,7 +590,7 @@ public class ActivityLauncher {
             return;
         }
 
-        Intent intent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(activity);
+        Intent intent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(activity, true, null);
         intent.putExtra(WordPress.SITE, site);
         intent.putExtra(EditPostBaseActivity.EXTRA_IS_PAGE, false);
         intent.putExtra(EditPostBaseActivity.EXTRA_IS_PROMO, isPromo);
@@ -601,7 +602,7 @@ public class ActivityLauncher {
             return;
         }
 
-        Intent intent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(activity);
+        Intent intent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(activity, false, post);
         intent.putExtra(WordPress.SITE, site);
         // PostModel objects can be quite large, since content field is not size restricted,
         // in order to avoid issues like TransactionTooLargeException it's better to pass the id of the post.
@@ -611,14 +612,14 @@ public class ActivityLauncher {
     }
 
     public static void editPageForResult(@NonNull Fragment fragment, @NonNull PageModel page) {
-        Intent intent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(fragment.getContext());
+        Intent intent = new Intent(fragment.getContext(), EditPostActivity.class);
         intent.putExtra(WordPress.SITE, page.getSite());
         intent.putExtra(EditPostBaseActivity.EXTRA_POST_LOCAL_ID, page.getPageId());
         fragment.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 
     public static void addNewPageForResult(@NonNull Fragment fragment, @NonNull SiteModel site) {
-        Intent intent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(fragment.getContext());
+        Intent intent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(fragment.getContext(), true, null);
         intent.putExtra(WordPress.SITE, site);
         intent.putExtra(EditPostBaseActivity.EXTRA_IS_PAGE, true);
         intent.putExtra(EditPostBaseActivity.EXTRA_IS_PROMO, false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -626,7 +626,8 @@ public class ActivityLauncher {
     }
 
     public static void addNewPageForResult(@NonNull Fragment fragment, @NonNull SiteModel site) {
-        Intent intent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(fragment.getContext(), true, null);
+        Intent intent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(
+                fragment.getContext(), true, null);
         intent.putExtra(WordPress.SITE, site);
         intent.putExtra(EditPostBaseActivity.EXTRA_IS_PAGE, true);
         intent.putExtra(EditPostBaseActivity.EXTRA_IS_PROMO, false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -589,7 +589,7 @@ public class ActivityLauncher {
             return;
         }
 
-        Intent intent = new Intent(activity, EditPostActivity.class);
+        Intent intent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(activity);
         intent.putExtra(WordPress.SITE, site);
         intent.putExtra(EditPostBaseActivity.EXTRA_IS_PAGE, false);
         intent.putExtra(EditPostBaseActivity.EXTRA_IS_PROMO, isPromo);
@@ -601,7 +601,7 @@ public class ActivityLauncher {
             return;
         }
 
-        Intent intent = new Intent(activity, EditPostActivity.class);
+        Intent intent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(activity);
         intent.putExtra(WordPress.SITE, site);
         // PostModel objects can be quite large, since content field is not size restricted,
         // in order to avoid issues like TransactionTooLargeException it's better to pass the id of the post.
@@ -611,14 +611,14 @@ public class ActivityLauncher {
     }
 
     public static void editPageForResult(@NonNull Fragment fragment, @NonNull PageModel page) {
-        Intent intent = new Intent(fragment.getContext(), EditPostActivity.class);
+        Intent intent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(fragment.getContext());
         intent.putExtra(WordPress.SITE, page.getSite());
         intent.putExtra(EditPostBaseActivity.EXTRA_POST_LOCAL_ID, page.getPageId());
         fragment.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 
     public static void addNewPageForResult(@NonNull Fragment fragment, @NonNull SiteModel site) {
-        Intent intent = new Intent(fragment.getContext(), EditPostActivity.class);
+        Intent intent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(fragment.getContext());
         intent.putExtra(WordPress.SITE, site);
         intent.putExtra(EditPostBaseActivity.EXTRA_IS_PAGE, true);
         intent.putExtra(EditPostBaseActivity.EXTRA_IS_PROMO, false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -138,7 +138,7 @@ public class AddQuickPressShortcutActivity extends ListActivity {
                                          ToastUtils.Duration.LONG);
                 } else {
                     Intent shortcutIntent =
-                            EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(getApplicationContext());
+                            EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(getApplicationContext(), true, null);
                     shortcutIntent.setAction(Intent.ACTION_MAIN);
                     shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);

--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -34,7 +34,6 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
-import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.EditPostBaseActivity;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.SiteUtils;

--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -35,6 +35,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.ui.posts.EditPostActivity;
+import org.wordpress.android.ui.posts.EditPostBaseActivity;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -140,8 +141,8 @@ public class AddQuickPressShortcutActivity extends ListActivity {
                     shortcutIntent.setAction(Intent.ACTION_MAIN);
                     shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                    shortcutIntent.putExtra(EditPostActivity.EXTRA_QUICKPRESS_BLOG_ID, siteIds[position]);
-                    shortcutIntent.putExtra(EditPostActivity.EXTRA_IS_QUICKPRESS, true);
+                    shortcutIntent.putExtra(EditPostBaseActivity.EXTRA_QUICKPRESS_BLOG_ID, siteIds[position]);
+                    shortcutIntent.putExtra(EditPostBaseActivity.EXTRA_IS_QUICKPRESS, true);
 
                     String shortcutName = quickPressShortcutName.getText().toString();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -137,7 +137,8 @@ public class AddQuickPressShortcutActivity extends ListActivity {
                     ToastUtils.showToast(AddQuickPressShortcutActivity.this, R.string.quickpress_add_error,
                                          ToastUtils.Duration.LONG);
                 } else {
-                    Intent shortcutIntent = new Intent(getApplicationContext(), EditPostActivity.class);
+                    Intent shortcutIntent =
+                            EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(getApplicationContext());
                     shortcutIntent.setAction(Intent.ACTION_MAIN);
                     shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);

--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -137,7 +137,8 @@ public class AddQuickPressShortcutActivity extends ListActivity {
                                          ToastUtils.Duration.LONG);
                 } else {
                     Intent shortcutIntent =
-                            EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(getApplicationContext(), true, null);
+                            EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(
+                                    getApplicationContext(), true, null);
                     shortcutIntent.setAction(Intent.ACTION_MAIN);
                     shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -70,7 +70,7 @@ import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.notifications.utils.PendingDraftsNotificationsUtils;
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogNegativeClickInterface;
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface;
-import org.wordpress.android.ui.posts.EditPostActivity;
+import org.wordpress.android.ui.posts.EditPostBaseActivity;
 import org.wordpress.android.ui.posts.PromoDialog;
 import org.wordpress.android.ui.posts.PromoDialog.PromoDialogClickInterface;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -686,7 +686,7 @@ public class WPMainActivity extends AppCompatActivity implements
                 if (resultCode != Activity.RESULT_OK || data == null || isFinishing()) {
                     return;
                 }
-                int localId = data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0);
+                int localId = data.getIntExtra(EditPostBaseActivity.EXTRA_POST_LOCAL_ID, 0);
                 final SiteModel site = getSelectedSite();
                 final PostModel post = mPostStore.getPostByLocalPostId(localId);
                 if (site != null && post != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -247,12 +247,16 @@ class PagesFragment : Fragment(), GutenbergWarningDialogClickInterface {
             page?.let {
                 val post = postStore.getPostByLocalPostId(page.pageId)
                 val isGutenbergContent = PostUtils.contentContainsGutenbergBlocks(post?.content)
-                if (isGutenbergContent && !AppPrefs.isGutenbergWarningDialogDisabled()) {
-                    PostUtils.showGutenbergCompatibilityWarningDialog(
-                            getActivity(), fragmentManager, post, viewModel.site
-                    )
+                if ( isGutenbergContent && AppPrefs.isGutenbergEditorEnabled()) {
+                    ActivityLauncher.editPageForResultOnGutenberg(this, page);
                 } else {
-                    ActivityLauncher.editPageForResult(this, page)
+                    if (isGutenbergContent && !AppPrefs.isGutenbergWarningDialogDisabled()) {
+                        PostUtils.showGutenbergCompatibilityWarningDialog(
+                                getActivity(), fragmentManager, post, viewModel.site
+                        )
+                    } else {
+                        ActivityLauncher.editPageForResult(this, page)
+                    }
                 }
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -246,8 +246,8 @@ class PagesFragment : Fragment(), GutenbergWarningDialogClickInterface {
         viewModel.editPage.observe(this, Observer { page ->
             page?.let {
                 val post = postStore.getPostByLocalPostId(page.pageId)
-                if ( PostUtils.shouldShowGutenbergEditor(false,  post)) {
-                    ActivityLauncher.editPageForResultOnGutenberg(this, page);
+                if (PostUtils.shouldShowGutenbergEditor(false, post)) {
+                    ActivityLauncher.editPageForResultOnGutenberg(this, page)
                 } else {
                     val isGutenbergContent = PostUtils.contentContainsGutenbergBlocks(post?.content)
                     if (isGutenbergContent && !AppPrefs.isGutenbergWarningDialogDisabled()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -36,7 +36,7 @@ import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.pages.PageItem.Page
 import org.wordpress.android.ui.posts.BasicFragmentDialog
-import org.wordpress.android.ui.posts.EditPostActivity
+import org.wordpress.android.ui.posts.EditPostBaseActivity
 import org.wordpress.android.ui.posts.GutenbergWarningFragmentDialog.GutenbergWarningDialogClickInterface
 import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.ui.prefs.AppPrefs
@@ -90,7 +90,7 @@ class PagesFragment : Fragment(), GutenbergWarningDialogClickInterface {
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (requestCode == RequestCodes.EDIT_POST && resultCode == Activity.RESULT_OK && data != null) {
-            val pageId = data.getLongExtra(EditPostActivity.EXTRA_POST_REMOTE_ID, -1)
+            val pageId = data.getLongExtra(EditPostBaseActivity.EXTRA_POST_REMOTE_ID, -1)
             if (pageId != -1L) {
                 onPageEditFinished(pageId)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -246,10 +246,10 @@ class PagesFragment : Fragment(), GutenbergWarningDialogClickInterface {
         viewModel.editPage.observe(this, Observer { page ->
             page?.let {
                 val post = postStore.getPostByLocalPostId(page.pageId)
-                val isGutenbergContent = PostUtils.contentContainsGutenbergBlocks(post?.content)
-                if ( isGutenbergContent && AppPrefs.isGutenbergEditorEnabled()) {
+                if ( PostUtils.shouldShowGutenbergEditor(false,  post)) {
                     ActivityLauncher.editPageForResultOnGutenberg(this, page);
                 } else {
+                    val isGutenbergContent = PostUtils.contentContainsGutenbergBlocks(post?.content)
                     if (isGutenbergContent && !AppPrefs.isGutenbergWarningDialogDisabled()) {
                         PostUtils.showGutenbergCompatibilityWarningDialog(
                                 getActivity(), fragmentManager, post, viewModel.site

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -29,7 +29,6 @@ import android.support.v4.app.FragmentTransaction;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
-import android.support.v7.app.AppCompatActivity;
 import android.text.Editable;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
@@ -189,7 +188,7 @@ import de.greenrobot.event.EventBus;
 
 import static org.wordpress.android.ui.history.HistoryDetailContainerFragment.KEY_REVISION;
 
-public class EditPostActivity extends AppCompatActivity implements
+public class EditPostActivity extends EditPostBaseActivity implements
         EditorFragmentActivity,
         EditorImageSettingsListener,
         EditorDragAndDropListener,
@@ -205,44 +204,7 @@ public class EditPostActivity extends AppCompatActivity implements
         PostSettingsListDialogFragment.OnPostSettingsDialogFragmentListener,
         PostDatePickerDialogFragment.OnPostDatePickerDialogListener,
         HistoryListFragment.HistoryItemClickInterface {
-    public static final String EXTRA_POST_LOCAL_ID = "postModelLocalId";
-    public static final String EXTRA_POST_REMOTE_ID = "postModelRemoteId";
-    public static final String EXTRA_IS_PAGE = "isPage";
-    public static final String EXTRA_IS_PROMO = "isPromo";
-    public static final String EXTRA_IS_QUICKPRESS = "isQuickPress";
-    public static final String EXTRA_QUICKPRESS_BLOG_ID = "quickPressBlogId";
-    public static final String EXTRA_SAVED_AS_LOCAL_DRAFT = "savedAsLocalDraft";
-    public static final String EXTRA_HAS_FAILED_MEDIA = "hasFailedMedia";
-    public static final String EXTRA_HAS_CHANGES = "hasChanges";
-    public static final String EXTRA_IS_DISCARDABLE = "isDiscardable";
-    public static final String EXTRA_INSERT_MEDIA = "insertMedia";
-    private static final String STATE_KEY_EDITOR_FRAGMENT = "editorFragment";
-    private static final String STATE_KEY_DROPPED_MEDIA_URIS = "stateKeyDroppedMediaUri";
-    private static final String STATE_KEY_POST_LOCAL_ID = "stateKeyPostModelLocalId";
-    private static final String STATE_KEY_POST_REMOTE_ID = "stateKeyPostModelRemoteId";
-    private static final String STATE_KEY_IS_DIALOG_PROGRESS_SHOWN = "stateKeyIsDialogProgressShown";
-    private static final String STATE_KEY_IS_DISCARDING_CHANGES = "stateKeyIsDiscardingChanges";
-    private static final String STATE_KEY_IS_NEW_POST = "stateKeyIsNewPost";
-    private static final String STATE_KEY_IS_PHOTO_PICKER_VISIBLE = "stateKeyPhotoPickerVisible";
-    private static final String STATE_KEY_HTML_MODE_ON = "stateKeyHtmlModeOn";
-    private static final String STATE_KEY_REVISION = "stateKeyRevision";
-    private static final String TAG_DISCARDING_CHANGES_ERROR_DIALOG = "tag_discarding_changes_error_dialog";
-    private static final String TAG_DISCARDING_CHANGES_NO_NETWORK_DIALOG = "tag_discarding_changes_no_network_dialog";
-    private static final String TAG_PUBLISH_CONFIRMATION_DIALOG = "tag_publish_confirmation_dialog";
-    private static final String TAG_REMOVE_FAILED_UPLOADS_DIALOG = "tag_remove_failed_uploads_dialog";
 
-    private static final int PAGE_CONTENT = 0;
-    private static final int PAGE_SETTINGS = 1;
-    private static final int PAGE_PREVIEW = 2;
-    private static final int PAGE_HISTORY = 3;
-
-    private static final String PHOTO_PICKER_TAG = "photo_picker";
-    private static final String ASYNC_PROMO_DIALOG_TAG = "async_promo";
-
-    private static final String WHAT_IS_NEW_IN_MOBILE_URL =
-            "https://make.wordpress.org/mobile/whats-new-in-android-media-uploading/";
-    private static final int CHANGE_SAVE_DELAY = 500;
-    public static final int MAX_UNSAVED_POSTS = 50;
     private AztecImageLoader mAztecImageLoader;
 
     enum AddExistingdMediaSource {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -5,7 +5,6 @@ import android.app.Activity;
 import android.app.ProgressDialog;
 import android.arch.lifecycle.Observer;
 import android.content.ClipData;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
@@ -143,7 +142,6 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.ListUtils;
-import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.PermissionUtils;
@@ -295,11 +293,6 @@ public class EditPostActivity extends EditPostBaseActivity implements
             }
         }
     };
-
-    @Override
-    protected void attachBaseContext(Context newBase) {
-        super.attachBaseContext(LocaleManager.setLocale(newBase));
-    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1990,8 +1990,7 @@ public class EditPostActivity extends EditPostBaseActivity implements
                 case 0:
                     // TODO: Remove editor options after testing.
                     if (mShowGutenbergEditor) {
-                        return GutenbergEditorFragment.newInstance("", "",
-                                AppPrefs.isAztecEditorToolbarExpanded(), mIsNewPost);
+                        return GutenbergEditorFragment.newInstance("", "", mIsNewPost);
                     } else if (mShowAztecEditor) {
                         return AztecEditorFragment.newInstance("", "",
                                                                AppPrefs.isAztecEditorToolbarExpanded());

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -202,7 +202,6 @@ public class EditPostActivity extends EditPostBaseActivity implements
         PostSettingsListDialogFragment.OnPostSettingsDialogFragmentListener,
         PostDatePickerDialogFragment.OnPostDatePickerDialogListener,
         HistoryListFragment.HistoryItemClickInterface {
-
     private AztecImageLoader mAztecImageLoader;
 
     private Handler mHandler;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -207,11 +207,6 @@ public class EditPostActivity extends EditPostBaseActivity implements
 
     private AztecImageLoader mAztecImageLoader;
 
-    enum AddExistingdMediaSource {
-        WP_MEDIA_LIBRARY,
-        STOCK_PHOTO_LIBRARY
-    }
-
     private Handler mHandler;
     private int mDebounceCounter = 0;
     private boolean mShowAztecEditor;
@@ -2082,7 +2077,7 @@ public class EditPostActivity extends EditPostBaseActivity implements
         return mMaxThumbWidth;
     }
 
-    private boolean addExistingMediaToEditor(@NonNull AddExistingdMediaSource source, long mediaId) {
+    private boolean addExistingMediaToEditor(@NonNull AddExistingMediaSource source, long mediaId) {
         MediaModel media = mMediaStore.getSiteMediaWithId(mSite, mediaId);
         if (media == null) {
             AppLog.w(T.MEDIA, "Cannot add null media to post");
@@ -2270,7 +2265,7 @@ public class EditPostActivity extends EditPostBaseActivity implements
         long[] idsArray = getIntent().getLongArrayExtra(NEW_MEDIA_POST_EXTRA_IDS);
         ArrayList<Long> idsList = ListUtils.fromLongArray(idsArray);
         for (Long id : idsList) {
-            addExistingMediaToEditor(AddExistingdMediaSource.WP_MEDIA_LIBRARY, id);
+            addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, id);
         }
         savePostAsync(null);
     }
@@ -2471,7 +2466,7 @@ public class EditPostActivity extends EditPostBaseActivity implements
      * @param source where the media is being added from
      * @param media media being added
      */
-    private void trackAddMediaEvent(@NonNull AddExistingdMediaSource source, @NonNull MediaModel media) {
+    private void trackAddMediaEvent(@NonNull AddExistingMediaSource source, @NonNull MediaModel media) {
         switch (source) {
             case WP_MEDIA_LIBRARY:
                 if (media.isVideo()) {
@@ -2787,7 +2782,7 @@ public class EditPostActivity extends EditPostBaseActivity implements
                         long[] mediaIds =
                                 data.getLongArrayExtra(StockMediaPickerActivity.KEY_UPLOADED_MEDIA_IDS);
                         for (long id : mediaIds) {
-                            addExistingMediaToEditor(AddExistingdMediaSource.STOCK_PHOTO_LIBRARY, id);
+                            addExistingMediaToEditor(AddExistingMediaSource.STOCK_PHOTO_LIBRARY, id);
                         }
                         savePostAsync(null);
                     }
@@ -2909,7 +2904,7 @@ public class EditPostActivity extends EditPostBaseActivity implements
             showInsertMediaDialog(ids);
         } else {
             for (Long id : ids) {
-                addExistingMediaToEditor(AddExistingdMediaSource.WP_MEDIA_LIBRARY, id);
+                addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, id);
             }
             savePostAsync(null);
         }
@@ -2932,7 +2927,7 @@ public class EditPostActivity extends EditPostBaseActivity implements
                         break;
                     case INDIVIDUALLY:
                         for (Long id : mediaIds) {
-                            addExistingMediaToEditor(AddExistingdMediaSource.WP_MEDIA_LIBRARY, id);
+                            addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, id);
                         }
                         savePostAsync(null);
                         break;
@@ -3374,7 +3369,7 @@ public class EditPostActivity extends EditPostBaseActivity implements
                 shouldFinishInit = false;
                 mMediaInsertedOnCreation = true;
                 for (MediaModel media : mediaList) {
-                    addExistingMediaToEditor(AddExistingdMediaSource.WP_MEDIA_LIBRARY, media.getMediaId());
+                    addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, media.getMediaId());
                 }
                 savePostAsync(new AfterSavePostListener() {
                     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostBaseActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostBaseActivity.java
@@ -42,7 +42,7 @@ public abstract class EditPostBaseActivity extends AppCompatActivity {
     protected static final int CHANGE_SAVE_DELAY = 500;
     public static final int MAX_UNSAVED_POSTS = 50;
 
-    protected enum AddExistingdMediaSource {
+    protected enum AddExistingMediaSource {
         WP_MEDIA_LIBRARY,
         STOCK_PHOTO_LIBRARY
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostBaseActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostBaseActivity.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 
 import org.wordpress.android.ui.prefs.AppPrefs;
+import org.wordpress.android.util.LocaleManager;
 
 public abstract class EditPostBaseActivity extends AppCompatActivity {
     public static final String EXTRA_POST_LOCAL_ID = "postModelLocalId";
@@ -59,5 +60,10 @@ public abstract class EditPostBaseActivity extends AppCompatActivity {
             intent = new Intent(context, EditPostActivity.class);
         }
         return intent;
+    }
+
+    @Override
+    protected void attachBaseContext(Context newBase) {
+        super.attachBaseContext(LocaleManager.setLocale(newBase));
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostBaseActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostBaseActivity.java
@@ -52,7 +52,8 @@ public abstract class EditPostBaseActivity extends AppCompatActivity {
         STOCK_PHOTO_LIBRARY
     }
 
-    public static Intent getNormalOrGutenbergEditPostActivityIntent(Context context, boolean isNewPost, PostModel post) {
+    public static Intent getNormalOrGutenbergEditPostActivityIntent(Context context,
+                                                                    boolean isNewPost, PostModel post) {
         Intent intent;
         if (PostUtils.shouldShowGutenbergEditor(isNewPost, post)) {
             intent = new Intent(context, GutenbergEditPostActivity.class);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostBaseActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostBaseActivity.java
@@ -1,0 +1,50 @@
+package org.wordpress.android.ui.posts;
+
+import android.support.v7.app.AppCompatActivity;
+
+public abstract class EditPostBaseActivity extends AppCompatActivity {
+    public static final String EXTRA_POST_LOCAL_ID = "postModelLocalId";
+    public static final String EXTRA_POST_REMOTE_ID = "postModelRemoteId";
+    public static final String EXTRA_IS_PAGE = "isPage";
+    public static final String EXTRA_IS_PROMO = "isPromo";
+    public static final String EXTRA_IS_QUICKPRESS = "isQuickPress";
+    public static final String EXTRA_QUICKPRESS_BLOG_ID = "quickPressBlogId";
+    public static final String EXTRA_SAVED_AS_LOCAL_DRAFT = "savedAsLocalDraft";
+    public static final String EXTRA_HAS_FAILED_MEDIA = "hasFailedMedia";
+    public static final String EXTRA_HAS_CHANGES = "hasChanges";
+    public static final String EXTRA_IS_DISCARDABLE = "isDiscardable";
+    public static final String EXTRA_INSERT_MEDIA = "insertMedia";
+    protected static final String STATE_KEY_EDITOR_FRAGMENT = "editorFragment";
+    protected static final String STATE_KEY_DROPPED_MEDIA_URIS = "stateKeyDroppedMediaUri";
+    protected static final String STATE_KEY_POST_LOCAL_ID = "stateKeyPostModelLocalId";
+    protected static final String STATE_KEY_POST_REMOTE_ID = "stateKeyPostModelRemoteId";
+    protected static final String STATE_KEY_IS_DIALOG_PROGRESS_SHOWN = "stateKeyIsDialogProgressShown";
+    protected static final String STATE_KEY_IS_DISCARDING_CHANGES = "stateKeyIsDiscardingChanges";
+    protected static final String STATE_KEY_IS_NEW_POST = "stateKeyIsNewPost";
+    protected static final String STATE_KEY_IS_PHOTO_PICKER_VISIBLE = "stateKeyPhotoPickerVisible";
+    protected static final String STATE_KEY_HTML_MODE_ON = "stateKeyHtmlModeOn";
+    protected static final String STATE_KEY_REVISION = "stateKeyRevision";
+    protected static final String TAG_DISCARDING_CHANGES_ERROR_DIALOG = "tag_discarding_changes_error_dialog";
+    protected static final String TAG_DISCARDING_CHANGES_NO_NETWORK_DIALOG = "tag_discarding_changes_no_network_dialog";
+    protected static final String TAG_PUBLISH_CONFIRMATION_DIALOG = "tag_publish_confirmation_dialog";
+    protected static final String TAG_REMOVE_FAILED_UPLOADS_DIALOG = "tag_remove_failed_uploads_dialog";
+
+    protected static final int PAGE_CONTENT = 0;
+    protected static final int PAGE_SETTINGS = 1;
+    protected static final int PAGE_PREVIEW = 2;
+    protected static final int PAGE_HISTORY = 3;
+
+    protected static final String PHOTO_PICKER_TAG = "photo_picker";
+    protected static final String ASYNC_PROMO_DIALOG_TAG = "async_promo";
+
+    protected static final String WHAT_IS_NEW_IN_MOBILE_URL =
+            "https://make.wordpress.org/mobile/whats-new-in-android-media-uploading/";
+    protected static final int CHANGE_SAVE_DELAY = 500;
+    public static final int MAX_UNSAVED_POSTS = 50;
+
+    protected enum AddExistingdMediaSource {
+        WP_MEDIA_LIBRARY,
+        STOCK_PHOTO_LIBRARY
+    }
+
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostBaseActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostBaseActivity.java
@@ -1,6 +1,10 @@
 package org.wordpress.android.ui.posts;
 
+import android.content.Context;
+import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
+
+import org.wordpress.android.ui.prefs.AppPrefs;
 
 public abstract class EditPostBaseActivity extends AppCompatActivity {
     public static final String EXTRA_POST_LOCAL_ID = "postModelLocalId";
@@ -47,4 +51,14 @@ public abstract class EditPostBaseActivity extends AppCompatActivity {
         STOCK_PHOTO_LIBRARY
     }
 
+    public static Intent getNormalOrGutenbergEditPostActivityIntent(Context context) {
+        Intent intent;
+        if (AppPrefs.isGutenbergEditorEnabled()) {
+            // TODO: return the GutenbergEditPostActivity when it's ready
+            intent = new Intent(context, EditPostActivity.class);
+        } else {
+            intent = new Intent(context, EditPostActivity.class);
+        }
+        return intent;
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostBaseActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostBaseActivity.java
@@ -54,8 +54,7 @@ public abstract class EditPostBaseActivity extends AppCompatActivity {
     public static Intent getNormalOrGutenbergEditPostActivityIntent(Context context) {
         Intent intent;
         if (AppPrefs.isGutenbergEditorEnabled()) {
-            // TODO: return the GutenbergEditPostActivity when it's ready
-            intent = new Intent(context, EditPostActivity.class);
+            intent = new Intent(context, GutenbergEditPostActivity.class);
         } else {
             intent = new Intent(context, EditPostActivity.class);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostBaseActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostBaseActivity.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 
-import org.wordpress.android.ui.prefs.AppPrefs;
+import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.util.LocaleManager;
 
 public abstract class EditPostBaseActivity extends AppCompatActivity {
@@ -52,9 +52,9 @@ public abstract class EditPostBaseActivity extends AppCompatActivity {
         STOCK_PHOTO_LIBRARY
     }
 
-    public static Intent getNormalOrGutenbergEditPostActivityIntent(Context context) {
+    public static Intent getNormalOrGutenbergEditPostActivityIntent(Context context, boolean isNewPost, PostModel post) {
         Intent intent;
-        if (AppPrefs.isGutenbergEditorEnabled()) {
+        if (PostUtils.shouldShowGutenbergEditor(isNewPost, post)) {
             intent = new Intent(context, GutenbergEditPostActivity.class);
         } else {
             intent = new Intent(context, EditPostActivity.class);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -85,7 +85,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 import static android.app.Activity.RESULT_OK;
-import static org.wordpress.android.ui.posts.EditPostActivity.EXTRA_POST_LOCAL_ID;
+import static org.wordpress.android.ui.posts.EditPostBaseActivity.EXTRA_POST_LOCAL_ID;
 import static org.wordpress.android.ui.posts.SelectCategoriesActivity.KEY_SELECTED_CATEGORY_IDS;
 
 public class EditPostSettingsFragment extends Fragment {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java
@@ -29,7 +29,6 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
 import android.text.Editable;
 import android.text.SpannableStringBuilder;
-import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.style.CharacterStyle;
 import android.text.style.SuggestionSpan;
@@ -193,8 +192,6 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
         PostSettingsListDialogFragment.OnPostSettingsDialogFragmentListener,
         PostDatePickerDialogFragment.OnPostDatePickerDialogListener,
         HistoryListFragment.HistoryItemClickInterface {
-
-
     private Handler mHandler;
     private int mDebounceCounter = 0;
     private boolean mMediaInsertedOnCreation;
@@ -982,7 +979,7 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
                 // don't show Discard Local Changes option if it's a completely local draft
                 boolean showDiscardChanges = mPost.isLocallyChanged() && !mPost.isLocalDraft();
 
-                //TODO: make "discardLocalChanges" functionality work the same on Gutenberg as it was on Aztec
+                // TODO: make "discardLocalChanges" functionality work the same on Gutenberg as it was on Aztec
 //                if (mEditorFragment instanceof AztecEditorFragment) {
 //                    if (((AztecEditorFragment) mEditorFragment).hasHistory()
 //                        && ((AztecEditorFragment) mEditorFragment).canUndo()
@@ -1404,7 +1401,8 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
     public void onLinkClicked(@NonNull String instanceTag) {
         switch (instanceTag) {
             case ASYNC_PROMO_DIALOG_TAG:
-                startActivity(ReleaseNotesActivity.createIntent(GutenbergEditPostActivity.this, WHAT_IS_NEW_IN_MOBILE_URL,
+                startActivity(ReleaseNotesActivity.createIntent(
+                        GutenbergEditPostActivity.this, WHAT_IS_NEW_IN_MOBILE_URL,
                         null, mSite));
                 break;
             default:
@@ -1728,7 +1726,7 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
                 }
 
                 // TODO check whether we need this back once media upload for Gutenberg is in place
-                //definitelyDeleteBackspaceDeletedMediaItems();
+                // definitelyDeleteBackspaceDeletedMediaItems();
 
                 if (shouldSave) {
                     if (isNewPost() && PostStatus.fromPost(mPost) == PostStatus.PUBLISHED) {
@@ -1864,7 +1862,8 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
                     mEditorFragment = (EditorFragmentAbstract) fragment;
                     mEditorFragment.setImageLoader(mImageLoader);
 
-                    mEditorFragment.getTitleOrContentChanged().observe(GutenbergEditPostActivity.this, new Observer<Editable>() {
+                    mEditorFragment.getTitleOrContentChanged().observe(GutenbergEditPostActivity.this,
+                            new Observer<Editable>() {
                         @Override public void onChanged(@Nullable Editable editable) {
                             if (mHandler != null) {
                                 mHandler.removeCallbacks(mSave);
@@ -2198,12 +2197,11 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
         if (mMediaInsertedOnCreation) {
             mMediaInsertedOnCreation = false;
             contentChanged = true;
-        }
         // TODO check if this is needed once media upload for Gutenberg is in place
-        /* else if (isCurrentMediaMarkedUploadingDifferentToOriginal(content)) {
+        /* } else if (isCurrentMediaMarkedUploadingDifferentToOriginal(content)) {
             contentChanged = true;
-        }*/
-        else {
+        */
+        } else {
             contentChanged = mPost.getContent().compareTo(content) != 0;
         }
         if (contentChanged) {
@@ -2563,7 +2561,7 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
                         ToastUtils.showToast(this, R.string.gallery_error, Duration.SHORT);
                     }
                     break;
-                    //TODO: check if this is needed when media upload is in place for Gutenberg
+                    // TODO: check if this is needed when media upload is in place for Gutenberg
 //                case RequestCodes.MEDIA_SETTINGS:
 //                    if (mEditorFragment instanceof AztecEditorFragment) {
 //                        mEditorFragment.onActivityResult(AztecEditorFragment.EDITOR_MEDIA_SETTINGS,
@@ -3356,7 +3354,8 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
 
                     if (mViewPager != null) {
                         Snackbar.make(mViewPager, getString(R.string.local_changes_discarded),
-                                AccessibilityUtils.getSnackbarDuration(GutenbergEditPostActivity.this, Snackbar.LENGTH_LONG))
+                                AccessibilityUtils.getSnackbarDuration(GutenbergEditPostActivity.this,
+                                        Snackbar.LENGTH_LONG))
                                 .setAction(getString(R.string.undo), new OnClickListener() {
                                     @Override public void onClick(View view) {
                                         AnalyticsTracker.track(Stat.EDITOR_DISCARDED_CHANGES_UNDO);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java
@@ -5,7 +5,6 @@ import android.app.Activity;
 import android.app.ProgressDialog;
 import android.arch.lifecycle.Observer;
 import android.content.ClipData;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
@@ -143,7 +142,6 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.ListUtils;
-import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.PermissionUtils;
@@ -295,11 +293,6 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
             }
         }
     };
-
-    @Override
-    protected void attachBaseContext(Context newBase) {
-        super.attachBaseContext(LocaleManager.setLocale(newBase));
-    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java
@@ -3019,7 +3019,7 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
     @Override
     public void onMediaDeleted(String localMediaId) {
         if (!TextUtils.isEmpty(localMediaId)) {
-            //TODO: check if this is needed when media upload is in place for Gutenberg
+            // TODO: check if this is needed when media upload is in place for Gutenberg
 //            mAztecBackspaceDeletedMediaItemIds.add(localMediaId);
 //            UploadService.setDeletedMediaItemIds(mAztecBackspaceDeletedMediaItemIds);
             // passing false here as we need to keep the media item in case the user wants to undo

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java
@@ -1,0 +1,3677 @@
+package org.wordpress.android.ui.posts;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.app.ProgressDialog;
+import android.arch.lifecycle.Observer;
+import android.content.ClipData;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
+import android.support.design.widget.Snackbar;
+import android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.app.FragmentTransaction;
+import android.support.v4.view.ViewPager;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AlertDialog;
+import android.text.Editable;
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
+import android.text.TextUtils;
+import android.text.style.CharacterStyle;
+import android.text.style.SuggestionSpan;
+import android.view.ContextThemeWrapper;
+import android.view.DragEvent;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+import android.widget.RelativeLayout;
+
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.BuildConfig;
+import org.wordpress.android.JavaScriptException;
+import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.analytics.AnalyticsTracker.Stat;
+import org.wordpress.android.editor.AztecEditorFragment;
+import org.wordpress.android.editor.EditorFragment;
+import org.wordpress.android.editor.EditorFragment.EditorFragmentNotAddedException;
+import org.wordpress.android.editor.EditorFragmentAbstract;
+import org.wordpress.android.editor.EditorFragmentAbstract.EditorDragAndDropListener;
+import org.wordpress.android.editor.EditorFragmentAbstract.EditorFragmentListener;
+import org.wordpress.android.editor.EditorFragmentAbstract.TrackableEvent;
+import org.wordpress.android.editor.EditorFragmentActivity;
+import org.wordpress.android.editor.EditorImageMetaData;
+import org.wordpress.android.editor.EditorImageSettingsListener;
+import org.wordpress.android.editor.EditorMediaUploadListener;
+import org.wordpress.android.editor.EditorMediaUtils;
+import org.wordpress.android.editor.EditorWebViewAbstract.ErrorListener;
+import org.wordpress.android.editor.EditorWebViewCompatibility;
+import org.wordpress.android.editor.EditorWebViewCompatibility.ReflectionException;
+import org.wordpress.android.editor.GutenbergEditorFragment;
+import org.wordpress.android.editor.ImageSettingsDialogFragment;
+import org.wordpress.android.editor.LegacyEditorFragment;
+import org.wordpress.android.editor.MediaToolbarAction;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.action.AccountAction;
+import org.wordpress.android.fluxc.generated.AccountActionBuilder;
+import org.wordpress.android.fluxc.generated.MediaActionBuilder;
+import org.wordpress.android.fluxc.generated.PostActionBuilder;
+import org.wordpress.android.fluxc.generated.UploadActionBuilder;
+import org.wordpress.android.fluxc.model.AccountModel;
+import org.wordpress.android.fluxc.model.CauseOfOnPostChanged;
+import org.wordpress.android.fluxc.model.MediaModel;
+import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
+import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.post.PostStatus;
+import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
+import org.wordpress.android.fluxc.store.MediaStore;
+import org.wordpress.android.fluxc.store.MediaStore.CancelMediaPayload;
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
+import org.wordpress.android.fluxc.store.MediaStore.MediaError;
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
+import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
+import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged;
+import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
+import org.wordpress.android.fluxc.store.PostStore;
+import org.wordpress.android.fluxc.store.PostStore.OnPostChanged;
+import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
+import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
+import org.wordpress.android.fluxc.store.QuickStartStore;
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask;
+import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.UploadStore;
+import org.wordpress.android.fluxc.store.UploadStore.ClearMediaPayload;
+import org.wordpress.android.fluxc.tools.FluxCImageLoader;
+import org.wordpress.android.support.ZendeskHelper;
+import org.wordpress.android.ui.ActivityId;
+import org.wordpress.android.ui.ActivityLauncher;
+import org.wordpress.android.ui.RequestCodes;
+import org.wordpress.android.ui.Shortcut;
+import org.wordpress.android.ui.accounts.HelpActivity.Origin;
+import org.wordpress.android.ui.giphy.GiphyPickerActivity;
+import org.wordpress.android.ui.history.HistoryListItem.Revision;
+import org.wordpress.android.ui.media.MediaBrowserActivity;
+import org.wordpress.android.ui.media.MediaBrowserType;
+import org.wordpress.android.ui.media.MediaSettingsActivity;
+import org.wordpress.android.ui.notifications.utils.PendingDraftsNotificationsUtils;
+import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
+import org.wordpress.android.ui.photopicker.PhotoPickerFragment;
+import org.wordpress.android.ui.photopicker.PhotoPickerFragment.PhotoPickerIcon;
+import org.wordpress.android.ui.posts.InsertMediaDialog.InsertMediaCallback;
+import org.wordpress.android.ui.posts.PromoDialog.PromoDialogClickInterface;
+import org.wordpress.android.ui.posts.services.AztecImageLoader;
+import org.wordpress.android.ui.posts.services.AztecVideoLoader;
+import org.wordpress.android.ui.prefs.AppPrefs;
+import org.wordpress.android.ui.prefs.ReleaseNotesActivity;
+import org.wordpress.android.ui.stockmedia.StockMediaPickerActivity;
+import org.wordpress.android.ui.uploads.PostEvents;
+import org.wordpress.android.ui.uploads.UploadService;
+import org.wordpress.android.ui.uploads.UploadUtils;
+import org.wordpress.android.ui.uploads.VideoOptimizer;
+import org.wordpress.android.util.AccessibilityUtils;
+import org.wordpress.android.util.ActivityUtils;
+import org.wordpress.android.util.AniUtils;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.AutolinkUtils;
+import org.wordpress.android.util.CrashlyticsUtils;
+import org.wordpress.android.util.DateTimeUtils;
+import org.wordpress.android.util.DisplayUtils;
+import org.wordpress.android.util.FluxCUtils;
+import org.wordpress.android.util.ImageUtils;
+import org.wordpress.android.util.ListUtils;
+import org.wordpress.android.util.LocaleManager;
+import org.wordpress.android.util.MediaUtils;
+import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.PermissionUtils;
+import org.wordpress.android.util.QuickStartUtils;
+import org.wordpress.android.util.ShortcutUtils;
+import org.wordpress.android.util.SiteUtils;
+import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.ToastUtils.Duration;
+import org.wordpress.android.util.WPHtml;
+import org.wordpress.android.util.WPMediaUtils;
+import org.wordpress.android.util.WPPermissionUtils;
+import org.wordpress.android.util.WPUrlUtils;
+import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.helpers.MediaFile;
+import org.wordpress.android.util.helpers.MediaGallery;
+import org.wordpress.android.util.helpers.MediaGalleryImageSpan;
+import org.wordpress.android.util.helpers.WPImageSpan;
+import org.wordpress.android.util.image.ImageManager;
+import org.wordpress.android.widgets.WPViewPager;
+import org.wordpress.aztec.AztecExceptionHandler;
+import org.wordpress.aztec.util.AztecLog;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.inject.Inject;
+
+import de.greenrobot.event.EventBus;
+
+import static org.wordpress.android.ui.history.HistoryDetailContainerFragment.KEY_REVISION;
+
+public class GutenbergEditPostActivity extends EditPostBaseActivity implements
+        EditorFragmentActivity,
+        EditorImageSettingsListener,
+        EditorDragAndDropListener,
+        EditorFragmentListener,
+        MediaToolbarAction.MediaToolbarButtonClickListener,
+        EditorWebViewCompatibility.ReflectionFailureListener,
+        OnRequestPermissionsResultCallback,
+        PhotoPickerFragment.PhotoPickerListener,
+        EditPostSettingsFragment.EditPostActivityHook,
+        BasicFragmentDialog.BasicDialogPositiveClickInterface,
+        BasicFragmentDialog.BasicDialogNegativeClickInterface,
+        PromoDialogClickInterface,
+        PostSettingsListDialogFragment.OnPostSettingsDialogFragmentListener,
+        PostDatePickerDialogFragment.OnPostDatePickerDialogListener,
+        HistoryListFragment.HistoryItemClickInterface {
+
+    private AztecImageLoader mAztecImageLoader;
+
+    private Handler mHandler;
+    private int mDebounceCounter = 0;
+    private boolean mShowAztecEditor;
+    private boolean mShowNewEditor;
+    private boolean mShowGutenbergEditor;
+    private boolean mMediaInsertedOnCreation;
+
+    private List<String> mPendingVideoPressInfoRequests;
+    private List<String> mAztecBackspaceDeletedMediaItemIds = new ArrayList<>();
+    private List<String> mMediaMarkedUploadingOnStartIds = new ArrayList<>();
+
+    /**
+     * The {@link android.support.v4.view.PagerAdapter} that will provide
+     * fragments for each of the sections. We use a
+     * {@link FragmentPagerAdapter} derivative, which will keep every
+     * loaded fragment in memory. If this becomes too memory intensive, it
+     * may be best to switch to a
+     * {@link android.support.v4.app.FragmentStatePagerAdapter}.
+     */
+    SectionsPagerAdapter mSectionsPagerAdapter;
+
+    /**
+     * The {@link ViewPager} that will host the section contents.
+     */
+    WPViewPager mViewPager;
+
+    private PostModel mPost;
+    private PostModel mPostForUndo;
+    private PostModel mOriginalPost;
+    private boolean mOriginalPostHadLocalChangesOnOpen;
+
+    private Revision mRevision;
+
+    private EditorFragmentAbstract mEditorFragment;
+    private EditPostSettingsFragment mEditPostSettingsFragment;
+    private EditPostPreviewFragment mEditPostPreviewFragment;
+
+    private EditorMediaUploadListener mEditorMediaUploadListener;
+
+    private ProgressDialog mProgressDialog;
+
+    private boolean mIsNewPost;
+    private boolean mIsPage;
+    private boolean mHasSetPostContent;
+    private boolean mIsDialogProgressShown;
+    private boolean mIsDiscardingChanges;
+    private boolean mIsUpdatingPost;
+
+    private View mPhotoPickerContainer;
+    private PhotoPickerFragment mPhotoPickerFragment;
+    private int mPhotoPickerOrientation = Configuration.ORIENTATION_UNDEFINED;
+
+    // For opening the context menu after permissions have been granted
+    private View mMenuView = null;
+
+    private boolean mHtmlModeMenuStateOn = false;
+
+    @Inject Dispatcher mDispatcher;
+    @Inject AccountStore mAccountStore;
+    @Inject SiteStore mSiteStore;
+    @Inject PostStore mPostStore;
+    @Inject MediaStore mMediaStore;
+    @Inject UploadStore mUploadStore;
+    @Inject FluxCImageLoader mImageLoader;
+    @Inject ShortcutUtils mShortcutUtils;
+    @Inject QuickStartStore mQuickStartStore;
+    @Inject ZendeskHelper mZendeskHelper;
+    @Inject ImageManager mImageManager;
+
+    private SiteModel mSite;
+
+    // for keeping the media uri while asking for permissions
+    private ArrayList<Uri> mDroppedMediaUris;
+
+    private boolean isModernEditor() {
+        return mShowNewEditor || mShowAztecEditor || mShowGutenbergEditor;
+    }
+
+    private Runnable mFetchMediaRunnable = new Runnable() {
+        @Override
+        public void run() {
+            if (mDroppedMediaUris != null) {
+                final List<Uri> mediaUris = mDroppedMediaUris;
+                mDroppedMediaUris = null;
+                addMediaList(mediaUris, false);
+            }
+        }
+    };
+
+    @Override
+    protected void attachBaseContext(Context newBase) {
+        super.attachBaseContext(LocaleManager.setLocale(newBase));
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ((WordPress) getApplication()).component().inject(this);
+        mDispatcher.register(this);
+        mHandler = new Handler();
+        setContentView(R.layout.new_edit_post_activity);
+
+        if (savedInstanceState == null) {
+            mSite = (SiteModel) getIntent().getSerializableExtra(WordPress.SITE);
+        } else {
+            mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
+        }
+
+        // Check whether to show the visual editor
+        PreferenceManager.setDefaultValues(this, R.xml.account_settings, false);
+        // AppPrefs.setAztecEditorAvailable(true);
+        // AppPrefs.setAztecEditorEnabled(true);
+        mShowAztecEditor = AppPrefs.isAztecEditorEnabled();
+        mShowNewEditor = AppPrefs.isVisualEditorEnabled();
+
+        // TODO when aztec is the only editor, remove this part and set the overlay bottom margin in xml
+        if (mShowAztecEditor) {
+            View overlay = findViewById(R.id.view_overlay);
+            RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) overlay.getLayoutParams();
+            layoutParams.bottomMargin = getResources().getDimensionPixelOffset(R.dimen.aztec_format_bar_height);
+            overlay.setLayoutParams(layoutParams);
+        }
+
+        // Set up the action bar.
+        final ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+
+        FragmentManager fragmentManager = getSupportFragmentManager();
+        Bundle extras = getIntent().getExtras();
+        String action = getIntent().getAction();
+        if (savedInstanceState == null) {
+            if (!getIntent().hasExtra(EXTRA_POST_LOCAL_ID)
+                || Intent.ACTION_SEND.equals(action)
+                || Intent.ACTION_SEND_MULTIPLE.equals(action)
+                || NEW_MEDIA_POST.equals(action)
+                || getIntent().hasExtra(EXTRA_IS_QUICKPRESS)) {
+                if (getIntent().hasExtra(EXTRA_QUICKPRESS_BLOG_ID)) {
+                    // QuickPress might want to use a different blog than the current blog
+                    int localSiteId = getIntent().getIntExtra(EXTRA_QUICKPRESS_BLOG_ID, -1);
+                    mSite = mSiteStore.getSiteByLocalId(localSiteId);
+                }
+
+                if (extras != null) {
+                    mIsPage = extras.getBoolean(EXTRA_IS_PAGE);
+                }
+                mIsNewPost = true;
+
+                if (mSite == null) {
+                    showErrorAndFinish(R.string.blog_not_found);
+                    return;
+                }
+                if (!mSite.isVisible()) {
+                    showErrorAndFinish(R.string.error_blog_hidden);
+                    return;
+                }
+
+                // Create a new post
+                mPost = mPostStore.instantiatePostModel(mSite, mIsPage, null, null);
+                mPost.setStatus(PostStatus.PUBLISHED.toString());
+                EventBus.getDefault().postSticky(
+                        new PostEvents.PostOpenedInEditor(mPost.getLocalSiteId(), mPost.getId()));
+                mShortcutUtils.reportShortcutUsed(Shortcut.CREATE_NEW_POST);
+            } else if (extras != null) {
+                // Load post passed in extras
+                mPost = mPostStore.getPostByLocalPostId(extras.getInt(EXTRA_POST_LOCAL_ID));
+                if (mPost != null) {
+                    initializePostObject();
+                }
+            }
+        } else {
+            mDroppedMediaUris = savedInstanceState.getParcelable(STATE_KEY_DROPPED_MEDIA_URIS);
+            mIsNewPost = savedInstanceState.getBoolean(STATE_KEY_IS_NEW_POST, false);
+            mIsDialogProgressShown = savedInstanceState.getBoolean(STATE_KEY_IS_DIALOG_PROGRESS_SHOWN, false);
+            mIsDiscardingChanges = savedInstanceState.getBoolean(STATE_KEY_IS_DISCARDING_CHANGES, false);
+            mRevision = savedInstanceState.getParcelable(STATE_KEY_REVISION);
+
+            showDialogProgress(mIsDialogProgressShown);
+
+            // if we have a remote id saved, let's first try with that, as the local Id might have changed
+            // after FETCH_POSTS
+            if (savedInstanceState.containsKey(STATE_KEY_POST_REMOTE_ID)) {
+                mPost = mPostStore.getPostByRemotePostId(savedInstanceState.getLong(STATE_KEY_POST_REMOTE_ID), mSite);
+                initializePostObject();
+            } else if (savedInstanceState.containsKey(STATE_KEY_POST_LOCAL_ID)) {
+                mPost = mPostStore.getPostByLocalPostId(savedInstanceState.getInt(STATE_KEY_POST_LOCAL_ID));
+                initializePostObject();
+            }
+
+            mEditorFragment =
+                    (EditorFragmentAbstract) fragmentManager.getFragment(savedInstanceState, STATE_KEY_EDITOR_FRAGMENT);
+
+            if (mEditorFragment instanceof EditorMediaUploadListener) {
+                mEditorMediaUploadListener = (EditorMediaUploadListener) mEditorFragment;
+            }
+        }
+
+        if (mSite == null) {
+            ToastUtils.showToast(this, R.string.blog_not_found, Duration.SHORT);
+            finish();
+            return;
+        }
+
+        QuickStartUtils.completeTask(mQuickStartStore, QuickStartTask.PUBLISH_POST, mDispatcher, mSite);
+
+        if (mHasSetPostContent = mEditorFragment != null) {
+            mEditorFragment.setImageLoader(mImageLoader);
+        }
+
+        // Ensure that this check happens when mPost is set
+        mShowGutenbergEditor = PostUtils.shouldShowGutenbergEditor(mIsNewPost, mPost);
+
+        // Ensure we have a valid post
+        if (mPost == null) {
+            showErrorAndFinish(R.string.post_not_found);
+            return;
+        }
+
+        if (savedInstanceState == null) {
+            // Bump the stat the first time the editor is opened.
+            PostUtils.trackOpenPostAnalytics(mPost, mSite);
+        }
+
+        if (mIsNewPost) {
+            trackEditorCreatedPost(action, getIntent());
+        } else {
+            // if we are opening a Post for which an error notification exists, we need to remove
+            // it from the dashboard to prevent the user from tapping RETRY on a Post that is
+            // being currently edited
+            UploadService.cancelFinalNotification(this, mPost);
+            resetUploadingMediaToFailedIfPostHasNotMediaInProgressOrQueued();
+        }
+
+        setTitle(SiteUtils.getSiteNameOrHomeURL(mSite));
+        mSectionsPagerAdapter = new SectionsPagerAdapter(fragmentManager);
+
+        // Set up the ViewPager with the sections adapter.
+        mViewPager = findViewById(R.id.pager);
+        mViewPager.setAdapter(mSectionsPagerAdapter);
+        mViewPager.setOffscreenPageLimit(3);
+        mViewPager.setPagingEnabled(false);
+
+        // When swiping between different sections, select the corresponding
+        // tab. We can also use ActionBar.Tab#select() to do this if we have
+        // a reference to the Tab.
+        mViewPager.setOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener() {
+            @Override
+            public void onPageSelected(int position) {
+                invalidateOptionsMenu();
+                if (position == PAGE_CONTENT) {
+                    setTitle(SiteUtils.getSiteNameOrHomeURL(mSite));
+                } else if (position == PAGE_SETTINGS) {
+                    setTitle(mPost.isPage() ? R.string.page_settings : R.string.post_settings);
+                    hidePhotoPicker();
+                } else if (position == PAGE_PREVIEW) {
+                    setTitle(mPost.isPage() ? R.string.preview_page : R.string.preview_post);
+                    hidePhotoPicker();
+                    savePostAsync(new AfterSavePostListener() {
+                        @Override
+                        public void onPostSave() {
+                            if (mEditPostPreviewFragment != null) {
+                                runOnUiThread(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        if (mEditPostPreviewFragment != null) {
+                                            mEditPostPreviewFragment.loadPost();
+                                        }
+                                    }
+                                });
+                            }
+                        }
+                    });
+                } else if (position == PAGE_HISTORY) {
+                    setTitle(R.string.history_title);
+                    hidePhotoPicker();
+                }
+            }
+        });
+
+        ActivityId.trackLastActivity(ActivityId.POST_EDITOR);
+    }
+
+    private void initializePostObject() {
+        if (mPost != null) {
+            mOriginalPost = mPost.clone();
+            mOriginalPostHadLocalChangesOnOpen = mOriginalPost.isLocallyChanged();
+            mPost = UploadService.updatePostWithCurrentlyCompletedUploads(mPost);
+            if (mShowAztecEditor) {
+                mMediaMarkedUploadingOnStartIds =
+                        AztecEditorFragment.getMediaMarkedUploadingInPostContent(this, mPost.getContent());
+                Collections.sort(mMediaMarkedUploadingOnStartIds);
+            }
+            mIsPage = mPost.isPage();
+
+            EventBus.getDefault().postSticky(
+                    new PostEvents.PostOpenedInEditor(mPost.getLocalSiteId(), mPost.getId()));
+
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    // run this purge in the background to not delay Editor initialization
+                    purgeMediaToPostAssociationsIfNotInPostAnymore();
+                }
+            }).start();
+        }
+    }
+
+    private void purgeMediaToPostAssociationsIfNotInPostAnymore() {
+        ArrayList<MediaModel> allMedia = new ArrayList<>();
+        allMedia.addAll(mUploadStore.getFailedMediaForPost(mPost));
+        allMedia.addAll(mUploadStore.getCompletedMediaForPost(mPost));
+        allMedia.addAll(mUploadStore.getUploadingMediaForPost(mPost));
+
+        if (!allMedia.isEmpty()) {
+            HashSet<MediaModel> mediaToDeleteAssociationFor = new HashSet<>();
+            for (MediaModel media : allMedia) {
+                if (!AztecEditorFragment.isMediaInPostBody(this, mPost.getContent(), String.valueOf(media.getId()))) {
+                    mediaToDeleteAssociationFor.add(media);
+                }
+            }
+
+            if (!mediaToDeleteAssociationFor.isEmpty()) {
+                // also remove the association of Media-to-Post for this post
+                ClearMediaPayload clearMediaPayload = new ClearMediaPayload(mPost, mediaToDeleteAssociationFor);
+                mDispatcher.dispatch(UploadActionBuilder.newClearMediaForPostAction(clearMediaPayload));
+            }
+        }
+    }
+
+    // this method aims at recovering the current state of media items if they're inconsistent within the PostModel.
+    private void resetUploadingMediaToFailedIfPostHasNotMediaInProgressOrQueued() {
+        boolean useAztec = AppPrefs.isAztecEditorEnabled();
+
+        if (!useAztec || UploadService.hasPendingOrInProgressMediaUploadsForPost(mPost)) {
+            return;
+        }
+
+        String oldContent = mPost.getContent();
+        if (!AztecEditorFragment.hasMediaItemsMarkedUploading(this, oldContent)
+            // we need to make sure items marked failed are still failed or not as well
+            && !AztecEditorFragment.hasMediaItemsMarkedFailed(this, oldContent)) {
+            return;
+        }
+
+        String newContent = AztecEditorFragment.resetUploadingMediaToFailed(this, oldContent);
+
+        if (!TextUtils.isEmpty(oldContent) && newContent != null && oldContent.compareTo(newContent) != 0) {
+            mPost.setContent(newContent);
+
+            // we changed the post, so let’s mark this down
+            if (!mPost.isLocalDraft()) {
+                mPost.setIsLocallyChanged(true);
+            }
+            mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
+        }
+    }
+
+    private Runnable mSave = new Runnable() {
+        @Override
+        public void run() {
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    mDebounceCounter = 0;
+                    try {
+                        updatePostObject(true);
+                    } catch (EditorFragmentNotAddedException e) {
+                        AppLog.e(T.EDITOR, "Impossible to save the post, we weren't able to update it.");
+                        return;
+                    }
+                    savePostToDb();
+                }
+            }).start();
+        }
+    };
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        EventBus.getDefault().register(this);
+
+        reattachUploadingMedia();
+    }
+
+    private void reattachUploadingMedia() {
+        if (mEditorMediaUploadListener != null) {
+            // UploadService.getPendingMediaForPost will be populated only when the user exits the editor
+            // But if the user doesn't exit the editor and sends the app to the background, a reattachment
+            // for the media within this Post is needed as soon as the app comes back to foreground,
+            // so we get the list of progressing media for this Post from the UploadService
+            List<MediaModel> allUploadingMediaInPost = new ArrayList<>();
+            Set<MediaModel> uploadingMediaInPost = UploadService.getPendingMediaForPost(mPost);
+            allUploadingMediaInPost.addAll(uploadingMediaInPost);
+            // add them to the array only if they are not in there yet
+            for (MediaModel media1 : UploadService.getPendingOrInProgressMediaUploadsForPost(mPost)) {
+                boolean found = false;
+                for (MediaModel media2 : uploadingMediaInPost) {
+                    if (media1.getId() == media2.getId()) {
+                        // if it exists, just break the loop and check for the next one
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found) {
+                    // we haven't found it before, so let's add it to the list.
+                    allUploadingMediaInPost.add(media1);
+                }
+            }
+
+            // now do proper re-attachment of upload progress on each media item
+            for (MediaModel media : allUploadingMediaInPost) {
+                if (media != null) {
+                    mEditorMediaUploadListener.onMediaUploadReattached(String.valueOf(media.getId()),
+                                                                       UploadService.getUploadProgressForMedia(media));
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+
+        EventBus.getDefault().unregister(this);
+    }
+
+    @Override protected void onStop() {
+        super.onStop();
+        if (mAztecImageLoader != null && isFinishing()) {
+            mAztecImageLoader.clearTargets();
+            mAztecImageLoader = null;
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        AnalyticsTracker.track(Stat.EDITOR_CLOSED);
+        mDispatcher.unregister(this);
+        if (mHandler != null) {
+            mHandler.removeCallbacks(mSave);
+            mHandler = null;
+        }
+        cancelAddMediaListThread();
+        removePostOpenInEditorStickyEvent();
+        if (mEditorFragment instanceof AztecEditorFragment) {
+            ((AztecEditorFragment) mEditorFragment).disableContentLogOnCrashes();
+        }
+        super.onDestroy();
+    }
+
+    private void removePostOpenInEditorStickyEvent() {
+        PostEvents.PostOpenedInEditor stickyEvent =
+                EventBus.getDefault().getStickyEvent(PostEvents.PostOpenedInEditor.class);
+        if (stickyEvent != null) {
+            // "Consume" the sticky event
+            EventBus.getDefault().removeStickyEvent(stickyEvent);
+        }
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        // Saves both post objects so we can restore them in onCreate()
+        savePostAsync(null);
+        outState.putInt(STATE_KEY_POST_LOCAL_ID, mPost.getId());
+        if (!mPost.isLocalDraft()) {
+            outState.putLong(STATE_KEY_POST_REMOTE_ID, mPost.getRemotePostId());
+        }
+        outState.putBoolean(STATE_KEY_IS_DISCARDING_CHANGES, mIsDiscardingChanges);
+        outState.putBoolean(STATE_KEY_IS_DIALOG_PROGRESS_SHOWN, mIsDialogProgressShown);
+        outState.putBoolean(STATE_KEY_IS_NEW_POST, mIsNewPost);
+        outState.putBoolean(STATE_KEY_IS_PHOTO_PICKER_VISIBLE, isPhotoPickerShowing());
+        outState.putBoolean(STATE_KEY_HTML_MODE_ON, mHtmlModeMenuStateOn);
+        outState.putSerializable(WordPress.SITE, mSite);
+        outState.putParcelable(STATE_KEY_REVISION, mRevision);
+
+        outState.putParcelableArrayList(STATE_KEY_DROPPED_MEDIA_URIS, mDroppedMediaUris);
+
+        if (mEditorFragment != null) {
+            getSupportFragmentManager().putFragment(outState, STATE_KEY_EDITOR_FRAGMENT, mEditorFragment);
+        }
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+
+        mHtmlModeMenuStateOn = savedInstanceState.getBoolean(STATE_KEY_HTML_MODE_ON);
+        if (savedInstanceState.getBoolean(STATE_KEY_IS_PHOTO_PICKER_VISIBLE, false)) {
+            showPhotoPicker();
+        }
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        // resize the photo picker if the user rotated the device
+        int orientation = newConfig.orientation;
+        if (orientation != mPhotoPickerOrientation) {
+            resizePhotoPicker();
+        }
+    }
+
+    private String getSaveButtonText() {
+        if (!userCanPublishPosts()) {
+            return getString(R.string.submit_for_review);
+        }
+
+        switch (PostStatus.fromPost(mPost)) {
+            case SCHEDULED:
+                return getString(R.string.schedule_verb);
+            case PUBLISHED:
+            case UNKNOWN:
+                if (mPost.isLocalDraft()) {
+                    return getString(R.string.post_status_publish_post);
+                } else {
+                    return getString(R.string.update_verb);
+                }
+            case PRIVATE:
+            case PENDING:
+            case TRASHED:
+            case DRAFT:
+            default:
+                if (mPost.isLocalDraft()) {
+                    return getString(R.string.save);
+                } else {
+                    return getString(R.string.update_verb);
+                }
+        }
+    }
+
+    private String getSaveAsADraftButtonText() {
+        if (!userCanPublishPosts()) {
+            return getString(R.string.submit_for_review);
+        }
+
+        if (isNewPost()) {
+            return getString(R.string.menu_save_as_draft);
+        }
+
+        switch (PostStatus.fromPost(mPost)) {
+            case DRAFT:
+            case PENDING:
+                return getString(R.string.menu_publish_now);
+            case PUBLISHED:
+            case UNKNOWN:
+                if (mPost.isLocalDraft()) {
+                    return getString(R.string.menu_publish_now);
+                } else {
+                    return getString(R.string.update_verb);
+                }
+            case PRIVATE:
+            case TRASHED:
+            case SCHEDULED:
+            default:
+                if (!isNewPost()) {
+                    return getString(R.string.menu_publish_now);
+                } else {
+                    return getString(R.string.menu_save_as_draft);
+                }
+        }
+    }
+
+    private boolean isPhotoPickerShowing() {
+        return mPhotoPickerContainer != null
+               && mPhotoPickerContainer.getVisibility() == View.VISIBLE;
+    }
+
+    /*
+     * resizes the photo picker based on device orientation - full height in landscape, half
+     * height in portrait
+     */
+    private void resizePhotoPicker() {
+        if (mPhotoPickerContainer == null) {
+            return;
+        }
+
+        if (DisplayUtils.isLandscape(this)) {
+            mPhotoPickerOrientation = Configuration.ORIENTATION_LANDSCAPE;
+            mPhotoPickerContainer.getLayoutParams().height = ViewGroup.LayoutParams.MATCH_PARENT;
+        } else {
+            mPhotoPickerOrientation = Configuration.ORIENTATION_PORTRAIT;
+            int displayHeight = DisplayUtils.getDisplayPixelHeight(this);
+            int containerHeight = (int) (displayHeight * 0.5f);
+            mPhotoPickerContainer.getLayoutParams().height = containerHeight;
+        }
+
+        if (mPhotoPickerFragment != null) {
+            mPhotoPickerFragment.reload();
+        }
+    }
+
+    /*
+     * loads the photo picker fragment, which is hidden until the user taps the media icon
+     */
+    private void initPhotoPicker() {
+        mPhotoPickerContainer = findViewById(R.id.photo_fragment_container);
+
+        // size the picker before creating the fragment to avoid having it load media now
+        resizePhotoPicker();
+
+        mPhotoPickerFragment = (PhotoPickerFragment) getSupportFragmentManager().findFragmentByTag(PHOTO_PICKER_TAG);
+        if (mPhotoPickerFragment == null) {
+            MediaBrowserType mediaBrowserType =
+                    mShowAztecEditor ? MediaBrowserType.AZTEC_EDITOR_PICKER : MediaBrowserType.EDITOR_PICKER;
+            mPhotoPickerFragment = PhotoPickerFragment.newInstance(this, mediaBrowserType, getSite());
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .add(R.id.photo_fragment_container, mPhotoPickerFragment, PHOTO_PICKER_TAG)
+                    .commit();
+        }
+    }
+
+    /*
+     * shows/hides the overlay which appears atop the editor, which effectively disables it
+     */
+    private void showOverlay(boolean animate) {
+        View overlay = findViewById(R.id.view_overlay);
+        if (animate) {
+            AniUtils.fadeIn(overlay, AniUtils.Duration.MEDIUM);
+        } else {
+            overlay.setVisibility(View.VISIBLE);
+        }
+    }
+
+    private void hideOverlay() {
+        View overlay = findViewById(R.id.view_overlay);
+        overlay.setVisibility(View.GONE);
+    }
+
+    /*
+     * user has requested to show the photo picker
+     */
+    private void showPhotoPicker() {
+        boolean isAlreadyShowing = isPhotoPickerShowing();
+
+        // make sure we initialized the photo picker
+        if (mPhotoPickerFragment == null) {
+            initPhotoPicker();
+        }
+
+        // hide soft keyboard
+        ActivityUtils.hideKeyboard(this);
+
+        // slide in the photo picker
+        if (!isAlreadyShowing) {
+            AniUtils.animateBottomBar(mPhotoPickerContainer, true, AniUtils.Duration.MEDIUM);
+            mPhotoPickerFragment.refresh();
+            mPhotoPickerFragment.setPhotoPickerListener(this);
+        }
+
+        // animate in the editor overlay
+        showOverlay(true);
+
+        if (mEditorFragment instanceof AztecEditorFragment) {
+            ((AztecEditorFragment) mEditorFragment).enableMediaMode(true);
+        }
+    }
+
+    private void hidePhotoPicker() {
+        if (isPhotoPickerShowing()) {
+            mPhotoPickerFragment.finishActionMode();
+            mPhotoPickerFragment.setPhotoPickerListener(null);
+            AniUtils.animateBottomBar(mPhotoPickerContainer, false);
+        }
+
+        hideOverlay();
+
+        if (mEditorFragment instanceof AztecEditorFragment) {
+            ((AztecEditorFragment) mEditorFragment).enableMediaMode(false);
+        }
+    }
+
+    /*
+     * called by PhotoPickerFragment when media is selected - may be a single item or a list of items
+     */
+    @Override
+    public void onPhotoPickerMediaChosen(@NonNull final List<Uri> uriList) {
+        hidePhotoPicker();
+
+        if (WPMediaUtils.shouldAdvertiseImageOptimization(this)) {
+            boolean hasSelectedPicture = false;
+            for (Uri uri : uriList) {
+                if (!MediaUtils.isVideo(uri.toString())) {
+                    hasSelectedPicture = true;
+                    break;
+                }
+            }
+            if (hasSelectedPicture) {
+                WPMediaUtils.advertiseImageOptimization(this,
+                                                        new WPMediaUtils.OnAdvertiseImageOptimizationListener() {
+                                                            @Override
+                                                            public void done() {
+                                                                addMediaList(uriList, false);
+                                                            }
+                                                        });
+                return;
+            }
+        }
+
+        addMediaList(uriList, false);
+    }
+
+    @Override
+    public void onMediaToolbarButtonClicked(MediaToolbarAction action) {
+        if (!isPhotoPickerShowing()) {
+            return;
+        }
+
+        switch (action) {
+            case CAMERA:
+                mPhotoPickerFragment.showCameraPopupMenu(findViewById(action.getButtonId()));
+                break;
+            case GALLERY:
+                mPhotoPickerFragment.showPickerPopupMenu(findViewById(action.getButtonId()));
+                break;
+            case LIBRARY:
+                mPhotoPickerFragment.doIconClicked(PhotoPickerIcon.WP_MEDIA);
+                break;
+        }
+    }
+
+    /*
+     * called by PhotoPickerFragment when user clicks an icon to launch the camera, native
+     * picker, or WP media picker
+     */
+    @Override
+    public void onPhotoPickerIconClicked(@NonNull PhotoPickerIcon icon) {
+        hidePhotoPicker();
+        switch (icon) {
+            case ANDROID_CAPTURE_PHOTO:
+                launchCamera();
+                break;
+            case ANDROID_CAPTURE_VIDEO:
+                launchVideoCamera();
+                break;
+            case ANDROID_CHOOSE_PHOTO:
+                launchPictureLibrary();
+                break;
+            case ANDROID_CHOOSE_VIDEO:
+                launchVideoLibrary();
+                break;
+            case WP_MEDIA:
+                ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.EDITOR_PICKER);
+                break;
+            case STOCK_MEDIA:
+                ActivityLauncher.showStockMediaPickerForResult(
+                        this, mSite, RequestCodes.STOCK_MEDIA_PICKER_MULTI_SELECT);
+                break;
+            case GIPHY:
+                ActivityLauncher.showGiphyPickerForResult(this, mSite, RequestCodes.GIPHY_PICKER);
+                break;
+        }
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        super.onCreateOptionsMenu(menu);
+        MenuInflater inflater = getMenuInflater();
+        if (isModernEditor()) {
+            inflater.inflate(R.menu.edit_post, menu);
+        } else {
+            inflater.inflate(R.menu.edit_post_legacy, menu);
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        boolean showMenuItems = true;
+        if (mViewPager != null && mViewPager.getCurrentItem() > PAGE_CONTENT) {
+            showMenuItems = false;
+        }
+
+
+        MenuItem saveAsDraftMenuItem = menu.findItem(R.id.menu_save_as_draft_or_publish);
+        MenuItem previewMenuItem = menu.findItem(R.id.menu_preview_post);
+        MenuItem viewHtmlModeMenuItem = menu.findItem(R.id.menu_html_mode);
+        MenuItem historyMenuItem = menu.findItem(R.id.menu_history);
+        MenuItem settingsMenuItem = menu.findItem(R.id.menu_post_settings);
+        MenuItem discardChanges = menu.findItem(R.id.menu_discard_changes);
+
+        if (saveAsDraftMenuItem != null && mPost != null) {
+            if (PostStatus.fromPost(mPost) == PostStatus.PRIVATE) {
+                saveAsDraftMenuItem.setVisible(false);
+            } else {
+                saveAsDraftMenuItem.setVisible(showMenuItems);
+                saveAsDraftMenuItem.setTitle(getSaveAsADraftButtonText());
+            }
+        }
+
+        if (previewMenuItem != null) {
+            previewMenuItem.setVisible(showMenuItems);
+        }
+
+        if (viewHtmlModeMenuItem != null) {
+            viewHtmlModeMenuItem.setVisible(((mEditorFragment instanceof AztecEditorFragment)
+                                             || (mEditorFragment instanceof GutenbergEditorFragment)) && showMenuItems);
+            viewHtmlModeMenuItem.setTitle(mHtmlModeMenuStateOn ? R.string.menu_visual_mode : R.string.menu_html_mode);
+        }
+
+        if (historyMenuItem != null) {
+            boolean hasHistory = !mIsNewPost && (mSite.isWPCom() || mSite.isJetpackConnected());
+            historyMenuItem.setVisible(showMenuItems && hasHistory);
+        }
+
+        if (settingsMenuItem != null) {
+            settingsMenuItem.setTitle(mIsPage ? R.string.page_settings : R.string.post_settings);
+            settingsMenuItem.setVisible(showMenuItems);
+        }
+
+        showHideDiscardLocalChangesMenuOption(showMenuItems, discardChanges);
+
+        // Set text of the save button in the ActionBar
+        if (mPost != null) {
+            MenuItem saveMenuItem = menu.findItem(R.id.menu_save_post);
+            if (saveMenuItem != null) {
+                saveMenuItem.setTitle(getSaveButtonText());
+                saveMenuItem.setVisible(mViewPager != null && mViewPager.getCurrentItem() != PAGE_HISTORY);
+            }
+        }
+
+        return super.onPrepareOptionsMenu(menu);
+    }
+
+    private void showHideDiscardLocalChangesMenuOption(boolean showMenuItems, MenuItem discardChanges) {
+        if (discardChanges != null) {
+            if (mIsNewPost) {
+                // by "local changes" we mean changes that are only local (that is to say, are not in the remote yet).
+                // if this is a new Post, then there aren't any local changes to discard yet (everything is local).
+                discardChanges.setVisible(false);
+                return;
+            }
+
+            if (mPost != null && showMenuItems) {
+                // don't show Discard Local Changes option if it's a completely local draft
+                boolean showDiscardChanges = mPost.isLocallyChanged() && !mPost.isLocalDraft();
+                if (mEditorFragment instanceof AztecEditorFragment) {
+                    if (((AztecEditorFragment) mEditorFragment).hasHistory()
+                        && ((AztecEditorFragment) mEditorFragment).canUndo()
+                            && !mPost.isLocalDraft()) {
+                        showDiscardChanges = true;
+                    } else {
+                        // we don't have history, so hide/show depending on the original post flag value
+                        showDiscardChanges = mOriginalPostHadLocalChangesOnOpen;
+                    }
+                }
+                discardChanges.setVisible(showDiscardChanges);
+            } else {
+                discardChanges.setVisible(false);
+            }
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode,
+                                           @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        boolean allGranted = WPPermissionUtils.setPermissionListAsked(
+                this, requestCode, permissions, grantResults, true);
+
+        if (allGranted) {
+            switch (requestCode) {
+                case WPPermissionUtils.EDITOR_MEDIA_PERMISSION_REQUEST_CODE:
+                    if (mMenuView != null) {
+                        super.openContextMenu(mMenuView);
+                        mMenuView = null;
+                    }
+                    break;
+                case WPPermissionUtils.EDITOR_DRAG_DROP_PERMISSION_REQUEST_CODE:
+                    runOnUiThread(mFetchMediaRunnable);
+                    break;
+            }
+        }
+    }
+
+    private boolean handleBackPressed() {
+        Fragment fragment = getSupportFragmentManager().findFragmentByTag(
+                ImageSettingsDialogFragment.IMAGE_SETTINGS_DIALOG_TAG);
+        if (fragment != null && fragment.isVisible()) {
+            if (fragment instanceof ImageSettingsDialogFragment) {
+                ImageSettingsDialogFragment imFragment = (ImageSettingsDialogFragment) fragment;
+                imFragment.dismissFragment();
+            }
+
+            return false;
+        }
+
+        if (mViewPager.getCurrentItem() > PAGE_CONTENT) {
+            if (mViewPager.getCurrentItem() == PAGE_SETTINGS) {
+                mEditorFragment.setFeaturedImageId(mPost.getFeaturedImageId());
+            }
+
+            mViewPager.setCurrentItem(PAGE_CONTENT);
+            invalidateOptionsMenu();
+        } else if (isPhotoPickerShowing()) {
+            hidePhotoPicker();
+        } else {
+            savePostAndOptionallyFinish(true);
+        }
+
+        return true;
+    }
+
+    // Menu actions
+    @Override
+    public boolean onOptionsItemSelected(final MenuItem item) {
+        int itemId = item.getItemId();
+
+        if (itemId == android.R.id.home) {
+            return handleBackPressed();
+        }
+
+        hidePhotoPicker();
+        boolean userCanPublishPosts = userCanPublishPosts();
+
+        if (itemId == R.id.menu_save_post || (itemId == R.id.menu_save_as_draft_or_publish && !userCanPublishPosts)) {
+            if (AppPrefs.isAsyncPromoRequired() && userCanPublishPosts
+                && PostStatus.fromPost(mPost) != PostStatus.DRAFT) {
+                showAsyncPromoDialog(mPost.isPage(), PostStatus.fromPost(mPost) == PostStatus.SCHEDULED);
+            } else {
+                showPublishConfirmationOrUpdateIfNotLocalDraft();
+            }
+        } else {
+            // Disable other action bar buttons while a media upload is in progress
+            // (unnecessary for Aztec since it supports progress reattachment)
+            if (!(mShowAztecEditor || mShowGutenbergEditor)
+                        && (mEditorFragment.isUploadingMedia() || mEditorFragment.isActionInProgress())) {
+                ToastUtils.showToast(this, R.string.editor_toast_uploading_please_wait, Duration.SHORT);
+                return false;
+            }
+
+            if (itemId == R.id.menu_history) {
+                AnalyticsTracker.track(Stat.REVISIONS_LIST_VIEWED);
+                ActivityUtils.hideKeyboard(this);
+                mViewPager.setCurrentItem(PAGE_HISTORY);
+            } else if (itemId == R.id.menu_preview_post) {
+                mViewPager.setCurrentItem(PAGE_PREVIEW);
+            } else if (itemId == R.id.menu_post_settings) {
+                if (mEditPostSettingsFragment != null) {
+                    mEditPostSettingsFragment.refreshViews();
+                }
+                ActivityUtils.hideKeyboard(this);
+                mViewPager.setCurrentItem(PAGE_SETTINGS);
+            } else if (itemId == R.id.menu_save_as_draft_or_publish) {
+                // save as draft if it's a local post with UNKNOWN status, or PUBLISH if it's a DRAFT (as this
+                //  R.id.menu_save_as_draft button will be "Publish Now" in that case)
+
+                if (UploadService.hasInProgressMediaUploadsForPost(mPost)) {
+                    ToastUtils.showToast(GutenbergEditPostActivity.this,
+                            getString(R.string.editor_toast_uploading_please_wait), Duration.SHORT);
+                    return false;
+                }
+
+                // we update the mPost object first, so we can pre-check Post publishability and inform the user
+                updatePostObject();
+                PostStatus status = PostStatus.fromPost(mPost);
+                if (status == PostStatus.DRAFT || status == PostStatus.PENDING) {
+                    if (isDiscardable()) {
+                        String message = getString(
+                                mIsPage ? R.string.error_publish_empty_page : R.string.error_publish_empty_post);
+                        ToastUtils.showToast(GutenbergEditPostActivity.this, message, Duration.SHORT);
+                        return false;
+                    }
+                    showPublishConfirmationDialog();
+                } else {
+                    if (isDiscardable()) {
+                        ToastUtils.showToast(GutenbergEditPostActivity.this,
+                                getString(R.string.error_save_empty_draft), Duration.SHORT);
+                        return false;
+                    }
+                    UploadUtils.showSnackbar(findViewById(R.id.editor_activity), R.string.editor_uploading_post);
+                    if (isNewPost()) {
+                        mPost.setStatus(PostStatus.DRAFT.toString());
+                    }
+                    savePostAndOptionallyFinish(false);
+                }
+            } else if (itemId == R.id.menu_html_mode) {
+                // toggle HTML mode
+                if (mEditorFragment instanceof AztecEditorFragment) {
+                    ((AztecEditorFragment) mEditorFragment).onToolbarHtmlButtonClicked();
+                    toggledHtmlModeSnackbar(new OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            // switch back
+                            ((AztecEditorFragment) mEditorFragment).onToolbarHtmlButtonClicked();
+                        }
+                    });
+                } else if (mEditorFragment instanceof GutenbergEditorFragment) {
+                    ((GutenbergEditorFragment) mEditorFragment).onToggleHtmlMode();
+                    toggledHtmlModeSnackbar(new OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            // switch back
+                            ((GutenbergEditorFragment) mEditorFragment).onToggleHtmlMode();
+                        }
+                    });
+                }
+            } else if (itemId == R.id.menu_discard_changes) {
+                if (NetworkUtils.isNetworkAvailable(getBaseContext())) {
+                    AnalyticsTracker.track(Stat.EDITOR_DISCARDED_CHANGES);
+                    showDialogProgress(true);
+                    mPostForUndo = mPost.clone();
+                    mIsDiscardingChanges = true;
+                    RemotePostPayload payload = new RemotePostPayload(mPost, mSite);
+                    mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(payload));
+                } else {
+                    showDialogError(R.string.local_changes_discarding_no_connection,
+                            R.string.dialog_button_ok,
+                            TAG_DISCARDING_CHANGES_NO_NETWORK_DIALOG,
+                            false);
+                }
+            }
+        }
+        return false;
+    }
+
+    private void toggledHtmlModeSnackbar(OnClickListener onUndoClickListener) {
+        UploadUtils.showSnackbarSuccessActionOrange(findViewById(R.id.editor_activity),
+                mHtmlModeMenuStateOn ? R.string.menu_html_mode_done_snackbar
+                        : R.string.menu_visual_mode_done_snackbar,
+                R.string.menu_undo_snackbar_action,
+                onUndoClickListener);
+    }
+
+    private void refreshEditorContent() {
+        mHasSetPostContent = false;
+        fillContentEditorFields();
+    }
+
+    private void showDialogError(@StringRes int resIdMessage, @StringRes int resIdPositiveButton, String tag,
+                                 boolean showCancel) {
+        BasicFragmentDialog dialog = new BasicFragmentDialog();
+        dialog.initialize(tag, "", getString(resIdMessage),
+                getString(resIdPositiveButton), showCancel ? getString(R.string.cancel) : null, null);
+        dialog.show(getSupportFragmentManager(), tag);
+    }
+
+    private void showDialogProgress(boolean show) {
+        if (show) {
+            mProgressDialog = new ProgressDialog(this);
+            mProgressDialog.setCancelable(false);
+            mProgressDialog.setIndeterminate(true);
+            mProgressDialog.setMessage(mIsDiscardingChanges
+                    ? getString(R.string.local_changes_discarding)
+                    : getString(R.string.history_loading_revision));
+            mProgressDialog.show();
+        } else if (mProgressDialog != null) {
+            mProgressDialog.dismiss();
+        }
+
+        mIsDialogProgressShown = show;
+    }
+
+    private void toggleHtmlModeOnMenu() {
+        mHtmlModeMenuStateOn = !mHtmlModeMenuStateOn;
+        invalidateOptionsMenu();
+    }
+
+    private void showPublishConfirmationDialog() {
+        BasicFragmentDialog publishConfirmationDialog = new BasicFragmentDialog();
+        publishConfirmationDialog.initialize(
+                TAG_PUBLISH_CONFIRMATION_DIALOG,
+                getString(R.string.dialog_confirm_publish_title),
+                mPost.isPage() ? getString(R.string.dialog_confirm_publish_message_page)
+                        : getString(R.string.dialog_confirm_publish_message_post),
+                getString(R.string.dialog_confirm_publish_yes),
+                getString(R.string.keep_editing),
+                null);
+        publishConfirmationDialog.show(getSupportFragmentManager(), TAG_PUBLISH_CONFIRMATION_DIALOG);
+    }
+
+    private void showPublishConfirmationOrUpdateIfNotLocalDraft() {
+        // if post is a draft, first make sure to confirm the PUBLISH action, in case
+        // the user tapped on it accidentally
+        PostStatus status = PostStatus.fromPost(mPost);
+        if (userCanPublishPosts() && (status == PostStatus.PUBLISHED || status == PostStatus.UNKNOWN)
+            && mPost.isLocalDraft()) {
+            showPublishConfirmationDialog();
+        } else {
+            // otherwise, if they're updating a Post, just go ahead and save it to the server
+            publishPost();
+        }
+    }
+
+    private void savePostOnlineAndFinishAsync(boolean isFirstTimePublish, boolean doFinishActivity) {
+        new SavePostOnlineAndFinishTask(isFirstTimePublish, doFinishActivity)
+                .executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
+    private void onUploadSuccess(MediaModel media) {
+        if (mEditorMediaUploadListener != null && media != null) {
+            mEditorMediaUploadListener.onMediaUploadSucceeded(String.valueOf(media.getId()),
+                                                              FluxCUtils.mediaFileFromMediaModel(media));
+        }
+    }
+
+    private void onUploadError(MediaModel media, MediaError error) {
+        String localMediaId = String.valueOf(media.getId());
+
+        Map<String, Object> properties = null;
+        MediaFile mf = FluxCUtils.mediaFileFromMediaModel(media);
+        if (mf != null) {
+            properties = AnalyticsUtils.getMediaProperties(this, mf.isVideo(), null, mf.getFilePath());
+            properties.put("error_type", error.type.name());
+        }
+        AnalyticsTracker.track(Stat.EDITOR_UPLOAD_MEDIA_FAILED, properties);
+
+        // Display custom error depending on error type
+        String errorMessage = WPMediaUtils.getErrorMessage(this, media, error);
+        if (errorMessage == null) {
+            errorMessage = TextUtils.isEmpty(error.message) ? getString(R.string.tap_to_try_again) : error.message;
+        }
+
+        if (mEditorMediaUploadListener != null) {
+            mEditorMediaUploadListener.onMediaUploadFailed(localMediaId,
+                                                           EditorFragmentAbstract.getEditorMimeType(mf), errorMessage);
+        }
+    }
+
+    private void onUploadProgress(MediaModel media, float progress) {
+        String localMediaId = String.valueOf(media.getId());
+        if (mEditorMediaUploadListener != null) {
+            mEditorMediaUploadListener.onMediaUploadProgress(localMediaId, progress);
+        }
+    }
+
+    private void launchPictureLibrary() {
+        WPMediaUtils.launchPictureLibrary(this, true);
+    }
+
+    private void launchVideoLibrary() {
+        WPMediaUtils.launchVideoLibrary(this, true);
+    }
+
+    private void launchVideoCamera() {
+        WPMediaUtils.launchVideoCamera(this);
+    }
+
+    private void showErrorAndFinish(int errorMessageId) {
+        ToastUtils.showToast(this, errorMessageId, Duration.LONG);
+        finish();
+    }
+
+    private void trackEditorCreatedPost(String action, Intent intent) {
+        Map<String, Object> properties = new HashMap<>();
+        // Post created from the post list (new post button).
+        String normalizedSourceName = "post-list";
+        if (Intent.ACTION_SEND.equals(action) || Intent.ACTION_SEND_MULTIPLE.equals(action)) {
+            // Post created with share with WordPress
+            normalizedSourceName = "shared-from-external-app";
+        }
+        if (GutenbergEditPostActivity.NEW_MEDIA_POST.equals(
+                action)) {
+            // Post created from the media library
+            normalizedSourceName = "media-library";
+        }
+        if (intent != null && intent.hasExtra(EXTRA_IS_QUICKPRESS)) {
+            // Quick press
+            normalizedSourceName = "quick-press";
+        }
+        properties.put("created_post_source", normalizedSourceName);
+        AnalyticsUtils.trackWithSiteDetails(
+                Stat.EDITOR_CREATED_POST,
+                mSiteStore.getSiteByLocalId(mPost.getLocalSiteId()),
+                properties
+        );
+    }
+
+    private synchronized void updatePostObject(boolean isAutosave) throws EditorFragmentNotAddedException {
+        if (mPost == null) {
+            AppLog.e(T.POSTS, "Attempted to save an invalid Post.");
+            return;
+        }
+
+        // Update post object from fragment fields
+        boolean postTitleOrContentChanged = false;
+        if (mEditorFragment != null) {
+            if (isModernEditor()) {
+                postTitleOrContentChanged =
+                        updatePostContentNewEditor(isAutosave, (String) mEditorFragment.getTitle(),
+                                (String) mEditorFragment.getContent(mPost.getContent()));
+            } else {
+                // TODO: Remove when legacy editor is dropped
+                postTitleOrContentChanged = updatePostContent(isAutosave);
+            }
+        }
+
+        // only makes sense to change the publish date and locallychanged date if the Post was actaully changed
+        if (postTitleOrContentChanged) {
+            PostUtils.updatePublishDateIfShouldBePublishedImmediately(mPost);
+            mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
+        }
+    }
+
+    private void savePostAsync(final AfterSavePostListener listener) {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    updatePostObject(false);
+                } catch (EditorFragmentNotAddedException e) {
+                    AppLog.e(T.EDITOR, "Impossible to save the post, we weren't able to update it.");
+                    return;
+                }
+                savePostToDb();
+                if (listener != null) {
+                    listener.onPostSave();
+                }
+            }
+        }).start();
+    }
+
+    @Override
+    public void initializeEditorFragment() {
+        if (mEditorFragment instanceof AztecEditorFragment) {
+            AztecEditorFragment aztecEditorFragment = (AztecEditorFragment) mEditorFragment;
+            aztecEditorFragment.setEditorImageSettingsListener(GutenbergEditPostActivity.this);
+            aztecEditorFragment.setMediaToolbarButtonClickListener(GutenbergEditPostActivity.this);
+
+            // Here we should set the max width for media, but the default size is already OK. No need
+            // to customize it further
+
+            Drawable loadingImagePlaceholder = EditorMediaUtils.getAztecPlaceholderDrawableFromResID(
+                    this,
+                    org.wordpress.android.editor.R.drawable.ic_gridicons_image,
+                    aztecEditorFragment.getMaxMediaSize()
+            );
+            mAztecImageLoader = new AztecImageLoader(getBaseContext(), mImageManager, loadingImagePlaceholder);
+            aztecEditorFragment.setAztecImageLoader(mAztecImageLoader);
+            aztecEditorFragment.setLoadingImagePlaceholder(loadingImagePlaceholder);
+
+            Drawable loadingVideoPlaceholder = EditorMediaUtils.getAztecPlaceholderDrawableFromResID(
+                    this,
+                    org.wordpress.android.editor.R.drawable.ic_gridicons_video_camera,
+                    aztecEditorFragment.getMaxMediaSize()
+            );
+            aztecEditorFragment.setAztecVideoLoader(new AztecVideoLoader(getBaseContext(), loadingVideoPlaceholder));
+            aztecEditorFragment.setLoadingVideoPlaceholder(loadingVideoPlaceholder);
+
+            if (getSite() != null && getSite().isWPCom() && !getSite().isPrivate()) {
+                // Add the content reporting for wpcom blogs that are not private
+                aztecEditorFragment.enableContentLogOnCrashes(
+                        new AztecExceptionHandler.ExceptionHandlerHelper() {
+                            @Override
+                            public boolean shouldLog(Throwable throwable) {
+                                // Do not log private or password protected post
+                                return getPost() != null && TextUtils.isEmpty(getPost().getPassword())
+                                       && !PostStatus.PRIVATE.toString().equals(getPost().getStatus());
+                            }
+                        }
+                );
+            }
+            aztecEditorFragment.setExternalLogger(new AztecLog.ExternalLogger() {
+                @Override
+                public void log(String s) {
+                    // For now, we're wrapping up the actual log into a Crashlytics exception to reduce possibility
+                    // of information not travelling to Crashlytics (Crashlytics rolls logs up to 8
+                    // entries and 64kb max, and they only travel with the next crash happening, so logging an
+                    // Exception assures us to have this information sent in the next batch).
+                    // For more info: http://bit.ly/2oJHMG7 and http://bit.ly/2oPOtFX
+                    CrashlyticsUtils.logException(new AztecEditorFragment.AztecLoggingException(s), T.EDITOR);
+                }
+
+                @Override
+                public void logException(Throwable throwable) {
+                    CrashlyticsUtils.logException(new AztecEditorFragment.AztecLoggingException(throwable), T.EDITOR);
+                }
+
+                @Override
+                public void logException(Throwable throwable, String s) {
+                    CrashlyticsUtils.logException(
+                            new AztecEditorFragment.AztecLoggingException(throwable), T.EDITOR, s);
+                }
+            });
+        }
+    }
+
+    @Override
+    public void onImageSettingsRequested(EditorImageMetaData editorImageMetaData) {
+        MediaSettingsActivity.showForResult(this, mSite, editorImageMetaData);
+    }
+
+    @Override
+    public void onNegativeClicked(@NonNull String instanceTag) {
+        switch (instanceTag) {
+            case ASYNC_PROMO_DIALOG_TAG:
+            case TAG_DISCARDING_CHANGES_ERROR_DIALOG:
+            case TAG_DISCARDING_CHANGES_NO_NETWORK_DIALOG:
+            case TAG_PUBLISH_CONFIRMATION_DIALOG:
+            case TAG_REMOVE_FAILED_UPLOADS_DIALOG:
+                break;
+            default:
+                AppLog.e(T.EDITOR, "Dialog instanceTag is not recognized");
+                throw new UnsupportedOperationException("Dialog instanceTag is not recognized");
+        }
+    }
+
+
+    @Override
+    public void onNeutralClicked(@NonNull String instanceTag) {
+    }
+
+    @Override
+    public void onPositiveClicked(@NonNull String instanceTag) {
+        switch (instanceTag) {
+            case TAG_DISCARDING_CHANGES_NO_NETWORK_DIALOG:
+                // no op
+                break;
+            case TAG_DISCARDING_CHANGES_ERROR_DIALOG:
+                mZendeskHelper.createNewTicket(this, Origin.DISCARD_CHANGES, mSite);
+                break;
+            case TAG_PUBLISH_CONFIRMATION_DIALOG:
+                mPost.setStatus(PostStatus.PUBLISHED.toString());
+                publishPost();
+                break;
+            case TAG_REMOVE_FAILED_UPLOADS_DIALOG:
+                // Clear failed uploads
+                mEditorFragment.removeAllFailedMediaUploads();
+                break;
+            case ASYNC_PROMO_DIALOG_TAG:
+                publishPost();
+                break;
+            default:
+                AppLog.e(T.EDITOR, "Dialog instanceTag is not recognized");
+                throw new UnsupportedOperationException("Dialog instanceTag is not recognized");
+        }
+    }
+
+    @Override
+    public void onLinkClicked(@NonNull String instanceTag) {
+        switch (instanceTag) {
+            case ASYNC_PROMO_DIALOG_TAG:
+                startActivity(ReleaseNotesActivity.createIntent(GutenbergEditPostActivity.this, WHAT_IS_NEW_IN_MOBILE_URL,
+                        null, mSite));
+                break;
+            default:
+                AppLog.e(T.EDITOR, "Dialog instanceTag is not recognized");
+                throw new UnsupportedOperationException("Dialog instanceTag is not recognized");
+        }
+    }
+
+    /*
+     * user clicked OK on a settings list dialog displayed from the settings fragment - pass the event
+     * along to the settings fragment
+     */
+    @Override
+    public void onPostSettingsFragmentPositiveButtonClicked(@NonNull PostSettingsListDialogFragment dialog) {
+        if (mEditPostSettingsFragment != null) {
+            mEditPostSettingsFragment.onPostSettingsFragmentPositiveButtonClicked(dialog);
+        }
+    }
+
+    /*
+     * user clicked OK on a settings date/time dialog displayed from the settings fragment - pass the event
+     * along to the settings fragment
+     */
+    @Override
+    public void onPostDatePickerDialogPositiveButtonClicked(@NonNull PostDatePickerDialogFragment dialog,
+                                                            @NonNull Calendar calender) {
+        if (mEditPostSettingsFragment != null) {
+            mEditPostSettingsFragment.onPostDatePickerDialogPositiveButtonClicked(dialog, calender);
+        }
+    }
+
+    private interface AfterSavePostListener {
+        void onPostSave();
+    }
+
+    private synchronized void savePostToDb() {
+        mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(mPost));
+
+        // update the original post object, so we'll know of new changes
+        mOriginalPost = mPost.clone();
+
+        if (mShowAztecEditor) {
+            // update the list of uploading ids
+            mMediaMarkedUploadingOnStartIds =
+                    AztecEditorFragment.getMediaMarkedUploadingInPostContent(this, mPost.getContent());
+        }
+    }
+
+    @Override
+    public void onBackPressed() {
+        handleBackPressed();
+    }
+
+    @Override
+    public void onHistoryItemClicked(@NonNull Revision revision, @NonNull ArrayList<Revision> revisions) {
+        AnalyticsTracker.track(Stat.REVISIONS_DETAIL_VIEWED_FROM_LIST);
+        mRevision = revision;
+
+        ActivityLauncher.viewHistoryDetailForResult(this, mRevision, revisions);
+    }
+
+    private void loadRevision() {
+        showDialogProgress(true);
+        mPostForUndo = mPost.clone();
+        mPost.setTitle(mRevision.getPostTitle());
+        mPost.setContent(mRevision.getPostContent());
+        mPost.setIsLocallyChanged(true);
+        mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
+        refreshEditorContent();
+
+        Snackbar.make(mViewPager, getString(R.string.history_loaded_revision),
+                AccessibilityUtils.getSnackbarDuration(GutenbergEditPostActivity.this, 4000))
+                .setAction(getString(R.string.undo), new OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        AnalyticsTracker.track(Stat.REVISIONS_LOAD_UNDONE);
+                        RemotePostPayload payload = new RemotePostPayload(mPostForUndo, mSite);
+                        mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(payload));
+                        mPost = mPostForUndo.clone();
+                        refreshEditorContent();
+                    }
+                })
+                .show();
+
+        showDialogProgress(false);
+    }
+
+    private boolean isNewPost() {
+        return mIsNewPost;
+    }
+
+    /*
+     * returns true if the user has permission to publish the post - assumed to be true for
+     * dot.org sites because we can't retrieve their capabilities
+     */
+    private boolean userCanPublishPosts() {
+        if (SiteUtils.isAccessedViaWPComRest(mSite)) {
+            return mSite.getHasCapabilityPublishPosts();
+        } else {
+            return true;
+        }
+    }
+
+    private class SavePostOnlineAndFinishTask extends AsyncTask<Void, Void, Void> {
+        boolean mIsFirstTimePublish;
+        boolean mDoFinishActivity;
+
+        SavePostOnlineAndFinishTask(boolean isFirstTimePublish, boolean doFinishActivity) {
+            this.mIsFirstTimePublish = isFirstTimePublish;
+            this.mDoFinishActivity = doFinishActivity;
+        }
+
+        @Override
+        protected Void doInBackground(Void... params) {
+            // mark as pending if the user doesn't have publishing rights
+            if (!userCanPublishPosts()) {
+                if (PostStatus.fromPost(mPost) != PostStatus.DRAFT
+                    && PostStatus.fromPost(mPost) != PostStatus.PENDING) {
+                    mPost.setStatus(PostStatus.PENDING.toString());
+                }
+            }
+
+            savePostToDb();
+            PostUtils.trackSavePostAnalytics(mPost, mSiteStore.getSiteByLocalId(mPost.getLocalSiteId()));
+
+            UploadService.setLegacyMode(!isModernEditor());
+            if (mIsFirstTimePublish) {
+                UploadService.uploadPostAndTrackAnalytics(GutenbergEditPostActivity.this, mPost);
+            } else {
+                UploadService.uploadPost(GutenbergEditPostActivity.this, mPost);
+            }
+
+            PendingDraftsNotificationsUtils.cancelPendingDraftAlarms(GutenbergEditPostActivity.this, mPost.getId());
+
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(Void saved) {
+            if (mDoFinishActivity) {
+                saveResult(true, false, false);
+                removePostOpenInEditorStickyEvent();
+                finish();
+            }
+        }
+    }
+
+    private class SavePostLocallyAndFinishTask extends AsyncTask<Void, Void, Boolean> {
+        boolean mDoFinishActivity;
+
+        SavePostLocallyAndFinishTask(boolean doFinishActivity) {
+            this.mDoFinishActivity = doFinishActivity;
+        }
+
+        @Override
+        protected Boolean doInBackground(Void... params) {
+            if (mOriginalPost != null && !PostUtils.postHasEdits(mOriginalPost, mPost)) {
+                // If no changes have been made to the post, set it back to the original - don't save it
+                mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(mOriginalPost));
+                return false;
+            } else {
+                // Changes have been made - save the post and ask for the post list to refresh
+                // We consider this being "manual save", it will replace some Android "spans" by an html
+                // or a shortcode replacement (for instance for images and galleries)
+                if (isModernEditor()) {
+                    // Update the post object directly, without re-fetching the fields from the EditorFragment
+                    updatePostContentNewEditor(false, mPost.getTitle(), mPost.getContent());
+                }
+
+                savePostToDb();
+
+                // now set the pending notification alarm to be triggered in the next day, week, and month
+                PendingDraftsNotificationsUtils.scheduleNextNotifications(GutenbergEditPostActivity.this, mPost);
+            }
+
+            return true;
+        }
+
+        @Override
+        protected void onPostExecute(Boolean saved) {
+            if (mDoFinishActivity) {
+                saveResult(saved, false, true);
+                removePostOpenInEditorStickyEvent();
+                finish();
+            }
+        }
+    }
+
+    private void saveResult(boolean saved, boolean discardable, boolean savedLocally) {
+        Intent i = getIntent();
+        i.putExtra(EXTRA_SAVED_AS_LOCAL_DRAFT, savedLocally);
+        i.putExtra(EXTRA_HAS_FAILED_MEDIA, hasFailedMedia());
+        i.putExtra(EXTRA_IS_PAGE, mIsPage);
+        i.putExtra(EXTRA_HAS_CHANGES, saved);
+        i.putExtra(EXTRA_POST_LOCAL_ID, mPost.getId());
+        i.putExtra(EXTRA_POST_REMOTE_ID, mPost.getRemotePostId());
+        i.putExtra(EXTRA_IS_DISCARDABLE, discardable);
+        setResult(RESULT_OK, i);
+    }
+
+    private void publishPost() {
+        AccountModel account = mAccountStore.getAccount();
+        // prompt user to verify e-mail before publishing
+        if (!account.getEmailVerified()) {
+            String message = TextUtils.isEmpty(account.getEmail())
+                    ? getString(R.string.editor_confirm_email_prompt_message)
+                    : String.format(getString(R.string.editor_confirm_email_prompt_message_with_email),
+                                    account.getEmail());
+
+            AlertDialog.Builder builder = new AlertDialog.Builder(
+                    new ContextThemeWrapper(this, R.style.Calypso_Dialog));
+            builder.setTitle(R.string.editor_confirm_email_prompt_title)
+                   .setMessage(message)
+                   .setPositiveButton(android.R.string.ok,
+                                      new DialogInterface.OnClickListener() {
+                                          public void onClick(DialogInterface dialog, int id) {
+                                              ToastUtils.showToast(GutenbergEditPostActivity.this,
+                                                                   getString(R.string.toast_saving_post_as_draft));
+                                              savePostAndOptionallyFinish(true);
+                                          }
+                                      })
+                   .setNegativeButton(R.string.editor_confirm_email_prompt_negative,
+                                      new DialogInterface.OnClickListener() {
+                                          public void onClick(DialogInterface dialog, int id) {
+                                              mDispatcher
+                                                      .dispatch(AccountActionBuilder.newSendVerificationEmailAction());
+                                          }
+                                      });
+            builder.create().show();
+            return;
+        }
+
+        boolean postUpdateSuccessful = updatePostObject();
+        if (!postUpdateSuccessful) {
+            // just return, since the only case updatePostObject() can fail is when the editor
+            // fragment is not added to the activity
+            return;
+        }
+
+        // Update post, save to db and publish in its own Thread, because 1. update can be pretty slow with a lot of
+        // text 2. better not to call `updatePostObject()` from the UI thread due to weird thread blocking behavior
+        // on API 16 (and 21) with the visual editor.
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                boolean isFirstTimePublish = isFirstTimePublish();
+
+                boolean postUpdateSuccessful = updatePostObject();
+                if (!postUpdateSuccessful) {
+                    // just return, since the only case updatePostObject() can fail is when the editor
+                    // fragment is not added to the activity
+                    return;
+                }
+
+                boolean isPublishable = PostUtils.isPublishable(mPost);
+
+                // if post was modified or has unsaved local changes and is publishable, save it
+                saveResult(isPublishable, false, false);
+
+                if (isPublishable) {
+                    if (NetworkUtils.isNetworkAvailable(getBaseContext())) {
+                        // Show an Alert Dialog asking the user if they want to remove all failed media before upload
+                        if (mEditorFragment.hasFailedMediaUploads()) {
+                            GutenbergEditPostActivity.this.runOnUiThread(new Runnable() {
+                                @Override
+                                public void run() {
+                                    showRemoveFailedUploadsDialog();
+                                }
+                            });
+                        } else {
+                            savePostOnlineAndFinishAsync(isFirstTimePublish, true);
+                        }
+                    } else {
+                        savePostLocallyAndFinishAsync(true);
+                    }
+                } else {
+                    GutenbergEditPostActivity.this.runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            String message = getString(
+                                    mIsPage ? R.string.error_publish_empty_page : R.string.error_publish_empty_post);
+                            ToastUtils.showToast(GutenbergEditPostActivity.this, message, Duration.SHORT);
+                        }
+                    });
+                }
+            }
+        }).start();
+    }
+
+    private void showRemoveFailedUploadsDialog() {
+        BasicFragmentDialog removeFailedUploadsDialog = new BasicFragmentDialog();
+        removeFailedUploadsDialog.initialize(
+                TAG_REMOVE_FAILED_UPLOADS_DIALOG,
+                "",
+                getString(R.string.editor_toast_failed_uploads),
+                getString(R.string.editor_remove_failed_uploads),
+                getString(android.R.string.cancel),
+                null);
+        removeFailedUploadsDialog.show(getSupportFragmentManager(), TAG_REMOVE_FAILED_UPLOADS_DIALOG);
+    }
+
+    private void savePostAndOptionallyFinish(final boolean doFinish) {
+        // Update post, save to db and post online in its own Thread, because 1. update can be pretty slow with a lot of
+        // text 2. better not to call `updatePostObject()` from the UI thread due to weird thread blocking behavior
+        // on API 16 (and 21) with the visual editor.
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                // check if the opened post had some unsaved local changes
+                boolean isFirstTimePublish = isFirstTimePublish();
+
+                boolean postUpdateSuccessful = updatePostObject();
+                if (!postUpdateSuccessful) {
+                    // just return, since the only case updatePostObject() can fail is when the editor
+                    // fragment is not added to the activity
+                    return;
+                }
+
+                boolean isPublishable = PostUtils.isPublishable(mPost);
+
+                // if post was modified or has unpublished local changes, save it
+                boolean shouldSave = shouldSavePost();
+
+                // if post is publishable or not new, sync it
+                boolean shouldSync = isPublishable || !isNewPost();
+
+                if (doFinish) {
+                    saveResult(shouldSave && shouldSync, isDiscardable(), false);
+                }
+
+                definitelyDeleteBackspaceDeletedMediaItems();
+
+                if (shouldSave) {
+                    if (isNewPost() && PostStatus.fromPost(mPost) == PostStatus.PUBLISHED) {
+                        // new post - user just left the editor without publishing, they probably want
+                        // to keep the post as a draft (unless they explicitly changed the status)
+                        mPost.setStatus(PostStatus.DRAFT.toString());
+                        if (mEditPostSettingsFragment != null) {
+                            runOnUiThread(new Runnable() {
+                                @Override
+                                public void run() {
+                                    mEditPostSettingsFragment.updatePostStatusRelatedViews();
+                                }
+                            });
+                        }
+                    }
+
+                    PostStatus status = PostStatus.fromPost(mPost);
+                    if ((status == PostStatus.DRAFT || status == PostStatus.PENDING) && isPublishable
+                        && !hasFailedMedia() && NetworkUtils.isNetworkAvailable(getBaseContext())) {
+                        savePostOnlineAndFinishAsync(isFirstTimePublish, doFinish);
+                    } else {
+                        savePostLocallyAndFinishAsync(doFinish);
+                    }
+                } else {
+                    // discard post if new & empty
+                    if (isDiscardable()) {
+                        mDispatcher.dispatch(PostActionBuilder.newRemovePostAction(mPost));
+                    }
+                    removePostOpenInEditorStickyEvent();
+                    if (doFinish) {
+                        finish();
+                    }
+                }
+            }
+        }).start();
+    }
+
+    private boolean shouldSavePost() {
+        boolean hasLocalChanges = mPost.isLocallyChanged() || mPost.isLocalDraft();
+        boolean hasChanges = PostUtils.postHasEdits(mOriginalPost, mPost);
+        boolean isPublishable = PostUtils.isPublishable(mPost);
+        boolean hasUnpublishedLocalDraftChanges = (PostStatus.fromPost(mPost) == PostStatus.DRAFT
+                                                   || PostStatus.fromPost(mPost) == PostStatus.PENDING)
+                                                      && isPublishable && hasLocalChanges;
+
+        // if post was modified or has unpublished local changes, save it
+        return (mOriginalPost != null && hasChanges)
+                             || hasUnpublishedLocalDraftChanges || (isPublishable && isNewPost());
+    }
+
+
+    private boolean isDiscardable() {
+        return !PostUtils.isPublishable(mPost) && isNewPost();
+    }
+
+    private boolean isFirstTimePublish() {
+        return (PostStatus.fromPost(mPost) == PostStatus.UNKNOWN || PostStatus.fromPost(mPost) == PostStatus.PUBLISHED)
+               && (mPost.isLocalDraft() || PostStatus.fromPost(mOriginalPost) == PostStatus.DRAFT
+                   || PostStatus.fromPost(mOriginalPost) == PostStatus.PENDING);
+    }
+
+    /**
+     * Can be dropped and replaced by mEditorFragment.hasFailedMediaUploads() when we drop the visual editor.
+     * mEditorFragment.isActionInProgress() was added to address a timing issue when adding media and immediately
+     * publishing or exiting the visual editor. It's not safe to upload the post in this state.
+     * See https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/294
+     */
+    private boolean hasFailedMedia() {
+        return mEditorFragment.hasFailedMediaUploads() || mEditorFragment.isActionInProgress();
+    }
+
+    private boolean updatePostObject() {
+        try {
+            updatePostObject(false);
+        } catch (EditorFragmentNotAddedException e) {
+            AppLog.e(T.EDITOR, "Impossible to save and publish the post, we weren't able to update it.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private void savePostLocallyAndFinishAsync(boolean doFinishActivity) {
+        new SavePostLocallyAndFinishTask(doFinishActivity).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
+    /**
+     * Disable visual editor mode and log the exception if we get a Reflection failure when the webview is being
+     * initialized.
+     */
+    @Override
+    public void onReflectionFailure(ReflectionException e) {
+        CrashlyticsUtils.logException(e, T.EDITOR, "Reflection Failure on Visual Editor init");
+        // Disable visual editor and show an error message
+        AppPrefs.setVisualEditorEnabled(false);
+        ToastUtils.showToast(this, R.string.new_editor_reflection_error, Duration.LONG);
+        // Restart the activity (will start the legacy editor)
+        finish();
+        startActivity(getIntent());
+    }
+
+    /**
+     * A {@link FragmentPagerAdapter} that returns a fragment corresponding to
+     * one of the sections/tabs/pages.
+     */
+    public class SectionsPagerAdapter extends FragmentPagerAdapter {
+        private static final int NUM_PAGES_EDITOR = 4;
+
+        public SectionsPagerAdapter(FragmentManager fm) {
+            super(fm);
+        }
+
+        @Override
+        public Fragment getItem(int position) {
+            // getItem is called to instantiate the fragment for the given page.
+            switch (position) {
+                case 0:
+                    // TODO: Remove editor options after testing.
+                    if (mShowGutenbergEditor) {
+                        return GutenbergEditorFragment.newInstance("", "",
+                                AppPrefs.isAztecEditorToolbarExpanded(), mIsNewPost);
+                    } else if (mShowAztecEditor) {
+                        return AztecEditorFragment.newInstance("", "",
+                                                               AppPrefs.isAztecEditorToolbarExpanded());
+                    } else if (mShowNewEditor) {
+                        EditorWebViewCompatibility.setReflectionFailureListener(GutenbergEditPostActivity.this);
+                        return new EditorFragment();
+                    } else {
+                        return new LegacyEditorFragment();
+                    }
+                case 1:
+                    return EditPostSettingsFragment.newInstance();
+                case 3:
+                    return HistoryListFragment.Companion.newInstance(mPost, mSite);
+                default:
+                    return EditPostPreviewFragment.newInstance(mPost);
+            }
+        }
+
+        @Override
+        public Object instantiateItem(ViewGroup container, int position) {
+            Fragment fragment = (Fragment) super.instantiateItem(container, position);
+            switch (position) {
+                case 0:
+                    mEditorFragment = (EditorFragmentAbstract) fragment;
+                    mEditorFragment.setImageLoader(mImageLoader);
+
+                    mEditorFragment.getTitleOrContentChanged().observe(GutenbergEditPostActivity.this, new Observer<Editable>() {
+                        @Override public void onChanged(@Nullable Editable editable) {
+                            if (mHandler != null) {
+                                mHandler.removeCallbacks(mSave);
+                                if (mDebounceCounter < MAX_UNSAVED_POSTS) {
+                                    mDebounceCounter++;
+                                    mHandler.postDelayed(mSave, CHANGE_SAVE_DELAY);
+                                } else {
+                                    mHandler.post(mSave);
+                                }
+                            }
+                        }
+                    });
+
+                    if (mEditorFragment instanceof EditorMediaUploadListener) {
+                        mEditorMediaUploadListener = (EditorMediaUploadListener) mEditorFragment;
+
+                        // Set up custom headers for the visual editor's internal WebView
+                        mEditorFragment.setCustomHttpHeader("User-Agent", WordPress.getUserAgent());
+
+                        reattachUploadingMedia();
+                    }
+                    break;
+                case 1:
+                    mEditPostSettingsFragment = (EditPostSettingsFragment) fragment;
+                    break;
+                case 2:
+                    mEditPostPreviewFragment = (EditPostPreviewFragment) fragment;
+                    break;
+            }
+            return fragment;
+        }
+
+        @Override
+        public int getCount() {
+            return NUM_PAGES_EDITOR;
+        }
+    }
+
+    // Moved from EditPostContentFragment
+    public static final String NEW_MEDIA_POST = "NEW_MEDIA_POST";
+    public static final String NEW_MEDIA_POST_EXTRA_IDS = "NEW_MEDIA_POST_EXTRA_IDS";
+    private String mMediaCapturePath = "";
+    private int mMaxThumbWidth = 0;
+
+    private int getMaximumThumbnailWidthForEditor() {
+        if (mMaxThumbWidth == 0) {
+            mMaxThumbWidth = EditorMediaUtils.getMaximumThumbnailSizeForEditor(this);
+        }
+        return mMaxThumbWidth;
+    }
+
+    private boolean addExistingMediaToEditor(@NonNull AddExistingMediaSource source, long mediaId) {
+        MediaModel media = mMediaStore.getSiteMediaWithId(mSite, mediaId);
+        if (media == null) {
+            AppLog.w(T.MEDIA, "Cannot add null media to post");
+            return false;
+        }
+
+        trackAddMediaEvent(source, media);
+
+        MediaFile mediaFile = FluxCUtils.mediaFileFromMediaModel(media);
+        String urlToUse = TextUtils.isEmpty(media.getUrl()) ? media.getFilePath() : media.getUrl();
+        mEditorFragment.appendMediaFile(mediaFile, urlToUse, mImageLoader);
+        return true;
+    }
+
+    private class LoadPostContentTask extends AsyncTask<String, Spanned, Spanned> {
+        @Override
+        protected Spanned doInBackground(String... params) {
+            if (params.length < 1 || mPost == null) {
+                return null;
+            }
+
+            String content = StringUtils.notNullStr(params[0]);
+            return WPHtml.fromHtml(content, GutenbergEditPostActivity.this, mPost, getMaximumThumbnailWidthForEditor());
+        }
+
+        @Override
+        protected void onPostExecute(Spanned spanned) {
+            if (spanned != null) {
+                mEditorFragment.setContent(spanned);
+            }
+        }
+    }
+
+    private String getUploadErrorHtml(String mediaId, String path) {
+        return String.format(Locale.US,
+                "<span id=\"img_container_%s\" class=\"img_container failed\" data-failed=\"%s\">"
+                + "<progress id=\"progress_%s\" value=\"0\" class=\"wp_media_indicator failed\" "
+                + "contenteditable=\"false\"></progress>"
+                + "<img data-wpid=\"%s\" src=\"%s\" alt=\"\" class=\"failed\"></span>",
+                mediaId, getString(R.string.tap_to_try_again), mediaId, mediaId, path);
+    }
+
+    private String migrateLegacyDraft(String content) {
+        if (content.contains("<img src=\"null\" android-uri=\"")) {
+            // We must replace image tags specific to the legacy editor local drafts:
+            // <img src="null" android-uri="file:///..." />
+            // And trigger an upload action for the specific image / video
+            Pattern pattern = Pattern.compile("<img src=\"null\" android-uri=\"([^\"]*)\".*>");
+            Matcher matcher = pattern.matcher(content);
+            StringBuffer stringBuffer = new StringBuffer();
+            while (matcher.find()) {
+                String stringUri = matcher.group(1);
+                Uri uri = Uri.parse(stringUri);
+                MediaFile mediaFile = FluxCUtils.mediaFileFromMediaModel(
+                        queueFileForUpload(uri, getContentResolver().getType(uri), MediaUploadState.FAILED));
+                if (mediaFile == null) {
+                    continue;
+                }
+                String replacement = getUploadErrorHtml(String.valueOf(mediaFile.getId()), mediaFile.getFilePath());
+                matcher.appendReplacement(stringBuffer, replacement);
+            }
+            matcher.appendTail(stringBuffer);
+            content = stringBuffer.toString();
+        }
+        if (content.contains("[caption")) {
+            // Convert old legacy post caption formatting to new format, to avoid being stripped by the visual editor
+            Pattern pattern = Pattern.compile("(\\[caption[^]]*caption=\"([^\"]*)\"[^]]*].+?)(\\[\\/caption])");
+            Matcher matcher = pattern.matcher(content);
+            StringBuffer stringBuffer = new StringBuffer();
+            while (matcher.find()) {
+                String replacement = matcher.group(1) + matcher.group(2) + matcher.group(3);
+                matcher.appendReplacement(stringBuffer, replacement);
+            }
+            matcher.appendTail(stringBuffer);
+            content = stringBuffer.toString();
+        }
+        return content;
+    }
+
+    private void fillContentEditorFields() {
+        // Needed blog settings needed by the editor
+        mEditorFragment.setFeaturedImageSupported(mSite.isFeaturedImageSupported());
+
+        // Set up the placeholder text
+        mEditorFragment.setContentPlaceholder(getString(R.string.editor_content_placeholder));
+        mEditorFragment.setTitlePlaceholder(getString(mIsPage ? R.string.editor_page_title_placeholder
+                                                              : R.string.editor_post_title_placeholder));
+
+        // Set post title and content
+        if (mPost != null) {
+            if (!TextUtils.isEmpty(mPost.getContent()) && !mHasSetPostContent) {
+                mHasSetPostContent = true;
+                if (mPost.isLocalDraft() && !isModernEditor()) {
+                    // TODO: Unnecessary for new editor, as all images are uploaded right away, even for local drafts
+                    // Load local post content in the background, as it may take time to generate images
+                    new LoadPostContentTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
+                                                                mPost.getContent().replaceAll("\uFFFC", ""));
+                } else {
+                    // TODO: Might be able to drop .replaceAll() when legacy editor is removed
+                    String content = mPost.getContent().replaceAll("\uFFFC", "");
+                    // Prepare eventual legacy editor local draft for the new editor
+                    content = migrateLegacyDraft(content);
+                    mEditorFragment.setContent(content);
+                }
+            }
+            if (!TextUtils.isEmpty(mPost.getTitle())) {
+                mEditorFragment.setTitle(mPost.getTitle());
+            }
+            // TODO: postSettingsButton.setText(post.isPage() ? R.string.page_settings : R.string.post_settings);
+            mEditorFragment.setLocalDraft(mPost.isLocalDraft());
+
+            mEditorFragment.setFeaturedImageId(mPost.getFeaturedImageId());
+        }
+
+        // Special actions
+        String action = getIntent().getAction();
+        if (Intent.ACTION_SEND.equals(action) || Intent.ACTION_SEND_MULTIPLE.equals(action)) {
+            setPostContentFromShareAction();
+        } else if (NEW_MEDIA_POST.equals(action)) {
+            prepareMediaPost();
+        }
+    }
+
+    private void launchCamera() {
+        WPMediaUtils.launchCamera(this, BuildConfig.APPLICATION_ID,
+                                  new WPMediaUtils.LaunchCameraCallback() {
+                                      @Override
+                                      public void onMediaCapturePathReady(String mediaCapturePath) {
+                                          mMediaCapturePath = mediaCapturePath;
+                                      }
+                                  });
+    }
+
+    protected void setPostContentFromShareAction() {
+        Intent intent = getIntent();
+
+        // Check for shared text
+        String text = intent.getStringExtra(Intent.EXTRA_TEXT);
+        String title = intent.getStringExtra(Intent.EXTRA_SUBJECT);
+        if (text != null) {
+            if (title != null) {
+                mEditorFragment.setTitle(title);
+                mPost.setTitle(title);
+            }
+            // Create an <a href> element around links
+            text = AutolinkUtils.autoCreateLinks(text);
+            if (mEditorFragment instanceof LegacyEditorFragment) {
+                mEditorFragment.setContent(WPHtml.fromHtml(StringUtils.addPTags(text), this, mPost,
+                                                           getMaximumThumbnailWidthForEditor()));
+            } else {
+                mEditorFragment.setContent(text);
+            }
+
+            // update PostModel
+            mPost.setContent(text);
+            PostUtils.updatePublishDateIfShouldBePublishedImmediately(mPost);
+            mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
+        }
+
+        // Check for shared media
+        if (intent.hasExtra(Intent.EXTRA_STREAM)) {
+            String action = intent.getAction();
+            String type = intent.getType();
+            ArrayList<Uri> sharedUris;
+
+            if (Intent.ACTION_SEND_MULTIPLE.equals(action)) {
+                sharedUris = intent.getParcelableArrayListExtra((Intent.EXTRA_STREAM));
+            } else {
+                // For a single media share, we only allow images and video types
+                if (type != null && (type.startsWith("image") || type.startsWith("video"))) {
+                    sharedUris = new ArrayList<Uri>();
+                    sharedUris.add((Uri) intent.getParcelableExtra(Intent.EXTRA_STREAM));
+                } else {
+                    return;
+                }
+            }
+
+            if (sharedUris != null) {
+                addMediaList(sharedUris, false);
+            }
+        }
+    }
+
+    private void prepareMediaPost() {
+        long[] idsArray = getIntent().getLongArrayExtra(NEW_MEDIA_POST_EXTRA_IDS);
+        ArrayList<Long> idsList = ListUtils.fromLongArray(idsArray);
+        for (Long id : idsList) {
+            addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, id);
+        }
+        savePostAsync(null);
+    }
+
+    // TODO: Replace with contents of the updatePostContentNewEditor() method when legacy editor is dropped
+
+    /**
+     * Updates post object with content of this fragment
+     */
+    public boolean updatePostContent(boolean isAutoSave) throws EditorFragmentNotAddedException {
+        if (mPost == null) {
+            return false;
+        }
+        String title = StringUtils.notNullStr((String) mEditorFragment.getTitle());
+        SpannableStringBuilder postContent;
+        if (mEditorFragment.getSpannedContent() != null) {
+            // needed by the legacy editor to save local drafts
+            try {
+                postContent = new SpannableStringBuilder(mEditorFragment.getSpannedContent());
+            } catch (RuntimeException e) {
+                // A core android bug might cause an out of bounds exception, if so we'll just use the current editable
+                // See https://code.google.com/p/android/issues/detail?id=5164
+                postContent = new SpannableStringBuilder(
+                        StringUtils.notNullStr((String) mEditorFragment.getContent(null)));
+            }
+        } else {
+            postContent = new SpannableStringBuilder(StringUtils.notNullStr((String) mEditorFragment.getContent(null)));
+        }
+
+        String content;
+        if (mPost.isLocalDraft()) {
+            // remove suggestion spans, they cause craziness in WPHtml.toHTML().
+            CharacterStyle[] characterStyles = postContent.getSpans(0, postContent.length(), CharacterStyle.class);
+            for (CharacterStyle characterStyle : characterStyles) {
+                if (characterStyle instanceof SuggestionSpan) {
+                    postContent.removeSpan(characterStyle);
+                }
+            }
+            content = WPHtml.toHtml(postContent);
+            // replace duplicate <p> tags so there's not duplicates, trac #86
+            content = content.replace("<p><p>", "<p>");
+            content = content.replace("</p></p>", "</p>");
+            content = content.replace("<br><br>", "<br>");
+            // sometimes the editor creates extra tags
+            content = content.replace("</strong><strong>", "").replace("</em><em>", "").replace("</u><u>", "")
+                             .replace("</strike><strike>", "").replace("</blockquote><blockquote>", "");
+        } else {
+            if (!isAutoSave) {
+                // Add gallery shortcode
+                MediaGalleryImageSpan[] gallerySpans = postContent.getSpans(0, postContent.length(),
+                                                                            MediaGalleryImageSpan.class);
+                for (MediaGalleryImageSpan gallerySpan : gallerySpans) {
+                    int start = postContent.getSpanStart(gallerySpan);
+                    postContent.removeSpan(gallerySpan);
+                    postContent.insert(start, WPHtml.getGalleryShortcode(gallerySpan));
+                }
+            }
+
+            WPImageSpan[] imageSpans = postContent.getSpans(0, postContent.length(), WPImageSpan.class);
+            if (imageSpans.length != 0) {
+                for (WPImageSpan wpIS : imageSpans) {
+                    MediaFile mediaFile = wpIS.getMediaFile();
+                    if (mediaFile == null) {
+                        continue;
+                    }
+
+                    if (mediaFile.getMediaId() != null) {
+                        updateMediaFileOnServer(mediaFile);
+                    } else {
+                        mediaFile.setFileName(wpIS.getImageSource().toString());
+                        mediaFile.setFilePath(wpIS.getImageSource().toString());
+                    }
+
+                    int tagStart = postContent.getSpanStart(wpIS);
+                    if (!isAutoSave) {
+                        postContent.removeSpan(wpIS);
+
+                        // network image has a mediaId
+                        if (mediaFile.getMediaId() != null && mediaFile.getMediaId().length() > 0) {
+                            postContent.insert(tagStart, WPHtml.getContent(wpIS));
+                        } else {
+                            // local image for upload
+                            postContent.insert(tagStart,
+                                               "<img android-uri=\"" + wpIS.getImageSource().toString() + "\" />");
+                        }
+                    }
+                }
+            }
+            content = postContent.toString();
+        }
+
+        boolean titleChanged = PostUtils.updatePostTitleIfDifferent(mPost, title);
+        boolean contentChanged = PostUtils.updatePostContentIfDifferent(mPost, content);
+        boolean statusChanged = mOriginalPost != null && mPost.getStatus() != mOriginalPost.getStatus();
+
+        if (!mPost.isLocalDraft() && (titleChanged || contentChanged || statusChanged)) {
+            mPost.setIsLocallyChanged(true);
+        }
+
+        return titleChanged || contentChanged;
+    }
+
+    /**
+     * Updates post object with given title and content
+     */
+    public boolean updatePostContentNewEditor(boolean isAutoSave, String title, String content) {
+        if (mPost == null) {
+            return false;
+        }
+
+        if (!isAutoSave) {
+            // TODO: Shortcode handling, media handling
+        }
+
+        boolean titleChanged = PostUtils.updatePostTitleIfDifferent(mPost, title);
+        boolean contentChanged;
+        if (mMediaInsertedOnCreation) {
+            mMediaInsertedOnCreation = false;
+            contentChanged = true;
+        } else if (isCurrentMediaMarkedUploadingDifferentToOriginal(content)) {
+            contentChanged = true;
+        } else {
+            contentChanged = mPost.getContent().compareTo(content) != 0;
+        }
+        if (contentChanged) {
+            mPost.setContent(content);
+        }
+
+        boolean statusChanged = mOriginalPost != null && mPost.getStatus() != mOriginalPost.getStatus();
+
+        if (!mPost.isLocalDraft() && (titleChanged || contentChanged || statusChanged)) {
+            mPost.setIsLocallyChanged(true);
+            mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
+        }
+
+        return titleChanged || contentChanged;
+    }
+
+    /*
+      * for as long as the user is in the Editor, we check whether there are any differences in media items
+      * being uploaded since they opened the Editor for this Post. If some items have finished, the current list
+      * won't be equal and thus we'll know we need to save the Post content as it's changed, given the local
+      * URLs will have been replaced with the remote ones.
+     */
+    private boolean isCurrentMediaMarkedUploadingDifferentToOriginal(String newContent) {
+        // this method makes use of AztecEditorFragment methods. Make sure to only run if Aztec is the current editor.
+        if (!mShowAztecEditor) {
+            return false;
+        }
+        List<String> currentUploadingMedia = AztecEditorFragment.getMediaMarkedUploadingInPostContent(this, newContent);
+        Collections.sort(currentUploadingMedia);
+        return !mMediaMarkedUploadingOnStartIds.equals(currentUploadingMedia);
+    }
+
+    private void updateMediaFileOnServer(MediaFile mediaFile) {
+        if (mediaFile == null) {
+            return;
+        }
+
+        MediaPayload payload = new MediaPayload(mSite, FluxCUtils.mediaModelFromMediaFile(mediaFile));
+        mDispatcher.dispatch(MediaActionBuilder.newPushMediaAction(payload));
+    }
+
+    /**
+     * Analytics about media from device
+     *
+     * @param isNew Whether is a fresh media
+     * @param isVideo Whether is a video or not
+     * @param uri The URI of the media on the device, or null
+     */
+    private void trackAddMediaFromDeviceEvents(boolean isNew, boolean isVideo, Uri uri) {
+        if (uri == null) {
+            AppLog.e(T.MEDIA, "Cannot track new media events if both path and mediaURI are null!!");
+            return;
+        }
+
+        Map<String, Object> properties = AnalyticsUtils.getMediaProperties(this, isVideo, uri, null);
+        Stat currentStat;
+        if (isVideo) {
+            if (isNew) {
+                currentStat = Stat.EDITOR_ADDED_VIDEO_NEW;
+            } else {
+                currentStat = Stat.EDITOR_ADDED_VIDEO_VIA_DEVICE_LIBRARY;
+            }
+        } else {
+            if (isNew) {
+                currentStat = Stat.EDITOR_ADDED_PHOTO_NEW;
+            } else {
+                currentStat = Stat.EDITOR_ADDED_PHOTO_VIA_DEVICE_LIBRARY;
+            }
+        }
+
+        AnalyticsUtils.trackWithSiteDetails(currentStat, mSite, properties);
+    }
+
+    /**
+     * Analytics about media already available in the blog's library.
+     * @param source where the media is being added from
+     * @param media media being added
+     */
+    private void trackAddMediaEvent(@NonNull AddExistingMediaSource source, @NonNull MediaModel media) {
+        switch (source) {
+            case WP_MEDIA_LIBRARY:
+                if (media.isVideo()) {
+                    AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_ADDED_VIDEO_VIA_WP_MEDIA_LIBRARY, mSite, null);
+                } else {
+                    AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_ADDED_PHOTO_VIA_WP_MEDIA_LIBRARY, mSite, null);
+                }
+                break;
+            case STOCK_PHOTO_LIBRARY:
+                AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_ADDED_PHOTO_VIA_STOCK_MEDIA_LIBRARY, mSite, null);
+                break;
+        }
+    }
+
+    private boolean addMedia(Uri mediaUri, boolean isNew) {
+        if (mediaUri == null) {
+            return false;
+        }
+
+        List<Uri> uriList = new ArrayList<>();
+        uriList.add(mediaUri);
+        addMediaList(uriList, isNew);
+        return true;
+    }
+
+    private AddMediaListThread mAddMediaListThread;
+
+    private void addMediaList(@NonNull List<Uri> uriList, boolean isNew) {
+        // fetch any shared media first - must be done on the main thread
+        List<Uri> fetchedUriList = fetchMediaList(uriList);
+        mAddMediaListThread = new AddMediaListThread(fetchedUriList, isNew);
+        mAddMediaListThread.start();
+    }
+
+    private void cancelAddMediaListThread() {
+        if (mAddMediaListThread != null && !mAddMediaListThread.isInterrupted()) {
+            try {
+                mAddMediaListThread.interrupt();
+            } catch (SecurityException e) {
+                AppLog.e(T.MEDIA, e);
+            }
+        }
+    }
+
+    /*
+     * processes a list of media in the background (optimizing, resizing, etc.) and adds them to
+     * the editor one at a time
+     */
+    private class AddMediaListThread extends Thread {
+        private final List<Uri> mUriList = new ArrayList<>();
+        private final boolean mIsNew;
+        private ProgressDialog mProgressDialog;
+        private boolean mDidAnyFail;
+
+        AddMediaListThread(@NonNull List<Uri> uriList, boolean isNew) {
+            this.mUriList.addAll(uriList);
+            this.mIsNew = isNew;
+            showOverlay(false);
+        }
+
+        private void showProgressDialog(final boolean show) {
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        if (show) {
+                            mProgressDialog = new ProgressDialog(GutenbergEditPostActivity.this);
+                            mProgressDialog.setCancelable(false);
+                            mProgressDialog.setIndeterminate(true);
+                            mProgressDialog.setMessage(getString(R.string.add_media_progress));
+                            mProgressDialog.show();
+                        } else if (mProgressDialog != null && mProgressDialog.isShowing()) {
+                            mProgressDialog.dismiss();
+                        }
+                    } catch (IllegalArgumentException e) {
+                        AppLog.e(T.MEDIA, e);
+                    }
+                }
+            });
+        }
+
+        @Override
+        public void run() {
+            // adding multiple media items at once can take several seconds on slower devices, so we show a blocking
+            // progress dialog in this situation - otherwise the user could accidentally back out of the process
+            // before all items were added
+            boolean shouldShowProgress = mUriList.size() > 2;
+            if (shouldShowProgress) {
+                showProgressDialog(true);
+            }
+            try {
+                for (Uri mediaUri : mUriList) {
+                    if (isInterrupted()) {
+                        return;
+                    }
+                    if (!processMedia(mediaUri)) {
+                        mDidAnyFail = true;
+                    }
+                }
+            } finally {
+                if (shouldShowProgress) {
+                    showProgressDialog(false);
+                }
+            }
+
+
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    if (!isInterrupted()) {
+                        savePostAsync(null);
+                        hideOverlay();
+                        if (mDidAnyFail) {
+                            ToastUtils.showToast(GutenbergEditPostActivity.this, R.string.gallery_error,
+                                                 Duration.SHORT);
+                        }
+                    }
+                }
+            });
+        }
+
+        private boolean processMedia(Uri mediaUri) {
+            if (mediaUri == null) {
+                return false;
+            }
+
+            Activity activity = GutenbergEditPostActivity.this;
+
+            String path = MediaUtils.getRealPathFromURI(activity, mediaUri);
+            if (path == null) {
+                return false;
+            }
+
+            final boolean isVideo = MediaUtils.isVideo(mediaUri.toString());
+            Uri optimizedMedia = WPMediaUtils.getOptimizedMedia(activity, path, isVideo);
+            if (optimizedMedia != null) {
+                mediaUri = optimizedMedia;
+            } else if (isModernEditor()) {
+                // Fix for the rotation issue https://github.com/wordpress-mobile/WordPress-Android/issues/5737
+                if (!mSite.isWPCom()) {
+                    // If it's not wpcom we must rotate the picture locally
+                    Uri rotatedMedia = WPMediaUtils.fixOrientationIssue(activity, path, isVideo);
+                    if (rotatedMedia != null) {
+                        mediaUri = rotatedMedia;
+                    }
+                } else {
+                    // It's a wpcom site. Just create a version of the picture rotated for the old visual editor
+                    // All the other editors read EXIF data
+                    if (mShowNewEditor) {
+                        Uri rotatedMedia = WPMediaUtils.fixOrientationIssue(activity, path, isVideo);
+                        if (rotatedMedia != null) {
+                            // The uri variable should remain the same since wpcom rotates the picture server side
+                            path = MediaUtils.getRealPathFromURI(activity, rotatedMedia);
+                        }
+                    }
+                }
+            }
+
+            if (isInterrupted()) {
+                return false;
+            }
+
+            trackAddMediaFromDeviceEvents(mIsNew, isVideo, mediaUri);
+            postProcessMedia(mediaUri, path, isVideo);
+
+            return true;
+        }
+
+        private void postProcessMedia(final Uri mediaUri, final String path, final boolean isVideo) {
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    if (isModernEditor()) {
+                        addMediaVisualEditor(mediaUri, path);
+                    } else {
+                        addMediaLegacyEditor(mediaUri, isVideo);
+                    }
+                }
+            });
+        }
+    }
+
+    private void addMediaVisualEditor(Uri uri, String path) {
+        MediaModel media = queueFileForUpload(uri, getContentResolver().getType(uri));
+        MediaFile mediaFile = FluxCUtils.mediaFileFromMediaModel(media);
+        if (media != null) {
+            mEditorFragment.appendMediaFile(mediaFile, path, mImageLoader);
+        }
+    }
+
+    private void addMediaLegacyEditor(Uri mediaUri, boolean isVideo) {
+        MediaModel mediaModel = buildMediaModel(mediaUri, getContentResolver().getType(mediaUri),
+                                                MediaUploadState.QUEUED);
+        if (mediaModel == null) {
+            ToastUtils.showToast(this, R.string.file_not_found, Duration.SHORT);
+            return;
+        }
+
+        if (isVideo) {
+            mediaModel.setTitle(getResources().getString(R.string.video));
+        } else {
+            mediaModel.setTitle(ImageUtils.getTitleForWPImageSpan(this, mediaUri.getEncodedPath()));
+        }
+        mediaModel.setLocalPostId(mPost.getId());
+
+        mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel));
+
+        MediaFile mediaFile = FluxCUtils.mediaFileFromMediaModel(mediaModel);
+        mEditorFragment.appendMediaFile(mediaFile, mediaFile.getFilePath(), mImageLoader);
+    }
+
+    private void addMediaItemGroupOrSingleItem(Intent data) {
+        ClipData clipData = data.getClipData();
+        if (clipData != null) {
+            for (int i = 0; i < clipData.getItemCount(); i++) {
+                ClipData.Item item = clipData.getItemAt(i);
+                addMedia(item.getUri(), false);
+            }
+        } else {
+            addMedia(data.getData(), false);
+        }
+    }
+
+    private void advertiseImageOptimisationAndAddMedia(final Intent data) {
+        if (WPMediaUtils.shouldAdvertiseImageOptimization(this)) {
+            WPMediaUtils.advertiseImageOptimization(this,
+                                                    new WPMediaUtils.OnAdvertiseImageOptimizationListener() {
+                                                        @Override
+                                                        public void done() {
+                                                            addMediaItemGroupOrSingleItem(data);
+                                                        }
+                                                    });
+        } else {
+            addMediaItemGroupOrSingleItem(data);
+        }
+    }
+
+    private void setFeaturedImageId(final long mediaId) {
+        mPost.setFeaturedImageId(mediaId);
+        savePostAsync(new AfterSavePostListener() {
+            @Override
+            public void onPostSave() {
+                GutenbergEditPostActivity.this.runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (mEditPostSettingsFragment != null) {
+                            mEditPostSettingsFragment.updateFeaturedImage(mediaId);
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (resultCode != Activity.RESULT_OK) {
+            return;
+        }
+
+        if (data != null || ((requestCode == RequestCodes.TAKE_PHOTO || requestCode == RequestCodes.TAKE_VIDEO))) {
+            switch (requestCode) {
+                case RequestCodes.MULTI_SELECT_MEDIA_PICKER:
+                    handleMediaPickerResult(data);
+                    // No need to bump analytics here. Bumped later in
+                    // handleMediaPickerResult -> addExistingMediaToEditorAndSave
+                    break;
+                case RequestCodes.PHOTO_PICKER:
+                case RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT:
+                    // user chose a featured image
+                    if (resultCode == RESULT_OK && data.hasExtra(PhotoPickerActivity.EXTRA_MEDIA_ID)) {
+                        long mediaId = data.getLongExtra(PhotoPickerActivity.EXTRA_MEDIA_ID, 0);
+                        setFeaturedImageId(mediaId);
+                    }
+                    break;
+                case RequestCodes.PICTURE_LIBRARY:
+                    advertiseImageOptimisationAndAddMedia(data);
+                    break;
+                case RequestCodes.TAKE_PHOTO:
+                    if (WPMediaUtils.shouldAdvertiseImageOptimization(this)) {
+                        WPMediaUtils.advertiseImageOptimization(
+                                this, new WPMediaUtils.OnAdvertiseImageOptimizationListener() {
+                                    @Override
+                                    public void done() {
+                                        addLastTakenPicture();
+                                    }
+                                });
+                    } else {
+                        addLastTakenPicture();
+                    }
+                    break;
+                case RequestCodes.VIDEO_LIBRARY:
+                    addMediaItemGroupOrSingleItem(data);
+                    break;
+                case RequestCodes.TAKE_VIDEO:
+                    Uri capturedVideoUri = MediaUtils.getLastRecordedVideoUri(this);
+                    if (addMedia(capturedVideoUri, true)) {
+                        AnalyticsTracker.track(Stat.EDITOR_ADDED_VIDEO_NEW);
+                    } else {
+                        ToastUtils.showToast(this, R.string.gallery_error, Duration.SHORT);
+                    }
+                    break;
+                case RequestCodes.MEDIA_SETTINGS:
+                    if (mEditorFragment instanceof AztecEditorFragment) {
+                        mEditorFragment.onActivityResult(AztecEditorFragment.EDITOR_MEDIA_SETTINGS,
+                                                         Activity.RESULT_OK, data);
+                    }
+                    break;
+                case RequestCodes.STOCK_MEDIA_PICKER_MULTI_SELECT:
+                    if (data.hasExtra(StockMediaPickerActivity.KEY_UPLOADED_MEDIA_IDS)) {
+                        long[] mediaIds =
+                                data.getLongArrayExtra(StockMediaPickerActivity.KEY_UPLOADED_MEDIA_IDS);
+                        for (long id : mediaIds) {
+                            addExistingMediaToEditor(AddExistingMediaSource.STOCK_PHOTO_LIBRARY, id);
+                        }
+                        savePostAsync(null);
+                    }
+                    break;
+                case RequestCodes.GIPHY_PICKER:
+                    if (data.hasExtra(GiphyPickerActivity.KEY_SAVED_MEDIA_MODEL_LOCAL_IDS)) {
+                        int[] localIds = data.getIntArrayExtra(GiphyPickerActivity.KEY_SAVED_MEDIA_MODEL_LOCAL_IDS);
+                        ArrayList<MediaModel> mediaModels = new ArrayList<>();
+                        for (int localId : localIds) {
+                            mediaModels.add(mMediaStore.getMediaWithLocalId(localId));
+                        }
+
+                        if (isModernEditor()) {
+                            startUploadService(mediaModels);
+                        }
+
+                        for (MediaModel mediaModel : mediaModels) {
+                            mediaModel.setLocalPostId(mPost.getId());
+                            mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel));
+
+                            MediaFile mediaFile = FluxCUtils.mediaFileFromMediaModel(mediaModel);
+                            mEditorFragment.appendMediaFile(mediaFile, mediaFile.getFilePath(), mImageLoader);
+                        }
+                    }
+                    break;
+                case RequestCodes.HISTORY_DETAIL:
+                    if (data.hasExtra(KEY_REVISION)) {
+                        mViewPager.setCurrentItem(PAGE_CONTENT);
+
+                        mRevision = data.getParcelableExtra(KEY_REVISION);
+                        new Handler().postDelayed(new Runnable() {
+                            @Override public void run() {
+                                loadRevision();
+                            }
+                        }, getResources().getInteger(R.integer.full_screen_dialog_animation_duration));
+                    }
+                    break;
+            }
+        }
+    }
+
+    private void addLastTakenPicture() {
+        try {
+            WPMediaUtils.scanMediaFile(this, mMediaCapturePath);
+            File f = new File(mMediaCapturePath);
+            Uri capturedImageUri = Uri.fromFile(f);
+            if (addMedia(capturedImageUri, true)) {
+                final Intent scanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
+                scanIntent.setData(capturedImageUri);
+                sendBroadcast(scanIntent);
+            } else {
+                ToastUtils.showToast(this, R.string.gallery_error, Duration.SHORT);
+            }
+        } catch (RuntimeException | OutOfMemoryError e) {
+            AppLog.e(T.EDITOR, e);
+        }
+    }
+
+    /*
+     * called before we add media to make sure we have access to any media shared from another app (Google Photos, etc.)
+     */
+    private List<Uri> fetchMediaList(@NonNull List<Uri> uriList) {
+        boolean didAnyFail = false;
+        List<Uri> fetchedUriList = new ArrayList<>();
+        for (int i = 0; i < uriList.size(); i++) {
+            Uri mediaUri = uriList.get(i);
+            if (mediaUri == null) {
+                continue;
+            }
+            if (!MediaUtils.isInMediaStore(mediaUri)) {
+                // Do not download the file in async task. See
+                // https://github.com/wordpress-mobile/WordPress-Android/issues/5818
+                Uri fetchedUri = null;
+                try {
+                    fetchedUri = MediaUtils.downloadExternalMedia(GutenbergEditPostActivity.this, mediaUri);
+                } catch (IllegalStateException e) {
+                    // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/5823
+                    AppLog.e(T.UTILS, "Can't download the image at: " + mediaUri.toString(), e);
+                    CrashlyticsUtils
+                            .logException(e, T.MEDIA, "Can't download the image at: " + mediaUri.toString()
+                                                             + " See issue #5823");
+                    didAnyFail = true;
+                }
+                if (fetchedUri != null) {
+                    fetchedUriList.add(fetchedUri);
+                } else {
+                    didAnyFail = true;
+                }
+            } else {
+                fetchedUriList.add(mediaUri);
+            }
+        }
+
+        if (didAnyFail) {
+            ToastUtils.showToast(GutenbergEditPostActivity.this, R.string.error_downloading_image, Duration.SHORT);
+        }
+
+        return fetchedUriList;
+    }
+
+    private void handleMediaPickerResult(Intent data) {
+        ArrayList<Long> ids = ListUtils.fromLongArray(data.getLongArrayExtra(MediaBrowserActivity.RESULT_IDS));
+        if (ids == null || ids.size() == 0) {
+            return;
+        }
+
+        boolean allAreImages = true;
+        for (Long id : ids) {
+            MediaModel media = mMediaStore.getSiteMediaWithId(mSite, id);
+            if (media != null && !MediaUtils.isValidImage(media.getUrl())) {
+                allAreImages = false;
+                break;
+            }
+        }
+
+        // if the user selected multiple items and they're all images, show the insert media
+        // dialog so the user can choose whether to insert them individually or as a gallery
+        if (ids.size() > 1 && allAreImages) {
+            showInsertMediaDialog(ids);
+        } else {
+            for (Long id : ids) {
+                addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, id);
+            }
+            savePostAsync(null);
+        }
+    }
+
+    /*
+     * called after user selects multiple photos from WP media library
+     */
+    private void showInsertMediaDialog(final ArrayList<Long> mediaIds) {
+        InsertMediaCallback callback = new InsertMediaCallback() {
+            @Override
+            public void onCompleted(@NonNull InsertMediaDialog dialog) {
+                switch (dialog.getInsertType()) {
+                    case GALLERY:
+                        MediaGallery gallery = new MediaGallery();
+                        gallery.setType(dialog.getGalleryType().toString());
+                        gallery.setNumColumns(dialog.getNumColumns());
+                        gallery.setIds(mediaIds);
+                        mEditorFragment.appendGallery(gallery);
+                        break;
+                    case INDIVIDUALLY:
+                        for (Long id : mediaIds) {
+                            addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, id);
+                        }
+                        savePostAsync(null);
+                        break;
+                }
+            }
+        };
+        InsertMediaDialog dialog = InsertMediaDialog.newInstance(callback, mSite);
+        FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+        ft.add(dialog, "insert_media");
+        ft.commitAllowingStateLoss();
+    }
+
+    private void refreshBlogMedia() {
+        if (NetworkUtils.isNetworkAvailable(this)) {
+            FetchMediaListPayload payload = new FetchMediaListPayload(
+                    mSite, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false);
+            mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(payload));
+        } else {
+            ToastUtils.showToast(this, R.string.error_media_refresh_no_connection, Duration.SHORT);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onAccountChanged(OnAccountChanged event) {
+        if (event.causeOfChange == AccountAction.SEND_VERIFICATION_EMAIL) {
+            if (!event.isError()) {
+                ToastUtils.showToast(this, getString(R.string.toast_verification_email_sent));
+            } else {
+                ToastUtils.showToast(this, getString(R.string.toast_verification_email_send_error));
+            }
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onMediaChanged(OnMediaChanged event) {
+        if (event.isError()) {
+            final String errorMessage;
+            switch (event.error.type) {
+                case FS_READ_PERMISSION_DENIED:
+                    errorMessage = getString(R.string.error_media_insufficient_fs_permissions);
+                    break;
+                case NOT_FOUND:
+                    errorMessage = getString(R.string.error_media_not_found);
+                    break;
+                case AUTHORIZATION_REQUIRED:
+                    errorMessage = getString(R.string.error_media_unauthorized);
+                    break;
+                case PARSE_ERROR:
+                    errorMessage = getString(R.string.error_media_parse_error);
+                    break;
+                case MALFORMED_MEDIA_ARG:
+                case NULL_MEDIA_ARG:
+                case GENERIC_ERROR:
+                default:
+                    errorMessage = getString(R.string.error_refresh_media);
+                    break;
+            }
+            if (!TextUtils.isEmpty(errorMessage)) {
+                ToastUtils.showToast(GutenbergEditPostActivity.this, errorMessage, Duration.SHORT);
+            }
+        } else {
+            if (mPendingVideoPressInfoRequests != null && !mPendingVideoPressInfoRequests.isEmpty()) {
+                // If there are pending requests for video URLs from VideoPress ids, query the DB for
+                // them again and notify the editor
+                for (String videoId : mPendingVideoPressInfoRequests) {
+                    String videoUrl = mMediaStore.
+                                                         getUrlForSiteVideoWithVideoPressGuid(mSite, videoId);
+                    String posterUrl = WPMediaUtils.getVideoPressVideoPosterFromURL(videoUrl);
+
+                    mEditorFragment.setUrlForVideoPressId(videoId, videoUrl, posterUrl);
+                }
+
+                mPendingVideoPressInfoRequests.clear();
+            }
+        }
+    }
+
+    /**
+     * Starts the upload service to upload selected media.
+     */
+    private void startUploadService(MediaModel media) {
+        final ArrayList<MediaModel> mediaList = new ArrayList<>();
+        mediaList.add(media);
+        startUploadService(mediaList);
+    }
+
+    /**
+     * Start the {@link UploadService} to upload the given {@code mediaModels}.
+     *
+     * Only {@link MediaModel} objects that have {@code MediaUploadState.QUEUED} statuses will be uploaded. .
+     */
+    private void startUploadService(@NonNull List<MediaModel> mediaModels) {
+        // make sure we only pass items with the QUEUED state to the UploadService
+        final ArrayList<MediaModel> queuedMediaModels = new ArrayList<>();
+        for (MediaModel media : mediaModels) {
+            if (MediaUploadState.QUEUED.toString().equals(media.getUploadState())) {
+                queuedMediaModels.add(media);
+            }
+        }
+
+        // before starting the service, we need to update the posts' contents so we are sure the service
+        // can retrieve it from there on
+        savePostAsync(new AfterSavePostListener() {
+            @Override public void onPostSave() {
+                UploadService.uploadMediaFromEditor(GutenbergEditPostActivity.this, queuedMediaModels);
+            }
+        });
+    }
+
+    private String getVideoThumbnail(String videoPath) {
+        String thumbnailPath = null;
+        try {
+            File outputFile = File.createTempFile("thumb", ".png", getCacheDir());
+            FileOutputStream outputStream = new FileOutputStream(outputFile);
+            Bitmap thumb = ImageUtils.getVideoFrameFromVideo(
+                    videoPath,
+                    EditorMediaUtils.getMaximumThumbnailSizeForEditor(this)
+            );
+            if (thumb != null) {
+                thumb.compress(Bitmap.CompressFormat.PNG, 75, outputStream);
+                thumbnailPath = outputFile.getAbsolutePath();
+            }
+        } catch (IOException e) {
+            AppLog.i(T.MEDIA, "Can't create thumbnail for video: " + videoPath);
+        }
+        return thumbnailPath;
+    }
+
+    /**
+     * Queues a media file for upload and starts the UploadService. Toasts will alert the user
+     * if there are issues with the file.
+     */
+    private MediaModel queueFileForUpload(Uri uri, String mimeType) {
+        return queueFileForUpload(uri, mimeType, MediaUploadState.QUEUED);
+    }
+
+    private MediaModel queueFileForUpload(Uri uri, String mimeType, MediaUploadState startingState) {
+        String path = MediaUtils.getRealPathFromURI(this, uri);
+
+        // Invalid file path
+        if (TextUtils.isEmpty(path)) {
+            ToastUtils.showToast(this, R.string.editor_toast_invalid_path, Duration.SHORT);
+            return null;
+        }
+
+        // File not found
+        File file = new File(path);
+        if (!file.exists()) {
+            ToastUtils.showToast(this, R.string.file_not_found, Duration.SHORT);
+            return null;
+        }
+
+        // we need to update media with the local post Id
+        MediaModel media = buildMediaModel(uri, mimeType, startingState);
+        if (media == null) {
+            ToastUtils.showToast(this, R.string.file_not_found, Duration.SHORT);
+            return null;
+        }
+        media.setLocalPostId(mPost.getId());
+        mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
+
+        startUploadService(media);
+
+        return media;
+    }
+
+    private MediaModel buildMediaModel(Uri uri, String mimeType, MediaUploadState startingState) {
+        MediaModel media = FluxCUtils.mediaModelFromLocalUri(this, uri, mimeType, mMediaStore, mSite.getId());
+        if (media == null) {
+            return null;
+        }
+        if (org.wordpress.android.fluxc.utils.MediaUtils.isVideoMimeType(media.getMimeType())) {
+            String path = MediaUtils.getRealPathFromURI(this, uri);
+            media.setThumbnailUrl(getVideoThumbnail(path));
+        }
+
+        media.setUploadState(startingState);
+        if (!mPost.isLocalDraft()) {
+            media.setPostId(mPost.getRemotePostId());
+        }
+
+        return media;
+    }
+
+    /**
+     * EditorFragmentListener methods
+     */
+
+    @Override
+    public void onSettingsClicked() {
+        mViewPager.setCurrentItem(PAGE_SETTINGS);
+    }
+
+    @Override
+    public void onAddMediaClicked() {
+        if (isPhotoPickerShowing()) {
+            hidePhotoPicker();
+        } else if (mShowGutenbergEditor) {
+            // show the WP media library only since that's the only mode integrated currently from Gutenberg-mobile
+            ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.EDITOR_PICKER);
+        } else if (WPMediaUtils.currentUserCanUploadMedia(mSite)) {
+            showPhotoPicker();
+        } else {
+            // show the WP media library instead of the photo picker if the user doesn't have upload permission
+            ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.EDITOR_PICKER);
+        }
+    }
+
+    @Override
+    public void onMediaDropped(final ArrayList<Uri> mediaUris) {
+        mDroppedMediaUris = mediaUris;
+        if (PermissionUtils
+                .checkAndRequestStoragePermission(this, WPPermissionUtils.EDITOR_DRAG_DROP_PERMISSION_REQUEST_CODE)) {
+            runOnUiThread(mFetchMediaRunnable);
+        }
+    }
+
+    @Override
+    public void onRequestDragAndDropPermissions(DragEvent dragEvent) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            requestTemporaryPermissions(dragEvent);
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.N)
+    private void requestTemporaryPermissions(DragEvent dragEvent) {
+        requestDragAndDropPermissions(dragEvent);
+    }
+
+    @Override
+    public boolean onMediaRetryClicked(final String mediaId) {
+        if (TextUtils.isEmpty(mediaId)) {
+            AppLog.e(T.MEDIA, "Invalid media id passed to onMediaRetryClicked");
+            return false;
+        }
+        MediaModel media = mMediaStore.getMediaWithLocalId(StringUtils.stringToInt(mediaId));
+        if (media == null) {
+            AppLog.e(T.MEDIA, "Can't find media with local id: " + mediaId);
+            AlertDialog.Builder builder = new AlertDialog.Builder(
+                    new ContextThemeWrapper(this, R.style.Calypso_Dialog));
+            builder.setTitle(getString(R.string.cannot_retry_deleted_media_item));
+            builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            mEditorFragment.removeMedia(mediaId);
+                        }
+                    });
+                    dialog.dismiss();
+                }
+            });
+
+            builder.setNegativeButton(getString(R.string.no), new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    dialog.dismiss();
+                }
+            });
+
+            AlertDialog dialog = builder.create();
+            dialog.show();
+
+            return false;
+        }
+
+        if (media.getUrl() != null && media.getUploadState().equals(MediaUploadState.UPLOADED.toString())) {
+            // Note: we should actually do this when the editor fragment starts instead of waiting for user input.
+            // Notify the editor fragment upload was successful and it should replace the local url by the remote url.
+            if (mEditorMediaUploadListener != null) {
+                mEditorMediaUploadListener.onMediaUploadSucceeded(String.valueOf(media.getId()),
+                        FluxCUtils.mediaFileFromMediaModel(media));
+            }
+        } else {
+            UploadService.cancelFinalNotification(this, mPost);
+            UploadService.cancelFinalNotificationForMedia(this, mSite);
+            media.setUploadState(MediaUploadState.QUEUED);
+            mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
+            startUploadService(media);
+        }
+
+        AnalyticsTracker.track(Stat.EDITOR_UPLOAD_MEDIA_RETRIED);
+        return true;
+    }
+
+    @Override
+    public void onMediaUploadCancelClicked(String localMediaId) {
+        if (!TextUtils.isEmpty(localMediaId)) {
+            cancelMediaUpload(StringUtils.stringToInt(localMediaId), true);
+        } else {
+            // Passed mediaId is incorrect: cancel all uploads for this post
+            ToastUtils.showToast(this, getString(R.string.error_all_media_upload_canceled));
+            EventBus.getDefault().post(new PostEvents.PostMediaCanceled(mPost));
+        }
+    }
+
+    @Override
+    public void onMediaDeleted(String localMediaId) {
+        if (!TextUtils.isEmpty(localMediaId)) {
+            mAztecBackspaceDeletedMediaItemIds.add(localMediaId);
+            UploadService.setDeletedMediaItemIds(mAztecBackspaceDeletedMediaItemIds);
+            // passing false here as we need to keep the media item in case the user wants to undo
+            cancelMediaUpload(StringUtils.stringToInt(localMediaId), false);
+        }
+    }
+
+    private void cancelMediaUpload(int localMediaId, boolean delete) {
+        MediaModel mediaModel = mMediaStore.getMediaWithLocalId(Integer.valueOf(localMediaId));
+        if (mediaModel != null) {
+            CancelMediaPayload payload = new CancelMediaPayload(mSite, mediaModel, delete);
+            mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload));
+        }
+    }
+
+    /*
+    * When the user deletes a media item that was being uploaded at that moment, we only cancel the
+    * upload but keep the media item in FluxC DB because the user might have deleted it accidentally,
+    * and they can always UNDO the delete action in Aztec.
+    * So, when the user exits then editor (and thus we lose the undo/redo history) we are safe to
+    * physically delete from the FluxC DB those items that have been deleted by the user using backspace.
+    * */
+    private void definitelyDeleteBackspaceDeletedMediaItems() {
+        for (String mediaId : mAztecBackspaceDeletedMediaItemIds) {
+            if (!TextUtils.isEmpty(mediaId)) {
+                // make sure the MediaModel exists
+                MediaModel mediaModel = mMediaStore.getMediaWithLocalId(StringUtils.stringToInt(mediaId));
+                if (mediaModel == null) {
+                    continue;
+                }
+
+                // also make sure it's not being uploaded anywhere else (maybe on some other Post,
+                // simultaneously)
+                if (mediaModel.getUploadState() != null
+                    && MediaUtils.isLocalFile(mediaModel.getUploadState().toLowerCase(Locale.ROOT))
+                    && !UploadService.isPendingOrInProgressMediaUpload(mediaModel)) {
+                    mDispatcher.dispatch(MediaActionBuilder.newRemoveMediaAction(mediaModel));
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onUndoMediaCheck(final String undoedContent) {
+        // here we check which elements tagged UPLOADING are there in undoedContent,
+        // and check for the ones that ARE NOT being uploaded or queued in the UploadService.
+        // These are the CANCELED ONES, so mark them FAILED now to retry.
+
+        List<MediaModel> currentlyUploadingMedia = UploadService.getPendingOrInProgressMediaUploadsForPost(mPost);
+        List<String> mediaMarkedUploading =
+                AztecEditorFragment.getMediaMarkedUploadingInPostContent(GutenbergEditPostActivity.this, undoedContent);
+
+        // go through the list of items marked UPLOADING within the Post content, and look in the UploadService
+        // to see whether they're really being uploaded or not. If an item is not really being uploaded,
+        // mark that item failed
+        for (String mediaId : mediaMarkedUploading) {
+            boolean found = false;
+            for (MediaModel media : currentlyUploadingMedia) {
+                if (StringUtils.stringToInt(mediaId) == media.getId()) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found) {
+                if (mEditorFragment instanceof AztecEditorFragment) {
+                    mAztecBackspaceDeletedMediaItemIds.remove(mediaId);
+                    // update the mediaIds list in UploadService
+                    UploadService.setDeletedMediaItemIds(mAztecBackspaceDeletedMediaItemIds);
+                    ((AztecEditorFragment) mEditorFragment).setMediaToFailed(mediaId);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onFeaturedImageChanged(long mediaId) {
+        mPost.setFeaturedImageId(mediaId);
+        mEditPostSettingsFragment.updateFeaturedImage(mediaId);
+    }
+
+    @Override
+    public void onVideoPressInfoRequested(final String videoId) {
+        String videoUrl = mMediaStore.
+                                             getUrlForSiteVideoWithVideoPressGuid(mSite, videoId);
+
+        if (videoUrl == null) {
+            AppLog.w(T.EDITOR, "The editor wants more info about the following VideoPress code: " + videoId
+                               + " but it's not available in the current site " + mSite.getUrl()
+                               + " Maybe it's from another site?");
+            return;
+        }
+
+        if (videoUrl.isEmpty()) {
+            if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(
+                    this, WPPermissionUtils.EDITOR_MEDIA_PERMISSION_REQUEST_CODE)) {
+                runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (mPendingVideoPressInfoRequests == null) {
+                            mPendingVideoPressInfoRequests = new ArrayList<>();
+                        }
+                        mPendingVideoPressInfoRequests.add(videoId);
+                        refreshBlogMedia();
+                    }
+                });
+            }
+        }
+
+        String posterUrl = WPMediaUtils.getVideoPressVideoPosterFromURL(videoUrl);
+
+        mEditorFragment.setUrlForVideoPressId(videoId, videoUrl, posterUrl);
+    }
+
+    @Override
+    public String onAuthHeaderRequested(String url) {
+        String authHeader = "";
+        String token = mAccountStore.getAccessToken();
+        if (mSite.isPrivate() && WPUrlUtils.safeToAddWordPressComAuthToken(url)
+            && !TextUtils.isEmpty(token)) {
+            authHeader = "Bearer " + token;
+        }
+        return authHeader;
+    }
+
+    @Override
+    public void onEditorFragmentInitialized() {
+        boolean shouldFinishInit = true;
+        // now that we have the Post object initialized,
+        // check whether we have media items to insert from the WRITE POST with media functionality
+        if (getIntent().hasExtra(EXTRA_INSERT_MEDIA)) {
+            // Bump analytics
+            AnalyticsTracker.track(Stat.NOTIFICATION_UPLOAD_MEDIA_SUCCESS_WRITE_POST);
+
+            List<MediaModel> mediaList = (List<MediaModel>) getIntent().getSerializableExtra(EXTRA_INSERT_MEDIA);
+            // removing this from the intent so it doesn't insert the media items again on each Acivity re-creation
+            getIntent().removeExtra(EXTRA_INSERT_MEDIA);
+            if (mediaList != null && !mediaList.isEmpty()) {
+                shouldFinishInit = false;
+                mMediaInsertedOnCreation = true;
+                for (MediaModel media : mediaList) {
+                    addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, media.getMediaId());
+                }
+                savePostAsync(new AfterSavePostListener() {
+                    @Override
+                    public void onPostSave() {
+                        runOnUiThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                onEditorFinalTouchesBeforeShowing();
+                            }
+                        });
+                    }
+                });
+            }
+        }
+
+        if (shouldFinishInit) {
+            onEditorFinalTouchesBeforeShowing();
+        }
+    }
+
+    private void onEditorFinalTouchesBeforeShowing() {
+        refreshEditorContent();
+        // Set the error listener
+        if (mEditorFragment instanceof EditorFragment) {
+            mEditorFragment.setDebugModeEnabled(BuildConfig.DEBUG);
+            ((EditorFragment) mEditorFragment).setWebViewErrorListener(new ErrorListener() {
+                @Override
+                public void onJavaScriptError(String sourceFile, int lineNumber, String message) {
+                    CrashlyticsUtils.logException(new JavaScriptException(sourceFile, lineNumber, message),
+                                                  T.EDITOR,
+                                                  String.format(Locale.US, "%s:%d: %s", sourceFile, lineNumber,
+                                                                message));
+                }
+
+                @Override
+                public void onJavaScriptAlert(String url, String message) {
+                    // no op
+                }
+            });
+        }
+    }
+
+    @Override
+    public void saveMediaFile(MediaFile mediaFile) {
+    }
+
+    @Override
+    public void onHtmlModeToggledInToolbar() {
+        toggleHtmlModeOnMenu();
+    }
+
+    @Override
+    public void onTrackableEvent(TrackableEvent event) {
+        switch (event) {
+            case BOLD_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_BOLD);
+                break;
+            case BLOCKQUOTE_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_BLOCKQUOTE);
+                break;
+            case ELLIPSIS_COLLAPSE_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_ELLIPSIS_COLLAPSE);
+                AppPrefs.setAztecEditorToolbarExpanded(false);
+                break;
+            case ELLIPSIS_EXPAND_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_ELLIPSIS_EXPAND);
+                AppPrefs.setAztecEditorToolbarExpanded(true);
+                break;
+            case HEADING_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HEADING);
+                break;
+            case HEADING_1_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HEADING_1);
+                break;
+            case HEADING_2_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HEADING_2);
+                break;
+            case HEADING_3_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HEADING_3);
+                break;
+            case HEADING_4_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HEADING_4);
+                break;
+            case HEADING_5_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HEADING_5);
+                break;
+            case HEADING_6_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HEADING_6);
+                break;
+            case HORIZONTAL_RULE_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HORIZONTAL_RULE);
+                break;
+            case HTML_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HTML);
+                hidePhotoPicker();
+                break;
+            case IMAGE_EDITED:
+                AnalyticsTracker.track(Stat.EDITOR_EDITED_IMAGE);
+                break;
+            case ITALIC_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_ITALIC);
+                break;
+            case LINK_ADDED_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_LINK_ADDED);
+                hidePhotoPicker();
+                break;
+            case LINK_REMOVED_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_LINK_REMOVED);
+                break;
+            case LIST_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_LIST);
+                break;
+            case LIST_ORDERED_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_LIST_ORDERED);
+                break;
+            case LIST_UNORDERED_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_LIST_UNORDERED);
+                break;
+            case MEDIA_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_IMAGE);
+                break;
+            case NEXT_PAGE_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_NEXT_PAGE);
+                break;
+            case PARAGRAPH_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_PARAGRAPH);
+                break;
+            case PREFORMAT_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_PREFORMAT);
+                break;
+            case READ_MORE_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_READ_MORE);
+                break;
+            case STRIKETHROUGH_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_STRIKETHROUGH);
+                break;
+            case UNDERLINE_BUTTON_TAPPED:
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_UNDERLINE);
+                break;
+        }
+    }
+
+    // FluxC events
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onMediaUploaded(OnMediaUploaded event) {
+        if (isFinishing()) {
+            return;
+        }
+
+        // event for unknown media, ignoring
+        if (event.media == null) {
+            AppLog.w(T.MEDIA, "Media event carries null media object, not recognized");
+            return;
+        }
+
+        if (event.isError()) {
+            onUploadError(event.media, event.error);
+        } else if (event.completed) {
+            // if the remote url on completed is null, we consider this upload wasn't successful
+            if (event.media.getUrl() == null) {
+                MediaError error = new MediaError(MediaErrorType.GENERIC_ERROR);
+                onUploadError(event.media, error);
+            } else {
+                onUploadSuccess(event.media);
+            }
+        } else {
+            onUploadProgress(event.media, event.progress);
+        }
+    }
+
+    // FluxC events
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onPostChanged(OnPostChanged event) {
+        if (event.causeOfChange instanceof CauseOfOnPostChanged.UpdatePost) {
+            if (!event.isError()) {
+                // here update the menu if it's not a draft anymore
+                invalidateOptionsMenu();
+
+                if (mIsUpdatingPost) {
+                    mIsUpdatingPost = false;
+                    mPost = mPostStore.getPostByLocalPostId(mPost.getId());
+                    refreshEditorContent();
+
+                    if (mViewPager != null) {
+                        Snackbar.make(mViewPager, getString(R.string.local_changes_discarded),
+                                AccessibilityUtils.getSnackbarDuration(GutenbergEditPostActivity.this, Snackbar.LENGTH_LONG))
+                                .setAction(getString(R.string.undo), new OnClickListener() {
+                                    @Override public void onClick(View view) {
+                                        AnalyticsTracker.track(Stat.EDITOR_DISCARDED_CHANGES_UNDO);
+                                        RemotePostPayload payload = new RemotePostPayload(mPostForUndo, mSite);
+                                        mDispatcher.dispatch(PostActionBuilder.newFetchPostAction(payload));
+                                        mPost = mPostForUndo.clone();
+                                        refreshEditorContent();
+                                    }
+                                })
+                                .show();
+                    }
+
+                    showDialogProgress(false);
+                }
+
+                if (mIsDiscardingChanges) {
+                    mIsDiscardingChanges = false;
+                    mPost = mPostStore.getPostByLocalPostId(mPost.getId());
+                    mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(mPost));
+                    mIsUpdatingPost = true;
+                }
+            } else {
+                if (mIsDiscardingChanges) {
+                    showDialogError(R.string.local_changes_discarding_error, R.string.contact_support,
+                            TAG_DISCARDING_CHANGES_ERROR_DIALOG,
+                            true);
+                }
+
+                mIsDiscardingChanges = false;
+                mIsUpdatingPost = false;
+                showDialogProgress(false);
+                AppLog.e(T.POSTS, "UPDATE_POST failed: " + event.error.type + " - " + event.error.message);
+            }
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onPostUploaded(OnPostUploaded event) {
+        final PostModel post = event.post;
+        if (post != null && post.getId() == mPost.getId()) {
+            View snackbarAttachView = findViewById(R.id.editor_activity);
+            UploadUtils.onPostUploadedSnackbarHandler(this, snackbarAttachView, event.isError(), post,
+                    event.isError() ? event.error.message : null, getSite(), mDispatcher);
+            if (!event.isError()) {
+                mPost = post;
+                mIsNewPost = false;
+                invalidateOptionsMenu();
+            }
+        }
+    }
+
+
+    @SuppressWarnings("unused")
+    public void onEventMainThread(VideoOptimizer.ProgressEvent event) {
+        if (!isFinishing()) {
+            // use upload progress rather than optimizer progress since the former includes upload+optimization
+            float progress = UploadService.getUploadProgressForMedia(event.media);
+            onUploadProgress(event.media, progress);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public void onEventMainThread(UploadService.UploadMediaRetryEvent event) {
+        if (!isFinishing()
+            && event.mediaModelList != null
+            && mEditorMediaUploadListener != null) {
+            for (MediaModel media : event.mediaModelList) {
+                String localMediaId = String.valueOf(media.getId());
+                EditorFragmentAbstract.MediaType mediaType = media.isVideo()
+                        ? EditorFragmentAbstract.MediaType.VIDEO : EditorFragmentAbstract.MediaType.IMAGE;
+                mEditorMediaUploadListener.onMediaUploadRetry(localMediaId, mediaType);
+            }
+        }
+    }
+
+    private void showAsyncPromoDialog(boolean isPage, boolean isScheduled) {
+        int title = isScheduled ? R.string.async_promo_title_schedule : R.string.async_promo_title_publish;
+        int description = isScheduled
+            ? (isPage ? R.string.async_promo_description_schedule_page : R.string.async_promo_description_schedule_post)
+            : (isPage ? R.string.async_promo_description_publish_page : R.string.async_promo_description_publish_post);
+        int button = isScheduled ? R.string.async_promo_schedule_now : R.string.async_promo_publish_now;
+
+        final PromoDialog asyncPromoDialog = new PromoDialog();
+        asyncPromoDialog.initialize(ASYNC_PROMO_DIALOG_TAG,
+                getString(title),
+                getString(description),
+                getString(button),
+                R.drawable.img_publish_button_124dp,
+                getString(R.string.keep_editing),
+                getString(R.string.async_promo_link));
+
+        asyncPromoDialog.show(getSupportFragmentManager(), ASYNC_PROMO_DIALOG_TAG);
+
+        AppPrefs.setAsyncPromoRequired(false);
+    }
+
+    // EditPostActivityHook methods
+
+    @Override
+    public PostModel getPost() {
+        return mPost;
+    }
+
+    @Override
+    public SiteModel getSite() {
+        return mSite;
+    }
+
+
+    // External Access to the Image Loader
+    public AztecImageLoader getAztecImageLoader() {
+        return mAztecImageLoader;
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java
@@ -1846,8 +1846,7 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
             // getItem is called to instantiate the fragment for the given page.
             switch (position) {
                 case 0:
-                    return GutenbergEditorFragment.newInstance("", "",
-                            AppPrefs.isAztecEditorToolbarExpanded(), mIsNewPost);
+                    return GutenbergEditorFragment.newInstance("", "", mIsNewPost);
                 case 1:
                     return EditPostSettingsFragment.newInstance();
                 case 3:

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java
@@ -209,7 +209,6 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
     private int mDebounceCounter = 0;
     private boolean mShowAztecEditor;
     private boolean mShowNewEditor;
-    private boolean mShowGutenbergEditor;
     private boolean mMediaInsertedOnCreation;
 
     private List<String> mPendingVideoPressInfoRequests;
@@ -280,7 +279,7 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
     private ArrayList<Uri> mDroppedMediaUris;
 
     private boolean isModernEditor() {
-        return mShowNewEditor || mShowAztecEditor || mShowGutenbergEditor;
+        return mShowNewEditor || mShowAztecEditor;
     }
 
     private Runnable mFetchMediaRunnable = new Runnable() {
@@ -409,9 +408,6 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
         if (mHasSetPostContent = mEditorFragment != null) {
             mEditorFragment.setImageLoader(mImageLoader);
         }
-
-        // Ensure that this check happens when mPost is set
-        mShowGutenbergEditor = PostUtils.shouldShowGutenbergEditor(mIsNewPost, mPost);
 
         // Ensure we have a valid post
         if (mPost == null) {
@@ -1132,7 +1128,7 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
         } else {
             // Disable other action bar buttons while a media upload is in progress
             // (unnecessary for Aztec since it supports progress reattachment)
-            if (!(mShowAztecEditor || mShowGutenbergEditor)
+            if (!mShowAztecEditor
                         && (mEditorFragment.isUploadingMedia() || mEditorFragment.isActionInProgress())) {
                 ToastUtils.showToast(this, R.string.editor_toast_uploading_please_wait, Duration.SHORT);
                 return false;
@@ -1988,19 +1984,8 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
             // getItem is called to instantiate the fragment for the given page.
             switch (position) {
                 case 0:
-                    // TODO: Remove editor options after testing.
-                    if (mShowGutenbergEditor) {
-                        return GutenbergEditorFragment.newInstance("", "",
-                                AppPrefs.isAztecEditorToolbarExpanded(), mIsNewPost);
-                    } else if (mShowAztecEditor) {
-                        return AztecEditorFragment.newInstance("", "",
-                                                               AppPrefs.isAztecEditorToolbarExpanded());
-                    } else if (mShowNewEditor) {
-                        EditorWebViewCompatibility.setReflectionFailureListener(GutenbergEditPostActivity.this);
-                        return new EditorFragment();
-                    } else {
-                        return new LegacyEditorFragment();
-                    }
+                    return GutenbergEditorFragment.newInstance("", "",
+                            AppPrefs.isAztecEditorToolbarExpanded(), mIsNewPost);
                 case 1:
                     return EditPostSettingsFragment.newInstance();
                 case 3:
@@ -3120,15 +3105,17 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
     public void onAddMediaClicked() {
         if (isPhotoPickerShowing()) {
             hidePhotoPicker();
-        } else if (mShowGutenbergEditor) {
+        } else {
             // show the WP media library only since that's the only mode integrated currently from Gutenberg-mobile
             ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.EDITOR_PICKER);
-        } else if (WPMediaUtils.currentUserCanUploadMedia(mSite)) {
-            showPhotoPicker();
-        } else {
-            // show the WP media library instead of the photo picker if the user doesn't have upload permission
-            ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.EDITOR_PICKER);
         }
+        // TODO: get this code piece back once we tie in image uploading into Gutenberg
+//        else if (WPMediaUtils.currentUserCanUploadMedia(mSite)) {
+//            showPhotoPicker();
+//        } else {
+//            // show the WP media library instead of the photo picker if the user doesn't have upload permission
+//            ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.EDITOR_PICKER);
+//        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergEditPostActivity.java
@@ -2431,7 +2431,7 @@ public class GutenbergEditPostActivity extends EditPostBaseActivity implements
                 } else {
                     // It's a wpcom site. Just create a version of the picture rotated for the old visual editor
                     // All the other editors read EXIF data
-                    // TODO check if this is needed for GUtenberg once Gutenberg media upload is ready
+                    // TODO check if this is needed for Gutenberg once Gutenberg media upload is ready
 //                    Uri rotatedMedia = WPMediaUtils.fixOrientationIssue(activity, path, isVideo);
 //                    if (rotatedMedia != null) {
 //                        // The uri variable should remain the same since wpcom rotates the picture server side

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -56,7 +56,7 @@ import javax.inject.Inject;
 
 import de.greenrobot.event.EventBus;
 
-import static org.wordpress.android.ui.posts.EditPostActivity.EXTRA_POST_LOCAL_ID;
+import static org.wordpress.android.ui.posts.EditPostBaseActivity.EXTRA_POST_LOCAL_ID;
 
 public class PostPreviewActivity extends AppCompatActivity implements
         BasicFragmentDialog.BasicDialogNegativeClickInterface,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewFragment.java
@@ -22,7 +22,7 @@ import org.wordpress.android.util.WPWebViewClient;
 
 import javax.inject.Inject;
 
-import static org.wordpress.android.ui.posts.EditPostActivity.EXTRA_POST_LOCAL_ID;
+import static org.wordpress.android.ui.posts.EditPostBaseActivity.EXTRA_POST_LOCAL_ID;
 
 public class PostPreviewFragment extends Fragment {
     private SiteModel mSite;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -45,7 +45,7 @@ import java.util.HashSet;
 
 import javax.inject.Inject;
 
-import static org.wordpress.android.ui.posts.EditPostActivity.EXTRA_POST_LOCAL_ID;
+import static org.wordpress.android.ui.posts.EditPostBaseActivity.EXTRA_POST_LOCAL_ID;
 import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
 
 public class SelectCategoriesActivity extends AppCompatActivity {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.notifications.ShareAndDismissNotificationReceiver;
 import org.wordpress.android.ui.pages.PagesActivity;
 import org.wordpress.android.ui.posts.EditPostActivity;
+import org.wordpress.android.ui.posts.EditPostBaseActivity;
 import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.posts.PostsListActivity;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -411,8 +412,8 @@ class PostUploadNotifier {
             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             writePostIntent.putExtra(WordPress.SITE, site);
-            writePostIntent.putExtra(EditPostActivity.EXTRA_IS_PAGE, false);
-            writePostIntent.putExtra(EditPostActivity.EXTRA_INSERT_MEDIA, mediaToIncludeInPost);
+            writePostIntent.putExtra(EditPostBaseActivity.EXTRA_IS_PAGE, false);
+            writePostIntent.putExtra(EditPostBaseActivity.EXTRA_INSERT_MEDIA, mediaToIncludeInPost);
             writePostIntent.setAction(String.valueOf(notificationId));
 
             PendingIntent actionPendingIntent =

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -408,7 +408,7 @@ class PostUploadNotifier {
         if (mediaList != null && !mediaList.isEmpty()) {
             ArrayList<MediaModel> mediaToIncludeInPost = new ArrayList<>(mediaList);
 
-            Intent writePostIntent = new Intent(mContext, EditPostActivity.class);
+            Intent writePostIntent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(mContext);
             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             writePostIntent.putExtra(WordPress.SITE, site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -408,7 +408,7 @@ class PostUploadNotifier {
         if (mediaList != null && !mediaList.isEmpty()) {
             ArrayList<MediaModel> mediaToIncludeInPost = new ArrayList<>(mediaList);
 
-            Intent writePostIntent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(mContext);
+            Intent writePostIntent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(mContext, true, null);
             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             writePostIntent.putExtra(WordPress.SITE, site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -21,7 +21,6 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.notifications.ShareAndDismissNotificationReceiver;
 import org.wordpress.android.ui.pages.PagesActivity;
-import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.EditPostBaseActivity;
 import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.posts.PostsListActivity;
@@ -408,7 +407,8 @@ class PostUploadNotifier {
         if (mediaList != null && !mediaList.isEmpty()) {
             ArrayList<MediaModel> mediaToIncludeInPost = new ArrayList<>(mediaList);
 
-            Intent writePostIntent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(mContext, true, null);
+            Intent writePostIntent = EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(
+                    mContext, true, null);
             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             writePostIntent.putExtra(WordPress.SITE, site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -20,7 +20,6 @@ import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.UploadStore.UploadError;
 import org.wordpress.android.ui.ActivityLauncher;
-import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.EditPostBaseActivity;
 import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -393,7 +392,8 @@ public class UploadUtils {
                             mediaListToInsertInPost.addAll(mediaList);
 
                             Intent writePostIntent =
-                                    EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(activity, true, null);
+                                    EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(
+                                            activity, true, null);
                             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
                             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                             writePostIntent.putExtra(WordPress.SITE, site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -393,7 +393,7 @@ public class UploadUtils {
                             mediaListToInsertInPost.addAll(mediaList);
 
                             Intent writePostIntent =
-                                    EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(activity);
+                                    EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(activity, true, null);
                             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
                             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                             writePostIntent.putExtra(WordPress.SITE, site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -392,7 +392,8 @@ public class UploadUtils {
                             ArrayList<MediaModel> mediaListToInsertInPost = new ArrayList<>();
                             mediaListToInsertInPost.addAll(mediaList);
 
-                            Intent writePostIntent = new Intent(activity, EditPostActivity.class);
+                            Intent writePostIntent =
+                                    EditPostBaseActivity.getNormalOrGutenbergEditPostActivityIntent(activity);
                             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
                             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                             writePostIntent.putExtra(WordPress.SITE, site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.UploadStore.UploadError;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.posts.EditPostActivity;
+import org.wordpress.android.ui.posts.EditPostBaseActivity;
 import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AccessibilityUtils;
@@ -101,13 +102,13 @@ public class UploadUtils {
                                                      @NonNull final PostModel post,
                                                      @NonNull final SiteModel site,
                                                      View.OnClickListener publishPostListener) {
-        boolean hasChanges = data.getBooleanExtra(EditPostActivity.EXTRA_HAS_CHANGES, false);
+        boolean hasChanges = data.getBooleanExtra(EditPostBaseActivity.EXTRA_HAS_CHANGES, false);
         if (!hasChanges) {
             // if there are no changes, we don't need to do anything
             return;
         }
 
-        boolean savedLocally = data.getBooleanExtra(EditPostActivity.EXTRA_SAVED_AS_LOCAL_DRAFT, false);
+        boolean savedLocally = data.getBooleanExtra(EditPostBaseActivity.EXTRA_SAVED_AS_LOCAL_DRAFT, false);
         if (savedLocally && !NetworkUtils.isNetworkAvailable(activity)) {
             // The network is not available, we can't do anything
             ToastUtils.showToast(activity, R.string.error_publish_no_network,
@@ -115,7 +116,7 @@ public class UploadUtils {
             return;
         }
 
-        boolean hasFailedMedia = data.getBooleanExtra(EditPostActivity.EXTRA_HAS_FAILED_MEDIA, false);
+        boolean hasFailedMedia = data.getBooleanExtra(EditPostBaseActivity.EXTRA_HAS_FAILED_MEDIA, false);
         if (hasFailedMedia) {
             showSnackbar(snackbarAttachView, R.string.editor_post_saved_locally_failed_media, R.string.button_edit,
                          new View.OnClickListener() {
@@ -395,8 +396,8 @@ public class UploadUtils {
                             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
                             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                             writePostIntent.putExtra(WordPress.SITE, site);
-                            writePostIntent.putExtra(EditPostActivity.EXTRA_IS_PAGE, false);
-                            writePostIntent.putExtra(EditPostActivity.EXTRA_INSERT_MEDIA, mediaListToInsertInPost);
+                            writePostIntent.putExtra(EditPostBaseActivity.EXTRA_IS_PAGE, false);
+                            writePostIntent.putExtra(EditPostBaseActivity.EXTRA_INSERT_MEDIA, mediaListToInsertInPost);
                             activity.startActivity(writePostIntent);
                         }
                     });

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -44,7 +44,7 @@ import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
 import org.wordpress.android.fluxc.store.UploadStore
 import org.wordpress.android.ui.notifications.utils.PendingDraftsNotificationsUtils
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
-import org.wordpress.android.ui.posts.EditPostActivity
+import org.wordpress.android.ui.posts.EditPostBaseActivity
 import org.wordpress.android.ui.posts.PostAdapterItem
 import org.wordpress.android.ui.posts.PostAdapterItemData
 import org.wordpress.android.ui.posts.PostAdapterItemUploadStatus
@@ -244,7 +244,7 @@ class PostListViewModel @Inject constructor(
     }
 
     fun handleEditPostResult(data: Intent?) {
-        val localPostId = data?.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0)
+        val localPostId = data?.getIntExtra(EditPostBaseActivity.EXTRA_POST_LOCAL_ID, 0)
         if (localPostId == null || localPostId == 0) {
             return
         }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -5,7 +5,6 @@ import android.arch.lifecycle.LiveData;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.os.Bundle;
-import android.os.Handler;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.text.Editable;
@@ -30,7 +29,6 @@ import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
-import org.wordpress.aztec.IHistoryListener;
 import org.wordpress.aztec.source.SourceViewEditText;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnGetContentTimeout;
@@ -38,8 +36,7 @@ import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnMediaLibraryButton
 
 public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         View.OnTouchListener,
-        EditorMediaUploadListener,
-        IHistoryListener {
+        EditorMediaUploadListener {
     private static final String KEY_HTML_MODE_ENABLED = "KEY_HTML_MODE_ENABLED";
     private static final String GUTENBERG_BLOCK_START = "<!-- wp:";
     private static final String ARG_IS_NEW_POST = "param_is_new_post";
@@ -50,9 +47,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     private EditTextWithKeyBackListener mTitle;
     private SourceViewEditText mSource;
-
-    private Handler mInvalidateOptionsHandler;
-    private Runnable mInvalidateOptionsRunnable;
 
     private LiveTextWatcher mTextWatcher = new LiveTextWatcher();
 
@@ -154,16 +148,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
         setHasOptionsMenu(true);
 
-        mInvalidateOptionsHandler = new Handler();
-        mInvalidateOptionsRunnable = new Runnable() {
-            @Override
-            public void run() {
-                if (isAdded()) {
-                    getActivity().invalidateOptionsMenu();
-                }
-            }
-        };
-
         mEditorFragmentListener.onEditorFragmentInitialized();
 
         if (mIsNewPost) {
@@ -263,28 +247,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         }
 
         return false;
-    }
-
-    @Override
-    public void onRedoEnabled() {
-        if (!isAdded()) {
-            return;
-        }
-
-        mInvalidateOptionsHandler.removeCallbacks(mInvalidateOptionsRunnable);
-        mInvalidateOptionsHandler.postDelayed(mInvalidateOptionsRunnable,
-                                              getResources().getInteger(android.R.integer.config_mediumAnimTime));
-    }
-
-    @Override
-    public void onUndoEnabled() {
-        if (!isAdded()) {
-            return;
-        }
-
-        mInvalidateOptionsHandler.removeCallbacks(mInvalidateOptionsRunnable);
-        mInvalidateOptionsHandler.postDelayed(mInvalidateOptionsRunnable,
-                                              getResources().getInteger(android.R.integer.config_mediumAnimTime));
     }
 
     private ActionBar getActionBar() {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -44,8 +44,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     private static final String GUTENBERG_BLOCK_START = "<!-- wp:";
     private static final String ARG_IS_NEW_POST = "param_is_new_post";
 
-    private static boolean mIsToolbarExpanded = false;
-
     private boolean mEditorWasPaused = false;
     private boolean mHideActionBarOnSoftKeyboardUp = false;
     private boolean mHtmlModeEnabled;
@@ -68,9 +66,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     public static GutenbergEditorFragment newInstance(String title,
                                                       String content,
-                                                      boolean isExpanded,
                                                       boolean isNewPost) {
-        mIsToolbarExpanded = isExpanded;
         GutenbergEditorFragment fragment = new GutenbergEditorFragment();
         Bundle args = new Bundle();
         args.putString(ARG_PARAM_TITLE, title);


### PR DESCRIPTION
This PR introduces a dedicated Activity for hosting the Gutenberg editor, as opposed to having all editors co-live within `EditPostActivity`, which already has lots of code to make a difference and tell which editor to launch in the first place, depending on user settings, Post contents, and more intricate conditions.

#### Context and goals
It is important to note where this particular effort comes from. This is not a real refactor of `EditPostActivity` which we've been discussing for long and postponing for when time is available to tackle such a non-trivial, and also not minor, effort. 

This PR on the contrary, represents what I've found to be the less disruptive way to achieve these goals:
1. have the Activity hosting Gutenberg not be re-created on orientation changes (although yes on other configuration changes) to let React Native handle that flow (see https://github.com/wordpress-mobile/WordPress-Android/pull/8800). This in particular would take care of fixing these two problems: https://github.com/wordpress-mobile/WordPress-Android/issues/8739 and https://github.com/wordpress-mobile/gutenberg-mobile/issues/377
2. avoid introducing more bugs into the existing editor (particularly Aztec, Visual, and Legacy), that we won't have time to maintain, by isolating any further changes in the time those editors have to still live together.

For this, we're introducing a new Activity to host the Gutenberg editor _only_, but will keep the current `EditPostActivity`.
I've elevated the shared constants and _only_ the most obvious common code into an abstract class, but I've no intention to maximize code reuse for this particular effort. This is a temporal situation that makes Aztec/Visual editors live without much of a problem while we introduce the new Gutenberg editor.
A real, thorough refactor would evidently demand that we not only remove code that is not used, but we'd also need to refactor and reuse code as much as possible. Such an effort would demand more valuable time and thought for a thing that we know we're going to remove soon as part of our known plans. Thus, containing new things in an isolated way and building up from there seems to come in very handy.

#### ToDo (general)
- [x] for new intents, build a helper method that returns the `Intent` we need depending on the Editor we need to launch. (https://github.com/wordpress-mobile/WordPress-Android/pull/8874/commits/13d3d75576f22e8974802b1b406ddf95771cc8ab and https://github.com/wordpress-mobile/WordPress-Android/pull/8874/commits/2ccd1791c6d37d92fd2e40d7649154d11f090c4d)
- [x] get all important constants up into an `abstract EditPostBaseActivity` class, and make `EditPostActivity` a derived class. (https://github.com/wordpress-mobile/WordPress-Android/pull/8874/commits/74765be3b1a5615b2e5a1eb68bc26921aded4a81)
- [x] make a separate GutenbergEditPostActivity that also derives from `EditPostBaseActivity`, and add the configchanges attributes in `AndroidManifest.xml` (https://github.com/wordpress-mobile/WordPress-Android/pull/8874/commits/79eef3230539b86147fd30ba03e016b6e0123e9e)
- [x] check the different entry points everywhere in the app for which we need to decide to open which editor, ~possibly make that logic centralized~ ended up having it all in `ActivityLauncher` where Activity intents where created. (https://github.com/wordpress-mobile/WordPress-Android/pull/8874/commits/2ccd1791c6d37d92fd2e40d7649154d11f090c4d and https://github.com/wordpress-mobile/WordPress-Android/pull/8874/commits/2f8ef0e4d1f2679a336d742580404802c89d1d90)
- [x] once we make sure all entry points work as expected, remove non-Gutenberg related code from `GutenbergEditPostActivity` _(left only commented code 5e1c762148c874c711e293e9b6a98c2088b08c2f)_
- [x] remove Gutenberg code from `EditPostActivity` (see ToDo lists below).

#### ToDo on `GutenbergEditPostActivity`
- [x] remove `mShowGutenbergEditor`  flag and usages as it's unneeded in this context (d008ed1642884521a0e2a20bdeb257178f898943)
- [x] remove `mShowAztec` flag and usages as it won't belong here (5e1c762148)
- [x] remove Aztec references and AztecImageLoader and AztecVideoLoader (5e1c762148)
- [x] remove `mShowNewEditor` flag and usages as it won't belong here (85263bb194)
- [ ] ~make "discardLocalChanges" functionality work the same on Gutenberg as it was on Aztec~ I'll tackle this on a separate PR once this one lands


#### Media - related ToDo (on separate PRs)
(5e1c762148c874c711e293e9b6a98c2088b08c2f commented out code that we'll need to reuse for Media soon)
Moved to issue https://github.com/wordpress-mobile/gutenberg-mobile/issues/459

#### ToDo on `EditPostActivity` (cleanup)
- [x] remove Gutenberg code from `EditPostActivity` (fd181f266d)

#### To test:

CASE A: use gutenberg
1. go to app settings and enable gutenberg (compile the alpha version for this)
2. go to posts list and open a Gutenberg post written on the web
3. see it loads Gutenberg (you should be able to see the blocks interface when tapping somewhere in the body)

CASE B: use Aztec in compatibility mode
1. go to app settings and disable gutenberg (compile the alpha version for this)
2. go to posts list and tap on a Gutenberg post written on the web
3. you should see the compatibility warning dialog, tap OPEN
4. see Aztec is the editor opened, and the content is rendered (to the extent that Aztec can render Gutenberg posts ofc)

CASE C: use Gutenberg and rotate
1. follow case A
2. when the post is open, scroll down to the middle of it (make sure you have several blocks in your post to be able to tell the difference in scroll positioning).
3. tap on a pargraph block and see the keyboard appears, and the caret starts blinking where you tapped.
4. tap back to dismiss the keyboard
5. rotate the device
6. observe the place where you were standing is still there, and the caret is blinking


CASE D: use Gutenberg and rotate, observe undo/redo
1. follow case A
2. when the post is open, scroll down to the middle of it (make sure you have several blocks in your post to be able to tell the difference in scroll positioning).
3. write some new blocks, see the UNDO action becomes available
4. tap UNDO, observe the last action is undone
5. tap REDO, observe the text come back as it was
6. rotate the device
7. observe the UNDO action is still available
8. repeat steps 4 and 5 to confirm that the history was effectively available and actions can be undone/redone.

**NOTE:** other entry points, such as uploading an image to the Media section of your site and then tapping on "WRITE POST" on the success snackbar/notification to include the just-uploaded picture in your post is not yet supported. We'll support that once Media is all wired up together.


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
