### PR TITLE
Suggestions for the Post Conflict Resolution PR: 8989

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -429,7 +429,6 @@ class PostListViewModel @Inject constructor(
             }
         }
         val onDismissAction = {
-            localPostIdForConflictResolutionDialog = null
             originalPostCopyForConflictUndo = null
         }
         val snackbarHolder = SnackbarMessageHolder(R.string.snackbar_conflict_local_version_discarded,
@@ -655,6 +654,7 @@ class PostListViewModel @Inject constructor(
                 publishPost(it)
             }
             CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG -> localPostIdForConflictResolutionDialog?.let {
+                localPostIdForConflictResolutionDialog = null
                 // here load version from remote
                 updateConflictedPostWithItsRemoteVersion(it)
             }
@@ -736,8 +736,6 @@ class PostListViewModel @Inject constructor(
             originalPostCopyForConflictUndo = post.clone()
             dispatcher.dispatch(PostActionBuilder.newFetchPostAction(RemotePostPayload(post, site)))
             _toastMessage.postValue(ToastMessageHolder(R.string.toast_conflict_updating_post, Duration.SHORT))
-        } else {
-            localPostIdForConflictResolutionDialog = null
         }
     }
 
@@ -746,8 +744,6 @@ class PostListViewModel @Inject constructor(
         if (!checkNetworkConnection()) {
             return
         }
-
-        localPostIdForConflictResolutionDialog = null
 
         // Keep a reference to which post is being updated with the local version so we can avoid showing the conflicted
         // label during the undo snackbar.


### PR DESCRIPTION
This PR implements a few suggestions for the #8989. I thought this would be the fastest way to talk about these changes since the code freeze is tomorrow. Here are my suggestions:

1. One concern I had is that we were dispatching an action to update the post from WPAndroid. Directly manipulating the post like this is something I'd like to avoid if possible especially for a flag that's specific to remote. I think there is a simpler way to achieve this by just not showing the conflicted label when we are keeping the local version of the post and waiting for the undo. We also need to check for this when we are showing the dialog, but I think it's still pretty simple. This change has been implemented in fdde7d290fffeaa55b4e6a9034324a4ba39603e4.
2. I've brought up nullyfing a reference for the conflict resolution dialog earlier than it was done in #8989. There was a concern about the undo not working as expected in that case, but I was able to handle that issue in this PR, so b65e8513702c5bf18d9bfa5cb7242f7064aefed2 implements this change. The undo logic has changed in the other two commits, so it's not a problem anymore.
3. I wasn't too comfortable with us having to check for whether we downloaded the remote version of the conflicted post in the `createPostAdapterItem`. That method takes a very long journey in FluxC and it really should be doing one thing and one thing alone. I think it'd be better to check for this in `onPostChanged` which will make it both more efficient and a more logical place. This change and a very small refactor has been implemented in 9f64fa746241fcec082fd078c43726358c0df8da.

**To test:**
The testing steps for this PR is the same as #8989. Make sure to create a conflicted post, tap to open the post and verify the dialog is shown. Try both keeping the local and remote versions of the post and verify the undo works as expected for each of them.

_P.S: There are still some edge cases this conflict resolution will fail, they are mostly related to `undo` but there are some other ones as well. These are very hard to solve and we already have some of them for other `undo` features as well, so I don't think it'd be very productive to try and address them. I am hoping to bring up a different way to handle these undo stuff in a later project 🤞_ 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
