### PR TITLE
Fix for empty Site title on the main toolbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -780,6 +780,9 @@ public class MySiteFragment extends Fragment implements
         // Do not show pages menu item to Collaborators.
         int pageVisibility = site.isSelfHostedAdmin() || site.getHasCapabilityEditPages() ? View.VISIBLE : View.GONE;
         mPageView.setVisibility(pageVisibility);
+
+        // Refresh the title
+        setTitle(site.getName());
     }
 
     private void toggleAdminVisibility(@Nullable final SiteModel site) {


### PR DESCRIPTION
Fixes #8880 by making sure to refresh the title of MySite Fragment in the `onResume` method.
(All other site's details are already updated in that method, so I only added a call to set the title).

Note that previously the `setTitle` method was called by the main activity before the Fragment was added, resulting in empty title. With this change we're ensuring the title is refreshed properly.

To test:
- Turn on "Don't keep activities" in developer options
- Start the app and select a tab other than the first one ("My Site") e.g. "Me"
- Minimise the app
- Come back to the app, and then switch back to My Site 
- The title should be there

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
