### PR TITLE
Fix PostListActivity started after user changed site issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -52,6 +52,11 @@ class PostsListActivity : AppCompatActivity(),
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        if (!intent.hasExtra(WordPress.SITE)) {
+            AppLog.e(AppLog.T.POSTS, "PostListActivity started without a site.")
+            finish()
+            return
+        }
         handleIntent(intent)
     }
 
@@ -127,7 +132,13 @@ class PostsListActivity : AppCompatActivity(),
     }
 
     private fun handleIntent(intent: Intent) {
-        // TODO site has changed and postListActivity opened with a target post is not implemented
+        val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
+        if (site.id != this.site.id) {
+            // restart the activity when the site has changed
+            finish()
+            startActivity(intent)
+            return
+        }
     }
 
     public override fun onResume() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -57,7 +57,16 @@ class PostsListActivity : AppCompatActivity(),
             finish()
             return
         }
-        handleIntent(intent)
+        restartWhenSiteHasChanged(intent)
+    }
+
+    private fun restartWhenSiteHasChanged(intent: Intent) {
+        val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
+        if (site.id != this.site.id) {
+            finish()
+            startActivity(intent)
+            return
+        }
     }
 
     public override fun onCreate(savedInstanceState: Bundle?) {
@@ -74,7 +83,6 @@ class PostsListActivity : AppCompatActivity(),
         setupActionBar()
         setupContent()
         initViewModel()
-        handleIntent(intent)
     }
 
     private fun setupActionBar() {
@@ -129,16 +137,6 @@ class PostsListActivity : AppCompatActivity(),
                 }
             }
         })
-    }
-
-    private fun handleIntent(intent: Intent) {
-        val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
-        if (site.id != this.site.id) {
-            // restart the activity when the site has changed
-            finish()
-            startActivity(intent)
-            return
-        }
     }
 
     public override fun onResume() {


### PR DESCRIPTION
First step in fixing #9225 

Fixes case when the PostListActivity is brought to the foreground with a different site than it was started with.

I've decided to go with the most simple solution. I considered changing the ACTIVITY_FLAG extras, but it'd require more changes if we want to provide [the recommended](https://developer.android.com/training/notify-user/navigation) behavior and afaik we use the current approach across the app.

![change-site](https://user-images.githubusercontent.com/2261188/53168118-3b90d180-35da-11e9-8c82-371e9ba88514.gif)


To test - testing this is a bit tricky, that's the main reason why I decided to create a separate PR.
1. Go to Blog Posts
2. Turn off wifi
3. Set the Network Type in the emulator settings to GPRS
4. Create a post + publish it (ideally with an image so it takes a while before it gets uploaded)
5. Press back
6. Switch site
7. Open Blog Posts
8. Press home button
9. Set the Network Type in the emulator settings to Full
10. Wait for the "post published" notification
11. Click on the notification and make sure PostList screen for the first site is displayed

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
