### PR TITLE
Tag for the Gutenberg default flag for Support

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -498,4 +498,5 @@ private object TicketFieldIds {
 
 object ZendeskExtraTags {
     const val connectingJetpack = "connecting_jetpack"
+    const val gutenbergIsDefault = "mobile_gutenberg_is_default"
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.ui.AppLogViewerActivity
 import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.util.LocaleManager
 import java.util.ArrayList
-import java.util.Collections
 import javax.inject.Inject
 
 class HelpActivity : AppCompatActivity() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -14,12 +14,14 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.support.SupportHelper
+import org.wordpress.android.support.ZendeskExtraTags
 import org.wordpress.android.support.ZendeskHelper
 import org.wordpress.android.ui.ActivityId
 import org.wordpress.android.ui.AppLogViewerActivity
 import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.util.LocaleManager
 import java.util.ArrayList
+import java.util.Collections
 import javax.inject.Inject
 
 class HelpActivity : AppCompatActivity() {
@@ -177,9 +179,27 @@ class HelpActivity : AppCompatActivity() {
             if (selectedSite != null) {
                 intent.putExtra(WordPress.SITE, selectedSite)
             }
-            if (extraSupportTags != null && !extraSupportTags.isEmpty()) {
-                intent.putStringArrayListExtra(HelpActivity.EXTRA_TAGS_KEY, extraSupportTags as ArrayList<String>?)
+
+            val tagsList: ArrayList<String>? = if (AppPrefs.isGutenbergDefaultForNewPosts()) {
+                // construct a mutable list to add the Gutenberg related extra tag
+                val list = ArrayList<String>()
+
+                // add the provided list of tags if any
+                extraSupportTags?.let {
+                    list.addAll(extraSupportTags)
+                }
+
+                // Append the "mobile_gutenberg_is_default" tag if gutenberg is set to default for new posts
+                list.add(ZendeskExtraTags.gutenbergIsDefault)
+                list // "return" the list
+            } else {
+                extraSupportTags as ArrayList<String>?
             }
+
+            if (tagsList != null && !tagsList.isEmpty()) {
+                intent.putStringArrayListExtra(HelpActivity.EXTRA_TAGS_KEY, tagsList)
+            }
+
             return intent
         }
     }


### PR DESCRIPTION
** Note, this PR targets another PR, not develop. **

Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/564

To test:

1. Place a breakpoint at https://github.com/wordpress-mobile/WordPress-Android/compare/feature/tag-gb-flag-for-support?expand=1#diff-3603bc7c4a38a2ba964dace2b1663661R183
2. Run the app and head over to the "Me" screen
3. Tap on the "Help & Support" item. The breakpoint will be hit.
4 Step through the code and verify that the `mobile_gutenberg_is_default` tag is added, depending on the state of the `AppPrefs.isGutenbergDefaultForNewPosts()` flag
5. Change the flag by going into the "App Settings" section of the app and toggle the "Use block editor for new posts" switch
6. Go to the "Help & Support" section again and verify that the tag is added or not depending on the new value of the flag.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
