### PR TITLE
Call setContent for empty posts for GB, so RN gets initialized

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2211,7 +2211,9 @@ public class EditPostActivity extends AppCompatActivity implements
 
         // Set post title and content
         if (mPost != null) {
-            if (!TextUtils.isEmpty(mPost.getContent()) && !mHasSetPostContent) {
+            // don't avoid calling setContent() for GutenbergEditorFragment so RN gets initialized
+            if ((!TextUtils.isEmpty(mPost.getContent()) || mEditorFragment instanceof GutenbergEditorFragment)
+                && !mHasSetPostContent) {
                 mHasSetPostContent = true;
                 if (mPost.isLocalDraft() && !isModernEditor()) {
                     // TODO: Unnecessary for new editor, as all images are uploaded right away, even for local drafts


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/489

To test:
1. Start a new post in Gutenberg.
2. Enter a title but don’t tap in the post content area.
3. Tap the back button to exit the editor (and save the post as a draft).
4. Find the draft in the posts list and open it.
5. observe you have the default block and can start typing in it.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
