### PR TITLE
Self Hosted- Site Settings: Do not hide the account section (username/pass) on non-admins

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1662,7 +1662,6 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void hideAdminRequiredPreferences() {
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_general);
-        WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_account);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_discussion);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_site_category);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_site_format);


### PR DESCRIPTION
This PR fixes #7272 by making sure to not hide the `Account` section of `Site->Settings`, where the username and password fields are located, on self hosted sites for non-admin users.

**Test A:**
- Add a self hosted site to the app (Make sure you're an `Editor` on the site)
- Go to Site->Settings 
- Make sure username/password fields are available on the screen

**Test B:**
- Add a self hosted site to the app (Make sure you're an `Admin` on the site)
- Go to Site->Settings 
- Make sure username/password fields are available on the screen, together with other settings about the site.

**Test C:**
- Login to wpcom
- Go to Site->Settings on a site where you've Admin rights.
- Make sure username/password fields are NOT available on the screen, but other settings are.

**Test D:**
- Login to wpcom
- Go to Site->Settings on a site where you're NOT an Admin
- No wait, you can't do that ;)

**Test E:**
- Login to wpcom
- Go to Site->Settings on a Jetpack site where you're an Admin
- Make sure username/password fields are NOT available on the screen, but other settings are.


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
