### PR TITLE
Remove specific logic for local drafts preview

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPreviewFragment.java
@@ -120,20 +120,11 @@ public class EditPostPreviewFragment extends Fragment {
             String postTitle = "<h1>" + mPost.getTitle() + "</h1>";
             String postContent = postTitle + mPost.getContent();
 
-            if (mPost.isLocalDraft()) {
-                contentSpannable = WPHtml.fromHtml(
-                        postContent.replaceAll("\uFFFC", ""),
-                        getActivity(),
-                        mPost,
-                        Math.min(mTextView.getWidth(), mTextView.getHeight())
-                );
-            } else {
-                String htmlText = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><html><head><link rel=\"stylesheet\" "
-                                  + "type=\"text/css\" href=\"webview.css\" /></head><body><div "
-                                  + "id=\"container\">%s</div></body></html>";
-                htmlText = String.format(htmlText, StringUtils.addPTags(postContent));
-                contentSpannable = new SpannableString(htmlText);
-            }
+            String htmlText = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><html><head><link rel=\"stylesheet\" "
+                              + "type=\"text/css\" href=\"webview.css\" /></head><body><div "
+                              + "id=\"container\">%s</div></body></html>";
+            htmlText = String.format(htmlText, StringUtils.addPTags(postContent));
+            contentSpannable = new SpannableString(htmlText);
 
             return contentSpannable;
         }
@@ -141,17 +132,11 @@ public class EditPostPreviewFragment extends Fragment {
         @Override
         protected void onPostExecute(Spanned spanned) {
             if (mPost != null && spanned != null) {
-                if (mPost.isLocalDraft()) {
-                    mTextView.setVisibility(View.VISIBLE);
-                    mWebView.setVisibility(View.GONE);
-                    mTextView.setText(spanned);
-                } else {
-                    mTextView.setVisibility(View.GONE);
-                    mWebView.setVisibility(View.VISIBLE);
+                mTextView.setVisibility(View.GONE);
+                mWebView.setVisibility(View.VISIBLE);
 
-                    mWebView.loadDataWithBaseURL("file:///android_asset/", spanned.toString(),
-                                                 "text/html", "utf-8", null);
-                }
+                mWebView.loadDataWithBaseURL("file:///android_asset/", spanned.toString(),
+                        "text/html", "utf-8", null);
             }
 
             mLoadTask = null;


### PR DESCRIPTION
Fixes #8755 

This PR removes logic specific to local drafts which wasn't showing images in preview. I think previously we didn't have HTML content for local drafts. However now it seems like the logic is not doing anything important and the Preview works well without it. 

![fixed_preview_for_local_drafts](https://user-images.githubusercontent.com/1079756/50974056-a4206500-14ea-11e9-8129-41a8e1d9c4f2.gif)

To test:
* Create a new post using the New Post button on the bottom tab bar.
* Add a title and a text on the body.
* While the soft keyboard is shown, click on the + button.
* Pick a photo from the shown gallery.
* After the photo is shown in the post's content, click on the options button at the top right.
* On the shown options menu, click on Preview.
* The Preview is shown correctly
