### PR TITLE
Fix gradle GB build from source flag check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 apply plugin: 'com.automattic.android.fetchstyle'
 
 project.ext.preDexLibs = !project.hasProperty('disablePreDex')
-project.ext.buildGutenbergFromSource = project.properties.getOrDefault('wp.BUILD_GUTENBERG_FROM_SOURCE', false)
+project.ext.buildGutenbergFromSource = project.properties.getOrDefault('wp.BUILD_GUTENBERG_FROM_SOURCE', false).toBoolean()
 
 allprojects {
     apply plugin: 'checkstyle'

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ include ':libs:analytics:WordPressAnalytics'
 include ':libs:editor:WordPressEditor'
 include ':libs:login:WordPressLoginFlow'
 
-if (properties.getOrDefault('wp.BUILD_GUTENBERG_FROM_SOURCE', false)) {
+if (properties.getOrDefault('wp.BUILD_GUTENBERG_FROM_SOURCE', false).toBoolean()) {
     include ':react-native-svg'
     project(':react-native-svg').projectDir = new File(rootProject.projectDir, 'libs/gutenberg-mobile/node_modules/react-native-svg/android')
     include ':react-native-aztec'


### PR DESCRIPTION
Fixes #8897

To test:

Easiest way to test this particular PR and what this particular PR tries to fix is by adding println in `gutenberg-tasks.gradle`, replacing the code section at the bottom with:

```
if (!rootProject.ext.buildGutenbergFromSource) {
    println " BUILD FROM SOURCE: NO"
    // Download the JS bundle if we're not building from source.
    // Usually happens when compiling this project as standalone or via jitpack
    preBuild.dependsOn(downloadJSBundle)
} else {
    println " BUILD FROM SOURCE: YES"
}

```

Test cases being:
#### CASE A
use this in `gradle.properties`
`wp.BUILD_GUTENBERG_FROM_SOURCE = true`


run this on the command line:
`./gradlew assembleZalphaRelease`

verify logs show this:
```
> Configure project :WordPress 
 BUILD FROM SOURCE: YES

> Configure project :react-native-gutenberg-bridge 
using gutenberg from source

```

also verify there's no traces of `Downloading JS bundle from...` as specified in the following case.

#### CASE B
use this in `gradle.properties`:
`wp.BUILD_GUTENBERG_FROM_SOURCE = false`

verify logs show:

```
> Configure project :WordPress 
 BUILD FROM SOURCE: NO

> Configure project :react-native-gutenberg-bridge 
Will use the RN maven repo at https://dl.bintray.com/wordpress-mobile/react-native-mirror/
```

And

```
> Task :WordPress:downloadJSBundle 
Downloading JS bundle from https://s3-us-west-1.amazonaws.com/gutenberg-mobile-js-bundle/wordpress-mobile/gutenberg-mobile/some-commit-hash/android/App.js
```


#### CASE C
delete the line `wp.BUILD_GUTENBERG_FROM_SOURCE` entirely (or comment by prefixing it with `#`) from `gradle.properties`
It should follow the default case, which is same as case B (don't build from source)

#### Note for the reviewer (👋 @hypest :D )
I've been trying executing `./gradlew assembleZalphaRelease` lots of times to test this flag, and on `develop` with this flag (`wp.BUILD_GUTENBERG_FROM_SOURCE`) being off  sometimes I can see the `doLast` part in `downloadJSBundle` in  `gutenberg-tasks.gradle` being executed, sometimes not. That means, I cannot always see the bundle gets downloaded and logs don't print this:
```
> Task :WordPress:downloadJSBundle 
Downloading JS bundle from https://s3-us-west-1.amazonaws.com/gutenberg-mobile-js-bundle/wordpress-mobile/gutenberg-mobile/some-commit-hash/android/App.js
```
 I've placed test `println` messages right as first thing in the `doLast` section and can see it doesn't get executed -  couldn't really grasp the actual reasons though. Given I could still isolate this behavior in `develop`, I don't consider that to be a problem this very PR should solve, however I'm pinging @hypest here to see if this might as well be a problem I'm only having locally (I tend to think the issue should be visible on continuous integration as well, but I couldn't find any evidence of that).



Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
