### PR TITLE
Issue/notifications settings feeds

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -582,9 +582,13 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         }
 
         for (final SubscriptionModel subscription : subscriptions) {
+            if (context == null) {
+                return;
+            }
+
             // Subscriptions with a "false" blogId are for feeds and don't have notifications settings.
-            if (context == null || subscription.getBlogId().equalsIgnoreCase("false")) {
-                break;
+            if (subscription.getBlogId().equalsIgnoreCase("false")) {
+                continue;
             }
 
             mSubscriptionCount++;


### PR DESCRIPTION
### Fix
Update excluding feeds from the ***Followed Sites*** list on the ***Notification Settings*** screen.  Using the `break` statement to exit early also excluded any followed sites after the first feed in the collection.  Using the `continue` statement will skip feeds while allowing followed sites afterwards to be included.

### Test
A feed must be followed to test these changes.  In order to follow a feed from the web, go to https://wordpress.com/following/manage, enter ***nytimes.com*** into the ***Search or enter URL to follow...*** field, and click the ***Follow nytimes.com*** button.

1. Go to ***Me*** tab.
2. Tap ***Notification Settings*** item.
3. Notice ***Followed Sites*** section.
4. Notice feed is not shown in ***Followed Sites*** list.
5. Tap ***Search*** action in toolbar.
6. Notice feed is not shown in ***Followed Sites*** list.
7. Enter name or URL of feed.
8. Notice feed is not shown in ***Followed Sites*** list.
9. Notice followed sites after ***nytimes.com*** alphabetically are shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.