### PR TITLE
Remove obsolete Gradle publishing config from subprojects

### DIFF
--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -5,13 +5,10 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.novoda:bintray-release:0.8.1'
     }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
-apply plugin: 'com.novoda.bintray-release' // must be applied after your artifact generating plugin (eg. java / com.android.library)
 
 repositories {
     google()
@@ -34,17 +31,4 @@ android {
         minSdkVersion 16
         targetSdkVersion 26
     }
-}
-
-publish {
-    artifactId = 'analytics'
-    userOrg = 'wordpress-mobile'
-    groupId = 'org.wordpress'
-    uploadName = 'analytics'
-    desc = 'Analytics library for WordPress for Android'
-    publishVersion = android.defaultConfig.versionName
-    licences = ['GPL-2.0']
-    website = 'https://github.com/wordpress-mobile/WordPress-Analytics-Android'
-    dryRun = 'false'
-    autoPublish = 'true'
 }

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -14,8 +14,6 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
-apply plugin: 'signing'
 
 repositories {
     google()
@@ -91,60 +89,4 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.6.2'
 
     lintChecks 'org.wordpress:lint:1.0.1'
-}
-
-signing {
-    required {
-        project.properties.containsKey("signing.keyId") && project.properties.containsKey("signing.secretKeyRingFile")
-    }
-    sign configurations.archives
-}
-
-version android.defaultConfig.versionName
-group = "org.wordpress"
-archivesBaseName = "editor"
-
-// http://central.sonatype.org/pages/gradle.html
-
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: project.properties.ossrhUsername, password: project.properties.ossrhPassword)
-            }
-
-            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: project.properties.ossrhUsername, password: project.properties.ossrhPassword)
-            }
-
-            pom.project {
-                name 'WordPress-Android-Editor'
-                packaging 'aar'
-                description 'A reusable Android rich text editor component'
-                url 'https://github.com/wordpress-mobile/WordPress-Android-Editor'
-                scm {
-                    connection 'scm:git:https://github.com/wordpress-mobile/WordPress-Android-Editor.git'
-                    developerConnection 'scm:git:https://github.com/wordpress-mobile/WordPress-Android-Editor.git'
-                    url 'https://github.com/wordpress-mobile/WordPress-Android-Editor'
-                }
-
-                licenses {
-                    license {
-                        name 'The MIT License (MIT)'
-                        url 'http://opensource.org/licenses/MIT'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id 'maxme'
-                        name 'Maxime Biais'
-                        email 'maxime@automattic.com'
-                    }
-                }
-            }
-        }
-    }
 }

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -15,7 +15,6 @@ repositories {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
 
 android {
     compileSdkVersion 28
@@ -33,19 +32,4 @@ dependencies {
     implementation 'com.automattic:rest:1.0.7'
 
     lintChecks 'org.wordpress:lint:1.0.1'
-}
-
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            def repo_url = ""
-            if (project.hasProperty("repository")) {
-                repo_url = project.repository
-            }
-            repository(url: repo_url)
-            pom.version = android.defaultConfig.versionName
-            pom.groupId = "org.wordpress"
-            pom.artifactId = "wordpress-networking"
-        }
-    }
 }

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -5,12 +5,10 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.novoda:bintray-release:0.8.1'
     }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'com.novoda.bintray-release'
 
 repositories {
     google()
@@ -38,34 +36,4 @@ android {
         minSdkVersion 15
         targetSdkVersion 26
     }
-}
-
-android.libraryVariants.all { variant ->
-    task("generate${variant.name}Javadoc", type: Javadoc) {
-        description "Generates Javadoc for $variant.name."
-        source = variant.javaCompile.source
-
-        options {
-            links "http://docs.oracle.com/javase/7/docs/api/"
-        }
-        exclude '**/R.java'
-        doFirst {
-            classpath =
-                    files(variant.javaCompile.classpath.files,
-                            project.android.getBootClasspath())
-        }
-    }
-}
-
-publish {
-    artifactId = 'utils'
-    userOrg = 'wordpress-mobile'
-    groupId = 'org.wordpress'
-    uploadName = 'utils'
-    desc = 'Utils library for Android'
-    publishVersion = android.defaultConfig.versionName
-    licences = ['MIT', 'GPL']
-    website = 'https://github.com/wordpress-mobile/WordPress-Utils-Android/'
-    dryRun = 'false'
-    autoPublish = 'true'
 }


### PR DESCRIPTION
When doing some Android builds I noticed we have Gradle deprecation warnings:

```
As part of making the publishing plugins stable, the 'deferred configurable' behavior of the 'publishing {}' block has been deprecated.
```

It turns out these warnings are caused by a bunch of code for publishing our subprojects which is no longer used since they are now subprojects. I'm removing this configuration here.

To test:

- CI checks are still green.
- Gradle sync runs fine & the app still builds and run, since this code is unused.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
