### PR TITLE
Guard for null Activity in a Gravatar showToast

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -50,6 +50,7 @@ import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource;
 import org.wordpress.android.ui.prefs.AppPrefsWrapper;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.MediaUtils;
@@ -328,6 +329,12 @@ public class MeFragment extends Fragment implements MainToolbarFragment {
                     newAvatarUploaded ? injectFilePath : avatarUrl, new RequestListener<Drawable>() {
                         @Override
                         public void onLoadFailed(@Nullable Exception e) {
+                            final String appLogMessage = "onLoadFailed while loading Gravatar image!";
+                            if (e == null) {
+                                AppLog.e(T.MAIN, appLogMessage + " e == null");
+                            } else {
+                                AppLog.e(T.MAIN, appLogMessage, e);
+                            }
                             ToastUtils.showToast(getActivity(), R.string.error_refreshing_gravatar,
                                     ToastUtils.Duration.SHORT);
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -335,8 +335,12 @@ public class MeFragment extends Fragment implements MainToolbarFragment {
                             } else {
                                 AppLog.e(T.MAIN, appLogMessage, e);
                             }
-                            ToastUtils.showToast(getActivity(), R.string.error_refreshing_gravatar,
-                                    ToastUtils.Duration.SHORT);
+
+                            // For some reason, the Activity can be null so, guard for it. See #8590.
+                            if (getActivity() != null) {
+                                ToastUtils.showToast(getActivity(), R.string.error_refreshing_gravatar,
+                                        ToastUtils.Duration.SHORT);
+                            }
                         }
 
                         @Override


### PR DESCRIPTION
Fixes #8590 

Couldn't replicate the issue so, just guarding for the null Activity case.

While at it, logging the exception reported by the Image Loader.

To test:
No test steps available. You might want to try the info found in the original ticket and the comments there ([this one in particular](https://github.com/wordpress-mobile/WordPress-Android/issues/8590#issuecomment-451442787)).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
