### PR TITLE
Offset needs to point beyond previous results

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSiteSearchAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSiteSearchAdapter.java
@@ -63,7 +63,7 @@ public class ReaderSiteSearchAdapter extends RecyclerView.Adapter<RecyclerView.V
             && position >= getItemCount() - 1
             && getItemCount() >= ReaderConstants.READER_MAX_SEARCH_RESULTS_TO_REQUEST) {
             mIsLoadingMore = true;
-            mListener.onLoadMore(getItemCount() - 1);
+            mListener.onLoadMore(getItemCount());
         }
     }
 


### PR DESCRIPTION
Fixes #8659 

The offset parameter of the `/read/feed/` API call needs to point beyond the previous results so, it has to be greater than the (zero-based) index of the last item. For example, if we're querying for 10 items, the first page will be from 0 index to index 9 so, the offset needs to be 10 to point to the start of the next page.

To test:

1. Go to the Reader
2. Have "Followed Sites" as the selected Reader section
3. Tap on the search on the right (the magnifier glass icon)
4. Type a query, for example: `test`
5. Select the "Sites" tab from the results
6. Scroll to the end of the list to trigger infinite scroll. Notice the last item while the new search is ongoing.
7. Scroll a couple of items down and notice that the last item of the first "page" is not repeated

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
