### PR TITLE
Build APK improvements

### DIFF
--- a/tools/build-all-apks.sh
+++ b/tools/build-all-apks.sh
@@ -14,6 +14,7 @@ if [ x"$3" == x ]; then
 fi
 
 mkdir -p $BUILDDIR
+> "$LOGFILE"
 
 current_branch=`git rev-parse --abbrev-ref HEAD`
 release_branch=$1

--- a/tools/build-alpha-beta-apk.sh
+++ b/tools/build-alpha-beta-apk.sh
@@ -14,6 +14,7 @@ if [ x"$2" == x ]; then
 fi
 
 mkdir -p $BUILDDIR
+> "$LOGFILE"
 
 current_branch=`git rev-parse --abbrev-ref HEAD`
 beta_branch=$1

--- a/tools/build-apk-core.sh
+++ b/tools/build-apk-core.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# Exit if any command fails
+set -eu
+# Print the logs on failure
+function cleanup {
+  cat "$LOGFILE"
+}
+trap cleanup EXIT
+
 # This script defines some shared functions that are used by the build-apk* set.
 
 function gradle_version_name {

--- a/tools/build-apk-core.sh
+++ b/tools/build-apk-core.sh
@@ -30,7 +30,7 @@ function build_apk {
   echo "Cleaning in branch: $branch" | tee -a $LOGFILE
   ./gradlew clean >> $LOGFILE 2>&1
   echo "Running lint in branch: $branch" | tee -a $LOGFILE
-  ./gradlew lint >> $LOGFILE 2>&1
+  ./gradlew lint"$flavor"Release >> $LOGFILE 2>&1
   echo "Building $version_name / $version_code - $apk..." | tee -a $LOGFILE
   ./gradlew assemble"$flavor"Release >> $LOGFILE 2>&1
   cp -v $OUTDIR/$flavor/release/$apk $BUILDDIR/$name | tee -a $LOGFILE

--- a/tools/build-release-apk.sh
+++ b/tools/build-release-apk.sh
@@ -14,6 +14,7 @@ if [ x"$1" == x ]; then
 fi
 
 mkdir -p $BUILDDIR
+> "$LOGFILE"
 
 current_branch=`git rev-parse --abbrev-ref HEAD`
 release_branch=$1


### PR DESCRIPTION
This makes two small improvements to how the scripts for building APKs work:

- Exit if any command fails. Currently if the build fails it still thinks everything is fine. Now it will exit and print the log contents.
- Only lint the relevant flavour. Right now it runs `./gradlew lint` which lints every single flavour config (`wasabiDebug`, `wasabiRelease`, `vanillaDebug`, `vanillaRelease` etc.). Linting only the flavour we want to build means we can build the APKs in a fraction of the time.

To test:

- Run `./tools/build-alpha-beta-apk.sh release/11.6 alpha-147`. It works as expected.
- Edit some file to make a compile error. Running `./tools/build-alpha-beta-apk.sh release/11.6 alpha-147` will now fail.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
