### PR TITLE
[Gutenberg] Release v1.0

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2515,19 +2515,24 @@
     <string name="new_site_creation_preview_back_pressed_warning">You may lose your progress. Are you sure you want to exit?</string>
 
     <!-- Gutenberg mobile strings -->
-    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_block_library_src_paragraph_edit_native_js_115">Add text or type / to add content</string>
+    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_format_library_src_link_modal_native_js_101">Link inserted</string>
     <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_block_library_src_image_edit_native_js_214">Add URL</string>
-    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_block_library_src_image_edit_native_js_221">Alt Text</string>
-    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_block_library_src_image_edit_native_js_227">Reset to Original</string>
-    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_block_library_src_image_edit_native_js_282">Failed to insert media.\nPlease tap for options.</string>
-    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_editor_src_components_media_placeholder_index_native_js_17">Upload a new image or select a file from your library.</string>
-    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_editor_src_components_media_placeholder_index_native_js_20">Device Library</string>
-    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_editor_src_components_media_placeholder_index_native_js_21">Take photo</string>
-    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_editor_src_components_default_block_appender_index_native_js_26">Start writing or press %s to add content</string>
+    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_format_library_src_link_modal_native_js_136">Link Text</string>
+    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_format_library_src_link_modal_native_js_138">Add Link Text</string>
+    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_format_library_src_link_modal_native_js_152">Remove Link</string>
+    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_block_library_src_paragraph_edit_native_js_128">Start writing…</string>
+    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_block_library_src_image_edit_native_js_196">Choose from device</string>
+    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_block_library_src_image_edit_native_js_197">Take a Photo</string>
+    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_block_library_src_image_edit_native_js_198">WordPress Media Library</string>
+    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_block_library_src_image_edit_native_js_273">Alt Text</string>
+    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_block_library_src_image_edit_native_js_280">Clear All Settings</string>
+    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_block_library_src_image_edit_native_js_374">Failed to insert media.\nPlease tap for options.</string>
+    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_editor_src_components_media_placeholder_index_native_js_26">CHOOSE IMAGE</string>
+    <string tools:ignore="UnusedResources" name="gutenberg_mobile_gutenberg_packages_editor_src_components_url_input_index_native_js_27">Paste URL</string>
     <string tools:ignore="UnusedResources" name="gutenberg_mobile_src_block_types_unsupported_block_index_js_21">Unsupported Block</string>
     <string tools:ignore="UnusedResources" name="gutenberg_mobile_src_block_types_unsupported_block_index_js_23">Unsupported block type.</string>
-    <string tools:ignore="UnusedResources" name="gutenberg_mobile_src_block_management_block_picker_js_30">ADD BLOCK</string>
-    <string tools:ignore="UnusedResources" name="gutenberg_mobile_src_block_management_block_manager_js_252">ADD BLOCK HERE</string>
+    <string tools:ignore="UnusedResources" name="gutenberg_mobile_src_block_types_unsupported_block_edit_js_27">Unsupported</string>
+    <string tools:ignore="UnusedResources" name="gutenberg_mobile_src_block_management_block_manager_js_285">ADD BLOCK HERE</string>
     <string tools:ignore="UnusedResources" name="gutenberg_mobile_src_block_management_inline_toolbar_index_js_48">Move block up</string>
     <string tools:ignore="UnusedResources" name="gutenberg_mobile_src_block_management_inline_toolbar_index_js_55">Move block down</string>
     <string tools:ignore="UnusedResources" name="gutenberg_mobile_src_block_management_inline_toolbar_index_js_66">Remove content</string>

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     ext {
-        aztecVersion = 'e02ec1387c739d73645e498a2e5ed1b3916b2587'
+        aztecVersion = 'v1.3.20'
     }
 
     repositories {


### PR DESCRIPTION
This PR tracks and brings in the v1.0 release of Gutenberg-mobile

~Depends on https://github.com/wordpress-mobile/gutenberg-mobile/issues/584. Edit: Done.~

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
