### PR TITLE
Retain mShowGutenbergEditor flag on rotate

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1138,17 +1138,20 @@ public class EditPostActivity extends AppCompatActivity implements
             switchToAztecMenuItem.setVisible(false);
 
             // Check whether the content has blocks.
-            boolean hasBlocksOrEmpty = false;
+            boolean hasBlocks = false;
+            boolean isEmpty = false;
             try {
                 final String content = (String) mEditorFragment.getContent(mPost.getContent());
-                hasBlocksOrEmpty = PostUtils.contentContainsGutenbergBlocks(content) || TextUtils.isEmpty(content);
+                hasBlocks = PostUtils.contentContainsGutenbergBlocks(content);
+                isEmpty = TextUtils.isEmpty(content);
             } catch (EditorFragmentNotAddedException e) {
                 // legacy exception; just ignore.
             }
 
             // if content has blocks or empty, offer the switch to Gutenberg. The block editor doesn't have good
-            //  "Classic Block" support yet so, don't offer a switch to it if content doesn't have blocks.
-            switchToGutenbergMenuItem.setVisible(hasBlocksOrEmpty);
+            //  "Classic Block" support yet so, don't offer a switch to it if content doesn't have blocks. If the post
+            //  is empty but the user hasn't enabled "Use Gutenberg for new posts" App setting, don't offer the switch.
+            switchToGutenbergMenuItem.setVisible(hasBlocks || (AppPrefs.isGutenbergDefaultForNewPosts() && isEmpty));
         }
 
         return super.onPrepareOptionsMenu(menu);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -228,6 +228,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private static final String STATE_KEY_IS_PHOTO_PICKER_VISIBLE = "stateKeyPhotoPickerVisible";
     private static final String STATE_KEY_HTML_MODE_ON = "stateKeyHtmlModeOn";
     private static final String STATE_KEY_REVISION = "stateKeyRevision";
+    private static final String STATE_KEY_GUTENERG_IS_SHOWN = "stateKeyGutenbergIsShown";
     private static final String TAG_DISCARDING_CHANGES_ERROR_DIALOG = "tag_discarding_changes_error_dialog";
     private static final String TAG_DISCARDING_CHANGES_NO_NETWORK_DIALOG = "tag_discarding_changes_no_network_dialog";
     private static final String TAG_PUBLISH_CONFIRMATION_DIALOG = "tag_publish_confirmation_dialog";
@@ -486,18 +487,17 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         // Ensure that this check happens when mPost is set
-        String restartEditorOptionName;
         if (savedInstanceState == null) {
-            restartEditorOptionName = getIntent().getStringExtra(EXTRA_RESTART_EDITOR);
-        } else {
-            restartEditorOptionName = savedInstanceState.getString(EXTRA_RESTART_EDITOR);
-        }
-        RestartEditorOptions restartEditorOption =
-                restartEditorOptionName == null ? RestartEditorOptions.RESTART_DONT_SUPPRESS_GUTENBERG
-                        : RestartEditorOptions.valueOf(restartEditorOptionName);
+            String restartEditorOptionName = getIntent().getStringExtra(EXTRA_RESTART_EDITOR);
+            RestartEditorOptions restartEditorOption =
+                    restartEditorOptionName == null ? RestartEditorOptions.RESTART_DONT_SUPPRESS_GUTENBERG
+                            : RestartEditorOptions.valueOf(restartEditorOptionName);
 
-        mShowGutenbergEditor = PostUtils.shouldShowGutenbergEditor(mIsNewPost, mPost)
-                               && restartEditorOption != RestartEditorOptions.RESTART_SUPPRESS_GUTENBERG;
+            mShowGutenbergEditor = PostUtils.shouldShowGutenbergEditor(mIsNewPost, mPost)
+                                   && restartEditorOption != RestartEditorOptions.RESTART_SUPPRESS_GUTENBERG;
+        } else {
+            mShowGutenbergEditor = savedInstanceState.getBoolean(STATE_KEY_GUTENERG_IS_SHOWN);
+        }
 
         // Ensure we have a valid post
         if (mPost == null) {
@@ -776,6 +776,7 @@ public class EditPostActivity extends AppCompatActivity implements
         outState.putBoolean(STATE_KEY_HTML_MODE_ON, mHtmlModeMenuStateOn);
         outState.putSerializable(WordPress.SITE, mSite);
         outState.putParcelable(STATE_KEY_REVISION, mRevision);
+        outState.putBoolean(STATE_KEY_GUTENERG_IS_SHOWN, mShowGutenbergEditor);
 
         outState.putParcelableArrayList(STATE_KEY_DROPPED_MEDIA_URIS, mDroppedMediaUris);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1127,20 +1127,29 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         MenuItem switchToAztecMenuItem = menu.findItem(R.id.menu_switch_to_aztec);
-        switchToAztecMenuItem.setVisible(mShowGutenbergEditor);
-
-        // Check whether the content has blocks. Warning: this can be a very slow operation if the post if big/complex
-        //  since it extracts the content from the editor, which can be slow in Gutenberg at the time of writing.
-        boolean hasBlocks = false;
-        try {
-            final String content = (String) mEditorFragment.getContent(mPost.getContent());
-            hasBlocks = PostUtils.contentContainsGutenbergBlocks(content) || TextUtils.isEmpty(content);
-        } catch (EditorFragmentNotAddedException e) {
-            // legacy exception; just ignore.
-        }
-
         MenuItem switchToGutenbergMenuItem = menu.findItem(R.id.menu_switch_to_gutenberg);
-        switchToGutenbergMenuItem.setVisible(!mShowGutenbergEditor && hasBlocks);
+
+        if (mShowGutenbergEditor) {
+            // we're showing Gutenberg so, just offer the Aztec switch
+            switchToAztecMenuItem.setVisible(true);
+            switchToGutenbergMenuItem.setVisible(false);
+        } else {
+            // we're showing Aztec so, hide the "Switch to Aztec" menu
+            switchToAztecMenuItem.setVisible(false);
+
+            // Check whether the content has blocks.
+            boolean hasBlocksOrEmpty = false;
+            try {
+                final String content = (String) mEditorFragment.getContent(mPost.getContent());
+                hasBlocksOrEmpty = PostUtils.contentContainsGutenbergBlocks(content) || TextUtils.isEmpty(content);
+            } catch (EditorFragmentNotAddedException e) {
+                // legacy exception; just ignore.
+            }
+
+            // if content has blocks or empty, offer the switch to Gutenberg. The block editor doesn't have good
+            //  "Classic Block" support yet so, don't offer a switch to it if content doesn't have blocks.
+            switchToGutenbergMenuItem.setVisible(hasBlocksOrEmpty);
+        }
 
         return super.onPrepareOptionsMenu(menu);
     }


### PR DESCRIPTION
Fixes #9263

@mzorz has recently opened #9266 to tackle the same problem, but I had some concerns about the introduction of additional state variables to govern which editor is going to be shown. Instead of the approach in that PR, I explored an alternative where we could try to just save the `mShowGutenbergEditor` flag on rotation.

That flag is denoting whether Gutenberg will be shown anyway and is set to `false` if we want to "suppress" Gutenberg for the while-editing editor switch (introduced in #9247).

Turned out that it was a workable solution and will minimal code change. There are still concerns that the way we're determining which editor to show is still convoluted. The 0e73c09 commit is about that.

While we were discussing and testing this, @mzorz shared an idea about trying to optimize the "hasBlocks" check, to avoid the costly `getContent()` calls under some conditions. That was a good idea and resulted to d4d50ae.

Finally, again while testing, Mario noticed a new issue that even happened in `develop`: With the app setting OFF, a new post was offering the switch to Gutenberg, but tapping on it would still bring up Aztec. The issue is addressed with f5ee44d.

And those are all the commits in the PR :)

### To test A

1. Open a GB post
2. Verify the three dots show option "switch to classic editor". Tap it.
3. Verify the classic editor is loaded (Aztec), and the three dots show now "switch to Block editor"
4. Rotate the screen
5. Verify the three dots menu still shows "switch to Block Editor" and tap on it
6. Verify that the block editor is loaded

### To test B

1. Disable "Use Block Editor" from Me > App Seetings
2. Start a new post
3. Verify Aztec is shown
4. Tap the 3-dots button at the top to open the menu
5. Verify that there is no option to switch editors there

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
