### PR TITLE
[Site Creation] Only show mobile segments

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModel.kt
@@ -121,7 +121,8 @@ class NewSiteCreationSegmentsViewModel
             )
         } else {
             tracker.trackSegmentsViewed()
-            updateUiStateToContent(ListState.Success(event.segmentList))
+            val segments = event.segmentList.filter { it.isMobileSegment }
+            updateUiStateToContent(ListState.Success(segments))
         }
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2294,8 +2294,6 @@
     <string name="reader_avatar_desc">profile picture</string>
     <string name="reader_gallery_images_desc">image gallery</string>
 
-
-    <!-- Site Creation -->
     <string name="content_description_done">Done</string>
     <string name="quick_start_button_negative" tools:ignore="UnusedResources">Not now</string>
     <string name="quick_start_button_negative_short" tools:ignore="UnusedResources">Cancel</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsViewModelTest.kt
@@ -46,20 +46,22 @@ private const val ERROR_MESSAGE = "dummy_error_message"
 
 private val FIRST_MODEL =
         VerticalSegmentModel(
-                FIRST_MODEL_TITLE,
-                FIRST_MODEL_SUBTITLE,
-                FIRST_MODEL_ICON_URL,
-                FIRST_MODEL_ICON_COLOR,
-                FIRST_MODEL_SEGMENT_ID
+                title = FIRST_MODEL_TITLE,
+                subtitle = FIRST_MODEL_SUBTITLE,
+                iconUrl = FIRST_MODEL_ICON_URL,
+                iconColor = FIRST_MODEL_ICON_COLOR,
+                segmentId = FIRST_MODEL_SEGMENT_ID,
+                isMobileSegment = true
         )
 
 private val SECOND_MODEL =
         VerticalSegmentModel(
-                SECOND_MODEL_TITLE,
-                SECOND_MODEL_SUBTITLE,
-                SECOND_MODEL_ICON_URL,
-                SECOND_MODEL_ICON_COLOR,
-                SECOND_MODEL_SEGMENT_ID
+                title = SECOND_MODEL_TITLE,
+                subtitle = SECOND_MODEL_SUBTITLE,
+                iconUrl = SECOND_MODEL_ICON_URL,
+                iconColor = SECOND_MODEL_ICON_COLOR,
+                segmentId = SECOND_MODEL_SEGMENT_ID,
+                isMobileSegment = true
         )
 
 private val PROGRESS_STATE = SegmentsContentUiState(listOf(HeaderUiState, ProgressUiState))

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -62,7 +62,7 @@ class PagesViewModelTest {
         viewModel.listState.observeForever { if (it != null) listStates.add(it) }
         viewModel.pages.observeForever { if (it != null) pages.add(it) }
         viewModel.searchPages.observeForever { if (it != null) searchPages.add(it) }
-        pageModel = PageModel(site, 1, "title", DRAFT, Date(), false, 1, null)
+        pageModel = PageModel(site, 1, "title", DRAFT, Date(), false, 1, null, 0)
         whenever(networkUtils.isNetworkAvailable()).thenReturn(true)
     }
 
@@ -107,7 +107,7 @@ class PagesViewModelTest {
     fun onSearchReturnsResultsFromStore() = test {
         initSearch()
         val query = "query"
-        val drafts = listOf(PageModel(site, 1, "title", DRAFT, Date(), false, 1, null))
+        val drafts = listOf(PageModel(site, 1, "title", DRAFT, Date(), false, 1, null, 0))
         val expectedResult = sortedMapOf(DRAFTS to drafts)
         whenever(pageStore.search(site, query)).thenReturn(drafts)
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
@@ -45,7 +45,7 @@ class SearchListViewModelTest {
 
     @Before
     fun setUp() {
-        page = PageModel(site, 1, "title", PUBLISHED, Date(), false, 11L, null)
+        page = PageModel(site, 1, "title", PUBLISHED, Date(), false, 11L, null, 0)
         viewModel = SearchListViewModel(resourceProvider, TEST_SCOPE)
         searchPages = MutableLiveData()
         whenever(pagesViewModel.searchPages).thenReturn(searchPages)

--- a/build.gradle
+++ b/build.gradle
@@ -92,5 +92,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '0b78142d158b06f3017807d0395d39bbc65ed88e'
+    fluxCVersion = 'b5f72ff5a2e6657ea6cd5301e07d9c3bd42100e2'
 }


### PR DESCRIPTION
Fixes #8999. We want to filter out non-mobile segments we get from the server before showing them to the user. We added `isMobileSegment` property to `VerticalSegmentModel` in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1089 and in this PR we are using that to filter out the results.

I've also addressed [this comment](https://github.com/wordpress-mobile/WordPress-Android/pull/9048#discussion_r249897249) by removing the unnecessary "Site Creation" comment from the `strings` resource.

To test:
* Go to Site Picker, tap on the + menu button and select "Create WordPress.com Site"
* Verify that `Online Store` is not in the list of segments since it's not a mobile segment. _This can be verified with this endpoint: https://public-api.wordpress.com/wpcom/v2/segments_

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
