### PR TITLE
Code Freeze: Use release branch instead of tag for get PR list

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -60,7 +60,7 @@ ENV[GHHELPER_REPO="wordpress-mobile/WordPress-Android"]
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{options[:codefreeze_version]}")
     setfrozentag(repository:GHHELPER_REPO, milestone: options[:codefreeze_version])
 
-    get_prs_list(repository:GHHELPER_REPO, start_tag:"#{old_version}", report_path:"#{File.expand_path('~')}/wpandroid_prs_list_#{old_version}_#{options[:codefreeze_version]}.txt")
+    get_prs_list(repository:GHHELPER_REPO, start_tag:"release/#{old_version}", report_path:"#{File.expand_path('~')}/wpandroid_prs_list_#{old_version}_#{options[:codefreeze_version]}.txt")
   end
 
 


### PR DESCRIPTION
Currently `bundle exec fastlane code_freeze codefreeze_version:11.7` can fail on `get_prs_list` because the `11.6` tag may not yet be set. In our typical release steps, we haven't set the tag at this point.

This is a small update to use the release branch for the previous version instead of the tag for comparison.

To test:

I'm not sure the best way to test this without touching the Github API for milestones etc. 🤔 Its quite a simple change though and it worked for the code freeze just now.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
