### PR TITLE
Update support library to 28

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 android_config: &android_config
   docker:
-    - image: circleci/android:api-27-alpha
+    - image: circleci/android:api-28-alpha
   environment:
     # kotlin.incremental=false and kotlin.compiler.execution.strategy=in-process are required due to an issue with the Kotlin compiler in
     # memory constrained environments: https://youtrack.jetbrains.com/issue/KT-15562

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -36,7 +36,7 @@ android {
         dexInProcess = true
     }
 
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
     defaultConfig {
@@ -44,7 +44,7 @@ android {
         versionName "alpha-150"
         versionCode 674
         minSdkVersion 21
-        targetSdkVersion 26
+        targetSdkVersion 28
 
         multiDexEnabled true
 
@@ -107,6 +107,11 @@ android {
         lintConfig file('lint.xml')
         baseline file("lint-baseline.xml")
     }
+
+    packagingOptions {
+        // MPAndroidChart uses androidX - remove this line when we migrate everything to androidX
+        exclude 'META-INF/proguard/androidx-annotations.pro'
+    }
 }
 
 // allows us to use cool things like @Parcelize annotations
@@ -127,17 +132,20 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.6.2'
     implementation 'org.ccil.cowan.tagsoup:tagsoup:1.2.1'
 
-    implementation 'com.android.support:support-compat:27.1.1'
-    implementation 'com.android.support:support-core-ui:27.1.1'
-    implementation 'com.android.support:support-fragment:27.1.1'
+    implementation 'com.android.support:support-compat:28.0.0'
+    implementation 'com.android.support:support-core-ui:28.0.0'
+    implementation 'com.android.support:support-fragment:28.0.0'
 
     implementation 'com.android.support:multidex:1.0.2'
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:cardview-v7:27.1.1'
-    implementation 'com.android.support:recyclerview-v7:27.1.1'
-    implementation 'com.android.support:design:27.1.1'
-    implementation 'com.android.support:percent:27.1.1'
-    implementation 'com.android.support:preference-v7:27.1.1'
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.android.support:exifinterface:28.0.0'
+    implementation'com.android.support:support-media-compat:28.0.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:cardview-v7:28.0.0'
+    implementation 'com.android.support:recyclerview-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
+    implementation 'com.android.support:percent:28.0.0'
+    implementation 'com.android.support:preference-v7:28.0.0'
 
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -44,7 +44,7 @@ android {
         versionName "alpha-150"
         versionCode 674
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 26
 
         multiDexEnabled true
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -29,6 +29,10 @@ android.defaultConfig.javaCompileOptions.annotationProcessorOptions.includeCompi
 
 android {
     useLibrary 'org.apache.http.legacy'
+    useLibrary 'android.test.runner'
+
+    useLibrary 'android.test.base'
+    useLibrary 'android.test.mock'
 
     dexOptions {
         jumboMode = true

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -3,7 +3,7 @@ package org.wordpress.android.ui.screenshots;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.v7.widget.CardView;
-import android.test.suitebuilder.annotation.LargeTest;
+import android.support.test.filters.LargeTest;
 
 import org.junit.ClassRule;
 import org.junit.Rule;

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -65,8 +65,8 @@ class ActivityLogListFragment : Fragment() {
 
         log_list_view.setEmptyView(actionable_empty_view)
         log_list_view.addOnScrollListener(object : RecyclerView.OnScrollListener() {
-            override fun onScrolled(recyclerView: RecyclerView?, dx: Int, dy: Int) {
-                if (!recyclerView!!.canScrollVertically(1) && dy != 0) {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                if (!recyclerView.canScrollVertically(1) && dy != 0) {
                     viewModel.onScrolledToBottom()
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -1,10 +1,10 @@
 package org.wordpress.android.ui.main
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.support.annotation.DrawableRes
 import android.support.annotation.IdRes
 import android.support.annotation.StringRes
+import android.support.design.bottomnavigation.LabelVisibilityMode
 import android.support.design.internal.BottomNavigationItemView
 import android.support.design.internal.BottomNavigationMenuView
 import android.support.design.widget.BottomNavigationView
@@ -27,8 +27,6 @@ import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.reader.ReaderPostListFragment
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.AniUtils.Duration
-import org.wordpress.android.util.AppLog
-import org.wordpress.android.util.AppLog.T
 
 /*
  * Bottom navigation view and related adapter used by the main activity for the
@@ -95,30 +93,8 @@ class WPMainNavigationView @JvmOverloads constructor(
         currentPosition = AppPrefs.getMainPageIndex()
     }
 
-    /*
-     * uses reflection to disable "shift mode" so the item are equal width
-     */
-    @SuppressLint("RestrictedApi")
     private fun disableShiftMode() {
-        val menuView = getChildAt(0) as BottomNavigationMenuView
-        try {
-            menuView.javaClass.getDeclaredField("mShiftingMode").apply {
-                isAccessible = true
-                setBoolean(menuView, false)
-                isAccessible = false
-            }
-            for (i in 0 until menuView.childCount) {
-                (menuView.getChildAt(i) as BottomNavigationItemView).apply {
-                    setShiftingMode(false)
-                    // force the view to update
-                    setChecked(itemData.isChecked)
-                }
-            }
-        } catch (e: NoSuchFieldException) {
-            AppLog.e(T.MAIN, "Unable to disable shift mode", e)
-        } catch (e: IllegalAccessException) {
-            AppLog.e(T.MAIN, "Unable to disable shift mode", e)
-        }
+        labelVisibilityMode = LabelVisibilityMode.LABEL_VISIBILITY_LABELED
     }
 
     private fun assignNavigationListeners(assign: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
@@ -148,7 +148,7 @@ class NewSiteCreationActivity : AppCompatActivity(),
         }
     }
 
-    private fun slideInFragment(fragment: Fragment?, tag: String) {
+    private fun slideInFragment(fragment: Fragment, tag: String) {
         val fragmentTransaction = supportFragmentManager.beginTransaction()
         fragmentTransaction.replace(R.id.fragment_container, fragment, tag)
         if (supportFragmentManager.findFragmentById(R.id.fragment_container) != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListItemDecoration.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListItemDecoration.kt
@@ -6,10 +6,10 @@ import android.view.View
 
 data class StatsListItemDecoration(val horizontalSpacing: Int, val verticalSpacing: Int, val columnCount: Int) :
         RecyclerView.ItemDecoration() {
-    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State?) {
+    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
         super.getItemOffsets(outRect, view, parent, state)
         val isFirst = parent.getChildAdapterPosition(view) == 0
-        val isLast = parent.getChildAdapterPosition(view) == parent.adapter.itemCount - 1
+        val isLast = parent.adapter?.let { parent.getChildAdapterPosition(view) == it.itemCount - 1 } ?: false
         outRect.set(
                 if (columnCount == 1) 2 * horizontalSpacing else horizontalSpacing,
                 if (isFirst) 2 * verticalSpacing else verticalSpacing,

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserAdapter.java
@@ -162,12 +162,10 @@ class ThemeBrowserAdapter extends BaseAdapter implements Filterable {
             themeViewHolder.mActiveView.setVisibility(View.VISIBLE);
             themeViewHolder.mCardView.setCardBackgroundColor(resources.getColor(R.color.blue_wordpress));
         } else {
-            themeViewHolder.mDetailsView.setBackgroundColor(resources.getColor(
-                    android.support.v7.cardview.R.color.cardview_light_background));
+            themeViewHolder.mDetailsView.setBackgroundColor(resources.getColor(R.color.white));
             themeViewHolder.mNameView.setTextColor(resources.getColor(R.color.black));
             themeViewHolder.mActiveView.setVisibility(View.GONE);
-            themeViewHolder.mCardView.setCardBackgroundColor(resources.getColor(
-                    android.support.v7.cardview.R.color.cardview_light_background));
+            themeViewHolder.mCardView.setCardBackgroundColor(resources.getColor(R.color.white));
         }
     }
 

--- a/WordPress/src/main/res/layout-sw600dp/theme_grid_cardview_header.xml
+++ b/WordPress/src/main/res/layout-sw600dp/theme_grid_cardview_header.xml
@@ -8,8 +8,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="@dimen/theme_browser_cardview_margin_large"
-        android:layout_marginBottom="@dimen/cardview_default_radius"
-        card_view:cardCornerRadius="@dimen/cardview_default_radius"
+        android:layout_marginBottom="@dimen/default_cardview_radius"
+        card_view:cardCornerRadius="@dimen/default_cardview_radius"
         card_view:cardElevation="@dimen/card_elevation"
         android:layout_marginStart="@dimen/theme_browser_cardview_margin_large"
         android:layout_marginEnd="@dimen/theme_browser_cardview_margin_large">

--- a/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
@@ -17,7 +17,7 @@
         <android.support.v7.widget.CardView
             style="@style/PostSettingsCardView"
             card_view:cardBackgroundColor="@color/white"
-            card_view:cardCornerRadius="@dimen/cardview_default_radius">
+            card_view:cardCornerRadius="@dimen/default_cardview_radius">
 
             <LinearLayout
                 style="@style/PostSettingsCardViewInnerLayout">
@@ -75,7 +75,7 @@
             style="@style/PostSettingsCardView"
             android:id="@+id/post_categories_and_tags_card"
             card_view:cardBackgroundColor="@color/white"
-            card_view:cardCornerRadius="@dimen/cardview_default_radius">
+            card_view:cardCornerRadius="@dimen/default_cardview_radius">
 
             <LinearLayout
                 style="@style/PostSettingsCardViewInnerLayout">
@@ -122,7 +122,7 @@
             android:id="@+id/post_featured_image_card_view"
             style="@style/PostSettingsCardView"
             card_view:cardBackgroundColor="@color/white"
-            card_view:cardCornerRadius="@dimen/cardview_default_radius">
+            card_view:cardCornerRadius="@dimen/default_cardview_radius">
 
             <LinearLayout
                 style="@style/PostSettingsCardViewInnerLayout">
@@ -159,7 +159,7 @@
         <android.support.v7.widget.CardView
             style="@style/PostSettingsCardView"
             card_view:cardBackgroundColor="@color/white"
-            card_view:cardCornerRadius="@dimen/cardview_default_radius">
+            card_view:cardCornerRadius="@dimen/default_cardview_radius">
 
             <LinearLayout
                 style="@style/PostSettingsCardViewInnerLayout">

--- a/WordPress/src/main/res/layout/login_epilogue_header.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_header.xml
@@ -29,7 +29,7 @@
         app:cardBackgroundColor="@color/white"
         app:cardElevation="@dimen/card_elevation"
         app:cardUseCompatPadding="true"
-        app:cardCornerRadius="@dimen/cardview_default_radius">
+        app:cardCornerRadius="@dimen/default_cardview_radius">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -89,7 +89,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/margin_extra_large"
                 app:cardBackgroundColor="@color/white"
-                app:cardCornerRadius="@dimen/cardview_default_radius"
+                app:cardCornerRadius="@dimen/default_cardview_radius"
                 app:cardElevation="@dimen/card_elevation">
 
                 <LinearLayout
@@ -226,7 +226,7 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/card1"
                 app:cardBackgroundColor="@color/white"
-                app:cardCornerRadius="@dimen/cardview_default_radius"
+                app:cardCornerRadius="@dimen/default_cardview_radius"
                 app:cardElevation="@dimen/card_elevation">
 
                 <LinearLayout
@@ -340,7 +340,7 @@
                 android:layout_below="@+id/card2"
                 android:layout_marginTop="@dimen/margin_extra_large"
                 app:cardBackgroundColor="@color/white"
-                app:cardCornerRadius="@dimen/cardview_default_radius"
+                app:cardCornerRadius="@dimen/default_cardview_radius"
                 app:cardElevation="@dimen/card_elevation">
 
                 <LinearLayout

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -35,7 +35,7 @@
                 android:layout_marginStart="@dimen/content_margin"
                 android:layout_marginTop="@dimen/margin_medium"
                 app:cardBackgroundColor="@color/white"
-                app:cardCornerRadius="@dimen/cardview_default_radius"
+                app:cardCornerRadius="@dimen/default_cardview_radius"
                 app:cardElevation="@dimen/card_elevation">
 
                 <RelativeLayout

--- a/WordPress/src/main/res/layout/plugin_browser_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_browser_activity.xml
@@ -26,7 +26,7 @@
                 android:layout_height="wrap_content"
                 android:visibility="gone"
                 card_view:cardBackgroundColor="@color/white"
-                card_view:cardCornerRadius="@dimen/cardview_default_radius"
+                card_view:cardCornerRadius="@dimen/default_cardview_radius"
                 tools:visibility="visible">
 
                 <RelativeLayout
@@ -58,7 +58,7 @@
                 android:layout_marginTop="@dimen/margin_extra_large"
                 android:visibility="gone"
                 card_view:cardBackgroundColor="@color/white"
-                card_view:cardCornerRadius="@dimen/cardview_default_radius"
+                card_view:cardCornerRadius="@dimen/default_cardview_radius"
                 tools:visibility="visible">
 
                 <RelativeLayout
@@ -90,7 +90,7 @@
                 android:layout_marginTop="@dimen/margin_extra_large"
                 android:visibility="gone"
                 card_view:cardBackgroundColor="@color/white"
-                card_view:cardCornerRadius="@dimen/cardview_default_radius"
+                card_view:cardCornerRadius="@dimen/default_cardview_radius"
                 tools:visibility="visible">
 
                 <RelativeLayout
@@ -122,7 +122,7 @@
                 android:layout_marginTop="@dimen/margin_extra_large"
                 android:visibility="gone"
                 card_view:cardBackgroundColor="@color/white"
-                card_view:cardCornerRadius="@dimen/cardview_default_radius"
+                card_view:cardCornerRadius="@dimen/default_cardview_radius"
                 tools:visibility="visible">
 
                 <RelativeLayout

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -73,7 +73,7 @@
             <android.support.v7.widget.CardView
                 style="@style/PluginCardView"
                 card_view:cardBackgroundColor="@color/white"
-                card_view:cardCornerRadius="@dimen/cardview_default_radius">
+                card_view:cardCornerRadius="@dimen/default_cardview_radius">
 
                 <LinearLayout style="@style/PluginCardViewVerticalContainer">
 
@@ -221,7 +221,7 @@
                 android:id="@+id/plugin_card_site"
                 style="@style/PluginCardView"
                 card_view:cardBackgroundColor="@color/white"
-                card_view:cardCornerRadius="@dimen/cardview_default_radius">
+                card_view:cardCornerRadius="@dimen/default_cardview_radius">
 
                 <LinearLayout style="@style/PluginCardViewVerticalContainer">
 
@@ -260,7 +260,7 @@
             <android.support.v7.widget.CardView
                 style="@style/PluginCardView"
                 card_view:cardBackgroundColor="@color/white"
-                card_view:cardCornerRadius="@dimen/cardview_default_radius">
+                card_view:cardCornerRadius="@dimen/default_cardview_radius">
 
                 <LinearLayout style="@style/PluginCardViewVerticalContainer">
 
@@ -319,7 +319,7 @@
                 style="@style/PluginCardView"
                 android:id="@+id/plugin_wp_org_details_container"
                 card_view:cardBackgroundColor="@color/white"
-                card_view:cardCornerRadius="@dimen/cardview_default_radius">
+                card_view:cardCornerRadius="@dimen/default_cardview_radius">
 
                 <LinearLayout style="@style/PluginCardViewVerticalContainer">
 

--- a/WordPress/src/main/res/layout/plugin_ratings_cardview.xml
+++ b/WordPress/src/main/res/layout/plugin_ratings_cardview.xml
@@ -5,7 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/PluginCardView"
     card_view:cardBackgroundColor="@color/white"
-    card_view:cardCornerRadius="@dimen/cardview_default_radius">
+    card_view:cardCornerRadius="@dimen/default_cardview_radius">
 
     <RelativeLayout
         android:id="@+id/plugin_ratings_section_container"

--- a/WordPress/src/main/res/layout/post_cardview.xml
+++ b/WordPress/src/main/res/layout/post_cardview.xml
@@ -9,7 +9,7 @@
                                     android:layout_height="wrap_content"
                                     android:stateListAnimator="@anim/pressed_card"
                                     card_view:cardBackgroundColor="@color/white"
-                                    card_view:cardCornerRadius="@dimen/cardview_default_radius"
+                                    card_view:cardCornerRadius="@dimen/default_cardview_radius"
                                     card_view:cardElevation="@dimen/card_elevation" >
 
     <LinearLayout

--- a/WordPress/src/main/res/layout/post_cardview_skeleton.xml
+++ b/WordPress/src/main/res/layout/post_cardview_skeleton.xml
@@ -6,7 +6,7 @@
     xmlns:wp="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    card_view:cardCornerRadius="@dimen/cardview_default_radius"
+    card_view:cardCornerRadius="@dimen/default_cardview_radius"
     card_view:cardElevation="@dimen/card_elevation">
 
     <com.facebook.shimmer.ShimmerFrameLayout

--- a/WordPress/src/main/res/layout/post_settings_tags_activity.xml
+++ b/WordPress/src/main/res/layout/post_settings_tags_activity.xml
@@ -12,7 +12,7 @@
         android:layout_alignParentTop="true"
         android:layout_margin="@dimen/margin_medium"
         card_view:cardBackgroundColor="@color/white"
-        card_view:cardCornerRadius="@dimen/cardview_default_radius"
+        card_view:cardCornerRadius="@dimen/default_cardview_radius"
         card_view:cardElevation="@dimen/card_elevation">
 
         <EditText

--- a/WordPress/src/main/res/layout/publicize_button_prefs_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_button_prefs_fragment.xml
@@ -54,7 +54,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 card_view:cardBackgroundColor="@color/white"
-                card_view:cardCornerRadius="@dimen/cardview_default_radius">
+                card_view:cardCornerRadius="@dimen/default_cardview_radius">
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -106,7 +106,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_large"
                 card_view:cardBackgroundColor="@color/white"
-                card_view:cardCornerRadius="@dimen/cardview_default_radius">
+                card_view:cardCornerRadius="@dimen/default_cardview_radius">
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -139,7 +139,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_large"
                 card_view:cardBackgroundColor="@color/white"
-                card_view:cardCornerRadius="@dimen/cardview_default_radius">
+                card_view:cardCornerRadius="@dimen/default_cardview_radius">
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -166,7 +166,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_large"
                 card_view:cardBackgroundColor="@color/white"
-                card_view:cardCornerRadius="@dimen/cardview_default_radius">
+                card_view:cardCornerRadius="@dimen/default_cardview_radius">
 
                 <LinearLayout
                     android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/publicize_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_detail_fragment.xml
@@ -19,7 +19,7 @@
         android:layout_marginTop="@dimen/margin_large"
         android:visibility="gone"
         app:cardBackgroundColor="@color/white"
-        app:cardCornerRadius="@dimen/cardview_default_radius"
+        app:cardCornerRadius="@dimen/default_cardview_radius"
         tools:visibility="visible" >
 
         <LinearLayout
@@ -55,7 +55,7 @@
         android:layout_marginTop="@dimen/margin_large"
         android:layout_width="match_parent"
         app:cardBackgroundColor="@color/white"
-        app:cardCornerRadius="@dimen/cardview_default_radius" >
+        app:cardCornerRadius="@dimen/default_cardview_radius" >
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/publicize_list_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_list_fragment.xml
@@ -23,7 +23,7 @@
                 android:layout_height="wrap_content"
                 android:layout_width="match_parent"
                 app:cardBackgroundColor="@color/white"
-                app:cardCornerRadius="@dimen/cardview_default_radius" >
+                app:cardCornerRadius="@dimen/default_cardview_radius" >
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -79,7 +79,7 @@
                 android:layout_marginTop="@dimen/margin_large"
                 android:layout_width="match_parent"
                 app:cardBackgroundColor="@color/white"
-                app:cardCornerRadius="@dimen/cardview_default_radius" >
+                app:cardCornerRadius="@dimen/default_cardview_radius" >
 
                 <RelativeLayout
                     android:id="@+id/sharing_module"

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -10,7 +10,7 @@
     android:layout_width="match_parent"
     android:stateListAnimator="@anim/pressed_card"
     app:cardBackgroundColor="@color/white"
-    app:cardCornerRadius="@dimen/cardview_default_radius"
+    app:cardCornerRadius="@dimen/default_cardview_radius"
     app:cardElevation="@dimen/reader_card_elevation" >
 
     <LinearLayout

--- a/WordPress/src/main/res/layout/reader_cardview_removed_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_removed_post.xml
@@ -8,7 +8,7 @@
     android:layout_height="wrap_content"
     android:stateListAnimator="@anim/pressed_card"
     app:cardBackgroundColor="@color/white"
-    app:cardCornerRadius="@dimen/cardview_default_radius"
+    app:cardCornerRadius="@dimen/default_cardview_radius"
     app:cardElevation="@dimen/reader_card_elevation" >
 
     <RelativeLayout

--- a/WordPress/src/main/res/layout/reader_cardview_xpost.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_xpost.xml
@@ -9,7 +9,7 @@
     android:layout_height="wrap_content"
     android:stateListAnimator="@anim/pressed_card"
     app:cardBackgroundColor="@color/white"
-    app:cardCornerRadius="@dimen/cardview_default_radius"
+    app:cardCornerRadius="@dimen/default_cardview_radius"
     app:cardElevation="@dimen/reader_card_elevation" >
 
     <LinearLayout

--- a/WordPress/src/main/res/layout/signup_epilogue.xml
+++ b/WordPress/src/main/res/layout/signup_epilogue.xml
@@ -40,7 +40,7 @@
                 android:layout_marginStart="@dimen/margin_large"
                 android:layout_width="match_parent"
                 app:cardBackgroundColor="@color/white"
-                app:cardCornerRadius="@dimen/cardview_default_radius"
+                app:cardCornerRadius="@dimen/default_cardview_radius"
                 app:cardElevation="@dimen/card_elevation"
                 app:cardUseCompatPadding="true" >
 

--- a/WordPress/src/main/res/layout/site_creation_category_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_category_screen.xml
@@ -58,7 +58,7 @@
                 android:focusable="true"
                 android:foreground="?android:attr/selectableItemBackground"
                 app:cardBackgroundColor="@color/white"
-                app:cardCornerRadius="@dimen/cardview_default_radius"
+                app:cardCornerRadius="@dimen/default_cardview_radius"
                 app:cardElevation="@dimen/card_elevation">
 
                 <RelativeLayout
@@ -112,7 +112,7 @@
                 android:focusable="true"
                 android:foreground="?android:attr/selectableItemBackground"
                 app:cardBackgroundColor="@color/white"
-                app:cardCornerRadius="@dimen/cardview_default_radius"
+                app:cardCornerRadius="@dimen/default_cardview_radius"
                 app:cardElevation="@dimen/card_elevation">
 
                 <RelativeLayout
@@ -166,7 +166,7 @@
                 android:focusable="true"
                 android:foreground="?android:attr/selectableItemBackground"
                 app:cardBackgroundColor="@color/white"
-                app:cardCornerRadius="@dimen/cardview_default_radius"
+                app:cardCornerRadius="@dimen/default_cardview_radius"
                 app:cardElevation="@dimen/card_elevation">
 
                 <RelativeLayout

--- a/WordPress/src/main/res/layout/site_creation_theme_item.xml
+++ b/WordPress/src/main/res/layout/site_creation_theme_item.xml
@@ -16,7 +16,7 @@
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/cardview_default_radius">
+        android:layout_margin="@dimen/default_cardview_radius">
 
         <ImageView
             android:id="@+id/theme_grid_item_image"

--- a/WordPress/src/main/res/layout/site_settings_tag_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/site_settings_tag_detail_fragment.xml
@@ -12,7 +12,7 @@
         android:layout_height="wrap_content"
         android:stateListAnimator="@anim/pressed_card"
         card_view:cardBackgroundColor="@color/white"
-        card_view:cardCornerRadius="@dimen/cardview_default_radius"
+        card_view:cardCornerRadius="@dimen/default_cardview_radius"
         card_view:cardElevation="@dimen/card_elevation">
 
         <LinearLayout

--- a/WordPress/src/main/res/layout/stats_list_block.xml
+++ b/WordPress/src/main/res/layout/stats_list_block.xml
@@ -5,8 +5,8 @@
                                     android:layout_height="wrap_content"
                                     android:animateLayoutChanges="false"
                                     android:id="@+id/container"
-                                    app:cardCornerRadius="@dimen/cardview_default_radius"
-                                    app:cardElevation="@dimen/cardview_default_elevation"
+                                    app:cardCornerRadius="@dimen/default_cardview_radius"
+                                    app:cardElevation="@dimen/default_cardview_elevation"
                                     style="@style/StatsBlock">
 
     <android.support.v7.widget.RecyclerView

--- a/WordPress/src/main/res/layout/theme_grid_cardview_header.xml
+++ b/WordPress/src/main/res/layout/theme_grid_cardview_header.xml
@@ -8,8 +8,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/theme_browser_cardview_margin_large"
-        android:layout_marginBottom="@dimen/cardview_default_radius"
-        card_view:cardCornerRadius="@dimen/cardview_default_radius"
+        android:layout_marginBottom="@dimen/default_cardview_radius"
+        card_view:cardCornerRadius="@dimen/default_cardview_radius"
         card_view:cardElevation="@dimen/card_elevation"
         android:layout_marginEnd="@dimen/theme_browser_cardview_margin_large"
         android:layout_marginStart="@dimen/theme_browser_cardview_margin_large">

--- a/WordPress/src/main/res/layout/theme_grid_item.xml
+++ b/WordPress/src/main/res/layout/theme_grid_item.xml
@@ -10,7 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/theme_browser_cardview_margin_large"
-        card_view:cardCornerRadius="@dimen/cardview_default_radius"
+        card_view:cardCornerRadius="@dimen/default_cardview_radius"
         card_view:cardElevation="@dimen/card_elevation"
         android:layout_marginStart="@dimen/theme_browser_cardview_margin_large"
         android:layout_marginEnd="@dimen/theme_browser_cardview_margin_large">
@@ -18,7 +18,7 @@
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/cardview_default_radius">
+            android:layout_margin="@dimen/default_cardview_radius">
 
             <FrameLayout
                 android:id="@+id/theme_grid_item_image_layout"
@@ -41,7 +41,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/theme_grid_item_image_layout"
-                android:layout_marginTop="@dimen/cardview_default_radius">
+                android:layout_marginTop="@dimen/default_cardview_radius">
 
                 <LinearLayout
                     android:layout_width="wrap_content"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -39,6 +39,9 @@
 
     <dimen name="post_editor_content_side_margin">20dp</dimen>
 
+    <dimen name="default_cardview_radius">2dp</dimen>
+    <dimen name="default_cardview_elevation">2dp</dimen>
+
     <!-- featured image in post list -->
     <dimen name="postlist_featured_image_height_normal">128dp</dimen>
     <dimen name="postlist_featured_image_height_tablet">220dp</dimen>

--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion "28.0.3"
 
     defaultConfig {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -30,14 +30,14 @@ apply from: 'https://gist.githubusercontent.com/hypest/e06f6097065728b6db7b7c462
 apply from: 'https://gist.githubusercontent.com/hypest/f526fe0775dedce0ce0133f1400d22a4/raw/0008b271a0d28fc79957fd3c2a027f57e98f796a/wait-jitpack.gradle'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
     defaultConfig {
         versionCode 13
         versionName "1.3"
         minSdkVersion 21
-        targetSdkVersion 26
+        targetSdkVersion 28
         buildConfigField "boolean", "BUILD_GUTENBERG_FROM_SOURCE", rootProject.ext.buildGutenbergFromSource.toString()
     }
     buildTypes {
@@ -58,9 +58,11 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:support-v4:27.1.1'
-    implementation 'com.android.support:design:27.1.1'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:animated-vector-drawable:28.0.0'
+    implementation 'com.android.support:gridlayout-v7:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'org.wordpress:utils:1.22'
 

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -37,7 +37,7 @@ android {
         versionCode 13
         versionName "1.3"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 26
         buildConfigField "boolean", "BUILD_GUTENBERG_FROM_SOURCE", rootProject.ext.buildGutenbergFromSource.toString()
     }
     buildTypes {

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -17,12 +17,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 2
         versionName "1.1"
 
@@ -35,8 +35,12 @@ dependencies {
         exclude group: "com.mcxiaoke.volley"
     }
 
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:design:27.1.1'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:animated-vector-drawable:28.0.0'
+    implementation 'com.android.support:support-media-compat:28.0.0'
+    implementation 'com.android.support:support-v13:28.0.0'
+    implementation 'com.android.support:gridlayout-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
 
     api 'com.google.android.gms:play-services-auth:15.0.1'
 

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 26
         versionCode 2
         versionName "1.1"
 

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
     defaultConfig {

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -20,8 +20,8 @@ repositories {
 dependencies {
     implementation 'org.apache.commons:commons-text:1.1'
     implementation 'com.mcxiaoke.volley:library:1.0.18'
-    implementation 'com.android.support:design:27.1.1'
-    implementation 'com.android.support:recyclerview-v7:27.1.1'
+    implementation 'com.android.support:design:28.0.0'
+    implementation 'com.android.support:recyclerview-v7:28.0.0'
     implementation 'org.greenrobot:eventbus:3.0.0'
 
     lintChecks 'org.wordpress:lint:1.0.1'
@@ -30,13 +30,13 @@ dependencies {
 android {
     useLibrary 'org.apache.http.legacy'
 
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
     defaultConfig {
         versionName "1.22"
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 28
     }
 }
 

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -36,7 +36,7 @@ android {
     defaultConfig {
         versionName "1.22"
         minSdkVersion 15
-        targetSdkVersion 28
+        targetSdkVersion 26
     }
 }
 


### PR DESCRIPTION
First step in preparation for #9209 (Migration to AndroidX).

- I've updated compileSdkVersion and support library version to api 28

- Some modules required me to explicitly add new dependencies to override versions of transitive dependencies. For example `exifinterface:27.1.1` was added as transitive dependency and AS was complaining that having dependencies from both 27.1.1 and 28.0.0 isn't recommended. (I recommend using AS diff tool to compare what has changed, since GitHub doesn't do a very good job)

- I've fixed places in the code which were targeting old apis. The biggest change is in [#1bf1872](https://github.com/wordpress-mobile/WordPress-Android/commit/1bf18720cee0c1cb679c7a0ef20e67239948279c). Reflection isn't required anymore in order to suppress shift animation on the bottom navigation bar.

- Some resources we use from the support library have been marked as private -> fixed in [da2dc8e](https://github.com/wordpress-mobile/WordPress-Android/pull/9215/commits/da2dc8e3f37276a3a2dab40afe00b93219605fdc)

To test:
- run the app
- switch tabs in the bottom navigation bar and make sure the animation hasn't changed

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

Question: Should we push the changes to the subtrees?
Note: One reviewer should be enough.
