### PR TITLE
Analytic event fixes for login, logout and visible tab tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -485,6 +485,9 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         if (mCredentialsClient != null && mCredentialsClient.isConnected()) {
             Auth.CredentialsApi.disableAutoSignIn(mCredentialsClient);
         }
+
+        // Once fully logged out refresh the metadata so the user information doesn't persist for logged out events
+        AnalyticsUtils.refreshMetadata(mAccountStore, mSiteStore);
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -871,8 +871,6 @@ public class WPMainActivity extends AppCompatActivity implements
         }
 
         if (mAccountStore.hasAccessToken()) {
-            AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNED_IN);
-
             if (mIsMagicLinkLogin) {
                 if (mIsMagicLinkSignup) {
                     // Sets a flag that we need to track a magic link sign up.

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -140,6 +140,9 @@ public class WPMainActivity extends AppCompatActivity implements
     public static final String ARG_ME = "show_me";
     public static final String ARG_SHOW_ZENDESK_NOTIFICATIONS = "show_zendesk_notifications";
 
+    // Track the first `onResume` event for the current session so we can use it for Analytics tracking
+    private static boolean mFirstResume = true;
+
     private WPMainNavigationView mBottomNav;
     private WPDialogSnackbar mQuickStartSnackbar;
 
@@ -531,7 +534,7 @@ public class WPMainActivity extends AppCompatActivity implements
         // We need to track the current item on the screen when this activity is resumed.
         // Ex: Notifications -> notifications detail -> back to notifications
         int currentItem = mBottomNav.getCurrentPosition();
-        trackLastVisiblePage(currentItem, false);
+        trackLastVisiblePage(currentItem, mFirstResume);
 
         if (currentItem == PAGE_NOTIFS) {
             // if we are presenting the notifications list, it's safe to clear any outstanding
@@ -553,6 +556,8 @@ public class WPMainActivity extends AppCompatActivity implements
         ProfilingUtils.split("WPMainActivity.onResume");
         ProfilingUtils.dump();
         ProfilingUtils.stop();
+
+        mFirstResume = false;
     }
 
     private void checkQuickStartNotificationStatus() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -646,15 +646,6 @@ public class WPMainActivity extends AppCompatActivity implements
         }
     }
 
-    private void checkMagicLinkSignIn() {
-        if (getIntent() != null) {
-            if (getIntent().getBooleanExtra(LoginActivity.MAGIC_LOGIN, false)) {
-                mLoginAnalyticsListener.trackLoginMagicLinkSucceeded();
-                startWithNewAccount();
-            }
-        }
-    }
-
     private void trackLastVisiblePage(int position, boolean trackAnalytics) {
         switch (position) {
             case PAGE_MY_SITE:


### PR DESCRIPTION
Fixes #8925. This PR fixes a few analytics issues:

1. We were tracking the `accessed` events only on tab changes as described in #8925. I've added a static `mFirstResume` variable to track the first time the main activity is visited and track the current tab in each session. _I was unable to use uppercase letters for the static variable, probably because it's not final._ I don't like this solution very much, but I don't see a better alternative with the Android life-cycle. f29ca2898a5a26be7166f09b38eb8acc126f42c0
2. @SylvesterWilmott pinged me today about where the `signed_in` event was being tracked. (login) While looking into it, I suspected that it was tracked more than once in each login. @aerych later confirmed this. I've removed the tracking in `WPMainActivity.onAuthenticationChanged` since we are already tracking login events in the login fragments. 7ac5a848183ad1ee85d75006ad9777e303d4929e
3. While testing above, @aerych found that when the user logged out, its metadata was not refreshed. I've added a fix for that as well. 29d9cea7b5721cb42b91d600a7ca4850676a29e7
4. I've also removed an unused method in `WPMainActivity.checkMagicLinkSignIn`. f7a260b2a51eaa84b8e94dc2a8d6a2ff8bbb5e6f

**To test**

These tests are best done through debugging or tracks live view.

1. Make sure you're logged into any account. Completely close the app. Re-open it and check that `WPMainActivity.trackLastVisiblePage` is triggered with the parameter `trackAnalytics=true`. Rotate your device and check that same method is triggered with `trackAnalytics=false`. Put the app in the background and open it back up again and check that it's again triggered with `trackAnalytics=false`.
2. Put a breakpoint [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java#L819). Try logging into the app with both password and magic link flows. Verify that the breakpoint is triggered only once for each one.
3. The best way to test this one is to login, create a few analytics events, logout and create a couple more and log back in to create a few more. After that check from Tracks that the logged in events have the user information and logged out events don't. If you login to different accounts, it'd be even better.
4. Nothing to test for this one.
