### PR TITLE
Feature/9225 post list target post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -262,7 +262,6 @@ class PostListFragment : Fragment() {
 
     private fun updatePagedListData(pagedListData: PagedPostList) {
         postListAdapter.submitList(pagedListData)
-        viewModel.onDataUpdated(pagedListData)
     }
 
     private fun updateEmptyViewForState(state: PostListEmptyUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -67,7 +67,7 @@ class PostListFragment : Fragment() {
         val displayWidth = DisplayUtils.getDisplayPixelWidth(context)
         val contentSpacing = nonNullActivity.resources.getDimensionPixelSize(R.dimen.content_margin)
         PostViewHolderConfig(
-                // endlist indicator height is hard-coded here so that its horizontal line is in the middle of the fab
+                // endList indicator height is hard-coded here so that its horizontal line is in the middle of the fab
                 endlistIndicatorHeight = DisplayUtils.dpToPx(context, 74),
                 photonWidth = displayWidth - contentSpacing * 2,
                 photonHeight = nonNullActivity.resources.getDimensionPixelSize(R.dimen.reader_featured_image_height),
@@ -134,8 +134,8 @@ class PostListFragment : Fragment() {
         viewModel.toastMessage.observe(this, Observer {
             it?.show(nonNullActivity)
         })
-        viewModel.snackbarAction.observe(this, Observer {
-            it?.let { snackbarHolder -> showSnackbar(snackbarHolder) }
+        viewModel.snackBarAction.observe(this, Observer {
+            it?.let { snackBarHolder -> showSnackBar(snackBarHolder) }
         })
         viewModel.dialogAction.observe(this, Observer {
             val fragmentManager = requireNotNull(fragmentManager) { "FragmentManager can't be null at this point" }
@@ -148,23 +148,23 @@ class PostListFragment : Fragment() {
         })
     }
 
-    private fun showSnackbar(holder: SnackbarMessageHolder) {
+    private fun showSnackBar(holder: SnackbarMessageHolder) {
         nonNullActivity.findViewById<View>(R.id.root_view)?.let { parent ->
             val message = getString(holder.messageRes)
             val duration = AccessibilityUtils.getSnackbarDuration(nonNullActivity)
-            val snackbar = Snackbar.make(parent, message, duration)
+            val snackBar = Snackbar.make(parent, message, duration)
             if (holder.buttonTitleRes != null) {
-                snackbar.setAction(getString(holder.buttonTitleRes)) {
+                snackBar.setAction(getString(holder.buttonTitleRes)) {
                     holder.buttonAction()
                 }
             }
-            snackbar.addCallback(object : Snackbar.Callback() {
+            snackBar.addCallback(object : Snackbar.Callback() {
                 override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
                     holder.onDismissAction()
                     super.onDismissed(transientBottomBar, event)
                 }
             })
-            snackbar.show()
+            snackBar.show()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -141,6 +141,11 @@ class PostListFragment : Fragment() {
             val fragmentManager = requireNotNull(fragmentManager) { "FragmentManager can't be null at this point" }
             it?.show(nonNullActivity, fragmentManager, uiHelpers)
         })
+        viewModel.scrollToPosition.observe(this, Observer {
+            it?.let { index ->
+                recyclerView?.scrollToPosition(index)
+            }
+        })
     }
 
     private fun showSnackbar(holder: SnackbarMessageHolder) {
@@ -257,6 +262,7 @@ class PostListFragment : Fragment() {
 
     private fun updatePagedListData(pagedListData: PagedPostList) {
         postListAdapter.submitList(pagedListData)
+        viewModel.onDataUpdated(pagedListData)
     }
 
     private fun updateEmptyViewForState(emptyViewState: PostListEmptyViewState) {
@@ -293,6 +299,10 @@ class PostListFragment : Fragment() {
 
     fun onDismissByOutsideTouchForBasicDialog(instanceTag: String) {
         viewModel.onDismissByOutsideTouchForBasicDialog(instanceTag)
+    }
+
+    fun scrollToTargetPost(localPostId: Int) {
+        viewModel.scrollToPost(localPostId)
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -3,18 +3,42 @@ package org.wordpress.android.ui.posts
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.wordpress.android.R.string
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.posts.PostListType.DRAFTS
 import org.wordpress.android.ui.posts.PostListType.PUBLISHED
 import org.wordpress.android.ui.posts.PostListType.SCHEDULED
 import org.wordpress.android.ui.posts.PostListType.TRASHED
+import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
+import javax.inject.Named
+import kotlin.coroutines.CoroutineContext
 
+private const val SCROLL_TO_DELAY = 50L
 private val FAB_VISIBLE_POST_LIST_PAGES = listOf(PUBLISHED, DRAFTS)
 val POST_LIST_PAGES = listOf(PUBLISHED, DRAFTS, SCHEDULED, TRASHED)
 
-class PostListMainViewModel @Inject constructor() : ViewModel() {
+class PostListMainViewModel @Inject constructor(
+    private val postStore: PostStore,
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+) : ViewModel(), CoroutineScope {
+    private val scrollToTargetPostJob: Job = Job()
+    override val coroutineContext: CoroutineContext
+        get() = bgDispatcher + scrollToTargetPostJob
+
     private lateinit var site: SiteModel
 
     private val _postListAction = SingleLiveEvent<PostListAction>()
@@ -23,8 +47,22 @@ class PostListMainViewModel @Inject constructor() : ViewModel() {
     private val _isFabVisible = MutableLiveData<Boolean>()
     val isFabVisible: LiveData<Boolean> = _isFabVisible
 
+    private val _selectTab = SingleLiveEvent<Int>()
+    val selectTab = _selectTab as LiveData<Int>
+
+    private val _scrollToLocalPostId = SingleLiveEvent<Int>()
+    val scrollToLocalPostId = _scrollToLocalPostId as LiveData<Int>
+
+    private val _snackBarMessage = SingleLiveEvent<UiString>()
+    val snackBarMessage = _snackBarMessage as LiveData<UiString>
+
     fun start(site: SiteModel) {
         this.site = site
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        scrollToTargetPostJob.cancel() // cancels all coroutines with the default coroutineContext
     }
 
     fun newPost() {
@@ -35,4 +73,24 @@ class PostListMainViewModel @Inject constructor() : ViewModel() {
         val currentPage = POST_LIST_PAGES[position]
         _isFabVisible.value = FAB_VISIBLE_POST_LIST_PAGES.contains(currentPage)
     }
+
+    fun showTargetPost(targetPostId: Int) {
+        val postModel = postStore.getPostByLocalPostId(targetPostId)
+        if (postModel == null) {
+            _snackBarMessage.value = UiStringRes(string.error_post_does_not_exist)
+        } else {
+            launch(mainDispatcher) {
+                val targetTab = PostListType.fromPostStatus(PostStatus.fromPost(postModel))
+                _selectTab.value = POST_LIST_PAGES.indexOf(targetTab)
+                // we need to make sure the ViewPager initializes the targetTab fragment before we can propagate
+                // the targetPostId to it
+                withContext(bgDispatcher) {
+                    delay(SCROLL_TO_DELAY)
+                }
+                _scrollToLocalPostId.value = postModel.id
+            }
+        }
+    }
+
+    data class NavigationTarget(val localPostId: Int, val targetTabPosition: Int)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -60,8 +60,8 @@ class PostListMainViewModel @Inject constructor(
     }
 
     override fun onCleared() {
-        super.onCleared()
         scrollToTargetPostJob.cancel() // cancels all coroutines with the default coroutineContext
+        super.onCleared()
     }
 
     fun newPost() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -15,12 +15,11 @@ import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.PostListType.DRAFTS
 import org.wordpress.android.ui.posts.PostListType.PUBLISHED
 import org.wordpress.android.ui.posts.PostListType.SCHEDULED
 import org.wordpress.android.ui.posts.PostListType.TRASHED
-import org.wordpress.android.ui.utils.UiString
-import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 import javax.inject.Named
@@ -53,8 +52,8 @@ class PostListMainViewModel @Inject constructor(
     private val _scrollToLocalPostId = SingleLiveEvent<Int>()
     val scrollToLocalPostId = _scrollToLocalPostId as LiveData<Int>
 
-    private val _snackBarMessage = SingleLiveEvent<UiString>()
-    val snackBarMessage = _snackBarMessage as LiveData<UiString>
+    private val _snackBarMessage = SingleLiveEvent<SnackbarMessageHolder>()
+    val snackBarMessage = _snackBarMessage as LiveData<SnackbarMessageHolder>
 
     fun start(site: SiteModel) {
         this.site = site
@@ -77,7 +76,7 @@ class PostListMainViewModel @Inject constructor(
     fun showTargetPost(targetPostId: Int) {
         val postModel = postStore.getPostByLocalPostId(targetPostId)
         if (postModel == null) {
-            _snackBarMessage.value = UiStringRes(string.error_post_does_not_exist)
+            _snackBarMessage.value = SnackbarMessageHolder(string.error_post_does_not_exist)
         } else {
             launch(mainDispatcher) {
                 val targetTab = PostListType.fromPostStatus(PostStatus.fromPost(postModel))
@@ -91,6 +90,4 @@ class PostListMainViewModel @Inject constructor(
             }
         }
     }
-
-    data class NavigationTarget(val localPostId: Int, val targetTabPosition: Int)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -147,7 +147,7 @@ class PostsListActivity : AppCompatActivity(),
                 tabLayout.getTabAt(tabIndex)?.select()
             }
         })
-        viewModel.scrollToLocalPostId.observe(this, Observer {targetLocalPostId ->
+        viewModel.scrollToLocalPostId.observe(this, Observer { targetLocalPostId ->
             targetLocalPostId?.let {
                 postsPagerAdapter.getItemAtPosition(pager.currentItem)?.scrollToTargetPost(targetLocalPostId)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -7,12 +7,14 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.support.design.widget.FloatingActionButton
+import android.support.design.widget.Snackbar
 import android.support.design.widget.TabLayout
 import android.support.v4.view.ViewPager
 import android.support.v4.view.ViewPager.OnPageChangeListener
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.Toolbar
 import android.view.MenuItem
+import kotlinx.android.synthetic.main.pages_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
@@ -22,6 +24,7 @@ import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogNegativeClickInterface
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogOnDismissByOutsideTouchInterface
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface
+import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.CrashlyticsUtils
 import org.wordpress.android.util.LocaleManager
@@ -35,6 +38,7 @@ class PostsListActivity : AppCompatActivity(),
         BasicDialogOnDismissByOutsideTouchInterface {
     @Inject internal lateinit var siteStore: SiteStore
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject internal lateinit var uiHelpers: UiHelpers
 
     private lateinit var site: SiteModel
     private lateinit var viewModel: PostListMainViewModel
@@ -58,6 +62,7 @@ class PostsListActivity : AppCompatActivity(),
             return
         }
         restartWhenSiteHasChanged(intent)
+        loadIntentData(intent)
     }
 
     private fun restartWhenSiteHasChanged(intent: Intent) {
@@ -83,6 +88,7 @@ class PostsListActivity : AppCompatActivity(),
         setupActionBar()
         setupContent()
         initViewModel()
+        loadIntentData(intent)
     }
 
     private fun setupActionBar() {
@@ -106,7 +112,6 @@ class PostsListActivity : AppCompatActivity(),
 
         // Just a safety measure - there shouldn't by any existing listeners since this method is called just once.
         pager.clearOnPageChangeListeners()
-
         pager.addOnPageChangeListener(object : OnPageChangeListener {
             override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {}
 
@@ -137,6 +142,32 @@ class PostsListActivity : AppCompatActivity(),
                 }
             }
         })
+        viewModel.selectTab.observe(this, Observer { tabIndex ->
+            tabIndex?.let {
+                tabLayout.getTabAt(tabIndex)?.select()
+            }
+        })
+        viewModel.scrollToLocalPostId.observe(this, Observer {targetLocalPostId ->
+            targetLocalPostId?.let {
+                postsPagerAdapter.getItemAtPosition(pager.currentItem)?.scrollToTargetPost(targetLocalPostId)
+            }
+        })
+        viewModel.snackBarMessage.observe(this, Observer {
+            it?.let { uiString ->
+                Snackbar.make(
+                        findViewById(R.id.coordinator),
+                        uiHelpers.getTextOfUiString(this, uiString),
+                        Snackbar.LENGTH_LONG
+                ).show()
+            }
+        })
+    }
+
+    private fun loadIntentData(intent: Intent) {
+        val targetPostId = intent.getIntExtra(EXTRA_TARGET_POST_LOCAL_ID, -1)
+        if (targetPostId != -1) {
+            viewModel.showTargetPost(targetPostId)
+        }
     }
 
     public override fun onResume() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -158,7 +158,7 @@ class PostsListActivity : AppCompatActivity(),
             it?.let { uiString ->
                 Snackbar.make(
                         findViewById(R.id.coordinator),
-                        uiHelpers.getTextOfUiString(this, uiString),
+                        getString(it.messageRes),
                         Snackbar.LENGTH_LONG
                 ).show()
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsPagerAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsPagerAdapter.kt
@@ -17,7 +17,7 @@ class PostsPagerAdapter(
     override fun getCount(): Int = pages.size
 
     override fun getItem(position: Int): PostListFragment =
-            PostListFragment.newInstance(site, pages[position], null)
+            PostListFragment.newInstance(site, pages[position])
 
     override fun instantiateItem(container: ViewGroup, position: Int): Any {
         val fragment = super.instantiateItem(container, position) as PostListFragment

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -459,7 +459,6 @@ class PostUploadNotifier {
 
         long notificationId = getNotificationIdForPost(post);
         Intent notificationIntent = getNotificationIntent(post, site, notificationId);
-        notificationIntent.putExtra(PostsListActivityKt.EXTRA_TARGET_POST_LOCAL_ID, post.getId());
         notificationIntent.setAction(String.valueOf(notificationId));
 
         PendingIntent pendingIntent = PendingIntent.getActivity(mContext,
@@ -507,6 +506,7 @@ class PostUploadNotifier {
             notificationIntent.putExtra(EXTRA_PAGE_REMOTE_ID_KEY, post.getRemotePostId());
         } else {
             notificationIntent = new Intent(mContext, PostsListActivity.class);
+            notificationIntent.putExtra(PostsListActivityKt.EXTRA_TARGET_POST_LOCAL_ID, post.getId());
         }
 
         notificationIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -158,7 +158,6 @@ class PostListViewModel @Inject constructor(
 
     val isFetchingFirstPage: LiveData<Boolean> by lazy { pagedListWrapper.isFetchingFirstPage }
     val isLoadingMore: LiveData<Boolean> by lazy { pagedListWrapper.isLoadingMore }
-    // Since we can only scroll to a post when the data is loaded, we are keeping the information together
     val pagedListData: LiveData<PagedPostList> by lazy { pagedListWrapper.data }
     val emptyViewState: LiveData<PostListEmptyUiState> by lazy {
         val result = MediatorLiveData<PostListEmptyUiState>()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -114,7 +114,7 @@ class PostListViewModel @Inject constructor(
     private val uploadStatusMap = HashMap<Int, PostAdapterItemUploadStatus>()
     private val featuredImageMap = HashMap<Long, String>()
 
-    // Keep a reference to the currently being trashed post, so we can hide it during Undo Snackbar
+    // Keep a reference to the currently being trashed post, so we can hide it during Undo SnackBar
     private var postIdToTrash: Pair<Int, Long>? = null
     // Since we are using DialogFragments we need to hold onto which post will be published or trashed / resolved
     private var localPostIdForPublishDialog: Int? = null
@@ -136,8 +136,8 @@ class PostListViewModel @Inject constructor(
     private val _dialogAction = SingleLiveEvent<DialogHolder>()
     val dialogAction: LiveData<DialogHolder> = _dialogAction
 
-    private val _snackbarAction = SingleLiveEvent<SnackbarMessageHolder>()
-    val snackbarAction: LiveData<SnackbarMessageHolder> = _snackbarAction
+    private val _snackBarAction = SingleLiveEvent<SnackbarMessageHolder>()
+    val snackBarAction: LiveData<SnackbarMessageHolder> = _snackBarAction
 
     private val _scrollToPosition = SingleLiveEvent<Int>()
     val scrollToPosition: LiveData<Int> = _scrollToPosition
@@ -455,8 +455,8 @@ class PostListViewModel @Inject constructor(
             }
         }
         val messageRes = if (post.isLocalDraft) R.string.post_deleted else R.string.post_trashed
-        val snackbarHolder = SnackbarMessageHolder(messageRes, R.string.undo, undoAction, onDismissAction)
-        _snackbarAction.postValue(snackbarHolder)
+        val snackBarHolder = SnackbarMessageHolder(messageRes, R.string.undo, undoAction, onDismissAction)
+        _snackBarAction.postValue(snackBarHolder)
     }
 
     // FluxC Events
@@ -765,11 +765,11 @@ class PostListViewModel @Inject constructor(
         val onDismissAction = {
             originalPostCopyForConflictUndo = null
         }
-        val snackbarHolder = SnackbarMessageHolder(
+        val snackBarHolder = SnackbarMessageHolder(
                 R.string.snackbar_conflict_local_version_discarded,
                 R.string.snackbar_conflict_undo, undoAction, onDismissAction
         )
-        _snackbarAction.postValue(snackbarHolder)
+        _snackBarAction.postValue(snackBarHolder)
     }
 
     private fun updateConflictedPostWithItsLocalVersion(localPostId: Int) {
@@ -779,13 +779,13 @@ class PostListViewModel @Inject constructor(
         }
 
         // Keep a reference to which post is being updated with the local version so we can avoid showing the conflicted
-        // label during the undo snackbar.
+        // label during the undo snackBar.
         localPostIdForFetchingRemoteVersionOfConflictedPost = localPostId
         pagedListWrapper.invalidateData()
 
         val post = postStore.getPostByLocalPostId(localPostId) ?: return
 
-        // and now show a snackbar, acting as if the Post was pushed, but effectively push it after the snackbar is gone
+        // and now show a snackBar, acting as if the Post was pushed, but effectively push it after the snackbar is gone
         var isUndoed = false
         val undoAction = {
             isUndoed = true
@@ -802,11 +802,11 @@ class PostListViewModel @Inject constructor(
                 dispatcher.dispatch(PostActionBuilder.newPushPostAction(RemotePostPayload(post, site)))
             }
         }
-        val snackbarHolder = SnackbarMessageHolder(
+        val snackBarHolder = SnackbarMessageHolder(
                 R.string.snackbar_conflict_web_version_discarded,
                 R.string.snackbar_conflict_undo, undoAction, onDismissAction
         )
-        _snackbarAction.postValue(snackbarHolder)
+        _snackBarAction.postValue(snackBarHolder)
     }
 
     fun scrollToPost(localPostId: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -733,7 +733,10 @@ class PostListViewModel @Inject constructor(
     fun scrollToPost(localPostId: Int) {
         val data = pagedListData.value
         if (data != null) {
-            _scrollToPosition.value = findItemListPosition(data, localPostId)
+            _scrollToPosition.value = findItemListPosition(data, localPostId) ?: run {
+                AppLog.e(AppLog.T.POSTS, "ScrollToPost failed - the post not found.")
+                null
+            }
         } else {
             // store the target post id and scroll there when the data is loaded
             scrollToLocalPostId = localPostId

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -158,7 +158,17 @@ class PostListViewModel @Inject constructor(
 
     val isFetchingFirstPage: LiveData<Boolean> by lazy { pagedListWrapper.isFetchingFirstPage }
     val isLoadingMore: LiveData<Boolean> by lazy { pagedListWrapper.isLoadingMore }
-    val pagedListData: LiveData<PagedPostList> by lazy { pagedListWrapper.data }
+    val pagedListData: LiveData<PagedPostList> by lazy {
+        val result = MediatorLiveData<PagedPostList>()
+        result.addSource(pagedListWrapper.data) { pagedPostList ->
+            pagedPostList?.let {
+                onDataUpdated(it)
+                result.value = it
+            }
+        }
+        result
+    }
+
     val emptyViewState: LiveData<PostListEmptyUiState> by lazy {
         val result = MediatorLiveData<PostListEmptyUiState>()
         val update = {
@@ -819,7 +829,7 @@ class PostListViewModel @Inject constructor(
         }
     }
 
-    fun onDataUpdated(data: PagedPostList) {
+    private fun onDataUpdated(data: PagedPostList) {
         val localPostId = scrollToLocalPostId
         if (localPostId != null) {
             scrollToLocalPostId = null

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -813,10 +813,7 @@ class PostListViewModel @Inject constructor(
     fun scrollToPost(localPostId: Int) {
         val data = pagedListData.value
         if (data != null) {
-            _scrollToPosition.value = findItemListPosition(data, localPostId) ?: run {
-                AppLog.e(AppLog.T.POSTS, "ScrollToPost failed - the post not found.")
-                null
-            }
+            updateScrollPosition(data, localPostId)
         } else {
             // store the target post id and scroll there when the data is loaded
             scrollToLocalPostId = localPostId
@@ -827,11 +824,15 @@ class PostListViewModel @Inject constructor(
         val localPostId = scrollToLocalPostId
         if (localPostId != null) {
             scrollToLocalPostId = null
-            _scrollToPosition.value = findItemListPosition(data, localPostId) ?: run {
-                AppLog.e(AppLog.T.POSTS, "ScrollToPost failed - the post not found.")
-                null
-            }
+            updateScrollPosition(data, localPostId)
         }
+    }
+
+    private fun updateScrollPosition(data: PagedPostList, localPostId: Int) {
+        val position = findItemListPosition(data, localPostId)
+        position?.let {
+            _scrollToPosition.value = it
+        } ?: AppLog.e(AppLog.T.POSTS, "ScrollToPost failed - the post not found.")
     }
 
     private fun findItemListPosition(data: PagedPostList, localPostId: Int): Int? {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1435,6 +1435,7 @@
     <string name="error_media_save">Unable to save media</string>
     <string name="error_media_canceled">Uploading media were canceled</string>
     <string name="error_media_recover_post">Unable to upload this post\'s media</string>
+    <string name="error_post_does_not_exist">This post no longer exists</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
     <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>
     <string name="error_copy_to_clipboard">An error occurred while copying text to clipboard</string>


### PR DESCRIPTION
Fixes #9225 

~~**NOTE: The target branch needs to be update to `feature/master-post-filters` when #9290 is merged.**~~

Adds support for selecting the correct tab and scrolling to a target post.
- I've also added support for scrolling to a targetPost from a "upload successful" notification in https://github.com/wordpress-mobile/WordPress-Android/pull/9301/commits/92066307462f43a137a3a312df4799a9a2bdac38

I'm not 100% satisfied with the solution, but it's the best solution I could come up with at the moment. I'm all ears if you have some suggestions how to improve it.

**Flow**
`PostsListActivity` is started with `EXTRA_TARGET_POST_LOCAL_ID` -> it propagates the `targetPostId` to `PostsListMainViewModel`.
`PostListMainViewModel` loads the post from database (snackbar with an error message is shown when the post is not found) and derives what tab to select from the post status. When the tab is selected and shown the `targetPostId` is propagated to the corresponding instance of the `PostListFragment` ("scrollToTargetPost()"). 
`PostListFragment` propagates the `targetPostId` to the `PostListViewModel`("scrollToPost()") 
- if the data in `PostListFragment` are already loaded, we scroll to the targetPost right away
- if the data aren't loaded yet, we store the `targetPostId` into `scrollToLocalPostId` field and we scroll to the target post in `onDataUpdated()`

![scroll-to-post](https://user-images.githubusercontent.com/2261188/53162683-d4b8eb80-35cc-11e9-989e-5b2928831079.gif)



To test:
1. My Site
2. Blog Posts
3. Start editing a post (ideally a post to which you need to scroll to)
1. Set Network Type in an emulator settings to GSM
2. Add an image to a post and click on Update
3. Click on the home button
4. Change the Network Type back to Full/LTE
5. Wait until a success notification is shown
6. Click on the notification
7. Make sure the correct tab is selected and the target post is visible

Repeat this test with some modifications
- press back in step 6 to leave the Blog Posts and then press home button
- edit a post from a different tab - eg. Scheduled

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
