### PR TITLE
Fixed using wrong string for post scheduled snackbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -333,7 +333,7 @@ public class UploadUtils {
                         break;
                     case SCHEDULED:
                         snackbarButtonRes = R.string.button_view;
-                        snackbarMessageRes = post.isPage() ? R.string.page_scheduled : R.string.post_published;
+                        snackbarMessageRes = post.isPage() ? R.string.page_scheduled : R.string.post_scheduled;
                         break;
                     default:
                         snackbarButtonRes = R.string.button_view;


### PR DESCRIPTION
Fixes #9017

To test:
1. start a draft
2. write something
3. tap the overflow menu icon (three dots on the top-right corner of the screen)
4. tap Post settings
5. tap on `Publish` -> `Immediately`, change the calendar to a date in the future.
6. Observe the action on the action bar (top of the screen, to the right) is now `SCHEDULE`.
7. Tap `SCHEDULE`
8. if this is your first time publishing, a `Schedule with confidence` will appear. Tap `Schedule Now`
9. observe you're taken back to the the Posts list screen (or main screen if you accessed the editor in point 1 from the bottom bar), and then shortly after a snackbar appears that reads `Post scheduled` (it was `Post published` before).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
