### PR TITLE
Fix empty views on Posts List screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.uploads.UploadUtils
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.AccessibilityUtils
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.NetworkUtils
@@ -263,26 +264,26 @@ class PostListFragment : Fragment() {
     }
 
     private fun updateEmptyViewForState(state: PostListEmptyUiState) {
-        if (state.listVisible) {
-            actionableEmptyView?.visibility = View.GONE
-        } else {
-            actionableEmptyView?.visibility = View.VISIBLE
-            actionableEmptyView?.let { view ->
-                setTextOrHide(view.title, state.titleResId)
-                setImageOrHide(view.image, state.imgResId)
-                setupButtonOrHide(view.button, state.buttonTextResId, state.onButtonClick)
+        actionableEmptyView?.let { emptyView ->
+            if (state.listVisible) {
+                emptyView.visibility = View.GONE
+            } else {
+                emptyView.visibility = View.VISIBLE
+                setTextOrHide(emptyView.title, state.title)
+                setImageOrHide(emptyView.image, state.imgResId)
+                setupButtonOrHide(emptyView.button, state.buttonText, state.onButtonClick)
             }
         }
     }
 
     private fun setupButtonOrHide(
         buttonView: Button,
-        textResId: Int?,
+        text: UiString?,
         onButtonClick: (() -> Unit)?
     ) {
-        buttonView.visibility = if (textResId == null) View.GONE else View.VISIBLE
-        textResId?.let {
-            buttonView.setText(textResId)
+        buttonView.visibility = if (text == null) View.GONE else View.VISIBLE
+        text?.let {
+            buttonView.text = uiHelpers.getTextOfUiString(nonNullActivity, text)
             buttonView.setOnClickListener { onButtonClick?.invoke() }
         }
     }
@@ -294,10 +295,10 @@ class PostListFragment : Fragment() {
         }
     }
 
-    private fun setTextOrHide(textView: TextView, resId: Int?) {
-        textView.visibility = if (resId == null) View.GONE else View.VISIBLE
-        resId?.let {
-            textView.text = resources.getString(resId)
+    private fun setTextOrHide(textView: TextView, text: UiString?) {
+        textView.visibility = if (text == null) View.GONE else View.VISIBLE
+        text?.let {
+            textView.text = uiHelpers.getTextOfUiString(nonNullActivity, text)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -266,13 +266,13 @@ class PostListFragment : Fragment() {
 
     private fun updateEmptyViewForState(state: PostListEmptyUiState) {
         actionableEmptyView?.let { emptyView ->
-            if (state.listVisible) {
-                emptyView.visibility = View.GONE
-            } else {
+            if (state.emptyViewVisible) {
                 emptyView.visibility = View.VISIBLE
                 setTextOrHide(emptyView.title, state.title)
                 setImageOrHide(emptyView.image, state.imgResId)
                 setupButtonOrHide(emptyView.button, state.buttonText, state.onButtonClick)
+            } else {
+                emptyView.visibility = View.GONE
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -6,6 +6,7 @@ import android.arch.lifecycle.ViewModelProvider
 import android.arch.lifecycle.ViewModelProviders
 import android.content.Intent
 import android.os.Bundle
+import android.support.annotation.DrawableRes
 import android.support.design.widget.Snackbar
 import android.support.v4.app.Fragment
 import android.support.v7.widget.LinearLayoutManager
@@ -281,14 +282,11 @@ class PostListFragment : Fragment() {
         text: UiString?,
         onButtonClick: (() -> Unit)?
     ) {
-        buttonView.visibility = if (text == null) View.GONE else View.VISIBLE
-        text?.let {
-            buttonView.text = uiHelpers.getTextOfUiString(nonNullActivity, text)
-            buttonView.setOnClickListener { onButtonClick?.invoke() }
-        }
+        setTextOrHide(buttonView, text)
+        buttonView.setOnClickListener { onButtonClick?.invoke() }
     }
 
-    private fun setImageOrHide(imageView: ImageView, resId: Int?) {
+    private fun setImageOrHide(imageView: ImageView, @DrawableRes resId: Int?) {
         imageView.visibility = if (resId == null) View.GONE else View.VISIBLE
         resId?.let {
             imageView.setImageResource(resId)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -185,9 +185,9 @@ class PostListViewModel @Inject constructor(
         val result = MediatorLiveData<PostListEmptyUiState>()
         val update = {
             createEmptyUiState(
-                    pagedListWrapper.isEmpty.value ?: false,
-                    pagedListWrapper.listError.value,
-                    pagedListWrapper.isFetchingFirstPage.value ?: false
+                    isListEmpty = pagedListWrapper.isEmpty.value ?: true,
+                    error = pagedListWrapper.listError.value,
+                    isFetchingFirstPage = pagedListWrapper.isFetchingFirstPage.value ?: false
             )
         }
         result.addSource(pagedListWrapper.isEmpty) { result.value = update() }
@@ -197,19 +197,19 @@ class PostListViewModel @Inject constructor(
     }
 
     private fun createEmptyUiState(
-        isEmpty: Boolean,
+        isListEmpty: Boolean,
         error: ListError?,
         isFetchingFirstPage: Boolean
     ): PostListEmptyUiState {
-        return if (isEmpty) {
-            PostListEmptyUiState.HiddenList
-        } else {
+        return if (isListEmpty) {
             val isLoadingFirstPage = isFetchingFirstPage
             when {
                 error != null -> createErrorListUiState(error)
                 isLoadingFirstPage -> PostListEmptyUiState.Loading
                 else -> createEmptyListUiState()
             }
+        } else {
+            PostListEmptyUiState.DataShown
         }
     }
 
@@ -251,34 +251,34 @@ class PostListViewModel @Inject constructor(
         @DrawableRes val imgResId: Int? = null,
         val buttonText: UiString? = null,
         val onButtonClick: (() -> Unit)? = null,
-        val listVisible: Boolean = true
+        val emptyViewVisible: Boolean = true
     ) {
         class EmptyList(
             title: UiString,
             buttonText: UiString? = null,
             onButtonClick: (() -> Unit)? = null
         ) : PostListEmptyUiState(
-                title,
-                R.drawable.img_illustration_posts_75dp,
-                buttonText,
-                onButtonClick
+                title = title,
+                imgResId = R.drawable.img_illustration_posts_75dp,
+                buttonText = buttonText,
+                onButtonClick = onButtonClick
         )
 
-        object HiddenList : PostListEmptyUiState(listVisible = false)
+        object DataShown : PostListEmptyUiState(emptyViewVisible = false)
 
         object Loading : PostListEmptyUiState(
-                UiStringRes(R.string.posts_fetching),
-                R.drawable.img_illustration_posts_75dp
+                title = UiStringRes(R.string.posts_fetching),
+                imgResId = R.drawable.img_illustration_posts_75dp
         )
 
         class RefreshError(title: UiString) : PostListEmptyUiState(
-                title,
-                R.drawable.img_illustration_posts_75dp
+                title = title,
+                imgResId = R.drawable.img_illustration_posts_75dp
         )
 
         object PermissionsError : PostListEmptyUiState(
-                UiStringRes(R.string.error_refresh_unauthorized_posts),
-                R.drawable.img_illustration_posts_75dp
+                title = UiStringRes(R.string.error_refresh_unauthorized_posts),
+                imgResId = R.drawable.img_illustration_posts_75dp
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -184,7 +184,11 @@ class PostListViewModel @Inject constructor(
     val emptyViewState: LiveData<PostListEmptyUiState> by lazy {
         val result = MediatorLiveData<PostListEmptyUiState>()
         val update = {
-            createEmptyUiState()
+            createEmptyUiState(
+                    pagedListWrapper.isEmpty.value ?: false,
+                    pagedListWrapper.listError.value,
+                    pagedListWrapper.isFetchingFirstPage.value ?: false
+            )
         }
         result.addSource(pagedListWrapper.isEmpty) { result.value = update() }
         result.addSource(pagedListWrapper.isFetchingFirstPage) { result.value = update() }
@@ -192,17 +196,20 @@ class PostListViewModel @Inject constructor(
         result
     }
 
-    private fun createEmptyUiState(): PostListEmptyUiState {
-        return if (pagedListWrapper.isEmpty.value != false) {
-            val error = pagedListWrapper.listError.value
-            val isLoadingFirstPage = pagedListWrapper.isFetchingFirstPage.value == true
+    private fun createEmptyUiState(
+        isEmpty: Boolean,
+        error: ListError?,
+        isFetchingFirstPage: Boolean
+    ): PostListEmptyUiState {
+        return if (isEmpty) {
+            PostListEmptyUiState.HiddenList
+        } else {
+            val isLoadingFirstPage = isFetchingFirstPage
             when {
                 error != null -> createErrorListUiState(error)
                 isLoadingFirstPage -> PostListEmptyUiState.Loading
                 else -> createEmptyListUiState()
             }
-        } else {
-            PostListEmptyUiState.HiddenList
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -230,17 +230,17 @@ class PostListViewModel @Inject constructor(
             PUBLISHED -> PostListEmptyUiState.EmptyList(
                     UiStringRes(R.string.posts_published_empty),
                     UiStringRes(R.string.posts_empty_list_button),
-                    this@PostListViewModel::newPost
+                    this::newPost
             )
             DRAFTS -> PostListEmptyUiState.EmptyList(
                     UiStringRes(R.string.posts_draft_empty),
                     UiStringRes(R.string.posts_empty_list_button),
-                    this@PostListViewModel::newPost
+                    this::newPost
             )
             SCHEDULED -> PostListEmptyUiState.EmptyList(
                     UiStringRes(R.string.posts_scheduled_empty),
                     UiStringRes(R.string.posts_empty_list_button),
-                    this@PostListViewModel::newPost
+                    this::newPost
             )
             TRASHED -> PostListEmptyUiState.EmptyList(UiStringRes(R.string.posts_trashed_empty))
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -10,7 +10,6 @@ import android.arch.lifecycle.ViewModel
 import android.arch.paging.PagedList
 import android.content.Intent
 import android.support.annotation.DrawableRes
-import android.support.annotation.StringRes
 import de.greenrobot.event.EventBus
 import org.apache.commons.text.StringEscapeUtils
 import org.greenrobot.eventbus.Subscribe
@@ -72,6 +71,7 @@ import org.wordpress.android.ui.reader.utils.ReaderImageScanner
 import org.wordpress.android.ui.uploads.PostEvents
 import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.uploads.VideoOptimizer
+import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
@@ -211,9 +211,9 @@ class PostListViewModel @Inject constructor(
             PostListEmptyUiState.PermissionsError
         } else {
             if (networkUtilsWrapper.isNetworkAvailable()) {
-                PostListEmptyUiState.RefreshError(R.string.error_refresh_posts)
+                PostListEmptyUiState.RefreshError(UiStringRes(R.string.error_refresh_posts))
             } else {
-                PostListEmptyUiState.RefreshError(R.string.no_network_message)
+                PostListEmptyUiState.RefreshError(UiStringRes(R.string.no_network_message))
             }
         }
     }
@@ -221,56 +221,56 @@ class PostListViewModel @Inject constructor(
     private fun createEmptyListUiState(): PostListEmptyUiState.EmptyList {
         return when (postListType) {
             PUBLISHED -> PostListEmptyUiState.EmptyList(
-                    R.string.posts_published_empty,
-                    R.string.posts_empty_list_button,
+                    UiStringRes(R.string.posts_published_empty),
+                    UiStringRes(R.string.posts_empty_list_button),
                     this@PostListViewModel::newPost
             )
             DRAFTS -> PostListEmptyUiState.EmptyList(
-                    R.string.posts_draft_empty,
-                    R.string.posts_empty_list_button,
+                    UiStringRes(R.string.posts_draft_empty),
+                    UiStringRes(R.string.posts_empty_list_button),
                     this@PostListViewModel::newPost
             )
             SCHEDULED -> PostListEmptyUiState.EmptyList(
-                    R.string.posts_scheduled_empty,
-                    R.string.posts_empty_list_button,
+                    UiStringRes(R.string.posts_scheduled_empty),
+                    UiStringRes(R.string.posts_empty_list_button),
                     this@PostListViewModel::newPost
             )
-            TRASHED -> PostListEmptyUiState.EmptyList(R.string.posts_trashed_empty)
+            TRASHED -> PostListEmptyUiState.EmptyList(UiStringRes(R.string.posts_trashed_empty))
         }
     }
 
     sealed class PostListEmptyUiState(
-        @StringRes val titleResId: Int? = null,
+        val title: UiString? = null,
         @DrawableRes val imgResId: Int? = null,
-        @StringRes val buttonTextResId: Int? = null,
+        val buttonText: UiString? = null,
         val onButtonClick: (() -> Unit)? = null,
         val listVisible: Boolean = true
     ) {
         class EmptyList(
-            titleResId: Int,
-            @StringRes buttonTextResId: Int? = null,
+            title: UiString,
+            buttonText: UiString? = null,
             onButtonClick: (() -> Unit)? = null
         ) : PostListEmptyUiState(
-                titleResId,
+                title,
                 R.drawable.img_illustration_posts_75dp,
-                buttonTextResId,
+                buttonText,
                 onButtonClick
         )
 
         object HiddenList : PostListEmptyUiState(listVisible = false)
 
         object Loading : PostListEmptyUiState(
-                R.string.posts_fetching,
+                UiStringRes(R.string.posts_fetching),
                 R.drawable.img_illustration_posts_75dp
         )
 
-        class RefreshError(@StringRes titleResId: Int) : PostListEmptyUiState(
-                titleResId,
+        class RefreshError(title: UiString) : PostListEmptyUiState(
+                title,
                 R.drawable.img_illustration_posts_75dp
         )
 
         object PermissionsError : PostListEmptyUiState(
-                R.string.error_refresh_unauthorized_posts,
+                UiStringRes(R.string.error_refresh_unauthorized_posts),
                 R.drawable.img_illustration_posts_75dp
         )
     }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -251,6 +251,10 @@
     <string name="posts_empty_list">No posts yet. Why not create one?</string>
     <string name="posts_empty_list_button">Create a post</string>
     <string name="empty_list_default">This list is empty</string>
+    <string name="posts_published_empty">You haven\'t published any posts yet</string>
+    <string name="posts_scheduled_empty">You don\'t have any scheduled posts</string>
+    <string name="posts_draft_empty">You don\'t have any draft posts</string>
+    <string name="posts_trashed_empty">You don\'t have any binned posts</string>
 
     <!-- buttons on post cards -->
     <string name="button_edit">Edit</string>


### PR DESCRIPTION
Fixes #9240 

Fixes Empty View state on the Posts List screen.

![post-list-empty-views](https://user-images.githubusercontent.com/2261188/53080562-3d369880-34f9-11e9-93e4-ea7e5e40b389.jpg)

Note: 
- changing tabs using swipe gesture doesn't update selected tab in the tab layout (#9285)
- the code touches other empty states - error/hidden list. However, it seems those states haven't been working even before this PR. (#9286)

To test:
1. Switch to a blog with no posts
2. My Site
3. Blog Posts
4. Swipe from left to right
- Make sure the text corresponds to the selected tab
- Make sure the button isn't visible only on the Trashed posts tab

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
