### PR TITLE
Fix attempt to refresh Note when tapping on notification

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -55,6 +55,9 @@ import javax.inject.Inject;
 
 import de.greenrobot.event.EventBus;
 
+import static org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter
+        .IS_TAPPED_ON_NOTIFICATION;
+
 public class GCMMessageService extends FirebaseMessagingService {
     private static final ArrayMap<Integer, Bundle> ACTIVE_NOTIFICATIONS_MAP = new ArrayMap<>();
     private static final NotificationHelper NOTIFICATION_HELPER = new NotificationHelper();
@@ -753,6 +756,7 @@ public class GCMMessageService extends FirebaseMessagingService {
             resultIntent.setAction("android.intent.action.MAIN");
             resultIntent.addCategory("android.intent.category.LAUNCHER");
             resultIntent.putExtra(NotificationsListFragment.NOTE_ID_EXTRA, wpcomNoteID);
+            resultIntent.putExtra(IS_TAPPED_ON_NOTIFICATION, true);
 
             showNotificationForBuilder(builder, context, resultIntent, pushId, notifyUser);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -468,7 +468,8 @@ public class WPMainActivity extends AppCompatActivity implements
                     boolean shouldShowKeyboard =
                             getIntent().getBooleanExtra(NotificationsListFragment.NOTE_INSTANT_REPLY_EXTRA, false);
                     NotificationsListFragment
-                            .openNoteForReply(this, noteId, shouldShowKeyboard, null, NotesAdapter.FILTERS.FILTER_ALL);
+                            .openNoteForReply(this, noteId, shouldShowKeyboard, null,
+                                    NotesAdapter.FILTERS.FILTER_ALL, true);
                 }
             } else {
                 AppLog.e(T.NOTIFS, "app launched from a PN that doesn't have a note_id in it!!");

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -62,6 +62,8 @@ import static org.wordpress.android.models.Note.NOTE_COMMENT_LIKE_TYPE;
 import static org.wordpress.android.models.Note.NOTE_COMMENT_TYPE;
 import static org.wordpress.android.models.Note.NOTE_FOLLOW_TYPE;
 import static org.wordpress.android.models.Note.NOTE_LIKE_TYPE;
+import static org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter
+        .IS_TAPPED_ON_NOTIFICATION;
 
 public class NotificationsDetailActivity extends AppCompatActivity implements
         CommentActions.OnNoteCommentActionListener,
@@ -73,6 +75,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
     @Inject SiteStore mSiteStore;
 
     private String mNoteId;
+    private boolean mIsTappedOnNotification;
 
     private WPViewPager mViewPager;
     private ViewPager.OnPageChangeListener mOnPageChangeListener;
@@ -98,11 +101,13 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
 
         if (savedInstanceState == null) {
             mNoteId = getIntent().getStringExtra(NotificationsListFragment.NOTE_ID_EXTRA);
+            mIsTappedOnNotification = getIntent().getBooleanExtra(IS_TAPPED_ON_NOTIFICATION, false);
         } else {
             if (savedInstanceState.containsKey(ARG_TITLE) && getSupportActionBar() != null) {
                 getSupportActionBar().setTitle(StringUtils.notNullStr(savedInstanceState.getString(ARG_TITLE)));
             }
             mNoteId = savedInstanceState.getString(NotificationsListFragment.NOTE_ID_EXTRA);
+            mIsTappedOnNotification = savedInstanceState.getBoolean(IS_TAPPED_ON_NOTIFICATION);
         }
 
         // set up the viewpager and adapter for lateral navigation
@@ -111,7 +116,9 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
                                       new WPViewPagerTransformer(WPViewPagerTransformer.TransformType.SLIDE_OVER));
 
         Note note = NotificationsTable.getNoteById(mNoteId);
-        updateUIAndNote(note == null);
+        // if this is coming from a tapped push notification, let's try refreshing it as its contents may have been
+        // updated since the notification was first received and created on the system's dashboard
+        updateUIAndNote((note == null) || mIsTappedOnNotification);
 
         // Hide the keyboard, unless we arrived here from the 'Reply' action in a push notification
         if (!getIntent().getBooleanExtra(NotificationsListFragment.NOTE_INSTANT_REPLY_EXTRA, false)) {
@@ -219,6 +226,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
             outState.putString(ARG_TITLE, getSupportActionBar().getTitle().toString());
         }
         outState.putString(NotificationsListFragment.NOTE_ID_EXTRA, mNoteId);
+        outState.putBoolean(IS_TAPPED_ON_NOTIFICATION, mIsTappedOnNotification);
         super.onSaveInstanceState(outState);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -58,6 +58,8 @@ import de.greenrobot.event.EventBus;
 import static android.app.Activity.RESULT_OK;
 import static org.wordpress.android.analytics.AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER;
 import static org.wordpress.android.ui.JetpackConnectionSource.NOTIFICATIONS;
+import static org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter
+        .IS_TAPPED_ON_NOTIFICATION;
 import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
 
 public class NotificationsListFragment extends Fragment implements WPMainActivity.OnScrollToTopListener,
@@ -292,7 +294,8 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
             // open the latest version of this note just in case it has changed - this can
             // happen if the note was tapped from the list fragment after it was updated
             // by another fragment (such as NotificationCommentLikeFragment)
-            openNoteForReply(getActivity(), noteId, false, null, mNotesAdapter.getCurrentFilter());
+            openNoteForReply(getActivity(), noteId, false, null,
+                    mNotesAdapter.getCurrentFilter(), false);
         }
     };
 
@@ -310,7 +313,8 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
                                         String noteId,
                                         boolean shouldShowKeyboard,
                                         String replyText,
-                                        NotesAdapter.FILTERS filter) {
+                                        NotesAdapter.FILTERS filter,
+                                        boolean isTappedFromPushNotification) {
         if (noteId == null || activity == null) {
             return;
         }
@@ -325,6 +329,7 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
             detailIntent.putExtra(NOTE_PREFILLED_REPLY_EXTRA, replyText);
         }
         detailIntent.putExtra(NOTE_CURRENT_LIST_FILTER_EXTRA, filter);
+        detailIntent.putExtra(IS_TAPPED_ON_NOTIFICATION, isTappedFromPushNotification);
 
         openNoteForReplyWithParams(detailIntent, activity);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateJobService.java
@@ -9,10 +9,11 @@ import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.LocaleManager;
 
+import static org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter
+        .IS_TAPPED_ON_NOTIFICATION;
+
 public class NotificationsUpdateJobService extends JobService
         implements NotificationsUpdateLogic.ServiceCompletionListener {
-    public static final String IS_TAPPED_ON_NOTIFICATION = "is-tapped-on-notification";
-
     private NotificationsUpdateLogic mNotificationsUpdateLogic;
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateService.java
@@ -9,9 +9,10 @@ import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.LocaleManager;
 
-public class NotificationsUpdateService extends Service implements NotificationsUpdateLogic.ServiceCompletionListener {
-    public static final String IS_TAPPED_ON_NOTIFICATION = "is-tapped-on-notification";
+import static org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter
+        .IS_TAPPED_ON_NOTIFICATION;
 
+public class NotificationsUpdateService extends Service implements NotificationsUpdateLogic.ServiceCompletionListener {
     private NotificationsUpdateLogic mNotificationsUpdateLogic;
 
     @Override


### PR DESCRIPTION
This is a follow up to #8912 and fixes the case of tapping on a push notification whose content in the meantime (between push notification creation and user tapping on it) had already suffered modifications on the server and thus we may be seeing an old copy. 

In particular, this PR makes sure to pass a dedicated parameter `IS_TAPPED_ON_NOTIFICATION` to ensure a Note is being shown as triggered by tapping no a notification rather than trying to infer it from other derivatives.

Also, I made sure the `IS_TAPPED_ON_NOTIFICATION` constant is defined once (it used to be defined in 3 different places before this PR).


To test:

1. have a third party (or use a different user on a browser) comment on a blog post on a website you're an admin of
2. observe you get a notification for the comment
3. drag the bottom edge down just to be able to read the comment
4. without tapping on it (that is, without opening the app by touching the notification), go have the author of the comment edit the comment text to something else on wp-admin on a web browser and hit UPDATE to save the new content for such comment.
5. now tap on the notification
6. observe the new Note content is loaded, as it should be.

Note this won't work if the device lacks connectivity at the time of opening the push notification, but that's as far as we can go.

Also note that if you open the Comments section as yourself on the web to edit the content, the notification will be erased from the device (as part of the "mark as read" functionality". So, you'd better be the same "third person"  doing both a) commenting and b) editing the comment (for which you should have admin access to the blog, but not be the person logged in to the device). Hope that makes sense! :sweatsmile: 


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
