### PR TITLE
[Site Creation] Fixes coroutine imports in site creation unit tests

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/CoroutinesUtils.kt
+++ b/WordPress/src/test/java/org/wordpress/android/CoroutinesUtils.kt
@@ -1,14 +1,32 @@
 package org.wordpress.android
 
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Delay
 import kotlinx.coroutines.Dispatchers.Unconfined
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.resume
 
 fun <T> test(context: CoroutineContext = EmptyCoroutineContext, block: suspend CoroutineScope.() -> T) {
     runBlocking(context, block)
 }
 
 @ExperimentalCoroutinesApi val TEST_SCOPE = CoroutineScope(Unconfined)
+@InternalCoroutinesApi val TEST_DISPATCHER: CoroutineDispatcher = TestDispatcher()
+
+@InternalCoroutinesApi
+private class TestDispatcher : CoroutineDispatcher(), Delay {
+    @InternalCoroutinesApi
+    override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
+        continuation.resume(Unit)
+    }
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        block.run()
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/creation/CreateSiteUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/creation/CreateSiteUseCaseTest.kt
@@ -1,9 +1,9 @@
 package org.wordpress.android.ui.sitecreation.creation
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/creation/NewSiteCreationServiceManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/creation/NewSiteCreationServiceManagerTest.kt
@@ -1,10 +1,11 @@
 package org.wordpress.android.ui.sitecreation.creation
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
-import com.nhaarman.mockito_kotlin.argumentCaptor
-import com.nhaarman.mockito_kotlin.times
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -42,6 +43,7 @@ private val CREATE_SITE_STATE = NewSiteCreationServiceState(CREATE_SITE)
 private val SUCCESS_STATE = NewSiteCreationServiceState(SUCCESS, NEW_SITE_REMOTE_ID)
 private val FAILURE_STATE = NewSiteCreationServiceState(FAILURE)
 
+@InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class NewSiteCreationServiceManagerTest {
     @Rule

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/NewSiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/NewSiteCreationDomainsViewModelTest.kt
@@ -2,12 +2,13 @@ package org.wordpress.android.ui.sitecreation.domains
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.Observer
-import com.nhaarman.mockito_kotlin.firstValue
-import com.nhaarman.mockito_kotlin.secondValue
-import com.nhaarman.mockito_kotlin.times
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
-import kotlinx.coroutines.experimental.CoroutineScope
+import com.nhaarman.mockitokotlin2.firstValue
+import com.nhaarman.mockitokotlin2.secondValue
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.InternalCoroutinesApi
 import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
@@ -32,6 +33,7 @@ private const val MULTI_RESULT_DOMAIN_FETCH_RESULT_SIZE = 20
 private val MULTI_RESULT_DOMAIN_FETCH_QUERY = Pair("multi_result_query", MULTI_RESULT_DOMAIN_FETCH_RESULT_SIZE)
 private val EMPTY_RESULT_DOMAIN_FETCH_QUERY = Pair("empty_result_query", 0)
 
+@InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class NewSiteCreationDomainsViewModelTest {
     @Rule

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
@@ -2,11 +2,12 @@ package org.wordpress.android.ui.sitecreation.segments
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.Observer
-import com.nhaarman.mockito_kotlin.anyOrNull
-import com.nhaarman.mockito_kotlin.inOrder
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.inOrder
+import com.nhaarman.mockitokotlin2.whenever
 import junit.framework.Assert.assertFalse
 import junit.framework.Assert.assertTrue
+import kotlinx.coroutines.InternalCoroutinesApi
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -93,6 +94,7 @@ private val SECOND_MODEL_EVENT = OnSegmentsFetched(listOf(SECOND_MODEL))
 private val FIRST_AND_SECOND_MODEL_EVENT = OnSegmentsFetched(listOf(FIRST_MODEL, SECOND_MODEL))
 private val ERROR_EVENT = OnSegmentsFetched(emptyList(), FetchSegmentsError(GENERIC_ERROR, ERROR_MESSAGE))
 
+@InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class NewSiteCreationSegmentsViewModelTest {
     @Rule

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/siteinfo/NewSiteCreationSiteInfoViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/siteinfo/NewSiteCreationSiteInfoViewModelTest.kt
@@ -2,7 +2,8 @@ package org.wordpress.android.ui.sitecreation.siteinfo
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.Observer
-import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -21,6 +22,7 @@ private const val TAG_LINE = "Test Tag Line"
 
 private val EMPTY_UI_STATE = SiteInfoUiState(siteTitle = "", tagLine = "")
 
+@InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class NewSiteCreationSiteInfoViewModelTest {
     @Rule

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCaseTest.kt
@@ -1,11 +1,11 @@
 package org.wordpress.android.ui.sitecreation.usecases
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
-import com.nhaarman.mockito_kotlin.KArgumentCaptor
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.argumentCaptor
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchSegmentsPromptUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchSegmentsPromptUseCaseTest.kt
@@ -1,11 +1,11 @@
 package org.wordpress.android.ui.sitecreation.usecases
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
-import com.nhaarman.mockito_kotlin.KArgumentCaptor
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.argumentCaptor
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchSegmentsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchSegmentsUseCaseTest.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.ui.sitecreation.usecases
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchVerticalsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchVerticalsUseCaseTest.kt
@@ -1,11 +1,11 @@
 package org.wordpress.android.ui.sitecreation.usecases
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
-import com.nhaarman.mockito_kotlin.KArgumentCaptor
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.argumentCaptor
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModelTest.kt
@@ -3,16 +3,17 @@ package org.wordpress.android.ui.sitecreation.verticals
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.Observer
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.anyOrNull
-import com.nhaarman.mockito_kotlin.firstValue
-import com.nhaarman.mockito_kotlin.lastValue
-import com.nhaarman.mockito_kotlin.secondValue
-import com.nhaarman.mockito_kotlin.thirdValue
-import com.nhaarman.mockito_kotlin.times
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
-import kotlinx.coroutines.experimental.CoroutineScope
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.firstValue
+import com.nhaarman.mockitokotlin2.lastValue
+import com.nhaarman.mockitokotlin2.secondValue
+import com.nhaarman.mockitokotlin2.thirdValue
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -110,6 +111,7 @@ private val ERROR_ON_VERTICALS_FETCHED = OnVerticalsFetched(
         FetchVerticalsError(GENERIC_ERROR, message = null)
 )
 
+@InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class NewSiteCreationVerticalsViewModelTest {
     @Rule


### PR DESCRIPTION
As we are closing in on finalizing site creation, I wanted to merge `origin/develop` into our master branch `feature/master-site-creation` and ended up having to make a lot of changes to the coroutine imports in our `ViewModel`s and `UseCase`s. I was going to make the changes in this PR in that merge commit as well, but I thought it might be best to review them.

This PR fixes the imports for coroutines and mockito in the site creation unit tests. It also reintroduces the `TEST_DISPATCHER` we had before. I think I accidentally removed it during the merge. Finally, it adds the necessary `InternalCoroutinesApi` annotation where necessary.

@malinajirka I was wondering if you had time to take this opportunity to look at whether we actually need the `TEST_DISPATCHER` as well as the changes our branch has for the `ThreadModule`. I assume we could remove some of the additions in `ThreadModule` and reuse the existing providers, but I haven't had a chance to test it yet.