### PR TITLE
Make Aztec the default for new posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -645,7 +645,7 @@ public class AppPrefs {
     }
 
     public static boolean isGutenbergDefaultForNewPosts() {
-        return getBoolean(DeletablePrefKey.GUTENBERG_DEAFULT_FOR_NEW_POSTS, true);
+        return getBoolean(DeletablePrefKey.GUTENBERG_DEAFULT_FOR_NEW_POSTS, false);
     }
 
     public static void setGutenbergDefaultForNewPosts(boolean defaultForNewPosts) {


### PR DESCRIPTION
We're shooting for a soft launch in so, Aztec will be the default editor for new posts until user actively enables the switch in the App Settings.

Note: the switch doesn't govern existing posts and if a post has blocks in it, Gutenberg will be launched for it regardless of the switch.

To test:

1. Clear the app data via Android Settings
2. Open the app and login as normal
3. Head over the Me > App Settings section and verify that the "Use block editor for new posts" is `OFF`
4. Start a new post and verify that it's Aztec that comes up (look for the "H" toolbar button which only appears in Aztec's case)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
