### PR TITLE
Run Gradle build scan on CI builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,10 @@ buildscript {
     }
 }
 
+plugins {
+  id 'com.gradle.build-scan' version '1.16'
+}
+
 apply plugin: 'com.automattic.android.fetchstyle'
 
 project.ext.buildGutenbergFromSource = project.properties.getOrDefault('wp.BUILD_GUTENBERG_FROM_SOURCE', false).toBoolean()
@@ -80,6 +84,16 @@ subprojects {
         main = "com.github.shyiko.ktlint.Main"
         classpath = configurations.ktlint
         args "-F", "src/**/*.kt"
+    }
+}
+
+buildScan {
+    // Always run Gradle scan on CI builds
+    if (System.getenv('CI')) {
+        licenseAgreementUrl = 'https://gradle.com/terms-of-service'
+        licenseAgree = 'yes'
+        tag 'CI'
+        publishAlways()
     }
 }
 


### PR DESCRIPTION
This is a small change to run a Gradle Build Scan (https://scans.gradle.com/) when running builds on CI.

It will help us see any performance or configuration issues that come up.

To test:

- See that there is a link the Gradle build scan in the [CircleCI build log](https://circleci.com/gh/wordpress-mobile/WordPress-Android/7639):

```
Publishing build scan...
https://gradle.com/s/66tywj763ohvi
```
- Check out the build scan (https://gradle.com/s/66tywj763ohvi) to see that it worked.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
