### PR TITLE
Design changes to the most popular block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/MostPopularInsightsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/MostPopularInsightsUseCase.kt
@@ -9,8 +9,7 @@ import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.MOST_POPULAR_D
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatelessUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItem
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.utils.DateUtils
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -47,28 +46,26 @@ class MostPopularInsightsUseCase
     override fun buildUiModel(domainModel: InsightsMostPopularModel): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
         items.add(Title(R.string.stats_insights_popular))
-        items.add(Header(
-                R.string.stats_insights_most_popular_day_and_hour_label,
-                R.string.stats_insights_most_popular_views_label)
-        )
         items.add(
-                ListItem(
-                        dateUtils.getWeekDay(domainModel.highestDayOfWeek),
-                        resourceProvider.getString(
+                ListItemWithIcon(
+                        icon = R.drawable.ic_calendar_grey_dark_24dp,
+                        text = dateUtils.getWeekDay(domainModel.highestDayOfWeek),
+                        value = resourceProvider.getString(
                                 R.string.stats_most_popular_percent_views,
                                 domainModel.highestDayPercent.roundToInt()
                         ),
-                        true
+                        showDivider = true
                 )
         )
         items.add(
-                ListItem(
-                        dateUtils.getHour(domainModel.highestHour),
-                        resourceProvider.getString(
+                ListItemWithIcon(
+                        icon = R.drawable.ic_time_grey_dark_24dp,
+                        text = dateUtils.getHour(domainModel.highestHour),
+                        value = resourceProvider.getString(
                                 R.string.stats_most_popular_percent_views,
                                 domainModel.highestHourPercent.roundToInt()
                         ),
-                        false
+                        showDivider = false
                 )
         )
         return items

--- a/WordPress/src/main/res/drawable/ic_calendar_grey_dark_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_calendar_grey_dark_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/grey_dark"
+        android:pathData="M19,4h-1V2h-2v2H8V2H6v2H5C3.895,4 3,4.896 3,6v13c0,1.104 0.895,2 2,2h14c1.104,0 2,-0.896 2,-2V6C21,4.896 20.104,4 19,4zM19,19H5V8h14V19z"/>
+</vector>

--- a/WordPress/src/main/res/drawable/ic_time_grey_dark_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_time_grey_dark_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportHeight="24.0"
+        android:viewportWidth="24.0">
+    <path
+        android:fillColor="@color/grey_dark"
+        android:pathData="M12,4c4.411,0,8,3.589,8,8s-3.589,8-8,8s-8-3.589-8-8S7.589,4,12,4 M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10s10-4.477,10-10S17.523,2,12,2L12,2z M15.8,15.4L13,11.667V7h-2v5.333l3.2,4.266L15.8,15.4z"/>
+</vector>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1008,14 +1008,12 @@
     <string name="stats_insights_latest_post_no_title">(no title)</string>
     <string name="stats_insights_latest_post_summary">Latest Post Summary</string>
     <string name="stats_insights_latest_post_trend">It\'s been %1$s since %2$s was published. Here\'s how the post has performed so far…</string>
-    <string name="stats_insights_popular">Most Popular Day and Hour</string>
+    <string name="stats_insights_popular">Most Popular Time</string>
     <string name="stats_insights_most_popular_day">Most popular day</string>
     <string name="stats_insights_most_popular_hour">Most popular hour</string>
     <string name="stats_insights_most_popular_percent_views">%1$d%% of views</string>
     <string name="stats_insights_best_ever">Best Views Ever</string>
     <string name="stats_insights_today_stats">Today\'s Stats</string>
-    <string name="stats_insights_most_popular_day_and_hour_label">Day/Hour</string>
-    <string name="stats_insights_most_popular_views_label">Views</string>
 
     <!-- Stats refreshed insights -->
     <string name="stats_insights_all_time_stats">All Time Stats</string>
@@ -1032,7 +1030,7 @@
     <string name="stats_insights_google_plus">Google+</string>
     <string name="stats_insights_linkedin">LinkedIn</string>
     <string name="stats_insights_path">Path</string>
-    <string name="stats_most_popular_percent_views">%1$d%%</string>
+    <string name="stats_most_popular_percent_views">%1$d%% of views</string>
 
     <string name="stats_posts_and_pages">Posts and Pages</string>
     <string name="stats_referrers">Referrers</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/MostPopularInsightsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/MostPopularInsightsUseCaseTest.kt
@@ -21,11 +21,9 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsBlock
 import org.wordpress.android.ui.stats.refresh.lists.StatsBlock.Type.BLOCK_LIST
 import org.wordpress.android.ui.stats.refresh.lists.StatsBlock.Type.ERROR
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItem
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.HEADER
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM_WITH_ICON
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
 import org.wordpress.android.ui.stats.refresh.utils.DateUtils
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -55,15 +53,19 @@ class MostPopularInsightsUseCaseTest : BaseUnitTest() {
 
         whenever(dateUtils.getHour(hour)).thenReturn(hourString)
 
-        whenever(resourceProvider.getString(
-                R.string.stats_most_popular_percent_views,
-                highestDayPercent.roundToInt()
-        )).thenReturn("${highestDayPercent.roundToInt()}%")
+        whenever(
+                resourceProvider.getString(
+                        R.string.stats_most_popular_percent_views,
+                        highestDayPercent.roundToInt()
+                )
+        ).thenReturn("${highestDayPercent.roundToInt()}% of views")
 
-        whenever(resourceProvider.getString(
-                R.string.stats_most_popular_percent_views,
-                highestHourPercent.roundToInt()
-        )).thenReturn("${highestHourPercent.roundToInt()}%")
+        whenever(
+                resourceProvider.getString(
+                        R.string.stats_most_popular_percent_views,
+                        highestHourPercent.roundToInt()
+                )
+        ).thenReturn("${highestHourPercent.roundToInt()}% of views")
     }
 
     @Test
@@ -80,11 +82,10 @@ class MostPopularInsightsUseCaseTest : BaseUnitTest() {
 
         assertThat(result.type).isEqualTo(BLOCK_LIST)
         (result as BlockList).apply {
-            assertThat(this.items).hasSize(4)
+            assertThat(this.items).hasSize(3)
             assertTitle(this.items[0])
-            assertLabel(this.items[1])
-            assertDay(this.items[2])
-            assertHour(this.items[3])
+            assertDay(this.items[1])
+            assertHour(this.items[2])
         }
     }
 
@@ -113,26 +114,21 @@ class MostPopularInsightsUseCaseTest : BaseUnitTest() {
     }
 
     private fun assertDay(blockListItem: BlockListItem) {
-        assertThat(blockListItem.type).isEqualTo(LIST_ITEM)
-        val item = blockListItem as ListItem
+        assertThat(blockListItem.type).isEqualTo(LIST_ITEM_WITH_ICON)
+        val item = blockListItem as ListItemWithIcon
+        assertThat(item.icon).isEqualTo(R.drawable.ic_calendar_grey_dark_24dp)
         assertThat(item.text).isEqualTo(dayString)
         assertThat(item.showDivider).isEqualTo(true)
-        assertThat(item.value).isEqualTo("${highestDayPercent.roundToInt()}%")
-    }
-
-    private fun assertLabel(blockListItem: BlockListItem) {
-        assertThat(blockListItem.type).isEqualTo(HEADER)
-        val item = blockListItem as Header
-        assertThat(item.leftLabel).isEqualTo(R.string.stats_insights_most_popular_day_and_hour_label)
-        assertThat(item.rightLabel).isEqualTo(R.string.stats_insights_most_popular_views_label)
+        assertThat(item.value).isEqualTo("${highestDayPercent.roundToInt()}% of views")
     }
 
     private fun assertHour(blockListItem: BlockListItem) {
-        assertThat(blockListItem.type).isEqualTo(LIST_ITEM)
-        val item = blockListItem as ListItem
+        assertThat(blockListItem.type).isEqualTo(LIST_ITEM_WITH_ICON)
+        val item = blockListItem as ListItemWithIcon
+        assertThat(item.icon).isEqualTo(R.drawable.ic_time_grey_dark_24dp)
         assertThat(item.text).isEqualTo(hourString)
         assertThat(item.showDivider).isEqualTo(false)
-        assertThat(item.value).isEqualTo("${highestHourPercent.roundToInt()}%")
+        assertThat(item.value).isEqualTo("${highestHourPercent.roundToInt()}% of views")
     }
 
     private suspend fun loadMostPopularInsights(refresh: Boolean, forced: Boolean): StatsBlock {


### PR DESCRIPTION
Fixes #9069 
This PR introduces design changes to the Most popular block. This includes:
* Changing title to "Most Popular Time"
* Removing of the list header
* Adding a calendar icon to the post popular day and time icon to the most popular time
* Adding a "of views" to the items value
 
![screenshot_1548930468](https://user-images.githubusercontent.com/1079756/52048614-229d7f00-254c-11e9-9a16-9c17dc296795.png)

To test:
* Go to Stats/Insights
* Scroll to the `Most Popular Time` block
* Check that the updated designs are correct
