### PR TITLE
Fix NPE when the view is gone when we want to change the elevation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -162,7 +162,11 @@ class StatsFragment : DaggerFragment() {
 
         viewModel.toolbarHasShadow.observe(this, Observer { toolbarElevation ->
             app_bar_layout.postDelayed(
-                    { ViewCompat.setElevation(app_bar_layout, toolbarElevation?.toFloat() ?: 0.0f) },
+                    {
+                        if (app_bar_layout != null) {
+                            ViewCompat.setElevation(app_bar_layout, toolbarElevation?.toFloat() ?: 0.0f)
+                        }
+                    },
                     100
             )
         })


### PR DESCRIPTION
Fixes #9415
Add a non-null check when setting a delayed elevation to the view. I think that in certain cases the view might be already gone when we want to set elevation.
To test:
* Nothing to test here
