### PR TITLE
Remove outdated todos in new site creation flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
@@ -12,8 +12,8 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleEmpty
 import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleStepCount
-import org.wordpress.android.ui.sitecreation.previews.NewSitePreviewViewModel.CreateSiteState
 import org.wordpress.android.ui.sitecreation.misc.NewSiteCreationTracker
+import org.wordpress.android.ui.sitecreation.previews.NewSitePreviewViewModel.CreateSiteState
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
 import org.wordpress.android.util.wizard.WizardState
@@ -24,7 +24,6 @@ import javax.inject.Inject
 private const val KEY_CURRENT_STEP = "key_current_step"
 private const val KEY_SITE_CREATION_STATE = "key_site_creation_state"
 private val SITE_CREATION_STEPS =
-        // TODO we'll receive this from a server/Firebase config
         listOf(
                 SiteCreationStep.fromString("site_creation_segments"),
                 SiteCreationStep.fromString("site_creation_verticals"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
@@ -13,7 +13,6 @@ enum class SiteCreationStep : WizardStep {
                 "site_creation_site_info" -> SITE_INFO
                 "site_creation_domains" -> DOMAINS
                 "site_creation_site_preview" -> SITE_PREVIEW
-                // TODO we should consider skipping the step when it's unknown
                 else -> throw IllegalArgumentException("SiteCreationStep not recognized: \$input")
             }
         }


### PR DESCRIPTION
Fixes 2 todos from #9079

I've decided to remove these todos as we don't support dynamic wizard steps in v1 of the SiteCreation project. 

To test:
- there is no need to test anything

Note: Update TODOs in #9079 after merge. Thanks! 

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
