### PR TITLE
Add placeholder to segments icon

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentViewHolder.kt
@@ -44,11 +44,15 @@ sealed class NewSiteCreationSegmentViewHolder(internal val parent: ViewGroup, @L
                     object : RequestListener<Drawable> {
                         override fun onLoadFailed(e: Exception?) {
                         }
+
                         override fun onResourceReady(resource: Drawable) {
                             try {
                                 icon.setColorFilter(Color.parseColor(uiState.iconColor), PorterDuff.Mode.SRC_IN)
                             } catch (e: IllegalArgumentException) {
-                                AppLog.e(AppLog.T.SITE_CREATION, "Error parsing segment icon color: ${uiState.iconColor}")
+                                AppLog.e(
+                                        AppLog.T.SITE_CREATION,
+                                        "Error parsing segment icon color: ${uiState.iconColor}"
+                                )
                             }
                         }
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentViewHolder.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.sitecreation.segments
 
 import android.graphics.Color
 import android.graphics.PorterDuff
+import android.graphics.drawable.Drawable
 import android.support.annotation.LayoutRes
 import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
@@ -14,7 +15,8 @@ import org.wordpress.android.ui.sitecreation.segments.SegmentsItemUiState.Header
 import org.wordpress.android.ui.sitecreation.segments.SegmentsItemUiState.SegmentUiState
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.image.ImageManager
-import org.wordpress.android.util.image.ImageType.IMAGE
+import org.wordpress.android.util.image.ImageManager.RequestListener
+import org.wordpress.android.util.image.ImageType.ICON
 
 sealed class NewSiteCreationSegmentViewHolder(internal val parent: ViewGroup, @LayoutRes layout: Int) :
         RecyclerView.ViewHolder(LayoutInflater.from(parent.context).inflate(layout, parent, false)) {
@@ -34,16 +36,23 @@ sealed class NewSiteCreationSegmentViewHolder(internal val parent: ViewGroup, @L
             uiState as SegmentUiState
             title.text = uiState.title
             subtitle.text = uiState.subtitle
-            imageManager.load(icon, IMAGE, uiState.iconUrl)
-            // TODO: Check with designers on how to handle icon url or color missing, this is only temporary
-            // TODO: https://github.com/wordpress-mobile/WordPress-Android/issues/8864
-            val blackColor = "#000000"
-            val iconColor = if (uiState.iconColor.isNotBlank()) uiState.iconColor else blackColor
-            try {
-                icon.setColorFilter(Color.parseColor(iconColor), PorterDuff.Mode.SRC_IN)
-            } catch (e: IllegalArgumentException) {
-                AppLog.e(AppLog.T.SITE_CREATION, "Error parsing segment icon color: ${uiState.iconColor}")
-            }
+            imageManager.loadWithResultListener(
+                    icon,
+                    ICON,
+                    uiState.iconUrl,
+                    null,
+                    object : RequestListener<Drawable> {
+                        override fun onLoadFailed(e: Exception?) {
+                        }
+                        override fun onResourceReady(resource: Drawable) {
+                            try {
+                                icon.setColorFilter(Color.parseColor(uiState.iconColor), PorterDuff.Mode.SRC_IN)
+                            } catch (e: IllegalArgumentException) {
+                                AppLog.e(AppLog.T.SITE_CREATION, "Error parsing segment icon color: ${uiState.iconColor}")
+                            }
+                        }
+                    }
+            )
             requireNotNull(uiState.onItemTapped) { "OnItemTapped is required." }
             container.setOnClickListener {
                 uiState.onItemTapped!!.invoke()

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
@@ -19,6 +19,7 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.THEME -> R.color.grey_lighten_30
             ImageType.UNKNOWN -> R.drawable.ic_notice_grey_500_48dp
             ImageType.VIDEO -> R.color.grey_lighten_30
+            ImageType.ICON -> R.color.grey_lighten_30
         }
     }
 
@@ -35,6 +36,7 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.THEME -> R.drawable.theme_loading
             ImageType.UNKNOWN -> R.drawable.legacy_dashicon_format_image_big_grey
             ImageType.VIDEO -> R.color.grey_light
+            ImageType.ICON -> R.color.grey_light
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
@@ -19,7 +19,7 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.THEME -> R.color.grey_lighten_30
             ImageType.UNKNOWN -> R.drawable.ic_notice_grey_500_48dp
             ImageType.VIDEO -> R.color.grey_lighten_30
-            ImageType.ICON -> R.color.grey_lighten_30
+            ImageType.ICON -> R.drawable.bg_grey_lighten_30_with_radius
         }
     }
 
@@ -36,7 +36,7 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.THEME -> R.drawable.theme_loading
             ImageType.UNKNOWN -> R.drawable.legacy_dashicon_format_image_big_grey
             ImageType.VIDEO -> R.color.grey_light
-            ImageType.ICON -> R.color.grey_light
+            ImageType.ICON -> R.drawable.bg_grey_light_with_radius
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
@@ -16,5 +16,6 @@ enum class ImageType {
     PLUGIN,
     THEME,
     UNKNOWN,
-    VIDEO
+    VIDEO,
+    ICON
 }

--- a/WordPress/src/main/res/drawable/bg_grey_light_with_radius.xml
+++ b/WordPress/src/main/res/drawable/bg_grey_light_with_radius.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/grey_light"/>
+    <corners android:radius="2dp"/>
+</shape>

--- a/WordPress/src/main/res/drawable/bg_grey_lighten_30_with_radius.xml
+++ b/WordPress/src/main/res/drawable/bg_grey_lighten_30_with_radius.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/grey_lighten_30"/>
+    <corners android:radius="2dp"/>
+</shape>


### PR DESCRIPTION
Fixes #9105 
Removes TODO #9079



Adds a grey placeholder to segment icons and removes the default color as the API shouldn't return an empty iconColor.

Since we need to tint the result image, but not the placeholder, we have to set the color filter after the result image is displayed. As you can see the solution isn't ideal. If we start using this approach on several places in the app we can create a custom ImageTarget with support for tinting.



To test:
- clear cache
- set eg. Edge connection on an Emulator
1. My Site
2. Plus sign icon
3. Create WordPress.com site
4. Notice the grey squares in place of the icons
5. Change the connection back to LTE/Full
6. Make sure the result icons are tinted

![screenshot_1548411012](https://user-images.githubusercontent.com/2261188/51740254-cb9f3200-2093-11e9-9060-fd1069370b6d.png)

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

cc @SylvesterWilmott 