### PR TITLE
Fix the image settings not being saved

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation 'org.wordpress:utils:1.22'
 
     api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.14')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.3.14')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:4a2ce6fe8b94803591f0e5c0297d263943b41e5a')
     api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.3.14')
 
     if (rootProject.ext.buildGutenbergFromSource) {


### PR DESCRIPTION
Fixes #8569.

**To test:**
1. Go to Blog Posts
2. Open a post with an image (or add one)
3. Tap on the image to open the media settings
4. Add a caption to the image
5. Change the alignment to Center, for example
6. Tap the X button to leave and save the settings
7. Tap on the image again
8. Notice the alignment attribute is correctly set to Center

**Note:** Before this PR is merged, the Aztec PR (wordpress-mobile/AztecEditor-Android#775) must be merged first. The Aztec reference should be updated to a properly versioned release.