### PR TITLE
Remove extra dot from image URL (..jpg)

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -208,7 +208,7 @@ public class MediaUtils {
         if (context == null || imageUri == null) {
             return null;
         }
-        String mimeType = context.getContentResolver().getType(imageUri);
+        String mimeType = UrlUtils.getUrlMimeType(imageUri.toString());
         File cacheDir = context.getCacheDir();
 
         if (cacheDir != null && !cacheDir.exists()) {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/9042

When user creates the Post and captures the image with Camera while "Image Optimization" is off, after Post is published, image URL will have an extra dot.

This PR removed an extra dot.