### PR TITLE
Fix bug in NewSiteCreationService - service started multiple times

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/NewSiteCreationService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/NewSiteCreationService.kt
@@ -111,17 +111,22 @@ class NewSiteCreationService : AutoForeground<NewSiteCreationServiceState>(NewSi
             retryFromState: NewSiteCreationServiceState?,
             data: NewSiteCreationServiceData
         ) {
-            clearSiteCreationServiceState()
+            val currentState = AutoForeground.getState(NewSiteCreationServiceState::class.java)
+            if (currentState == null || currentState.step == FAILURE) {
+                clearSiteCreationServiceState()
 
-            val intent = Intent(context, NewSiteCreationService::class.java)
+                val intent = Intent(context, NewSiteCreationService::class.java)
 
-            intent.putExtra(ARG_DATA, data)
+                intent.putExtra(ARG_DATA, data)
 
-            if (retryFromState != null) {
-                intent.putExtra(ARG_RESUME_PHASE, retryFromState.stepName)
+                if (retryFromState != null) {
+                    intent.putExtra(ARG_RESUME_PHASE, retryFromState.stepName)
+                }
+
+                context.startService(intent)
+            } else {
+                AppLog.w(T.SITE_CREATION, "Service not started - it seems it's already running.")
             }
-
-            context.startService(intent)
         }
 
         fun clearSiteCreationServiceState() {


### PR DESCRIPTION
Fixes #9081 

The service is started multiple times, which results in an exception `Create site request has already been sent`.

To test:
- set "don't keep activities" in the developer settings
1. My Site
2. Switch Site
3. Plus sign icon
4. Create WordPress.com site
5. Select segment
6. Skip
7. Skip
8. Select a domain and click on Create Site
9. Press the home button
10. Go back to the app
11. Make sure the fullscreen error is **not** shown and the site is eventually created

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
