### PR TITLE
Issue/8443 signup password errors

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -516,8 +516,8 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     }
 
     private boolean isPasswordInErrorMessage(String message) {
-        String lowercaseMessage = message.toLowerCase();
-        String lowercasePassword = getString(R.string.password).toLowerCase();
+        String lowercaseMessage = message.toLowerCase(Locale.getDefault());
+        String lowercasePassword = getString(R.string.password).toLowerCase(Locale.getDefault());
         return lowercaseMessage.contains(lowercasePassword);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -429,7 +429,12 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
             AppLog.e(T.API, "SignupEpilogueFragment.onAccountChanged: "
                             + event.error.type + " - " + event.error.message);
             endProgress();
-            showErrorDialog(getString(R.string.signup_epilogue_error_generic));
+
+            if (isPasswordInErrorMessage(event.error.message)) {
+                showErrorDialogAvatar(event.error.message);
+            } else {
+                showErrorDialog(getString(R.string.signup_epilogue_error_generic));
+            }
         // Wait to populate epilogue for email interface until account is fetched and email address
         // is available since flow is coming from magic link with no instance argument values.
         } else if (mIsEmailSignup && event.causeOfChange == AccountAction.FETCH_ACCOUNT
@@ -508,6 +513,12 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
      */
     private String createUsernameFromEmail() {
         return mEmailAddress.split("@")[0].replaceAll("[^A-Za-z0-9]", "").toLowerCase(Locale.ROOT);
+    }
+
+    private boolean isPasswordInErrorMessage(String message) {
+        String lowercaseMessage = message.toLowerCase();
+        String lowercasePassword = getString(R.string.password).toLowerCase();
+        return lowercaseMessage.contains(lowercasePassword);
     }
 
     protected void launchDialog() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -431,7 +431,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
             endProgress();
 
             if (isPasswordInErrorMessage(event.error.message)) {
-                showErrorDialogAvatar(event.error.message);
+                showErrorDialogWithCloseButton(event.error.message);
             } else {
                 showErrorDialog(getString(R.string.signup_epilogue_error_generic));
             }
@@ -561,7 +561,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                         @Override
                         public void onLoadFailed(@Nullable Exception e) {
                             AppLog.e(T.NUX, "Uploading image to Gravatar succeeded, but setting image view failed");
-                            showErrorDialogAvatar(getString(R.string.signup_epilogue_error_avatar_view));
+                            showErrorDialogWithCloseButton(getString(R.string.signup_epilogue_error_avatar_view));
                         }
 
                         @Override
@@ -621,7 +621,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
         dialog.show();
     }
 
-    protected void showErrorDialogAvatar(String message) {
+    protected void showErrorDialogWithCloseButton(String message) {
         AlertDialog dialog = new AlertDialog.Builder(new ContextThemeWrapper(getActivity(), R.style.LoginTheme))
                 .setMessage(message)
                 .setPositiveButton(R.string.login_error_button, null)
@@ -669,7 +669,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                             @Override
                             public void onError() {
                                 endProgress();
-                                showErrorDialogAvatar(getString(R.string.signup_epilogue_error_avatar));
+                                showErrorDialogWithCloseButton(getString(R.string.signup_epilogue_error_avatar));
                                 AppLog.e(T.NUX, "Uploading image to Gravatar failed");
                             }
                         });


### PR DESCRIPTION
### Fix
Add details to the dialog message when an error occurs while updating the account password on the signup epilogue screen as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8443.  Since the same endpoint is used to update the display name, username, and password on the signup epilogue screen, the callback is also the same and there is no definitive way to detect when the error is due to the password.  In order to show detailed messages, the error message received from the server is used as the dialog text when that message contains the "password" term and the generic, default dialog is shown otherwise.  See the screenshots below for illustration.

![signup_epilogue_password_error](https://user-images.githubusercontent.com/3827611/50457375-ff6a2900-0928-11e9-9ca2-d655ef9140a5.png)

### Test
0. Clear app data.
1. Tap ***Sign Up*** button.
2. Tap ***Sign Up with Email*** button.
3. Enter email address _not_ associated with WordPress.com account.
4. Notice ***Signup Magic Link*** screen.
5. Check email inbox of address used in Step 3.
6. Notice signup email from WordPress.com.
7. Tap ***Sign up to WordPress.com*** button in email.
8. Notice  ***Epilogue for Email*** screen.
9. Enter "12345" into ***Password*** field.
10. Tap ***Continue*** button.
11. Notice error message shown in _**Characters**_ screenshot above.
12. Tap ***Close*** button.
13. Enter "123456" into ***Password*** field.
14. Tap ***Continue*** button.
15. Notice error message shown in _**Common**_ screenshot above.
16. Tap ***Close*** button.
17. Enter "a a a " into ***Password*** field.
18. Tap ***Continue*** button.
19. Notice error message shown in _**Complex**_ screenshot above.
20. Tap ***Close*** button.
21. Enable airplane mode.
22. Tap ***Continue*** button.
23. Notice error message shown in _**Default**_ screenshot above.

### Review
Only one developer is required to review these changes, but anyone can perform the review.