### PR TITLE
Don't use React Native's version of okhttp3 to fix self signed SSL

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -64,9 +64,15 @@ dependencies {
     api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.3.14')
 
     if (rootProject.ext.buildGutenbergFromSource) {
-        implementation project(':react-native-gutenberg-bridge')
+        implementation (project(':react-native-gutenberg-bridge')) {
+            exclude group: 'com.squareup.okhttp3'
+        }
     } else {
-        implementation (waitJitpack('com.github.wordpress-mobile', 'gutenberg-mobile', submoduleGitHash('../../../', 'libs/gutenberg-mobile')))
+        implementation (waitJitpack('com.github.wordpress-mobile', 'gutenberg-mobile', submoduleGitHash('../../../', 'libs/gutenberg-mobile'))) {
+            // Inheriting RN's okhttp version can interfere with FluxC SSL handling
+            // See https://github.com/wordpress-mobile/WordPress-Android/issues/9032 and https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/919
+            exclude group: 'com.squareup.okhttp3'
+        }
     }
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/9032

Rect native uses okhttp version 3.11.0 while FluxC uses 3.9.0. Normally this would not be a major issue but there is a known problem with later versions of okhttp breaking self signed SSL (https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/919).

We don't fully understand the scope of the issue but I think the safest thing to do is to use the version that we know works as expected (I have tested this). Gutenberg/React Native also seems to be working fine with this version (both binary and source versions).

To test:

Follow these steps on `release/11.6` and on this branch:

1. Open the app
2. Tap "Login" and "Login by entering site address"
3. Enter a self signed SSL site address
4. Click next

On `release/11.6`, it will give an error saying the site does not exist. On this branch it will allow you to login as expected.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
