### PR TITLE
Avoid multiple selection of pics/video when Gutenberg enabled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1395,11 +1395,13 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private void launchPictureLibrary() {
-        WPMediaUtils.launchPictureLibrary(this, true);
+        // don't allow multiple selection for Gutenberg, as we're on a single image block for now
+        WPMediaUtils.launchPictureLibrary(this, !mShowGutenbergEditor);
     }
 
     private void launchVideoLibrary() {
-        WPMediaUtils.launchVideoLibrary(this, true);
+        // don't allow multiple selection for Gutenberg, as we're on a single image block for now
+        WPMediaUtils.launchVideoLibrary(this, !mShowGutenbergEditor);
     }
 
     private void launchVideoCamera() {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/519

To test:
1. start a draft
2. insert an image block
3. tap on DEVICE LIBRARY button
4. see you can only choose one image.
5. choose an image
6. see it uploads and doesn't crash

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
