### PR TITLE
Merge Release/11.6 into develop

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -43,8 +43,8 @@ android {
 
     defaultConfig {
         applicationId "org.wordpress.android"
-        versionName "11.6-rc-2"
-        versionCode 665
+        versionName "11.6-rc-3"
+        versionCode 668
         minSdkVersion 21
         targetSdkVersion 26
 


### PR DESCRIPTION
Bring changes from https://github.com/wordpress-mobile/WordPress-Android/pull/9040 (already reviewed) back to develop.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
