### PR TITLE
Issue/9424 add domain registration feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -64,6 +64,7 @@ android {
         buildConfigField "boolean", "REVISIONS_ENABLED", "false"
         buildConfigField "boolean", "NEW_SITE_CREATION_ENABLED", "true"
         buildConfigField "boolean", "OFFER_GUTENBERG", "true"
+        buildConfigField "boolean", "DOMAIN_REGISTRATION_ENABLED", "false"
     }
 
     flavorDimensions "buildType"
@@ -82,6 +83,7 @@ android {
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
             applicationId "org.wordpress.android.beta"
             dimension "buildType"
+            buildConfigField "boolean", "DOMAIN_REGISTRATION_ENABLED", "true"
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
@@ -25,12 +25,17 @@ public class PluginUtils {
         if (site.isUsingWpComRestApi() && site.isJetpackConnected()) {
             return SiteUtils.checkMinimalJetpackVersion(site, "5.6");
         }
+
+        boolean isCustomDomain = !site.getUrl().contains(".wordpress.com");
+        boolean isCustomDomainRegistrationAvailable = BuildConfig.DOMAIN_REGISTRATION_ENABLED;
+
         // If the site has business plan we can do an Automated Transfer
         return site.isWPCom()
                && SiteUtils.hasNonJetpackBusinessPlan(site)
                && site.getHasCapabilityManageOptions() // Automated Transfer require admin capabilities
-               // Automated Transfers require custom domains
-               && (!site.getUrl().contains(".wordpress.com") || BuildConfig.DOMAIN_REGISTRATION_ENABLED)
+               // Automated Transfers require custom domains, so if the user has a `xyz.wordpress.com` site
+               // custom domain registrations feature needs to be enabled in order to access plugin feature
+               && (isCustomDomain || isCustomDomainRegistrationAvailable)
                && !site.isPrivate(); // Private sites are not eligible for Automated Transfer
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.plugin.ImmutablePluginModel;
 import org.wordpress.android.util.AppLog;
@@ -28,7 +29,8 @@ public class PluginUtils {
         return site.isWPCom()
                && SiteUtils.hasNonJetpackBusinessPlan(site)
                && site.getHasCapabilityManageOptions() // Automated Transfer require admin capabilities
-               && !site.getUrl().contains(".wordpress.com") // Automated Transfers require custom domains
+               // Automated Transfers require custom domains
+               && (!site.getUrl().contains(".wordpress.com") || BuildConfig.DOMAIN_REGISTRATION_ENABLED)
                && !site.isPrivate(); // Private sites are not eligible for Automated Transfer
     }
 


### PR DESCRIPTION
This PR adds a feature flag that exposes a Plugins screen to wpcom sites without a custom domain on ` wasabi `build.

### Test

**Enabled**
1. Build project with `wasabi` variant.
2. Go to My Site tab.
3. Select a public wpcom site without the custom domain (site on .wordpress.com subdomain) on a business plan, where you have admin rights.
4. Notice the Plugins row in a Configuration section of My Site screen.

[![Image from Gyazo](https://i.gyazo.com/a1c3a045c7b9f16dec10258c4dd1b9d1.png)](https://gyazo.com/a1c3a045c7b9f16dec10258c4dd1b9d1)

**Disabled**

1. Build project with `vanilla` or `zalpha` variant.
2. Go to My Site tab.
3. Select a public wpcom site without the custom domain (site on .wordpress.com subdomain) on a business plan, where you have admin rights.
4. Notice that there is no Plugins row in a Configuration section of My Site screen.