### PR TITLE
Post detail activity setup

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -292,6 +292,11 @@
             android:launchMode="singleTop"
             android:theme="@style/Calypso.NoActionBar" />
         <activity
+            android:name=".ui.stats.refresh.lists.detail.StatsDetailActivity"
+            android:label="@string/stats"
+            android:launchMode="singleTop"
+            android:theme="@style/Calypso.NoActionBar" />
+        <activity
             android:name=".ui.WPWebViewActivity"
             android:theme="@style/Calypso.NoActionBar" />
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -142,6 +142,7 @@ import org.wordpress.android.ui.stats.StatsWidgetConfigureActivity;
 import org.wordpress.android.ui.stats.StatsWidgetConfigureAdapter;
 import org.wordpress.android.ui.stats.StatsWidgetProvider;
 import org.wordpress.android.ui.stats.refresh.StatsModule;
+import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailActivity;
 import org.wordpress.android.ui.stats.service.StatsServiceLogic;
 import org.wordpress.android.ui.stockmedia.StockMediaPickerActivity;
 import org.wordpress.android.ui.suggestion.adapters.SuggestionAdapter;
@@ -471,6 +472,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(PlansListAdapter object);
 
     void inject(PlanDetailsFragment object);
+
+    void inject(StatsDetailActivity object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -41,9 +41,6 @@ public abstract class ApplicationModule {
     @ContributesAndroidInjector
     abstract StatsFragment contributeStatsFragment();
 
-    @ContributesAndroidInjector
-    abstract StatsDetailActivity contributeStatsDetailActivity();
-
     @Provides
     public static WizardManager<SiteCreationStep> provideWizardManager(NewSiteCreationStepsProvider stepsProvider) {
         return new WizardManager<>(stepsProvider.getSteps());

--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -11,6 +11,7 @@ import org.wordpress.android.ui.sitecreation.SiteCreationStep;
 import org.wordpress.android.ui.stats.refresh.StatsFragment;
 import org.wordpress.android.ui.stats.refresh.StatsViewAllFragment;
 import org.wordpress.android.ui.stats.refresh.lists.StatsListFragment;
+import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailActivity;
 import org.wordpress.android.util.wizard.WizardManager;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatusLiveData;
@@ -39,6 +40,9 @@ public abstract class ApplicationModule {
 
     @ContributesAndroidInjector
     abstract StatsFragment contributeStatsFragment();
+
+    @ContributesAndroidInjector
+    abstract StatsDetailActivity contributeStatsDetailActivity();
 
     @Provides
     public static WizardManager<SiteCreationStep> provideWizardManager(NewSiteCreationStepsProvider stepsProvider) {

--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -11,7 +11,6 @@ import org.wordpress.android.ui.sitecreation.SiteCreationStep;
 import org.wordpress.android.ui.stats.refresh.StatsFragment;
 import org.wordpress.android.ui.stats.refresh.StatsViewAllFragment;
 import org.wordpress.android.ui.stats.refresh.lists.StatsListFragment;
-import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailActivity;
 import org.wordpress.android.util.wizard.WizardManager;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatusLiveData;

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -13,6 +13,7 @@ import org.wordpress.android.ui.sitecreation.segments.NewSiteCreationSegmentsVie
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationSiteInfoViewModel;
 import org.wordpress.android.ui.sitecreation.verticals.NewSiteCreationVerticalsViewModel;
 import org.wordpress.android.ui.stats.refresh.StatsViewModel;
+import org.wordpress.android.ui.stats.refresh.lists.detail.DetailListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.DaysListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.MonthsListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.WeeksListViewModel;
@@ -112,6 +113,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(YearsListViewModel.class)
     abstract ViewModel yearsTabViewModel(YearsListViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(DetailListViewModel.class)
+    abstract ViewModel statsDetailViewModel(DetailListViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -76,7 +76,6 @@ import org.wordpress.android.ui.stats.StatsViewType;
 import org.wordpress.android.ui.stats.models.StatsPostModel;
 import org.wordpress.android.ui.stats.refresh.StatsActivity;
 import org.wordpress.android.ui.stats.refresh.StatsViewAllFragment;
-import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailActivity;
 import org.wordpress.android.ui.stockmedia.StockMediaPickerActivity;
 import org.wordpress.android.ui.themes.ThemeBrowserActivity;
 import org.wordpress.android.util.AppLog;

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -76,6 +76,7 @@ import org.wordpress.android.ui.stats.StatsViewType;
 import org.wordpress.android.ui.stats.models.StatsPostModel;
 import org.wordpress.android.ui.stats.refresh.StatsActivity;
 import org.wordpress.android.ui.stats.refresh.StatsViewAllFragment;
+import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailActivity;
 import org.wordpress.android.ui.stockmedia.StockMediaPickerActivity;
 import org.wordpress.android.ui.themes.ThemeBrowserActivity;
 import org.wordpress.android.util.AppLog;
@@ -762,7 +763,6 @@ public class ActivityLauncher {
         if (post == null) {
             return;
         }
-
         Intent statsPostViewIntent = new Intent(context, StatsSingleItemDetailsActivity.class);
         statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_REMOTE_BLOG_ID, post.getBlogID());
         statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_REMOTE_ITEM_ID, post.getItemID());

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -15,6 +15,8 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DETAIL
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
 import org.wordpress.android.ui.stats.refresh.lists.UiModelMapper
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode
@@ -38,9 +40,8 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.P
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.PublicizeUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TagsAndCategoriesUseCase.TagsAndCategoriesUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TodayStatsUseCase
-import org.wordpress.android.ui.stats.refresh.utils.SelectedSectionManager
-import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
+import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -53,6 +54,9 @@ const val LIST_STATS_USE_CASES = "ListStatsUseCases"
 const val BLOCK_INSIGHTS_USE_CASES = "BlockInsightsUseCases"
 const val VIEW_ALL_INSIGHTS_USE_CASES = "ViewAllInsightsUseCases"
 const val GRANULAR_USE_CASE_FACTORIES = "GranularUseCaseFactories"
+const val DETAIL_USE_CASE = "DetailUseCase"
+// These are injected only internally
+private const val DETAIL_USE_CASES = "DetailUseCases"
 
 /**
  * Module that provides use cases for Stats.
@@ -149,6 +153,16 @@ class StatsModule {
                 overviewUseCaseFactory
         )
     }
+    /**
+     * Provides a list of use cases for the Post detail screen in Stats. Modify this method when you want to add more
+     * blocks to the post detail screen.
+     */
+    @Provides
+    @Singleton
+    @Named(DETAIL_USE_CASES)
+    fun provideDetailUseCases(): List<@JvmSuppressWildcards BaseStatsUseCase<*, *>> {
+        return listOf()
+    }
 
     /**
      * Provides a singleton usecase that represents the Insights screen. It consists of list of use cases that build
@@ -161,7 +175,6 @@ class StatsModule {
         statsStore: StatsStore,
         @Named(BG_THREAD) bgDispatcher: CoroutineDispatcher,
         @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
-        statsSectionManager: SelectedSectionManager,
         selectedDateProvider: SelectedDateProvider,
         statsDateFormatter: StatsDateFormatter,
         statsSiteProvider: StatsSiteProvider,
@@ -171,7 +184,7 @@ class StatsModule {
         return BaseListUseCase(
                 bgDispatcher,
                 mainDispatcher,
-                statsSectionManager,
+                INSIGHTS,
                 selectedDateProvider,
                 statsDateFormatter,
                 statsSiteProvider,
@@ -192,7 +205,6 @@ class StatsModule {
         statsStore: StatsStore,
         @Named(BG_THREAD) bgDispatcher: CoroutineDispatcher,
         @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
-        statsSectionManager: SelectedSectionManager,
         selectedDateProvider: SelectedDateProvider,
         statsDateFormatter: StatsDateFormatter,
         statsSiteProvider: StatsSiteProvider,
@@ -202,7 +214,7 @@ class StatsModule {
         return BaseListUseCase(
                 bgDispatcher,
                 mainDispatcher,
-                statsSectionManager,
+                StatsSection.DAYS,
                 selectedDateProvider,
                 statsDateFormatter,
                 statsSiteProvider,
@@ -223,7 +235,6 @@ class StatsModule {
         statsStore: StatsStore,
         @Named(BG_THREAD) bgDispatcher: CoroutineDispatcher,
         @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
-        statsSectionManager: SelectedSectionManager,
         selectedDateProvider: SelectedDateProvider,
         statsDateFormatter: StatsDateFormatter,
         statsSiteProvider: StatsSiteProvider,
@@ -233,7 +244,7 @@ class StatsModule {
         return BaseListUseCase(
                 bgDispatcher,
                 mainDispatcher,
-                statsSectionManager,
+                StatsSection.WEEKS,
                 selectedDateProvider,
                 statsDateFormatter,
                 statsSiteProvider,
@@ -254,7 +265,6 @@ class StatsModule {
         statsStore: StatsStore,
         @Named(BG_THREAD) bgDispatcher: CoroutineDispatcher,
         @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
-        statsSectionManager: SelectedSectionManager,
         selectedDateProvider: SelectedDateProvider,
         statsSiteProvider: StatsSiteProvider,
         statsDateFormatter: StatsDateFormatter,
@@ -263,7 +273,7 @@ class StatsModule {
     ): BaseListUseCase {
         return BaseListUseCase(
                 bgDispatcher, mainDispatcher,
-                statsSectionManager,
+                StatsSection.MONTHS,
                 selectedDateProvider,
                 statsDateFormatter,
                 statsSiteProvider,
@@ -284,7 +294,6 @@ class StatsModule {
         statsStore: StatsStore,
         @Named(BG_THREAD) bgDispatcher: CoroutineDispatcher,
         @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
-        statsSectionManager: SelectedSectionManager,
         selectedDateProvider: SelectedDateProvider,
         statsSiteProvider: StatsSiteProvider,
         statsDateFormatter: StatsDateFormatter,
@@ -294,7 +303,7 @@ class StatsModule {
         return BaseListUseCase(
                 bgDispatcher,
                 mainDispatcher,
-                statsSectionManager,
+                StatsSection.YEARS,
                 selectedDateProvider,
                 statsDateFormatter,
                 statsSiteProvider,
@@ -323,6 +332,36 @@ class StatsModule {
                 StatsSection.WEEKS to weekStatsUseCase,
                 StatsSection.MONTHS to monthStatsUseCase,
                 StatsSection.YEARS to yearStatsUseCase
+        )
+    }
+
+    /**
+     * Provides a singleton usecase that represents the Year stats screen.
+     * @param useCases build the use cases for the YEARS granularity
+     */
+    @Provides
+    @Singleton
+    @Named(DETAIL_USE_CASE)
+    fun provideDetailStatsUseCase(
+        statsStore: StatsStore,
+        @Named(BG_THREAD) bgDispatcher: CoroutineDispatcher,
+        @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
+        selectedDateProvider: SelectedDateProvider,
+        statsDateFormatter: StatsDateFormatter,
+        statsSiteProvider: StatsSiteProvider,
+        @Named(DETAIL_USE_CASES) useCases: List<@JvmSuppressWildcards BaseStatsUseCase<*, *>>,
+        uiModelMapper: UiModelMapper
+    ): BaseListUseCase {
+        return BaseListUseCase(
+                bgDispatcher,
+                mainDispatcher,
+                DETAIL,
+                selectedDateProvider,
+                statsDateFormatter,
+                statsSiteProvider,
+                useCases,
+                { statsStore.getInsights() },
+                uiModelMapper::mapInsights
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -13,14 +13,18 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_PERIOD_MONTHS
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_PERIOD_WEEKS_ACCESSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_PERIOD_YEARS_ACCESSED
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.pages.PageItem.Action
 import org.wordpress.android.ui.pages.PageItem.Page
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DAYS
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.MONTHS
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.WEEKS
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.YEARS
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.utils.SelectedSectionManager
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
@@ -82,7 +86,7 @@ class StatsViewModel
                 analyticsTracker.track(AnalyticsTracker.Stat.STATS_WIDGET_TAPPED, site)
             }
         }
-        listUseCases.values.forEach { it.updateDateSelector(statsSectionManager.getSelectedStatsGranularity()) }
+        listUseCases.values.forEach { it.updateDateSelector(statsSectionManager.getSelectedSection()) }
     }
 
     private fun CoroutineScope.loadData(executeLoading: suspend () -> Unit) = launch {
@@ -117,9 +121,9 @@ class StatsViewModel
         }
     }
 
-    fun onSelectedDateChange(statsGranularity: StatsGranularity) {
+    fun onSelectedDateChange(statsSection: StatsSection) {
         launch {
-            listUseCases[statsGranularity.toStatsSection()]?.onDateChanged(statsGranularity)
+            listUseCases[statsSection]?.onDateChanged(statsSection)
         }
     }
 
@@ -127,14 +131,16 @@ class StatsViewModel
 
     fun onSectionSelected(statsSection: StatsSection) {
         statsSectionManager.setSelectedSection(statsSection)
-        listUseCases[statsSection]?.updateDateSelector(statsSectionManager.getSelectedStatsGranularity())
+        listUseCases[statsSection]?.updateDateSelector(statsSection)
         _toolbarHasShadow.value = statsSection == INSIGHTS
         when (statsSection) {
-            StatsSection.INSIGHTS -> analyticsTracker.track(STATS_INSIGHTS_ACCESSED)
-            StatsSection.DAYS -> analyticsTracker.track(STATS_PERIOD_DAYS_ACCESSED)
-            StatsSection.WEEKS -> analyticsTracker.track(STATS_PERIOD_WEEKS_ACCESSED)
-            StatsSection.MONTHS -> analyticsTracker.track(STATS_PERIOD_MONTHS_ACCESSED)
-            StatsSection.YEARS -> analyticsTracker.track(STATS_PERIOD_YEARS_ACCESSED)
+            INSIGHTS -> analyticsTracker.track(STATS_INSIGHTS_ACCESSED)
+            DAYS -> analyticsTracker.track(STATS_PERIOD_DAYS_ACCESSED)
+            WEEKS -> analyticsTracker.track(STATS_PERIOD_WEEKS_ACCESSED)
+            MONTHS -> analyticsTracker.track(STATS_PERIOD_MONTHS_ACCESSED)
+            YEARS -> analyticsTracker.track(STATS_PERIOD_YEARS_ACCESSED)
+            DETAIL -> {
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -28,7 +28,6 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSect
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.utils.SelectedSectionManager
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
-import org.wordpress.android.ui.stats.refresh.utils.toStatsSection
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.mapNullable
@@ -86,7 +85,7 @@ class StatsViewModel
                 analyticsTracker.track(AnalyticsTracker.Stat.STATS_WIDGET_TAPPED, site)
             }
         }
-        listUseCases.values.forEach { it.updateDateSelector(statsSectionManager.getSelectedSection()) }
+        listUseCases.values.forEach { it.updateDateSelector() }
     }
 
     private fun CoroutineScope.loadData(executeLoading: suspend () -> Unit) = launch {
@@ -123,7 +122,7 @@ class StatsViewModel
 
     fun onSelectedDateChange(statsSection: StatsSection) {
         launch {
-            listUseCases[statsSection]?.onDateChanged(statsSection)
+            listUseCases[statsSection]?.onDateChanged()
         }
     }
 
@@ -131,7 +130,7 @@ class StatsViewModel
 
     fun onSectionSelected(statsSection: StatsSection) {
         statsSectionManager.setSelectedSection(statsSection)
-        listUseCases[statsSection]?.updateDateSelector(statsSection)
+        listUseCases[statsSection]?.updateDateSelector()
         _toolbarHasShadow.value = statsSection == INSIGHTS
         when (statsSection) {
             INSIGHTS -> analyticsTracker.track(STATS_INSIGHTS_ACCESSED)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
@@ -23,7 +23,6 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
-import org.wordpress.android.ui.stats.refresh.utils.SelectedSectionManager
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.DistinctMutableLiveData
@@ -36,7 +35,7 @@ import org.wordpress.android.util.mergeNotNull
 class BaseListUseCase(
     private val bgDispatcher: CoroutineDispatcher,
     private val mainDispatcher: CoroutineDispatcher,
-    private val statsSectionManager: SelectedSectionManager,
+    private val statsSection: StatsSection,
     private val selectedDateProvider: SelectedDateProvider,
     private val statsDateFormatter: StatsDateFormatter,
     private val statsSiteProvider: StatsSiteProvider,
@@ -108,12 +107,12 @@ class BaseListUseCase(
         data.value = null
     }
 
-    suspend fun onDateChanged(statsSection: StatsSection) {
-        updateDateSelector(statsSection)
+    suspend fun onDateChanged() {
+        updateDateSelector()
         refreshData()
     }
 
-    fun updateDateSelector(statsSection: StatsSection) {
+    fun updateDateSelector() {
         val shouldShowDateSelection = statsSection != INSIGHTS
 
         val updatedDate = getDateLabelForSection(statsSection)
@@ -161,10 +160,10 @@ class BaseListUseCase(
     }
 
     fun onNextDateSelected() {
-        selectedDateProvider.selectNextDate(statsSectionManager.getSelectedSection())
+        selectedDateProvider.selectNextDate(statsSection)
     }
 
     fun onPreviousDateSelected() {
-        selectedDateProvider.selectPreviousDate(statsSectionManager.getSelectedSection())
+        selectedDateProvider.selectPreviousDate(statsSection)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
@@ -24,8 +24,8 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.utils.SelectedSectionManager
-import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
+import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.DistinctMutableLiveData
 import org.wordpress.android.util.PackageUtils
 import org.wordpress.android.util.combineMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.stats.refresh.StatsListItemDecoration
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel
+import org.wordpress.android.ui.stats.refresh.lists.detail.DetailListViewModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.DaysListViewModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.MonthsListViewModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.WeeksListViewModel
@@ -126,6 +127,7 @@ class StatsListFragment : DaggerFragment() {
         val statsSection = arguments?.getSerializable(typeKey) as StatsSection
 
         val viewModelClass = when (statsSection) {
+            StatsSection.DETAIL -> DetailListViewModel::class.java
             StatsSection.INSIGHTS -> InsightsListViewModel::class.java
             StatsSection.DAYS -> DaysListViewModel::class.java
             StatsSection.WEEKS -> WeeksListViewModel::class.java

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -31,7 +31,8 @@ abstract class StatsListViewModel(
         DAYS(R.string.stats_timeframe_days),
         WEEKS(R.string.stats_timeframe_weeks),
         MONTHS(R.string.stats_timeframe_months),
-        YEARS(R.string.stats_timeframe_years);
+        YEARS(R.string.stats_timeframe_years),
+        DETAIL(R.string.stats);
     }
 
     val navigationTarget: LiveData<NavigationTarget> = statsUseCase.navigationTarget

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/DetailListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/DetailListViewModel.kt
@@ -1,10 +1,13 @@
 package org.wordpress.android.ui.stats.refresh.lists.detail
 
 import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.ui.stats.refresh.INSIGHTS_USE_CASE
+import org.wordpress.android.ui.stats.refresh.DETAIL_USE_CASE
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel
+import org.wordpress.android.ui.stats.refresh.utils.StatsPostProvider
+import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
 import javax.inject.Named
@@ -12,6 +15,19 @@ import javax.inject.Named
 class DetailListViewModel
 @Inject constructor(
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
-    @Named(INSIGHTS_USE_CASE) private val insightsUseCase: BaseListUseCase,
-    analyticsTracker: AnalyticsTrackerWrapper
-) : StatsListViewModel(mainDispatcher, insightsUseCase, analyticsTracker)
+    @Named(DETAIL_USE_CASE) private val insightsUseCase: BaseListUseCase,
+    analyticsTracker: AnalyticsTrackerWrapper,
+    private val statsSiteProvider: StatsSiteProvider,
+    private val statsPostProvider: StatsPostProvider
+) : StatsListViewModel(mainDispatcher, insightsUseCase, analyticsTracker) {
+    fun init(
+        site: SiteModel,
+        postId: String,
+        postType: String,
+        postTitle: String,
+        postUrl: String?
+    ) {
+        statsSiteProvider.start(site)
+        statsPostProvider.init(postId, postType, postTitle, postUrl)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/DetailListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/DetailListViewModel.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.ui.stats.refresh.lists.detail
+
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.stats.refresh.INSIGHTS_USE_CASE
+import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import javax.inject.Inject
+import javax.inject.Named
+
+class DetailListViewModel
+@Inject constructor(
+    @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
+    @Named(INSIGHTS_USE_CASE) private val insightsUseCase: BaseListUseCase,
+    analyticsTracker: AnalyticsTrackerWrapper
+) : StatsListViewModel(mainDispatcher, insightsUseCase, analyticsTracker)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
@@ -1,22 +1,31 @@
 package org.wordpress.android.ui.stats.refresh.lists.detail
 
+import android.arch.lifecycle.ViewModelProvider
+import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
+import dagger.android.AndroidInjection
 import kotlinx.android.synthetic.main.toolbar.*
 import org.wordpress.android.R
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
+import javax.inject.Inject
 
 class StatsDetailActivity : AppCompatActivity() {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        AndroidInjection.inject(this)
 
         setContentView(R.layout.stats_detail_activity)
-
         setSupportActionBar(toolbar)
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)
         }
+        val viewModel = ViewModelProviders.of(this, viewModelFactory)
+                .get(StatsSection.DETAIL.name, DetailListViewModel::class.java)
+
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
@@ -1,0 +1,29 @@
+package org.wordpress.android.ui.stats.refresh.lists.detail
+
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import android.view.MenuItem
+import kotlinx.android.synthetic.main.toolbar.*
+import org.wordpress.android.R
+
+class StatsDetailActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(R.layout.stats_detail_activity)
+
+        setSupportActionBar(toolbar)
+        supportActionBar?.let {
+            it.setHomeButtonEnabled(true)
+            it.setDisplayHomeAsUpEnabled(true)
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            onBackPressed()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
@@ -2,20 +2,29 @@ package org.wordpress.android.ui.stats.refresh.lists.detail
 
 import android.arch.lifecycle.ViewModelProvider
 import android.arch.lifecycle.ViewModelProviders
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
-import dagger.android.AndroidInjection
 import kotlinx.android.synthetic.main.toolbar.*
 import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.stats.refresh.lists.StatsListFragment
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import javax.inject.Inject
+
+private const val POST_ID = "POST_ID"
+private const val POST_TYPE = "POST_ID"
+private const val POST_TITLE = "POST_TITLE"
+private const val POST_URL = "POST_URL"
 
 class StatsDetailActivity : AppCompatActivity() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        AndroidInjection.inject(this)
+        (application as WordPress).component().inject(this)
 
         setContentView(R.layout.stats_detail_activity)
         setSupportActionBar(toolbar)
@@ -23,9 +32,22 @@ class StatsDetailActivity : AppCompatActivity() {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)
         }
+
+        val site = intent?.getSerializableExtra(WordPress.SITE) as SiteModel?
+        val postId = intent?.getSerializableExtra(POST_ID) as String?
+        val postType = intent?.getSerializableExtra(POST_TYPE) as String?
+        val postTitle = intent?.getSerializableExtra(POST_TITLE) as String?
+        val postUrl = intent?.getSerializableExtra(POST_URL) as String?
+
         val viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get(StatsSection.DETAIL.name, DetailListViewModel::class.java)
-
+        viewModel.init(
+                checkNotNull(site),
+                checkNotNull(postId),
+                checkNotNull(postType),
+                checkNotNull(postTitle),
+                postUrl
+        )
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -34,5 +56,27 @@ class StatsDetailActivity : AppCompatActivity() {
             return true
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    companion object {
+        fun start(
+            context: Context,
+            site: SiteModel,
+            postId: String,
+            postType: String,
+            postTitle: String,
+            postUrl: String?
+        ) {
+            val statsPostViewIntent = Intent(context, StatsDetailActivity::class.java)
+            statsPostViewIntent.putExtra(WordPress.SITE, site)
+            statsPostViewIntent.putExtra(POST_ID, postId)
+            statsPostViewIntent.putExtra(POST_TYPE, postType)
+            statsPostViewIntent.putExtra(POST_TITLE, postTitle)
+            statsPostViewIntent.putExtra(StatsListFragment.LIST_TYPE, StatsSection.DETAIL)
+            if (postUrl != null) {
+                statsPostViewIntent.putExtra(POST_URL, postUrl)
+            }
+            context.startActivity(statsPostViewIntent)
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
 import javax.inject.Inject
 
@@ -15,7 +16,8 @@ const val SELECTED_SECTION_KEY = "SELECTED_STATS_SECTION_KEY"
 class SelectedSectionManager
 @Inject constructor(private val sharedPrefs: SharedPreferences) {
     fun getSelectedSection(): StatsSection {
-        return StatsSection.valueOf(sharedPrefs.getString(SELECTED_SECTION_KEY, StatsSection.INSIGHTS.name))
+        val value = sharedPrefs.getString(SELECTED_SECTION_KEY, StatsSection.INSIGHTS.name)
+        return value?.let { StatsSection.valueOf(value) } ?: StatsSection.INSIGHTS
     }
 
     fun getSelectedStatsGranularity(): StatsGranularity? {
@@ -29,7 +31,7 @@ class SelectedSectionManager
 
 fun StatsSection.toStatsGranularity(): StatsGranularity? {
     return when (this) {
-        INSIGHTS -> null
+        DETAIL, INSIGHTS -> null
         StatsSection.DAYS -> DAYS
         StatsSection.WEEKS -> WEEKS
         StatsSection.MONTHS -> MONTHS

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.ui.stats.StatsViewType.FOLLOWERS
 import org.wordpress.android.ui.stats.StatsViewType.REFERRERS
 import org.wordpress.android.ui.stats.StatsViewType.TAGS_AND_CATEGORIES
 import org.wordpress.android.ui.stats.StatsViewType.TOP_POSTS_AND_PAGES
-import org.wordpress.android.ui.stats.models.StatsPostModel
 import org.wordpress.android.ui.stats.refresh.NavigationTarget
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.AddNewPost
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.SharePost
@@ -36,6 +35,7 @@ import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTag
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTagsAndCategoriesStats
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewUrl
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewVideoPlays
+import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailActivity
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -67,14 +67,13 @@ class StatsNavigator
                 }
             }
             is ViewPostDetailStats -> {
-                val postModel = StatsPostModel(
-                        siteProvider.siteModel.siteId,
+                StatsDetailActivity.start(
+                        activity,
+                        siteProvider.siteModel,
                         target.postId,
                         target.postTitle,
-                        target.postUrl,
-                        target.postType
-                )
-                ActivityLauncher.viewStatsSinglePostDetails(activity, postModel)
+                        target.postType,
+                        target.postUrl)
             }
             is ViewFollowersStats -> {
                 ActivityLauncher.viewAllTabbedInsightsStats(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsPostProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsPostProvider.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.ui.stats.refresh.utils
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class StatsPostProvider
+@Inject constructor() {
+    private lateinit var postId: String
+    private lateinit var postType: String
+    private lateinit var postTitle: String
+    private var postUrl: String? = null
+    fun init(postId: String, postType: String, postTitle: String, postUrl: String?) {
+        this.postId = postId
+        this.postType = postType
+        this.postTitle = postTitle
+        this.postUrl = postUrl
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsSiteProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsSiteProvider.kt
@@ -15,11 +15,15 @@ import javax.inject.Singleton
 class StatsSiteProvider
 @Inject constructor(private val siteStore: SiteStore, private val dispatcher: Dispatcher) {
     lateinit var siteModel: SiteModel
+    private var initialized = false
     private val mutableSiteChanged = SingleLiveEvent<OnSiteChanged>()
     val siteChanged: LiveData<OnSiteChanged> = mutableSiteChanged
 
     fun start(site: SiteModel) {
-        dispatcher.register(this)
+        if (!initialized) {
+            dispatcher.register(this)
+            initialized = true
+        }
         this.siteModel = site
     }
 
@@ -30,7 +34,10 @@ class StatsSiteProvider
     }
 
     fun stop() {
-        dispatcher.unregister(this)
+        if (initialized) {
+            dispatcher.unregister(this)
+            initialized = false
+        }
     }
 
     fun hasLoadedSite(): Boolean = siteModel.siteId != 0L

--- a/WordPress/src/main/res/layout/stats_detail_activity.xml
+++ b/WordPress/src/main/res/layout/stats_detail_activity.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/coordinator"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <fragment
+        android:id="@+id/fragment_container"
+        android:name="org.wordpress.android.ui.stats.refresh.lists.StatsListFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+</FrameLayout>

--- a/WordPress/src/main/res/layout/stats_detail_activity.xml
+++ b/WordPress/src/main/res/layout/stats_detail_activity.xml
@@ -1,14 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<android.support.constraint.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/coordinator"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/constraintLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <fragment
-        android:id="@+id/fragment_container"
-        android:name="org.wordpress.android.ui.stats.refresh.lists.StatsListFragment"
+    <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/coordinatorLayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent">
 
-</FrameLayout>
+        <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
+            android:id="@+id/pullToRefresh"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/white"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+            <fragment
+                android:id="@+id/fragment_container"
+                android:name="org.wordpress.android.ui.stats.refresh.lists.StatsListFragment"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"/>
+
+        </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
+
+        <android.support.design.widget.AppBarLayout
+            android:id="@+id/app_bar_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:animateLayoutChanges="true"
+            android:fitsSystemWindows="true">
+
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:layout_collapseMode="pin"
+                app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+                app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+                app:title="@string/stats"/>
+
+            <android.support.design.widget.TabLayout
+                android:id="@+id/tabLayout"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:layout_gravity="start"
+                android:background="@color/color_primary"
+                android:visibility="gone"
+                app:tabGravity="fill"
+                app:tabIndicatorColor="@color/white"
+                app:tabMode="scrollable"
+                app:tabPaddingEnd="16dp"
+                app:tabPaddingStart="16dp"
+                app:tabSelectedTextColor="@color/white"
+                app:tabTextColor="@color/white"
+                app:theme="@style/Base.Widget.Design.TabLayout"/>
+
+        </android.support.design.widget.AppBarLayout>
+
+    </android.support.design.widget.CoordinatorLayout>
+
+</android.support.constraint.ConstraintLayout>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.stats.refresh
 
 import android.arch.lifecycle.MutableLiveData
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
@@ -15,7 +16,6 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_PERIOD_MONTHS
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_PERIOD_WEEKS_ACCESSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_PERIOD_YEARS_ACCESSED
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DAYS
@@ -103,19 +103,19 @@ class StatsViewModelTest : BaseUnitTest() {
     fun `updates date selector on insights screen`() {
         viewModel.onSectionSelected(INSIGHTS)
 
-        verify(baseListUseCase).updateDateSelector(null)
+        verify(baseListUseCase).updateDateSelector(INSIGHTS)
     }
 
     @Test
     fun `updates date selector on date change`() {
-        val statsGranularity = StatsGranularity.DAYS
+        val statsSection = StatsSection.DAYS
 
-        whenever(statsSectionManager.getSelectedStatsGranularity()).thenReturn(statsGranularity)
+        whenever(statsSectionManager.getSelectedSection()).thenReturn(statsSection)
 
         viewModel.onSectionSelected(DAYS)
 
-        viewModel.onSelectedDateChange(statsGranularity)
+        viewModel.onSelectedDateChange(statsSection)
 
-        verify(baseListUseCase).updateDateSelector(StatsGranularity.DAYS)
+        verify(baseListUseCase).updateDateSelector(statsSection)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.stats.refresh
 
 import android.arch.lifecycle.MutableLiveData
-import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
@@ -109,8 +108,6 @@ class StatsViewModelTest : BaseUnitTest() {
     @Test
     fun `updates date selector on date change`() {
         val statsSection = StatsSection.DAYS
-
-        whenever(statsSectionManager.getSelectedSection()).thenReturn(statsSection)
 
         viewModel.onSectionSelected(DAYS)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.stats.refresh
 
 import android.arch.lifecycle.MutableLiveData
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
@@ -102,7 +103,7 @@ class StatsViewModelTest : BaseUnitTest() {
     fun `updates date selector on insights screen`() {
         viewModel.onSectionSelected(INSIGHTS)
 
-        verify(baseListUseCase).updateDateSelector(INSIGHTS)
+        verify(baseListUseCase).updateDateSelector()
     }
 
     @Test
@@ -113,6 +114,6 @@ class StatsViewModelTest : BaseUnitTest() {
 
         viewModel.onSelectedDateChange(statsSection)
 
-        verify(baseListUseCase).updateDateSelector(statsSection)
+        verify(baseListUseCase, times(2)).updateDateSelector()
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCaseTest.kt
@@ -9,8 +9,10 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.utils.SelectedSectionManager
@@ -39,7 +41,7 @@ class BaseListUseCaseTest : BaseUnitTest() {
                 { listOf() },
                 { _, _ -> UiModel.Error() }
         )
-        whenever(selectedDateProvider.getSelectedDate(any())).thenReturn(selectedDate)
+        whenever(selectedDateProvider.getSelectedDate(any<StatsSection>())).thenReturn(selectedDate)
         whenever(statsDateFormatter.printGranularDate(eq(selectedDate), any())).thenReturn(selectedDateLabel)
     }
 
@@ -48,7 +50,7 @@ class BaseListUseCaseTest : BaseUnitTest() {
         var model: DateSelectorUiModel? = null
         useCase.showDateSelector.observeForever { model = it }
 
-        useCase.updateDateSelector(null)
+        useCase.updateDateSelector(INSIGHTS)
 
         Assertions.assertThat(model).isNotNull
         Assertions.assertThat(model?.isVisible).isFalse()
@@ -59,28 +61,28 @@ class BaseListUseCaseTest : BaseUnitTest() {
         val models = mutableListOf<DateSelectorUiModel>()
         useCase.showDateSelector.observeForever { model -> model?.let { models.add(it) } }
 
-        useCase.updateDateSelector(null)
+        useCase.updateDateSelector(INSIGHTS)
 
         Assertions.assertThat(models).hasSize(1)
 
-        useCase.updateDateSelector(null)
+        useCase.updateDateSelector(INSIGHTS)
 
         Assertions.assertThat(models).hasSize(1)
     }
 
     @Test
     fun `shows date selector on days screen`() {
-        val statsGranularity = StatsGranularity.DAYS
+        val statsSection = StatsSection.DAYS
         val selectedDate = Date(0)
         val label = "Jan 1"
-        whenever(selectedDateProvider.getSelectedDate(statsGranularity)).thenReturn(selectedDate)
-        whenever(statsDateFormatter.printGranularDate(selectedDate, statsGranularity)).thenReturn(label)
-        whenever(selectedDateProvider.hasPreviousDate(statsGranularity)).thenReturn(true)
-        whenever(selectedDateProvider.hasNextData(statsGranularity)).thenReturn(true)
+        whenever(selectedDateProvider.getSelectedDate(statsSection)).thenReturn(selectedDate)
+        whenever(statsDateFormatter.printGranularDate(selectedDate, DAYS)).thenReturn(label)
+        whenever(selectedDateProvider.hasPreviousDate(statsSection)).thenReturn(true)
+        whenever(selectedDateProvider.hasNextData(statsSection)).thenReturn(true)
         var model: DateSelectorUiModel? = null
         useCase.showDateSelector.observeForever { model = it }
 
-        useCase.updateDateSelector(StatsGranularity.DAYS)
+        useCase.updateDateSelector(statsSection)
 
         Assertions.assertThat(model).isNotNull
         Assertions.assertThat(model?.isVisible).isTrue()
@@ -91,22 +93,22 @@ class BaseListUseCaseTest : BaseUnitTest() {
 
     @Test
     fun `updates date selector on date change`() {
-        val statsGranularity = StatsGranularity.DAYS
+        val statsSection = StatsSection.DAYS
         val updatedDate = Date(10)
         val updatedLabel = "Jan 2"
-        whenever(statsDateFormatter.printGranularDate(updatedDate, statsGranularity)).thenReturn(updatedLabel)
-        whenever(selectedDateProvider.hasPreviousDate(statsGranularity)).thenReturn(true)
-        whenever(selectedDateProvider.hasNextData(statsGranularity)).thenReturn(true)
+        whenever(statsDateFormatter.printGranularDate(updatedDate, DAYS)).thenReturn(updatedLabel)
+        whenever(selectedDateProvider.hasPreviousDate(statsSection)).thenReturn(true)
+        whenever(selectedDateProvider.hasNextData(statsSection)).thenReturn(true)
         var model: DateSelectorUiModel? = null
         useCase.showDateSelector.observeForever { model = it }
 
-        useCase.updateDateSelector(statsGranularity)
+        useCase.updateDateSelector(statsSection)
 
         Assertions.assertThat(model?.date).isEqualTo(selectedDateLabel)
 
-        whenever(selectedDateProvider.getSelectedDate(statsGranularity)).thenReturn(updatedDate)
+        whenever(selectedDateProvider.getSelectedDate(statsSection)).thenReturn(updatedDate)
 
-        useCase.updateDateSelector(statsGranularity)
+        useCase.updateDateSelector(statsSection)
 
         Assertions.assertThat(model?.date).isEqualTo(updatedLabel)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCaseTest.kt
@@ -12,16 +12,13 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
-import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
-import org.wordpress.android.ui.stats.refresh.utils.SelectedSectionManager
-import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
+import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import java.util.Date
 
 class BaseListUseCaseTest : BaseUnitTest() {
-    @Mock lateinit var statsSectionManager: SelectedSectionManager
     @Mock lateinit var selectedDateProvider: SelectedDateProvider
     @Mock lateinit var statsDateFormatter: StatsDateFormatter
     @Mock lateinit var statsSiteProvider: StatsSiteProvider
@@ -33,7 +30,7 @@ class BaseListUseCaseTest : BaseUnitTest() {
         useCase = BaseListUseCase(
                 Dispatchers.Unconfined,
                 Dispatchers.Unconfined,
-                statsSectionManager,
+                StatsSection.DAYS,
                 selectedDateProvider,
                 statsDateFormatter,
                 statsSiteProvider,
@@ -47,10 +44,21 @@ class BaseListUseCaseTest : BaseUnitTest() {
 
     @Test
     fun `hides date selector on insights screen`() {
+        useCase = BaseListUseCase(
+                Dispatchers.Unconfined,
+                Dispatchers.Unconfined,
+                StatsSection.INSIGHTS,
+                selectedDateProvider,
+                statsDateFormatter,
+                statsSiteProvider,
+                listOf(),
+                { listOf() },
+                { _, _ -> UiModel.Error() }
+        )
         var model: DateSelectorUiModel? = null
         useCase.showDateSelector.observeForever { model = it }
 
-        useCase.updateDateSelector(INSIGHTS)
+        useCase.updateDateSelector()
 
         Assertions.assertThat(model).isNotNull
         Assertions.assertThat(model?.isVisible).isFalse()
@@ -61,11 +69,11 @@ class BaseListUseCaseTest : BaseUnitTest() {
         val models = mutableListOf<DateSelectorUiModel>()
         useCase.showDateSelector.observeForever { model -> model?.let { models.add(it) } }
 
-        useCase.updateDateSelector(INSIGHTS)
+        useCase.updateDateSelector()
 
         Assertions.assertThat(models).hasSize(1)
 
-        useCase.updateDateSelector(INSIGHTS)
+        useCase.updateDateSelector()
 
         Assertions.assertThat(models).hasSize(1)
     }
@@ -82,7 +90,7 @@ class BaseListUseCaseTest : BaseUnitTest() {
         var model: DateSelectorUiModel? = null
         useCase.showDateSelector.observeForever { model = it }
 
-        useCase.updateDateSelector(statsSection)
+        useCase.updateDateSelector()
 
         Assertions.assertThat(model).isNotNull
         Assertions.assertThat(model?.isVisible).isTrue()
@@ -102,13 +110,13 @@ class BaseListUseCaseTest : BaseUnitTest() {
         var model: DateSelectorUiModel? = null
         useCase.showDateSelector.observeForever { model = it }
 
-        useCase.updateDateSelector(statsSection)
+        useCase.updateDateSelector()
 
         Assertions.assertThat(model?.date).isEqualTo(selectedDateLabel)
 
         whenever(selectedDateProvider.getSelectedDate(statsSection)).thenReturn(updatedDate)
 
-        useCase.updateDateSelector(statsSection)
+        useCase.updateDateSelector()
 
         Assertions.assertThat(model?.date).isEqualTo(updatedLabel)
     }


### PR DESCRIPTION
Fixes #9384

This PR adds an empty Post detail activity. You can find it when you go to Stats/DWMY/Posts and Pages block and click on any post. The empty activity contains an empty date selector and nothing else.

To test:
* Go to Stats/DWMY/Posts and Pages
* Click on a post
* A new empty activity opens in a new screen
* Back button works
