### PR TITLE
Revert "Code freeze: Don't add branch protection to individual release branches

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 1cfb99dcb2d7284165a6ee4fa149f1c9374db312
-  tag: 0.1.8
+  revision: a7f414b31dc383075d3489b3d9d4ec039529ef67
+  tag: 0.1.9
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.1.8)
+    fastlane-plugin-wpmreleasetoolkit (0.1.9)
       diffy
       git
       nokogiri

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -58,6 +58,7 @@ ENV[GHHELPER_REPO="wordpress-mobile/WordPress-Android"]
     old_version = android_codefreeze(options)
    
     localize_libs()
+    setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{options[:codefreeze_version]}")
     setfrozentag(repository:GHHELPER_REPO, milestone: options[:codefreeze_version])
 
     get_prs_list(repository:GHHELPER_REPO, start_tag:"release/#{old_version}", report_path:"#{File.expand_path('~')}/wpandroid_prs_list_#{old_version}_#{options[:codefreeze_version]}.txt")

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,7 +2,7 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.1.8'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.1.9'
 
 
 


### PR DESCRIPTION
This reverts https://github.com/wordpress-mobile/WordPress-Android/pull/9317 and updates the release toolkit to 0.1.9 (so the action is available).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
