### PR TITLE
Align tabs left in stats

### DIFF
--- a/WordPress/src/main/res/layout/stats_block_tabs_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_tabs_item.xml
@@ -8,12 +8,14 @@
 
     <android.support.design.widget.TabLayout
         android:id="@+id/tab_layout"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="top"
-        app:tabGravity="fill"
+        app:tabGravity="center"
         app:tabIndicatorColor="@color/wp_blue"
         app:tabSelectedTextColor="@color/wp_blue"
+        app:tabPaddingStart="@dimen/margin_extra_large"
+        app:tabPaddingEnd="@dimen/margin_extra_large"
         app:tabTextColor="@color/wp_grey_darken_20"/>
 
     <View


### PR DESCRIPTION
Fixes #9155 
This PR aligns tabs in the tab layout (in blocks like Followers or Comments) to the left. There are no changes to behaviour).

![screenshot_1548937014](https://user-images.githubusercontent.com/1079756/52053800-ab231c00-255a-11e9-981a-d8a4618fe341.png)

To test:
* Go to Stats/Insights
* Scroll to the Followers block
* Check it looks according to the designs and there are not changes to functionality
