### PR TITLE
Update to new FluxC interceptor usage for Stetho

### DIFF
--- a/WordPress/src/debug/java/org/wordpress/android/modules/InterceptorModule.java
+++ b/WordPress/src/debug/java/org/wordpress/android/modules/InterceptorModule.java
@@ -2,14 +2,17 @@ package org.wordpress.android.modules;
 
 import com.facebook.stetho.okhttp3.StethoInterceptor;
 
+import javax.inject.Named;
+
 import dagger.Module;
 import dagger.Provides;
+import dagger.multibindings.IntoSet;
 import okhttp3.Interceptor;
 
 @Module
 public class InterceptorModule {
-    @Provides
-    public Interceptor provideNetworkInterceptor() {
+    @Provides @IntoSet @Named("network-interceptors")
+    public Interceptor provideStethoInterceptor() {
         return new StethoInterceptor();
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -104,5 +104,5 @@ buildScan {
 }
 
 ext {
-    fluxCVersion = 'df65f093c45907103bf59b73b8927827feb1f564'
+    fluxCVersion = 'cfafbfec81e337e7fdfb97dc985d25095effaea9'
 }


### PR DESCRIPTION
Updates our usage of Stetho to follow the injection style added to FluxC in 
https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1155 - that PR should be reviewed and merged before this one.

### Mocking network responses from tests

The ultimate purpose of this is to allow Android tests to mock network responses by replacing requests to `public-api.wordpress.com` from FluxC with a URL supplying mocked responses. This work isn't contained in this PR and will require some changes to the Dagger setup of the tests, but I set up [this branch](https://github.com/wordpress-mobile/WordPress-Android/tree/demo/fluxc-host-overwrite) with a proof of concept.

In that branch (see 4faabb7705a48c30feef4ec8a5e6c35a9f23b720), all calls to `public-api.wordpress.com` in a debug build of the app are replaced with `do.wpmt.co`. This coexists with Stetho, so to test:

1. Build `demo/fluxc-host-overwrite` and run the app
2. Open chrome://inspect from your computer and open the appropriate instance of the app on the device
3. Make some network requests and verify that all `public-api.wordpress.com` requests are being sent to `do.wpmt.co` instead

(cc @jtreanor)

## To test:

There should be no behavior changes. To test Stetho is still working:

1. With the app running this branch, open chrome://inspect from your computer and open the appropriate instance of the app on the device.
2. Visit the Network tab and make sure you're seeing networking traffic

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
