### PR TITLE
Fix bug that blocks reopening of view all screens

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -319,7 +319,7 @@ public class ActivityLauncher {
         intent.putExtra(StatsAbstractFragment.ARGS_IS_SINGLE_VIEW, true);
         intent.putExtra(OldStatsActivity.ARG_LOCAL_TABLE_SITE_ID, site.getId());
 
-        String title = context.getResources().getString(R.string.stats_view_tags_and_categories);
+        String title = context.getResources().getString(R.string.stats_view_top_posts_and_pages);
         intent.putExtra(StatsViewAllActivity.ARG_STATS_VIEW_ALL_TITLE, title);
         context.startActivity(intent);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
@@ -52,7 +52,10 @@ class BaseListUseCase(
         }
     }.distinct()
 
-    val navigationTarget: LiveData<NavigationTarget> = mergeNotNull(useCases.map { it.navigationTarget })
+    val navigationTarget: LiveData<NavigationTarget> = mergeNotNull(
+            useCases.map { it.navigationTarget },
+            distinct = false
+    )
 
     private val mutableShowDateSelector = MutableLiveData<DateSelectorUiModel>()
     val showDateSelector: LiveData<DateSelectorUiModel> = mutableShowDateSelector


### PR DESCRIPTION
This PR fixes a bug where the navigation only accepted distinct events. This means that going back and forth between the Stats and the View all page was impossible.
I've also noticed the title of the Posts and pages was incorrect so I'm also fixing that as part of this PR.

To test:
* Go to Stats - any block
* Click on `View more` button
* Notice a screen with all the data appears
* Go back
* Click on the same `View more` button
* The screen appears again
