### PR TITLE
Issue/9002 site creation new params

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/creation/CreateSiteUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/creation/CreateSiteUseCase.kt
@@ -38,6 +38,9 @@ class CreateSiteUseCase @Inject constructor(
                     siteData.siteTitle ?: "",
                     languageWordPressId,
                     siteVisibility,
+                    siteData.verticalId,
+                    siteData.segmentId,
+                    siteData.siteTagLine,
                     dryRun
             )
             continuation = cont

--- a/build.gradle
+++ b/build.gradle
@@ -92,5 +92,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '3ee26c3f02b80d1b4c79777e337c4f8509d9d1ac'
+    fluxCVersion = '57952d11a2f340cfe52546da1d1e1e66fb60141f'
 }


### PR DESCRIPTION
Fixes #9002

Adds vertical_id, segment_id and tagline to the new/site requests.

Note: Vertical_id for custom verticals (isUserInputVertical=true) is always "". We'll probably fix it on the backend side.

To test:
1. My Site
2. Switch Site
3. Plus sign icon in the top right corner
4. Create WordPress.com site
5. Choose a segment
6. Type something and choose a vertical (ideally not a custom vertical due to the bug on the backend)
7. Type a title and tagline
8. Choose a domain
9. Create Site -> Ideally also make sure all the attributes are part of the request using for example Stetho.



Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
