### PR TITLE
Add unit tests for WizardManager

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/util/wizard/WizardManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/wizard/WizardManagerTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.util.wizard
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.Observer
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -14,6 +15,7 @@ import org.wordpress.android.ui.sitecreation.SiteCreationStep
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.VERTICALS
 
 private val STEPS = listOf(SEGMENTS, DOMAINS, SITE_PREVIEW)
 private val LAST_STEP_INDEX = STEPS.size - 1
@@ -35,14 +37,15 @@ class WizardManagerTest {
     @Test
     fun `showNextStep is propagated`() {
         manager.showNextStep()
-        verify(navigatorLiveDataObserver).onChanged(STEPS[0])
+        verify(navigatorLiveDataObserver).onChanged(any())
     }
 
     @Test
     fun `showNextStep increments currentStepIndex`() {
-        val initialStepIndex = manager.currentStep
-        manager.showNextStep()
-        assertThat(manager.currentStep).isEqualTo(initialStepIndex + 1)
+        for (i in 0..LAST_STEP_INDEX) {
+            manager.showNextStep()
+            assertThat(manager.currentStep).isEqualTo(i)
+        }
     }
 
     @Test
@@ -77,6 +80,11 @@ class WizardManagerTest {
     fun `exception thrown on navigation to invalid index`() {
         manager = createWizardManager(initialStepIndex = LAST_STEP_INDEX)
         manager.showNextStep()
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `exception thrown on getting position of unknown step`() {
+        manager.stepPosition(VERTICALS)
     }
 
     private fun createWizardManager(initialStepIndex: Int) = WizardManager(STEPS, initialStepIndex)

--- a/WordPress/src/test/java/org/wordpress/android/util/wizard/WizardManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/wizard/WizardManagerTest.kt
@@ -81,4 +81,3 @@ class WizardManagerTest {
 
     private fun createWizardManager(initialStepIndex: Int) = WizardManager(STEPS, initialStepIndex)
 }
-

--- a/WordPress/src/test/java/org/wordpress/android/util/wizard/WizardManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/wizard/WizardManagerTest.kt
@@ -1,7 +1,14 @@
 package org.wordpress.android.util.wizard
 
+import android.arch.core.executor.testing.InstantTaskExecutorRule
+import android.arch.lifecycle.Observer
+import com.nhaarman.mockitokotlin2.verify
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.ui.sitecreation.SiteCreationStep
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
@@ -9,14 +16,69 @@ import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
 
 private val STEPS = listOf(SEGMENTS, DOMAINS, SITE_PREVIEW)
+private val LAST_STEP_INDEX = STEPS.size - 1
 
 @RunWith(MockitoJUnitRunner::class)
 class WizardManagerTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
     private lateinit var manager: WizardManager<SiteCreationStep>
+    @Mock private lateinit var navigatorLiveDataObserver: Observer<SiteCreationStep>
 
     @Before
     fun setUp() {
         manager = WizardManager(STEPS)
+        manager.navigatorLiveData.observeForever(navigatorLiveDataObserver)
     }
+
+    @Test
+    fun `showNextStep is propagated`() {
+        manager.showNextStep()
+        verify(navigatorLiveDataObserver).onChanged(STEPS[0])
+    }
+
+    @Test
+    fun `showNextStep increments currentStepIndex`() {
+        val initialStepIndex = manager.currentStep
+        manager.showNextStep()
+        assertThat(manager.currentStep).isEqualTo(initialStepIndex + 1)
+    }
+
+    @Test
+    fun `step position is correctly calculated`() {
+        STEPS.forEach { step ->
+            assertThat(manager.stepPosition(step)).isEqualTo(STEPS.indexOf(step) + 1)
+        }
+    }
+
+    @Test
+    fun `isLastStep returns true only for last step`() {
+        STEPS.forEachIndexed { currentStepIndex, _ ->
+            manager.showNextStep()
+            assertThat(manager.isLastStep()).isEqualTo(currentStepIndex == LAST_STEP_INDEX)
+        }
+    }
+
+    @Test
+    fun `manager is initialized with provided step index`() {
+        manager = createWizardManager(initialStepIndex = LAST_STEP_INDEX)
+        assertThat(manager.currentStep).isEqualTo(LAST_STEP_INDEX)
+    }
+
+    @Test
+    fun `onBackPressed decrements currentStepIndex`() {
+        manager = createWizardManager(initialStepIndex = LAST_STEP_INDEX)
+        manager.onBackPressed()
+        assertThat(manager.currentStep).isEqualTo(LAST_STEP_INDEX - 1)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `exception thrown on navigation to invalid index`() {
+        manager = createWizardManager(initialStepIndex = LAST_STEP_INDEX)
+        manager.showNextStep()
+    }
+
+    private fun createWizardManager(initialStepIndex: Int) = WizardManager(STEPS, initialStepIndex)
 }
 

--- a/WordPress/src/test/java/org/wordpress/android/util/wizard/WizardManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/wizard/WizardManagerTest.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.util.wizard
+
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.ui.sitecreation.SiteCreationStep
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
+
+private val STEPS = listOf(SEGMENTS, DOMAINS, SITE_PREVIEW)
+
+@RunWith(MockitoJUnitRunner::class)
+class WizardManagerTest {
+    private lateinit var manager: WizardManager<SiteCreationStep>
+
+    @Before
+    fun setUp() {
+        manager = WizardManager(STEPS)
+    }
+}
+


### PR DESCRIPTION
Adds few basic unit tests for WizardManager

To test:
- CI should take care of testing
Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
