### PR TITLE
Remove all posts from DB when logging out.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -48,6 +48,7 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.ListActionBuilder;
+import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.generated.ThemeActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -572,6 +573,8 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());
         // remove all lists
         mDispatcher.dispatch(ListActionBuilder.newRemoveAllListsAction());
+        // remove all posts
+        mDispatcher.dispatch(PostActionBuilder.newRemoveAllPostsAction());
 
         // reset all user prefs
         AppPrefs.reset();


### PR DESCRIPTION
Fixes #9299 

This PR adds extra an step at logout that removes all the posts from DB.

To test (from the original issue):
* Log in to the app.
* Create a local change on a post in the app (e.g. edit a published post but exit the editor without syncing the change remotely).
* Log out of the app and confirm you see the "You have changes ..." prompt as expected.
* Log in to a different account.
* Without making any changes, log out again.
* Make sure "You have changes ..." prompt is not visible.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
