### PR TITLE
Bump tracks version to 1.1.5

### DIFF
--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.automattic:tracks:1.1.4'
+    implementation 'com.automattic:tracks:1.1.5'
     implementation 'org.wordpress:utils:1.19.0'
 
     lintChecks 'org.wordpress:lint:1.0.1'


### PR DESCRIPTION
Fixes #9109 

Update Tracks version to 1.1.5 -> all events contain "device_orientation" property.

To test:
- I think successful build is enough. However, if you want to be 100%, double-check the device_orientation property is being sent.

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
