### PR TITLE
Remove date selection when leaving stats to get rid of inconsistency

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -39,7 +39,7 @@ class StatsViewModel
     @Named(MONTH_STATS_USE_CASE) private val monthStatsUseCase: BaseListUseCase,
     @Named(YEAR_STATS_USE_CASE) private val yearStatsUseCase: BaseListUseCase,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
-    selectedDateProvider: SelectedDateProvider,
+    private val selectedDateProvider: SelectedDateProvider,
     private val statsSectionManager: SelectedSectionManager,
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) : ScopedViewModel(mainDispatcher) {
@@ -127,5 +127,10 @@ class StatsViewModel
             StatsSection.MONTHS -> analyticsTracker.track(STATS_PERIOD_MONTHS_ACCESSED)
             StatsSection.YEARS -> analyticsTracker.track(STATS_PERIOD_YEARS_ACCESSED)
         }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        selectedDateProvider.clear()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
@@ -3,10 +3,6 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.granular
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
-import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
-import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
-import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
-import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -14,21 +10,21 @@ import javax.inject.Singleton
 @Singleton
 class SelectedDateProvider
 @Inject constructor() {
-    private val mutableDates = mutableMapOf<StatsGranularity, Date?>(
-            DAYS to null,
-            WEEKS to null,
-            MONTHS to null,
-            YEARS to null
-    )
+    private val mutableDates = mutableMapOf<StatsGranularity, Date?>()
 
     private val mutableSelectedDateChanged = MutableLiveData<StatsGranularity>()
     val selectedDateChanged: LiveData<StatsGranularity> = mutableSelectedDateChanged
 
     fun selectDate(date: Date, statsGranularity: StatsGranularity) {
-        mutableDates[statsGranularity] = date
-        mutableSelectedDateChanged.value = statsGranularity
+        if (mutableDates[statsGranularity] != date) {
+            mutableDates[statsGranularity] = date
+            mutableSelectedDateChanged.value = statsGranularity
+        }
     }
 
     fun getSelectedDate(statsGranularity: StatsGranularity) = mutableDates[statsGranularity]
     fun getCurrentDate() = Date()
+    fun clear() {
+        mutableDates.clear()
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
@@ -79,12 +79,10 @@ constructor(
         val items = mutableListOf<BlockListItem>()
         if (domainModel.dates.isNotEmpty()) {
             val selectedDate = uiState.selectedDate ?: domainModel.dates.last().period
-            if (selectedDateProvider.getSelectedDate(statsGranularity) == null) {
-                selectedDateProvider.selectDate(
-                        statsDateFormatter.parseStatsDate(statsGranularity, selectedDate),
-                        statsGranularity
-                )
-            }
+            selectedDateProvider.selectDate(
+                    statsDateFormatter.parseStatsDate(statsGranularity, selectedDate),
+                    statsGranularity
+            )
             val selectedItem = domainModel.dates.find { it.period == uiState.selectedDate }
                     ?: domainModel.dates.last()
             items.add(


### PR DESCRIPTION
Fixes #9088 
This PR makes sure of 2 things. One is that the date selected in the `Overview` block is always set in the `SelectedDateProvider` and the other one is that leaving the Stats clears the selected date.

To test:
* Go to Stats/Days
* Select a date
* Blocks get updated
* Leave Stats
* Go back to Stats
* The last column in the Overview block is selected and the correct data is loaded

