### PR TITLE
Fix null site while updating post formats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -153,7 +153,6 @@ public class EditPostSettingsFragment extends Fragment {
                 new ArrayList<>(Arrays.asList(getResources().getStringArray(R.array.post_format_keys)));
         mDefaultPostFormatNames = new ArrayList<>(Arrays.asList(getResources()
                 .getStringArray(R.array.post_format_display_names)));
-
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -779,7 +779,7 @@ public class EditPostSettingsFragment extends Fragment {
 
     private void updatePostFormatKeysAndNames() {
         final SiteModel site = getSite();
-        if (getActivity() == null || site == null) {
+        if (!isAdded() || site == null) {
             // Since this method can get called after a callback, we have to make sure we have the site
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -119,6 +119,8 @@ public class EditPostSettingsFragment extends Fragment {
 
     private PostLocation mPostLocation;
 
+    private ArrayList<String> mDefaultPostFormatKeys;
+    private ArrayList<String> mDefaultPostFormatNames;
     private ArrayList<String> mPostFormatKeys;
     private ArrayList<String> mPostFormatNames;
 
@@ -144,6 +146,14 @@ public class EditPostSettingsFragment extends Fragment {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplicationContext()).component().inject(this);
         mDispatcher.register(this);
+
+        // Early load the default lists for post format keys and names.
+        // Will use it later without needing to have access to the Resources.
+        mDefaultPostFormatKeys =
+                new ArrayList<>(Arrays.asList(getResources().getStringArray(R.array.post_format_keys)));
+        mDefaultPostFormatNames = new ArrayList<>(Arrays.asList(getResources()
+                .getStringArray(R.array.post_format_display_names)));
+
     }
 
     @Override
@@ -779,14 +789,14 @@ public class EditPostSettingsFragment extends Fragment {
 
     private void updatePostFormatKeysAndNames() {
         final SiteModel site = getSite();
-        if (!isAdded() || site == null) {
+        if (site == null) {
             // Since this method can get called after a callback, we have to make sure we have the site
             return;
         }
-        // Default values
-        mPostFormatKeys = new ArrayList<>(Arrays.asList(getResources().getStringArray(R.array.post_format_keys)));
-        mPostFormatNames = new ArrayList<>(Arrays.asList(getResources()
-                                                                 .getStringArray(R.array.post_format_display_names)));
+
+        // Initialize the lists from the defaults
+        mPostFormatKeys = new ArrayList<>(mDefaultPostFormatKeys);
+        mPostFormatNames = new ArrayList<>(mDefaultPostFormatNames);
 
         // If we have specific values for this site, use them
         List<PostFormatModel> postFormatModels = mSiteStore.getPostFormats(site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -778,7 +778,8 @@ public class EditPostSettingsFragment extends Fragment {
     // Post Format Helpers
 
     private void updatePostFormatKeysAndNames() {
-        if (getActivity() == null || getSite() == null) {
+        final SiteModel site = getSite();
+        if (getActivity() == null || site == null) {
             // Since this method can get called after a callback, we have to make sure we have the site
             return;
         }
@@ -788,7 +789,7 @@ public class EditPostSettingsFragment extends Fragment {
                                                                  .getStringArray(R.array.post_format_display_names)));
 
         // If we have specific values for this site, use them
-        List<PostFormatModel> postFormatModels = mSiteStore.getPostFormats(getSite());
+        List<PostFormatModel> postFormatModels = mSiteStore.getPostFormats(site);
         for (PostFormatModel postFormatModel : postFormatModels) {
             if (!mPostFormatKeys.contains(postFormatModel.getSlug())) {
                 mPostFormatKeys.add(postFormatModel.getSlug());


### PR DESCRIPTION
Fixes #8814 

Can't reproduce the issue but, judging from the code and especially the fact that there's already null checks for both the Activity and the Site ref at the start of the updatePostFormatKeysAndNames() method, this seems like a case of timing: the Activity is lost in the time between the null check and the second `getSite()` call. The method is only trying to update some Fragment-local data so, holding on the Site ref to use it seems safe enough.

To test:

No steps available unfortunately, haven't been able to reproduce the crash.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
