### PR TITLE
Issue/8648 update checklist notification

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -41,6 +41,7 @@ import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
 import org.wordpress.android.fluxc.store.QuickStartStore;
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartPayload;
 import org.wordpress.android.fluxc.store.SiteStore.OnQuickStartCompleted;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
@@ -104,6 +105,7 @@ import javax.inject.Inject;
 import de.greenrobot.event.EventBus;
 
 import static org.wordpress.android.WordPress.SITE;
+import static org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartVariant.NEXT_STEPS;
 import static org.wordpress.android.ui.JetpackConnectionSource.NOTIFICATIONS;
 import static org.wordpress.android.ui.main.WPMainNavigationView.PAGE_ME;
 import static org.wordpress.android.ui.main.WPMainNavigationView.PAGE_MY_SITE;
@@ -524,7 +526,8 @@ public class WPMainActivity extends AppCompatActivity implements
         if (getSelectedSite() != null && NetworkUtils.isNetworkAvailable(this)
             && QuickStartUtils.isEveryQuickStartTaskDone(mQuickStartStore)
             && !mQuickStartStore.getQuickStartNotificationReceived(getSelectedSite().getId())) {
-            mDispatcher.dispatch(SiteActionBuilder.newCompleteQuickStartAction(getSelectedSite()));
+            CompleteQuickStartPayload payload = new CompleteQuickStartPayload(getSelectedSite(), NEXT_STEPS.toString());
+            mDispatcher.dispatch(SiteActionBuilder.newCompleteQuickStartAction(payload));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -29,6 +29,8 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.ENABLE_P
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.FOLLOW_SITE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.PUBLISH_POST
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.VIEW_SITE
+import org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartPayload
+import org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartVariant.NEXT_STEPS
 import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.themes.ThemeBrowserActivity
 
@@ -196,7 +198,8 @@ class QuickStartUtils {
 
             if (isEveryQuickStartTaskDone(quickStartStore)) {
                 AnalyticsTracker.track(Stat.QUICK_START_ALL_TASKS_COMPLETED)
-                dispatcher.dispatch(SiteActionBuilder.newCompleteQuickStartAction(site))
+                val payload = CompleteQuickStartPayload(site, NEXT_STEPS.toString())
+                dispatcher.dispatch(SiteActionBuilder.newCompleteQuickStartAction(payload))
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -83,5 +83,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '51c9ad2661cbbc6b103612629aba2c9934b8ea91'
+    fluxCVersion = '8dc2c32672ccca2e2ca3037757300cc866202896'
 }


### PR DESCRIPTION
### Fix
Update the notification when the ***Quick Start*** checklist is completed as described in https://github.com/wordpress-mobile/WordPress-Android/issues/8648.  See the screenshots below for illustration.

![v2_notifications_notification](https://user-images.githubusercontent.com/3827611/51643089-988c5f80-1f28-11e9-9dd9-533c664628d8.png)

### Test
0. Select site with Quick Start in progress.
1. Complete remaining Quick Start tasks.
2. Go to **_Notifications_** tab.
3. Notice notification as shown above.