### PR TITLE
Make stats full width and flat

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,2 +1,3 @@
 * Updated Plans with new design
 * Add Visitors overlay to the Overview block in Stats
+* Change Stats design to flat on smaller devices

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListItemDecoration.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsListItemDecoration.kt
@@ -4,7 +4,14 @@ import android.graphics.Rect
 import android.support.v7.widget.RecyclerView
 import android.view.View
 
-data class StatsListItemDecoration(val horizontalSpacing: Int, val verticalSpacing: Int, val columnCount: Int) :
+data class StatsListItemDecoration(
+    val horizontalSpacing: Int,
+    val topSpacing: Int,
+    val bottomSpacing: Int,
+    val firstSpacing: Int,
+    val lastSpacing: Int,
+    val columnCount: Int
+) :
         RecyclerView.ItemDecoration() {
     override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
         super.getItemOffsets(outRect, view, parent, state)
@@ -12,9 +19,9 @@ data class StatsListItemDecoration(val horizontalSpacing: Int, val verticalSpaci
         val isLast = parent.adapter?.let { parent.getChildAdapterPosition(view) == it.itemCount - 1 } ?: false
         outRect.set(
                 if (columnCount == 1) 2 * horizontalSpacing else horizontalSpacing,
-                if (isFirst) 2 * verticalSpacing else verticalSpacing,
+                if (isFirst) firstSpacing else topSpacing,
                 if (columnCount == 1) 2 * horizontalSpacing else horizontalSpacing,
-                if (isLast) 2 * verticalSpacing else verticalSpacing
+                if (isLast) lastSpacing else bottomSpacing
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -120,8 +120,11 @@ class StatsListFragment : DaggerFragment() {
         recyclerView.layoutManager = this.layoutManager
         recyclerView.addItemDecoration(
                 StatsListItemDecoration(
-                        resources.getDimensionPixelSize(dimen.margin_small),
-                        resources.getDimensionPixelSize(dimen.margin_small),
+                        resources.getDimensionPixelSize(dimen.stats_list_card_horizontal_spacing),
+                        resources.getDimensionPixelSize(dimen.stats_list_card_top_spacing),
+                        resources.getDimensionPixelSize(dimen.stats_list_card_bottom_spacing),
+                        resources.getDimensionPixelSize(dimen.stats_list_card_first_spacing),
+                        resources.getDimensionPixelSize(dimen.stats_list_card_last_spacing),
                         columns
                 )
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
@@ -168,7 +168,12 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
     protected abstract fun buildLoadingItem(): List<BlockListItem>
 
     protected open fun buildErrorItem(): List<BlockListItem> {
-        return buildLoadingItem() + listOf(BlockListItem.Text(textResource = R.string.stats_loading_block_error))
+        return buildLoadingItem() + listOf(
+                BlockListItem.Text(
+                        textResource = R.string.stats_loading_block_error,
+                        isLast = true
+                )
+        )
     }
 
     protected open fun buildEmptyItem(): List<BlockListItem> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -88,7 +88,12 @@ sealed class BlockListItem(val type: Type) {
 
     data class Information(val text: String) : BlockListItem(INFO)
 
-    data class Text(val text: String? = null, val textResource: Int? = null, val links: List<Clickable>? = null) :
+    data class Text(
+        val text: String? = null,
+        val textResource: Int? = null,
+        val links: List<Clickable>? = null,
+        val isLast: Boolean = false
+    ) :
             BlockListItem(TEXT) {
         data class Clickable(
             val link: String,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItemViewHolder.kt
@@ -189,6 +189,7 @@ sealed class BlockListItemViewHolder(
             parent,
             R.layout.stats_block_text_item
     ) {
+        private val container = itemView.findViewById<FrameLayout>(R.id.container)
         private val text = itemView.findViewById<TextView>(R.id.text)
         fun bind(textItem: Text) {
             val loadedText = textItem.text
@@ -202,6 +203,14 @@ sealed class BlockListItemViewHolder(
             text.text = spannableString
             text.linksClickable = true
             text.movementMethod = LinkMovementMethod.getInstance()
+            val params = container.layoutParams as RecyclerView.LayoutParams
+            val bottomMargin = if (textItem.isLast) {
+                container.resources.getDimensionPixelSize(R.dimen.margin_extra_large)
+            } else {
+                0
+            }
+            params.setMargins(0, 0, 0, bottomMargin)
+            container.layoutParams = params
         }
 
         private fun SpannableString.withClickableSpan(

--- a/WordPress/src/main/res/layout-w528dp/stats_list_block.xml
+++ b/WordPress/src/main/res/layout-w528dp/stats_list_block.xml
@@ -2,7 +2,6 @@
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/container"
     style="@style/StatsBlock"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout-w528dp/stats_list_block.xml
+++ b/WordPress/src/main/res/layout-w528dp/stats_list_block.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.facebook.shimmer.ShimmerFrameLayout
+<android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/StatsLoadingBlock"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/container"
+    style="@style/StatsBlock"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:animateLayoutChanges="false">
+    android:animateLayoutChanges="false"
+    app:cardCornerRadius="@dimen/default_cardview_radius"
+    app:cardElevation="@dimen/default_cardview_elevation">
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/stats_block_list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
-</com.facebook.shimmer.ShimmerFrameLayout>
+
+</android.support.v7.widget.CardView>

--- a/WordPress/src/main/res/layout-w528dp/stats_loading_view.xml
+++ b/WordPress/src/main/res/layout-w528dp/stats_loading_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+                                    style="@style/StatsLoadingBlock"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:animateLayoutChanges="false">
+
+    <com.facebook.shimmer.ShimmerFrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/stats_block_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+    </com.facebook.shimmer.ShimmerFrameLayout>
+</android.support.v7.widget.CardView>

--- a/WordPress/src/main/res/layout/stats_block_list_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_list_item.xml
@@ -13,7 +13,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/margin_extra_large"
-        android:layout_marginStart="@dimen/margin_extra_extra_large"
+        android:layout_marginStart="@dimen/stats_list_item_left_margin"
         android:layout_marginTop="@dimen/margin_large"
         android:ellipsize="end"
         android:lines="1"

--- a/WordPress/src/main/res/layout/stats_block_text_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_text_item.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
              style="@style/StatsBlockLine"
+             android:id="@+id/container"
              android:layout_width="match_parent"
              android:layout_height="wrap_content"
              android:minHeight="@dimen/one_line_list_item_height"
-             android:paddingBottom="@dimen/margin_extra_large"
              android:paddingStart="@dimen/margin_extra_large"
              android:paddingEnd="@dimen/margin_extra_large">
 

--- a/WordPress/src/main/res/layout/stats_list_block.xml
+++ b/WordPress/src/main/res/layout/stats_list_block.xml
@@ -1,17 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-                                    xmlns:app="http://schemas.android.com/apk/res-auto"
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:animateLayoutChanges="false"
-                                    android:id="@+id/container"
-                                    app:cardCornerRadius="@dimen/default_cardview_radius"
-                                    app:cardElevation="@dimen/default_cardview_elevation"
-                                    style="@style/StatsBlock">
-
-    <android.support.v7.widget.RecyclerView
-        android:id="@+id/stats_block_list"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
-
-</android.support.v7.widget.CardView>
+<android.support.v7.widget.RecyclerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/stats_block_list"
+    style="@style/StatsBlock"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"/>

--- a/WordPress/src/main/res/values-w528dp/dimens.xml
+++ b/WordPress/src/main/res/values-w528dp/dimens.xml
@@ -5,6 +5,5 @@
     <dimen name="stats_list_card_bottom_spacing">4dp</dimen>
     <dimen name="stats_list_card_first_spacing">8dp</dimen>
     <dimen name="stats_list_card_last_spacing">8dp</dimen>
-    <dimen name="stats_list_card_left_padding">24dp</dimen>
     <dimen name="stats_list_item_left_margin">48dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values-w528dp/dimens.xml
+++ b/WordPress/src/main/res/values-w528dp/dimens.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="stats_list_card_horizontal_spacing">8dp</dimen>
+    <dimen name="stats_list_card_top_spacing">4dp</dimen>
+    <dimen name="stats_list_card_bottom_spacing">4dp</dimen>
+    <dimen name="stats_list_card_first_spacing">8dp</dimen>
+    <dimen name="stats_list_card_last_spacing">8dp</dimen>
+    <dimen name="stats_list_card_left_padding">24dp</dimen>
+    <dimen name="stats_list_item_left_margin">48dp</dimen>
+</resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -399,7 +399,6 @@
     <dimen name="stats_list_card_bottom_spacing">16dp</dimen>
     <dimen name="stats_list_card_first_spacing">0dp</dimen>
     <dimen name="stats_list_card_last_spacing">16dp</dimen>
-    <dimen name="stats_list_card_left_padding">16dp</dimen>
     <dimen name="stats_list_item_left_margin">56dp</dimen>
 
     <dimen name="settings_icon_size">24dp</dimen>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -394,6 +394,13 @@
     <dimen name="stats_header_height">32dp</dimen>
     <dimen name="stats_bar_chart_height">180dp</dimen>
     <dimen name="stats_block_icon_size">24dp</dimen>
+    <dimen name="stats_list_card_horizontal_spacing">0dp</dimen>
+    <dimen name="stats_list_card_top_spacing">0dp</dimen>
+    <dimen name="stats_list_card_bottom_spacing">16dp</dimen>
+    <dimen name="stats_list_card_first_spacing">0dp</dimen>
+    <dimen name="stats_list_card_last_spacing">16dp</dimen>
+    <dimen name="stats_list_card_left_padding">16dp</dimen>
+    <dimen name="stats_list_item_left_margin">56dp</dimen>
 
     <dimen name="settings_icon_size">24dp</dimen>
 


### PR DESCRIPTION
Fixes #9185 
The changes in this PR:
* Stats are full width on screens with width < 512dp
* In the full width mode the vertical spacing is 16dp
* In the full width mode there is no top margin
* In the full width mode there is no card elevation (flat cards)
* In the full width mode text items with icons align to the 72dp keyline
* Remove of bottom padding of text in the Latest post summary block

To test - width < 512dp:
* Open Stats
* Notice: 
  * The Stats are shown in flat design - without shadows
  * There is no top and side margins

To test - width >= 512dp:
* Open Stats
* There is no change to the designs

![screenshot_1550592482](https://user-images.githubusercontent.com/1079756/53029860-06fe0800-346a-11e9-9130-a164e09dcc2e.png)

![screenshot_1550592491](https://user-images.githubusercontent.com/1079756/53029865-08c7cb80-346a-11e9-8548-9910370d0efc.png)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
