### PR TITLE
Issue/8993 fixing my site rtl layout

### DIFF
--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -166,6 +166,7 @@
                         android:minHeight="?attr/listPreferredItemHeightSmall" >
 
                         <org.wordpress.android.widgets.WPTextView
+                            android:textAlignment="viewStart"
                             android:id="@+id/quick_start_title"
                             android:ellipsize="end"
                             android:fontFamily="sans-serif-light"

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -489,6 +489,7 @@
     </style>
 
     <style name="QuickStartTypeTitle">
+        <item name="android:textAlignment">viewStart</item>
         <item name="android:ellipsize">end</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_width">match_parent</item>
@@ -499,6 +500,7 @@
     </style>
 
     <style name="QuickStartTypeSubtitle">
+        <item name="android:textAlignment">viewStart</item>
         <item name="android:ellipsize">end</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_width">match_parent</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -330,6 +330,7 @@
 
     <style name="MySiteListHeader">
         <item name="android:ellipsize">end</item>
+        <item name="android:textAlignment">viewStart</item>
         <item name="android:fontFamily">sans-serif-medium</item>
         <item name="android:layout_centerVertical">true</item>
         <item name="android:layout_height">wrap_content</item>


### PR DESCRIPTION
Fixes #8993 

To test:
- Toggle "Force RTL layout direction" in developer settings.
- Open app on My Site screen with Quick Start active.
- Make sure that My Site category titles are properly aligned.
- Make sure that content of Quick Srtart card is properly aligned.

Everything should look like this:
![screenshot_1550530764](https://user-images.githubusercontent.com/728822/52980234-d96d7c00-33e1-11e9-96a9-e294f7847e02.png)
