### PR TITLE
Fall back to Aztec if media is being fed / shared to start a Post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -522,6 +522,13 @@ public class EditPostActivity extends AppCompatActivity implements
 
             mShowGutenbergEditor = PostUtils.shouldShowGutenbergEditor(mIsNewPost, mPost)
                                    && restartEditorOption != RestartEditorOptions.RESTART_SUPPRESS_GUTENBERG;
+
+            // override this if we're being fed media to start a Post for now
+            // EXTRA_INSERT_MEDIA comes from the WP app Media section, and EXTRA_STREAM is what we check
+            // for when receiving content from outside the WP app to be shared there
+            if (getIntent().hasExtra(EXTRA_INSERT_MEDIA) || getIntent().hasExtra(Intent.EXTRA_STREAM)) {
+                mShowGutenbergEditor = false;
+            }
         } else {
             mShowGutenbergEditor = savedInstanceState.getBoolean(STATE_KEY_GUTENBERG_IS_SHOWN);
         }


### PR DESCRIPTION
Fixes #9244 

For now, we don't have support in Gutenberg to receive and insert Media into a new Post (either by tapping `WRITE POST` in the snackbar when an upload is done in the Media section, or when receiving media being shared to WordPress app and choosing to start a new Post with it). 

So, this PR falls back to show Aztec when that's the case.

To test:

First, make sure you have selected Gutenberg as the default Editor for new posts.

#### CASE A: Media section
1. go to the apps media section
2. upload a new image and wait for the upload to finish
3. once the upload finishes, a snackbar is presented with a `WRITE POST` action
4. tap on `WRITE POST`
5. observe Aztec is loaded (regardless of Gutenberg being selected for new posts in settings) and the image is fed

#### CASE B: share to WordPress app
1. go to the Photos app or some other app on Android
2. share a picture to WordPress
3. when the WP app opens, tap on `ADD TO NEW POST` button
4. observe Aztec is loaded (regardless of Gutenberg being selected for new posts in settings) and the image is fed and starts uploading

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
