### PR TITLE
Add Violations plugin to comment on lint violations on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,10 +43,14 @@ jobs:
           command: $GRADLEW checkstyle
       - run:
           name: ktlint
-          command: $GRADLEW ktlint
+          command: $GRADLEW ciktlint
       - run:
           name: Lint
           command: $GRADLEW lintVanillaRelease || (grep -A20 -B2 'severity="Error"' -r --include="*.xml" WordPress libs; exit 1)
+      - run:
+          name: Violations
+          when: on_fail
+          command: $GRADLEW violationCommentsToGitHub -DGITHUB_PULLREQUESTID=${CIRCLE_PULL_REQUEST##*/} -DGITHUB_OAUTH2TOKEN=$DANGER_GITHUB_API_TOKEN
       - android/save-gradle-cache:
           cache-prefix: lint-cache
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
             if [ -n "$GITHUB_API_TOKEN" ]; then
               $GRADLEW violationCommentsToGitHub -DGITHUB_PULLREQUESTID=${CIRCLE_PULL_REQUEST##*/} -DGITHUB_OAUTH2TOKEN=$GITHUB_API_TOKEN
             else
-              echo "Not running danger because $GITHUB_API_TOKEN is not found"
+              echo "Not posting lint errors to Github because \$GITHUB_API_TOKEN is not found"
             fi 
       - android/save-gradle-cache:
           cache-prefix: lint-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,12 @@ jobs:
       - run:
           name: Violations
           when: on_fail
-          command: $GRADLEW violationCommentsToGitHub -DGITHUB_PULLREQUESTID=${CIRCLE_PULL_REQUEST##*/} -DGITHUB_OAUTH2TOKEN=$DANGER_GITHUB_API_TOKEN
+          command: |
+            if [ -n "$GITHUB_API_TOKEN" ]; then
+              $GRADLEW violationCommentsToGitHub -DGITHUB_PULLREQUESTID=${CIRCLE_PULL_REQUEST##*/} -DGITHUB_OAUTH2TOKEN=$GITHUB_API_TOKEN
+            else
+              echo "Not running danger because $GITHUB_API_TOKEN is not found"
+            fi 
       - android/save-gradle-cache:
           cache-prefix: lint-cache
       - store_artifacts:

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -2,11 +2,13 @@ buildscript {
     repositories {
         jcenter()
         maven { url 'https://maven.fabric.io/public' }
+        maven { url 'https://plugins.gradle.org/m2/' }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'io.fabric.tools:gradle:1.27.0'
         classpath 'com.google.gms:google-services:3.2.0'
+        classpath 'se.bjurr.violations:violation-comments-to-github-gradle-plugin:1.51'
     }
 }
 
@@ -24,6 +26,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'io.fabric'
+apply plugin: 'se.bjurr.violations.violation-comments-to-github-gradle-plugin'
 
 android.defaultConfig.javaCompileOptions.annotationProcessorOptions.includeCompileClasspath = true
 
@@ -308,6 +311,31 @@ android.buildTypes.all { buildType ->
     if ((new File('WordPress/google-services.json').text) == (new File('WordPress/google-services.json-example').text)) {
         println("WARNING: You're using the example google-services.json file. Google login will fail.")
     }
+}
+
+task violationCommentsToGitHub(type: se.bjurr.violations.comments.github.plugin.gradle.ViolationCommentsToGitHubTask) {
+   repositoryOwner = "wordpress-mobile";
+   repositoryName = "WordPress-Android"
+   pullRequestId = System.properties['GITHUB_PULLREQUESTID']
+   username = System.properties['GITHUB_USERNAME']
+   password = System.properties['GITHUB_PASSWORD']
+   oAuth2Token = System.properties['GITHUB_OAUTH2TOKEN']
+   gitHubUrl = "https://api.github.com/"
+   createCommentWithAllSingleFileComments = false
+   createSingleFileComments = true
+   commentOnlyChangedContent = true
+   minSeverity = se.bjurr.violations.lib.model.SEVERITY.INFO //ERROR, INFO, WARN
+   commentTemplate = """
+**Reporter**: {{violation.reporter}}{{#violation.rule}}
+**Rule**: {{violation.rule}}{{/violation.rule}}
+**Severity**: {{violation.severity}}
+**File**: {{violation.file}} L{{violation.startLine}}{{#violation.source}}
+**Source**: {{violation.source}}{{/violation.source}}
+{{violation.message}}
+"""
+   violations = [
+    ["CHECKSTYLE", ".", ".*/build/.*\\.xml\$", "Checkstyle"]
+   ]
 }
 
 def checkGradlePropertiesFile() {

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -326,7 +326,7 @@ task violationCommentsToGitHub(type: se.bjurr.violations.comments.github.plugin.
    commentOnlyChangedContent = true
    minSeverity = se.bjurr.violations.lib.model.SEVERITY.INFO //ERROR, INFO, WARN
    commentTemplate = """
-**Reporter**: {{violation.reporter}}{{#violation.rule}}
+**Reporter**: {{violation.reporter}}{{#violation.rule}}\n
 **Rule**: {{violation.rule}}{{/violation.rule}}
 **Severity**: {{violation.severity}}
 **File**: {{violation.file}} L{{violation.startLine}}{{#violation.source}}

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,12 @@ subprojects {
         classpath = configurations.ktlint
         args "-F", "src/**/*.kt"
     }
+
+    task ciktlint(type: JavaExec) {
+        main = "com.github.shyiko.ktlint.Main"
+        classpath = configurations.ktlint
+        args "src/**/*.kt", "--reporter=checkstyle,output=${buildDir}/ktlint.xml"
+    }
 }
 
 ext {


### PR DESCRIPTION
This plugin adds inline comments on GitHub on lint violations discovered by the checks run by the CI.

To test you can branch from here, create a new PR after having added some lint errors. I did this here: https://github.com/wordpress-mobile/WordPress-Android/pull/9365. 

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
