### PR TITLE
Fix opening premium themes in customizer

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
@@ -44,7 +44,7 @@ public class ThemeWebActivity extends WPWebViewActivity {
     }
 
     public static void openTheme(Activity activity, SiteModel site, ThemeModel theme, ThemeWebActivityType type) {
-        String url = getUrl(site, theme, type, false);
+        String url = getUrl(site, theme, type, !theme.isFree());
         if (TextUtils.isEmpty(url)) {
             ToastUtils.showToast(activity, R.string.could_not_load_theme);
             return;


### PR DESCRIPTION
Fixes #8929

We were passing `false` as the value for `isPremium` parameter. I'm changing that so we pass in `isPremium == true` if `isFree` param is false instead. 

To test:
* Go to My Site > Theme > Customize
* The Customizer opens in the browser
