### PR TITLE
Passing mediaId in appendMediaFile gluecode and updated gb-mobile hash

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -413,7 +413,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         }
 
         if (URLUtil.isNetworkUrl(mediaUrl)) {
-            mWPAndroidGlueCode.appendMediaFile(mediaUrl);
+            mWPAndroidGlueCode.appendMediaFile(Integer.valueOf(mediaFile.getMediaId()), mediaUrl);
         } else {
             mWPAndroidGlueCode.appendUploadMediaFile(mediaFile.getId(), "file://" + mediaUrl);
             mUploadingMediaProgressMax.put(String.valueOf(mediaFile.getId()), 0f);


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/520

To test:
1. start a new draft
2. insert an image block
3. tap on MEDIA LIBRARY
4. choose an image
5. verify it is loaded in the block

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
