### PR TITLE
Remove icons from Clicks in Stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCase.kt
@@ -88,7 +88,6 @@ constructor(
             items.add(Header(R.string.stats_clicks_link_label, R.string.stats_clicks_label))
             domainModel.groups.forEachIndexed { index, group ->
                 val headerItem = ListItemWithIcon(
-                        iconUrl = group.icon,
                         text = group.name,
                         value = group.views?.toFormattedString(),
                         showDivider = index < domainModel.groups.size - 1,
@@ -104,7 +103,6 @@ constructor(
                     if (isExpanded) {
                         items.addAll(group.clicks.map { click ->
                             ListItemWithIcon(
-                                    iconUrl = click.icon,
                                     text = click.name,
                                     value = click.views.toFormattedString(),
                                     showDivider = false,

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCaseTest.kt
@@ -101,10 +101,9 @@ class ClicksUseCaseTest : BaseUnitTest() {
         assertSingleItem(
                 this[2],
                 singleClick.name!!,
-                singleClick.views,
-                singleClick.icon
+                singleClick.views
         )
-        return assertExpandableItem(this[3], group.name!!, group.views!!, group.icon)
+        return assertExpandableItem(this[3], group.name!!, group.views!!)
     }
 
     private fun List<BlockListItem>.assertExpandedList(): ExpandableItem {
@@ -114,11 +113,10 @@ class ClicksUseCaseTest : BaseUnitTest() {
         assertSingleItem(
                 this[2],
                 singleClick.name!!,
-                singleClick.views,
-                singleClick.icon
+                singleClick.views
         )
-        val expandableItem = assertExpandableItem(this[3], group.name!!, group.views!!, group.icon)
-        assertSingleItem(this[4], click.name, click.views, click.icon)
+        val expandableItem = assertExpandableItem(this[3], group.name!!, group.views!!)
+        assertSingleItem(this[4], click.name, click.views)
         assertThat(this[5]).isEqualTo(Divider)
         return expandableItem
     }
@@ -145,8 +143,7 @@ class ClicksUseCaseTest : BaseUnitTest() {
             assertSingleItem(
                     this[2],
                     singleClick.name!!,
-                    singleClick.views,
-                    singleClick.icon
+                    singleClick.views
             )
             assertLink(this[3])
         }
@@ -202,8 +199,7 @@ class ClicksUseCaseTest : BaseUnitTest() {
     private fun assertSingleItem(
         item: BlockListItem,
         key: String,
-        views: Int?,
-        icon: String?
+        views: Int?
     ) {
         assertThat(item.type).isEqualTo(LIST_ITEM_WITH_ICON)
         assertThat((item as ListItemWithIcon).text).isEqualTo(key)
@@ -212,19 +208,18 @@ class ClicksUseCaseTest : BaseUnitTest() {
         } else {
             assertThat(item.value).isNull()
         }
-        assertThat(item.iconUrl).isEqualTo(icon)
+        assertThat(item.iconUrl).isNull()
     }
 
     private fun assertExpandableItem(
         item: BlockListItem,
         label: String,
-        views: Int,
-        icon: String?
+        views: Int
     ): ExpandableItem {
         assertThat(item.type).isEqualTo(EXPANDABLE_ITEM)
         assertThat((item as ExpandableItem).header.text).isEqualTo(label)
         assertThat(item.header.value).isEqualTo(views.toFormattedString())
-        assertThat(item.header.iconUrl).isEqualTo(icon)
+        assertThat(item.header.iconUrl).isNull()
         return item
     }
 


### PR DESCRIPTION
Fixes #9194
This PR removes all the icons from clicks - both from expandable and expanded items.

To test:
* Open stats
* Go to Day/Week/Month/Year stats
* Notice that the clicks don't have icons any more

![screenshot_1550582827](https://user-images.githubusercontent.com/1079756/53018530-e9717400-3452-11e9-9bf4-5c296b372d02.png)

