### PR TITLE
Update wrong date format

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -43,8 +43,8 @@ android {
 
     defaultConfig {
         applicationId "org.wordpress.android"
-        versionName "alpha-145"
-        versionCode 661
+        versionName "alpha-146"
+        versionCode 663
         minSdkVersion 21
         targetSdkVersion 26
 

--- a/build.gradle
+++ b/build.gradle
@@ -92,5 +92,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'f84fcda65c183f5d8fb4cc119d64dc50aa357a8a'
+    fluxCVersion = '0080c785a87b8f56d245317db97c86475c12b280'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -92,5 +92,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '3ee26c3f02b80d1b4c79777e337c4f8509d9d1ac'
+    fluxCVersion = 'f84fcda65c183f5d8fb4cc119d64dc50aa357a8a'
 }


### PR DESCRIPTION
PR to test the FluxC fix for a crash caused by nonfixed timeformat https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1075

To test:
* Click around in Stats
* The Latest post summary should still be showing the correct date 
