### PR TITLE
Issue/notifications filter divider

### DIFF
--- a/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
@@ -146,7 +146,7 @@
                     </HorizontalScrollView>
 
                     <View
-                        android:background="@drawable/notifications_list_divider"
+                        android:background="@drawable/notifications_list_divider_full_width"
                         android:layout_height="1dp"
                         android:layout_width="match_parent"/>
 


### PR DESCRIPTION
### Fix
Update the divider at the bottom of the filter view on the ***Notifications*** tab to be full-width for consistency with the list items below it.  See the screenshots below for illustration.  Click the image to see it in a higher resolution.

![notifications_filter_divider](https://user-images.githubusercontent.com/3827611/51961187-241a5a80-2419-11e9-9393-b3efe4140542.png)

### Test
1. Go to ***Notifications*** tab.
2. Notice filter divider is full-width.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.