### PR TITLE
Issue/update style xml

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -89,6 +89,7 @@
       </extensions>
     </Objective-C-extensions>
     <XML>
+      <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
     <codeStyleSettings language="JAVA">

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -2,6 +2,21 @@
   <code_scheme name="Project" version="173">
     <AndroidXmlCodeStyleSettings>
       <option name="USE_CUSTOM_SETTINGS" value="true" />
+      <option name="LAYOUT_SETTINGS">
+        <value>
+          <option name="INSERT_LINE_BREAK_BEFORE_NAMESPACE_DECLARATION" value="true" />
+        </value>
+      </option>
+      <option name="MANIFEST_SETTINGS">
+        <value>
+          <option name="INSERT_LINE_BREAK_BEFORE_NAMESPACE_DECLARATION" value="true" />
+        </value>
+      </option>
+      <option name="OTHER_SETTINGS">
+        <value>
+          <option name="INSERT_LINE_BREAK_BEFORE_NAMESPACE_DECLARATION" value="true" />
+        </value>
+      </option>
     </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -131,18 +131,8 @@
             <rule>
               <match>
                 <AND>
-                  <NAME>xmlns:android</NAME>
-                  <XML_NAMESPACE>^$</XML_NAMESPACE>
-                </AND>
-              </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
                   <NAME>xmlns:.*</NAME>
-                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
                 </AND>
               </match>
               <order>BY_NAME</order>
@@ -153,7 +143,7 @@
               <match>
                 <AND>
                   <NAME>.*:id</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
                 </AND>
               </match>
             </rule>
@@ -163,7 +153,7 @@
               <match>
                 <AND>
                   <NAME>.*:name</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
                 </AND>
               </match>
             </rule>
@@ -172,102 +162,7 @@
             <rule>
               <match>
                 <AND>
-                  <NAME>name</NAME>
-                  <XML_NAMESPACE>^$</XML_NAMESPACE>
-                </AND>
-              </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>style</NAME>
-                  <XML_NAMESPACE>^$</XML_NAMESPACE>
-                </AND>
-              </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*</NAME>
-                  <XML_NAMESPACE>^$</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:layout_width</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:layout_height</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:layout_.*</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:width</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:height</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*</NAME>
+                  <NAME>.*:.*</NAME>
                   <XML_NAMESPACE>.*</XML_NAMESPACE>
                 </AND>
               </match>


### PR DESCRIPTION
### Fix
Update the project code style scheme for better readability.  These changes include the following:
- update arrangement to order attributes alphabetically
- add line break before namespace declaration
- add space inside empty tag

Updating the arrangement to order attributes alphabetically increases code readability.  Assigning a standard ordering scheme makes it easier for developers to parse view attributes and determine if like attributes are missing or present.  Applying alphabetical order simplifies the arrangement rules to remember by using a universal standard.  Only the `android:id` and `android:name` attributes are exceptions since they are the identification attribute for tags.  They will be the first attribute if present.  See the _**Before**_ and _**After**_ example below for illustration.

#### Before
```xml
<TextView
    android:layout_width="wrap_content"
    android:layout_height="wrap_content"
    android:id="@+id/item_text"
    android:paddingTop="@dimen/padding_small"
    android:textColor="@color/white"
    android:paddingBottom="@dimen/padding_small"
    android:layout_marginStart="@dimen/margin_large"
    android:visibility="gone"
    android:layout_marginTop="@dimen/margin_large"
    android:textSize="@dimen/text_item"
    android:paddingEnd="@dimen/padding_medium"
    tools:text="Title"
    android:textStyle="bold"
    android:paddingStart="@dimen/padding_medium"
    android:layout_marginEnd="@dimen/margin_large" />
```

#### After
```xml
<TextView
    android:id="@+id/item_text"
    android:layout_height="wrap_content"
    android:layout_marginEnd="@dimen/margin_large"
    android:layout_marginStart="@dimen/margin_large"
    android:layout_marginTop="@dimen/margin_large"
    android:layout_width="wrap_content"
    android:paddingBottom="@dimen/padding_small"
    android:paddingEnd="@dimen/padding_medium"
    android:paddingStart="@dimen/padding_medium"
    android:paddingTop="@dimen/padding_small"
    android:textColor="@color/white"
    android:textSize="@dimen/text_item"
    android:textStyle="bold"
    android:visibility="gone"
    tools:text="Title" />
```

Adding a line break before namespace declaration avoids appending the namespace after the leading tag and causing the following attributes to be vertically aligned to the beginning of that namespace with a deep indention.  It aligns namespace declaration and following attributes to the standard four-space indention below the leading tag rather than using a variable and possibly deep indention based on the leading tag length.  It makes XML files more readable by aligning tags with namespace declaration with the same formatting as other tags in the file.  See the _**Before**_ and _**After**_ example below for illustration.

#### Before
```xml
<?xml version="1.0" encoding="utf-8"?>

<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
                                    xmlns:app="http://schemas.android.com/apk/res-auto"
                                    android:id="@+id/card_view"
                                    android:layout_width="match_parent"
                                    android:layout_height="wrap_content"
                                    app:cardBackgroundColor="@color/white"
                                    app:cardCornerRadius="@dimen/card_radius"
                                    app:cardElevation="@dimen/card_elevation" >

    <LinearLayout
        android:background="?android:selectableItemBackground"
        android:layout_height="match_parent"
        android:layout_width="match_parent"
        android:orientation="vertical">
```

#### After
```xml
<?xml version="1.0" encoding="utf-8"?>

<android.support.v7.widget.CardView
    xmlns:android="http://schemas.android.com/apk/res/android"
    xmlns:app="http://schemas.android.com/apk/res-auto"
    android:id="@+id/card_view"
    android:layout_height="wrap_content"
    android:layout_width="match_parent"
    card_view:cardBackgroundColor="@color/white"
    card_view:cardCornerRadius="@dimen/card_radius"
    card_view:cardElevation="@dimen/card_elevation">

    <LinearLayout
        android:background="?android:selectableItemBackground"
        android:layout_height="match_parent"
        android:layout_width="match_parent"
        android:orientation="vertical">
```

Adding a space inside an empty tag helps make empty tags a little easier to distinguish from non-empty tags.  See the _**Before**_ and _**After**_ example below for illustration.

#### Before
```xml
<LinearLayout
    android:id="@+id/item_container"
    android:background="?android:selectableItemBackground"
    android:layout_height="match_parent"
    android:layout_width="match_parent"
    android:orientation="vertical">

    <ImageView
        android:id="@+id/item_image"
        android:contentDescription="@string/item_image_description"
        android:layout_height="@dimen/item_image_height"
        android:layout_width="match_parent"
        tools:visibility="visible"/>
```

#### After
```xml
<LinearLayout
    android:id="@+id/item_container"
    android:background="?android:selectableItemBackground"
    android:layout_height="match_parent"
    android:layout_width="match_parent"
    android:orientation="vertical">

    <ImageView
        android:id="@+id/item_image"
        android:contentDescription="@string/item_image_description"
        android:layout_height="@dimen/item_image_height"
        android:layout_width="match_parent"
        tools:visibility="visible" />
```

### Test
To test these changes, go to an XML source code file and select _**Code**_ > _**Reformat Code**_ (i.e. Command+Option+L on Mac or Control+Alt+L on Windows) or select part of an XML source code file to apply the code format to that snippet of the file.

#### Attribute Order Arrangement
1. Go to [`post_cardview.xml`](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/update-style-xml/WordPress/src/main/res/layout/post_cardview.xml) file.
2. Notice [`WPTextView`](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/update-style-xml/WordPress/src/main/res/layout/post_cardview.xml#L37-L46) attributes are randomly ordered.
3. Select [`WPTextView`](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/update-style-xml/WordPress/src/main/res/layout/post_cardview.xml#L37-L46) view.
4. Apply code reformat.
5. Notice [`WPTextView`](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/update-style-xml/WordPress/src/main/res/layout/post_cardview.xml#L37-L46) attributes are alphabetically ordered.

#### Namespace Declaration Break
1. Go to [`post_cardview.xml`](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/update-style-xml/WordPress/src/main/res/layout/post_cardview.xml) file.
2. Notice [`CardView`](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/update-style-xml/WordPress/src/main/res/layout/post_cardview.xml#L3-L13) namespace declaration and attributes are deeply indented unlike other views.
3. Select [`CardView`](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/update-style-xml/WordPress/src/main/res/layout/post_cardview.xml#L3-L13) view.
4. Apply code reformat.
5. Notice [`CardView`](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/update-style-xml/WordPress/src/main/res/layout/post_cardview.xml#L3-L13) namespace declaration and attributes are indented four spaces like other views.

#### Empty Tag Space
1. Go to [`post_cardview.xml`](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/update-style-xml/WordPress/src/main/res/layout/post_cardview.xml) file.
2. Notice [`WPTextView`](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/update-style-xml/WordPress/src/main/res/layout/post_cardview.xml#L29-L35) does not have a space inside the empty tag.
3. Select [`WPTextView`](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/update-style-xml/WordPress/src/main/res/layout/post_cardview.xml#L29-L35) view.
4. Apply code reformat.
5. Notice [`WPTextView`](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/update-style-xml/WordPress/src/main/res/layout/post_cardview.xml#L29-L35)does have a space inside the empty tag.

### Review
Only one developer is required to review these changes, but anyone can perform the review.