### PR TITLE
[Gutenberg] Fix for editor not initialized if title is empty

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2230,7 +2230,11 @@ public class EditPostActivity extends AppCompatActivity implements
             }
             if (!TextUtils.isEmpty(mPost.getTitle())) {
                 mEditorFragment.setTitle(mPost.getTitle());
+            } else if (mEditorFragment instanceof GutenbergEditorFragment) {
+                // don't avoid calling setTitle() for GutenbergEditorFragment so RN gets initialized
+                mEditorFragment.setTitle("");
             }
+
             // TODO: postSettingsButton.setText(post.isPage() ? R.string.page_settings : R.string.post_settings);
             mEditorFragment.setLocalDraft(mPost.isLocalDraft());
 


### PR DESCRIPTION
This PR fixes #9144 by making sure to set the title for `GutenbergEditorFragment` so RN gets initialized.

To test:
- Enable Gutenberg
- Create New Post
- Put some paragraph
- Leave title EMPTY
- Press back arrow
- Open the drafted Post and check the editor is started properly

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
