### PR TITLE
Site Creation: Open keyboard as user enters verticals and domains screens

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SearchInputWithHeader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SearchInputWithHeader.kt
@@ -11,6 +11,7 @@ import android.widget.EditText
 import android.widget.TextView
 import org.wordpress.android.R
 import org.wordpress.android.ui.utils.getTextOfUiString
+import org.wordpress.android.util.ActivityUtils
 
 class SearchInputWithHeader(rootView: View, onClear: () -> Unit) {
     private val headerLayout = rootView.findViewById<ViewGroup>(R.id.header_layout)
@@ -73,6 +74,11 @@ class SearchInputWithHeader(rootView: View, onClear: () -> Unit) {
         searchInput.hint = getTextOfUiString(context, uiState.hint)
         updateVisibility(progressBar, uiState.showProgress)
         updateVisibility(clearAllButton, uiState.showClearButton)
+    }
+
+    fun requestInputFocusAndShowKeyboard() {
+        searchInput.requestFocus()
+        ActivityUtils.showKeyboard(searchInput)
     }
 
     private fun updateVisibility(view: View, visible: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domain/NewSiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domain/NewSiteCreationDomainsFragment.kt
@@ -137,6 +137,9 @@ class NewSiteCreationDomainsFragment : NewSiteCreationBaseFormFragment<NewSiteCr
         viewModel.onHelpClicked.observe(this, Observer {
             helpClickedListener.onHelpClicked(HelpActivity.Origin.NEW_SITE_CREATION_DOMAINS)
         })
+        viewModel.onInputFocusRequested.observe(this, Observer {
+            searchInputWithHeader.requestInputFocusAndShowKeyboard()
+        })
         viewModel.start(getSiteTitleFromArguments())
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domain/NewSiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domain/NewSiteCreationDomainsViewModel.kt
@@ -78,6 +78,9 @@ class NewSiteCreationDomainsViewModel @Inject constructor(
     private val _onHelpClicked = SingleLiveEvent<Unit>()
     val onHelpClicked: LiveData<Unit> = _onHelpClicked
 
+    private val _onInputFocusRequested = SingleLiveEvent<Unit>()
+    val onInputFocusRequested: LiveData<Unit> = _onInputFocusRequested
+
     init {
         dispatcher.register(fetchDomainsUseCase)
     }
@@ -98,6 +101,8 @@ class NewSiteCreationDomainsViewModel @Inject constructor(
         } else {
             updateQueryInternal(TitleQuery(siteTitle))
         }
+        // Show keyboard
+        _onInputFocusRequested.call()
     }
 
     fun createSiteBtnClicked() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationSiteInfoViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationSiteInfoViewModel.kt
@@ -7,12 +7,8 @@ import android.support.annotation.ColorRes
 import android.support.annotation.StringRes
 import kotlinx.coroutines.experimental.CoroutineScope
 import kotlinx.coroutines.experimental.Job
-import kotlinx.coroutines.experimental.delay
-import kotlinx.coroutines.experimental.launch
-import kotlinx.coroutines.experimental.withContext
 import org.wordpress.android.R
 import org.wordpress.android.modules.IO_DISPATCHER
-import org.wordpress.android.modules.MAIN_DISPATCHER
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel.SiteInfoUiState.SkipNextButtonState.NEXT
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel.SiteInfoUiState.SkipNextButtonState.SKIP
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -21,11 +17,8 @@ import javax.inject.Named
 import kotlin.coroutines.experimental.CoroutineContext
 import kotlin.properties.Delegates
 
-private const val REQUEST_INPUT_FOCUS_DELAY: Long = 500L
-
 class NewSiteCreationSiteInfoViewModel @Inject constructor(
-    @Named(IO_DISPATCHER) private val IO: CoroutineContext,
-    @Named(MAIN_DISPATCHER) private val MAIN: CoroutineContext
+    @Named(IO_DISPATCHER) private val IO: CoroutineContext
 ) : ViewModel(), CoroutineScope {
     private var currentUiState: SiteInfoUiState by Delegates.observable(
             SiteInfoUiState(
@@ -65,7 +58,8 @@ class NewSiteCreationSiteInfoViewModel @Inject constructor(
             return
         }
         isStarted = true
-        requestTitleInputFocus()
+        // Show keyboard
+        _onTitleInputFocusRequested.call()
     }
 
     fun onHelpClicked() {
@@ -88,15 +82,6 @@ class NewSiteCreationSiteInfoViewModel @Inject constructor(
         when (currentUiState.skipButtonState) {
             SKIP -> _skipBtnClicked.call()
             NEXT -> _nextBtnClicked.value = currentUiState
-        }
-    }
-
-    private fun requestTitleInputFocus(delayDuration: Long = REQUEST_INPUT_FOCUS_DELAY) {
-        launch(IO) {
-            delay(delayDuration)
-            withContext(MAIN) {
-                _onTitleInputFocusRequested.call()
-            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
@@ -166,6 +166,9 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment<NewSite
         viewModel.onHelpClicked.observe(this, Observer {
             helpClickedListener.onHelpClicked(HelpActivity.Origin.NEW_SITE_CREATION_VERTICALS)
         })
+        viewModel.onInputFocusRequested.observe(this, Observer {
+            searchInputWithHeader.requestInputFocusAndShowKeyboard()
+        })
         viewModel.start(segmentId)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
@@ -76,6 +76,9 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
     private val _onHelpClicked = SingleLiveEvent<Unit>()
     val onHelpClicked: LiveData<Unit> = _onHelpClicked
 
+    private val _onInputFocusRequested = SingleLiveEvent<Unit>()
+    val onInputFocusRequested: LiveData<Unit> = _onInputFocusRequested
+
     init {
         dispatcher.register(fetchVerticalsUseCase)
         dispatcher.register(fetchSegmentPromptUseCase)
@@ -128,6 +131,8 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
         } else {
             segmentPrompt = event.prompt!!
             updateUiStateToContent("", ListState.Ready(emptyList()))
+            // Show the keyboard
+            _onInputFocusRequested.call()
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/siteinfo/NewSiteCreationSiteInfoViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/siteinfo/NewSiteCreationSiteInfoViewModelTest.kt
@@ -35,7 +35,7 @@ class NewSiteCreationSiteInfoViewModelTest {
 
     @Before
     fun setUp() {
-        viewModel = NewSiteCreationSiteInfoViewModel(TEST_DISPATCHER, TEST_DISPATCHER)
+        viewModel = NewSiteCreationSiteInfoViewModel(TEST_DISPATCHER)
         viewModel.uiState.observeForever(uiStateObserver)
         viewModel.onTitleInputFocusRequested.observeForever(onTitleInputFocusRequestedObserver)
         viewModel.skipBtnClicked.observeForever(onSkipClickedObserver)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModelTest.kt
@@ -123,6 +123,7 @@ class NewSiteCreationVerticalsViewModelTest {
     @Mock private lateinit var verticalSelectedObserver: Observer<String?>
     @Mock private lateinit var skipBtnClickedObservable: Observer<Unit>
     @Mock private lateinit var onHelpClickedObserver: Observer<Unit>
+    @Mock private lateinit var onInputFocusRequestedObserver: Observer<Unit>
     @Mock private lateinit var networkUtils: NetworkUtilsWrapper
 
     private lateinit var viewModel: NewSiteCreationVerticalsViewModel
@@ -142,6 +143,7 @@ class NewSiteCreationVerticalsViewModelTest {
         viewModel.verticalSelected.observeForever(verticalSelectedObserver)
         viewModel.skipBtnClicked.observeForever(skipBtnClickedObservable)
         viewModel.onHelpClicked.observeForever(onHelpClickedObserver)
+        viewModel.onInputFocusRequested.observeForever(onInputFocusRequestedObserver)
         whenever(networkUtils.isNetworkAvailable()).thenReturn(true)
     }
 
@@ -169,6 +171,13 @@ class NewSiteCreationVerticalsViewModelTest {
     fun verifyInputShownAfterPromptFetched() = testWithSuccessResponses {
         viewModel.start(SEGMENT_ID)
         verifyEmptySearchInputVisible(viewModel.uiState)
+    }
+
+    @Test
+    fun verifyInputRequestsFocusAfterPromptFetched() = testWithSuccessResponses {
+        viewModel.start(SEGMENT_ID)
+        val captor = ArgumentCaptor.forClass(Unit::class.java)
+        verify(onInputFocusRequestedObserver).onChanged(captor.capture())
     }
 
     @Test


### PR DESCRIPTION
This is a small PR that improves the keyboard handling for the new site creation flow. We recently added a way to open the keyboard in the site info screen when the user first entered it. That felt quite weird to me within the flow, because we weren't doing the same in the other two screens for verticals and domains. This PR follows the same approach to site info to rectify the situation as well as adding unit tests for it in verticals page. (We don't have unit tests for domains view model yet #8508) It also removes the extra delay I have added to the site info page for the keyboard to appear as it looks like that wasn't necessary in the first place.

To test:
* Go to site picker page, tap on `+` menu button and select `Create WordPress.com site`
* Select any segment
* Verify the keyboard opens as you enter verticals page
* Skip to the site info page and verify the keyboard opens as you enter the page
* Skip to domains page and verify the keyboard opens as you enter the page

Here is a gif showcasing these steps: https://cloudup.com/cewtzNyZHwE

One reviewer should be enough for this PR and since we'll do a full design review at the end of the project it's not necessary for this PR.
