### PR TITLE
Fix todo in CreateSiteuseCaseTest

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/CreateSiteUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/CreateSiteUseCaseTest.kt
@@ -70,10 +70,9 @@ class CreateSiteUseCaseTest {
         val payload = captor.value.payload as NewSitePayload
         assertThat(payload.siteName).isEqualTo(DUMMY_SITE_DATA.domain)
         assertThat(payload.siteTitle).isEqualTo(DUMMY_SITE_DATA.siteTitle)
-        // TODO uncomment when the API is ready
-//        assertThat(payload.segmentId).isEqualTo(DUMMY_SITE_DATA.segmentId)
-//        assertThat(payload.verticalId).isEqualTo(DUMMY_SITE_DATA.verticalId)
-//        assertThat(payload.tagLine).isEqualTo(DUMMY_SITE_DATA.siteTagLine)
+        assertThat(payload.segmentId).isEqualTo(DUMMY_SITE_DATA.segmentId)
+        assertThat(payload.verticalId).isEqualTo(DUMMY_SITE_DATA.verticalId)
+        assertThat(payload.tagLine).isEqualTo(DUMMY_SITE_DATA.siteTagLine)
     }
 
     @Test


### PR DESCRIPTION
Fixes a todo from #9079 

Add test to check "segmentId, verticalId and siteTagLine" is correctly propagated to FluxC in CreateSiteUseCase.

To test:
- CI tests should be enough

Note: Update TODOs in #9079 after merge. Thanks!

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
