### PR TITLE
Site Creation: Save and Restore state in Main VM

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
@@ -54,12 +54,17 @@ class NewSiteCreationActivity : AppCompatActivity(),
 
         setContentView(R.layout.new_site_creation_activity)
         mainViewModel = ViewModelProviders.of(this, viewModelFactory).get(NewSiteCreationMainVM::class.java)
-        mainViewModel.start(null, null)
+        mainViewModel.start(savedInstanceState)
 
         if (savedInstanceState == null) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.SITE_CREATION_ACCESSED)
         }
         observeVMState()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        mainViewModel.writeToBundle(outState)
     }
 
     private fun observeVMState() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
@@ -54,7 +54,7 @@ class NewSiteCreationActivity : AppCompatActivity(),
 
         setContentView(R.layout.new_site_creation_activity)
         mainViewModel = ViewModelProviders.of(this, viewModelFactory).get(NewSiteCreationMainVM::class.java)
-        mainViewModel.start()
+        mainViewModel.start(null, null)
 
         if (savedInstanceState == null) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.SITE_CREATION_ACCESSED)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
@@ -66,12 +66,13 @@ class NewSiteCreationMainVM @Inject constructor() : ViewModel() {
             siteCreationState = SiteCreationState()
             wizardManager = WizardManager(SITE_CREATION_STEPS)
         } else {
+            siteCreationState = savedInstanceState.getParcelable(KEY_SITE_CREATION_STATE)
             val currentStepIndex = savedInstanceState.getInt(KEY_CURRENT_STEP)
             wizardManager = WizardManager(SITE_CREATION_STEPS, currentStepIndex)
-            siteCreationState = savedInstanceState.getParcelable(KEY_SITE_CREATION_STATE)
         }
         isStarted = true
         if (savedInstanceState == null) {
+            // Show the next step only if it's a fresh activity so we can handle the navigation
             wizardManager.showNextStep()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/wizard/WizardManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/wizard/WizardManager.kt
@@ -8,6 +8,8 @@ class WizardManager<T : WizardStep>(
     private var currentStepIndex: Int = -1
 ) {
     val stepsCount = steps.size
+    val currentStep: Int
+        get() = currentStepIndex
 
     private val _navigatorLiveData = SingleLiveEvent<T>()
     val navigatorLiveData: LiveData<T> = _navigatorLiveData

--- a/WordPress/src/main/java/org/wordpress/android/util/wizard/WizardManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/wizard/WizardManager.kt
@@ -4,13 +4,13 @@ import android.arch.lifecycle.LiveData
 import org.wordpress.android.viewmodel.SingleLiveEvent
 
 class WizardManager<T : WizardStep>(
-    private val steps: List<T>
+    private val steps: List<T>,
+    private var currentStepIndex: Int = -1
 ) {
     val stepsCount = steps.size
 
     private val _navigatorLiveData = SingleLiveEvent<T>()
     val navigatorLiveData: LiveData<T> = _navigatorLiveData
-    private var currentStepIndex: Int = -1
 
     fun showNextStep() {
         if (isIndexValid(++currentStepIndex)) {


### PR DESCRIPTION
Fixes #8683. This PR adds the functionality of saving and restoring the site creation state when the activity and the main view model is destroyed.

_Although `ViewModel`s survive configuration changes, there is no guarantee that the system will not destroy it while the app is in the background. If the `Don't keep activities` developer option is turned on and the app is put the background while in an activity with a `ViewModel`, one can observe that the activity and the `ViewModel` is destroyed. This is not very common, but it's not considered an edge case either._

For site creation, we want to make sure that the user can continue where they left off after putting the app in the background and opening the app back again. This will work perfectly in most cases, but as explained above, if the activity is destroyed and we don't store the state in the `savedInstanceState`, it'll return back to the first fragment. Here is a gif showcasing several scenarios in which the user puts the app in the background in a fragment later in the flow and when they open it, the initial fragment shows up: https://cloudup.com/cjKpnE7qnma

In this PR, we save the `SiteCreationState` as well as the current step in the `WizardManager` in the `savedInstanceState` and restored in the `start` method _**only if**_ the `ViewModel` was not previously started. If it was started before, there is no need to do anything else, because it means the `ViewModel` survived but the activity hasn't. Here is a gif after this change showing that the correct fragment shows up even if the `ViewModel` was destroyed with the activity: https://cloudup.com/c0Bt3UkQCd3

A couple notes:

* This PR does not handle restoring specific fragments exactly the way they were before. We considered this at the beginning of the project and decided it wasn't necessary and ended up NOT saving the verticals, segments etc in the DB. As mentioned before, we are handling a rare case and in that rare case, we are completely fine with user needing to type a small text and make an extra network request. We do save some things like title and tagline in the state, so they will show up, but we don't save the current query for verticals or domains or the results of them.
* @malinajirka does not like to import `Bundle` in the `ViewModel`s for testing purposes as it does make the tests take longer to run. I definitely agree with him on this as a rule of thumb, but my priority is the actual implementation. In this specific case not importing the `Bundle` in the `ViewModel` would mean that we'll expose the state and the current step to the activity which is not something I like to do very much. In any case, we have a separate issue #8676 to write unit tests for this `ViewModel` in which we could potentially refactor this implementation slightly. Since we don't have the unit tests right now, I don't think it's an issue we need to be concerned about.

To test:
* Please see the [before](https://cloudup.com/cjKpnE7qnma) and [after](https://cloudup.com/c0Bt3UkQCd3) gifs and follow the steps there. I think that's much better than a long set of steps here  especially since I _once again_ wrote a fairly wrong PR description.

_P.S: A design review is not necessary since we'll do a general one in #8864 and one reviewer is enough for this PR._