### PR TITLE
Add post header use case for detail screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockDiffCallback.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM_WITH_ICON
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LOADING_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.MAP
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.REFERRED_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TABS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TEXT
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
@@ -61,6 +62,7 @@ class BlockDiffCallback(
                 LOADING_ITEM,
                 MAP,
                 CHART_LEGEND,
+                REFERRED_ITEM,
                 EMPTY -> oldItem == newItem
             }
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.lists.UiModelMapper
 import org.wordpress.android.ui.stats.refresh.lists.detail.PostDayViewsUseCase
+import org.wordpress.android.ui.stats.refresh.lists.detail.PostHeaderUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
@@ -150,6 +151,7 @@ class StatsModule {
                 overviewUseCaseFactory
         )
     }
+
     /**
      * Provides a list of use cases for the Post detail screen in Stats. Modify this method when you want to add more
      * blocks to the post detail screen.
@@ -158,9 +160,10 @@ class StatsModule {
     @Singleton
     @Named(DETAIL_USE_CASES)
     fun provideDetailUseCases(
+        postHeaderUseCase: PostHeaderUseCase,
         postDayViewsUseCase: PostDayViewsUseCase
     ): List<@JvmSuppressWildcards BaseStatsUseCase<*, *>> {
-        return listOf(postDayViewsUseCase)
+        return listOf(postHeaderUseCase, postDayViewsUseCase)
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostHeaderUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostHeaderUseCase.kt
@@ -1,0 +1,36 @@
+package org.wordpress.android.ui.stats.refresh.lists.detail
+
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.R.string
+import org.wordpress.android.fluxc.store.StatsStore.PostDetailTypes
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatelessUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ReferredItem
+import org.wordpress.android.ui.stats.refresh.utils.StatsPostProvider
+import javax.inject.Inject
+import javax.inject.Named
+
+class PostHeaderUseCase
+@Inject constructor(
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+    private val statsPostProvider: StatsPostProvider
+) : StatelessUseCase<String>(
+        PostDetailTypes.POST_HEADER,
+        mainDispatcher
+) {
+    override suspend fun loadCachedData(): String? {
+        return statsPostProvider.postTitle
+    }
+
+    override suspend fun fetchRemoteData(forced: Boolean): State<String> {
+        val title = statsPostProvider.postTitle
+        return if (title != null) State.Data(title) else State.Empty()
+    }
+
+    override fun buildUiModel(domainModel: String): List<BlockListItem> {
+        return listOf(ReferredItem(string.showing_stats_for, domainModel))
+    }
+
+    override fun buildLoadingItem(): List<BlockListItem> = listOf()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailViewModel.kt
@@ -70,6 +70,7 @@ class StatsDetailViewModel
         super.onCleared()
         dateSelector.clear()
         detailUseCase.onCleared()
+        statsPostProvider.clear()
     }
 
     fun onPullToRefresh() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListI
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.LoadingItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.MapItem
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ReferredItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TabsItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Text
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
@@ -37,6 +38,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM_WITH_ICON
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LOADING_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.MAP
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.REFERRED_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TABS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TEXT
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
@@ -58,6 +60,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ListIte
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ListItemWithIconViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.LoadingItemViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.MapViewHolder
+import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ReferredItemViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.TabsViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.TextViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.TitleViewHolder
@@ -113,6 +116,7 @@ class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockListItemVi
             MAP -> MapViewHolder(parent)
             VALUE_ITEM -> ValueViewHolder(parent)
             ACTIVITY_ITEM -> ActivityViewHolder(parent)
+            REFERRED_ITEM -> ReferredItemViewHolder(parent)
         }
     }
 
@@ -145,6 +149,7 @@ class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockListItemVi
             is EmptyViewHolder -> holder.bind(item as Empty)
             is ActivityViewHolder -> holder.bind(item as ActivityItem)
             is LoadingItemViewHolder -> holder.bind(item as LoadingItem)
+            is ReferredItemViewHolder -> holder.bind(item as ReferredItem)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM_WITH_ICON
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LOADING_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.MAP
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.REFERRED_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TABS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TEXT
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
@@ -47,10 +48,13 @@ sealed class BlockListItem(val type: Type) {
         EXPANDABLE_ITEM,
         DIVIDER,
         LOADING_ITEM,
-        ACTIVITY_ITEM
+        ACTIVITY_ITEM,
+        REFERRED_ITEM
     }
 
     data class Title(@StringRes val textResource: Int? = null, val text: String? = null) : BlockListItem(TITLE)
+
+    data class ReferredItem(@StringRes val label: Int, val itemTitle: String) : BlockListItem(REFERRED_ITEM)
 
     data class ValueItem(
         val value: String,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ReferredItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ReferredItemViewHolder.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
+
+import android.view.ViewGroup
+import android.widget.TextView
+import org.wordpress.android.R.id
+import org.wordpress.android.R.layout
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ReferredItem
+
+class ReferredItemViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
+        parent,
+        layout.stats_block_referred_item
+) {
+    private val label = itemView.findViewById<TextView>(id.label)
+    private val title = itemView.findViewById<TextView>(id.title)
+    fun bind(item: ReferredItem) {
+        label.setText(item.label)
+        title.text = item.itemTitle
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
@@ -72,9 +72,9 @@ class StatsNavigator
                         activity,
                         siteProvider.siteModel,
                         target.postId,
-                        target.postTitle,
-                        target.postType,
-                        target.postUrl)
+                        postType = target.postType,
+                        postTitle = target.postTitle,
+                        postUrl = target.postUrl)
             }
             is ViewFollowersStats -> {
                 ActivityLauncher.viewAllTabbedInsightsStats(activity, FOLLOWERS, target.selectedTab)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsPostProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsPostProvider.kt
@@ -7,13 +7,20 @@ import javax.inject.Singleton
 class StatsPostProvider
 @Inject constructor() {
     var postId: Long? = null
-    private lateinit var postType: String
-    private lateinit var postTitle: String
-    private var postUrl: String? = null
+    var postType: String? = null
+    var postTitle: String? = null
+    var postUrl: String? = null
     fun init(postId: Long, postType: String, postTitle: String, postUrl: String?) {
         this.postId = postId
         this.postType = postType
         this.postTitle = postTitle
         this.postUrl = postUrl
+    }
+
+    fun clear() {
+        postId = null
+        postType = null
+        postTitle = null
+        postUrl = null
     }
 }

--- a/WordPress/src/main/res/layout/stats_block_referred_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_referred_item.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:minHeight="@dimen/two_line_list_item_height"
+              android:layout_marginStart="@dimen/margin_extra_large"
+              android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/label"
+        style="@style/StatsReferredItemLabel"
+        android:text="@string/showing_stats_for"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
+    <TextView
+        android:id="@+id/title"
+        style="@style/StatsReferredItemTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:ellipsize="end"
+        android:lines="1"
+        android:text="@string/unknown"/>
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/stats_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/stats_detail_fragment.xml
@@ -15,7 +15,6 @@
             android:id="@+id/pullToRefresh"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="@color/white"
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
             <fragment

--- a/WordPress/src/main/res/values/stats_styles.xml
+++ b/WordPress/src/main/res/values/stats_styles.xml
@@ -205,4 +205,15 @@
         <item name="android:layout_height">@dimen/stats_activity_box_size</item>
         <item name="android:layout_marginEnd">@dimen/stats_activity_box_end_margin</item>
     </style>
+
+    <style name="StatsReferredItemLabel" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:layout_marginTop">@dimen/margin_extra_large</item>
+        <item name="android:textColor">@color/grey_dark</item>
+        <item name="android:textSize">@dimen/text_sz_medium</item>
+    </style>
+
+    <style name="StatsReferredItemTitle" parent="TextAppearance.AppCompat.Body2">
+        <item name="android:textColor">@color/grey_dark</item>
+        <item name="android:textSize">@dimen/text_sz_large</item>
+    </style>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -815,6 +815,7 @@
     <string name="stats_fewer_posts">Fewer posts</string>
     <string name="stats_more_posts">More posts</string>
     <string name="stats_site_not_loaded_yet" tools:ignore="UnusedResources">Site not loaded yet</string>
+    <string name="showing_stats_for">Showing stats for:</string>
 
     <!-- Jetpack install -->
     <string name="jetpack">Jetpack</string>

--- a/build.gradle
+++ b/build.gradle
@@ -104,5 +104,5 @@ buildScan {
 }
 
 ext {
-    fluxCVersion = '637402c47c2051c028e0fa7c79b42712d1c5c300'
+    fluxCVersion = 'd8f81a2d5e013f86b91321b9447948a63f9bfde1'
 }


### PR DESCRIPTION
This PR adds a `Header` item to the post detail. This header shows the `Showing stats for:` message to the user. 
 
To test:
* Go to Stats/DWMY/Posts and Pages
* Click on a Page
* The Post detail screen opens
* Notice the `Header` block saying `Showing stats for:` for the selected post on top

![Screenshot_1552569446](https://user-images.githubusercontent.com/1079756/54360008-26044a00-4664-11e9-8065-844542efadd7.png)
