### PR TITLE
Drop the vcs.xml exclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ local.properties
 /.idea/*
 
 # IntelliJ/Android Studio exceptions
-!/.idea/vcs.xml
 !/.idea/codeStyles/
 !/.idea/fileTemplates/
 !/.idea/inspectionProfiles/


### PR DESCRIPTION
The file gets touched by AndroidStudio when doing gutenberg development and that's annoying. The non-gb developers don't checkout the gutenberg-mobile code so the file stays untouched in those cases anyway. Removing the exclusion let's the file be ignored by git.

To test:
No particular test instructions other than any changes to the file wont be noted by git

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
