### PR TITLE
Improve and simplify default Gradle configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ android_config: &android_config
   environment:
     # kotlin.incremental=false and kotlin.compiler.execution.strategy=in-process are required due to an issue with the Kotlin compiler in
     # memory constrained environments: https://youtrack.jetbrains.com/issue/KT-15562
-    GRADLE_OPTS: -Xmx1536m -XX:+HeapDumpOnOutOfMemoryError -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false
-    GRADLEW: "./gradlew --stacktrace --no-parallel --build-cache --configure-on-demand -PdisablePreDex -PjavaMaxHeapSize=1536m"
+    GRADLE_OPTS: -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false
+    GRADLEW: "./gradlew --stacktrace"
 
 copy_gradle_properties: &copy_gradle_properties
   run:

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -36,7 +36,6 @@ android {
 
     dexOptions {
         jumboMode = true
-        javaMaxHeapSize = project.properties.getOrDefault("javaMaxHeapSize", "6g")
         dexInProcess = true
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ buildscript {
 
 apply plugin: 'com.automattic.android.fetchstyle'
 
-project.ext.preDexLibs = !project.hasProperty('disablePreDex')
 project.ext.buildGutenbergFromSource = project.properties.getOrDefault('wp.BUILD_GUTENBERG_FROM_SOURCE', false).toBoolean()
 
 allprojects {
@@ -62,13 +61,6 @@ allprojects {
 }
 
 subprojects {
-    project.plugins.whenPluginAdded { plugin ->
-        if ("com.android.build.gradle.AppPlugin".equals(plugin.class.name)) {
-            project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
-        } else if ("com.android.build.gradle.LibraryPlugin".equals(plugin.class.name)) {
-            project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
-        }
-    }
 
     configurations {
         ktlint

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -1,20 +1,11 @@
 # Project-wide Gradle settings.
 
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-
-# For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
-
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+# These are the default Gradle properties for WordPress-Android
+# Feel free to tweak them for your machine (e.g. change -Xmx value below)
+org.gradle.jvmargs=-Xmx1536m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.parallel=true
+org.gradle.configureondemand=true
+org.gradle.caching=true
 
 # WordPress-Android properties.
 


### PR DESCRIPTION
Currently, we use `javaMaxHeapSize` and `preDexLibraries` to configure our Gradle builds. The former is equivalent to the `-Xmx` option we already have in `gradle.properties` so is duplication and `preDexLibraries` no longer gives a noticeable difference to build performance with recent Gradle versions (in my testing).

I have also updated `gradle.properties-example` with more extensive and sensible default values. This includes enabling parallelization and build caching.

**Note:** I have set the `-Xmx` to 1.5 GB rather than the 6 GB we were using for `javaMaxHeapSize` as I could see no noticeable improvement by using 6 GB and 1.5 GB is a more reasonable default. Anyone can tweak this locally as they see fit.

If merged, I will update the `gradle.properties` file in the secrets repo to reflect the same changes.

To test:

- CircleCI checks are still green.
- `./gradlew assembleVanillaRelease` works and is not slow.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
