### PR TITLE
Instant changes to overview block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
@@ -118,7 +118,7 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
      * Clears the LiveData value when we switch the current Site so we don't show the old data for a new site
      */
     fun clear() {
-        domainModel.postValue(null)
+        domainModel.postValue(State.Loading())
         uiState.postValue(null)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections
 
 import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MediatorLiveData
 import android.arch.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -27,7 +28,7 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
     private val defaultUiState: UI_STATE
 ) {
     private val domainModel = MutableLiveData<State<DOMAIN_MODEL>>()
-    private val uiState = MutableLiveData<UI_STATE>()
+    protected val uiState = MediatorLiveData<UI_STATE>()
     val liveData: LiveData<StatsBlock> = merge(domainModel, uiState) { data, uiState ->
         try {
             when (data) {
@@ -97,7 +98,7 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
      * Trigger this method when the UI state has changed.
      * @param newState
      */
-    fun onUiState(newState: UI_STATE?) {
+    fun onUiState(newState: UI_STATE? = null) {
         uiState.value = newState ?: uiState.value
     }
 
@@ -117,7 +118,7 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
      * Clears the LiveData value when we switch the current Site so we don't show the old data for a new site
      */
     fun clear() {
-        domainModel.postValue(State.Loading())
+        domainModel.postValue(null)
         uiState.postValue(null)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.granular
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.util.filter
 import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -14,6 +15,10 @@ class SelectedDateProvider
 
     private val mutableSelectedDateChanged = MutableLiveData<StatsGranularity>()
     val selectedDateChanged: LiveData<StatsGranularity> = mutableSelectedDateChanged
+
+    fun granularSelectedDateChanged(statsGranularity: StatsGranularity): LiveData<StatsGranularity> {
+        return selectedDateChanged.filter { it == statsGranularity }
+    }
 
     fun selectDate(date: Date, statsGranularity: StatsGranularity) {
         val selectedDate = mutableDates[statsGranularity]

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
@@ -41,6 +41,11 @@ constructor(
         mainDispatcher,
         UiState()
 ) {
+    init {
+        uiState.addSource(selectedDateProvider.granularSelectedDateChanged(statsGranularity)) {
+            onUiState()
+        }
+    }
     override fun buildLoadingItem(): List<BlockListItem> =
             listOf(
                     ValueItem(value = 0.toFormattedString(), unit = R.string.stats_views)

--- a/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
@@ -118,26 +118,6 @@ fun <S, T, U, V> merge(
 }
 
 /**
- * Merges four LiveData sources using a given function. The function returns an object of a new type.
- * @param sourceR first source
- * @param sourceS second source
- * @param sourceT third source
- * @param sourceU fourth source
- * @return new data source
- */
-fun <R, S, T, U, V> merge(
-    sourceR: LiveData<R>,
-    sourceS: LiveData<S>,
-    sourceT: LiveData<T>,
-    sourceU: LiveData<U>,
-    merger: (R?, S?, T?, U?) -> V
-): LiveData<V> {
-    val resultA: LiveData<Pair<R?, S?>> = merge(sourceR, sourceS) { r, s -> r to s }
-    val resultB: LiveData<Pair<T?, U?>> = merge(sourceT, sourceU) { t, u -> t to u }
-    return mergeNotNull(resultA, resultB) { (r, s), (t, u) -> merger(r, s, t, u) }
-}
-
-/**
  * Combines all the LiveData values in the given Map into one LiveData with the map of values.
  * @param sources is a map of all the live data sources in a map by a given key
  * @return one livedata instance that combines all the values into one map

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCaseTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 
+import android.arch.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
@@ -50,6 +51,7 @@ class OverviewUseCaseTest : BaseUnitTest() {
     private val currentDate = Date(10)
     @Before
     fun setUp() {
+        whenever(selectedDateProvider.granularSelectedDateChanged(statsGranularity)).thenReturn(MutableLiveData())
         useCase = OverviewUseCase(
                 statsGranularity,
                 store,


### PR DESCRIPTION
This small PR improves behaviour of the Date selector. The Overview block is now redrawn immediately after the user selects a different date with the next/previous buttons. 

To test:
* Go to Stats/DWMY
* Click on Previous/Next time periods in the date select
* Notice that the Overview block gets updated immediately and the rest of the blocks is updated after the change
