### PR TITLE
Issue/publicize connection broken

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/PublicizeConnection.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/PublicizeConnection.java
@@ -129,12 +129,12 @@ public class PublicizeConnection {
     }
 
     public ConnectStatus getStatusEnum() {
-        if (getStatus().equalsIgnoreCase(ConnectStatus.BROKEN.toString())) {
-            return ConnectStatus.BROKEN;
+        if (getStatus().equalsIgnoreCase(ConnectStatus.OK.toString())) {
+            return ConnectStatus.OK;
         } else if (getStatus().equalsIgnoreCase(ConnectStatus.MUST_DISCONNECT.toString())) {
             return ConnectStatus.MUST_DISCONNECT;
         } else {
-            return ConnectStatus.OK;
+            return ConnectStatus.BROKEN;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -110,7 +110,7 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
         setTitle(mService.getLabel());
 
         // disable the ability to add another G+ connection
-        if (mService.getId().equals(PublicizeConstants.GOOGLE_PLUS_ID)) {
+        if (isGooglePlus()) {
             mServiceCardView.setVisibility(View.GONE);
         } else {
             String serviceLabel = String.format(getString(R.string.connection_service_label), mService.getLabel());
@@ -121,31 +121,43 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
             TextView txtDescription = (TextView) mServiceCardView.findViewById(R.id.text_description);
             txtDescription.setText(description);
 
-            if (mService.getId().equals(PublicizeConstants.FACEBOOK_ID)) {
-                String noticeText = getString(R.string.connection_service_facebook_notice);
-                TextView txtNotice = (TextView) mServiceCardView.findViewById(R.id.text_description_notice);
-                txtNotice.setText(noticeText);
-                txtNotice.setVisibility(View.VISIBLE);
-
-                TextView learnMoreButton = (TextView) mServiceCardView.findViewById(R.id.learn_more_button);
-                learnMoreButton.setOnClickListener(new OnClickListener() {
-                    @Override public void onClick(View v) {
-                        WPWebViewActivity.openURL(getActivity(),
-                                FACEBOOK_SHARING_CHANGE_BLOG_POST);
-                    }
-                });
-                learnMoreButton.setVisibility(View.VISIBLE);
+            if (isFacebook()) {
+                showFacebookWarning();
             }
         }
 
         long currentUserId = mAccountStore.getAccount().getUserId();
         PublicizeConnectionAdapter adapter = new PublicizeConnectionAdapter(
-                getActivity(), mSite.getSiteId(), mServiceId, currentUserId);
+                getActivity(), mSite.getSiteId(), mService, currentUserId);
         adapter.setOnPublicizeActionListener(getOnPublicizeActionListener());
         adapter.setOnAdapterLoadedListener(this);
 
         mRecycler.setAdapter(adapter);
         adapter.refresh();
+    }
+
+    private boolean isGooglePlus() {
+        return mService.getId().equals(PublicizeConstants.GOOGLE_PLUS_ID);
+    }
+
+    private boolean isFacebook() {
+        return mService.getId().equals(PublicizeConstants.FACEBOOK_ID);
+    }
+
+    private void showFacebookWarning() {
+        String noticeText = getString(R.string.connection_service_facebook_notice);
+        TextView txtNotice = (TextView) mServiceCardView.findViewById(R.id.text_description_notice);
+        txtNotice.setText(noticeText);
+        txtNotice.setVisibility(View.VISIBLE);
+
+        TextView learnMoreButton = (TextView) mServiceCardView.findViewById(R.id.learn_more_button);
+        learnMoreButton.setOnClickListener(new OnClickListener() {
+            @Override public void onClick(View v) {
+                WPWebViewActivity.openURL(getActivity(),
+                        FACEBOOK_SHARING_CHANGE_BLOG_POST);
+            }
+        });
+        learnMoreButton.setVisibility(View.VISIBLE);
     }
 
     private boolean hasOnPublicizeActionListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -245,7 +245,8 @@ public class PublicizeListActivity extends AppCompatActivity
      */
     @Override
     public void onRequestReconnect(PublicizeService service, PublicizeConnection publicizeConnection) {
-        showWebViewFragment(service, publicizeConnection);
+        PublicizeActions.reconnect(publicizeConnection);
+        showWebViewFragment(service, null);
     }
 
     /*
@@ -298,17 +299,20 @@ public class PublicizeListActivity extends AppCompatActivity
             return;
         }
 
-        closeWebViewFragment();
-        if (mProgressDialog != null && mProgressDialog.isShowing()) {
-            mProgressDialog.dismiss();
+        if (event.getAction() != ConnectAction.RECONNECT) {
+            closeWebViewFragment();
+            if (mProgressDialog != null && mProgressDialog.isShowing()) {
+                mProgressDialog.dismiss();
+            }
+            reloadDetailFragment();
         }
-        reloadDetailFragment();
 
         if (event.didSucceed()) {
             Map<String, Object> analyticsProperties = new HashMap<>();
             analyticsProperties.put("service", event.getService());
 
-            if (event.getAction() == ConnectAction.CONNECT || event.getAction() == ConnectAction.RECONNECT) {
+
+            if (event.getAction() == ConnectAction.CONNECT) {
                 AnalyticsUtils.trackWithSiteDetails(Stat.PUBLICIZE_SERVICE_CONNECTED, mSite, analyticsProperties);
             } else if (event.getAction() == ConnectAction.DISCONNECT) {
                 AnalyticsUtils.trackWithSiteDetails(Stat.PUBLICIZE_SERVICE_DISCONNECTED, mSite, analyticsProperties);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeConnectionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeConnectionAdapter.java
@@ -104,15 +104,35 @@ public class PublicizeConnectionAdapter extends RecyclerView.Adapter<PublicizeCo
         mImageManager.loadIntoCircle(holder.mImgAvatar, ImageType.AVATAR_WITH_BACKGROUND,
                 connection.getExternalProfilePictureUrl());
 
-        holder.mBtnConnect.setAction(PublicizeConstants.ConnectAction.DISCONNECT);
-        holder.mBtnConnect.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (mActionListener != null) {
-                    mActionListener.onRequestDisconnect(connection);
-                }
-            }
-        });
+        bindButton(holder.mBtnConnect, connection);
+    }
+
+    private void bindButton(ConnectButton btnConnect, final PublicizeConnection connection) {
+        ConnectStatus status = connection.getStatusEnum();
+        switch (status) {
+            case BROKEN:
+                btnConnect.setAction(ConnectAction.RECONNECT);
+                btnConnect.setOnClickListener(new View.OnClickListener() {
+                    @Override public void onClick(View view) {
+                        if (mActionListener != null) {
+                            mActionListener.onRequestReconnect(mService, connection);
+                        }
+                    }
+                });
+                break;
+            case OK:
+            case MUST_DISCONNECT:
+            default:
+                btnConnect.setAction(PublicizeConstants.ConnectAction.DISCONNECT);
+                btnConnect.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        if (mActionListener != null) {
+                            mActionListener.onRequestDisconnect(connection);
+                        }
+                    }
+                });
+        }
     }
 
     class ConnectionViewHolder extends RecyclerView.ViewHolder {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeConnectionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeConnectionAdapter.java
@@ -110,25 +110,25 @@ public class PublicizeConnectionAdapter extends RecyclerView.Adapter<PublicizeCo
     private void bindButton(ConnectButton btnConnect, final PublicizeConnection connection) {
         ConnectStatus status = connection.getStatusEnum();
         switch (status) {
-            case BROKEN:
-                btnConnect.setAction(ConnectAction.RECONNECT);
-                btnConnect.setOnClickListener(new View.OnClickListener() {
-                    @Override public void onClick(View view) {
-                        if (mActionListener != null) {
-                            mActionListener.onRequestReconnect(mService, connection);
-                        }
-                    }
-                });
-                break;
             case OK:
             case MUST_DISCONNECT:
-            default:
                 btnConnect.setAction(PublicizeConstants.ConnectAction.DISCONNECT);
                 btnConnect.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
                         if (mActionListener != null) {
                             mActionListener.onRequestDisconnect(connection);
+                        }
+                    }
+                });
+                break;
+            case BROKEN:
+            default:
+                btnConnect.setAction(ConnectAction.RECONNECT);
+                btnConnect.setOnClickListener(new View.OnClickListener() {
+                    @Override public void onClick(View view) {
+                        if (mActionListener != null) {
+                            mActionListener.onRequestReconnect(mService, connection);
                         }
                     }
                 });

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeConnectionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeConnectionAdapter.java
@@ -12,11 +12,13 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.PublicizeTable;
 import org.wordpress.android.models.PublicizeConnection;
+import org.wordpress.android.models.PublicizeConnection.ConnectStatus;
 import org.wordpress.android.models.PublicizeConnectionList;
+import org.wordpress.android.models.PublicizeService;
 import org.wordpress.android.ui.publicize.ConnectButton;
 import org.wordpress.android.ui.publicize.PublicizeActions;
 import org.wordpress.android.ui.publicize.PublicizeConstants;
-import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
 
@@ -31,18 +33,18 @@ public class PublicizeConnectionAdapter extends RecyclerView.Adapter<PublicizeCo
 
     private final long mSiteId;
     private final long mCurrentUserId;
-    private final String mServiceId;
+    private final PublicizeService mService;
 
     private PublicizeActions.OnPublicizeActionListener mActionListener;
     private OnAdapterLoadedListener mLoadedListener;
 
     @Inject ImageManager mImageManager;
 
-    public PublicizeConnectionAdapter(Context context, long siteId, String serviceId, long currentUserId) {
+    public PublicizeConnectionAdapter(Context context, long siteId, PublicizeService service, long currentUserId) {
         super();
         ((WordPress) context.getApplicationContext()).component().inject(this);
         mSiteId = siteId;
-        mServiceId = StringUtils.notNullStr(serviceId);
+        mService = service;
         mCurrentUserId = currentUserId;
         setHasStableIds(true);
     }
@@ -58,7 +60,7 @@ public class PublicizeConnectionAdapter extends RecyclerView.Adapter<PublicizeCo
     public void refresh() {
         PublicizeConnectionList siteConnections = PublicizeTable.getConnectionsForSite(mSiteId);
         PublicizeConnectionList serviceConnections =
-                siteConnections.getServiceConnectionsForUser(mCurrentUserId, mServiceId);
+                siteConnections.getServiceConnectionsForUser(mCurrentUserId, mService.getId());
 
         if (!mConnections.isSameAs(serviceConnections)) {
             mConnections.clear();


### PR DESCRIPTION
A continuation of https://github.com/wordpress-mobile/WordPress-Android/pull/9284 except being merged into 11.8.

From previous PR:

> This is similar to @aerych's change [wordpress-mobile/WordPress-iOS#10965](https://github.com/wordpress-mobile/WordPress-iOS/pull/10965)
> 
> What this does is when a user has a broken connection (triggered by changing line 111 in `PublicizeConnectionAdapter` to `ConnectStatus status = ConnectStatus.BROKEN;`), it triggers a reconnect path.
> 
> What happens in reconnect is we disconnect the current connection and start up a new connection.
> 
> Full disclosure: Publicize is very broken and I don't even know if this change is worth it. It may be worth looking into a comprehensive fix to also address #8652. @aerych let me know what you think.