### PR TITLE
Call reattachUploadingMedia() only for Aztec

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2183,8 +2183,6 @@ public class EditPostActivity extends AppCompatActivity implements
 
                         // Set up custom headers for the visual editor's internal WebView
                         mEditorFragment.setCustomHttpHeader("User-Agent", WordPress.getUserAgent());
-
-                        reattachUploadingMedia();
                     }
                     break;
                 case 1:

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -681,11 +681,11 @@ public class EditPostActivity extends AppCompatActivity implements
 
         EventBus.getDefault().register(this);
 
-        reattachUploadingMedia();
+        reattachUploadingMediaForAztec();
     }
 
-    private void reattachUploadingMedia() {
-        if (mEditorMediaUploadListener != null) {
+    private void reattachUploadingMediaForAztec() {
+        if (mEditorFragment instanceof AztecEditorFragment && mEditorMediaUploadListener != null) {
             // UploadService.getPendingMediaForPost will be populated only when the user exits the editor
             // But if the user doesn't exit the editor and sends the app to the background, a reattachment
             // for the media within this Post is needed as soon as the app comes back to foreground,
@@ -2183,6 +2183,8 @@ public class EditPostActivity extends AppCompatActivity implements
 
                         // Set up custom headers for the visual editor's internal WebView
                         mEditorFragment.setCustomHttpHeader("User-Agent", WordPress.getUserAgent());
+
+                        reattachUploadingMediaForAztec();
                     }
                     break;
                 case 1:


### PR DESCRIPTION
EDIT: updated description and title to reflect solution as added in 3e6608a

Fixes #9268 by making sure to only make _host app -> editor_ calls to media upload progress reattachment code for Aztec, as Gutenberg relies on the RN side of things to request the host app to start sending updates the other way around (_editor -> host app_). This is done by means of the `OnReattachQueryListener` call once `componenDidMount` callback gets called on the JS side.

The crash started happening in current `develop` after the introduction of [0e2237f](https://github.com/wordpress-mobile/WordPress-Android/commit/0e2237f995abe580082843e20d7a787f087db246) in #9030, after media upload progress reattachment code was merged.

There was a call in the SectionsPagerAdapter's  `instantiateItem` when the Fragment was still not attached, but this was unneeded as Gutenberg works differently in this regard: instead of taking the list of currently progressing uploads and then telling the Editor to paint the progress when we know we're about to show it (i.e. `onResume()` or on the pager adapter `instantiateItem` call) as we do for Aztec, we need to wait to know the RN side of things is ready to receive progress updates, which happens after `componentDidMount` gets called, which in turn makes the query to the host app through the bridge's `OnReattachQueryListener`.

To test (copied from #9129):
1. start a new draft
2. insert an image
3. once it starts uploading, exit the editor
4. open the Post in the editor again
5. observe the upload progress bar is updated correspondingly.

Try the same on Aztec posts as well.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
