### PR TITLE
Issue/remove revisions flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -61,7 +61,6 @@ android {
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
 
-        buildConfigField "boolean", "REVISIONS_ENABLED", "false"
         buildConfigField "boolean", "NEW_SITE_CREATION_ENABLED", "true"
         buildConfigField "boolean", "OFFER_GUTENBERG", "true"
     }


### PR DESCRIPTION
### Fix
Remove the `REVISIONS_ENABLED` feature flag from the `WordPress/build.gradle` file.

### Review
Only one developer is required to review these changes, but anyone can perform the review.