### PR TITLE
Issue/navigation scroll top

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -23,6 +23,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.ImageView;
+import android.widget.ScrollView;
 import android.widget.TextView;
 
 import com.yalantis.ucrop.UCrop;
@@ -67,7 +68,7 @@ import javax.inject.Inject;
 
 import de.greenrobot.event.EventBus;
 
-public class MeFragment extends Fragment implements MainToolbarFragment {
+public class MeFragment extends Fragment implements MainToolbarFragment, WPMainActivity.OnScrollToTopListener {
     private static final String IS_DISCONNECTING = "IS_DISCONNECTING";
     private static final String IS_UPDATING_GRAVATAR = "IS_UPDATING_GRAVATAR";
 
@@ -83,6 +84,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment {
     private View mNotificationsView;
     private View mNotificationsDividerView;
     private ProgressDialog mDisconnectProgressDialog;
+    private ScrollView mScrollView;
 
     @Nullable
     private Toolbar mToolbar = null;
@@ -136,6 +138,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment {
         mAccountSettingsView = rootView.findViewById(R.id.row_account_settings);
         mNotificationsView = rootView.findViewById(R.id.row_notifications);
         mNotificationsDividerView = rootView.findViewById(R.id.me_notifications_divider);
+        mScrollView = rootView.findViewById(R.id.scroll_view);
 
         OnClickListener showPickerListener = new View.OnClickListener() {
             @Override
@@ -218,6 +221,13 @@ public class MeFragment extends Fragment implements MainToolbarFragment {
         outState.putBoolean(IS_UPDATING_GRAVATAR, mIsUpdatingGravatar);
 
         super.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public void onScrollToTop() {
+        if (isAdded()) {
+            mScrollView.smoothScrollTo(0, 0);
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -189,7 +189,7 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
             return;
         }
         clearPendingNotificationsItemsOnUI();
-        if (getFirstVisibleItemID() > 0) {
+        if (mLinearLayoutManager.findFirstCompletelyVisibleItemPosition() > 0) {
             mLinearLayoutManager.smoothScrollToPosition(mRecyclerView, null, 0);
         }
     }


### PR DESCRIPTION
### Fix
These changes update the condition to scroll to the top when the _**Notifications**_ bottom navigation is reselected and add the scroll to top behavior when the _**Me**_ bottom navigation is reselected, which will match the behavior of the ***Sites*** and ***Reader*** tabs.

### Test
1. Go to ***Me*** tab.
2. Scroll down any amount.
3. Tap ***Me*** navigation.
4. Notice view scrolls to top.
5. Go to ***Notifications*** tab.
6. Scroll until first item in list is at least partially not visible.
7. Tap ***Notifications*** navigation.
8. Notice list scrolls to top.

### Review
Only one developer is required to review these changes, but anyone can perform the review.