### PR TITLE
Use the end of the day for data selection

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateFormatter.kt
@@ -125,6 +125,8 @@ class StatsDateFormatter
                 calendar.time = parsedDate
                 // last day of this month
                 calendar.set(Calendar.DAY_OF_MONTH, calendar.getActualMaximum(Calendar.DAY_OF_MONTH))
+                calendar.set(Calendar.HOUR_OF_DAY, calendar.getActualMaximum(Calendar.HOUR_OF_DAY))
+                calendar.set(Calendar.MINUTE, calendar.getActualMaximum(Calendar.MINUTE))
                 calendar.time
             }
             YEARS -> {
@@ -147,6 +149,8 @@ class StatsDateFormatter
         calendar.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
         // last day of this week
         calendar.add(Calendar.DAY_OF_WEEK, +6)
+        calendar.set(Calendar.HOUR_OF_DAY, calendar.getActualMaximum(Calendar.HOUR_OF_DAY))
+        calendar.set(Calendar.MINUTE, calendar.getActualMaximum(Calendar.MINUTE))
         return calendar.time
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -91,5 +91,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'fe614fb5b6a1ea13c1b8ba4e4b3fd8c74f8f5090'
+    fluxCVersion = '0b1dde6c44833f940c8700b29e794c6534617b93'
 }


### PR DESCRIPTION
Fixes #8994
To test - https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1078
This PR includes the FluxC change and changes the last date of the week at the actual end of the last day of the week (to show the same data as the previous Stats version)

To test:
* Open current and previous version of Stats
* Compare data for various days/weeks/months/years
* The data should be the same as before
