### PR TITLE
Change merge method for RELEASE-NOTES.txt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@ gradlew text eol=lf
 *.bat text eol=crlf
 *.png binary
 *.jpg binary
+RELEASE-NOTES.txt merge=union


### PR DESCRIPTION
The same as wordpress-mobile/WordPress-iOS#10842: This PR changes the merge method to reduce the amount of conflicts.