### PR TITLE
Make Stats Header 32dp high

### DIFF
--- a/WordPress/src/main/res/layout/stats_block_header_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_header_item.xml
@@ -5,7 +5,7 @@
               android:paddingStart="@dimen/margin_extra_large"
               android:paddingEnd="@dimen/margin_extra_large"
               android:layout_width="match_parent"
-              android:layout_height="@dimen/page_list_divider_height"
+              android:layout_height="@dimen/stats_header_height"
               android:orientation="horizontal">
 
     <TextView

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -346,8 +346,6 @@
     <dimen name="post_list_row_skeleton_view_excerpt_height">@dimen/margin_extra_medium_large</dimen>
     <dimen name="post_list_row_skeleton_view_date_width">80dp</dimen>
     <dimen name="post_list_row_skeleton_view_date_height">@dimen/margin_extra_large</dimen>
-    <dimen name="stats_bar_chart_height">180dp</dimen>
-    <dimen name="stats_block_icon_size">24dp</dimen>
 
     <!--site creation-->
     <dimen name="site_creation_segments_icon_size">24dp</dimen>
@@ -370,4 +368,9 @@
 
     <dimen name="new_site_creation_preview_skeleton_mid_size_width">174dp</dimen>
     <dimen name="new_site_creation_preview_skeleton_large_block_height">136dp</dimen>
+
+    <!-- stats -->
+    <dimen name="stats_header_height">32dp</dimen>
+    <dimen name="stats_bar_chart_height">180dp</dimen>
+    <dimen name="stats_block_icon_size">24dp</dimen>
 </resources>


### PR DESCRIPTION
Fixes #9064 
Change the Stats block header to be 32dp high instead of 40dp

![screenshot_1548321374](https://user-images.githubusercontent.com/1079756/51667851-316eb980-1fc1-11e9-9bf4-e40b05785797.png)

