### PR TITLE
CircleCI: Use explicit Gradle options to prevent out of memory errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,10 @@ android_config: &android_config
   docker:
     - image: circleci/android:api-27-alpha
   environment:
-    GRADLE: "./gradlew --build-cache --stacktrace -PdisablePreDex -PjavaMaxHeapSize=2g"
+    # kotlin.incremental=false and kotlin.compiler.execution.strategy=in-process are required due to an issue with the Kotlin compiler in
+    # memory constrained environments: https://youtrack.jetbrains.com/issue/KT-15562
+    GRADLE_OPTS: -Xmx1536m -XX:+HeapDumpOnOutOfMemoryError -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false
+    GRADLEW: "./gradlew --stacktrace --no-parallel --build-cache --configure-on-demand -PdisablePreDex -PjavaMaxHeapSize=1536m"
 
 copy_gradle_properties: &copy_gradle_properties
   run:
@@ -26,7 +29,7 @@ jobs:
           command: ./tools/validate-login-strings.sh
       - run:
           name: Test
-          command: $GRADLE testVanillaRelease
+          command: $GRADLEW testVanillaRelease
       - save_cache:
           paths:
             - ~/.gradle
@@ -45,13 +48,13 @@ jobs:
       - <<: *copy_gradle_properties
       - run:
           name: Checkstyle
-          command: $GRADLE checkstyle
+          command: $GRADLEW checkstyle
       - run:
           name: ktlint
-          command: $GRADLE ktlint
+          command: $GRADLEW ktlint
       - run:
           name: Lint
-          command: $GRADLE lintVanillaRelease || (grep -A20 -B2 'severity="Error"' -r --include="*.xml" WordPress libs; exit 1)
+          command: $GRADLEW lintVanillaRelease || (grep -A20 -B2 'severity="Error"' -r --include="*.xml" WordPress libs; exit 1)
       - save_cache:
           paths:
             - ~/.gradle


### PR DESCRIPTION
Although CircleCI is pretty stable, there have been occasional failures (e.g. here and here) caused by out of memory errors.

This adds some explicit options to keep Gradle under control when running on CircleCI. It includes a workaround for a Kotlin compiler crash (https://youtrack.jetbrains.com/issue/KT-15562).

Its possible the memory config is a bit conservative (only 1.5GB) but I would rather have it stable and increase from there to get better performance.

To test:

- See that CircleCI is green on this PR. We will only get true confidence in this if it proves to be robust over time.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
