### PR TITLE
Stop setting CommentDetailFragment's id manually

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -99,7 +99,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     private static final String KEY_COMMENT_ID = "KEY_COMMENT_ID";
     private static final String KEY_NOTE_ID = "KEY_NOTE_ID";
     private static final String KEY_REPLY_TEXT = "KEY_REPLY_TEXT";
-    private static final String KEY_FRAGMENT_CONTAINER_ID = "KEY_FRAGMENT_CONTAINER_ID";
 
     private static final int INTENT_COMMENT_EDITOR = 1010;
     private static final int FROM_BLOG_COMMENT = 1;
@@ -109,7 +108,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     private SiteModel mSite;
 
     private Note mNote;
-    private int mIdForFragmentContainer;
     private SuggestionAdapter mSuggestionAdapter;
     private SuggestionServiceConnectionManager mSuggestionServiceConnectionManager;
     private TextView mTxtStatus;
@@ -172,14 +170,12 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     /*
      * used when called from notification list for a comment notification
      */
-    public static CommentDetailFragment newInstance(final String noteId, final String replyText,
-                                                    final int idForFragmentContainer) {
+    public static CommentDetailFragment newInstance(final String noteId, final String replyText) {
         CommentDetailFragment fragment = new CommentDetailFragment();
         Bundle args = new Bundle();
         args.putInt(KEY_MODE, FROM_NOTE);
         args.putString(KEY_NOTE_ID, noteId);
         args.putString(KEY_REPLY_TEXT, replyText);
-        args.putInt(KEY_FRAGMENT_CONTAINER_ID, idForFragmentContainer + R.id.note_comment_fragment_container_base_id);
         fragment.setArguments(args);
         return fragment;
     }
@@ -196,12 +192,10 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             case FROM_NOTE:
                 setNote(getArguments().getString(KEY_NOTE_ID));
                 setReplyText(getArguments().getString(KEY_REPLY_TEXT));
-                setIdForFragmentContainer(getArguments().getInt(KEY_FRAGMENT_CONTAINER_ID));
                 break;
         }
 
         if (savedInstanceState != null) {
-            mIdForFragmentContainer = savedInstanceState.getInt(KEY_FRAGMENT_CONTAINER_ID);
             if (savedInstanceState.getString(KEY_NOTE_ID) != null) {
                 // The note will be set in onResume()
                 // See WordPress.deferredInit()
@@ -227,7 +221,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         if (mNote != null) {
             outState.putString(KEY_NOTE_ID, mNote.getId());
         }
-        outState.putInt(KEY_FRAGMENT_CONTAINER_ID, mIdForFragmentContainer);
     }
 
     @Override
@@ -424,8 +417,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         mComment = comment;
         mSite = site;
 
-        setIdForCommentContainer();
-
         // is this comment on one of the user's blogs? it won't be if this was displayed from a
         // notification about a reply to a comment this user posted on someone else's blog
         mIsUsersBlog = (comment != null && site != null);
@@ -466,7 +457,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             mSite = createDummyWordPressComSite(mNote.getSiteId());
         }
         if (isAdded() && mNote != null) {
-            setIdForCommentContainer();
             showComment();
         }
     }
@@ -484,12 +474,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             return;
         }
         setNote(note);
-    }
-
-    private void setIdForFragmentContainer(int id) {
-        if (id > 0) {
-            mIdForFragmentContainer = id;
-        }
     }
 
     private void setReplyText(String replyText) {
@@ -1111,18 +1095,12 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
 
     private void addDetailFragment(String noteId) {
         // Now we'll add a detail fragment list
-        FragmentManager fragmentManager = getFragmentManager();
+        FragmentManager fragmentManager = getChildFragmentManager();
         FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
         mNotificationsDetailListFragment = NotificationsDetailListFragment.newInstance(noteId);
         mNotificationsDetailListFragment.setFooterView(mLayoutButtons);
         fragmentTransaction.replace(mCommentContentLayout.getId(), mNotificationsDetailListFragment);
         fragmentTransaction.commitAllowingStateLoss();
-    }
-
-    private void setIdForCommentContainer() {
-        if (mCommentContentLayout != null) {
-            mCommentContentLayout.setId(mIdForFragmentContainer);
-        }
     }
 
     // Like or unlike a comment via the REST API

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -317,7 +317,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
      * Tries to pick the correct fragment detail type for a given note
      * Defaults to NotificationDetailListFragment
      */
-    private Fragment getDetailFragmentForNote(Note note, int idForFragmentContainer) {
+    private Fragment getDetailFragmentForNote(Note note) {
         if (note == null) {
             return null;
         }
@@ -329,8 +329,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
                                                                  false);
             fragment = CommentDetailFragment.newInstance(note.getId(),
                                                          getIntent().getStringExtra(
-                                                                 NotificationsListFragment.NOTE_PREFILLED_REPLY_EXTRA),
-                                                         idForFragmentContainer);
+                                                                 NotificationsListFragment.NOTE_PREFILLED_REPLY_EXTRA));
 
             if (isInstantReply) {
                 ((CommentDetailFragment) fragment).enableShouldFocusReplyField();
@@ -478,7 +477,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
 
         @Override
         public Fragment getItem(int position) {
-            return getDetailFragmentForNote(mNoteList.get(position), position);
+            return getDetailFragmentForNote(mNoteList.get(position));
         }
 
         @Override

--- a/WordPress/src/main/res/values/ids.xml
+++ b/WordPress/src/main/res/values/ids.xml
@@ -12,7 +12,6 @@
     <item type="id" name="stats_top_authors" />
     <item type="id" name="stats_top_posts" />
     <item type="id" name="note_block_tag_id" />
-    <item type="id" name="note_comment_fragment_container_base_id" />
     <item type="id" name="bottom_nav_reader_button" />
     <item type="id" name="bottom_nav_new_post_button" />
     <item type="id" name="media_grid_file_path_id" />


### PR DESCRIPTION
Fixes #8019 

This one was a bit tough to determine, as it's difficult to reproduce.

#### Diagnosis

Theory: the Layout Id corresponds (overlaps with)  another known view. So, the `findViewById()` algorithm finds the first matching id, and returns that, with that being not a `ViewGroup`, generating the exception referred to in #8019 .

When checking the code, we can see we're setting the id which is made of the following in `CommentDetailFragment`:

```
       args.putInt(KEY_FRAGMENT_CONTAINER_ID, idForFragmentContainer + R.id.note_comment_fragment_container_base_id);
```

There, the `R.id.note_comment_fragment_container_base_id` is a true Android id, but the integer gets added a (very) small integer that happens to be the `CommentDetail` index in the `ViewPager`. This is really nothing else but 0, 1, 2, 3... so basically at some point there is always a possibility one of the Ids in the hierarchy is already used, thus `findViewById()` internally finds the first one, which happens not to be the correct View we're looking for.

#### Fix explanation

I was first tempted to fix this one in particular by using the `generateViewId()` method instead of using the `index + base_number` composition and leave code with as minimum touches as possible, but looking into history it turns out this whole mechanism was actually a workaround we needed to make when we introduced the swipe gesture to navigate Notes horizontally (left/right), as we could not use `ChildFragmentManager`, which is specially designed to handle nested fragments like this case, while supporting API level 16.

This was introduced in this commit https://github.com/wordpress-mobile/WordPress-Android/commit/98c2884338e6498f653a44dc262b68b3aabc8e35 and this other one https://github.com/wordpress-mobile/WordPress-Android/commit/8da2cea871bac1f25a776f5499c33aa317bdf52f
(PR https://github.com/wordpress-mobile/WordPress-Android/pull/4796)

As said above, that was made on purpose in order to avoid using `ChildFragmentManager`, which is only available starting from API 17+. See relevant comment explaining the situation (and the hack) here https://github.com/wordpress-mobile/WordPress-Android/pull/4796#issuecomment-261518692 and https://github.com/wordpress-mobile/WordPress-Android/pull/4796#discussion_r89198449)

Now our `minSdk` is 21, so we should be able to use `ChildFragmentManger` freely. 

This PR eliminates the manual setting of the fragment's id, and uses the proper `getChildFragmentManager()` where corresponding.


***NOTE***: only one reviewer is needed, whoever tackles this first 👍 

#### To test:
1. Go to the notifications tab
2. swipe right/left and verify all kinds of Notes are rendered correctly, specifically look into this part of code `getDetailFragmentForNote()` in `NotificationsDetailActivity`:
a) also make sure a comment type note renders OK (this is mostly the one affected)
b) see a like-type note renders OK
c) see a comment-type note renders OK
d) see a new post type note renders OK
3. Now go to the Reader tab in the app
4. look for a Post that has comments in it
5. open the Post
6. verify you can also open the comments section of such post
7. bonus: perform tests for all of the above rotating the screen





Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
