### PR TITLE
Upgrade Tracks to 1.1.6

### DIFF
--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.automattic:tracks:1.1.5'
+    implementation 'com.automattic:tracks:1.1.6'
     implementation 'org.wordpress:utils:1.19.0'
 
     lintChecks 'org.wordpress:lint:1.0.1'


### PR DESCRIPTION
This version adds `device_info_is_online` to all tracked events.

This completes #9253. 