### PR TITLE
Fix low hanging deprecation warnings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -19,7 +19,6 @@ import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.BaseAdapter;
 import android.widget.EditText;
-import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.RelativeLayout;
@@ -75,7 +74,7 @@ public class AddQuickPressShortcutActivity extends ListActivity {
 
         ListView listView = (ListView) findViewById(android.R.id.list);
 
-        ImageView iv = new ImageView(this);
+        View iv = new View(this);
         iv.setBackgroundResource(R.drawable.list_divider);
         listView.addFooterView(iv);
         listView.setVerticalFadingEdgeEnabled(false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -76,17 +76,17 @@ public class AddQuickPressShortcutActivity extends ListActivity {
         ListView listView = (ListView) findViewById(android.R.id.list);
 
         ImageView iv = new ImageView(this);
-        iv.setBackgroundDrawable(getResources().getDrawable(R.drawable.list_divider));
+        iv.setBackgroundResource(R.drawable.list_divider);
         listView.addFooterView(iv);
         listView.setVerticalFadingEdgeEnabled(false);
         listView.setVerticalScrollBarEnabled(true);
 
         if (sites.size() > 0) {
             ScrollView sv = new ScrollView(this);
-            sv.setLayoutParams(new LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.WRAP_CONTENT));
+            sv.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
             LinearLayout layout = new LinearLayout(this);
             layout.setPadding(10, 10, 10, 0);
-            layout.setLayoutParams(new LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.WRAP_CONTENT));
+            layout.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
 
             layout.setOrientation(LinearLayout.VERTICAL);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -288,7 +288,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             mTabLayout.addTab(mTabLayout.newTab().setText(R.string.media_videos)); // FILTER_VIDEOS
             mTabLayout.addTab(mTabLayout.newTab().setText(R.string.media_audio)); // FILTER_AUDIO
 
-            mTabLayout.setOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
+            mTabLayout.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
                 @Override
                 public void onTabSelected(TabLayout.Tab tab) {
                     setFilter(getFilterForPosition(tab.getPosition()));

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -282,6 +282,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             int selectedColor = ContextCompat.getColor(this, R.color.white);
             mTabLayout.setTabTextColors(normalColor, selectedColor);
 
+            mTabLayout.removeAllTabs();
             mTabLayout.addTab(mTabLayout.newTab().setText(R.string.media_all)); // FILTER_ALL
             mTabLayout.addTab(mTabLayout.newTab().setText(R.string.media_images)); // FILTER_IMAGES
             mTabLayout.addTab(mTabLayout.newTab().setText(R.string.media_documents)); // FILTER_DOCUMENTS

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -288,6 +288,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             mTabLayout.addTab(mTabLayout.newTab().setText(R.string.media_videos)); // FILTER_VIDEOS
             mTabLayout.addTab(mTabLayout.newTab().setText(R.string.media_audio)); // FILTER_AUDIO
 
+            mTabLayout.clearOnTabSelectedListeners();
             mTabLayout.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
                 @Override
                 public void onTabSelected(TabLayout.Tab tab) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -496,7 +496,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // When swiping between different sections, select the corresponding
         // tab. We can also use ActionBar.Tab#select() to do this if we have
         // a reference to the Tab.
-        mViewPager.setOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener() {
+        mViewPager.addOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener() {
             @Override
             public void onPageSelected(int position) {
                 invalidateOptionsMenu();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -496,6 +496,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // When swiping between different sections, select the corresponding
         // tab. We can also use ActionBar.Tab#select() to do this if we have
         // a reference to the Tab.
+        mViewPager.clearOnPageChangeListeners();
         mViewPager.addOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener() {
             @Override
             public void onPageSelected(int position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPreviewFragment.java
@@ -60,7 +60,7 @@ public class EditPostPreviewFragment extends Fragment {
                 if (getActivity() != null) {
                     loadPost();
                 }
-                mWebView.getViewTreeObserver().removeGlobalOnLayoutListener(this);
+                mWebView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
             }
         });
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SmoothScrollLinearLayoutManager.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SmoothScrollLinearLayoutManager.java
@@ -22,7 +22,7 @@ public class SmoothScrollLinearLayoutManager extends LinearLayoutManager {
     public void smoothScrollToPosition(RecyclerView recyclerView, RecyclerView.State state, int position) {
         final View firstVisibleChild = recyclerView.getChildAt(0);
         final int itemHeight = firstVisibleChild.getHeight();
-        final int currentPosition = recyclerView.getChildLayoutPosition(firstVisibleChild);
+        final int currentPosition = recyclerView.getChildAdapterPosition(firstVisibleChild);
         int distanceInPixels = Math.abs((currentPosition - position) * itemHeight);
 
         if (distanceInPixels == 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SmoothScrollLinearLayoutManager.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SmoothScrollLinearLayoutManager.java
@@ -22,7 +22,7 @@ public class SmoothScrollLinearLayoutManager extends LinearLayoutManager {
     public void smoothScrollToPosition(RecyclerView recyclerView, RecyclerView.State state, int position) {
         final View firstVisibleChild = recyclerView.getChildAt(0);
         final int itemHeight = firstVisibleChild.getHeight();
-        final int currentPosition = recyclerView.getChildPosition(firstVisibleChild);
+        final int currentPosition = recyclerView.getChildLayoutPosition(firstVisibleChild);
         int distanceInPixels = Math.abs((currentPosition - position) * itemHeight);
 
         if (distanceInPixels == 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
@@ -101,7 +101,7 @@ public class StatsGeoviewsFragment extends StatsAbstractListFragment {
                 new ViewTreeObserver.OnGlobalLayoutListener() {
             @Override
             public void onGlobalLayout() {
-                mTopPagerContainer.getViewTreeObserver().removeGlobalOnLayoutListener(this);
+                mTopPagerContainer.getViewTreeObserver().removeOnGlobalLayoutListener(this);
                 if (!isAdded()) {
                     return;
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureAdapter.java
@@ -133,9 +133,9 @@ public class StatsWidgetConfigureAdapter extends RecyclerView.Adapter<StatsWidge
         mImageManager.load(holder.mImgBlavatar, ImageType.BLAVATAR, site.getBlavatarUrl());
 
         if (site.getLocalId() == mPrimarySiteId) {
-            holder.mLayoutContainer.setBackgroundDrawable(mSelectedItemBackground);
+            holder.mLayoutContainer.setBackground(mSelectedItemBackground);
         } else {
-            holder.mLayoutContainer.setBackgroundDrawable(null);
+            holder.mLayoutContainer.setBackground(null);
         }
 
         // different styling for visible/hidden sites

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
@@ -268,7 +268,7 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
     private ViewTreeObserver.OnGlobalLayoutListener mGlobalLayoutListener
             = new ViewTreeObserver.OnGlobalLayoutListener() {
         public void onGlobalLayout() {
-            mRootView.getViewTreeObserver().removeGlobalOnLayoutListener(this);
+            mRootView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
             mFullViewBottom = mRootView.getBottom();
         }
     };

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DeviceUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DeviceUtils.java
@@ -144,6 +144,7 @@ public class DeviceUtils {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {
             return stat.getBlockSizeLong() * stat.getAvailableBlocksLong();
         } else {
+            //noinspection deprecation - Deprecated calls properly handled
             bytesAvailable = (long) stat.getBlockSize() * (long) stat.getAvailableBlocks();
         }
         return bytesAvailable;


### PR DESCRIPTION
This relates to #5247 but only fixes some low hanging deprecation warnings that don’t need extensive testing to ensure they don’t break functionality.

To test: Load into the various Activities/Fragments to ensure they still work as expected
