### PR TITLE
Open Posts and Pages detail stats instead of the post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -425,6 +425,23 @@ public class ActivityLauncher {
         context.startActivity(intent);
     }
 
+    public static void viewItemStatsDetails(
+            Context context,
+            final long siteId,
+            final String postId,
+            @Nullable final String itemType,
+            final String itemTitle,
+            final String itemUrl
+                                       ) {
+        Intent statsPostViewIntent = new Intent(context, StatsSingleItemDetailsActivity.class);
+        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_REMOTE_BLOG_ID, siteId);
+        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_REMOTE_ITEM_ID, postId);
+        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_REMOTE_ITEM_TYPE, itemType);
+        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_ITEM_TITLE, itemTitle);
+        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_ITEM_URL, itemUrl);
+        context.startActivity(statsPostViewIntent);
+    }
+
     public static void viewBlogStatsAfterJetpackSetup(Context context, SiteModel site) {
         Intent intent = new Intent(context, StatsActivity.class);
         intent.putExtra(WordPress.SITE, site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -425,23 +425,6 @@ public class ActivityLauncher {
         context.startActivity(intent);
     }
 
-    public static void viewItemStatsDetails(
-            Context context,
-            final long siteId,
-            final String postId,
-            @Nullable final String itemType,
-            final String itemTitle,
-            final String itemUrl
-                                       ) {
-        Intent statsPostViewIntent = new Intent(context, StatsSingleItemDetailsActivity.class);
-        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_REMOTE_BLOG_ID, siteId);
-        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_REMOTE_ITEM_ID, postId);
-        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_REMOTE_ITEM_TYPE, itemType);
-        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_ITEM_TITLE, itemTitle);
-        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_ITEM_URL, itemUrl);
-        context.startActivity(statsPostViewIntent);
-    }
-
     public static void viewBlogStatsAfterJetpackSetup(Context context, SiteModel site) {
         Intent intent = new Intent(context, StatsActivity.class);
         intent.putExtra(WordPress.SITE, site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -186,7 +186,7 @@ class StatsListFragment : DaggerFragment() {
                 is ViewPostDetailStats -> {
                     val postModel = StatsPostModel(
                             site.siteId,
-                            it.postId.toString(),
+                            it.postId,
                             it.postTitle,
                             it.postUrl,
                             it.postType
@@ -294,9 +294,9 @@ sealed class NavigationTarget : Event() {
 
     data class SharePost(val url: String, val title: String) : NavigationTarget()
     data class ViewPostDetailStats(
-        val postId: Long,
+        val postId: String,
         val postTitle: String,
-        val postUrl: String,
+        val postUrl: String?,
         val postType: String = StatsConstants.ITEM_TYPE_POST
     ) : NavigationTarget()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
@@ -111,7 +111,10 @@ constructor(
                                     text = post.title,
                                     value = post.views.toFormattedString(),
                                     showDivider = false,
-                                    navigationAction = create(PostClickParams(post.id, post.url, post.title), this::onPostClicked)
+                                    navigationAction = create(
+                                            PostClickParams(post.id, post.url, post.title),
+                                            this::onPostClicked
+                                    )
                             )
                         })
                         items.add(Divider)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
@@ -10,8 +10,9 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.AUTHORS
 import org.wordpress.android.fluxc.store.stats.time.AuthorsStore
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.stats.StatsConstants
 import org.wordpress.android.ui.stats.refresh.lists.NavigationTarget.ViewAuthors
-import org.wordpress.android.ui.stats.refresh.lists.NavigationTarget.ViewUrl
+import org.wordpress.android.ui.stats.refresh.lists.NavigationTarget.ViewPostDetailStats
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Divider
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
@@ -28,9 +29,9 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.granular.UseCaseFac
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.AuthorsUseCase.SelectedAuthor
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
-import java.util.Date
 import org.wordpress.android.ui.stats.refresh.utils.trackGranular
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -110,7 +111,7 @@ constructor(
                                     text = post.title,
                                     value = post.views.toFormattedString(),
                                     showDivider = false,
-                                    navigationAction = post.url?.let { create(it, this::onPostClicked) }
+                                    navigationAction = create(PostClickParams(post.id, post.url, post.title), this::onPostClicked)
                             )
                         })
                         items.add(Divider)
@@ -135,12 +136,25 @@ constructor(
         navigateTo(ViewAuthors(statsGranularity, statsDateFormatter.todaysDateInStatsFormat()))
     }
 
-    private fun onPostClicked(url: String) {
+    private fun onPostClicked(params: PostClickParams) {
         analyticsTracker.trackGranular(AnalyticsTracker.Stat.STATS_AUTHORS_VIEW_POST_TAPPED, statsGranularity)
-        navigateTo(ViewUrl(url))
+        navigateTo(
+                ViewPostDetailStats(
+                        postId = params.postId,
+                        postTitle = params.postTitle,
+                        postUrl = params.postUrl,
+                        postType = StatsConstants.ITEM_TYPE_POST
+                )
+        )
     }
 
     data class SelectedAuthor(val author: AuthorsModel.Author? = null)
+
+    private data class PostClickParams(
+        val postId: String,
+        val postUrl: String?,
+        val postTitle: String
+    )
 
     class AuthorsUseCaseFactory
     @Inject constructor(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCase.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.fluxc.store.stats.time.PostAndPageViewsStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.StatsConstants.ITEM_TYPE_HOME_PAGE
 import org.wordpress.android.ui.stats.StatsConstants.ITEM_TYPE_POST
-import org.wordpress.android.ui.stats.refresh.lists.NavigationTarget.ViewPost
+import org.wordpress.android.ui.stats.refresh.lists.NavigationTarget.ViewPostDetailStats
 import org.wordpress.android.ui.stats.refresh.lists.NavigationTarget.ViewPostsAndPages
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
@@ -29,9 +29,9 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDa
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.UseCaseFactory
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
-import java.util.Date
 import org.wordpress.android.ui.stats.refresh.utils.trackGranular
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -100,7 +100,7 @@ constructor(
                         value = viewsModel.views.toFormattedString(),
                         showDivider = index < domainModel.views.size - 1,
                         navigationAction = create(
-                                LinkClickParams(viewsModel.id, viewsModel.url, viewsModel.type),
+                                LinkClickParams(viewsModel.id, viewsModel.url, viewsModel.title, viewsModel.type),
                                 this::onLinkClicked
                         )
                 )
@@ -128,12 +128,20 @@ constructor(
             PAGE, HOMEPAGE -> ITEM_TYPE_HOME_PAGE
         }
         analyticsTracker.trackGranular(AnalyticsTracker.Stat.STATS_POSTS_AND_PAGES_ITEM_TAPPED, statsGranularity)
-        navigateTo(ViewPost(params.postId, params.postUrl, type))
+        navigateTo(
+                ViewPostDetailStats(
+                        postId = params.postId.toString(),
+                        postTitle = params.postTitle,
+                        postUrl = params.postUrl,
+                        postType = type
+                )
+        )
     }
 
     private data class LinkClickParams(
         val postId: Long,
         val postUrl: String,
+        val postTitle: String,
         val postType: PostAndPageViewsModel.ViewsType
     )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCase.kt
@@ -108,7 +108,7 @@ class LatestPostSummaryUseCase
 
     private fun onViewMore(params: ViewMoreParams) {
         analyticsTracker.track(STATS_LATEST_POST_SUMMARY_VIEW_POST_DETAILS_TAPPED)
-        navigateTo(ViewPostDetailStats(params.postId, params.postTitle, params.postUrl))
+        navigateTo(ViewPostDetailStats(params.postId.toString(), params.postTitle, params.postUrl))
     }
 
     private fun onSharePost(params: SharePostParams) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCaseTest.kt
@@ -152,7 +152,7 @@ class LatestPostSummaryUseCaseTest : BaseUnitTest() {
                 assertThat(this).isInstanceOf(ViewPostDetailStats::class.java)
                 assertThat((this as ViewPostDetailStats).postUrl).isEqualTo(model.postURL)
                 assertThat(this.postTitle).isEqualTo(model.postTitle)
-                assertThat(this.postId).isEqualTo(model.postId)
+                assertThat(this.postId).isEqualTo(model.postId.toString())
             }
         }
     }


### PR DESCRIPTION
Fixes #9006 
Clicking on an item in the Posts and Pages block will now open the Post stats detail screen. The same goes for the Authors block for the posts of an Author.

To test:
* Go to Stats
* Open Days/Weeks/Months/Years tab
* Go to Posts and Pages block
* Click on a Post
* Post detail opens (instead of WebView)
