### PR TITLE
Avoid using content resolver to get valid mime type, instead use UrlU…

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -120,7 +120,7 @@ public class FluxCUtils {
         String fileExtension = org.wordpress.android.fluxc.utils.MediaUtils.getExtension(path);
 
         if (TextUtils.isEmpty(mimeType)) {
-            mimeType = context.getContentResolver().getType(uri);
+            mimeType = UrlUtils.getUrlMimeType(uri.toString());
             if (mimeType == null) {
                 mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension);
                 if (mimeType == null) {


### PR DESCRIPTION
Based on this [PR](https://github.com/wordpress-mobile/WordPress-Android/pull/9043) and following @daniloercoli [suggestion](https://github.com/wordpress-mobile/WordPress-Android/pull/9043#issuecomment-456485554) we have removed the logic for getting mime type from content provider and added the logic which will provide us the mime type on other way.

### Test

There is no clear scenario, so we should test everything that has something with Image operations. 