### PR TITLE
Country stats rendering issue

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,4 @@
 * Add Importing from Giphy in Editor and Media Library
-* Adds support for .blog subdomains on new sites.
+* Add support for .blog subdomains on new sites.
 * First version of the refreshed stats project - all tabs and all the blocks are completely rewritten in new design
+* Fix the coloring issue with Countries map stats block

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
@@ -110,7 +110,7 @@ public class StatsGeoviewsFragment extends StatsAbstractListFragment {
 
                 for (int i = 0; i < countries.size(); i++) {
                     final GeoviewModel currentCountry = countries.get(i);
-                    dataToLoad.append("['").append(currentCountry.getCountryFullName()).append("',")
+                    dataToLoad.append("['").append(currentCountry.getCountryShortName()).append("',")
                             .append(currentCountry.getViews()).append("],");
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCase.kt
@@ -80,7 +80,7 @@ constructor(
         } else {
             val stringBuilder = StringBuilder()
             for (country in domainModel.countries) {
-                stringBuilder.append("['").append(country.fullName).append("',").append(country.views).append("],")
+                stringBuilder.append("['").append(country.countryCode).append("',").append(country.views).append("],")
             }
             items.add(MapItem(stringBuilder.toString(), R.string.stats_country_views_label))
             items.add(Header(string.stats_country_label, string.stats_country_views_label))

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCaseTest.kt
@@ -80,7 +80,7 @@ class CountryViewsUseCaseTest : BaseUnitTest() {
             Assertions.assertThat(this.items).hasSize(4)
             assertTitle(this.items[0])
             val mapItem = (this.items[1] as MapItem)
-            assertThat(mapItem.mapData).isEqualTo("['Czech Republic',500],")
+            assertThat(mapItem.mapData).isEqualTo("['CZ',500],")
             assertThat(mapItem.label).isEqualTo(R.string.stats_country_views_label)
             assertLabel(this.items[2])
             assertItem(this.items[3], country.fullName, country.views, country.flagIconUrl)


### PR DESCRIPTION
Fixes #8905.

To test:

1. On WP.com, go to Account settings and change the UI language to some language other than English
2. Open the app and navigate to Stats
3. Select one of the time tabs (Years, for example)
4. Scroll down to the Countries block
5. Notice the map is properly colored based on the view stats below
6. Tap the View more button on the card
7. Notice the map is also colored correctly
