### PR TITLE
Add scrolled-to-bottom event tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -8,7 +8,9 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.support.v4.app.FragmentActivity
 import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
 import android.support.v7.widget.RecyclerView.LayoutManager
+import android.support.v7.widget.RecyclerView.OnScrollListener
 import android.support.v7.widget.StaggeredGridLayoutManager
 import android.view.LayoutInflater
 import android.view.View
@@ -121,6 +123,13 @@ class StatsListFragment : DaggerFragment() {
                         columns
                 )
         )
+        recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: RecyclerView?, dx: Int, dy: Int) {
+                if (!recyclerView!!.canScrollVertically(1) && dy != 0) {
+                    viewModel.onScrolledToBottom()
+                }
+            }
+        })
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -4,11 +4,16 @@ import android.arch.lifecycle.LiveData
 import android.support.annotation.StringRes
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
+import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.throttle
 import org.wordpress.android.viewmodel.ScopedViewModel
 
-abstract class StatsListViewModel(defaultDispatcher: CoroutineDispatcher, private val statsUseCase: BaseListUseCase) :
-        ScopedViewModel(defaultDispatcher) {
+abstract class StatsListViewModel(
+    defaultDispatcher: CoroutineDispatcher,
+    private val statsUseCase: BaseListUseCase,
+    private val analyticsTracker: AnalyticsTrackerWrapper
+) : ScopedViewModel(defaultDispatcher) {
     enum class StatsSection(@StringRes val titleRes: Int) {
         INSIGHTS(R.string.stats_insights),
         DAYS(R.string.stats_timeframe_days),

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -3,17 +3,24 @@ package org.wordpress.android.ui.stats.refresh.lists
 import android.arch.lifecycle.LiveData
 import android.support.annotation.StringRes
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.throttle
 import org.wordpress.android.viewmodel.ScopedViewModel
 
+const val SCROLL_EVENT_DELAY = 2000L
+
 abstract class StatsListViewModel(
     defaultDispatcher: CoroutineDispatcher,
     private val statsUseCase: BaseListUseCase,
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) : ScopedViewModel(defaultDispatcher) {
+    private var trackJob: Job? = null
+
     enum class StatsSection(@StringRes val titleRes: Int) {
         INSIGHTS(R.string.stats_insights),
         DAYS(R.string.stats_timeframe_days),
@@ -29,5 +36,14 @@ abstract class StatsListViewModel(
     override fun onCleared() {
         statsUseCase.onCleared()
         super.onCleared()
+    }
+
+    fun onScrolledToBottom() {
+        if (trackJob?.isCompleted != false) {
+            trackJob = launch {
+                analyticsTracker.track(AnalyticsTracker.Stat.STATS_SCROLLED_TO_BOTTOM)
+                delay(SCROLL_EVENT_DELAY)
+            }
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/DaysListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/DaysListViewModel.kt
@@ -5,10 +5,12 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.DAY_STATS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
 import javax.inject.Named
 
 class DaysListViewModel @Inject constructor(
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
-    @Named(DAY_STATS_USE_CASE) statsUseCase: BaseListUseCase
-) : StatsListViewModel(mainDispatcher, statsUseCase)
+    @Named(DAY_STATS_USE_CASE) statsUseCase: BaseListUseCase,
+    analyticsTracker: AnalyticsTrackerWrapper
+) : StatsListViewModel(mainDispatcher, statsUseCase, analyticsTracker)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/MonthsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/MonthsListViewModel.kt
@@ -5,10 +5,12 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.MONTH_STATS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
 import javax.inject.Named
 
 class MonthsListViewModel @Inject constructor(
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
-    @Named(MONTH_STATS_USE_CASE) statsUseCase: BaseListUseCase
-) : StatsListViewModel(mainDispatcher, statsUseCase)
+    @Named(MONTH_STATS_USE_CASE) statsUseCase: BaseListUseCase,
+    analyticsTracker: AnalyticsTrackerWrapper
+) : StatsListViewModel(mainDispatcher, statsUseCase, analyticsTracker)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/WeeksListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/WeeksListViewModel.kt
@@ -5,10 +5,12 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.WEEK_STATS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
 import javax.inject.Named
 
 class WeeksListViewModel @Inject constructor(
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
-    @Named(WEEK_STATS_USE_CASE) statsUseCase: BaseListUseCase
-) : StatsListViewModel(mainDispatcher, statsUseCase)
+    @Named(WEEK_STATS_USE_CASE) statsUseCase: BaseListUseCase,
+    analyticsTracker: AnalyticsTrackerWrapper
+) : StatsListViewModel(mainDispatcher, statsUseCase, analyticsTracker)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/YearsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/YearsListViewModel.kt
@@ -5,10 +5,12 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.YEAR_STATS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
 import javax.inject.Named
 
 class YearsListViewModel @Inject constructor(
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
-    @Named(YEAR_STATS_USE_CASE) statsUseCase: BaseListUseCase
-) : StatsListViewModel(mainDispatcher, statsUseCase)
+    @Named(YEAR_STATS_USE_CASE) statsUseCase: BaseListUseCase,
+    analyticsTracker: AnalyticsTrackerWrapper
+) : StatsListViewModel(mainDispatcher, statsUseCase, analyticsTracker)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/InsightsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/InsightsListViewModel.kt
@@ -5,11 +5,13 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.INSIGHTS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
 import javax.inject.Named
 
 class InsightsListViewModel
 @Inject constructor(
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
-    @Named(INSIGHTS_USE_CASE) private val insightsUseCase: BaseListUseCase
-) : StatsListViewModel(mainDispatcher, insightsUseCase)
+    @Named(INSIGHTS_USE_CASE) private val insightsUseCase: BaseListUseCase,
+    analyticsTracker: AnalyticsTrackerWrapper
+) : StatsListViewModel(mainDispatcher, insightsUseCase, analyticsTracker)


### PR DESCRIPTION
This PR adds `wpandroid_stats_scrolled_to_bottom` event in Stats.

To test:
1. Go to Stats
2. Scroll to the bottom
3. Verify the `wpandroid_stats_scrolled_to_bottom` event is recorded