### PR TITLE
Update DialogHolder to use UiString

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.posts.adapters.PostListAdapter
 import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.uploads.UploadUtils
+import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AccessibilityUtils
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.DisplayUtils
@@ -53,6 +54,7 @@ import javax.inject.Inject
 class PostListFragment : Fragment() {
     @Inject internal lateinit var imageManager: ImageManager
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject internal lateinit var uiHelpers: UiHelpers
     private lateinit var viewModel: PostListViewModel
 
     private var swipeToRefreshHelper: SwipeToRefreshHelper? = null
@@ -143,7 +145,8 @@ class PostListFragment : Fragment() {
             it?.let { snackbarHolder -> showSnackbar(snackbarHolder) }
         })
         viewModel.dialogAction.observe(this, Observer {
-            it?.show(nonNullActivity, requireNotNull(fragmentManager) { "FragmentManager can't be null at this point" })
+            val fragmentManager = requireNotNull(fragmentManager) { "FragmentManager can't be null at this point" }
+            it?.show(nonNullActivity, fragmentManager, uiHelpers)
         })
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/helpers/DialogHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/helpers/DialogHolder.kt
@@ -1,25 +1,28 @@
 package org.wordpress.android.viewmodel.helpers
 
 import android.content.Context
-import android.support.annotation.StringRes
 import android.support.v4.app.FragmentManager
 import org.wordpress.android.ui.posts.BasicFragmentDialog
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.ui.utils.UiString
 
 class DialogHolder(
-    val tag: String,
-    @StringRes val titleRes: Int,
-    @StringRes val messageRes: Int,
-    @StringRes val positiveButtonTextRes: Int,
-    @StringRes val negativeButtonTextRes: Int
+    private val tag: String,
+    private val title: UiString,
+    private val message: UiString,
+    private val positiveButton: UiString,
+    private val negativeButton: UiString
 ) {
-    fun show(context: Context, fragmentManager: FragmentManager) {
+    fun show(context: Context, fragmentManager: FragmentManager, uiHelpers: UiHelpers) {
         val dialog = BasicFragmentDialog()
-        dialog.initialize(tag,
-                context.getString(titleRes),
-                context.getString(messageRes),
-                context.getString(positiveButtonTextRes),
-                context.getString(negativeButtonTextRes),
-                null)
+        dialog.initialize(
+                tag = tag,
+                title = uiHelpers.getTextOfUiString(context, title),
+                message = uiHelpers.getTextOfUiString(context, message),
+                positiveButtonLabel = uiHelpers.getTextOfUiString(context, positiveButton),
+                negativeButtonLabel = uiHelpers.getTextOfUiString(context, negativeButton),
+                cancelButtonLabel = null
+        )
         dialog.show(fragmentManager, tag)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -15,6 +15,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
+import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
@@ -63,6 +64,7 @@ import org.wordpress.android.ui.reader.utils.ReaderImageScanner
 import org.wordpress.android.ui.uploads.PostEvents
 import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.uploads.VideoOptimizer
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.SiteUtils
@@ -294,10 +296,10 @@ class PostListViewModel @Inject constructor(
         }
         val dialogHolder = DialogHolder(
                 tag = CONFIRM_DELETE_POST_DIALOG_TAG,
-                titleRes = R.string.delete_post,
-                messageRes = messageRes,
-                positiveButtonTextRes = R.string.delete,
-                negativeButtonTextRes = R.string.cancel
+                title = UiStringRes(R.string.delete_post),
+                message = UiStringRes(messageRes),
+                positiveButton = UiStringRes(R.string.delete),
+                negativeButton = UiStringRes(R.string.cancel)
         )
         localPostIdForTrashDialog = post.id
         _dialogAction.postValue(dialogHolder)
@@ -313,10 +315,10 @@ class PostListViewModel @Inject constructor(
         }
         val dialogHolder = DialogHolder(
                 tag = CONFIRM_PUBLISH_POST_DIALOG_TAG,
-                titleRes = R.string.dialog_confirm_publish_title,
-                messageRes = R.string.dialog_confirm_publish_message_post,
-                positiveButtonTextRes = R.string.dialog_confirm_publish_yes,
-                negativeButtonTextRes = R.string.cancel
+                title = UiStringRes(R.string.dialog_confirm_publish_title),
+                message = UiStringRes(string.dialog_confirm_publish_message_post),
+                positiveButton = UiStringRes(R.string.dialog_confirm_publish_yes),
+                negativeButton = UiStringRes(R.string.cancel)
         )
         localPostIdForPublishDialog = post.id
         _dialogAction.postValue(dialogHolder)


### PR DESCRIPTION
This PR updates `DialogHolder` to use `UiString` instead of `StringRes Int` to make it easier and more structured to use either string resources and regular strings easily. It makes it so that each string is known to be either a resource or a regular string, but never both or never neither. Injected `UiHelpers` is passed in to increase testability of `DialogHolder` even though it currently doesn't have tests. (maybe an improvement for the future)

To test:
* Go to `Blog Posts`
* Create a draft (local or remote doesn't matter)
* Tap on the `Publish` button and verify the dialog shows up as expected (Title, message, button names are still correct)
* Cancel the dialog - We don't need to test the functionality of the dialog because this PR doesn't change it
* Tap on the `Trash` button and verify the dialog shows up as expected (Title, message, button names are still correct)
* Cancel the dialog - We don't need to test the functionality of the dialog because this PR doesn't change it

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
