### PR TITLE
Remove negative infinity when item drops to zero

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
@@ -34,10 +34,9 @@ class OverviewMapper
         val positive = value >= (previousValue ?: 0)
         val change = previousValue?.let {
             val difference = value - previousValue
-            val percentage = when {
-                previousValue == value -> "0"
-                previousValue == 0L -> "∞"
-                value == 0L -> "-∞"
+            val percentage = when (previousValue) {
+                value -> "0"
+                0L -> "∞"
                 else -> (difference * 100 / previousValue).toFormattedString()
             }
             if (positive) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapperTest.kt
@@ -95,6 +95,24 @@ class OverviewMapperTest : BaseUnitTest() {
     }
 
     @Test
+    fun `builds title with max negative difference`() {
+        val newLikes: Long = 0
+        val newItem = selectedItem.copy(likes = newLikes)
+        val selectedPosition = 2
+        val uiState = UiState(selectedPosition)
+        val negativeLabel = "-20 (-100%)"
+        whenever(resourceProvider.getString(eq(R.string.stats_traffic_change), eq("-20"), eq("-100")))
+                .thenReturn(negativeLabel)
+
+        val title = mapper.buildTitle(newItem, selectedItem, uiState.selectedPosition)
+
+        assertThat(title.value).isEqualTo(newLikes.toString())
+        assertThat(title.unit).isEqualTo(R.string.stats_likes)
+        assertThat(title.change).isEqualTo(negativeLabel)
+        assertThat(title.positive).isFalse()
+    }
+
+    @Test
     fun `builds title with zero difference`() {
         val previousLikes: Long = 20
         val previousItem = selectedItem.copy(likes = previousLikes)


### PR DESCRIPTION
Fixes #9343 
This PR fixes a bug when we were showing a -infinity% when the number of likes/views/comments dropped to 0. We should be showing -100% instead. Infinity is shown only when there is a positive change from 0. 

To test:
* Go to Stats/DWMY
* Click on a Column with value 0 which has a previous value > 0
* There is `-100%` in the red change value on the right side 

![screenshot_1551708781](https://user-images.githubusercontent.com/1079756/53738687-2d6f6a80-3e90-11e9-896b-c8381eec419a.png)

