### PR TITLE
Point to latest gutenberg-mobile release v0.3.5

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     ext {
-        aztecVersion = 'd2f24f4a7c21e2be77ef77cd646e67a3a2b9802a'
+        aztecVersion = 'v1.3.19'
     }
 
     repositories {


### PR DESCRIPTION
This PR updates the gutenberg-mobile reference to point to the latest release, v0.3.5. No wpandroid integration changes introduced.

The reference is currently pointing to the `release/0.3.5` branch on https://github.com/wordpress-mobile/gutenberg-mobile. Relevant PR: [wordpress-mobile/gutenberg-mobile#558](https://github.com/wordpress-mobile/gutenberg-mobile/pull/558).

When that gets merged to gutenberg-mobile master, I'll update the ref here to point to the merge commit.

To test:
The block editor should work as normal.

Update release notes:

* [x]  If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.