### PR TITLE
Update the Gutenberg switch copy, add a summary

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -583,7 +583,7 @@
     <string name="site_settings_amp_title">Accelerated Mobile Pages (AMP)</string>
     <string name="site_settings_amp_summary">Your WordPress.com site supports the use of Accelerated Mobile Pages, a Google-led initiative that dramatically speeds up loading times on mobile devices</string>
     <string name="site_settings_gutenberg_default_for_new_posts">Use Block Editor</string>
-    <string name="site_settings_gutenberg_default_for_new_posts_summary">Edit new posts and pages with the block editor.</string>
+    <string name="site_settings_gutenberg_default_for_new_posts_summary">Edit new posts and pages with the block editor</string>
 
     <!-- Media -->
     <string name="site_settings_quota_header">Media</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -582,7 +582,8 @@
     <string name="site_settings_timezones_error">Unable to load timezones</string>
     <string name="site_settings_amp_title">Accelerated Mobile Pages (AMP)</string>
     <string name="site_settings_amp_summary">Your WordPress.com site supports the use of Accelerated Mobile Pages, a Google-led initiative that dramatically speeds up loading times on mobile devices</string>
-    <string name="site_settings_gutenberg_default_for_new_posts">Use block editor for new posts</string>
+    <string name="site_settings_gutenberg_default_for_new_posts">Use Block Editor</string>
+    <string name="site_settings_gutenberg_default_for_new_posts_summary">Edit new posts and pages with the block editor.</string>
 
     <!-- Media -->
     <string name="site_settings_quota_header">Media</string>

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -66,7 +66,8 @@
             android:id="@+id/pref_gutenberg_default_for_new_posts"
             android:key="@string/pref_key_gutenberg_default_for_new_posts"
             android:layout="@layout/wp_preference_layout"
-            android:title="@string/site_settings_gutenberg_default_for_new_posts"/>
+            android:title="@string/site_settings_gutenberg_default_for_new_posts"
+            android:summary="@string/site_settings_gutenberg_default_for_new_posts_summary"/>
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/567#issuecomment-463644959 by updating the copy and adding a setting summary.

To test:

Run the app and notice the updated copy+summary in the "Me tab > App Settings" section.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
