### PR TITLE
Fix OOM Crash after opening Media section

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -432,7 +432,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
     private void loadVideoThumbnail(final int position, final @NonNull MediaModel media,
                                     @NonNull final ImageView imageView) {
         // if we have a thumbnail url, use it and be done
-        if (!TextUtils.isEmpty(media.getThumbnailUrl())) {
+        if (!TextUtils.isEmpty(media.getThumbnailUrl()) && !MediaUtils.isVideo(media.getThumbnailUrl())) {
             mImageManager.load(imageView, ImageType.VIDEO, media.getThumbnailUrl(), ScaleType.CENTER_CROP);
             return;
         }


### PR DESCRIPTION
Fixes #8894 by making sure the thumbnail-URL is not pointing to a mp4 file before downloading it.

The problem was reported by a self.hosted user whose site has a "kind of weird configuration?" where the `thumbnail-URL` field of video files is pointing to the full video URL.
So basically the mobile app tried to read the whole video, and generate the preview picture from it, resulting in OOM. On default WP installation video files does have a thumb attached to them, but it's a picture, or the thumb field is empty.

In this PR I added a check to be sure the thumb URL is not a video, before reading all the content from the network. For video files, the normal flow is followed where the metadata retriever is invoked and only the first secs of the videos downloaded from the network.

To test:

- Just load a WP.com site and access the media section. Everything should work as expected.
- Repeat the steps above on Jetpack sites.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
