### PR TITLE
Update FluxC hash which updates sites/new endpoint to v1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,5 +104,5 @@ buildScan {
 }
 
 ext {
-    fluxCVersion = 'cfafbfec81e337e7fdfb97dc985d25095effaea9'
+    fluxCVersion = 'd5d2cead7d0a46a04d605fb5b989f16b586e52b0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -104,5 +104,5 @@ buildScan {
 }
 
 ext {
-    fluxCVersion = 'd5d2cead7d0a46a04d605fb5b989f16b586e52b0'
+    fluxCVersion = '1c5c1f98a24eaac4efe55a9e85f3c4874a18a5ad'
 }


### PR DESCRIPTION
This PR updates FluxC hash which updates the sites/new endpoint to v1.1 to be consistent with Calypso and iOS platforms. The PR is kept as draft so that we can first merge FluxC PR and update the hash to the latest one: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1169

To test:
* Go through the new site creation flow which is enabled by default right now: [my test](https://cloudup.com/cSE8v3wB8vL)
* Change `NEW_SITE_CREATION_ENABLED` build flag to `false` and go through the old site creation flow [my test](https://cloudup.com/chEP2v22iO6)
* Check from Stetho that v1.1 endpoint is called for `sites/new`: [my test](https://cloudup.com/cdRro5zYVd5)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
