### PR TITLE
Don't download Gutenberg JS Bundle on every build

### DIFF
--- a/WordPress/gutenberg-tasks.gradle
+++ b/WordPress/gutenberg-tasks.gradle
@@ -5,19 +5,23 @@ apply from: 'https://gist.githubusercontent.com/hypest/e06f6097065728b6db7b7c462
 def gutenbergMobileJsBundleFilename = 'index.android.bundle'
 
 task downloadJSBundle {
+    def gutenbergHash = submoduleGitHash("${project.projectDir}/../", 'libs/gutenberg-mobile')
+    def assetsFolderName = "${project.projectDir}/src/main/assets"
+    def gutenbergMobileJsBundlePath = new File("${assetsFolderName}/${gutenbergMobileJsBundleFilename}")
+
+    inputs.property("JS Bundle Hash", gutenbergHash)
+    outputs.file(gutenbergMobileJsBundlePath)
+
     doLast {
-        def assetsFolderName = "${project.projectDir}/src/main/assets"
         File assetsFolder = new File(assetsFolderName)
         if (! assetsFolder.exists()){
-            assetsFolder.mkdirs();
+            assetsFolder.mkdirs()
         }
 
-        def targetFile = new File("${assetsFolderName}/${gutenbergMobileJsBundleFilename}")
-        def hash = submoduleGitHash("${project.projectDir}/../", 'libs/gutenberg-mobile')
-        def url = new URL("https://s3-us-west-1.amazonaws.com/gutenberg-mobile-js-bundle/wordpress-mobile/gutenberg-mobile/${hash}/android/App.js")
+        def url = new URL("https://s3-us-west-1.amazonaws.com/gutenberg-mobile-js-bundle/wordpress-mobile/gutenberg-mobile/${gutenbergHash}/android/App.js")
 
         println "Downloading JS bundle from ${url}"
-        url.withInputStream{ i -> targetFile.withOutputStream{ it << i }}
+        url.withInputStream{ i -> gutenbergMobileJsBundlePath.withOutputStream{ it << i }}
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/8877

This uses Gradle task inputs and outputs to allow caching of the `downloadJSBundle` task. See the Gradle docs [here](https://docs.gradle.org/4.0/userguide/more_about_tasks.html#sec:up_to_date_checks).

To test:

- Run `./gradlew prebuild --info`. You will see the JS bundle being downloaded:
```
> Task :WordPress:downloadJSBundle
Putting task artifact state for task ':WordPress:downloadJSBundle' into context took 0.0 secs.
Up-to-date check for task ':WordPress:downloadJSBundle' took 0.0 secs. It is not up-to-date because:
  Task ':WordPress:downloadJSBundle' has no history
Downloading JS bundle from https://s3-us-west-1.amazonaws.com/gutenberg-mobile-js-bundle/wordpress-mobile/gutenberg-mobile/11aa98f76d5450d7a8d231d97f4d2ee3eb9ed98f/android/App.js

:WordPress:downloadJSBundle (Thread[Task worker for ':',5,main]) completed. Took 2.172 secs.
:WordPress:preBuild (Thread[Task worker for ':',5,main]) started.
```

- Now run `./gradlew prebuild --info` again. You will see that downloading the JS is skipped:
```
> Task :WordPress:downloadJSBundle UP-TO-DATE
Putting task artifact state for task ':WordPress:downloadJSBundle' into context took 0.0 secs.
Skipping task ':WordPress:downloadJSBundle' as it is up-to-date (took 0.0 secs).

:WordPress:downloadJSBundle (Thread[Task worker for ':',5,main]) completed. Took 0.003 secs.
:WordPress:preBuild (Thread[Task worker for ':',5,main]) started.
```
- Change the submodule hash in `libs/gutenberg-mobile`. `./gradlew prebuild --info` will download the JS bundle again since the hash has changed.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

cc @oguzkocer 