### PR TITLE
Fixing About App layout overlap

### DIFF
--- a/WordPress/src/main/res/layout/about_activity.xml
+++ b/WordPress/src/main/res/layout/about_activity.xml
@@ -49,7 +49,6 @@
                 android:paddingBottom="?attr/actionBarSize"
                 app:maxWidth="@dimen/nux_width">
 
-
                 <ImageView
                     android:id="@+id/nux_fragment_icon"
                     android:layout_width="50dp"

--- a/WordPress/src/main/res/layout/about_activity.xml
+++ b/WordPress/src/main/res/layout/about_activity.xml
@@ -13,8 +13,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:fitsSystemWindows="true"
-        app:elevation="0dp"
-        android:theme="@style/ThemeOverlay.AppCompat.ActionBar">
+        android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
+        app:elevation="0dp">
 
         <android.support.v7.widget.Toolbar
             android:id="@+id/toolbar"
@@ -22,7 +22,7 @@
             android:layout_height="?attr/actionBarSize"
             android:background="@color/transparent"
             android:theme="@style/WordPress.TransparentToolbar"
-            app:layout_scrollFlags="scroll|enterAlways" >
+            app:layout_scrollFlags="scroll|enterAlways">
         </android.support.v7.widget.Toolbar>
 
     </android.support.design.widget.AppBarLayout>
@@ -33,21 +33,22 @@
         android:layout_gravity="center_vertical"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <org.wordpress.android.widgets.WPLinearLayoutSizeBound
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:paddingBottom="?attr/actionBarSize"
-            android:gravity="center"
-            app:maxWidth="@dimen/nux_width">
+            android:orientation="vertical">
 
-            <LinearLayout
+            <org.wordpress.android.widgets.WPLinearLayoutSizeBound
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center"
                 android:layout_marginEnd="16dp"
                 android:layout_marginStart="16dp"
                 android:gravity="center"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:paddingBottom="?attr/actionBarSize"
+                app:maxWidth="@dimen/nux_width">
+
 
                 <ImageView
                     android:id="@+id/nux_fragment_icon"
@@ -111,8 +112,8 @@
                     android:clickable="true"
                     android:focusable="true"
                     android:text="@string/automattic_url"/>
-            </LinearLayout>
 
-        </org.wordpress.android.widgets.WPLinearLayoutSizeBound>
+            </org.wordpress.android.widgets.WPLinearLayoutSizeBound>
+        </LinearLayout>
     </android.support.v4.widget.NestedScrollView>
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
Fixes #8639

I traced down the issue to weird behavior of `android:layout_gravity="center"` in the child of `NestedScrollView`. Flipping some things around fixed the issue.

To test:

1. Increase the device's font size to the largest
2. Open the app's About screen
3. Rotate to landscape
4. Note the WP icon is not cut off by toolbar.

[![Image from Gyazo](https://i.gyazo.com/0d4dbcbd94cd7b1fc7a0826012ce3b6c.png)](https://gyazo.com/0d4dbcbd94cd7b1fc7a0826012ce3b6c)
