### PR TITLE
Issue/8974 site creation domains tests

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/NewSiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/NewSiteCreationDomainsViewModelTest.kt
@@ -257,7 +257,6 @@ class NewSiteCreationDomainsViewModelTest {
         assertThat(captor.lastValue, Is(RequestFocusMode.FOCUS_AND_KEYBOARD))
     }
 
-
     /**
      * Helper function to verify a [DomainsUiState] with [DomainsUiContentState.Initial] content state.
      */

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/NewSiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/NewSiteCreationDomainsViewModelTest.kt
@@ -128,6 +128,17 @@ class NewSiteCreationDomainsViewModelTest {
     }
 
     /**
+     * Verifies the UI state for after the VM is started with a non-empty site title and it results in error
+     */
+    @Test
+    fun verifyErrorResultTitleQueryUiStateAfterResponse() = testWithErrorResponse {
+        viewModel.start(ERROR_RESULT_FETCH_QUERY)
+        val captor = ArgumentCaptor.forClass(DomainsUiState::class.java)
+        verify(uiStateObserver, times(2)).onChanged(captor.capture())
+        verifyInitialContentUiState(captor.secondValue)
+    }
+
+    /**
      * Verifies the initial UI state for when the user enters a non-empty query.
      */
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/NewSiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/NewSiteCreationDomainsViewModelTest.kt
@@ -35,7 +35,7 @@ import org.wordpress.android.util.NetworkUtilsWrapper
 import org.hamcrest.CoreMatchers.`is` as Is
 
 private const val MULTI_RESULT_DOMAIN_FETCH_RESULT_SIZE = 20
-private const val ERROR_RESULT_FETCH_QUERY = "test"
+private const val ERROR_RESULT_FETCH_QUERY = "error_result_query"
 private val MULTI_RESULT_DOMAIN_FETCH_QUERY = Pair("multi_result_query", MULTI_RESULT_DOMAIN_FETCH_RESULT_SIZE)
 private val EMPTY_RESULT_DOMAIN_FETCH_QUERY = Pair("empty_result_query", 0)
 
@@ -129,7 +129,7 @@ class NewSiteCreationDomainsViewModelTest {
     }
 
     /**
-     * Verifies the UI state for after the VM is started with a non-empty site title and it results in error
+     * Verifies the UI state for after the VM is started with a non-empty site title and fetchDomains results in error
      */
     @Test
     fun verifyErrorResultTitleQueryUiStateAfterResponse() = testWithErrorResponse {

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/NewSiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/NewSiteCreationDomainsViewModelTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.sitecreation.domains
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.firstValue
+import com.nhaarman.mockitokotlin2.lastValue
 import com.nhaarman.mockitokotlin2.secondValue
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
@@ -222,6 +223,40 @@ class NewSiteCreationDomainsViewModelTest {
         verify(createSiteBtnObserver, times(1)).onChanged(captor.capture())
         assertThat(captor.firstValue, Is(domainName))
     }
+
+    /**
+     * Verifies the input focus is requested when the VM is started with a non-empty site title.
+     */
+    @Test
+    fun verifyInputFocusRequestedAfterVMStartedWithNonEmptyTitle() = testWithSuccessResponse {
+        viewModel.start(MULTI_RESULT_DOMAIN_FETCH_QUERY.first)
+        val captor = ArgumentCaptor.forClass(RequestFocusMode::class.java)
+        verify(onInputFocusRequestedObserver, times(1)).onChanged(captor.capture())
+        assertThat(captor.lastValue, Is(RequestFocusMode.FOCUS_ONLY))
+    }
+
+    /**
+     * Verifies the input focus and keyboard is requested when the VM is started with an empty site title.
+     */
+    @Test
+    fun verifyInputFocusAndKeyboardRequestedAfterVMStartedWithEmptyTitle() = testWithSuccessResponse {
+        viewModel.start("")
+        val captor = ArgumentCaptor.forClass(RequestFocusMode::class.java)
+        verify(onInputFocusRequestedObserver, times(1)).onChanged(captor.capture())
+        assertThat(captor.lastValue, Is(RequestFocusMode.FOCUS_AND_KEYBOARD))
+    }
+
+    /**
+     * Verifies the input focus and keyboard is requested when the VM is started with null site title.
+     */
+    @Test
+    fun verifyInputFocusAndKeyboardRequestedAfterVMStartedWithNullTitle() = testWithSuccessResponse {
+        viewModel.start(null)
+        val captor = ArgumentCaptor.forClass(RequestFocusMode::class.java)
+        verify(onInputFocusRequestedObserver, times(1)).onChanged(captor.capture())
+        assertThat(captor.lastValue, Is(RequestFocusMode.FOCUS_AND_KEYBOARD))
+    }
+
 
     /**
      * Helper function to verify a [DomainsUiState] with [DomainsUiContentState.Initial] content state.


### PR DESCRIPTION
Fixes #8974 

Adds unit tests for when FetchDomains results in an error and for logic related to requestInputFocus.

To test:
- CI should take care of testing
Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
