### PR TITLE
Add the remaining view all screens

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -66,12 +66,9 @@ import org.wordpress.android.ui.publicize.PublicizeListActivity;
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity;
 import org.wordpress.android.ui.sitecreation.NewSiteCreationActivity;
 import org.wordpress.android.ui.stats.StatsAbstractFragment;
-import org.wordpress.android.ui.stats.OldStatsActivity;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
 import org.wordpress.android.ui.stats.StatsConstants;
 import org.wordpress.android.ui.stats.StatsSingleItemDetailsActivity;
-import org.wordpress.android.ui.stats.StatsTimeframe;
-import org.wordpress.android.ui.stats.StatsViewAllActivity;
 import org.wordpress.android.ui.stats.StatsViewType;
 import org.wordpress.android.ui.stats.models.StatsPostModel;
 import org.wordpress.android.ui.stats.refresh.StatsActivity;
@@ -301,75 +298,6 @@ public class ActivityLauncher {
         Intent intent = new Intent(context, org.wordpress.android.ui.stats.refresh.StatsViewAllActivity.class);
         intent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, statsType);
         intent.putExtra(StatsAbstractFragment.ARGS_TIMEFRAME, granularity);
-        context.startActivity(intent);
-    }
-
-    public static void viewCountriesStats(Context context, SiteModel site, StatsTimeframe statsTimeframe,
-                                          String selectedDate) {
-        Intent intent = new Intent(context, StatsViewAllActivity.class);
-        intent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, StatsViewType.GEOVIEWS);
-        intent.putExtra(StatsAbstractFragment.ARGS_TIMEFRAME, statsTimeframe);
-        intent.putExtra(StatsAbstractFragment.ARGS_SELECTED_DATE, selectedDate);
-        intent.putExtra(StatsAbstractFragment.ARGS_IS_SINGLE_VIEW, true);
-        intent.putExtra(OldStatsActivity.ARG_LOCAL_TABLE_SITE_ID, site.getId());
-
-        String title = context.getResources().getString(R.string.stats_view_countries);
-        intent.putExtra(StatsViewAllActivity.ARG_STATS_VIEW_ALL_TITLE, title);
-        context.startActivity(intent);
-    }
-
-    public static void viewVideoPlays(Context context, SiteModel site, StatsTimeframe statsTimeframe,
-                                      String selectedDate) {
-        Intent intent = new Intent(context, StatsViewAllActivity.class);
-        intent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, StatsViewType.VIDEO_PLAYS);
-        intent.putExtra(StatsAbstractFragment.ARGS_TIMEFRAME, statsTimeframe);
-        intent.putExtra(StatsAbstractFragment.ARGS_SELECTED_DATE, selectedDate);
-        intent.putExtra(StatsAbstractFragment.ARGS_IS_SINGLE_VIEW, true);
-        intent.putExtra(OldStatsActivity.ARG_LOCAL_TABLE_SITE_ID, site.getId());
-
-        String title = context.getResources().getString(R.string.stats_view_videos);
-        intent.putExtra(StatsViewAllActivity.ARG_STATS_VIEW_ALL_TITLE, title);
-        context.startActivity(intent);
-    }
-
-    public static void viewSearchTerms(Context context, SiteModel site, StatsTimeframe statsTimeframe,
-                                       String selectedDate) {
-        Intent intent = new Intent(context, StatsViewAllActivity.class);
-        intent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, StatsViewType.SEARCH_TERMS);
-        intent.putExtra(StatsAbstractFragment.ARGS_TIMEFRAME, statsTimeframe);
-        intent.putExtra(StatsAbstractFragment.ARGS_SELECTED_DATE, selectedDate);
-        intent.putExtra(StatsAbstractFragment.ARGS_IS_SINGLE_VIEW, true);
-        intent.putExtra(OldStatsActivity.ARG_LOCAL_TABLE_SITE_ID, site.getId());
-
-        String title = context.getResources().getString(R.string.stats_view_search_terms);
-        intent.putExtra(StatsViewAllActivity.ARG_STATS_VIEW_ALL_TITLE, title);
-        context.startActivity(intent);
-    }
-
-    public static void viewAuthorsStats(Context context, SiteModel site, StatsTimeframe statsTimeframe,
-                                        String selectedDate) {
-        Intent intent = new Intent(context, StatsViewAllActivity.class);
-        intent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, StatsViewType.AUTHORS);
-        intent.putExtra(StatsAbstractFragment.ARGS_TIMEFRAME, statsTimeframe);
-        intent.putExtra(StatsAbstractFragment.ARGS_SELECTED_DATE, selectedDate);
-        intent.putExtra(StatsAbstractFragment.ARGS_IS_SINGLE_VIEW, true);
-        intent.putExtra(OldStatsActivity.ARG_LOCAL_TABLE_SITE_ID, site.getId());
-
-        String title = context.getResources().getString(R.string.stats_view_authors);
-        intent.putExtra(StatsViewAllActivity.ARG_STATS_VIEW_ALL_TITLE, title);
-        context.startActivity(intent);
-    }
-
-    public static void viewPublicizeStats(Context context, SiteModel site) {
-        Intent intent = new Intent(context, StatsViewAllActivity.class);
-        intent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, StatsViewType.PUBLICIZE);
-        intent.putExtra(StatsAbstractFragment.ARGS_TIMEFRAME, StatsTimeframe.DAY);
-        intent.putExtra(StatsAbstractFragment.ARGS_SELECTED_DATE, "");
-        intent.putExtra(StatsAbstractFragment.ARGS_IS_SINGLE_VIEW, true);
-        intent.putExtra(OldStatsActivity.ARG_LOCAL_TABLE_SITE_ID, site.getId());
-
-        String title = context.getResources().getString(R.string.stats_view_publicize);
-        intent.putExtra(StatsViewAllActivity.ARG_STATS_VIEW_ALL_TITLE, title);
         context.startActivity(intent);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -34,7 +34,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.F
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.LatestPostSummaryUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.MostPopularInsightsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.PostingActivityUseCase
-import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.PublicizeUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.PublicizeUseCase.PublicizeUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TagsAndCategoriesUseCase.TagsAndCategoriesUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TodayStatsUseCase
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
@@ -71,7 +71,7 @@ class StatsModule {
         commentsUseCaseFactory: CommentsUseCaseFactory,
         mostPopularInsightsUseCase: MostPopularInsightsUseCase,
         tagsAndCategoriesUseCaseFactory: TagsAndCategoriesUseCaseFactory,
-        publicizeUseCase: PublicizeUseCase,
+        publicizeUseCaseFactory: PublicizeUseCaseFactory,
         postingActivityUseCase: PostingActivityUseCase
     ): List<@JvmSuppressWildcards BaseStatsUseCase<*, *>> {
         return listOf(
@@ -82,7 +82,7 @@ class StatsModule {
                 commentsUseCaseFactory.build(UseCaseMode.BLOCK),
                 mostPopularInsightsUseCase,
                 tagsAndCategoriesUseCaseFactory.build(UseCaseMode.BLOCK),
-                publicizeUseCase,
+                publicizeUseCaseFactory.build(UseCaseMode.BLOCK),
                 postingActivityUseCase
         )
     }
@@ -102,7 +102,7 @@ class StatsModule {
         commentsUseCaseFactory: CommentsUseCaseFactory,
         mostPopularInsightsUseCase: MostPopularInsightsUseCase,
         tagsAndCategoriesUseCaseFactory: TagsAndCategoriesUseCaseFactory,
-        publicizeUseCase: PublicizeUseCase,
+        publicizeUseCaseFactory: PublicizeUseCaseFactory,
         postingActivityUseCase: PostingActivityUseCase
     ): List<@JvmSuppressWildcards BaseStatsUseCase<*, *>> {
         return listOf(
@@ -113,7 +113,7 @@ class StatsModule {
                 commentsUseCaseFactory.build(UseCaseMode.VIEW_ALL),
                 mostPopularInsightsUseCase,
                 tagsAndCategoriesUseCaseFactory.build(UseCaseMode.VIEW_ALL),
-                publicizeUseCase,
+                publicizeUseCaseFactory.build(UseCaseMode.VIEW_ALL),
                 postingActivityUseCase
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllViewModelFactory.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllViewModelFactory.kt
@@ -16,7 +16,9 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.A
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.ClicksUseCase.ClicksUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.CountryViewsUseCase.CountryViewsUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.PostsAndPagesUseCase.PostsAndPagesUseCaseFactory
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.ReferrersUseCase.ReferrersUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.SearchTermsUseCase.SearchTermsUseCaseFactory
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.VideoPlaysUseCase.VideoPlaysUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.AllTimeStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.CommentsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.FollowersUseCase
@@ -105,7 +107,7 @@ class StatsViewAllViewModelFactory(
             return when (type) {
                 StatsViewType.TOP_POSTS_AND_PAGES -> Pair(granularFactories.first { it is PostsAndPagesUseCaseFactory }
                         .build(granularity, VIEW_ALL), R.string.stats_view_top_posts_and_pages)
-                StatsViewType.REFERRERS -> Pair(granularFactories.first { it is PostsAndPagesUseCaseFactory }
+                StatsViewType.REFERRERS -> Pair(granularFactories.first { it is ReferrersUseCaseFactory }
                         .build(granularity, VIEW_ALL), R.string.stats_view_referrers)
                 StatsViewType.CLICKS -> Pair(granularFactories.first { it is ClicksUseCaseFactory }
                         .build(granularity, VIEW_ALL), R.string.stats_view_clicks)
@@ -115,7 +117,7 @@ class StatsViewAllViewModelFactory(
                         .build(granularity, VIEW_ALL), R.string.stats_view_countries)
                 StatsViewType.SEARCH_TERMS -> Pair(granularFactories.first { it is SearchTermsUseCaseFactory }
                         .build(granularity, VIEW_ALL), R.string.stats_view_search_terms)
-                StatsViewType.VIDEO_PLAYS -> Pair(granularFactories.first { it is CountryViewsUseCaseFactory }
+                StatsViewType.VIDEO_PLAYS -> Pair(granularFactories.first { it is VideoPlaysUseCaseFactory }
                         .build(granularity, VIEW_ALL), R.string.stats_view_videos)
                 else -> throw InvalidParameterException("Invalid granular stats type: ${type.name}")
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCase.kt
@@ -66,8 +66,8 @@ constructor(
         return store.getClicks(
                 site,
                 statsGranularity,
-                selectedDate,
-                LimitMode.Top(itemsToLoad)
+                LimitMode.Top(itemsToLoad),
+                selectedDate
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCase.kt
@@ -5,12 +5,15 @@ import org.wordpress.android.R
 import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.CountryViewsModel
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.COUNTRIES
 import org.wordpress.android.fluxc.store.stats.time.CountryViewsStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewCountries
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
@@ -30,7 +33,8 @@ import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
 
-private const val PAGE_SIZE = 6
+private const val BLOCK_ITEM_COUNT = 6
+private const val VIEW_ALL_ITEM_COUNT = 1000
 
 class CountryViewsUseCase
 constructor(
@@ -39,7 +43,8 @@ constructor(
     private val store: CountryViewsStore,
     statsSiteProvider: StatsSiteProvider,
     selectedDateProvider: SelectedDateProvider,
-    private val analyticsTracker: AnalyticsTrackerWrapper
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val useCaseMode: UseCaseMode
 ) : GranularStatelessUseCase<CountryViewsModel>(
         COUNTRIES,
         mainDispatcher,
@@ -47,13 +52,15 @@ constructor(
         statsSiteProvider,
         statsGranularity
 ) {
+    private val itemsToLoad = if (useCaseMode == VIEW_ALL) VIEW_ALL_ITEM_COUNT else BLOCK_ITEM_COUNT
+
     override fun buildLoadingItem(): List<BlockListItem> = listOf(Title(R.string.stats_countries))
 
     override suspend fun loadCachedData(selectedDate: Date, site: SiteModel): CountryViewsModel? {
         return store.getCountryViews(
                 site,
                 statsGranularity,
-                PAGE_SIZE,
+                LimitMode.Top(itemsToLoad),
                 selectedDate
         )
     }
@@ -65,8 +72,8 @@ constructor(
     ): State<CountryViewsModel> {
         val response = store.fetchCountryViews(
                 site,
-                PAGE_SIZE,
                 statsGranularity,
+                LimitMode.Top(itemsToLoad),
                 selectedDate,
                 forced
         )
@@ -82,7 +89,10 @@ constructor(
 
     override fun buildUiModel(domainModel: CountryViewsModel): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
-        items.add(Title(R.string.stats_countries))
+
+        if (useCaseMode == BLOCK) {
+            items.add(Title(R.string.stats_countries))
+        }
 
         if (domainModel.countries.isEmpty()) {
             items.add(Empty(R.string.stats_no_data_for_period))
@@ -104,7 +114,7 @@ constructor(
                 )
             }
 
-            if (domainModel.hasMore) {
+            if (useCaseMode == BLOCK && domainModel.hasMore) {
                 items.add(
                         Link(
                                 text = string.stats_insights_view_more,
@@ -141,7 +151,8 @@ constructor(
                         store,
                         statsSiteProvider,
                         selectedDateProvider,
-                        analyticsTracker
+                        analyticsTracker,
+                        useCaseMode
                 )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.OVERVIEW
@@ -24,7 +25,7 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
 import javax.inject.Named
 
-private const val PAGE_SIZE = 15
+private const val ITEMS_TO_LOAD = 15
 
 class OverviewUseCase
 constructor(
@@ -54,17 +55,18 @@ constructor(
     override suspend fun loadCachedData(): VisitsAndViewsModel? {
         return visitsAndViewsStore.getVisits(
                 statsSiteProvider.siteModel,
-                selectedDateProvider.getCurrentDate(),
-                statsGranularity
+                statsGranularity,
+                LimitMode.All,
+                selectedDateProvider.getCurrentDate()
         )
     }
 
     override suspend fun fetchRemoteData(forced: Boolean): State<VisitsAndViewsModel> {
         val response = visitsAndViewsStore.fetchVisits(
                 statsSiteProvider.siteModel,
-                PAGE_SIZE,
-                selectedDateProvider.getCurrentDate(),
                 statsGranularity,
+                LimitMode.Top(ITEMS_TO_LOAD),
+                selectedDateProvider.getCurrentDate(),
                 forced
         )
         val model = response.model

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
@@ -67,8 +67,8 @@ constructor(
         return referrersStore.getReferrers(
                 site,
                 statsGranularity,
-                selectedDate,
-                LimitMode.Top(itemsToLoad)
+                LimitMode.Top(itemsToLoad),
+                selectedDate
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCase.kt
@@ -5,12 +5,15 @@ import org.wordpress.android.R
 import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.SearchTermsModel
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.SEARCH_TERMS
 import org.wordpress.android.fluxc.store.stats.time.SearchTermsStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewSearchTerms
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
@@ -29,7 +32,8 @@ import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
 
-private const val PAGE_SIZE = 6
+private const val BLOCK_ITEM_COUNT = 6
+private const val VIEW_ALL_ITEM_COUNT = 1000
 
 class SearchTermsUseCase
 constructor(
@@ -38,7 +42,8 @@ constructor(
     private val store: SearchTermsStore,
     statsSiteProvider: StatsSiteProvider,
     selectedDateProvider: SelectedDateProvider,
-    private val analyticsTracker: AnalyticsTrackerWrapper
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val useCaseMode: UseCaseMode
 ) : GranularStatelessUseCase<SearchTermsModel>(
         SEARCH_TERMS,
         mainDispatcher,
@@ -46,13 +51,15 @@ constructor(
         statsSiteProvider,
         statsGranularity
 ) {
+    private val itemsToLoad = if (useCaseMode == VIEW_ALL) VIEW_ALL_ITEM_COUNT else BLOCK_ITEM_COUNT
+
     override fun buildLoadingItem(): List<BlockListItem> = listOf(Title(R.string.stats_search_terms))
 
     override suspend fun loadCachedData(selectedDate: Date, site: SiteModel): SearchTermsModel? {
         return store.getSearchTerms(
                 site,
                 statsGranularity,
-                PAGE_SIZE,
+                LimitMode.Top(itemsToLoad),
                 selectedDate
         )
     }
@@ -64,8 +71,8 @@ constructor(
     ): State<SearchTermsModel> {
         val response = store.fetchSearchTerms(
                 site,
-                PAGE_SIZE,
                 statsGranularity,
+                LimitMode.Top(itemsToLoad),
                 selectedDate,
                 forced
         )
@@ -81,7 +88,10 @@ constructor(
 
     override fun buildUiModel(domainModel: SearchTermsModel): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
-        items.add(Title(R.string.stats_search_terms))
+
+        if (useCaseMode == BLOCK) {
+            items.add(Title(R.string.stats_search_terms))
+        }
 
         if (domainModel.searchTerms.isEmpty()) {
             items.add(Empty(R.string.stats_no_data_for_period))
@@ -108,7 +118,7 @@ constructor(
                 items.addAll(mappedSearchTerms)
             }
 
-            if (domainModel.hasMore) {
+            if (useCaseMode == BLOCK && domainModel.hasMore) {
                 items.add(
                         Link(
                                 text = string.stats_insights_view_more,
@@ -145,7 +155,8 @@ constructor(
                         store,
                         statsSiteProvider,
                         selectedDateProvider,
-                        analyticsTracker
+                        analyticsTracker,
+                        useCaseMode
                 )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCase.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.R
 import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.VideoPlaysModel
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes.VIDEOS
@@ -12,6 +13,8 @@ import org.wordpress.android.fluxc.store.stats.time.VideoPlaysStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewUrl
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewVideoPlays
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
@@ -30,7 +33,8 @@ import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
 
-private const val PAGE_SIZE = 6
+private const val BLOCK_ITEM_COUNT = 6
+private const val VIEW_ALL_ITEM_COUNT = 1000
 
 class VideoPlaysUseCase
 constructor(
@@ -39,7 +43,8 @@ constructor(
     private val store: VideoPlaysStore,
     statsSiteProvider: StatsSiteProvider,
     selectedDateProvider: SelectedDateProvider,
-    private val analyticsTracker: AnalyticsTrackerWrapper
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val useCaseMode: UseCaseMode
 ) : GranularStatelessUseCase<VideoPlaysModel>(
         VIDEOS,
         mainDispatcher,
@@ -47,13 +52,15 @@ constructor(
         statsSiteProvider,
         statsGranularity
 ) {
+    private val itemsToLoad = if (useCaseMode == VIEW_ALL) VIEW_ALL_ITEM_COUNT else BLOCK_ITEM_COUNT
+
     override fun buildLoadingItem(): List<BlockListItem> = listOf(Title(string.stats_videos))
 
     override suspend fun loadCachedData(selectedDate: Date, site: SiteModel): VideoPlaysModel? {
         return store.getVideoPlays(
                 site,
                 statsGranularity,
-                PAGE_SIZE,
+                LimitMode.Top(itemsToLoad),
                 selectedDate
         )
     }
@@ -61,8 +68,8 @@ constructor(
     override suspend fun fetchRemoteData(selectedDate: Date, site: SiteModel, forced: Boolean): State<VideoPlaysModel> {
         val response = store.fetchVideoPlays(
                 site,
-                PAGE_SIZE,
                 statsGranularity,
+                LimitMode.Top(itemsToLoad),
                 selectedDate,
                 forced
         )
@@ -78,7 +85,10 @@ constructor(
 
     override fun buildUiModel(domainModel: VideoPlaysModel): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
-        items.add(Title(string.stats_videos))
+
+        if (useCaseMode == BLOCK) {
+            items.add(Title(string.stats_videos))
+        }
 
         if (domainModel.plays.isEmpty()) {
             items.add(Empty(R.string.stats_no_data_for_period))
@@ -93,7 +103,7 @@ constructor(
                 )
             })
 
-            if (domainModel.hasMore) {
+            if (useCaseMode == BLOCK && domainModel.hasMore) {
                 items.add(
                         Link(
                                 text = string.stats_insights_view_more,
@@ -135,7 +145,8 @@ constructor(
                         store,
                         statsSiteProvider,
                         selectedDateProvider,
-                        analyticsTracker
+                        analyticsTracker,
+                        useCaseMode
                 )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCase.kt
@@ -4,25 +4,30 @@ import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
 import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.PublicizeModel
 import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.PUBLICIZE
 import org.wordpress.android.fluxc.store.stats.insights.PublicizeStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewPublicizeStats
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatelessUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.NavigationAction
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
+import org.wordpress.android.ui.stats.refresh.lists.sections.insights.InsightUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.utils.ServiceMapper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
 import javax.inject.Named
 
-private const val PAGE_SIZE = 5
+private const val BLOCK_ITEM_COUNT = 6
+private const val VIEW_ALL_ITEM_COUNT = 100
 
 class PublicizeUseCase
 @Inject constructor(
@@ -30,19 +35,23 @@ class PublicizeUseCase
     private val publicizeStore: PublicizeStore,
     private val statsSiteProvider: StatsSiteProvider,
     private val mapper: ServiceMapper,
-    private val analyticsTracker: AnalyticsTrackerWrapper
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val useCaseMode: UseCaseMode
 ) : StatelessUseCase<PublicizeModel>(PUBLICIZE, mainDispatcher) {
+    private val itemsToLoad = if (useCaseMode == VIEW_ALL) VIEW_ALL_ITEM_COUNT else BLOCK_ITEM_COUNT
+
     override suspend fun loadCachedData(): PublicizeModel? {
         return publicizeStore.getPublicizeData(
                 statsSiteProvider.siteModel,
-                PAGE_SIZE
+                LimitMode.Top(itemsToLoad)
         )
     }
 
     override suspend fun fetchRemoteData(forced: Boolean): State<PublicizeModel> {
         val response = publicizeStore.fetchPublicizeData(
                 statsSiteProvider.siteModel,
-                PAGE_SIZE, forced
+                LimitMode.Top(itemsToLoad),
+                forced
         )
         val model = response.model
         val error = response.error
@@ -60,13 +69,17 @@ class PublicizeUseCase
 
     override fun buildUiModel(domainModel: PublicizeModel): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
-        items.add(Title(string.stats_view_publicize))
+
+        if (useCaseMode == BLOCK) {
+            items.add(Title(string.stats_view_publicize))
+        }
+
         if (domainModel.services.isEmpty()) {
             items.add(Empty())
         } else {
             items.add(Header(string.stats_publicize_service_label, string.stats_publicize_followers_label))
             items.addAll(domainModel.services.let { mapper.map(it) })
-            if (domainModel.hasMore) {
+            if (useCaseMode == BLOCK && domainModel.hasMore) {
                 items.add(
                         Link(
                                 text = string.stats_insights_view_more,
@@ -81,5 +94,24 @@ class PublicizeUseCase
     private fun onLinkClick() {
         analyticsTracker.track(AnalyticsTracker.Stat.STATS_PUBLICIZE_VIEW_MORE_TAPPED)
         return navigateTo(ViewPublicizeStats())
+    }
+
+    class PublicizeUseCaseFactory
+    @Inject constructor(
+        @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+        private val publicizeStore: PublicizeStore,
+        private val statsSiteProvider: StatsSiteProvider,
+        private val mapper: ServiceMapper,
+        private val analyticsTracker: AnalyticsTrackerWrapper
+    ) : InsightUseCaseFactory {
+        override fun build(useCaseMode: UseCaseMode) =
+                PublicizeUseCase(
+                        mainDispatcher,
+                        publicizeStore,
+                        statsSiteProvider,
+                        mapper,
+                        analyticsTracker,
+                        useCaseMode
+                )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
@@ -3,14 +3,8 @@ package org.wordpress.android.ui.stats.refresh.utils
 import android.content.Intent
 import android.support.v4.app.FragmentActivity
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.network.utils.StatsGranularity
-import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
-import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
-import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
-import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.WPWebViewActivity
-import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.StatsUtils
 import org.wordpress.android.ui.stats.StatsViewType.AUTHORS
 import org.wordpress.android.ui.stats.StatsViewType.CLICKS
@@ -48,7 +42,7 @@ import javax.inject.Singleton
 
 @Singleton
 class StatsNavigator
-@Inject constructor(private val statsDateFormatter: StatsDateFormatter, private val siteProvider: StatsSiteProvider) {
+@Inject constructor(private val siteProvider: StatsSiteProvider) {
     fun navigate(activity: FragmentActivity, target: NavigationTarget) {
         when (target) {
             is AddNewPost -> ActivityLauncher.addNewPostForResult(activity, siteProvider.siteModel, false)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
@@ -12,13 +12,17 @@ import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.StatsUtils
+import org.wordpress.android.ui.stats.StatsViewType.AUTHORS
 import org.wordpress.android.ui.stats.StatsViewType.CLICKS
 import org.wordpress.android.ui.stats.StatsViewType.COMMENTS
 import org.wordpress.android.ui.stats.StatsViewType.FOLLOWERS
+import org.wordpress.android.ui.stats.StatsViewType.GEOVIEWS
 import org.wordpress.android.ui.stats.StatsViewType.PUBLICIZE
 import org.wordpress.android.ui.stats.StatsViewType.REFERRERS
+import org.wordpress.android.ui.stats.StatsViewType.SEARCH_TERMS
 import org.wordpress.android.ui.stats.StatsViewType.TAGS_AND_CATEGORIES
 import org.wordpress.android.ui.stats.StatsViewType.TOP_POSTS_AND_PAGES
+import org.wordpress.android.ui.stats.StatsViewType.VIDEO_PLAYS
 import org.wordpress.android.ui.stats.models.StatsPostModel
 import org.wordpress.android.ui.stats.refresh.NavigationTarget
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.AddNewPost
@@ -103,49 +107,20 @@ class StatsNavigator
                 ActivityLauncher.viewAllGranularStats(activity, target.statsGranularity, CLICKS)
             }
             is ViewCountries -> {
-                ActivityLauncher.viewCountriesStats(
-                        activity,
-                        siteProvider.siteModel,
-                        target.statsGranularity.toStatsTimeFrame(),
-                        statsDateFormatter.printStatsDate(target.selectedDate)
-                )
+                ActivityLauncher.viewAllGranularStats(activity, target.statsGranularity, GEOVIEWS)
             }
             is ViewVideoPlays -> {
-                ActivityLauncher.viewVideoPlays(
-                        activity,
-                        siteProvider.siteModel,
-                        target.statsGranularity.toStatsTimeFrame(),
-                        statsDateFormatter.printStatsDate(target.selectedDate)
-                )
+                ActivityLauncher.viewAllGranularStats(activity, target.statsGranularity, VIDEO_PLAYS)
             }
             is ViewSearchTerms -> {
-                ActivityLauncher.viewSearchTerms(
-                        activity,
-                        siteProvider.siteModel,
-                        target.statsGranularity.toStatsTimeFrame(),
-                        statsDateFormatter.printStatsDate(target.selectedDate)
-                )
+                ActivityLauncher.viewAllGranularStats(activity, target.statsGranularity, SEARCH_TERMS)
             }
             is ViewAuthors -> {
-                ActivityLauncher.viewAuthorsStats(
-                        activity,
-                        siteProvider.siteModel,
-                        target.statsGranularity.toStatsTimeFrame(),
-                        statsDateFormatter.printStatsDate(target.selectedDate)
-                )
+                ActivityLauncher.viewAllGranularStats(activity, target.statsGranularity, AUTHORS)
             }
             is ViewUrl -> {
                 WPWebViewActivity.openURL(activity, target.url)
             }
         }
-    }
-}
-
-fun StatsGranularity.toStatsTimeFrame(): StatsTimeframe {
-    return when (this) {
-        DAYS -> StatsTimeframe.DAY
-        WEEKS -> StatsTimeframe.WEEK
-        MONTHS -> StatsTimeframe.MONTH
-        YEARS -> StatsTimeframe.YEAR
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.ui.stats.StatsUtils
 import org.wordpress.android.ui.stats.StatsViewType.CLICKS
 import org.wordpress.android.ui.stats.StatsViewType.COMMENTS
 import org.wordpress.android.ui.stats.StatsViewType.FOLLOWERS
+import org.wordpress.android.ui.stats.StatsViewType.PUBLICIZE
 import org.wordpress.android.ui.stats.StatsViewType.REFERRERS
 import org.wordpress.android.ui.stats.StatsViewType.TAGS_AND_CATEGORIES
 import org.wordpress.android.ui.stats.StatsViewType.TOP_POSTS_AND_PAGES
@@ -90,7 +91,7 @@ class StatsNavigator
                 ActivityLauncher.openStatsUrl(activity, target.link)
             }
             is ViewPublicizeStats -> {
-                ActivityLauncher.viewPublicizeStats(activity, siteProvider.siteModel)
+                ActivityLauncher.viewAllInsightsStats(activity, PUBLICIZE)
             }
             is ViewPostsAndPages -> {
                 ActivityLauncher.viewAllGranularStats(activity, target.statsGranularity, TOP_POSTS_AND_PAGES)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCaseTest.kt
@@ -9,6 +9,7 @@ import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.AuthorsModel
 import org.wordpress.android.fluxc.model.stats.time.AuthorsModel.Author
 import org.wordpress.android.fluxc.model.stats.time.AuthorsModel.Post
@@ -18,6 +19,7 @@ import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.stats.time.AuthorsStore
 import org.wordpress.android.test
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
@@ -40,7 +42,7 @@ import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import java.util.Date
 
-private const val pageSize = 6
+private const val ITEMS_TO_LOAD = 6
 private val statsGranularity = DAYS
 private val selectedDate = Date(0)
 
@@ -64,7 +66,8 @@ class AuthorsUseCaseTest : BaseUnitTest() {
                 store,
                 statsSiteProvider,
                 selectedDateProvider,
-                tracker
+                tracker,
+                BLOCK
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         whenever((selectedDateProvider.getSelectedDate(statsGranularity))).thenReturn(selectedDate)
@@ -80,7 +83,8 @@ class AuthorsUseCaseTest : BaseUnitTest() {
     fun `maps authors to UI model`() = test {
         val forced = false
         val model = AuthorsModel(10, listOf(authorWithoutPosts, authorWithPosts), false)
-        whenever(store.fetchAuthors(site, pageSize, statsGranularity, selectedDate, forced)).thenReturn(
+        whenever(store.fetchAuthors(site,
+                statsGranularity, LimitMode.Top(ITEMS_TO_LOAD), selectedDate, forced)).thenReturn(
                 OnStatsFetched(
                         model
                 )
@@ -143,7 +147,8 @@ class AuthorsUseCaseTest : BaseUnitTest() {
     fun `adds view more button when hasMore`() = test {
         val forced = false
         val model = AuthorsModel(10, listOf(authorWithoutPosts), true)
-        whenever(store.fetchAuthors(site, pageSize, statsGranularity, selectedDate, forced)).thenReturn(
+        whenever(store.fetchAuthors(site, statsGranularity, LimitMode.Top(ITEMS_TO_LOAD),
+                selectedDate, forced)).thenReturn(
                 OnStatsFetched(
                         model
                 )
@@ -168,7 +173,8 @@ class AuthorsUseCaseTest : BaseUnitTest() {
     @Test
     fun `maps empty authors to UI model`() = test {
         val forced = false
-        whenever(store.fetchAuthors(site, pageSize, statsGranularity, selectedDate, forced)).thenReturn(
+        whenever(store.fetchAuthors(site, statsGranularity, LimitMode.Top(ITEMS_TO_LOAD),
+                selectedDate, forced)).thenReturn(
                 OnStatsFetched(AuthorsModel(0, listOf(), false))
         )
 
@@ -189,8 +195,8 @@ class AuthorsUseCaseTest : BaseUnitTest() {
         whenever(
                 store.fetchAuthors(
                         site,
-                        pageSize,
                         statsGranularity,
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         selectedDate,
                         forced
                 )

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCaseTest.kt
@@ -9,6 +9,7 @@ import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.CountryViewsModel
 import org.wordpress.android.fluxc.model.stats.time.CountryViewsModel.Country
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
@@ -17,6 +18,7 @@ import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.stats.time.CountryViewsStore
 import org.wordpress.android.test
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
@@ -36,7 +38,7 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import java.util.Date
 
-private const val pageSize = 6
+private const val itemsToLoad = 6
 private val statsGranularity = DAYS
 private val selectedDate = Date(0)
 
@@ -56,7 +58,8 @@ class CountryViewsUseCaseTest : BaseUnitTest() {
                 store,
                 statsSiteProvider,
                 selectedDateProvider,
-                tracker
+                tracker,
+                BLOCK
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         whenever((selectedDateProvider.getSelectedDate(statsGranularity))).thenReturn(selectedDate)
@@ -72,7 +75,8 @@ class CountryViewsUseCaseTest : BaseUnitTest() {
     fun `maps country views to UI model`() = test {
         val forced = false
         val model = CountryViewsModel(10, 15, listOf(country), false)
-        whenever(store.fetchCountryViews(site, pageSize, statsGranularity, selectedDate, forced)).thenReturn(
+        whenever(store.fetchCountryViews(site, statsGranularity,
+                LimitMode.Top(itemsToLoad), selectedDate, forced)).thenReturn(
                 OnStatsFetched(
                         model
                 )
@@ -97,7 +101,7 @@ class CountryViewsUseCaseTest : BaseUnitTest() {
         val forced = false
         val model = CountryViewsModel(10, 15, listOf(country), true)
         whenever(
-                store.fetchCountryViews(site, pageSize, statsGranularity, selectedDate, forced)
+                store.fetchCountryViews(site, statsGranularity, LimitMode.Top(itemsToLoad), selectedDate, forced)
         ).thenReturn(
                 OnStatsFetched(
                         model
@@ -116,7 +120,7 @@ class CountryViewsUseCaseTest : BaseUnitTest() {
     fun `maps empty country views to UI model`() = test {
         val forced = false
         whenever(
-                store.fetchCountryViews(site, pageSize, statsGranularity, selectedDate, forced)
+                store.fetchCountryViews(site, statsGranularity, LimitMode.Top(itemsToLoad), selectedDate, forced)
         ).thenReturn(
                 OnStatsFetched(CountryViewsModel(0, 0, listOf(), false))
         )
@@ -136,7 +140,7 @@ class CountryViewsUseCaseTest : BaseUnitTest() {
         val forced = false
         val message = "Generic error"
         whenever(
-                store.fetchCountryViews(site, pageSize, statsGranularity, selectedDate, forced)
+                store.fetchCountryViews(site, statsGranularity, LimitMode.Top(itemsToLoad), selectedDate, forced)
         ).thenReturn(
                 OnStatsFetched(
                         StatsError(GENERIC_ERROR, message)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCaseTest.kt
@@ -11,6 +11,7 @@ import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel.PeriodData
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
@@ -45,7 +46,7 @@ class OverviewUseCaseTest : BaseUnitTest() {
     private lateinit var useCase: OverviewUseCase
     private val periodData = PeriodData("2018-10-08", 10, 15, 20, 25, 30, 35)
     private val modelPeriod = "2018-10-10"
-    private val pageSize = 15
+    private val itemsToLoad = 15
     private val statsGranularity = DAYS
     private val model = VisitsAndViewsModel(modelPeriod, listOf(periodData))
     private val currentDate = Date(10)
@@ -73,7 +74,7 @@ class OverviewUseCaseTest : BaseUnitTest() {
     fun `maps domain model to UI model`() = test {
         val forced = false
 
-        whenever(store.fetchVisits(site, pageSize, currentDate, statsGranularity, forced)).thenReturn(
+        whenever(store.fetchVisits(site, statsGranularity, LimitMode.Top(itemsToLoad), currentDate, forced)).thenReturn(
                 OnStatsFetched(
                         model
                 )
@@ -94,7 +95,7 @@ class OverviewUseCaseTest : BaseUnitTest() {
     fun `maps error item to UI model`() = test {
         val forced = false
         val message = "Generic error"
-        whenever(store.fetchVisits(site, pageSize, currentDate, statsGranularity, forced)).thenReturn(
+        whenever(store.fetchVisits(site, statsGranularity, LimitMode.Top(itemsToLoad), currentDate, forced)).thenReturn(
                 OnStatsFetched(
                         StatsError(GENERIC_ERROR, message)
                 )

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCaseTest.kt
@@ -9,6 +9,7 @@ import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.SearchTermsModel
 import org.wordpress.android.fluxc.model.stats.time.SearchTermsModel.SearchTerm
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
@@ -18,6 +19,7 @@ import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes
 import org.wordpress.android.fluxc.store.stats.time.SearchTermsStore
 import org.wordpress.android.test
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
@@ -36,7 +38,7 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import java.util.Date
 
-private const val pageSize = 6
+private const val ITEMS_TO_LOAD = 6
 private val statsGranularity = DAYS
 private val selectedDate = Date(0)
 
@@ -56,7 +58,8 @@ class SearchTermsUseCaseTest : BaseUnitTest() {
                 store,
                 statsSiteProvider,
                 selectedDateProvider,
-                tracker
+                tracker,
+                BLOCK
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         whenever((selectedDateProvider.getSelectedDate(statsGranularity))).thenReturn(selectedDate)
@@ -72,7 +75,8 @@ class SearchTermsUseCaseTest : BaseUnitTest() {
     fun `maps search_terms to UI model`() = test {
         val forced = false
         val model = SearchTermsModel(10, 15, 0, listOf(searchTerm), false)
-        whenever(store.fetchSearchTerms(site, pageSize, statsGranularity, selectedDate, forced)).thenReturn(
+        whenever(store.fetchSearchTerms(site, statsGranularity, LimitMode.Top(ITEMS_TO_LOAD), selectedDate,
+                forced)).thenReturn(
                 OnStatsFetched(
                         model
                 )
@@ -94,7 +98,7 @@ class SearchTermsUseCaseTest : BaseUnitTest() {
         val forced = false
         val model = SearchTermsModel(10, 15, 0, listOf(searchTerm), true)
         whenever(
-                store.fetchSearchTerms(site, pageSize, statsGranularity, selectedDate, forced)
+                store.fetchSearchTerms(site, statsGranularity, LimitMode.Top(ITEMS_TO_LOAD), selectedDate, forced)
         ).thenReturn(
                 OnStatsFetched(
                         model
@@ -123,7 +127,7 @@ class SearchTermsUseCaseTest : BaseUnitTest() {
                 false
         )
         whenever(
-                store.fetchSearchTerms(site, pageSize, statsGranularity, selectedDate, forced)
+                store.fetchSearchTerms(site, statsGranularity, LimitMode.Top(ITEMS_TO_LOAD), selectedDate, forced)
         ).thenReturn(
                 OnStatsFetched(
                         model
@@ -152,7 +156,7 @@ class SearchTermsUseCaseTest : BaseUnitTest() {
     fun `maps empty search_terms to UI model`() = test {
         val forced = false
         whenever(
-                store.fetchSearchTerms(site, pageSize, statsGranularity, selectedDate, forced)
+                store.fetchSearchTerms(site, statsGranularity, LimitMode.Top(ITEMS_TO_LOAD), selectedDate, forced)
         ).thenReturn(
                 OnStatsFetched(SearchTermsModel(0, 0, 0, listOf(), false))
         )
@@ -173,7 +177,7 @@ class SearchTermsUseCaseTest : BaseUnitTest() {
         val forced = false
         val message = "Generic error"
         whenever(
-                store.fetchSearchTerms(site, pageSize, statsGranularity, selectedDate, forced)
+                store.fetchSearchTerms(site, statsGranularity, LimitMode.Top(ITEMS_TO_LOAD), selectedDate, forced)
         ).thenReturn(
                 OnStatsFetched(
                         StatsError(GENERIC_ERROR, message)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCaseTest.kt
@@ -9,6 +9,7 @@ import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.VideoPlaysModel
 import org.wordpress.android.fluxc.model.stats.time.VideoPlaysModel.VideoPlays
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
@@ -18,6 +19,7 @@ import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsTypes
 import org.wordpress.android.fluxc.store.stats.time.VideoPlaysStore
 import org.wordpress.android.test
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
@@ -35,7 +37,7 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import java.util.Date
 
-private const val pageSize = 6
+private const val ITEMS_TO_LOAD = 6
 private val statsGranularity = DAYS
 private val selectedDate = Date(0)
 
@@ -55,7 +57,8 @@ class VideoPlaysUseCaseTest : BaseUnitTest() {
                 store,
                 siteModelProvider,
                 selectedDateProvider,
-                tracker
+                tracker,
+                BLOCK
         )
         whenever(siteModelProvider.siteModel).thenReturn(site)
         whenever((selectedDateProvider.getSelectedDate(statsGranularity))).thenReturn(selectedDate)
@@ -71,7 +74,8 @@ class VideoPlaysUseCaseTest : BaseUnitTest() {
     fun `maps video plays to UI model`() = test {
         val forced = false
         val model = VideoPlaysModel(10, 15, listOf(videoPlay), false)
-        whenever(store.fetchVideoPlays(site, pageSize, statsGranularity, selectedDate, forced)).thenReturn(
+        whenever(store.fetchVideoPlays(site, statsGranularity, LimitMode.Top(ITEMS_TO_LOAD), selectedDate,
+                forced)).thenReturn(
                 OnStatsFetched(
                         model
                 )
@@ -93,7 +97,7 @@ class VideoPlaysUseCaseTest : BaseUnitTest() {
         val forced = false
         val model = VideoPlaysModel(10, 15, listOf(videoPlay), true)
         whenever(
-                store.fetchVideoPlays(site, pageSize, statsGranularity, selectedDate, forced)
+                store.fetchVideoPlays(site, statsGranularity, LimitMode.Top(ITEMS_TO_LOAD), selectedDate, forced)
         ).thenReturn(
                 OnStatsFetched(
                         model
@@ -116,7 +120,7 @@ class VideoPlaysUseCaseTest : BaseUnitTest() {
     fun `maps empty video plays to UI model`() = test {
         val forced = false
         whenever(
-                store.fetchVideoPlays(site, pageSize, statsGranularity, selectedDate, forced)
+                store.fetchVideoPlays(site, statsGranularity, LimitMode.Top(ITEMS_TO_LOAD), selectedDate, forced)
         ).thenReturn(
                 OnStatsFetched(VideoPlaysModel(0, 0, listOf(), false))
         )
@@ -137,7 +141,7 @@ class VideoPlaysUseCaseTest : BaseUnitTest() {
         val forced = false
         val message = "Generic error"
         whenever(
-                store.fetchVideoPlays(site, pageSize, statsGranularity, selectedDate, forced)
+                store.fetchVideoPlays(site, statsGranularity, LimitMode.Top(ITEMS_TO_LOAD), selectedDate, forced)
         ).thenReturn(
                 OnStatsFetched(
                         StatsError(GENERIC_ERROR, message)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCaseTest.kt
@@ -10,6 +10,7 @@ import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.PublicizeModel
 import org.wordpress.android.fluxc.model.stats.PublicizeModel.Service
 import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes
@@ -18,6 +19,7 @@ import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.stats.insights.PublicizeStore
 import org.wordpress.android.test
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
@@ -38,7 +40,7 @@ class PublicizeUseCaseTest : BaseUnitTest() {
     @Mock lateinit var serviceMapper: ServiceMapper
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
     private lateinit var useCase: PublicizeUseCase
-    private val pageSize = 5
+    private val itemsToLoad = 5
     @Before
     fun setUp() {
         useCase = PublicizeUseCase(
@@ -46,7 +48,8 @@ class PublicizeUseCaseTest : BaseUnitTest() {
                 insightsStore,
                 statsSiteProvider,
                 serviceMapper,
-                tracker
+                tracker,
+                BLOCK
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
     }
@@ -56,7 +59,7 @@ class PublicizeUseCaseTest : BaseUnitTest() {
         val forced = false
         val followers = 100
         val services = listOf(Service("facebook", followers))
-        whenever(insightsStore.fetchPublicizeData(site, pageSize, forced)).thenReturn(
+        whenever(insightsStore.fetchPublicizeData(site, LimitMode.Top(itemsToLoad), forced)).thenReturn(
                 OnStatsFetched(
                         PublicizeModel(services, false)
                 )
@@ -85,7 +88,7 @@ class PublicizeUseCaseTest : BaseUnitTest() {
         val services = listOf(
                 Service("service1", followers)
         )
-        whenever(insightsStore.fetchPublicizeData(site, pageSize, forced)).thenReturn(
+        whenever(insightsStore.fetchPublicizeData(site, LimitMode.Top(itemsToLoad), forced)).thenReturn(
                 OnStatsFetched(
                         PublicizeModel(services, true)
                 )
@@ -111,7 +114,7 @@ class PublicizeUseCaseTest : BaseUnitTest() {
     @Test
     fun `maps empty services to UI model`() = test {
         val forced = false
-        whenever(insightsStore.fetchPublicizeData(site, pageSize, forced)).thenReturn(
+        whenever(insightsStore.fetchPublicizeData(site, LimitMode.Top(itemsToLoad), forced)).thenReturn(
                 OnStatsFetched(PublicizeModel(listOf(), false))
         )
 
@@ -129,7 +132,7 @@ class PublicizeUseCaseTest : BaseUnitTest() {
     fun `maps error item to UI model`() = test {
         val forced = false
         val message = "Generic error"
-        whenever(insightsStore.fetchPublicizeData(site, pageSize, forced)).thenReturn(
+        whenever(insightsStore.fetchPublicizeData(site, LimitMode.Top(itemsToLoad), forced)).thenReturn(
                 OnStatsFetched(
                         StatsError(GENERIC_ERROR, message)
                 )

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCaseTest.kt
@@ -40,7 +40,8 @@ class PublicizeUseCaseTest : BaseUnitTest() {
     @Mock lateinit var serviceMapper: ServiceMapper
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
     private lateinit var useCase: PublicizeUseCase
-    private val itemsToLoad = 5
+    private val itemsToLoad = 6
+    private val limitMode = LimitMode.Top(itemsToLoad)
     @Before
     fun setUp() {
         useCase = PublicizeUseCase(
@@ -59,7 +60,7 @@ class PublicizeUseCaseTest : BaseUnitTest() {
         val forced = false
         val followers = 100
         val services = listOf(Service("facebook", followers))
-        whenever(insightsStore.fetchPublicizeData(site, LimitMode.Top(itemsToLoad), forced)).thenReturn(
+        whenever(insightsStore.fetchPublicizeData(site, limitMode, forced)).thenReturn(
                 OnStatsFetched(
                         PublicizeModel(services, false)
                 )
@@ -88,7 +89,7 @@ class PublicizeUseCaseTest : BaseUnitTest() {
         val services = listOf(
                 Service("service1", followers)
         )
-        whenever(insightsStore.fetchPublicizeData(site, LimitMode.Top(itemsToLoad), forced)).thenReturn(
+        whenever(insightsStore.fetchPublicizeData(site, limitMode, forced)).thenReturn(
                 OnStatsFetched(
                         PublicizeModel(services, true)
                 )
@@ -114,7 +115,7 @@ class PublicizeUseCaseTest : BaseUnitTest() {
     @Test
     fun `maps empty services to UI model`() = test {
         val forced = false
-        whenever(insightsStore.fetchPublicizeData(site, LimitMode.Top(itemsToLoad), forced)).thenReturn(
+        whenever(insightsStore.fetchPublicizeData(site, limitMode, forced)).thenReturn(
                 OnStatsFetched(PublicizeModel(listOf(), false))
         )
 
@@ -132,7 +133,7 @@ class PublicizeUseCaseTest : BaseUnitTest() {
     fun `maps error item to UI model`() = test {
         val forced = false
         val message = "Generic error"
-        whenever(insightsStore.fetchPublicizeData(site, LimitMode.Top(itemsToLoad), forced)).thenReturn(
+        whenever(insightsStore.fetchPublicizeData(site, limitMode, forced)).thenReturn(
                 OnStatsFetched(
                         StatsError(GENERIC_ERROR, message)
                 )

--- a/build.gradle
+++ b/build.gradle
@@ -104,5 +104,5 @@ buildScan {
 }
 
 ext {
-    fluxCVersion = '7a03ff9379255b5023da1eb33643679fb53f9c3d'
+    fluxCVersion = 'ea717ec1c16d42bf4f382e9b066ffb7de26c6706'
 }


### PR DESCRIPTION
This PR adds the view-all screen support for the following stats types:
- Publicize
- Authors
- Countries
- Search terms
- Videos

To test:
1. Open a site that contains enough stats data for all of the stats types above
2. Go to Stats
3. Notice all the stats types contain the View more button
4. Tap on the View more button
5. Verify that additional data of that type is displayed