### PR TITLE
Showing better quality for featured image in Post Settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -62,6 +62,7 @@ import org.wordpress.android.ui.posts.PostSettingsListDialogFragment.DialogType;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface.SiteSettingsListener;
+import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
@@ -866,14 +867,11 @@ public class EditPostSettingsFragment extends Fragment {
         // Get max width for photon thumbnail
         int width = DisplayUtils.getDisplayPixelWidth(getActivity());
         int height = DisplayUtils.getDisplayPixelHeight(getActivity());
-        int size = Math.max(width, height);
 
         String mediaUri = StringUtils.notNullStr(media.getThumbnailUrl());
-        if (SiteUtils.isPhotonCapable(siteModel)) {
-            mediaUri = PhotonUtils.getPhotonImageUrl(mediaUri, size, 0);
-        }
-
-        mImageManager.load(mFeaturedImageView, ImageType.PHOTO, mediaUri, ScaleType.FIT_CENTER);
+        String photonUrl = ReaderUtils.getResizedImageUrl(
+                mediaUri, width, height, !SiteUtils.isPhotonCapable(siteModel));
+        mImageManager.load(mFeaturedImageView, ImageType.PHOTO, photonUrl, ScaleType.FIT_CENTER);
     }
 
     private void launchFeaturedMediaPicker() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -68,7 +68,6 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.GeocoderUtils;
-import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;


### PR DESCRIPTION

Fixes #9020 

The title has it - I only checked what we were using in the Posts list as featured images look good there, and identified and reused the code from `ReaderUtils`.

#### Before
<img width="296" alt="screen shot 2019-01-18 at 18 04 11" src="https://user-images.githubusercontent.com/6597771/51412988-2e507500-1b4c-11e9-9cc8-93510b353206.png">


#### After
<img width="298" alt="screen shot 2019-01-18 at 18 05 44" src="https://user-images.githubusercontent.com/6597771/51413000-35778300-1b4c-11e9-8729-d91ad4cc79ac.png">


To test:
1. start a new draft
2. set a featured image
3. observe the featured image looks good :)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
