### PR TITLE
Date formatting crash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,3 +2,4 @@
 * Add support for .blog subdomains on new sites.
 * First version of the refreshed stats project - all tabs and all the blocks are completely rewritten in new design
 * Fix the coloring issue with Countries map stats block
+* Fix an occasional crash in Stats (date parsing in the Overview block)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
@@ -105,9 +105,9 @@ constructor(
                     )
             )
             items.add(overviewMapper.buildColumns(selectedItem, this::onColumnSelected, uiState.selectedPosition))
-        }
-        else {
+        } else {
             AppLog.e(T.STATS, "There is no data to be shown in the overview block")
+            selectedDateProvider.notifyMissingDate(statsGranularity)
         }
         return items
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
@@ -16,6 +16,8 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.granular.UseCaseFac
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.OverviewUseCase.UiState
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.trackGranular
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
 import javax.inject.Named
@@ -75,33 +77,38 @@ constructor(
 
     override fun buildStatefulUiModel(domainModel: VisitsAndViewsModel, uiState: UiState): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
-        val selectedDate = uiState.selectedDate ?: domainModel.dates.lastOrNull()?.period
-        if (selectedDateProvider.getSelectedDate(statsGranularity) == null && selectedDate != null) {
-            selectedDateProvider.selectDate(
-                    statsDateFormatter.parseStatsDate(statsGranularity, selectedDate),
-                    statsGranularity
-            )
-        }
-        val selectedItem = domainModel.dates.find { it.period == uiState.selectedDate }
-                ?: domainModel.dates.lastOrNull()
-        items.add(
-                overviewMapper.buildTitle(
-                        selectedItem?.period,
-                        selectedDate,
-                        domainModel.period,
+        if (domainModel.dates.isNotEmpty()) {
+            val selectedDate = uiState.selectedDate ?: domainModel.dates.last().period
+            if (selectedDateProvider.getSelectedDate(statsGranularity) == null) {
+                selectedDateProvider.selectDate(
+                        statsDateFormatter.parseStatsDate(statsGranularity, selectedDate),
                         statsGranularity
                 )
-        )
-        items.add(
-                overviewMapper.buildChart(
-                        domainModel,
-                        statsGranularity,
-                        this::onBarSelected,
-                        uiState.selectedPosition,
-                        selectedDate
-                )
-        )
-        items.add(overviewMapper.buildColumns(selectedItem, this::onColumnSelected, uiState.selectedPosition))
+            }
+            val selectedItem = domainModel.dates.find { it.period == uiState.selectedDate }
+                    ?: domainModel.dates.last()
+            items.add(
+                    overviewMapper.buildTitle(
+                            selectedItem.period,
+                            selectedDate,
+                            domainModel.period,
+                            statsGranularity
+                    )
+            )
+            items.add(
+                    overviewMapper.buildChart(
+                            domainModel,
+                            statsGranularity,
+                            this::onBarSelected,
+                            uiState.selectedPosition,
+                            selectedDate
+                    )
+            )
+            items.add(overviewMapper.buildColumns(selectedItem, this::onColumnSelected, uiState.selectedPosition))
+        }
+        else {
+            AppLog.e(T.STATS, "There is no data to be shown in the overview block")
+        }
         return items
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
@@ -107,7 +107,6 @@ constructor(
             items.add(overviewMapper.buildColumns(selectedItem, this::onColumnSelected, uiState.selectedPosition))
         } else {
             AppLog.e(T.STATS, "There is no data to be shown in the overview block")
-            selectedDateProvider.notifyMissingDate(statsGranularity)
         }
         return items
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/ErrorViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/ErrorViewHolder.kt
@@ -3,13 +3,19 @@ package org.wordpress.android.ui.stats.refresh.lists.viewholders
 import android.view.ViewGroup
 import android.widget.TextView
 import org.wordpress.android.R
-import org.wordpress.android.R.layout
 import org.wordpress.android.ui.stats.refresh.lists.Error
 
-class ErrorViewHolder(parent: ViewGroup) : BaseStatsViewHolder<Error>(parent, layout.stats_error_view) {
+class ErrorViewHolder(val parent: ViewGroup) : BaseStatsViewHolder<Error>(parent, R.layout.stats_error_view) {
     private val title: TextView = itemView.findViewById(R.id.error_message)
     override fun bind(item: Error) {
         super.bind(item)
-        title.text = item.errorMessage
+        if (item.errorMessage.isNotBlank()) {
+            title.text = String.format("%s: %s", item.statsTypes.toString(), item.errorMessage)
+        } else {
+            title.text = String.format("%s: %s",
+                    item.statsTypes.toString(),
+                    parent.resources.getString(R.string.stats_generic_error)
+            )
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -91,5 +91,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'a3864fc925e563e74028510b492be8dee80e45f9'
+    fluxCVersion = 'c8e5012e10a80faac8130c688776e6263665ec1f'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -91,5 +91,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'c8e5012e10a80faac8130c688776e6263665ec1f'
+    fluxCVersion = '8905b77d0755c3b0e802697177ae56b475aece37'
 }


### PR DESCRIPTION
Fixes #8886.

This bug is caused by an inconsistent API behavior that is hard to reproduce (random empty parameter response). This PR references a FluxC build that treats empty data as an error and makes sure the empty data is never parsed.