### PR TITLE
build-apk-core.sh: Only print logs on error

### DIFF
--- a/tools/build-apk-core.sh
+++ b/tools/build-apk-core.sh
@@ -6,7 +6,7 @@ set -eu
 function cleanup {
   cat "$LOGFILE"
 }
-trap cleanup EXIT
+trap cleanup ERR
 
 # This script defines some shared functions that are used by the build-apk* set.
 


### PR DESCRIPTION
This is a very small change to improve the ones I made in https://github.com/wordpress-mobile/WordPress-Android/pull/8995. Currently, the log is printed after every build. This change means it is only printed on failed builds.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
