### PR TITLE
Update contribution guide to add a note for addressing existing issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Here's a quick guide to create a pull request for your WordPress-Android patch:
 
 4. Setup your build environment (see [build instructions in our README][build-instructions]) and start hacking the project. You must follow our [code style guidelines][style], write good commit messages, comment your code and write automated tests.
 
-5. When your patch is ready, [submit a pull request][pr]. Add some comments or screen shots to help us.
+5. When your patch is ready, [submit a pull request][pr]. Make sure the pull request addresses one of our existing issues and its description refers to that issue. Add some comments or screen shots to help us.
 
 6. Wait for us to review your pull request. If something is wrong or if we want you to make some changes before the merge, we'll let you know through commit comments or pull request comments.
 


### PR DESCRIPTION
Adds a note to our contribution guidelines for making sure the PRs address existing issues and don't tackle random things. We can still consider reviewing PRs that adds value, but this change will hopefully make it easier to handle cases where the PR is only changing some random comments for a Github contribution.

Note that this was originally suggested by @0nko on Slack. I have also added @jkmassel for review as Platform 9 representative :)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
