### PR TITLE
Issue/8390 missing reader tags after account creation for non-english locales

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -11,13 +11,14 @@ import java.util.Locale;
 import java.util.regex.Pattern;
 
 public class ReaderTag implements Serializable, FilterCriteria {
+    public static final String FOLLOWING_PATH = "/read/following";
+    public static final String DISCOVER_PATH = String.format(Locale.US, "read/sites/%d/posts",
+            ReaderConstants.DISCOVER_SITE_ID);
+
     public static final String TAG_TITLE_FOLLOWED_SITES = "Followed Sites";
     public static final String TAG_SLUG_BOOKMARKED = "bookmarked-posts";
     public static final String TAG_TITLE_DEFAULT = TAG_TITLE_FOLLOWED_SITES;
-
-    public static final String DISCOVER_PATH = String.format(Locale.US, "read/sites/%d/posts",
-            ReaderConstants.DISCOVER_SITE_ID);
-    public static final String FOLLOWING_PATH = "/read/following";
+    public static final String TAG_ENDPOINT_DEFAULT = FOLLOWING_PATH;
 
     private String mTagSlug; // tag for API calls
     private String mTagDisplayName; // tag for display, usually the same as the slug

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -262,10 +262,10 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
         super.onActivityCreated(savedInstanceState);
 
         if (savedInstanceState == null) {
-             // Start loading reader tags so they will be available asap
-             ReaderUpdateServiceStarter.startService(getActivity(), EnumSet.of(ReaderUpdateLogic.UpdateTask.TAGS));
+            // Start loading reader tags so they will be available asap
+            ReaderUpdateServiceStarter.startService(getActivity(), EnumSet.of(ReaderUpdateLogic.UpdateTask.TAGS));
 
-             if (mIsEmailSignup) {
+            if (mIsEmailSignup) {
                 AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_EMAIL_EPILOGUE_VIEWED);
 
                 // Start progress and wait for account to be fetched before populating views when

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -263,7 +263,8 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
 
         if (savedInstanceState == null) {
             // Start loading reader tags so they will be available asap
-            ReaderUpdateServiceStarter.startService(getActivity(), EnumSet.of(ReaderUpdateLogic.UpdateTask.TAGS));
+            ReaderUpdateServiceStarter.startService(WordPress.getContext(),
+                    EnumSet.of(ReaderUpdateLogic.UpdateTask.TAGS));
 
             if (mIsEmailSignup) {
                 AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_EMAIL_EPILOGUE_VIEWED);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -59,6 +59,8 @@ import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource;
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment;
 import org.wordpress.android.ui.prefs.AppPrefsWrapper;
+import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic;
+import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.GravatarUtils;
@@ -74,6 +76,7 @@ import org.wordpress.android.widgets.WPTextView;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Locale;
 
@@ -259,7 +262,10 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
         super.onActivityCreated(savedInstanceState);
 
         if (savedInstanceState == null) {
-            if (mIsEmailSignup) {
+             // Start loading reader tags so they will be available asap
+             ReaderUpdateServiceStarter.startService(getActivity(), EnumSet.of(ReaderUpdateLogic.UpdateTask.TAGS));
+
+             if (mIsEmailSignup) {
                 AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_EMAIL_EPILOGUE_VIEWED);
 
                 // Start progress and wait for account to be fetched before populating views when

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -76,7 +76,7 @@ public class ReaderUtils {
                     .replaceAll("&[^\\s]*;", "") // remove html entities
                     .replaceAll("[\\.\\s]+", "-") // replace periods and whitespace with a dash
                     .replaceAll("[^\\p{L}\\p{Nd}\\-]+",
-                                "") // remove remaining non-alphanum/non-dash chars (Unicode aware)
+                            "") // remove remaining non-alphanum/non-dash chars (Unicode aware)
                     .replaceAll("--", "-"); // reduce double dashes potentially added above
     }
 
@@ -214,12 +214,16 @@ public class ReaderUtils {
      * the user hasn't already chosen one
      */
     public static ReaderTag getDefaultTag() {
-        return getTagFromTagName(ReaderTag.TAG_TITLE_DEFAULT, ReaderTagType.DEFAULT);
+        ReaderTag defaultTag = getTagFromEndpoint(ReaderTag.TAG_ENDPOINT_DEFAULT);
+        if (defaultTag == null) {
+            defaultTag = getTagFromTagName(ReaderTag.TAG_TITLE_DEFAULT, ReaderTagType.DEFAULT);
+        }
+        return defaultTag;
     }
 
     /*
-  * used when storing search results in the reader post table
-  */
+     * used when storing search results in the reader post table
+     */
     public static ReaderTag getTagForSearchQuery(@NonNull String query) {
         String trimQuery = query != null ? query.trim() : "";
         String slug = ReaderUtils.sanitizeWithDashes(trimQuery);


### PR DESCRIPTION
Fixes #8390

This PR partially fixes the issue with Reader, where it shows an error screen and picks "My Likes" as a default filter, for users who just created a new account with a fresh installation of the app, while using non-english locales.

Original problem comes from a way we handle hardcoded default tag for reader, which assumes english locale and fact that we were not trying to get reader tags beforehand (like we do with a login flow).

I call this a partial fix, because underlying issue is a bit bigger, and requires substantial changes to the default tag logic and `FilterCriteria` used in `FilteredRecyclerView`. This fix adresses immidiate problem for majority of users.

To test:
- Switch your device to a locale other than English.
- Create a new account.
- After account is created open Reader tab.
- Notice that "Followed sites" filter is selected, and the correct empty view for "Followed sites" is shown.