### PR TITLE
Issue/9143 update migration dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -803,6 +803,9 @@ public class WPMainActivity extends AppCompatActivity implements
 
         promoDialog.show(getSupportFragmentManager(), tag);
         AnalyticsTracker.track(Stat.QUICK_START_REQUEST_VIEWED);
+
+        // Set migration dialog flag so it is not shown for new sites.
+        AppPrefs.setQuickStartMigrationDialogShown(true);
     }
 
     private void appLanguageChanged() {


### PR DESCRIPTION
### Fix
Update the Quick Start migration dialog to be shown for existing sites with Quick Start in progress only and not for new sites as described in https://github.com/wordpress-mobile/WordPress-Android/issues/9143.

### Test
There are two scenarios to test; new site creation and existing site migration.  The new site creation steps should be performed on this branch.  The existing site migration steps should start on a commit before Quick Start v2 (i.e. 5c034b4ac314a8bfe89e6a1a953993ab40fb4d7f) then continued on this branch.

#### New Site Creation
1. Go to ***Sites*** tab.
2. Tap ***Switch Site*** button.
3. Tap ***Add new site*** action.
4. Tap ***Create WordPress.com site*** option.
5. Follow site creation steps.
6. Tap ***Configure*** button.
7. Notice ***Want a little help getting started?*** dialog is shown.
8. Tap ***Accept*** action.
9. Go to ***Reader***, ***Me***, or ***Notifications*** tab.
10. Go to ***Sites*** tab.
11. Notice ***We've made some changes to your checklist*** dialog is not shown.

#### Existing Site Migration
0. Run app with 5c034b4ac314a8bfe89e6a1a953993ab40fb4d7f.
1. Go to ***Sites*** tab.
2. Tap ***Switch Site*** button.
3. Tap ***Add new site*** action.
4. Tap ***Create WordPress.com site*** option.
5. Follow site creation steps.
6. Tap ***Configure*** button.
7. Notice ***Want a little help getting started?*** dialog is shown.
8. Tap ***Accept*** action.
9. Go to ***Reader***, ***Me***, or ***Notifications*** tab.
10. Run app with `issue/9143-update-migration-dialog`
11. Go to ***Sites*** tab.
12. Notice ***We've made some changes to your checklist*** dialog is shown.