### PR TITLE
Issue/8676 scmainvm tests

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -6,8 +6,11 @@ import android.content.Context;
 
 import org.wordpress.android.ui.news.LocalNewsService;
 import org.wordpress.android.ui.news.NewsService;
+import org.wordpress.android.ui.sitecreation.NewSiteCreationStepsProvider;
+import org.wordpress.android.ui.sitecreation.SiteCreationStep;
 import org.wordpress.android.ui.stats.refresh.StatsFragment;
 import org.wordpress.android.ui.stats.refresh.lists.StatsListFragment;
+import org.wordpress.android.util.wizard.WizardManager;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatusLiveData;
 
@@ -32,6 +35,11 @@ public abstract class ApplicationModule {
 
     @ContributesAndroidInjector
     abstract StatsFragment contributeStatsFragment();
+
+    @Provides
+    public static WizardManager<SiteCreationStep> provideWizardManager(NewSiteCreationStepsProvider stepsProvider) {
+        return new WizardManager<>(stepsProvider.getSteps());
+    }
 
     @Provides
     public static LiveData<ConnectionStatus> provideConnectionStatusLiveData(Context context) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
@@ -37,11 +37,11 @@ data class SiteCreationState(
 typealias NavigationTarget = WizardNavigationTarget<SiteCreationStep, SiteCreationState>
 
 class NewSiteCreationMainVM @Inject constructor(
-    private val stepsProvider: NewSiteCreationStepsProvider,
-    private val tracker: NewSiteCreationTracker
+    private val tracker: NewSiteCreationTracker,
+    private val wizardManager: WizardManager<SiteCreationStep>
 ) : ViewModel() {
     private var isStarted = false
-    private lateinit var wizardManager: WizardManager<SiteCreationStep>
+
     private lateinit var siteCreationState: SiteCreationState
 
     val navigationTargetObservable: SingleEventObservable<NavigationTarget> by lazy {
@@ -60,11 +60,10 @@ class NewSiteCreationMainVM @Inject constructor(
         if (savedInstanceState == null) {
             tracker.trackSiteCreationAccessed()
             siteCreationState = SiteCreationState()
-            wizardManager = WizardManager(stepsProvider.getSteps())
         } else {
             siteCreationState = savedInstanceState.getParcelable(KEY_SITE_CREATION_STATE)
             val currentStepIndex = savedInstanceState.getInt(KEY_CURRENT_STEP)
-            wizardManager = WizardManager(stepsProvider.getSteps(), currentStepIndex)
+            wizardManager.setCurrentStepIndex(currentStepIndex)
         }
         isStarted = true
         if (savedInstanceState == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
@@ -23,14 +23,6 @@ import javax.inject.Inject
 
 private const val KEY_CURRENT_STEP = "key_current_step"
 private const val KEY_SITE_CREATION_STATE = "key_site_creation_state"
-private val SITE_CREATION_STEPS =
-        listOf(
-                SiteCreationStep.fromString("site_creation_segments"),
-                SiteCreationStep.fromString("site_creation_verticals"),
-                SiteCreationStep.fromString("site_creation_site_info"),
-                SiteCreationStep.fromString("site_creation_domains"),
-                SiteCreationStep.fromString("site_creation_site_preview")
-        )
 
 @Parcelize
 @SuppressLint("ParcelCreator")
@@ -44,7 +36,10 @@ data class SiteCreationState(
 
 typealias NavigationTarget = WizardNavigationTarget<SiteCreationStep, SiteCreationState>
 
-class NewSiteCreationMainVM @Inject constructor(private val tracker: NewSiteCreationTracker) : ViewModel() {
+class NewSiteCreationMainVM @Inject constructor(
+    private val stepsProvider: NewSiteCreationStepsProvider,
+    private val tracker: NewSiteCreationTracker
+) : ViewModel() {
     private var isStarted = false
     private lateinit var wizardManager: WizardManager<SiteCreationStep>
     private lateinit var siteCreationState: SiteCreationState
@@ -65,11 +60,11 @@ class NewSiteCreationMainVM @Inject constructor(private val tracker: NewSiteCrea
         if (savedInstanceState == null) {
             tracker.trackSiteCreationAccessed()
             siteCreationState = SiteCreationState()
-            wizardManager = WizardManager(SITE_CREATION_STEPS)
+            wizardManager = WizardManager(stepsProvider.getSteps())
         } else {
             siteCreationState = savedInstanceState.getParcelable(KEY_SITE_CREATION_STATE)
             val currentStepIndex = savedInstanceState.getInt(KEY_CURRENT_STEP)
-            wizardManager = WizardManager(SITE_CREATION_STEPS, currentStepIndex)
+            wizardManager = WizardManager(stepsProvider.getSteps(), currentStepIndex)
         }
         isStarted = true
         if (savedInstanceState == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVM.kt
@@ -21,8 +21,8 @@ import org.wordpress.android.viewmodel.SingleEventObservable
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 
-private const val KEY_CURRENT_STEP = "key_current_step"
-private const val KEY_SITE_CREATION_STATE = "key_site_creation_state"
+const val KEY_CURRENT_STEP = "key_current_step"
+const val KEY_SITE_CREATION_STATE = "key_site_creation_state"
 
 @Parcelize
 @SuppressLint("ParcelCreator")

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.ui.sitecreation
 
 import org.wordpress.android.util.wizard.WizardStep
+import javax.inject.Inject
+import javax.inject.Singleton
 
 enum class SiteCreationStep : WizardStep {
     SEGMENTS, VERTICALS, SITE_INFO, DOMAINS, SITE_PREVIEW;
@@ -16,5 +18,18 @@ enum class SiteCreationStep : WizardStep {
                 else -> throw IllegalArgumentException("SiteCreationStep not recognized: \$input")
             }
         }
+    }
+}
+
+@Singleton
+class NewSiteCreationStepsProvider @Inject constructor() {
+    fun getSteps(): List<SiteCreationStep> {
+        return listOf(
+                SiteCreationStep.fromString("site_creation_segments"),
+                SiteCreationStep.fromString("site_creation_verticals"),
+                SiteCreationStep.fromString("site_creation_site_info"),
+                SiteCreationStep.fromString("site_creation_domains"),
+                SiteCreationStep.fromString("site_creation_site_preview")
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/wizard/WizardManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/wizard/WizardManager.kt
@@ -3,10 +3,12 @@ package org.wordpress.android.util.wizard
 import android.arch.lifecycle.LiveData
 import org.wordpress.android.viewmodel.SingleLiveEvent
 
+private const val DEFAULT_STEP_INDEX = -1
+
 class WizardManager<T : WizardStep>(
-    private val steps: List<T>,
-    private var currentStepIndex: Int = -1
+    private val steps: List<T>
 ) {
+    private var currentStepIndex: Int = DEFAULT_STEP_INDEX
     val stepsCount = steps.size
     val currentStep: Int
         get() = currentStepIndex
@@ -40,6 +42,13 @@ class WizardManager<T : WizardStep>(
         } else {
             throw IllegalStateException("Step $T is not present.")
         }
+    }
+
+    fun setCurrentStepIndex(stepIndex: Int) {
+        if (!isIndexValid(stepIndex)) {
+            throw IllegalStateException("Invalid index.")
+        }
+        currentStepIndex = stepIndex
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/SingleEventObservable.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/SingleEventObservable.kt
@@ -16,7 +16,8 @@ import android.arch.lifecycle.Observer
  * Note that only one observer can be subscribed.
  */
 class SingleEventObservable<T>(private val sourceLiveData: LiveData<T>) {
-    private var lastEvent: T? = null
+    var lastEvent: T? = null
+        private set
 
     fun observe(owner: LifecycleOwner, observer: Observer<T>) {
         if (sourceLiveData.hasObservers()) {
@@ -28,5 +29,17 @@ class SingleEventObservable<T>(private val sourceLiveData: LiveData<T>) {
                 observer.onChanged(it)
             }
         })
+    }
+
+    fun observeForever(observer: Observer<T>) {
+        if (sourceLiveData.hasObservers()) {
+            throw IllegalStateException("SingleEventObservable can be observed only by a single observer.")
+        }
+        sourceLiveData.observeForever {
+            if (it !== lastEvent) {
+                lastEvent = it
+                observer.onChanged(it)
+            }
+        }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/MainVM/NewSiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/MainVM/NewSiteCreationMainVMTest.kt
@@ -164,8 +164,8 @@ class NewSiteCreationMainVMTest {
 
     @Test
     fun titlesForOtherThanFirstAndLastStepIsStepCount() {
-        val isFirstStep = {index: Int -> index == 0}
-        val isLastStep = {index: Int -> index == SITE_CREATION_STEPS.size - 1 }
+        val isFirstStep = { index: Int -> index == 0 }
+        val isLastStep = { index: Int -> index == SITE_CREATION_STEPS.size - 1 }
 
         SITE_CREATION_STEPS.filterIndexed({ index, step ->
             !isFirstStep(index) && !isLastStep(index)
@@ -177,7 +177,7 @@ class NewSiteCreationMainVMTest {
     @Test
     fun siteCreationStateWrittenToBundle() {
         viewModel.writeToBundle(savedInstanceState)
-        verify(savedInstanceState).putParcelable(any(), argThat(){this is SiteCreationState })
+        verify(savedInstanceState).putParcelable(any(), argThat() { this is SiteCreationState })
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/MainVM/NewSiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/MainVM/NewSiteCreationMainVMTest.kt
@@ -1,0 +1,209 @@
+package org.wordpress.android.ui.sitecreation.MainVM
+
+import android.arch.core.executor.testing.InstantTaskExecutorRule
+import android.arch.lifecycle.Observer
+import android.os.Bundle
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argThat
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.ui.sitecreation.NavigationTarget
+import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM
+import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleEmpty
+import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleGeneral
+import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleStepCount
+import org.wordpress.android.ui.sitecreation.NewSiteCreationStepsProvider
+import org.wordpress.android.ui.sitecreation.SiteCreationState
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_INFO
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.VERTICALS
+import org.wordpress.android.ui.sitecreation.misc.NewSiteCreationTracker
+import org.wordpress.android.ui.sitecreation.previews.NewSitePreviewViewModel.CreateSiteState
+import org.wordpress.android.ui.sitecreation.previews.NewSitePreviewViewModel.CreateSiteState.SiteCreationCompleted
+
+private const val LOCAL_SITE_ID = 1
+private const val SEGMENT_ID = 1L
+private const val VERTICAL_ID = "m1v1"
+private const val SITE_TITLE = "test title"
+private const val SITE_TAGLINE = "test tagline"
+private const val DOMAIN = "test.domain.com"
+
+private val SITE_CREATION_STEPS = listOf(SITE_INFO, VERTICALS, SEGMENTS, DOMAINS, SITE_PREVIEW)
+
+@RunWith(MockitoJUnitRunner::class)
+class NewSiteCreationMainVMTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    @Mock lateinit var tracker: NewSiteCreationTracker
+    @Mock lateinit var stepsProvider: NewSiteCreationStepsProvider
+    @Mock lateinit var navigationTargetObserver: Observer<NavigationTarget>
+    @Mock lateinit var wizardFinishedObserver: Observer<CreateSiteState>
+    @Mock lateinit var savedInstanceState: Bundle
+
+    @Captor
+    private val captorNavigationTarget: ArgumentCaptor<NavigationTarget>? = null
+
+    private lateinit var viewModel: NewSiteCreationMainVM
+
+    @Before
+    fun setUp() {
+        whenever(stepsProvider.getSteps()).thenReturn(SITE_CREATION_STEPS)
+        viewModel = NewSiteCreationMainVM(stepsProvider, tracker)
+        viewModel.start(null)
+        viewModel.navigationTargetObservable.observeForever(navigationTargetObserver)
+        viewModel.wizardFinishedObservable.observeForever(wizardFinishedObserver)
+    }
+
+    @Test
+    fun skipClickedResultsInNextStep() {
+        viewModel.onSkipClicked()
+        verifyNavigatedToNextStep()
+    }
+
+    @Test
+    fun segmentSelectedResultsInNextStep() {
+        viewModel.onSegmentSelected(SEGMENT_ID)
+        verifyNavigatedToNextStep()
+    }
+
+    @Test
+    fun verticalSelectedResultsInNextStep() {
+        viewModel.onVerticalsScreenFinished(VERTICAL_ID)
+        verifyNavigatedToNextStep()
+    }
+
+    @Test
+    fun siteInfoFinishedResultsInNextStep() {
+        viewModel.onInfoScreenFinished(SITE_TITLE, null)
+        verifyNavigatedToNextStep()
+    }
+
+    @Test
+    fun domainSelectedResultsInNextStep() {
+        viewModel.onDomainsScreenFinished(DOMAIN)
+        verifyNavigatedToNextStep()
+    }
+
+    @Test
+    fun siteCreationStateUpdatedWithSelectedSegment() {
+        viewModel.onSegmentSelected(SEGMENT_ID)
+        assertThat(viewModel.navigationTargetObservable.lastEvent!!.wizardState.segmentId).isEqualTo(SEGMENT_ID)
+    }
+
+    @Test
+    fun siteCreationStateUpdatedWithSelectedVertical() {
+        viewModel.onVerticalsScreenFinished(VERTICAL_ID)
+        assertThat(viewModel.navigationTargetObservable.lastEvent!!.wizardState.verticalId).isEqualTo(VERTICAL_ID)
+    }
+
+    @Test
+    fun siteCreationStateUpdatedWithSiteInfo() {
+        viewModel.onInfoScreenFinished(SITE_TITLE, SITE_TAGLINE)
+        assertThat(viewModel.navigationTargetObservable.lastEvent!!.wizardState.siteTitle).isEqualTo(SITE_TITLE)
+        assertThat(viewModel.navigationTargetObservable.lastEvent!!.wizardState.siteTagLine).isEqualTo(SITE_TAGLINE)
+    }
+
+    @Test
+    fun siteCreationStateUpdatedWithSelectedDomain() {
+        viewModel.onDomainsScreenFinished(DOMAIN)
+        assertThat(viewModel.navigationTargetObservable.lastEvent!!.wizardState.domain).isEqualTo(DOMAIN)
+    }
+
+    @Test
+    fun wizardFinishedInvokedOnSitePreviewCompleted() {
+        val state = SiteCreationCompleted(LOCAL_SITE_ID)
+        viewModel.onSitePreviewScreenFinished(state)
+
+        val captor = ArgumentCaptor.forClass(CreateSiteState::class.java)
+        verify(wizardFinishedObserver).onChanged(captor.capture())
+
+        assertThat(captor.value).isEqualTo(state)
+    }
+
+    @Test
+    fun nextStepAfterOnBackPressedIsCurrentStep() {
+        val startingStep = currentStep()
+        viewModel.onBackPressed() // navigate to previous step
+        viewModel.onSkipClicked() // navigate to next step
+        assertThat(currentStep()).isEqualTo(startingStep)
+    }
+
+    @Test
+    fun backSupressedOnlyForLastStep() {
+        while (!isAtLastStep()) {
+            assertThat(viewModel.shouldSuppressBackPress()).isFalse()
+            viewModel.onSkipClicked() // navigate to a next step
+        }
+        assertThat(viewModel.shouldSuppressBackPress()).isTrue()
+    }
+
+    @Test
+    fun titleForFirstStepIsGeneralSiteCreation() {
+        assertThat(viewModel.screenTitleForWizardStep(SITE_CREATION_STEPS.first()))
+                .isInstanceOf(ScreenTitleGeneral::class.java)
+    }
+
+    @Test
+    fun titleForLastStepIsEmptyTitle() {
+        assertThat(viewModel.screenTitleForWizardStep(SITE_CREATION_STEPS.last()))
+                .isInstanceOf(ScreenTitleEmpty::class.java)
+    }
+
+    @Test
+    fun titlesForOtherThanFirstAndLastStepIsStepCount() {
+        val isFirstStep = {index: Int -> index == 0}
+        val isLastStep = {index: Int -> index == SITE_CREATION_STEPS.size - 1 }
+
+        SITE_CREATION_STEPS.filterIndexed({ index, step ->
+            !isFirstStep(index) && !isLastStep(index)
+        }).forEach() { step ->
+            assertThat(viewModel.screenTitleForWizardStep(step)).isInstanceOf(ScreenTitleStepCount::class.java)
+        }
+    }
+
+    @Test
+    fun siteCreationStateWrittenToBundle() {
+        viewModel.writeToBundle(savedInstanceState)
+        verify(savedInstanceState).putParcelable(any(), argThat(){this is SiteCreationState })
+    }
+
+    @Test
+    fun siteCreationStateRestored() {
+        val expectedState = SiteCreationState()
+        whenever(savedInstanceState.getParcelable<SiteCreationState>(any()))
+                .thenReturn(expectedState)
+
+        // we need to create a new instance of the VM as the `viewModel` has already been started in setUp()
+        val newViewModel = NewSiteCreationMainVM(stepsProvider, tracker)
+        newViewModel.start(savedInstanceState)
+
+        /* we need to navigate to the next step as the value of navigationTargetObservable isn't changed when the VM
+        is restored from a savedInstanceState. */
+        newViewModel.onSkipClicked()
+
+        newViewModel.navigationTargetObservable.observeForever(navigationTargetObserver)
+        assertThat(newViewModel.navigationTargetObservable.lastEvent!!.wizardState).isSameAs(expectedState)
+    }
+
+    private fun verifyNavigatedToNextStep() {
+        // onChange invoked after viewModel.start() and after viewModel.onSkipClicked()
+        verify(navigationTargetObserver, times(2)).onChanged(captorNavigationTarget!!.capture())
+    }
+
+    private fun currentStep() = viewModel.navigationTargetObservable.lastEvent!!.wizardStep
+
+    private fun isAtLastStep() = SITE_CREATION_STEPS.last().equals(currentStep())
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVMTest.kt
@@ -5,7 +5,7 @@ import android.arch.lifecycle.Observer
 import android.os.Bundle
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argThat
-import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.clearInvocations
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
@@ -14,29 +14,26 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
-import org.mockito.Captor
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleEmpty
 import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleStepCount
-import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
-import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
-import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_INFO
-import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
-import org.wordpress.android.ui.sitecreation.SiteCreationStep.VERTICALS
 import org.wordpress.android.ui.sitecreation.misc.NewSiteCreationTracker
 import org.wordpress.android.ui.sitecreation.previews.NewSitePreviewViewModel.CreateSiteState
 import org.wordpress.android.ui.sitecreation.previews.NewSitePreviewViewModel.CreateSiteState.SiteCreationCompleted
+import org.wordpress.android.util.wizard.WizardManager
+import org.wordpress.android.viewmodel.SingleLiveEvent
 
 private const val LOCAL_SITE_ID = 1
 private const val SEGMENT_ID = 1L
 private const val VERTICAL_ID = "m1v1"
 private const val SITE_TITLE = "test title"
-private const val SITE_TAGLINE = "test tagline"
+private const val SITE_TAG_LINE = "test tagLine"
 private const val DOMAIN = "test.domain.com"
-
-private val SITE_CREATION_STEPS = listOf(SITE_INFO, VERTICALS, SEGMENTS, DOMAINS, SITE_PREVIEW)
+private const val STEP_COUNT = 20
+private const val FIRST_STEP_INDEX = 1
+private const val LAST_STEP_INDEX = STEP_COUNT
 
 @RunWith(MockitoJUnitRunner::class)
 class NewSiteCreationMainVMTest {
@@ -44,81 +41,87 @@ class NewSiteCreationMainVMTest {
     @JvmField val rule = InstantTaskExecutorRule()
 
     @Mock lateinit var tracker: NewSiteCreationTracker
-    @Mock lateinit var stepsProvider: NewSiteCreationStepsProvider
     @Mock lateinit var navigationTargetObserver: Observer<NavigationTarget>
     @Mock lateinit var wizardFinishedObserver: Observer<CreateSiteState>
     @Mock lateinit var savedInstanceState: Bundle
-
-    @Captor
-    private val captorNavigationTarget: ArgumentCaptor<NavigationTarget>? = null
+    @Mock lateinit var wizardManager: WizardManager<SiteCreationStep>
+    @Mock lateinit var siteCreationStep: SiteCreationStep
+    private val wizardManagerNavigatorLiveData = SingleLiveEvent<SiteCreationStep>()
 
     private lateinit var viewModel: NewSiteCreationMainVM
 
     @Before
     fun setUp() {
-        whenever(stepsProvider.getSteps()).thenReturn(SITE_CREATION_STEPS)
-        viewModel = NewSiteCreationMainVM(stepsProvider, tracker)
+        whenever(wizardManager.navigatorLiveData).thenReturn(wizardManagerNavigatorLiveData)
+        whenever(wizardManager.showNextStep()).then {
+            wizardManagerNavigatorLiveData.value = siteCreationStep
+            Unit
+        }
+        viewModel = NewSiteCreationMainVM(tracker, wizardManager)
         viewModel.start(null)
         viewModel.navigationTargetObservable.observeForever(navigationTargetObserver)
         viewModel.wizardFinishedObservable.observeForever(wizardFinishedObserver)
+        whenever(wizardManager.stepsCount).thenReturn(STEP_COUNT)
+        // clear invocations since viewModel.start() calls wizardManager.showNextStep
+        clearInvocations(wizardManager)
     }
 
     @Test
     fun skipClickedResultsInNextStep() {
         viewModel.onSkipClicked()
-        verifyNavigatedToNextStep()
+        verify(wizardManager).showNextStep()
     }
 
     @Test
     fun segmentSelectedResultsInNextStep() {
         viewModel.onSegmentSelected(SEGMENT_ID)
-        verifyNavigatedToNextStep()
+        verify(wizardManager).showNextStep()
     }
 
     @Test
     fun verticalSelectedResultsInNextStep() {
         viewModel.onVerticalsScreenFinished(VERTICAL_ID)
-        verifyNavigatedToNextStep()
+        verify(wizardManager).showNextStep()
     }
 
     @Test
     fun siteInfoFinishedResultsInNextStep() {
         viewModel.onInfoScreenFinished(SITE_TITLE, null)
-        verifyNavigatedToNextStep()
+        verify(wizardManager).showNextStep()
     }
 
     @Test
     fun domainSelectedResultsInNextStep() {
         viewModel.onDomainsScreenFinished(DOMAIN)
-        verifyNavigatedToNextStep()
+        verify(wizardManager).showNextStep()
     }
 
     @Test
     fun siteCreationStateUpdatedWithSelectedSegment() {
         viewModel.onSegmentSelected(SEGMENT_ID)
-        assertThat(viewModel.navigationTargetObservable.lastEvent!!.wizardState.segmentId).isEqualTo(SEGMENT_ID)
+        assertThat(currentWizardState(viewModel).segmentId).isEqualTo(SEGMENT_ID)
     }
 
     @Test
     fun siteCreationStateUpdatedWithSelectedVertical() {
         viewModel.onVerticalsScreenFinished(VERTICAL_ID)
-        assertThat(viewModel.navigationTargetObservable.lastEvent!!.wizardState.verticalId).isEqualTo(VERTICAL_ID)
+        assertThat(currentWizardState(viewModel).verticalId).isEqualTo(VERTICAL_ID)
     }
 
     @Test
     fun siteCreationStateUpdatedWithSiteInfo() {
         viewModel.onInfoScreenFinished(
                 SITE_TITLE,
-                SITE_TAGLINE
+                SITE_TAG_LINE
         )
-        assertThat(viewModel.navigationTargetObservable.lastEvent!!.wizardState.siteTitle).isEqualTo(SITE_TITLE)
-        assertThat(viewModel.navigationTargetObservable.lastEvent!!.wizardState.siteTagLine).isEqualTo(SITE_TAGLINE)
+        assertThat(currentWizardState(viewModel).siteTitle).isEqualTo(SITE_TITLE)
+        assertThat(currentWizardState(viewModel).siteTagLine).isEqualTo(SITE_TAG_LINE)
     }
 
     @Test
     fun siteCreationStateUpdatedWithSelectedDomain() {
         viewModel.onDomainsScreenFinished(DOMAIN)
-        assertThat(viewModel.navigationTargetObservable.lastEvent!!.wizardState.domain).isEqualTo(DOMAIN)
+        assertThat(currentWizardState(viewModel).domain).isEqualTo(DOMAIN)
     }
 
     @Test
@@ -133,43 +136,44 @@ class NewSiteCreationMainVMTest {
     }
 
     @Test
-    fun nextStepAfterOnBackPressedIsCurrentStep() {
-        val startingStep = currentStep()
-        viewModel.onBackPressed() // navigate to previous step
-        viewModel.onSkipClicked() // navigate to next step
-        assertThat(currentStep()).isEqualTo(startingStep)
+    fun onBackPressedPropagatedToWizardManager() {
+        viewModel.onBackPressed()
+        verify(wizardManager).onBackPressed()
     }
 
     @Test
-    fun backSuppressedOnlyForLastStep() {
-        while (!isAtLastStep()) {
-            assertThat(viewModel.shouldSuppressBackPress()).isFalse()
-            viewModel.onSkipClicked() // navigate to a next step
-        }
+    fun backNotSuppressedWhenNotLastStep() {
+        whenever(wizardManager.isLastStep()).thenReturn(false)
+        assertThat(viewModel.shouldSuppressBackPress()).isFalse()
+    }
+
+    @Test
+    fun backSuppressedForLastStep() {
+        whenever(wizardManager.isLastStep()).thenReturn(true)
         assertThat(viewModel.shouldSuppressBackPress()).isTrue()
     }
 
     @Test
     fun titleForFirstStepIsGeneralSiteCreation() {
-        assertThat(viewModel.screenTitleForWizardStep(SITE_CREATION_STEPS.first()))
+        whenever(wizardManager.stepPosition(siteCreationStep)).thenReturn(FIRST_STEP_INDEX)
+        assertThat(viewModel.screenTitleForWizardStep(siteCreationStep))
                 .isInstanceOf(ScreenTitleGeneral::class.java)
     }
 
     @Test
     fun titleForLastStepIsEmptyTitle() {
-        assertThat(viewModel.screenTitleForWizardStep(SITE_CREATION_STEPS.last()))
+        whenever(wizardManager.stepPosition(siteCreationStep)).thenReturn(LAST_STEP_INDEX)
+        assertThat(viewModel.screenTitleForWizardStep(siteCreationStep))
                 .isInstanceOf(ScreenTitleEmpty::class.java)
     }
 
     @Test
     fun titlesForOtherThanFirstAndLastStepIsStepCount() {
-        val isFirstStep = { index: Int -> index == 0 }
-        val isLastStep = { index: Int -> index == SITE_CREATION_STEPS.size - 1 }
+        (FIRST_STEP_INDEX + 1 until STEP_COUNT).forEach { stepIndex ->
+            whenever(wizardManager.stepPosition(siteCreationStep)).thenReturn(stepIndex)
 
-        SITE_CREATION_STEPS.filterIndexed { index, _ ->
-            !isFirstStep(index) && !isLastStep(index)
-        }.forEach { step ->
-            assertThat(viewModel.screenTitleForWizardStep(step)).isInstanceOf(ScreenTitleStepCount::class.java)
+            assertThat(viewModel.screenTitleForWizardStep(siteCreationStep))
+                    .isInstanceOf(ScreenTitleStepCount::class.java)
         }
     }
 
@@ -182,27 +186,37 @@ class NewSiteCreationMainVMTest {
     @Test
     fun siteCreationStateRestored() {
         val expectedState = SiteCreationState()
-        whenever(savedInstanceState.getParcelable<SiteCreationState>(any()))
+        whenever(savedInstanceState.getParcelable<SiteCreationState>("key_site_creation_state"))
                 .thenReturn(expectedState)
 
         // we need to create a new instance of the VM as the `viewModel` has already been started in setUp()
-        val newViewModel = NewSiteCreationMainVM(stepsProvider, tracker)
+        val newViewModel = NewSiteCreationMainVM(tracker, wizardManager)
         newViewModel.start(savedInstanceState)
 
-        /* we need to navigate to the next step as the value of navigationTargetObservable isn't changed when the VM
-        is restored from a savedInstanceState. */
-        newViewModel.onSkipClicked()
+        /* we need simulate navigation to the next step as wizardManager.showNextStep() isn't invoked
+        when the VM is restored from a savedInstanceState. */
+        wizardManagerNavigatorLiveData.value = siteCreationStep
 
         newViewModel.navigationTargetObservable.observeForever(navigationTargetObserver)
-        assertThat(newViewModel.navigationTargetObservable.lastEvent!!.wizardState).isSameAs(expectedState)
+        assertThat(currentWizardState(newViewModel)).isSameAs(expectedState)
     }
 
-    private fun verifyNavigatedToNextStep() {
-        // onChange invoked after viewModel.start() and after viewModel.onSkipClicked()
-        verify(navigationTargetObserver, times(2)).onChanged(captorNavigationTarget!!.capture())
+    @Test
+    fun siteCreationStepIndexRestored() {
+        val index = 17
+        whenever(savedInstanceState.getInt("key_current_step")).thenReturn(index)
+
+        // siteCreationState is not nullable - we need to set it
+        whenever(savedInstanceState.getParcelable<SiteCreationState>("key_site_creation_state"))
+                .thenReturn(SiteCreationState())
+
+        // we need to create a new instance of the VM as the `viewModel` has already been started in setUp()
+        val newViewModel = NewSiteCreationMainVM(tracker, wizardManager)
+        newViewModel.start(savedInstanceState)
+
+        verify(wizardManager).setCurrentStepIndex(index)
     }
 
-    private fun currentStep() = viewModel.navigationTargetObservable.lastEvent!!.wizardStep
-
-    private fun isAtLastStep() = SITE_CREATION_STEPS.last() == currentStep()
+    private fun currentWizardState(vm: NewSiteCreationMainVM) =
+            vm.navigationTargetObservable.lastEvent!!.wizardState
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVMTest.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.sitecreation.MainVM
+package org.wordpress.android.ui.sitecreation
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.Observer
@@ -17,13 +17,9 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Captor
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.wordpress.android.ui.sitecreation.NavigationTarget
-import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM
 import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleEmpty
 import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM.NewSiteCreationScreenTitle.ScreenTitleStepCount
-import org.wordpress.android.ui.sitecreation.NewSiteCreationStepsProvider
-import org.wordpress.android.ui.sitecreation.SiteCreationState
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_INFO
@@ -111,7 +107,10 @@ class NewSiteCreationMainVMTest {
 
     @Test
     fun siteCreationStateUpdatedWithSiteInfo() {
-        viewModel.onInfoScreenFinished(SITE_TITLE, SITE_TAGLINE)
+        viewModel.onInfoScreenFinished(
+                SITE_TITLE,
+                SITE_TAGLINE
+        )
         assertThat(viewModel.navigationTargetObservable.lastEvent!!.wizardState.siteTitle).isEqualTo(SITE_TITLE)
         assertThat(viewModel.navigationTargetObservable.lastEvent!!.wizardState.siteTagLine).isEqualTo(SITE_TAGLINE)
     }
@@ -142,7 +141,7 @@ class NewSiteCreationMainVMTest {
     }
 
     @Test
-    fun backSupressedOnlyForLastStep() {
+    fun backSuppressedOnlyForLastStep() {
         while (!isAtLastStep()) {
             assertThat(viewModel.shouldSuppressBackPress()).isFalse()
             viewModel.onSkipClicked() // navigate to a next step
@@ -167,9 +166,9 @@ class NewSiteCreationMainVMTest {
         val isFirstStep = { index: Int -> index == 0 }
         val isLastStep = { index: Int -> index == SITE_CREATION_STEPS.size - 1 }
 
-        SITE_CREATION_STEPS.filterIndexed({ index, step ->
+        SITE_CREATION_STEPS.filterIndexed { index, _ ->
             !isFirstStep(index) && !isLastStep(index)
-        }).forEach() { step ->
+        }.forEach { step ->
             assertThat(viewModel.screenTitleForWizardStep(step)).isInstanceOf(ScreenTitleStepCount::class.java)
         }
     }
@@ -177,7 +176,7 @@ class NewSiteCreationMainVMTest {
     @Test
     fun siteCreationStateWrittenToBundle() {
         viewModel.writeToBundle(savedInstanceState)
-        verify(savedInstanceState).putParcelable(any(), argThat() { this is SiteCreationState })
+        verify(savedInstanceState).putParcelable(any(), argThat { this is SiteCreationState })
     }
 
     @Test
@@ -205,5 +204,5 @@ class NewSiteCreationMainVMTest {
 
     private fun currentStep() = viewModel.navigationTargetObservable.lastEvent!!.wizardStep
 
-    private fun isAtLastStep() = SITE_CREATION_STEPS.last().equals(currentStep())
+    private fun isAtLastStep() = SITE_CREATION_STEPS.last() == currentStep()
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/NewSiteCreationMainVMTest.kt
@@ -186,7 +186,7 @@ class NewSiteCreationMainVMTest {
     @Test
     fun siteCreationStateRestored() {
         val expectedState = SiteCreationState()
-        whenever(savedInstanceState.getParcelable<SiteCreationState>("key_site_creation_state"))
+        whenever(savedInstanceState.getParcelable<SiteCreationState>(KEY_SITE_CREATION_STATE))
                 .thenReturn(expectedState)
 
         // we need to create a new instance of the VM as the `viewModel` has already been started in setUp()
@@ -204,10 +204,10 @@ class NewSiteCreationMainVMTest {
     @Test
     fun siteCreationStepIndexRestored() {
         val index = 17
-        whenever(savedInstanceState.getInt("key_current_step")).thenReturn(index)
+        whenever(savedInstanceState.getInt(KEY_CURRENT_STEP)).thenReturn(index)
 
         // siteCreationState is not nullable - we need to set it
-        whenever(savedInstanceState.getParcelable<SiteCreationState>("key_site_creation_state"))
+        whenever(savedInstanceState.getParcelable<SiteCreationState>(KEY_SITE_CREATION_STATE))
                 .thenReturn(SiteCreationState())
 
         // we need to create a new instance of the VM as the `viewModel` has already been started in setUp()


### PR DESCRIPTION
Fixes #8676 

- Adds units tests for NewSiteCreationMainVM
- Introduces NewSiteCreationStepsProvider so we can mock it in tests
- Adds observeForever() to SingleEventObservable so we can easily listen for changes in tests (regular observer() requires a LifecycleOwner)

To test:
- set the feature flag `NEW_SITE_CREATION_ENABLED`  in build.gradle to `true`
- test the new site creation flow -> make sure all the screens are shown in the correct order -> Segments, Verticals, SiteInfo, Domain, SitePreview


Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
