### PR TITLE
Hot fix: Stats crash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,4 +2,4 @@
 * Add support for .blog subdomains on new sites.
 * First version of the refreshed stats project - all tabs and all the blocks are completely rewritten in new design
 * Fix the coloring issue with Countries map stats block
-* Fix an occasional crash in Stats (date parsing in the Overview block)
+* Fix a crash in Stats for new sites with no data (date parsing in the Overview block)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsBlock
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.State.Data
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.State.Empty
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatelessUseCase.NotUsedUiState
+import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.merge
 
 /**
@@ -27,11 +28,17 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
     private val domainModel = MutableLiveData<State<DOMAIN_MODEL>>()
     private val uiState = MutableLiveData<UI_STATE>()
     val liveData: LiveData<StatsBlock> = merge(domainModel, uiState) { data, uiState ->
-        when (data) {
-            is State.Loading -> Loading(type, buildLoadingItem())
-            is State.Error -> Error(type, data.error)
-            is Data -> BlockList(type, buildUiModel(data.model, uiState ?: defaultUiState))
-            is Empty, null -> null
+        try {
+            when (data) {
+                is State.Loading -> Loading(type, buildLoadingItem())
+                is State.Error -> Error(type, data.error)
+                is Data -> BlockList(type, buildUiModel(data.model, uiState ?: defaultUiState))
+                is Empty, null -> null
+            }
+        }
+        catch (e: Exception) {
+            AppLog.e(AppLog.T.STATS, e)
+            Error(type, "An error occurred (${e.message ?: "Unknown"})")
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
@@ -35,8 +35,7 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
                 is Data -> BlockList(type, buildUiModel(data.model, uiState ?: defaultUiState))
                 is Empty, null -> null
             }
-        }
-        catch (e: Exception) {
+        } catch (e: Exception) {
             AppLog.e(AppLog.T.STATS, e)
             Error(type, "An error occurred (${e.message ?: "Unknown"})")
         }

--- a/build.gradle
+++ b/build.gradle
@@ -91,5 +91,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'fe614fb5b6a1ea13c1b8ba4e4b3fd8c74f8f5090'
+    fluxCVersion = '0b342b4b3890486c6515eeb165285262413e45ea'
 }


### PR DESCRIPTION
Fixes #8886.

This PR references a fix in FluxC that would resolve the issue by itself, but I added a general exception handler that should prevent any future API/data-related crashes.

To test:
1. Create a new WordPress.com site (with a new or existing account).
2. Go to My Sites > Stats.
3. Select a the Days tab.
4. Notice the app does not crash (displays an error message at the top, instead)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
