### PR TITLE
Code freeze: Don't add branch protection to individual release branches

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -56,8 +56,7 @@ ENV[GHHELPER_REPO="wordpress-mobile/WordPress-Android"]
   desc "Creates a new release branch from the current develop"
   lane :code_freeze do | options |
     old_version = android_codefreeze(options)
-    
-    setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{options[:codefreeze_version]}")
+
     setfrozentag(repository:GHHELPER_REPO, milestone: options[:codefreeze_version])
 
     get_prs_list(repository:GHHELPER_REPO, start_tag:"release/#{old_version}", report_path:"#{File.expand_path('~')}/wpandroid_prs_list_#{old_version}_#{options[:codefreeze_version]}.txt")


### PR DESCRIPTION
As discussed this removes the step to set branch protection on every release branch.

Since Github now supports patterns for branch protection rules we no longer need to set it on individual branches through the API.

I have set up a protection rule for `release/*` so release branches are automatically protected.

Related to https://github.com/wordpress-mobile/release-toolkit/pull/24 and https://github.com/wordpress-mobile/WordPress-iOS/pull/11117.

I don't think there is any need to update the release-toolkit since the only change is that this action is removed.

To test:

- See that we no longer call `setbranchprotection `.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.