### PR TITLE
PostUploader service: moved initialization of helper classes to onCreate()

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -87,6 +87,18 @@ public class UploadService extends Service {
         mDispatcher.register(this);
         sInstance = this;
         // TODO: Recover any posts/media uploads that were interrupted by the service being stopped
+
+        if (mMediaUploadHandler == null) {
+            mMediaUploadHandler = new MediaUploadHandler();
+        }
+
+        if (mPostUploadNotifier == null) {
+            mPostUploadNotifier = new PostUploadNotifier(getApplicationContext(), this);
+        }
+
+        if (mPostUploadHandler == null) {
+            mPostUploadHandler = new PostUploadHandler(mPostUploadNotifier);
+        }
     }
 
     @Override
@@ -126,18 +138,6 @@ public class UploadService extends Service {
             AppLog.e(T.MAIN, "UploadService > Killed and restarted with an empty intent");
             stopServiceIfUploadsComplete();
             return START_NOT_STICKY;
-        }
-
-        if (mMediaUploadHandler == null) {
-            mMediaUploadHandler = new MediaUploadHandler();
-        }
-
-        if (mPostUploadNotifier == null) {
-            mPostUploadNotifier = new PostUploadNotifier(getApplicationContext(), this);
-        }
-
-        if (mPostUploadHandler == null) {
-            mPostUploadHandler = new PostUploadHandler(mPostUploadNotifier);
         }
 
         if (intent.hasExtra(KEY_MEDIA_LIST)) {


### PR DESCRIPTION
This PR moved the creation of helper classes `MediaUploadHandler`, `PostUploadNotifier` and `PostUploadHandler` into `onCreate()` as the Service can be created and destroyed even prior to ever receiving an `onStartCommand` signal from another component.

This should fix the following reported crash

```
2019-01-23 22:51:25.430 15055-15055/org.wordpress.android.beta E/AndroidRuntime: FATAL EXCEPTION: main
    Process: org.wordpress.android.beta, PID: 15055
    java.lang.RuntimeException: Unable to stop service org.wordpress.android.ui.uploads.UploadService@5a432bb: java.lang.NullPointerException: Attempt to invoke virtual method 'void org.wordpress.android.ui.uploads.PostUploadHandler.upload(org.wordpress.android.fluxc.model.PostModel)' on a null object reference
        at android.app.ActivityThread.handleStopService(ActivityThread.java:3522)
        at android.app.ActivityThread.-wrap26(Unknown Source:0)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1697)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:164)
        at android.app.ActivityThread.main(ActivityThread.java:6494)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
     Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void org.wordpress.android.ui.uploads.PostUploadHandler.upload(org.wordpress.android.fluxc.model.PostModel)' on a null object reference
        at org.wordpress.android.ui.uploads.UploadService.doFinalProcessingOfPosts(UploadService.java:915)
        at org.wordpress.android.ui.uploads.UploadService.onDestroy(UploadService.java:105)
        at android.app.ActivityThread.handleStopService(ActivityThread.java:3504)

```


To test:
1. start a draft, put an image in it
2. right when it's about to be done uploading, exit the editor.
3. should not crash
Bonus: use the app normally

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
