### PR TITLE
Make sure to save Post when dismissing the EditPostActivity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -745,7 +745,8 @@ public class EditPostActivity extends AppCompatActivity implements
         }
         cancelAddMediaListThread();
         removePostOpenInEditorStickyEvent();
-        savePostAndOptionallyFinish(false);
+        handlePostStatusForNewPost();
+        savePostLocallyAndFinishAsync(false);
 
         if (mEditorFragment instanceof AztecEditorFragment) {
             ((AztecEditorFragment) mEditorFragment).disableContentLogOnCrashes();
@@ -2032,19 +2033,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 definitelyDeleteBackspaceDeletedMediaItems();
 
                 if (shouldSave) {
-                    if (isNewPost() && PostStatus.fromPost(mPost) == PostStatus.PUBLISHED) {
-                        // new post - user just left the editor without publishing, they probably want
-                        // to keep the post as a draft (unless they explicitly changed the status)
-                        mPost.setStatus(PostStatus.DRAFT.toString());
-                        if (mEditPostSettingsFragment != null) {
-                            runOnUiThread(new Runnable() {
-                                @Override
-                                public void run() {
-                                    mEditPostSettingsFragment.updatePostStatusRelatedViews();
-                                }
-                            });
-                        }
-                    }
+                    handlePostStatusForNewPost();
 
                     PostStatus status = PostStatus.fromPost(mPost);
                     boolean isNotRestarting = mRestartEditorOption == RestartEditorOptions.NO_RESTART;
@@ -2066,6 +2055,22 @@ public class EditPostActivity extends AppCompatActivity implements
                 }
             }
         }).start();
+    }
+
+    private void handlePostStatusForNewPost() {
+        if (isNewPost() && PostStatus.fromPost(mPost) == PostStatus.PUBLISHED) {
+            // new post - user just left the editor without publishing, they probably want
+            // to keep the post as a draft (unless they explicitly changed the status)
+            mPost.setStatus(PostStatus.DRAFT.toString());
+            if (mEditPostSettingsFragment != null) {
+                runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        mEditPostSettingsFragment.updatePostStatusRelatedViews();
+                    }
+                });
+            }
+        }
     }
 
     private boolean shouldSavePost() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -745,6 +745,8 @@ public class EditPostActivity extends AppCompatActivity implements
         }
         cancelAddMediaListThread();
         removePostOpenInEditorStickyEvent();
+        savePostAndOptionallyFinish(false);
+
         if (mEditorFragment instanceof AztecEditorFragment) {
             ((AztecEditorFragment) mEditorFragment).disableContentLogOnCrashes();
         }


### PR DESCRIPTION

Fixes #8570 

This PR makes the save logic run in `onDestroy()` to make sure the `UploadService` gets the latest copy of the Post if running in parallel as the `EditPostActivity` is killed.

To test:
1. start a draft
2. add an image (preferrably something large so it takes time to upload)
3. while the image is uploading, tap the recent apps list button on Android and dismiss the app
4. observe the upload notification continues to upload
5. open the app again, observe the Post is a draft.


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
