### PR TITLE
Fix vertical id for custom verticals

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsViewModel.kt
@@ -265,7 +265,11 @@ class NewSiteCreationVerticalsViewModel @Inject constructor(
             data.forEachIndexed { index, model ->
                 val onItemTapped = {
                     tracker.trackVerticalSelected(model.name, model.verticalId, model.isUserInputVertical)
-                    _verticalSelected.value = model.verticalId
+                    _verticalSelected.value = if (model.isUserInputVertical) {
+                        model.name.toLowerCase()
+                    } else {
+                        model.verticalId
+                    }
                 }
                 val itemUiState = if (model.isUserInputVertical) {
                     VerticalsCustomModelUiState(


### PR DESCRIPTION
Fixes #9025

Manually sets verticalId for custom/userInput verticals.

To test
1.  My Site
2. Switch Site
3. Plus sign icon in the top right corner
4. Create WordPress.com site
5. Choose a segment
6. Type something and choose the custom vertical at the end of the suggestions list
7. Type a title and tagline
8. Choose a domain
9. Create Site -> Ideally also make sure the vertical_id is set using for example Stetho.

Update release notes:

[ X ] If there are user facing changes, I have added an item to RELEASE-NOTES.txt.