### PR TITLE
Track button and item clicks on post list screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostViewHolder.kt
@@ -304,8 +304,8 @@ class PostViewHolder(private val view: View, private val config: PostViewHolderC
             when (buttonType) {
                 PostListButton.BUTTON_MORE -> animateButtonRows(postData, false)
                 PostListButton.BUTTON_BACK -> animateButtonRows(postData, true)
-                else -> postAdapterItem.onButtonClicked(buttonType)
             }
+            postAdapterItem.onButtonClicked(buttonType)
         }
         editButton.setOnClickListener(btnClickListener)
         viewButton.setOnClickListener(btnClickListener)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -569,23 +569,23 @@ class PostListViewModel @Inject constructor(
             properties["post_id"] = postData.remotePostId
         }
 
-        when (buttonType) {
+        properties["action"] = when (buttonType) {
             PostListButton.BUTTON_EDIT -> {
-                properties["action"] = "edit"
                 properties[AnalyticsUtils.HAS_GUTENBERG_BLOCKS_KEY] = PostUtils
                         .contentContainsGutenbergBlocks(postData.content)
+                "edit"
             }
-            PostListButton.BUTTON_RETRY -> properties["action"] = "retry"
-            PostListButton.BUTTON_SUBMIT -> properties["action"] = "submit"
-            PostListButton.BUTTON_VIEW -> properties["action"] = "view"
-            PostListButton.BUTTON_PREVIEW -> properties["action"] = "preview"
-            PostListButton.BUTTON_STATS -> properties["action"] = "stats"
-            PostListButton.BUTTON_TRASH -> properties["action"] = "trash"
-            PostListButton.BUTTON_DELETE -> properties["action"] = "delete"
-            PostListButton.BUTTON_PUBLISH -> properties["action"] = "publish"
-            PostListButton.BUTTON_SYNC -> properties["action"] = "sync"
-            PostListButton.BUTTON_MORE -> properties["action"] = "more"
-            PostListButton.BUTTON_BACK -> properties["action"] = "back"
+            PostListButton.BUTTON_RETRY -> "retry"
+            PostListButton.BUTTON_SUBMIT -> "submit"
+            PostListButton.BUTTON_VIEW -> "view"
+            PostListButton.BUTTON_PREVIEW -> "preview"
+            PostListButton.BUTTON_STATS -> "stats"
+            PostListButton.BUTTON_TRASH -> "trash"
+            PostListButton.BUTTON_DELETE -> "delete"
+            PostListButton.BUTTON_PUBLISH -> "publish"
+            PostListButton.BUTTON_SYNC -> "sync"
+            PostListButton.BUTTON_MORE -> "more"
+            PostListButton.BUTTON_BACK -> "back"
             else -> AppLog.e(AppLog.T.POSTS, "Unknown button type")
         }
 
@@ -752,8 +752,10 @@ class PostListViewModel @Inject constructor(
         val onDismissAction = {
             originalPostCopyForConflictUndo = null
         }
-        val snackbarHolder = SnackbarMessageHolder(R.string.snackbar_conflict_local_version_discarded,
-                R.string.snackbar_conflict_undo, undoAction, onDismissAction)
+        val snackbarHolder = SnackbarMessageHolder(
+                R.string.snackbar_conflict_local_version_discarded,
+                R.string.snackbar_conflict_undo, undoAction, onDismissAction
+        )
         _snackbarAction.postValue(snackbarHolder)
     }
 
@@ -787,8 +789,10 @@ class PostListViewModel @Inject constructor(
                 dispatcher.dispatch(PostActionBuilder.newPushPostAction(RemotePostPayload(post, site)))
             }
         }
-        val snackbarHolder = SnackbarMessageHolder(R.string.snackbar_conflict_web_version_discarded,
-                R.string.snackbar_conflict_undo, undoAction, onDismissAction)
+        val snackbarHolder = SnackbarMessageHolder(
+                R.string.snackbar_conflict_web_version_discarded,
+                R.string.snackbar_conflict_undo, undoAction, onDismissAction
+        )
         _snackbarAction.postValue(snackbarHolder)
     }
 

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -132,6 +132,7 @@ public final class AnalyticsTracker {
         EDITOR_SCHEDULED_POST,
         EDITOR_OPENED,
         POST_LIST_BUTTON_PRESSED,
+        POST_LIST_ITEM_SELECTED,
         EDITOR_CLOSED,
         EDITOR_PUBLISHED_POST,
         EDITOR_SAVED_DRAFT,

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -682,6 +682,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "editor_closed";
             case POST_LIST_BUTTON_PRESSED:
                 return "post_list_button_pressed";
+            case POST_LIST_ITEM_SELECTED:
+                return "post_list_item_selected";
             case EDITOR_OPENED:
                 return "editor_opened";
             case EDITOR_ADDED_PHOTO_NEW:


### PR DESCRIPTION
Fixes #9228 

Start tracking button and item clicks on the Post list screen. 
- Previously only "edit" button and item clicks were being tracked. Both events were identical so we couldn't differentiate them.

I also replaced `properties["button"]` with `properties["action"]` so we don't have an inconsistent tracks history for "edit" event.

The events are being tracked even when the actions isn't performed - they really track just the intention of the user (eg. When the user clicks on `Publish` button a dialog is shown - we track the "published clicked" event no matter what the user does next).

To test:
1. My Site
2. Blog Posts
3. Click on items/buttons and make sure they are being correctly tracked (in LogCat)
 
Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.


cc @SylvesterWilmott @kwonye 

Note:
We might want to consider targeting  10.8, so we can gather the data asap. Wdyt?