### PR TITLE
Fix MediaSettingsScreen can't save image on atomic site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -575,6 +575,8 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         NotificationsTable.reset();
     }
 
+    private static String mDefaultUserAgent;
+
     /**
      * Device's default User-Agent string.
      * E.g.:
@@ -582,8 +584,6 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
      * AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile
      * Safari/537.36"
      */
-    private static String mDefaultUserAgent;
-
     public static String getDefaultUserAgent() {
         if (mDefaultUserAgent == null) {
             try {
@@ -601,6 +601,10 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         return mDefaultUserAgent;
     }
 
+
+    public static final String USER_AGENT_APPNAME = "wp-android";
+    private static String mUserAgent;
+
     /**
      * User-Agent string when making HTTP connections, for both API traffic and WebViews.
      * Appends "wp-android/version" to WebView's default User-Agent string for the webservers
@@ -610,9 +614,6 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
      * Safari/537.36 wp-android/4.7"
      * Note that app versions prior to 2.7 simply used "wp-android" as the user agent
      **/
-    public static final String USER_AGENT_APPNAME = "wp-android";
-    private static String mUserAgent;
-
     public static String getUserAgent() {
         if (mUserAgent == null) {
             String defaultUserAgent = getDefaultUserAgent();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -995,6 +995,7 @@ public class MediaSettingsActivity extends AppCompatActivity
         }
         request.allowScanningByMediaScanner();
         request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE);
+        request.addRequestHeader("User-Agent", WordPress.getDefaultUserAgent());
 
         mDownloadId = dm.enqueue(request);
         invalidateOptionsMenu();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -996,7 +996,7 @@ public class MediaSettingsActivity extends AppCompatActivity
         }
         request.allowScanningByMediaScanner();
         request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE);
-        request.addRequestHeader("User-Agent", WordPress.getDefaultUserAgent());
+        request.addRequestHeader("User-Agent", WordPress.getUserAgent());
 
         mDownloadId = dm.enqueue(request);
         invalidateOptionsMenu();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -852,7 +852,8 @@ public class MediaSettingsActivity extends AppCompatActivity
                 if (cursor != null && cursor.moveToFirst()) {
                     // meaning of `reason` depends on the value of COLUMN_STATUS
                     int reason = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_REASON));
-                    if (reason == DownloadManager.STATUS_FAILED) {
+                    int status = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_STATUS));
+                    if (status == DownloadManager.STATUS_FAILED) {
                         ToastUtils.showToast(MediaSettingsActivity.this, R.string.error_media_save);
                         // If an HTTP error occurred, this will hold the HTTP status code as defined in RFC 2616.
                         // Otherwise, it will hold one of the ERROR_* constants

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -850,9 +850,13 @@ public class MediaSettingsActivity extends AppCompatActivity
                 DownloadManager dm = (DownloadManager) getSystemService(DOWNLOAD_SERVICE);
                 Cursor cursor = dm.query(query);
                 if (cursor != null && cursor.moveToFirst()) {
+                    // meaning of `reason` depends on the value of COLUMN_STATUS
                     int reason = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_REASON));
                     if (reason == DownloadManager.STATUS_FAILED) {
                         ToastUtils.showToast(MediaSettingsActivity.this, R.string.error_media_save);
+                        // If an HTTP error occurred, this will hold the HTTP status code as defined in RFC 2616.
+                        // Otherwise, it will hold one of the ERROR_* constants
+                        AppLog.e(AppLog.T.MEDIA, "MediaSettingsActivity > save > STATUS_FAILED - reason: " + reason);
                     }
                 }
                 mDownloadId = 0;


### PR DESCRIPTION
Fixes #8840 by making sure the default app-UA string is set on requests enqueued to the `DownloadManager`.

Note: The `AndroidDownloadManager` default UA string(s) -->  `AndroidDownloadManager/8.0.0 (Linux; U; Android 8.0.0; Android SDK built for x86 Build/OSR1.170901.043)` was blocked on our servers long time ago. We've removed the block yesterday and the app works already OK.

We also agreed that we should use the default app-UA string in the AndroidDownloadManager requests.

To test:
- Start the app
- Setup Charles proxy on your emulator
- Go to media
- Tap on a media, and try to download it locally
- The download should finish properly, and the pictures available in media gallery app.
- Go to Charles proxy (or equivalent) and check the user agent set on the request. It should be something like `Mozilla/5.0 (Linux; Android 8.0.0; Android SDK built for x86 Build/OSR1.170901.043; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36 wp-android/xxx`


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
