### PR TITLE
Fix IllegalArgumentException in WordPress.getDefaultUserAgent()

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -591,11 +591,13 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         if (mDefaultUserAgent == null) {
             try {
                 mDefaultUserAgent = WebSettings.getDefaultUserAgent(getContext());
-            } catch (AndroidRuntimeException | NullPointerException e) {
+            } catch (AndroidRuntimeException | NullPointerException | IllegalArgumentException e) {
                 // Catch AndroidRuntimeException that could be raised by the WebView() constructor.
                 // See https://github.com/wordpress-mobile/WordPress-Android/issues/3594
                 // Catch NullPointerException that could be raised by WebSettings.getDefaultUserAgent()
                 // See https://github.com/wordpress-mobile/WordPress-Android/issues/3838
+                // Catch IllegalArgumentException that could be raised by WebSettings.getDefaultUserAgent()
+                // See https://github.com/wordpress-mobile/WordPress-Android/issues/9015
 
                 // init with the empty string, it's a rare issue
                 mDefaultUserAgent = "";


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/9015

To test:

This is very difficult to test since the crash only happens for very specific devices. It's a small code change so should be easy to follow.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
