### PR TITLE
Add bottom stroke to Titles in Stats

### DIFF
--- a/WordPress/src/main/res/layout/stats_block_text_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_text_item.xml
@@ -3,6 +3,7 @@
               style="@style/StatsBlockLine"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
+             android:paddingTop="@dimen/margin_extra_large"
               android:minHeight="@dimen/one_line_list_item_height">
 
     <TextView

--- a/WordPress/src/main/res/layout/stats_block_title_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_title_item.xml
@@ -1,15 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:layout_width="match_parent"
-              style="@style/StatsBlockLine"
-              android:orientation="horizontal">
+              android:layout_height="@dimen/one_line_list_item_height"
+              android:orientation="vertical">
 
     <TextView
         android:id="@+id/text"
         android:layout_gravity="center_vertical"
+        android:gravity="center_vertical"
         style="@style/StatsBlockTitle"
+        android:layout_marginStart="@dimen/margin_extra_large"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
+        android:layout_weight="1"
         android:text="@string/unknown"/>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/grey_lighten_30"
+        android:visibility="visible"/>
 
 </LinearLayout>


### PR DESCRIPTION
Fixes #9136 
This PR is adding a bottom stroke to the Titles in the refreshed Stats. The stroke is 1dp high and the same color as the dividers we're already using. The text in the Latest post summary had to be shifted down in order to be 16dp from the bottom stroke of the title.

To test:
* Open Stats
* All the titles have now bottom stroke
* The test in the Latest post summary has a top margin under the stroke

![screenshot_1549554405](https://user-images.githubusercontent.com/1079756/52423234-fc518380-2af7-11e9-9c8a-e0e760d8085f.png)

