### PR TITLE
Support for the EditorDidMount callback from GB

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -5,6 +5,7 @@ import android.support.v4.app.Fragment;
 import android.view.ViewGroup;
 
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode;
+import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnEditorMountListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnGetContentTimeout;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnMediaLibraryButtonListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnReattachQueryListener;
@@ -32,8 +33,10 @@ public class GutenbergContainerFragment extends Fragment {
     }
 
     public void attachToContainer(ViewGroup viewGroup, OnMediaLibraryButtonListener onMediaLibraryButtonListener,
-                                  OnReattachQueryListener onReattachQueryListener) {
-        mWPAndroidGlueCode.attachToContainer(viewGroup, onMediaLibraryButtonListener, onReattachQueryListener);
+                                  OnReattachQueryListener onReattachQueryListener,
+                                  OnEditorMountListener onEditorMountListener) {
+        mWPAndroidGlueCode.attachToContainer(viewGroup, onMediaLibraryButtonListener, onReattachQueryListener,
+                onEditorMountListener);
     }
 
     @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -163,7 +163,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                     }
                 },
                 new OnEditorMountListener() {
-                    @Override public void onEditorDidMount(boolean hasUnsupportedBlocks) {
+                    @Override
+                    public void onEditorDidMount(boolean hasUnsupportedBlocks) {
                         // TODO: add Tracks
                     }
                 }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -37,6 +37,7 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.aztec.IHistoryListener;
+import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnEditorMountListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnGetContentTimeout;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnMediaLibraryButtonListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnReattachQueryListener;
@@ -159,6 +160,11 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                     public void onQueryCurrentProgressForUploadingMedia() {
                         updateFailedMediaState();
                         updateMediaProgress();
+                    }
+                },
+                new OnEditorMountListener() {
+                    @Override public void onEditorDidMount(boolean hasUnsupportedBlocks) {
+                        // TODO: add Tracks
                     }
                 }
             );


### PR DESCRIPTION
This is the wpandroid side PR to support https://github.com/wordpress-mobile/gutenberg-mobile/pull/587

It adds support for the "boot" callback the editor is calling to inform that mounting has happened. It also passes a flag to denote if any unsupported blocks have been detected. We'll use that in a follow up PR to add Tracks.

Note: we will update the submodule hash when the gutenberg-mobile PR gets merged.

To test:

1. Compile and run the app. It should succeed.

Additional test:
2. Add a toast in the `onEditorDidMount` override in the `GutenbergEditorFragment` fragment to see the callback be called.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
