### PR TITLE
Re-introduce the changes required to  "Implement the editor title in RN for Gutenberg""

### DIFF
--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_gutenberg_editor.xml
@@ -1,67 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout  xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/white"
-    android:orientation="vertical"
-    android:focusable="false"
-    android:focusableInTouchMode="true">
-
-    <org.wordpress.android.editor.EditTextWithKeyBackListener
-        android:id="@+id/title"
-        android:hint="@string/post_title"
-        android:inputType="textCapSentences|textAutoCorrect|textMultiLine"
-        android:background="@null"
-        android:layout_height="wrap_content"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:background="@color/white"
+              android:focusable="false"
+              android:focusableInTouchMode="true"
+              android:orientation="vertical">
+    <com.facebook.react.ReactRootView
+        android:id="@+id/gutenberg"
         android:layout_width="match_parent"
-        android:padding="@dimen/margin_extra_large"
-        android:fontFamily="serif"
-        android:textStyle="bold"
-        android:textSize="@dimen/aztec_title_size"
-        android:imeOptions="flagNoExtractUi"
-        android:lineSpacingExtra="@dimen/spacing_extra_title"
-        android:textColor="@color/grey_dark"
-        android:textColorHint="@color/hint_text">
-    </org.wordpress.android.editor.EditTextWithKeyBackListener>
-
-    <View
-        android:id="@+id/sourceview_horizontal_divider"
-        android:layout_width="fill_parent"
-        android:layout_height="@dimen/format_bar_horizontal_divider_height"
-        android:layout_marginLeft="@dimen/sourceview_side_margin"
-        android:layout_marginRight="@dimen/sourceview_side_margin"
-        style="@style/DividerSourceView"/>
-
-    <FrameLayout
         android:layout_height="match_parent"
-        android:layout_width="match_parent" >
-
-        <com.facebook.react.ReactRootView
-            android:id="@+id/gutenberg"
-            android:hint="@string/editor_content_hint"
-            android:layout_height="match_parent"
-            android:layout_width="match_parent"
+        android:hint="@string/editor_content_hint"
         />
-
-        <org.wordpress.aztec.source.SourceViewEditText
-            android:id="@+id/source"
-            android:gravity="top|start"
-            android:inputType="textNoSuggestions|textMultiLine"
-            android:layout_height="match_parent"
-            android:layout_width="match_parent"
-            android:paddingTop="16dp"
-            android:paddingLeft="16dp"
-            android:paddingStart="16dp"
-            android:paddingRight="16dp"
-            android:paddingEnd="16dp"
-            android:scrollbars="vertical"
-            android:textColorHint="@color/hint_text"
-            android:background="@null"
-            android:textSize="14sp"
-            android:visibility="gone"
-            android:fontFamily="monospace"
-            android:imeOptions="flagNoExtractUi" />
-
-    </FrameLayout>
-
 </LinearLayout>


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-Android#9123

and bring https://github.com/wordpress-mobile/WordPress-Android/pull/9027 back!

🎉 