### PR TITLE
issue/8559 - Dismiss Removed Posts After Refreshing Saved Posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -654,6 +654,9 @@ public class ReaderPostListFragment extends Fragment
                     // make sure swipe-to-refresh progress shows since this is a manual refresh
                     mRecyclerView.setRefreshing(true);
                 }
+
+                ReaderPostTable.purgeUnbookmarkedPostsWithBookmarkTag();
+                refreshPosts();
             }
 
             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -655,8 +655,10 @@ public class ReaderPostListFragment extends Fragment
                     mRecyclerView.setRefreshing(true);
                 }
 
-                ReaderPostTable.purgeUnbookmarkedPostsWithBookmarkTag();
-                refreshPosts();
+                if (getCurrentTag() != null && getCurrentTag().isBookmarked()) {
+                    ReaderPostTable.purgeUnbookmarkedPostsWithBookmarkTag();
+                    refreshPosts();
+                }
             }
 
             @Override


### PR DESCRIPTION
Fixes #8559 

To test:

###
1. Save post(s).
2. Go to _**Reader**_ tab.
3. Tap filter dropdown list in toolbar.
4. Tap _**Saved Posts**_ item in list.
5. Tap _**Add to Saved Posts**_ action (i.e. bookmark icon) on saved post.
6. Notice card showing post is removed from list is shown.
7. Swipe down to refresh list.
8. Notice card showing post is removed from list is not showing any more.


<img src="https://user-images.githubusercontent.com/2581647/52384827-d7103700-2a5d-11e9-991b-38c025ff4d11.gif" height="500">

