### PR TITLE
Decrease font size in charts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartUtils.kt
@@ -87,7 +87,7 @@ fun BarChart.draw(
         }
         textColor = greyColor
         gridColor = lightGreyColor
-        textSize = 12f
+        textSize = 10f
         gridLineWidth = 1f
     }
     axisRight.apply {

--- a/WordPress/src/main/res/layout/stats_block_bar_chart_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_bar_chart_item.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
               android:id="@+id/link_wrapper"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
@@ -25,6 +26,7 @@
             android:id="@+id/label_start"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            tools:text="January 2019"
             style="@style/StatsGraphLabel"/>
         <View
             android:layout_width="0dp"
@@ -32,6 +34,7 @@
             android:layout_weight="1"/>
         <TextView
             android:id="@+id/label_end"
+            tools:text="December 2019"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/StatsGraphLabel"/>

--- a/WordPress/src/main/res/values/stats_styles.xml
+++ b/WordPress/src/main/res/values/stats_styles.xml
@@ -182,6 +182,6 @@
 
     <style name="StatsGraphLabel">
         <item name="android:textColor">@color/wp_grey</item>
-        <item name="android:textSize">@dimen/text_small</item>
+        <item name="android:textSize">@dimen/text_sz_extra_small</item>
     </style>
 </resources>

--- a/libs/editor/WordPressEditor/src/main/res/values/dimens.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/dimens.xml
@@ -59,7 +59,4 @@
     <item name="spacing_multiplier_body" format="float" type="dimen">1.2</item>
 
     <dimen name="aztec_title_size">24sp</dimen>
-
-    <dimen name="text_small">12sp</dimen>
-
 </resources>


### PR DESCRIPTION
Fixes #9093 
Change font size in Bar chart in Stats to 10sp from 12sp.

To test:
* Open Stats
* Check the text size on bar chart is decreased

![screenshot_1548666842](https://user-images.githubusercontent.com/1079756/51825713-a0ac1c80-22e5-11e9-86e3-814dd5f99542.png)
