### PR TITLE
CircleCI: Use Orb for caching and storing test results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,17 +12,18 @@ copy_gradle_properties: &copy_gradle_properties
     name: Setup gradle.properties
     command: cp gradle.properties-example gradle.properties && cp libs/login/gradle.properties-example libs/login/gradle.properties
 
-version: 2.0
+orbs:
+  danger: wordpress-mobile/danger@0.0.19
+  android: wordpress-mobile/android@0.0.19
+
+version: 2.1
 jobs:
   test:
     <<: *android_config
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - wordpress-android-gradle-build-cache-{{ checksum "build.gradle" }}-{{ checksum "WordPress/build.gradle" }}
-            - wordpress-android-gradle-build-cache-{{ checksum "build.gradle" }}-
-            - wordpress-android-gradle-build-cache-
+      - android/restore-gradle-cache:
+          cache-prefix: test-cache
       - <<: *copy_gradle_properties
       - run:
           name: Validate login strings
@@ -30,21 +31,15 @@ jobs:
       - run:
           name: Test
           command: $GRADLEW testVanillaRelease
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: wordpress-android-gradle-build-cache-{{ checksum "build.gradle" }}-{{ checksum "WordPress/build.gradle" }}
-      - store_test_results:
-          path: WordPress/build/test-results/testVanillaReleaseUnitTest
+      - android/save-gradle-cache:
+          cache-prefix: test-cache
+      - android/save-test-results
   lint:
     <<: *android_config
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - wordpress-android-gradle-lint-cache-{{ checksum "build.gradle" }}-{{ checksum "WordPress/build.gradle" }}
-            - wordpress-android-gradle-lint-cache-{{ checksum "build.gradle" }}-
-            - wordpress-android-gradle-lint-cache-
+      - android/restore-gradle-cache:
+          cache-prefix: lint-cache
       - <<: *copy_gradle_properties
       - run:
           name: Checkstyle
@@ -55,37 +50,16 @@ jobs:
       - run:
           name: Lint
           command: $GRADLEW lintVanillaRelease || (grep -A20 -B2 'severity="Error"' -r --include="*.xml" WordPress libs; exit 1)
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: wordpress-android-gradle-lint-cache-{{ checksum "build.gradle" }}-{{ checksum "WordPress/build.gradle" }}
+      - android/save-gradle-cache:
+          cache-prefix: lint-cache
       - store_artifacts:
           path: WordPress/build/reports
           destination: reports
-  danger:
-    docker:
-      - image: circleci/ruby:2.3-browsers
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - wordpress-android-gems-{{ checksum "Gemfile.lock" }}
-            - wordpress-android-gems-
-      - run:
-          name: Bundle install
-          command: bundle install --path=vendor/bundle
-      - save_cache:
-          paths:
-            - vendor/bundle
-          key: wordpress-android-gems-{{ checksum "Gemfile.lock" }}
-      - run:
-          name: Danger
-          command: if [ -n "$DANGER_GITHUB_API_TOKEN" ]; then bundle exec danger --fail-on-errors=true; else echo "Not running danger because $DANGER_GITHUB_API_TOKEN is not found"; fi
 
 workflows:
-  version: 2
   wordpress_android:
     jobs:
       - test
       - lint
-      - danger
+      - danger/danger-ruby:
+          name: danger


### PR DESCRIPTION
This simplifies much of the CircleCI config by moving a lot of the boilerplate to an Orb defined in https://github.com/wordpress-mobile/circleci-orbs. Similar to what we have done on iOS, this will allow us to more easily add CircleCI to other projects while keeping it maintainable.

You can see the Android Orb here: https://github.com/wordpress-mobile/circleci-orbs/pull/11.

The config can be further simplified once https://github.com/wordpress-mobile/WordPress-Android/pull/9211 is merged.

To test:

- CircleCI checks should still be green.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
