### PR TITLE
Fix tab selection not updated when changing pages using swipe gesture

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -88,12 +88,12 @@ class PostsListActivity : AppCompatActivity(),
                 supportFragmentManager
         )
         pager.adapter = postsPagerAdapter
-        val tabLayout = findViewById<TabLayout>(R.id.tabLayout)
-        tabLayout.setupWithViewPager(pager)
 
         // Just a safety measure - there shouldn't by any existing listeners since this method is called just once.
         pager.clearOnPageChangeListeners()
 
+        val tabLayout = findViewById<TabLayout>(R.id.tabLayout)
+        tabLayout.setupWithViewPager(pager)
         pager.addOnPageChangeListener(object : OnPageChangeListener {
             override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {}
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -93,6 +93,7 @@ class PostsListActivity : AppCompatActivity(),
         pager.clearOnPageChangeListeners()
 
         val tabLayout = findViewById<TabLayout>(R.id.tabLayout)
+        // this method call needs to be below `clearOnPageChangeListeners` as it internally adds an OnPageChangeListener
         tabLayout.setupWithViewPager(pager)
         pager.addOnPageChangeListener(object : OnPageChangeListener {
             override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {}


### PR DESCRIPTION
Fixes #9285 

When the user changes pages in PostList using a swipe gesture the selected tab in the TabLayout is correctly updated.

The safety measure bit us:D. `TabLayout.setupWithViewPager` internally connect itself to the ViewPager using an OnPageChangeListener.

Before
![9db633080721709caccef0bef80abc7e](https://user-images.githubusercontent.com/2261188/53082737-c6e86500-34fd-11e9-883c-8dddd5be82ce.gif)

Now
![4e41a5a32b177fd547f8ffa4e2492fbd](https://user-images.githubusercontent.com/2261188/53082744-ca7bec00-34fd-11e9-8b15-05c8ca91cca1.gif)

To test:
1. My Site
2. Blog Posts
3. Change pages using swipe gesture and make sure the correct tab in the TabLayout is selected

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
