### PR TITLE
Update to Gradle 4.10.3/Android Gradle plugin 3.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ android:
     - extra-android-support
     - platform-tools
     - tools
-    - build-tools-27.0.3
+    - build-tools-28.0.3
     - android-27
 
 env:

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -39,7 +39,7 @@ android {
     }
 
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "org.wordpress.android"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -161,7 +161,7 @@ dependencies {
     implementation 'org.wordpress:graphview:3.4.0'
     implementation 'org.wordpress:persistentedittext:1.0.2'
     implementation 'org.wordpress:emailchecker2:1.1.0'
-    implementation 'com.squareup.okio:okio:1.13.0'
+    implementation 'com.squareup.okio:okio:1.14.0'
     implementation 'org.apache.commons:commons-text:1.1'
     implementation 'com.airbnb.android:lottie:2.0.0-rc2'
     implementation 'com.facebook.shimmer:shimmer:0.3.0'
@@ -185,7 +185,7 @@ dependencies {
     androidTestImplementation 'org.objenesis:objenesis:2.1'
     androidTestImplementation 'org.mockito:mockito-core:1.10.19'
     androidTestImplementation 'com.squareup.okhttp:mockwebserver:2.7.5'
-    androidTestImplementation 'com.squareup.okio:okio:1.13.0'
+    androidTestImplementation 'com.squareup.okio:okio:1.14.0'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     }

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'io.fabric.tools:gradle:1.+'
+        classpath 'io.fabric.tools:gradle:1.27.0'
         classpath 'com.google.gms:google-services:3.2.0'
     }
 }

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -250,18 +250,6 @@ configurations.all {
     exclude group: 'org.wordpress', module: 'analytics'
 }
 
-task copyGoogleServicesExampleFile(type: Copy) {
-    from('.')
-    into('.')
-    include('google-services.json-example')
-    rename('google-services.json-example', 'google-services.json')
-}
-
-task copyGoogleServicesBuddybuildFile(type: Copy) {
-    from(file(System.getenv("BUDDYBUILD_SECURE_FILES") + "/google-services.json"))
-    into('.')
-}
-
 task generateCrashlyticsConfig(group: "generate", description: "Generate Crashlytics config") {
     def outputFile = new File("${rootDir}/WordPress/crashlytics.properties")
     def inputFile = checkGradlePropertiesFile()
@@ -300,11 +288,11 @@ android.buildTypes.all { buildType ->
     // If Google services file doesn't exist...
     if (!file("google-services.json").exists()) {
         // ... copy example file.
-        if (!file(System.getenv("BUDDYBUILD_SECURE_FILES") + "/google-services.json").exists()) {
-            tasks.copyGoogleServicesExampleFile.execute()
-        // ... copy Buddybuild file.
-        } else {
-            tasks.copyGoogleServicesBuddybuildFile.execute()
+        copy {
+            from(".")
+            into(".")
+            include("google-services.json-example")
+            rename('google-services.json-example', 'google-services.json')
         }
     }
 
@@ -317,11 +305,7 @@ android.buildTypes.all { buildType ->
 def checkGradlePropertiesFile() {
     def inputFile = file("${rootDir}/gradle.properties")
     if (!inputFile.exists()) {
-        // Try the BuddyBuild provided file if it's there
-        inputFile = file(System.getenv("BUDDYBUILD_SECURE_FILES") + "/gradle.properties")
-        if (!inputFile.exists()) {
-            throw new StopActionException("Build configuration file gradle.properties doesn't exist, follow README instructions")
-        }
+        throw new StopActionException("Build configuration file gradle.properties doesn't exist, follow README instructions")
     }
     return inputFile
 }

--- a/WordPress/lint-baseline.xml
+++ b/WordPress/lint-baseline.xml
@@ -2,28 +2,6 @@
 <issues format="4" by="lint 3.1.3">
 
     <issue
-        id="DefaultLocale"
-        message="Implicitly using the default locale is a common source of bugs: Use `toUpperCase(Locale)` instead. For strings meant to be internal use `Locale.ROOT`, otherwise `Locale.getDefault()`."
-        errorLine1="            matched.appendReplacement(sb, matched.group(1).toUpperCase());"
-        errorLine2="                                                           ~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/horcrux/svg/RenderableShadowNode.java"
-            line="400"
-            column="60"/>
-    </issue>
-
-    <issue
-        id="WrongCall"
-        message="Suspicious method call; should probably call &quot;`layout`&quot; rather than &quot;`onLayout`&quot;"
-        errorLine1="                    onLayout(false, getLeft(), getTop(), getRight(), getBottom());"
-        errorLine2="                    ~~~~~~~~">
-        <location
-            file="src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollView.java"
-            line="364"
-            column="21"/>
-    </issue>
-
-    <issue
         id="ClickableViewAccessibility"
         message="Custom view ``EditTextWithKeyBackListener`` has `setOnTouchListener` called on it but does not override `performClick`"
         errorLine1="        mTitle.setOnTouchListener(this);"
@@ -193,30 +171,14 @@
     </issue>
 
     <issue
-        id="ManifestOrder"
-        severity="Warning"
-        message="`&lt;uses-permission>` tag appears after `&lt;application>` tag"
-        category="Correctness"
-        priority="5"
-        summary="Incorrect order of elements in manifest"
-        explanation="The &lt;application> tag should appear after the elements which declare which version you need, which features you need, which libraries you need, and so on. In the past there have been subtle bugs (such as themes not getting applied correctly) when the `&lt;application>` tag appears before some of these other elements, so it&apos;s best to order your manifest in the logical dependency order."
-        errorLine1="    &lt;uses-permission android:name=&quot;android.permission.DISABLE_KEYGUARD&quot;/>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="../WordPress/src/debug/AndroidManifest.xml"
-            line="18"
-            column="5"/>
-    </issue>
-
-    <issue
         id="GradleDependency"
         severity="Warning"
-        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1"
+        message="A newer version of com.android.tools.build:gradle than 3.2.1 is available: 3.3.0"
         category="Correctness"
         priority="4"
         summary="Obsolete Gradle Dependency"
         explanation="This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find."
-        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.1.2&apos;"
+        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.2.1&apos;"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
         quickfix="studio">
         <location
@@ -228,12 +190,12 @@
     <issue
         id="GradleDependency"
         severity="Warning"
-        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1"
+        message="A newer version of com.android.tools.build:gradle than 3.2.1 is available: 3.3.0"
         category="Correctness"
         priority="4"
         summary="Obsolete Gradle Dependency"
         explanation="This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find."
-        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.1.2&apos;"
+        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.2.1&apos;"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
         quickfix="studio">
         <location
@@ -245,12 +207,12 @@
     <issue
         id="GradleDependency"
         severity="Warning"
-        message="A newer version of com.android.tools.build:gradle than 3.1.2 is available: 3.2.1"
+        message="A newer version of com.android.tools.build:gradle than 3.2.1 is available: 3.3.0"
         category="Correctness"
         priority="4"
         summary="Obsolete Gradle Dependency"
         explanation="This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find."
-        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.1.2&apos;"
+        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.2.1&apos;"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
         quickfix="studio">
         <location
@@ -262,12 +224,12 @@
     <issue
         id="GradleDependency"
         severity="Warning"
-        message="A newer version of com.android.tools.build:gradle than 3.1.3 is available: 3.2.1"
+        message="A newer version of com.android.tools.build:gradle than 3.2.1 is available: 3.3.0"
         category="Correctness"
         priority="4"
         summary="Obsolete Gradle Dependency"
         explanation="This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find."
-        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.1.3&apos;"
+        errorLine1="        classpath &apos;com.android.tools.build:gradle:3.2.1&apos;"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
         quickfix="studio">
         <location

--- a/WordPress/lint.xml
+++ b/WordPress/lint.xml
@@ -83,10 +83,6 @@
         <ignore regexp="java-common-1.13.jar" />
     </issue>
 
-    <issue id="IconLauncherFormat">
-        <ignore path="src/main/res/mipmap-anydpi-v26/app_icon.xml" />
-    </issue>
-
     <issue id="UnusedResources" severity="error">
         <ignore path="**/WordPressEditor/**" />
         <ignore path="**/WordPressLoginFlow/**" />

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/service/InstallationReferrerServiceLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/service/InstallationReferrerServiceLogic.java
@@ -104,6 +104,10 @@ public class InstallationReferrerServiceLogic {
                         // if this is retried but the error persists
                         AppLog.i(T.UTILS, "installation referrer: service unavailable");
                         break;
+                    case InstallReferrerResponse.DEVELOPER_ERROR:
+                        break;
+                    case InstallReferrerResponse.SERVICE_DISCONNECTED:
+                        break;
                 }
 
                 stopService();

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1395,7 +1395,7 @@
     <!-- Error Messages -->
     <!-- The following messages can\'t be factorized due to i18n -->
     <string name="error_refresh_posts">Posts couldn\'t be refreshed at this time</string>
-    <string name="error_refresh_pages">Pages couldn\'t be refreshed at this time</string>
+    <string name="error_refresh_pages" tools:ignore="UnusedResources">Pages couldn\'t be refreshed at this time</string>
     <string name="error_refresh_comments">Comments couldn\'t be refreshed at this time</string>
     <string name="error_refresh_comments_showing_older">Comments couldn\'t be refreshed at this time - showing older comments</string>
     <string name="error_refresh_stats">Stats couldn\'t be refreshed at this time</string>

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.automattic.android:fetchstyle:1.1'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 28 12:21:02 CEST 2018
+#Tue Jan 22 14:59:58 GMT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip

--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.novoda:bintray-release:0.8.1'
     }
 }
@@ -27,7 +27,7 @@ dependencies {
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         versionName "1.3.0"

--- a/libs/editor/.travis.yml
+++ b/libs/editor/.travis.yml
@@ -7,7 +7,7 @@ android:
     - extra-android-support
     - platform-tools
     - tools
-    - build-tools-27.0.3
+    - build-tools-28.0.3
     - android-27
 
 env:

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
@@ -26,7 +26,7 @@ apply from: 'https://gist.githubusercontent.com/hypest/f526fe0775dedce0ce0133f14
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         versionCode 13
@@ -66,12 +66,14 @@ dependencies {
     if (rootProject.ext.buildGutenbergFromSource) {
         implementation (project(':react-native-gutenberg-bridge')) {
             exclude group: 'com.squareup.okhttp3'
+            exclude group: 'com.google.code.findbugs'
         }
     } else {
         implementation (waitJitpack('com.github.wordpress-mobile', 'gutenberg-mobile', submoduleGitHash('../../../', 'libs/gutenberg-mobile'))) {
             // Inheriting RN's okhttp version can interfere with FluxC SSL handling
             // See https://github.com/wordpress-mobile/WordPress-Android/issues/9032 and https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/919
             exclude group: 'com.squareup.okhttp3'
+            exclude group: 'com.google.code.findbugs'
         }
     }
 

--- a/libs/editor/example/build.gradle
+++ b/libs/editor/example/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 

--- a/libs/login/.travis.yml
+++ b/libs/login/.travis.yml
@@ -7,7 +7,7 @@ android:
     - extra-android-support
     - platform-tools
     - tools
-    - build-tools-27.0.3
+    - build-tools-28.0.3
     - android-27
 
 env:

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
@@ -18,7 +18,7 @@ repositories {
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
@@ -19,7 +19,7 @@ apply plugin: 'maven'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 14

--- a/libs/utils/.travis.yml
+++ b/libs/utils/.travis.yml
@@ -7,7 +7,7 @@ android:
     - extra-android-support
     - platform-tools
     - tools
-    - build-tools-27.0.3
+    - build-tools-28.0.3
     - android-27
 
 env:

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.novoda:bintray-release:0.8.1'
     }
 }
@@ -31,7 +31,7 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         versionName "1.22"


### PR DESCRIPTION
This updates Gradle and the Android Gradle plugin to much more recent versions. These are not quite the latest (newest plugin is 3.3.0) but its a big improvement. We can't yet update to 3.3.0 of the Gradle plugin due to an incompatibility with the Fabric Gradle plugin (see https://github.com/woocommerce/woocommerce-android/issues/694). 3.3.0 is required to update to Gradle 5.

There have been many improvements since Gradle 4.4 including better performance and improved caching. This should also help build reliability (related to https://github.com/wordpress-mobile/WordPress-Android/pull/9075).

Gradle release notes are [here](https://docs.gradle.org/4.10.3/release-notes.html).
Android Gradle plugin release notes are [here](https://developer.android.com/studio/releases/gradle-plugin#3-2-0).

I will wait until after the 11.7 code freeze to merge this to reduce any risk this brings.

To test:

- See CI is green.
- Build and run the app.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
