### PR TITLE
Initialize AppRatingDialog inside application class.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -92,6 +92,7 @@ import org.wordpress.android.util.PackageUtils;
 import org.wordpress.android.util.ProfilingUtils;
 import org.wordpress.android.util.RateLimitedTask;
 import org.wordpress.android.util.VolleyUtils;
+import org.wordpress.android.widgets.AppRatingDialog;
 
 import java.io.File;
 import java.io.IOException;
@@ -255,6 +256,8 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         versionName = PackageUtils.getVersionName(this);
         initWpDb();
         enableHttpResponseCache(mContext);
+
+        AppRatingDialog.INSTANCE.init(this);
 
         // EventBus setup
         EventBus.TAG = "WordPress-EVENT";

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -322,7 +322,6 @@ public class WPMainActivity extends AppCompatActivity implements
                     new Intent(this, GCMRegistrationIntentService.class));
         }
 
-        AppRatingDialog.INSTANCE.init(this);
         if (canShowAppRatingPrompt) {
             AppRatingDialog.INSTANCE.showRateDialogIfNeeded(getFragmentManager());
         }


### PR DESCRIPTION
Fixes #9416

This PR moves the initialization of `AppRatingDialog` from main activity to application class. There are some cases when we access it without the main activity being launched first, and this causes crashes.


To test:
- Make sure the App Rating Prompt was not yet shown to you (or better, use a fresh install of the app).
- Close the app completely (using task manager).
- Navigate to Gallery on your phone and share any image to WordPress app.
- Add the shared image to a New Post and post it.
- Notice app does not crash.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
