### PR TITLE
Added gutenberg_enabled tracking as an event and as user metadata

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.ui.stats.StatsTimeframe;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.WPMediaUtils;
+import org.wordpress.android.util.analytics.AnalyticsUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -640,6 +641,7 @@ public class AppPrefs {
     }
 
     public static void setGutenbergDefaultForNewPosts(boolean defaultForNewPosts) {
+        AnalyticsTracker.track(defaultForNewPosts ? Stat.EDITOR_GUTENBERG_ENABLED : Stat.EDITOR_GUTENBERG_DISABLED);
         setBoolean(DeletablePrefKey.GUTENBERG_DEAFULT_FOR_NEW_POSTS, defaultForNewPosts);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -18,7 +18,6 @@ import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.ui.stats.StatsTimeframe;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.WPMediaUtils;
-import org.wordpress.android.util.analytics.AnalyticsUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -307,6 +307,8 @@ public class AppSettingsFragment extends PreferenceFragment
                                          getLabelForVideoEncoderBitrateValue(AppPrefs.getVideoOptimizeQuality()));
         } else if (preference == mGutenbergDefaultForNewPosts) {
             AppPrefs.setGutenbergDefaultForNewPosts((Boolean) newValue);
+            // we need to refresh metadata as gutenberg_enabled is now part of the user data
+            AnalyticsUtils.refreshMetadata(mAccountStore, mSiteStore);
         } else if (preference == mStripImageLocation) {
             AppPrefs.setStripImageLocation((Boolean) newValue);
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.PushAccountSettingsPayload;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.ReaderPost;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.ImageUtils;
@@ -102,6 +103,7 @@ public class AnalyticsUtils {
         metadata.setNumBlogs(siteStore.getSitesCount());
         metadata.setUsername(accountStore.getAccount().getUserName());
         metadata.setEmail(accountStore.getAccount().getEmail());
+        metadata.setGutenbergEnabled(AppPrefs.isGutenbergDefaultForNewPosts());
 
         AnalyticsTracker.refreshMetadata(metadata);
     }
@@ -123,6 +125,7 @@ public class AnalyticsUtils {
         metadata.setNumBlogs(1);
         metadata.setUsername(username);
         metadata.setEmail(email);
+        metadata.setGutenbergEnabled(AppPrefs.isGutenbergDefaultForNewPosts());
         AnalyticsTracker.refreshMetadata(metadata);
     }
 

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsMetadata.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsMetadata.java
@@ -8,6 +8,7 @@ public class AnalyticsMetadata {
     private int mNumBlogs;
     private String mUsername = "";
     private String mEmail = "";
+    private boolean mIsGutenbergEnabled;
 
     public AnalyticsMetadata() {
     }
@@ -66,5 +67,13 @@ public class AnalyticsMetadata {
 
     public void setEmail(String email) {
         this.mEmail = email;
+    }
+
+    public boolean isGutenbergEnabled() {
+        return mIsGutenbergEnabled;
+    }
+
+    public void setGutenbergEnabled(boolean gutenbergEnabled) {
+        this.mIsGutenbergEnabled = gutenbergEnabled;
     }
 }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -173,6 +173,8 @@ public final class AnalyticsTracker {
         EDITOR_AZTEC_TOGGLED_OFF, // Aztec editor only
         EDITOR_AZTEC_TOGGLED_ON, // Aztec editor only
         EDITOR_AZTEC_ENABLED, // Aztec editor only
+        EDITOR_GUTENBERG_ENABLED, // Gutenberg editor only
+        EDITOR_GUTENBERG_DISABLED, // Gutenberg editor only
         REVISIONS_LIST_VIEWED,
         REVISIONS_DETAIL_VIEWED_FROM_LIST,
         REVISIONS_DETAIL_VIEWED_FROM_SWIPE,

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -19,6 +19,7 @@ public class AnalyticsTrackerNosara extends Tracker {
     private static final String TRACKS_ANON_ID = "nosara_tracks_anon_id";
     @SuppressWarnings("checkstyle:RegexpSingleline")
     private static final String WPCOM_USER = "dotcom_user";
+    private static final String IS_GUTENBERG_ENABLED = "gutenberg_enabled";
 
     private static final String EVENTS_PREFIX = "wpandroid_";
 
@@ -511,6 +512,7 @@ public class AnalyticsTrackerNosara extends Tracker {
             properties.put(JETPACK_USER, metadata.isJetpackUser());
             properties.put(NUMBER_OF_BLOGS, metadata.getNumBlogs());
             properties.put(WPCOM_USER, metadata.isWordPressComUser());
+            properties.put(IS_GUTENBERG_ENABLED, metadata.isGutenbergEnabled());
             mNosaraClient.registerUserProperties(properties);
         } catch (JSONException e) {
             AppLog.e(AppLog.T.UTILS, e);
@@ -680,6 +682,10 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "editor_upload_media_retried";
             case EDITOR_CLOSED:
                 return "editor_closed";
+            case EDITOR_GUTENBERG_ENABLED:
+                return "gutenberg_enabled";
+            case EDITOR_GUTENBERG_DISABLED:
+                return "gutenberg_disabled";
             case POST_LIST_BUTTON_PRESSED:
                 return "post_list_button_pressed";
             case POST_LIST_ITEM_SELECTED:


### PR DESCRIPTION
Mirroring iOS PR https://github.com/wordpress-mobile/WordPress-iOS/pull/11043

Adds the Gutenberg setting tracking described on https://github.com/wordpress-mobile/gutenberg-mobile/issues/556:

* App setting to enable Gutenberg: `gutenberg_enabled` when switched on, `gutenberg_disabled` when switched off.
* Add a `gutenberg_enabled` property to the user properties that are sent with every event.

To test:
- enable/disable Gutenberg and check that the Tracks signal is sent
- check the user information metadata carries now the `gutenberg_enabled` flag as well

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
