### PR TITLE
Issue/9341 quick start strike

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -560,6 +560,8 @@ public class MySiteFragment extends Fragment implements
             if (countCustomizeUncompleted > 0) {
                 mQuickStartCustomizeIcon.setEnabled(true);
                 mQuickStartCustomizeTitle.setEnabled(true);
+                mQuickStartCustomizeTitle.setPaintFlags(
+                        mQuickStartCustomizeTitle.getPaintFlags() & ~Paint.STRIKE_THRU_TEXT_FLAG);
             } else {
                 mQuickStartCustomizeIcon.setEnabled(false);
                 mQuickStartCustomizeTitle.setEnabled(false);
@@ -573,6 +575,8 @@ public class MySiteFragment extends Fragment implements
             if (countGrowUncompleted > 0) {
                 mQuickStartGrowIcon.setBackgroundResource(R.drawable.bg_oval_pink_500_multiple_users_white_40dp);
                 mQuickStartGrowTitle.setEnabled(true);
+                mQuickStartGrowTitle.setPaintFlags(
+                        mQuickStartGrowTitle.getPaintFlags() & ~Paint.STRIKE_THRU_TEXT_FLAG);
             } else {
                 mQuickStartGrowIcon.setBackgroundResource(R.drawable.bg_oval_grey_multiple_users_white_40dp);
                 mQuickStartGrowTitle.setEnabled(false);


### PR DESCRIPTION
### Fix
Add strikethrough text format removal from Quick Start type title when creating a new site after completing tasks for the previously selected site as described in https://github.com/wordpress-mobile/WordPress-Android/issues/9341.  When tasks remain for a Quick Start type, the title has no strikethrough format for that type.  When no tasks remain for a Quick Start type, the title has strikethrough format for that type.

### Test
0. Select site with Quick Start completed and not removed.
1. Go to ***Sites*** tab.
2. Notice ***Next Steps*** view is shown.
3. Notice ***Customize Your Site*** and ***Grow Your Audience*** are disabled with strikethrough.
4. Tap _**Switch Site**_ button.
5. Tap ***Add New Site*** button.
6. Tap ***Create WordPress.com Site*** option in dialog.
7. Follow site creation steps.
8. Tap ***OK*** button.
9. Notice ***Want a little help getting started?*** dialog.
10. Tap ***Accept*** button.
11. Notice ***Next Steps*** view is shown.
12. Notice ***Customize Your Site*** and ***Grow Your Audience*** are enabled without strikethrough.

### Review
Only one developer is required to review these changes, but anyone can perform the review.