### PR TITLE
Fix a slight repo typo

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,7 +35,7 @@ import "./ScreenshotFastfile"
 # Environment
 ########################################################################
 Dotenv.load('~/.wpandroid-env.default')
-ENV[GHHELPER_REPO="wordpress-mobile/WordPress-android"]
+ENV[GHHELPER_REPO="wordpress-mobile/WordPress-Android"]
 
 ########################################################################
 # Release Lanes


### PR DESCRIPTION
Fixes a minor typo in the repo name that I came across

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
