### PR TITLE
Restore broken lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -57,8 +57,8 @@ ENV[GHHELPER_REPO="wordpress-mobile/WordPress-Android"]
   lane :code_freeze do | options |
     old_version = android_codefreeze(options)
     
-    #setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{options[:codefreeze_version]}")
-    #setfrozentag(repository:GHHELPER_REPO, milestone: options[:codefreeze_version])
+    setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{options[:codefreeze_version]}")
+    setfrozentag(repository:GHHELPER_REPO, milestone: options[:codefreeze_version])
 
     get_prs_list(repository:GHHELPER_REPO, start_tag:"#{old_version}", report_path:"#{File.expand_path('~')}/wpandroid_prs_list_#{old_version}_#{options[:codefreeze_version]}.txt")
   end


### PR DESCRIPTION
This PR reverts https://github.com/wordpress-mobile/WordPress-Android/commit/b9e96eff39baa93f35c76d07024a9027e6ad8dbe#diff-56c5021ef06ac6cea807ae53269b6f4f because, given the commit message, I guess it was pushed by mistake. 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
