### PR TITLE
Add comment for translators

### DIFF
--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -10,6 +10,7 @@ msgstr ""
 "X-Generator: VsCode\n"
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
+#. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
 msgctxt "release_note_118"
 msgid ""
 "11.8:\n"


### PR DESCRIPTION
This PR adds a comment in `PlayStoreStrings.po` to let translators know about the length limits for release notes.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
