### PR TITLE
Passing converted Int mediaId

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -453,7 +453,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         if (URLUtil.isNetworkUrl(mediaUrl)) {
             mWPAndroidGlueCode.appendMediaFile(mediaUrl);
         } else {
-            mWPAndroidGlueCode.appendUploadMediaFile(String.valueOf(mediaFile.getId()), "file://" + mediaUrl);
+            mWPAndroidGlueCode.appendUploadMediaFile(mediaFile.getId(), "file://" + mediaUrl);
         }
     }
 
@@ -506,18 +506,19 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void onMediaUploadSucceeded(final String localMediaId, final MediaFile mediaFile) {
-        mWPAndroidGlueCode.mediaFileUploadSucceeded(localMediaId, mediaFile.getFileURL());
+        mWPAndroidGlueCode.mediaFileUploadSucceeded(Integer.valueOf(localMediaId), mediaFile.getFileURL(),
+                Integer.valueOf(mediaFile.getMediaId()));
     }
 
     @Override
     public void onMediaUploadProgress(final String localMediaId, final float progress) {
-        mWPAndroidGlueCode.mediaFileUploadProgress(localMediaId, progress);
+        mWPAndroidGlueCode.mediaFileUploadProgress(Integer.valueOf(localMediaId), progress);
     }
 
     @Override
     public void onMediaUploadFailed(final String localMediaId, final MediaType
             mediaType, final String errorMessage) {
-        mWPAndroidGlueCode.mediaFileUploadFailed(localMediaId);
+        mWPAndroidGlueCode.mediaFileUploadFailed(Integer.valueOf(localMediaId));
     }
 
     @Override


### PR DESCRIPTION
This PR just makes sure to pass the converted `int` for `mediaId`, and also makes sure to pass `mediaFile.getMedaId()` upon successful upload.

Related PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/491

To test:
1. put a breakpoint on `private void onUploadSuccess(MediaModel media) {` in EditPostActivity
2. start a GB post and upload an image
3. wait until it finishes
4. observe the breakpoint is reached, and look into the `media` parameter, it should have a `mediaId` set that is different from its local `id`. Follow down to the Glue code and observe it's being set correctly in https://github.com/wordpress-mobile/gutenberg-mobile/pull/491/files#diff-f2e1dfe800569dfb4ee4830f88779890R261

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
