### PR TITLE
Create Site: .blog subdomain support

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SiteCreationActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SiteCreationActivity.java
@@ -191,10 +191,8 @@ public class SiteCreationActivity extends AppCompatActivity implements SiteCreat
 
     @Override
     public void withDomain(String domain) {
-        String siteSlug = UrlUtils.extractSubDomain(domain);
-
         SiteCreationCreatingFragment siteCreationCreatingFragment =
-                SiteCreationCreatingFragment.newInstance(mSiteTitle, mSiteTagline, siteSlug, mThemeId);
+                SiteCreationCreatingFragment.newInstance(mSiteTitle, mSiteTagline, domain, mThemeId);
         slideInFragment(siteCreationCreatingFragment, SiteCreationCreatingFragment.TAG);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SiteCreationActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SiteCreationActivity.java
@@ -22,7 +22,6 @@ import org.wordpress.android.ui.accounts.signup.SiteCreationThemeLoaderFragment;
 import org.wordpress.android.ui.main.SitePickerActivity;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.UrlUtils;
 
 public class SiteCreationActivity extends AppCompatActivity implements SiteCreationListener {
     public static final String KEY_DO_NEW_POST = "KEY_DO_NEW_POST";

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
@@ -18,6 +18,7 @@ import junit.framework.Assert;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.ui.accounts.signup.SiteCreationService.SiteCreationState;
@@ -215,10 +216,14 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
         }
     }
 
-    private PreviewWebViewClient loadWebview() {
-        Assert.assertNotNull("Arguments can't be null at this point!", getArguments());
-        String siteAddress = getArguments().getString(ARG_SITE_ADDRESS);
-        Assert.assertNotNull("Site address must be provided in the arguments!", siteAddress);
+    private @Nullable PreviewWebViewClient loadWebview() {
+        String siteAddress = getArguments() != null ? getArguments().getString(ARG_SITE_ADDRESS, "") : "";
+        if (siteAddress.isEmpty()) {
+            if (BuildConfig.DEBUG) {
+                throw new IllegalStateException("The newly created site address should not be null!");
+            }
+            return null;
+        }
         /*
           For wordpress.com sites we need to load the site with `https` protocol whereas the `.blog` sub-domains only
           work with `http`protocol.

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
@@ -33,7 +33,7 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
 
     private static final String ARG_SITE_TITLE = "ARG_SITE_TITLE";
     private static final String ARG_SITE_TAGLINE = "ARG_SITE_TAGLINE";
-    private static final String ARG_SITE_SLUG = "ARG_SITE_SLUG";
+    private static final String ARG_SITE_ADDRESS = "ARG_SITE_ADDRESS";
     private static final String ARG_SITE_THEME_ID = "ARG_SITE_THEME_ID";
 
     private static final String KEY_WEBVIEW_LOADED_IN_TIME = "KEY_WEBVIEW_LOADED_IN_TIME";
@@ -79,13 +79,13 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
         return !state.isAfterCreation();
     }
 
-    public static SiteCreationCreatingFragment newInstance(String siteTitle, String siteTagline, String siteSlug,
+    public static SiteCreationCreatingFragment newInstance(String siteTitle, String siteTagline, String siteAddress,
                                                            String themeId) {
         SiteCreationCreatingFragment fragment = new SiteCreationCreatingFragment();
         Bundle args = new Bundle();
         args.putString(ARG_SITE_TITLE, siteTitle);
         args.putString(ARG_SITE_TAGLINE, siteTagline);
-        args.putString(ARG_SITE_SLUG, siteSlug);
+        args.putString(ARG_SITE_ADDRESS, siteAddress);
         args.putString(ARG_SITE_THEME_ID, themeId);
         fragment.setArguments(args);
         return fragment;
@@ -191,9 +191,9 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
     void createSite(SiteCreationState retryFromState) {
         String siteTitle = getArguments().getString(ARG_SITE_TITLE);
         String siteTagline = getArguments().getString(ARG_SITE_TAGLINE);
-        String siteSlug = getArguments().getString(ARG_SITE_SLUG);
+        String siteAddress = getArguments().getString(ARG_SITE_ADDRESS);
         String themeId = getArguments().getString(ARG_SITE_THEME_ID);
-        SiteCreationService.createSite(getContext(), retryFromState, siteTitle, siteTagline, siteSlug, themeId);
+        SiteCreationService.createSite(getContext(), retryFromState, siteTitle, siteTagline, siteAddress, themeId);
     }
 
     private void mutateToCompleted(boolean showWebView) {
@@ -214,7 +214,7 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
     }
 
     private PreviewWebViewClient loadWebview() {
-        String siteAddress = "https://" + getArguments().getString(ARG_SITE_SLUG) + ".wordpress.com";
+        String siteAddress = getArguments().getString(ARG_SITE_ADDRESS);
         PreviewWebViewClient client = new PreviewWebViewClient(siteAddress);
         mWebView.setWebViewClient(client);
         mWebView.loadUrl(siteAddress);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
@@ -14,6 +14,8 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import junit.framework.Assert;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.R;
@@ -214,10 +216,20 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
     }
 
     private PreviewWebViewClient loadWebview() {
+        Assert.assertNotNull("Arguments can't be null at this point!", getArguments());
         String siteAddress = getArguments().getString(ARG_SITE_ADDRESS);
-        PreviewWebViewClient client = new PreviewWebViewClient(siteAddress);
+        Assert.assertNotNull("Site address must be provided in the arguments!", siteAddress);
+        /*
+          For wordpress.com sites we need to load the site with `https` protocol whereas the `.blog` sub-domains only
+          work with `http`protocol.
+
+          Ideally, we'd get the full url from the site creation service so we don't do this guess work but since this
+          flow is completely being replaced in an upcoming version, it's good enough a solution as it's less disrupting.
+         */
+        String url = (siteAddress.contains("wordpress.com") ? "https://" : "http://") + siteAddress;
+        PreviewWebViewClient client = new PreviewWebViewClient(url);
         mWebView.setWebViewClient(client);
-        mWebView.loadUrl(siteAddress);
+        mWebView.loadUrl(url);
         return client;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
@@ -14,8 +14,6 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import junit.framework.Assert;
-
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.BuildConfig;


### PR DESCRIPTION
Fixes #8908. When #8806 was implemented, it looks like there was an oversight since the site created would always be a `wordpress.com` subdomain as described in #8908. This was due to the subdomain being stripped and then attached to `.wordpress.com` before the site creation step. I believe the previous iteration was written with the assumption that we'll only create `wordpress.com` site and it wasn't updated in the latest one.

**Preface**

I have looked into how Calypso handles different domains during site creation. It looks like `blog_name` parameter is set to just the subdomain for `wordpress.com` sites and set to the full url for `.blog` subdomains. Here is an example:

_If we are creating `example.wordpress.com`, we'll send `blog_name=example` to the `sites/new` endpoint.
If we are creating `example.home.blog`, we'll send `blog_name=example.home.blog` to the `/sites/new` endpoint._

I don't know what would happen if I were to use a paid domain but since we don't have support for that I don't think it matters for this PR.

**Implementation:**

[NewSitePayload](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.java#L61-L75) will send whatever is provided as `siteName` to the `sites/new` endpoint as `blog_name`, so all we have to do is to create the correct payload for it.

Since we are replacing this whole flow in an upcoming release this PR aims to do the least disruptive changes possible even when there are better options. It also adds some comments to relevant parts of the code to reflect this.

**Site Preview**

The only other change in this PR is to how we load the preview web page when the site is created. It looks like `wordpress.com` subdomains require `https` whereas `.blog` subdomains require `http`. That's a little weird and I expect that it'll change some time soon, but since (as also previously mentioned) we are replacing the whole flow, the PR implements this as is. We'll handle this properly in the new site creation flow and get the full site url from the server.

**Test 1**

1. Go to site picker > Add new site.
2. Select “Create WordPress.com site.”
3. Select “Start with a Blog.” (.blog domains will only show up if the Blog category is selected)
4. Select a theme.
5. Enter a site title.
6. Search for a keyword and select a result with a .blog subdomain (e.g. `oguzkocertestingdotblogissue11.home.blog`).
7. Finish creating the site.
8. Check the site and see that it has correct address. (e.g. `oguzkocertestingdotblogissue11.home.blog`).

Here is an example test: https://cloudup.com/cEO8X3dwiCU

**Test 2**

1. Go to site picker > Add new site.
2. Select “Create WordPress.com site.”
3. Select “Start with a Blog.” (It'd be good to retry this test with other categories)
4. Select a theme.
5. Enter a site title.
6. Search for a keyword and select a result with a `wordpress.com` subdomain (e.g. `oguzkocertestingdotblogissue6.wordpress.com`).
7. Finish creating the site.
8. Check the site and see that it has correct address. (e.g. `oguzkocertestingdotblogissue6.wordpress.com`).

Here is an example test: https://cloudup.com/cHPQMfyOgDK

**Update release notes:**

These changes were already added to release notes, it was just not working correctly.

_P.S: A single review _should_ be enough for this PR, but multiple people has been pinged as it's a priority. Having said that, multiple reviews & tests are always welcome._

/cc @rachelmcr @elibud 
