### PR TITLE
Fix issue - NewSiteCreationService can enter invalid state

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/NewSiteCreationService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/NewSiteCreationService.kt
@@ -100,7 +100,7 @@ class NewSiteCreationService : AutoForeground<NewSiteCreationServiceState>(NewSi
             data: NewSiteCreationServiceData
         ) {
             val currentState = AutoForeground.getState(NewSiteCreationServiceState::class.java)
-            if (currentState == null || currentState.step == INITIAL_STATE || currentState.step == FAILURE ) {
+            if (currentState == null || currentState.step == INITIAL_STATE || currentState.step == FAILURE) {
                 clearSiteCreationServiceState()
 
                 val intent = Intent(context, NewSiteCreationService::class.java)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/NewSiteCreationService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/NewSiteCreationService.kt
@@ -19,7 +19,9 @@ import org.wordpress.android.util.LocaleManager
 import java.util.HashMap
 import javax.inject.Inject
 
-class NewSiteCreationService : AutoForeground<NewSiteCreationServiceState>(NewSiteCreationServiceState(IDLE)),
+private val INITIAL_STATE = IDLE
+
+class NewSiteCreationService : AutoForeground<NewSiteCreationServiceState>(NewSiteCreationServiceState(INITIAL_STATE)),
         NewSiteCreationServiceManagerListener {
     @Inject lateinit var manager: NewSiteCreationServiceManager
 
@@ -98,7 +100,7 @@ class NewSiteCreationService : AutoForeground<NewSiteCreationServiceState>(NewSi
             data: NewSiteCreationServiceData
         ) {
             val currentState = AutoForeground.getState(NewSiteCreationServiceState::class.java)
-            if (currentState == null || currentState.step == FAILURE) {
+            if (currentState == null || currentState.step == INITIAL_STATE || currentState.step == FAILURE ) {
                 clearSiteCreationServiceState()
 
                 val intent = Intent(context, NewSiteCreationService::class.java)


### PR DESCRIPTION
Fixes #9138 

This PR fixes a bug when NewSiteCreation service could enter an invalid state - the UI kept showing an infinite progress indicator.

This is happening when we start creating the site when we don't have an internet connection. The `NewSiteCreationService.createSite(..)` is not called since we check the internet availability before we call it. However, the service is created anyway when NewSiteCreationPreviewFragment binds to it in onResume. The default state of the service is IDLE, however [this](https://github.com/wordpress-mobile/WordPress-Android/blob/ce978083e48580afb82dcfadf6db91f1ee3673b5/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/NewSiteCreationService.kt#L101) line prevents the service from actually starting the task when the user clicks on the retry button.

The flow works as expected when the internet connection is available since the `NewSiteCreationService.createSite(..)` is invoked before the service is created and therefore the state of the service is `null` and not `IDLE`.

To test:

- set "don't keep activities" in the developer settings

1. My Site
2. Switch Site
3. Plus sign icon
4. Create WordPress.com site
5. Select segment
6. Skip
7. Skip
8. Select a domain 
9. Turn On Airplane mode
10. Create Site
11. Error is shown
12. Turn off Airplane mode
13. Retry
14. Press the home button
15. Go back to the app
16. Make sure the fullscreen error is not shown and the site is eventually created

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
