### PR TITLE
Do not mark post as changed when loading revision without changes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1814,10 +1814,11 @@ public class EditPostActivity extends AppCompatActivity implements
             mPostForUndo = mPost.clone();
             mPost.setTitle(mRevision.getPostTitle());
             mPost.setContent(mRevision.getPostContent());
-            mPost.setIsLocallyChanged(true);
             mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
             refreshEditorContent();
         }
+
+        mPost.setIsLocallyChanged(isRevisionSameAsPost);
 
         Snackbar.make(mViewPager, getString(R.string.history_loaded_revision),
                 AccessibilityUtils.getSnackbarDuration(EditPostActivity.this, 4000))


### PR DESCRIPTION
Fixes #8773 

This PR adds a check when loading a revision that prevents post from being marked as "changed" if the content of post and its title are identical to revision.

I decided to still leave a "Revision loaded" toast and undo button that does nothing (otherwise it might be confusing, and give an impression that something is not working).

To test (from original issue):
* start a new Post in Aztec
* type a title
* start a paragraph, enter "first version" as text.
* tap back
* observe the post gets uploaded as a draft
* open it again and edit paragraph "first version" enter something else, for example "second version"
* tap back to make the first entry in history
* open it again
* now change the content to "third version"
* tap back to make the second entry in history
* navigate back to post and load the revision with "third version" (same as the content of editor)
* naviagate back and notice that post was not uploaded

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
