### PR TITLE
Fix media upload error notifications & local Urls on Aztec

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 Faster opening of large posts
 * Updated Notifications with tabs
 * Add Posting activity block to the Stats/Insights
+* Fixed error notifications for failed uploads
 
 11.9
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadReadyProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadReadyProcessor.java
@@ -20,7 +20,7 @@ public class MediaUploadReadyProcessor implements MediaUploadReadyListener {
             boolean showNewEditor = AppPrefs.isVisualEditorEnabled();
             boolean showGutenbergEditor = AppPrefs.isGutenbergEditorEnabled();
 
-            if (showGutenbergEditor) {
+            if (showGutenbergEditor && PostUtils.contentContainsGutenbergBlocks(post.getContent())) {
                 post.setContent(
                         PostUtils.replaceMediaFileWithUrlInGutenbergPost(post.getContent(), localMediaId, mediaFile));
             } else if (showAztecEditor) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -429,6 +429,11 @@ class PostUploadNotifier {
         long postIdToUse = post.getRemotePostId();
         if (post.isLocalDraft()) {
             postIdToUse = post.getId();
+            // Note: local drafts just don't have a remote post Id set yet, so they are all 0. Because of this, we only
+            // use the local id for local drafts.
+            // there could be the case where a local draft on the device, and a remote post, can get the same ID,
+            // since the ID is returned from 2 different sources. In theory this is true, but however the chances are
+            // too low so it seems it should work in practically 100% of times.
         }
         // We can't use the local table post id here because it can change between first post (local draft) to
         // first edit (post pulled from the server)

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -426,10 +426,18 @@ class PostUploadNotifier {
     }
 
     public static long getNotificationIdForPost(PostModel post) {
-        long remotePostId = post.getRemotePostId();
+        long postIdToUse = post.getRemotePostId();
+        if (post.isLocalDraft()) {
+            postIdToUse = post.getId();
+        }
         // We can't use the local table post id here because it can change between first post (local draft) to
         // first edit (post pulled from the server)
-        return post.getLocalSiteId() + remotePostId;
+        // but, if this is a local draft, we don't have a choice but to use the local id.
+        // otherwise, remote ID is always 0 for any local draft, and this means we'd be providing the same
+        // notificationId for 2 different local drafts for the same site, with this ending in the latest notification
+        // "stepping" on the first one (the user would always get to see the latest failed local draft, but wouldn't get
+        // a notice about the previous ones).
+        return post.getLocalSiteId() + postIdToUse;
     }
 
     public static long getNotificationIdForMedia(SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -816,9 +816,10 @@ public class UploadService extends Service {
                 // the user actively cancelled it. No need to show an error then.
                 String message = UploadUtils.getErrorMessageFromMediaError(this, event.media, event.error);
 
-                int siteLocalId = AppPrefs.getSelectedSite();
+                // if media has a local site id, use that. If not, default to currently selected site.
+                int siteLocalId = event.media.getLocalSiteId() > 0 ? event.media.getLocalSiteId()
+                        : AppPrefs.getSelectedSite();
                 SiteModel selectedSite = mSiteStore.getSiteByLocalId(siteLocalId);
-
 
                 List<MediaModel> failedStandAloneMedia = getRetriableStandaloneMedia(selectedSite);
                 if (failedStandAloneMedia.isEmpty()) {


### PR DESCRIPTION
Fixes #9159 along with other general error notification / Posting issues

### Foreword: How the UploadService currently works
The `UploadService` will always re-create the notifications once any of the states is updated (for example, if a failed post is re-tried and ends up successfully, the service will run again through _all_ failed Posts and re-create the error notifications for those. This happens in method `doFinalProcessingOfPosts()` within the Service). This means that even if you dismiss them, but then upload something else (a new post or anything), chances are the Service will also create the error notifications for the failed Posts reminding that there's something to care about; as well as indicate the success for the recently uploaded Post (also note, the success notification is only shown when the app is not on the foreground).
This is probably a behavior that we may want to get revisited, but may imply a more complex mechanism of detection of changes (i.e. do we want to delete notifications if the user dismissed them already? how do we know if a Post has failed, then was fixed, but then failed again - do we notify the user in that case?, etc.)

### Fixes made in this PR

#### A) Make different error notification id for different failed local drafts

What was happening here regarding the described issue, as reported by @rachelmcr elsewhere:

> When I try to share media to the app I am now consistently seeing the issue reported here with the upload failed message: 
... (see #9159)

and

> Several upload attempts actually failed first, so that could be a factor in the failed upload message continuing to appear; I’m not sure about that.

This ˆˆˆ. 

The error notifications for media for local drafts were using a local ID that was being re-used. If you had 2 local drafts (that is, drafts that couldn't be uploaded to the server), then due to this bug there would only be _one_ error notification for the _latest_ post to have failed (first we'd generate an error notification for the first Post, then for the second, but using the same id, thus giving the impression the latest Post failed). Using step by step debugging, I could verify we were rather updating the same notification on each pass, rather than generating a different notification for each failed Post/media.

This was fixed in commit  25747a9. Steps to both reproduce the issue and test this PR fixes the bug are shown below.

#### B) Wrong site name for failed media shared to the app
> I also noticed that the upload failed message will always show the site title for the site I selected in the app, even if that isn’t the site that the media is being uploaded to.

This other case was only happening when sharing media to the WP app, choosing media section and choosing a site other than the one selected in the app. This is fixed in dd6cb03.

#### C) Local URL within Aztec posts with media
This is something I saw while doing tests, and is quite an important issue. When you draft and add an image to a Post and finish uploading successfully, the Post on the web contained the local URL for the media file on the Android OS instead of using the remote, because of a bad check when introducing Gutenberg that affected the condition being checked.

This was fixed in f7ecaf7.


### To test:
All of this should be done with Aztec enabled - that is, make sure you have the Gutenberg setting (Use Block Editor) set to `off`, except for CASE C, where both ON and OFF should be tested.

#### CASE A: error notification showing error for wrong Post 
(latest Post even if it was successfully uploaded, as long as there were previous failed Posts).

1. start a draft, title it "Test 1".
2. add an image
3. tap back
4. turn airplane mode ON (this will make neither the media or the enqueued Post finally reach the server, even when it started to upload).
5. observe the post is marked as failed, and the error notification appears with the right Post title. Technically this ends with a local draft with failed media in our local db.

now, still leaving airplane mode ON:

6. start a new draft and title it "Test 2".
7. insert an image
8. (PREVIOUSLY) observe the notification is reset (shows now `Upload failed for "Test 1" (1 file not uploaded)`.
8. (NOW) observe there's a new notification, one for each of the failed Posts, that show the right title for each.

What was happening here is what I described above, regarding the error notification Id being re-used and thus wrongly updated.

now, let's continue, still leaving airplane mode ON as well:

9. now, open the Photos app and share an image to WP.
10. select a site _different than the one you were using_, and create new Post.
11. this will create a new failed local draft.

12. (PREVIOUSLY) observe how there are 2 notifications: one that is just for the last failed post for the app's selected site, and another one for the shared media that failed, that also shows the wrong site name (shows the app's selected site name instead of the site for which we chose to create this Post on).
12. (NOW) observe there's 3 notifications: one for each failed post, and another one for the failed media.

finally, let's continue, this time set airplane mode OFF, and:

13. start a new draft
14. add an image
15. exit the editor before the image finishes uploading and see how it continues to upload, and the Post is enqueued to upload as well.
16. let it finish
17. observe it finishes alright, and the error notifications for the rest of the Posts still are the same. Also note the error snackbar will be shown on the main screen, as there are still outstanding failed Posts as informed by the UploadService (this is OK given the current behavior described above).

#### CASE B: error notification showing error for wrong Site
1. share an image to WP Android
2. select a site other than the currently selected in the app
3. tap on Add to Media Library
4. once the upload starts, turn airplane mode ON.
5. observe a new error notification is displayed, saying "Upload failed for _correct_sitename_", with "1 file not uploaded" as a subtext.

#### CASE C: no local urls in Posts
1. share an image to WP Android, or start a new draft and add an image
2. tap Back to exit the editor
3. once the upload finishes, make sure to open it on the web and see the image is correctly displayed
4. also, view the HTML view for the post on the web and verify the image URL starts with `http`.


cc @jtreanor @rachelmcr 🙇 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
