### PR TITLE
Issue/9345 quick start dismiss

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -49,6 +49,7 @@ import org.wordpress.android.ui.ActionableEmptyView;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.FullScreenDialogFragment;
 import org.wordpress.android.ui.FullScreenDialogFragment.OnConfirmListener;
+import org.wordpress.android.ui.FullScreenDialogFragment.OnDismissListener;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.accounts.LoginActivity;
 import org.wordpress.android.ui.comments.CommentsListFragment.CommentStatusCriteria;
@@ -108,7 +109,7 @@ public class MySiteFragment extends Fragment implements
         BasicFragmentDialog.BasicDialogPositiveClickInterface,
         BasicFragmentDialog.BasicDialogNegativeClickInterface,
         BasicFragmentDialog.BasicDialogOnDismissByOutsideTouchInterface, PromoDialogClickInterface, MainToolbarFragment,
-        OnConfirmListener {
+        OnConfirmListener, OnDismissListener {
     public static final int HIDE_WP_ADMIN_YEAR = 2015;
     public static final int HIDE_WP_ADMIN_MONTH = 9;
     public static final int HIDE_WP_ADMIN_DAY = 7;
@@ -614,6 +615,7 @@ public class MySiteFragment extends Fragment implements
                 new FullScreenDialogFragment.Builder(requireContext())
                         .setTitle(R.string.quick_start_sites_type_customize)
                         .setOnConfirmListener(this)
+                        .setOnDismissListener(this)
                         .setContent(QuickStartFullScreenDialogFragment.class, bundle)
                         .build()
                         .show(requireActivity().getSupportFragmentManager(), FullScreenDialogFragment.TAG);
@@ -622,6 +624,7 @@ public class MySiteFragment extends Fragment implements
                 new FullScreenDialogFragment.Builder(requireContext())
                         .setTitle(R.string.quick_start_sites_type_grow)
                         .setOnConfirmListener(this)
+                        .setOnDismissListener(this)
                         .setContent(QuickStartFullScreenDialogFragment.class, bundle)
                         .build()
                         .show(requireActivity().getSupportFragmentManager(), FullScreenDialogFragment.TAG);
@@ -780,6 +783,11 @@ public class MySiteFragment extends Fragment implements
             mActiveTutorialPrompt = QuickStartMySitePrompts.getPromptDetailsForTask(task);
             showActiveQuickStartTutorial();
         }
+    }
+
+    @Override
+    public void onDismiss() {
+        updateQuickStartContainer();
     }
 
     private void startSiteIconUpload(final String filePath) {


### PR DESCRIPTION
### Fix
Add dismiss listener to update Quick Start progress (e.g. "1 of 6 complete") when returning to _**Sites**_ tab after skipping task(s) as described in https://github.com/wordpress-mobile/WordPress-Android/issues/9345.

### Test
0. Select site with Quick Start in progress.
1. Notice _**Next Steps**_ view is shown.
2. Notice progress of _**Customize Your Site**_ and _**Grow Your Audience**_ types.
3. Tap _**Customize Your Site**_ or _**Grow Your Audience**_ type.
4. Long-press uncompleted task in list.
5. Tap ***Skip Task*** option.
6. Tap ***X*** in top app bar.
7. Notice progress of _**Customize Your Site**_ and _**Grow Your Audience**_ types is different than Step 2.

### Review
Only one developer is required to review these changes, but anyone can perform the review.