### PR TITLE
Revert "Implements the editor title in RN for Gutenberg"

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -10,6 +10,7 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.text.Editable;
 import android.text.Spanned;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -17,6 +18,7 @@ import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 
 import com.android.volley.toolbox.ImageLoader;
@@ -24,10 +26,12 @@ import com.android.volley.toolbox.ImageLoader;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.ProfilingUtils;
+import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.aztec.IHistoryListener;
+import org.wordpress.aztec.source.SourceViewEditText;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnGetContentTimeout;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnMediaLibraryButtonListener;
@@ -45,6 +49,9 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     private boolean mEditorWasPaused = false;
     private boolean mHideActionBarOnSoftKeyboardUp = false;
     private boolean mHtmlModeEnabled;
+
+    private EditTextWithKeyBackListener mTitle;
+    private SourceViewEditText mSource;
 
     private Handler mInvalidateOptionsHandler;
     private Runnable mInvalidateOptionsRunnable;
@@ -91,6 +98,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_gutenberg_editor, container, false);
 
+        mTitle = view.findViewById(R.id.title);
+
         if (getArguments() != null) {
             mIsNewPost = getArguments().getBoolean(ARG_IS_NEW_POST);
         }
@@ -107,11 +116,45 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                 BuildConfig.DEBUG,
                 BuildConfig.BUILD_GUTENBERG_FROM_SOURCE,
                 mIsNewPost);
+        mSource = view.findViewById(R.id.source);
+
+        mTitle.addTextChangedListener(mTextWatcher);
 
         // request dependency injection. Do this after setting min/max dimensions
         if (getActivity() instanceof EditorFragmentActivity) {
             ((EditorFragmentActivity) getActivity()).initializeEditorFragment();
         }
+
+        mTitle.setOnTouchListener(this);
+        mSource.setOnTouchListener(this);
+
+        mTitle.setOnImeBackListener(new OnImeBackListener() {
+            public void onImeBack() {
+                showActionBarIfNeeded();
+            }
+        });
+
+        mTitle.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                for (int i = s.length(); i > 0; i--) {
+                    if (s.subSequence(i - 1, i).toString().equals("\n")) {
+                        s.replace(i - 1, i, " ");
+                    }
+                }
+            }
+        });
+
+        // We need to intercept the "Enter" key on the title field, and replace it with a space instead
+        mSource.setHint("<p>" + getString(R.string.editor_content_hint) + "</p>");
 
         setHasOptionsMenu(true);
 
@@ -128,6 +171,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         mEditorFragmentListener.onEditorFragmentInitialized();
 
         if (mIsNewPost) {
+            mTitle.requestFocus();
             showImplicitKeyboard();
         }
 
@@ -140,6 +184,16 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         mEditorWasPaused = true;
 
         mWPAndroidGlueCode.onPause(getActivity());
+
+        // Reset soft input mode to default as we have change it in onResume()
+        setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN
+                | WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+    }
+
+    private void setSoftInputMode(int mode) {
+        if (mIsNewPost && mTitle.hasFocus()) {
+            getActivity().getWindow().setSoftInputMode(mode);
+        }
     }
 
     private void showImplicitKeyboard() {
@@ -161,6 +215,11 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         }
 
         mWPAndroidGlueCode.onResume(this, getActivity());
+
+        // In AndroidManifest for EditActivity we have set android:windowSoftInputMode="stateHidden|adjustResize"
+        // which doesn't allow us to present the keyboard programmatically.
+        // Ugly way to allow showing the keyboard would be to change soft input mode.
+        setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
     }
 
     @Override
@@ -245,16 +304,15 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void setTitle(CharSequence title) {
-        if (title == null) {
-            title = "";
+    public void setTitle(CharSequence text) {
+        if (text == null) {
+            text = "";
         }
 
-        if (!mWPAndroidGlueCode.hasReactRootView()) {
+        if (mTitle == null) {
             return;
         }
-
-        mWPAndroidGlueCode.setContent(title.toString(), null);
+        mTitle.setText(text);
     }
 
     @Override
@@ -263,12 +321,22 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
             text = "";
         }
 
-        if (!mWPAndroidGlueCode.hasReactRootView()) {
+        if (!mWPAndroidGlueCode.hasReactRootView() || mSource == null) {
             return;
         }
 
         String postContent = removeVisualEditorProgressTag(text.toString());
-        mWPAndroidGlueCode.setContent(null, postContent);
+        if (contentContainsGutenbergBlocks(postContent)) {
+            mSource.setCalypsoMode(false);
+        } else {
+            mSource.setCalypsoMode(true);
+        }
+
+        // Initialize both editors (visual, source) with the same content. Need to do that so the starting point used in
+        //  their content diffing algorithm is the same. That's assumed by the Toolbar's mode-switching logic too.
+        mSource.displayStyledAndFormattedHtml(postContent);
+
+        mWPAndroidGlueCode.setContent(postContent);
     }
 
     public void onToggleHtmlMode() {
@@ -337,12 +405,9 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         if (!isAdded()) {
             return "";
         }
-        return mWPAndroidGlueCode.getTitle(new OnGetContentTimeout() {
-            @Override public void onGetContentTimeout(InterruptedException ie) {
-                AppLog.e(T.EDITOR, ie);
-                Thread.currentThread().interrupt();
-            }
-        });
+
+        // TODO: Aztec returns a ZeroWidthJoiner when empty so, strip it. Aztec needs fixing to return empty string.
+        return StringUtils.notNullStr(mTitle.getText().toString().replaceAll("&nbsp;$", "").replaceAll("\u200B", ""));
     }
 
     @Override
@@ -522,13 +587,16 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
             ToastUtils.showToast(getActivity(), R.string.alert_action_while_uploading, ToastUtils.Duration.LONG);
         }
 
-
-        getActivity().runOnUiThread(new Runnable() {
+        if (mSource.isFocused()) {
+            ToastUtils.showToast(getActivity(), R.string.alert_insert_image_html_mode, ToastUtils.Duration.LONG);
+        } else {
+            getActivity().runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
                     mEditorFragmentListener.onAddMediaClicked();
                 }
             });
+        }
 
         return true;
     }

--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml
@@ -1,15 +1,67 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:background="@color/white"
-              android:focusable="false"
-              android:focusableInTouchMode="true"
-              android:orientation="vertical">
-    <com.facebook.react.ReactRootView
-        android:id="@+id/gutenberg"
+<LinearLayout  xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    android:orientation="vertical"
+    android:focusable="false"
+    android:focusableInTouchMode="true">
+
+    <org.wordpress.android.editor.EditTextWithKeyBackListener
+        android:id="@+id/title"
+        android:hint="@string/post_title"
+        android:inputType="textCapSentences|textAutoCorrect|textMultiLine"
+        android:background="@null"
+        android:layout_height="wrap_content"
         android:layout_width="match_parent"
+        android:padding="@dimen/margin_extra_large"
+        android:fontFamily="serif"
+        android:textStyle="bold"
+        android:textSize="@dimen/aztec_title_size"
+        android:imeOptions="flagNoExtractUi"
+        android:lineSpacingExtra="@dimen/spacing_extra_title"
+        android:textColor="@color/grey_dark"
+        android:textColorHint="@color/hint_text">
+    </org.wordpress.android.editor.EditTextWithKeyBackListener>
+
+    <View
+        android:id="@+id/sourceview_horizontal_divider"
+        android:layout_width="fill_parent"
+        android:layout_height="@dimen/format_bar_horizontal_divider_height"
+        android:layout_marginLeft="@dimen/sourceview_side_margin"
+        android:layout_marginRight="@dimen/sourceview_side_margin"
+        style="@style/DividerSourceView"/>
+
+    <FrameLayout
         android:layout_height="match_parent"
-        android:hint="@string/editor_content_hint"
+        android:layout_width="match_parent" >
+
+        <com.facebook.react.ReactRootView
+            android:id="@+id/gutenberg"
+            android:hint="@string/editor_content_hint"
+            android:layout_height="match_parent"
+            android:layout_width="match_parent"
         />
+
+        <org.wordpress.aztec.source.SourceViewEditText
+            android:id="@+id/source"
+            android:gravity="top|start"
+            android:inputType="textNoSuggestions|textMultiLine"
+            android:layout_height="match_parent"
+            android:layout_width="match_parent"
+            android:paddingTop="16dp"
+            android:paddingLeft="16dp"
+            android:paddingStart="16dp"
+            android:paddingRight="16dp"
+            android:paddingEnd="16dp"
+            android:scrollbars="vertical"
+            android:textColorHint="@color/hint_text"
+            android:background="@null"
+            android:textSize="14sp"
+            android:visibility="gone"
+            android:fontFamily="monospace"
+            android:imeOptions="flagNoExtractUi" />
+
+    </FrameLayout>
+
 </LinearLayout>


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-Android#9027 since we need to wait until the cut of the main app today. 