### PR TITLE
Post list filter by status

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -4,10 +4,11 @@ import android.arch.lifecycle.ViewModel;
 import android.arch.lifecycle.ViewModelProvider;
 
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel;
+import org.wordpress.android.ui.posts.PostListMainViewModel;
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel;
 import org.wordpress.android.ui.sitecreation.NewSiteCreationMainVM;
-import org.wordpress.android.ui.sitecreation.previews.NewSitePreviewViewModel;
 import org.wordpress.android.ui.sitecreation.domains.NewSiteCreationDomainsViewModel;
+import org.wordpress.android.ui.sitecreation.previews.NewSitePreviewViewModel;
 import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentsViewModel;
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel;
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel;
@@ -156,6 +157,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(PostListViewModel.class)
     abstract ViewModel postListViewModel(PostListViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(PostListMainViewModel.class)
+    abstract ViewModel postListMainViewModel(PostListMainViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
@@ -1,7 +1,11 @@
 package org.wordpress.android.ui.posts
 
+import android.support.v4.app.FragmentActivity
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.push.NativeNotificationsUtils
+import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.uploads.UploadService
 
 sealed class PostListAction {
     class EditPost(val site: SiteModel, val post: PostModel) : PostListAction()
@@ -19,3 +23,46 @@ sealed class PostListAction {
     class ShowGutenbergWarningDialog(val site: SiteModel, val post: PostModel) : PostListAction()
     class DismissPendingNotification(val pushId: Int) : PostListAction()
 }
+
+fun handlePostListAction(activity: FragmentActivity, action: PostListAction) {
+    when (action) {
+        is PostListAction.EditPost -> {
+            ActivityLauncher.editPostOrPageForResult(activity, action.site, action.post)
+        }
+        is PostListAction.NewPost -> {
+            ActivityLauncher.addNewPostForResult(activity, action.site, action.isPromo)
+        }
+        is PostListAction.PreviewPost -> {
+            ActivityLauncher.viewPostPreviewForResult(activity, action.site, action.post)
+        }
+        is PostListAction.RetryUpload -> {
+            // restart the UploadService with retry parameters
+            val intent = UploadService.getUploadPostServiceIntent(
+                    activity,
+                    action.post,
+                    action.trackAnalytics,
+                    action.publish,
+                    action.retry
+            )
+            activity.startService(intent)
+        }
+        is PostListAction.ViewStats -> {
+            ActivityLauncher.viewStatsSinglePostDetails(activity, action.site, action.post)
+        }
+        is PostListAction.ViewPost -> {
+            ActivityLauncher.browsePostOrPage(activity, action.site, action.post)
+        }
+        is PostListAction.ShowGutenbergWarningDialog -> {
+            PostUtils.showGutenbergCompatibilityWarningDialog(
+                    activity,
+                    activity.supportFragmentManager,
+                    action.post,
+                    action.site
+            )
+        }
+        is PostListAction.DismissPendingNotification -> {
+            NativeNotificationsUtils.dismissNotification(action.pushId, activity)
+        }
+    }
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
@@ -65,4 +65,3 @@ fun handlePostListAction(activity: FragmentActivity, action: PostListAction) {
         }
     }
 }
-

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -51,6 +51,8 @@ import org.wordpress.android.viewmodel.posts.PostListViewModel
 import org.wordpress.android.widgets.RecyclerItemDecoration
 import javax.inject.Inject
 
+private const val EXTRA_POST_LIST_TYPE = "post_list_type"
+
 class PostListFragment : Fragment() {
     @Inject internal lateinit var imageManager: ImageManager
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
@@ -117,9 +119,10 @@ class PostListFragment : Fragment() {
         val targetLocalPostId = activity?.intent?.getIntExtra(EXTRA_TARGET_POST_LOCAL_ID, -1)?.let {
             if (it != -1) it else null
         }
+        val postListType = requireNotNull(arguments).getSerializable(EXTRA_POST_LIST_TYPE) as PostListType
         viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get<PostListViewModel>(PostListViewModel::class.java)
-        viewModel.start(site, targetLocalPostId)
+        viewModel.start(site, postListType, targetLocalPostId)
         viewModel.pagedListDataAndScrollPosition.observe(this, Observer {
             it?.let { (pagedListData, scrollPosition) -> updatePagedListData(pagedListData, scrollPosition) }
         })
@@ -386,11 +389,11 @@ class PostListFragment : Fragment() {
         const val TAG = "post_list_fragment_tag"
 
         @JvmStatic
-        fun newInstance(site: SiteModel, listType: PostListType, targetPost: PostModel?): PostListFragment {
-            // TODO implement post status filtering
+        fun newInstance(site: SiteModel, postListType: PostListType, targetPost: PostModel?): PostListFragment {
             val fragment = PostListFragment()
             val bundle = Bundle()
             bundle.putSerializable(WordPress.SITE, site)
+            bundle.putSerializable(EXTRA_POST_LIST_TYPE, postListType)
             targetPost?.let {
                 bundle.putInt(PostsListActivity.EXTRA_TARGET_POST_LOCAL_ID, it.id)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -1,0 +1,38 @@
+package org.wordpress.android.ui.posts
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.ViewModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.posts.PostListType.DRAFTS
+import org.wordpress.android.ui.posts.PostListType.PUBLISHED
+import org.wordpress.android.ui.posts.PostListType.SCHEDULED
+import org.wordpress.android.ui.posts.PostListType.TRASHED
+import org.wordpress.android.viewmodel.SingleLiveEvent
+import javax.inject.Inject
+
+private val FAB_VISIBLE_POST_LIST_PAGES = listOf(PUBLISHED, DRAFTS)
+val POST_LIST_PAGES = listOf(PUBLISHED, DRAFTS, SCHEDULED, TRASHED)
+
+class PostListMainViewModel @Inject constructor() : ViewModel() {
+    private lateinit var site: SiteModel
+
+    private val _postListAction = SingleLiveEvent<PostListAction>()
+    val postListAction: LiveData<PostListAction> = _postListAction
+
+    private val _isFabVisible = MutableLiveData<Boolean>()
+    val isFabVisible: LiveData<Boolean> = _isFabVisible
+
+    fun start(site: SiteModel) {
+        this.site = site
+    }
+
+    fun newPost() {
+        _postListAction.postValue(PostListAction.NewPost(site))
+    }
+
+    fun onTabChanged(position: Int) {
+        val currentPage = POST_LIST_PAGES[position]
+        _isFabVisible.value = FAB_VISIBLE_POST_LIST_PAGES.contains(currentPage)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsPagerAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsPagerAdapter.kt
@@ -5,24 +5,20 @@ import android.support.v4.app.FragmentManager
 import android.support.v4.app.FragmentPagerAdapter
 import android.view.ViewGroup
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.ui.posts.PostListType.DRAFTS
-import org.wordpress.android.ui.posts.PostListType.PUBLISHED
-import org.wordpress.android.ui.posts.PostListType.SCHEDULED
-import org.wordpress.android.ui.posts.PostListType.TRASHED
 import java.lang.ref.WeakReference
 
-class PostsPagerAdapter(private val site: SiteModel, val context: Context, val fm: FragmentManager) :
-        FragmentPagerAdapter(fm) {
-    companion object {
-        val postTypes = listOf(PUBLISHED, DRAFTS, SCHEDULED, TRASHED)
-    }
-
+class PostsPagerAdapter(
+    private val pages: List<PostListType>,
+    private val site: SiteModel,
+    val context: Context,
+    val fm: FragmentManager
+) : FragmentPagerAdapter(fm) {
     private val listFragments = mutableMapOf<Int, WeakReference<PostListFragment>>()
 
-    override fun getCount(): Int = postTypes.size
+    override fun getCount(): Int = pages.size
 
     override fun getItem(position: Int): PostListFragment =
-            PostListFragment.newInstance(site, postTypes[position], null)
+            PostListFragment.newInstance(site, pages[position], null)
 
     override fun instantiateItem(container: ViewGroup, position: Int): Any {
         val fragment = super.instantiateItem(container, position) as PostListFragment
@@ -30,7 +26,7 @@ class PostsPagerAdapter(private val site: SiteModel, val context: Context, val f
         return fragment
     }
 
-    override fun getPageTitle(position: Int): CharSequence? = context.getString(postTypes[position].titleResId)
+    override fun getPageTitle(position: Int): CharSequence? = context.getString(pages[position].titleResId)
 
     fun getItemAtPosition(position: Int): PostListFragment? {
         return listFragments[position]?.get()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -51,6 +51,7 @@ import org.wordpress.android.ui.posts.PostAdapterItemData
 import org.wordpress.android.ui.posts.PostAdapterItemUploadStatus
 import org.wordpress.android.ui.posts.PostListAction
 import org.wordpress.android.ui.posts.PostListAction.DismissPendingNotification
+import org.wordpress.android.ui.posts.PostListType
 import org.wordpress.android.ui.posts.PostUploadAction
 import org.wordpress.android.ui.posts.PostUploadAction.CancelPostAndMediaUpload
 import org.wordpress.android.ui.posts.PostUploadAction.EditPostResult
@@ -214,15 +215,15 @@ class PostListViewModel @Inject constructor(
         lifecycleRegistry.markState(Lifecycle.State.CREATED)
     }
 
-    fun start(site: SiteModel, targetLocalPostId: Int?) {
+    fun start(site: SiteModel, postListType: PostListType, targetLocalPostId: Int?) {
         if (isStarted) {
             return
         }
         this.site = site
         this.listDescriptor = if (site.isUsingWpComRestApi) {
-            PostListDescriptorForRestSite(site)
+            PostListDescriptorForRestSite(site, postListType.postStatuses)
         } else {
-            PostListDescriptorForXmlRpcSite(site)
+            PostListDescriptorForXmlRpcSite(site, postListType.postStatuses)
         }
         // We want to update the target post only for the first time ViewModel is started
         this.targetLocalPostId = targetLocalPostId

--- a/WordPress/src/main/res/layout/post_list_activity.xml
+++ b/WordPress/src/main/res/layout/post_list_activity.xml
@@ -2,15 +2,10 @@
 <android.support.design.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/coordinatorLayout"
+    android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.v4.view.ViewPager
-        android:id="@+id/postPager"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
 
     <android.support.design.widget.AppBarLayout
         android:layout_width="match_parent"
@@ -43,4 +38,23 @@
             app:theme="@style/Base.Widget.Design.TabLayout"/>
 
     </android.support.design.widget.AppBarLayout>
+
+    <android.support.v4.view.ViewPager
+        android:id="@+id/postPager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/fab_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|bottom"
+        android:layout_marginBottom="@dimen/fab_margin"
+        android:layout_marginEnd="@dimen/fab_margin"
+        android:contentDescription="@string/fab_create_desc"
+        android:src="@drawable/ic_create_white_24dp"
+        app:borderWidth="0dp"
+        app:rippleColor="@color/fab_pressed"/>
+
 </android.support.design.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/post_list_fragment.xml
+++ b/WordPress/src/main/res/layout/post_list_fragment.xml
@@ -7,57 +7,39 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
-    <android.support.design.widget.CoordinatorLayout
-        android:id="@+id/coordinator"
+
+    <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
+        android:id="@+id/ptr_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
-            android:id="@+id/ptr_layout"
+        <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <RelativeLayout
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/recycler_view"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:paddingTop="@dimen/margin_medium"
+                android:scrollbars="vertical"/>
 
-                <android.support.v7.widget.RecyclerView
-                    android:id="@+id/recycler_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:clipToPadding="false"
-                    android:paddingTop="@dimen/margin_medium"
-                    android:scrollbars="vertical"/>
+            <org.wordpress.android.ui.ActionableEmptyView
+                android:id="@+id/actionable_empty_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/background_grey"
+                android:visibility="gone"
+                app:aevButton="@string/posts_empty_list_button"
+                app:aevImage="@drawable/img_illustration_posts_75dp"
+                app:aevTitle="@string/posts_empty_list"
+                tools:visibility="visible">
+            </org.wordpress.android.ui.ActionableEmptyView>
 
-                <org.wordpress.android.ui.ActionableEmptyView
-                    android:id="@+id/actionable_empty_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:background="@color/background_grey"
-                    android:visibility="gone"
-                    app:aevButton="@string/posts_empty_list_button"
-                    app:aevImage="@drawable/img_illustration_posts_75dp"
-                    app:aevTitle="@string/posts_empty_list"
-                    tools:visibility="visible">
-                </org.wordpress.android.ui.ActionableEmptyView>
+        </RelativeLayout>
 
-            </RelativeLayout>
-
-        </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
-
-        <android.support.design.widget.FloatingActionButton
-            android:id="@+id/fab_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end|bottom"
-            android:layout_marginBottom="@dimen/fab_margin"
-            android:layout_marginEnd="@dimen/fab_margin"
-            android:contentDescription="@string/fab_create_desc"
-            app:borderWidth="0dp"
-            app:rippleColor="@color/fab_pressed"
-            android:src="@drawable/ic_create_white_24dp"/>
-
-    </android.support.design.widget.CoordinatorLayout>
+    </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
     <ProgressBar
         android:id="@+id/progress"


### PR DESCRIPTION
Fixes #4693 

**NOTE: update the target branch to "feature/master-post-filters" when #9226 is merged.**

Adds support for filtering posts by their status.

Adds logic to display FAB (new post button) only on Scheduled and Drafts tabs.

To test:
1. My Site
2. Blog posts
3. Notice each tab/section contains only relevant posts
4. Swipe/change tabs and notice the fab button is visible only on first two tabs + there is a fadeIn/out animation

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
