### PR TITLE
Keep track of user-made choice when switching editors

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1147,8 +1147,9 @@ public class EditPostActivity extends AppCompatActivity implements
             switchToAztecMenuItem.setVisible(mCurrentEditorSelection == UserSwitchedEditor.GUTENBERG);
             switchToGutenbergMenuItem.setVisible(mCurrentEditorSelection == UserSwitchedEditor.AZTEC);
         } else {
-            // Check whether the content has blocks. Warning: this can be a very slow operation if the post if big/complex
-            //  since it extracts the content from the editor, which can be slow in Gutenberg at the time of writing.
+            // Check whether the content has blocks. Warning: this can be a very slow operation if the post if
+            // big/complex since it extracts the content from the editor, which can be slow in Gutenberg at the
+            // time of writing.
             boolean hasBlocks = false;
             try {
                 final String content = (String) mEditorFragment.getContent(mPost.getContent());

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -493,6 +493,12 @@ public class EditPostActivity extends AppCompatActivity implements
             mEditorFragment.setImageLoader(mImageLoader);
         }
 
+        // Ensure we have a valid post
+        if (mPost == null) {
+            showErrorAndFinish(R.string.post_not_found);
+            return;
+        }
+
         // Ensure that this check happens when mPost is set
         String restartEditorOptionName;
         String userSwitchedEditorsOptionName = null;
@@ -512,12 +518,6 @@ public class EditPostActivity extends AppCompatActivity implements
 
         mShowGutenbergEditor = PostUtils.shouldShowGutenbergEditor(mIsNewPost, mPost)
                                && restartEditorOption != RestartEditorOptions.RESTART_SUPPRESS_GUTENBERG;
-
-        // Ensure we have a valid post
-        if (mPost == null) {
-            showErrorAndFinish(R.string.post_not_found);
-            return;
-        }
 
         if (savedInstanceState == null) {
             // Bump the stat the first time the editor is opened.


### PR DESCRIPTION
Fixes #9263 

This fixes a bug introduced with changes in https://github.com/wordpress-mobile/WordPress-Android/pull/9247

What this PR does is it keeps state of the choice made by the user when switching editors within the same editing session. On config change (rotation), the state of the selected Editor was lost and the options shown in the menu were inconsistent with the editor being shown.

I first attempted to solve this by just keeping the state of the pre-existing `mRestartEditorOption` variable in [this diff here](https://github.com/wordpress-mobile/WordPress-Android/compare/issue/9263-switch-editor-option-state-lost-rotate?expand=1
), but that proved to not work well as the `RestartEditorOptions` actually is meant to be a _signal_  to perform an action (the replacement of the editor as an actual switch) rather than a vault for keeping the _current state of things_.

So, in order to better reflect the reality when rotation occurs, I'm adding a flag that keeps the state of the currently selected editor, as an indicator of something that _has been selected by the user_ temporarily for the time the user is currently in the Editor.


To test:
1. open a GB post
2. verify the three dots show option "switch to classic editor". Tap it.
3. verify the classic editor is loaded (Aztec), and the three dots show now "switch to Block editor"
4. rotate the screen
5. verify the three dots still show "switch to Block Editor", showing consistency with what is being currently displayed as expected

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
