### PR TITLE
Remove vcs.xml

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>


### PR DESCRIPTION
The `vcs.xml` file changes keep showing up even though it's included in `.gitignore`. Because the file has been committed, it's still being tracked so it needs to be removed.