### PR TITLE
Make new Posts status `draft` by default

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1339,6 +1339,13 @@ public class EditPostActivity extends AppCompatActivity implements
                                 getString(R.string.error_save_empty_draft), Duration.SHORT);
                         return false;
                     }
+
+                    if (status == PostStatus.SCHEDULED && isNewPost()) {
+                        // if user pressed `Save as draft` on a new, Scheduled Post, re-convert it to draft.
+                        if (mEditPostSettingsFragment != null) {
+                            mEditPostSettingsFragment.updatePostStatus(PostStatus.DRAFT.toString());
+                        }
+                    }
                     UploadUtils.showSnackbar(findViewById(R.id.editor_activity), R.string.editor_uploading_post);
                     mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
                     savePostAndOptionallyFinish(false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -852,15 +852,15 @@ public class EditPostActivity extends AppCompatActivity implements
                 } else {
                     return getString(R.string.update_verb);
                 }
-            case PRIVATE:
-            case PENDING:
-            case TRASHED:
             case DRAFT:
                 if (isNewPost() && mPost.isLocalDraft()) {
                     return getString(R.string.post_status_publish_post);
                 } else {
                     return handleDefaultForSaveButtonText();
                 }
+            case PRIVATE:
+            case PENDING:
+            case TRASHED:
             default:
                 return handleDefaultForSaveButtonText();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -380,7 +380,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
         // Create a new post
         mPost = mPostStore.instantiatePostModel(mSite, mIsPage, null, null);
-        mPost.setStatus(PostStatus.PUBLISHED.toString());
+        mPost.setStatus(PostStatus.DRAFT.toString());
         EventBus.getDefault().postSticky(
                 new PostEvents.PostOpenedInEditor(mPost.getLocalSiteId(), mPost.getId()));
         mShortcutUtils.reportShortcutUsed(Shortcut.CREATE_NEW_POST);
@@ -857,7 +857,9 @@ public class EditPostActivity extends AppCompatActivity implements
             case TRASHED:
             case DRAFT:
             default:
-                if (mPost.isLocalDraft()) {
+                if (isNewPost() && mPost.isLocalDraft()) {
+                    return getString(R.string.post_status_publish_post);
+                } else if (mPost.isLocalDraft()) {
                     return getString(R.string.save);
                 } else {
                     return getString(R.string.update_verb);
@@ -1322,7 +1324,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 // we update the mPost object first, so we can pre-check Post publishability and inform the user
                 updatePostObject();
                 PostStatus status = PostStatus.fromPost(mPost);
-                if (status == PostStatus.DRAFT || status == PostStatus.PENDING) {
+                if (!isNewPost() && (status == PostStatus.DRAFT || status == PostStatus.PENDING)) {
                     if (isDiscardable()) {
                         String message = getString(
                                 mIsPage ? R.string.error_publish_empty_page : R.string.error_publish_empty_post);
@@ -1331,15 +1333,13 @@ public class EditPostActivity extends AppCompatActivity implements
                     }
                     showPublishConfirmationDialog();
                 } else {
+                    // this is a new post, save as draft
                     if (isDiscardable()) {
                         ToastUtils.showToast(EditPostActivity.this,
                                 getString(R.string.error_save_empty_draft), Duration.SHORT);
                         return false;
                     }
                     UploadUtils.showSnackbar(findViewById(R.id.editor_activity), R.string.editor_uploading_post);
-                    if (isNewPost()) {
-                        mPost.setStatus(PostStatus.DRAFT.toString());
-                    }
                     mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
                     savePostAndOptionallyFinish(false);
                 }
@@ -1461,7 +1461,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // if post is a draft, first make sure to confirm the PUBLISH action, in case
         // the user tapped on it accidentally
         PostStatus status = PostStatus.fromPost(mPost);
-        if (userCanPublishPosts() && (status == PostStatus.PUBLISHED || status == PostStatus.UNKNOWN)
+        if (userCanPublishPosts() && (status == PostStatus.DRAFT || status == PostStatus.UNKNOWN)
             && mPost.isLocalDraft()) {
             showPublishConfirmationDialog();
         } else {
@@ -2079,21 +2079,6 @@ public class EditPostActivity extends AppCompatActivity implements
                 definitelyDeleteBackspaceDeletedMediaItems();
 
                 if (shouldSave) {
-                    if (isNewPost() && PostStatus.fromPost(mPost) == PostStatus.PUBLISHED) {
-                        // new post - user just left the editor without publishing, they probably want
-                        // to keep the post as a draft (unless they explicitly changed the status)
-                        mPost.setStatus(PostStatus.DRAFT.toString());
-                        mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
-                        if (mEditPostSettingsFragment != null) {
-                            runOnUiThread(new Runnable() {
-                                @Override
-                                public void run() {
-                                    mEditPostSettingsFragment.updatePostStatusRelatedViews();
-                                }
-                            });
-                        }
-                    }
-
                     PostStatus status = PostStatus.fromPost(mPost);
                     boolean isNotRestarting = mRestartEditorOption == RestartEditorOptions.NO_RESTART;
                     if ((status == PostStatus.DRAFT || status == PostStatus.PENDING) && isPublishable
@@ -2139,7 +2124,7 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private boolean isFirstTimePublish() {
-        return (PostStatus.fromPost(mPost) == PostStatus.UNKNOWN || PostStatus.fromPost(mPost) == PostStatus.PUBLISHED)
+        return (PostStatus.fromPost(mPost) == PostStatus.UNKNOWN || PostStatus.fromPost(mPost) == PostStatus.DRAFT)
                && (mPost.isLocalDraft() || PostStatus.fromPost(mOriginalPost) == PostStatus.DRAFT
                    || PostStatus.fromPost(mOriginalPost) == PostStatus.PENDING);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1351,6 +1351,8 @@ public class EditPostActivity extends AppCompatActivity implements
                         // if user pressed `Save as draft` on a new, Scheduled Post, re-convert it to draft.
                         if (mEditPostSettingsFragment != null) {
                             mEditPostSettingsFragment.updatePostStatus(PostStatus.DRAFT.toString());
+                            ToastUtils.showToast(EditPostActivity.this,
+                                    getString(R.string.editor_post_converted_back_to_draft), Duration.SHORT);
                         }
                     }
                     UploadUtils.showSnackbar(findViewById(R.id.editor_activity), R.string.editor_uploading_post);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -856,14 +856,21 @@ public class EditPostActivity extends AppCompatActivity implements
             case PENDING:
             case TRASHED:
             case DRAFT:
-            default:
                 if (isNewPost() && mPost.isLocalDraft()) {
                     return getString(R.string.post_status_publish_post);
-                } else if (mPost.isLocalDraft()) {
-                    return getString(R.string.save);
                 } else {
-                    return getString(R.string.update_verb);
+                    return handleDefaultForSaveButtonText();
                 }
+            default:
+                return handleDefaultForSaveButtonText();
+        }
+    }
+
+    private String handleDefaultForSaveButtonText() {
+        if (mPost.isLocalDraft()) {
+            return getString(R.string.save);
+        } else {
+            return getString(R.string.update_verb);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2036,6 +2036,9 @@ public class EditPostActivity extends AppCompatActivity implements
                         savePostLocallyAndFinishAsync(true);
                     }
                 } else {
+                    // the user has just tapped on "PUBLISH" on an empty post, make sure to set the status back to the
+                    // original post's status as we could not proceed with the action
+                    mPost.setStatus(mOriginalPost.getStatus());
                     EditPostActivity.this.runOnUiThread(new Runnable() {
                         @Override
                         public void run() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -653,7 +653,7 @@ public class EditPostSettingsFragment extends Fragment {
         updateCategoriesTextView();
     }
 
-    private void updatePostStatus(String postStatus) {
+    public void updatePostStatus(String postStatus) {
         getPost().setStatus(postStatus);
         updatePostStatusRelatedViews();
         updateSaveButton();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -709,6 +709,11 @@ public class EditPostSettingsFragment extends Fragment {
 
     private void updatePublishDate(Calendar calendar) {
         getPost().setDateCreated(DateTimeUtils.iso8601FromDate(calendar.getTime()));
+        // Posts that are scheduled have a `future` date for REST but their status should be set to `published` as
+        // there is no `future` entry in XML-RPC (see PostStatus in FluxC for more info)
+        if (!PostUtils.shouldPublishImmediately(getPost())) {
+            updatePostStatus(PostStatus.PUBLISHED.toString());
+        }
         updatePublishDateTextView();
         updateSaveButton();
     }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1193,6 +1193,7 @@
     <string name="editor_draft_saved_locally">Draft saved on device</string>
     <string name="editor_post_saved_locally_failed_media">The post has failed media uploads and has been saved locally</string>
     <string name="editor_uploading_post">Your post is uploading</string>
+    <string name="editor_post_converted_back_to_draft">Post converted back to draft</string>
     <string name="visual_editor_enabled">Visual Editor enabled</string>
     <string name="visual_editor_disabled">Visual Editor disabled</string>
     <string name="new_editor_reflection_error">Visual editor is not compatible with your device. It was


### PR DESCRIPTION
Fixes #8570 and possibly other issues by making a Post satus `DRAFT` by default.

- in 50a5d30c977798074da2f875e4a1569f7085b099 we only changed the default `PUBLISHED` state to `DRAFT`
- in 7e20bbff48f5abaf4b316fce8ae1ababcb32a7ad we make the behavior for `SCHEDULED` posts consistent with FluxC handling of `future` Posts (see [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostStatus.java#L40-L46) and [comment here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostStatus.java#L16))
- finally, introduced this particular case handling when the user has a scheduled new draft that hasn't yet been saved online, and the user taps on `Save as draft`. Given uploading as is would mean to actually save a Post that is being scheduled (and that should/can be done through the SCHEDULE button), if the user taps on `Save as draft` we should assume they just want to save the draft (as opposed to publishing / scheduling its publishing for the future). So, introduced this behavior in cccc1c4e839291c03d5b668cc2718a118bb30444.

The behavior implemented in this PR should stick to what was defined before and is best defined by the test cases as follow. In particular, the test steps in these PRs should still be valid:
- https://github.com/wordpress-mobile/WordPress-Android/pull/7583
- https://github.com/wordpress-mobile/WordPress-Android/pull/7606


Adding to the tests described in #7583 the following test cases for the `SCHEDULED` state:
#### CASE D: start a draft, edit post settings to schedule it, schedule
1. start a draft
2. enter some title /text
3. tap on Post settings on the overflow menu
4. change the `Publish` value from `Immediately` to a point in the future (i.e. tomorrow)
5. Tap on SCHEDULE
6. observe the Post is uploaded and it shows state "scheduled" in the Posts list once uploaded.

#### CASE E: start a draft, edit post settings to schedule it, then save as draft
1. start a draft
2. enter some title /text
3. tap on Post settings on the overflow menu
4. change the `Publish` value from `Immediately` to a point in the future (i.e. tomorrow)
5. tap on `save as draft` on the overflow menu icon
6. should behave the same as CASE C above (it should just upload the draft, as that's what the user intended to do).


## General / App dismissal test cases
And now, the whole set of test cases that take into account app dismissal (as explained in issue #8570):
#### CASE A: draft and exit
1. start a draft
2. enter something
3. tap back
4. draft should be saved.

#### CASE B: draft, add media, and exit
1. start a draft
2. enter something
3. add media
4. tap back
5. media should still get uploaded and draft should be saved once finished uploading.


#### CASE C: draft, add media, publish
1. start a draft
2. enter something
3. add media
4. tap PUBLISH, accept confirmation
5. media should still get uploaded and Post should be published once finished uploading.


#### CASE D: draft, add media, schedule
1. start a draft
2. enter something
3. open post settings and change publish immediately to a date in the future to schedule
4. add media
5. tap SCHEDULE, accept confirmation if any
6. media should still get uploaded and Post should be saved as SCHEDULED once finished uploading.

#### CASE E: start draft, dismiss app
1. start a draft
2. enter something
3. tap on the recent apps list and dismiss the WP app
4. open the app again and go to Posts list
5. verify the Post has been saved as a local draft


#### CASE F: start a draft, add media, dismiss app
1. start a draft
2. enter something
3. add some media from device to start uploading
4. tap on the recent apps list and dismiss the WP app
5. open the app again and go to Posts list
6. verify the Post has been saved as a draft, media continued to upload and is OK in the Post

#### CASE G: start a draft, add media, tap PUBLISH, dismiss app
1. start a draft
2. enter something
3. add some media from device to start uploading
4. tap PUBLISH and accept confirmation dialog if any - the app will go back to previous screen while uploading media and enqueing Post to upload in the background async.
5. tap on the recent apps list and dismiss the WP app
6. open the app again and go to Posts list
7. verify the Post has been saved as PUBLISHED, media continued to upload and is OK in the Post

#### CASE H: start a draft, add media, wait for it to upload, dismiss app
1. start a draft
2. enter something
3. add some media from device to start uploading, and wait until it finishes uploading
4. tap on the recent apps list and dismiss the WP app
5. open the app again and go to Posts list
6. verify the Post has been saved as a draft, media/Post resume uploading if needed, and media is OK in the Post


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
