### PR TITLE
Design improvements to stats detail

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 12.1
 -----
+* Refreshed post stats detail screen - opens from the Blog posts/Stats and from Stats/Posts and Pages
 
 12.0
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -76,6 +76,7 @@ import org.wordpress.android.ui.stats.StatsViewType;
 import org.wordpress.android.ui.stats.models.StatsPostModel;
 import org.wordpress.android.ui.stats.refresh.StatsActivity;
 import org.wordpress.android.ui.stats.refresh.StatsViewAllFragment;
+import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailActivity;
 import org.wordpress.android.ui.stockmedia.StockMediaPickerActivity;
 import org.wordpress.android.ui.themes.ThemeBrowserActivity;
 import org.wordpress.android.util.AppLog;
@@ -730,19 +731,19 @@ public class ActivityLauncher {
     }
 
     public static void viewStatsSinglePostDetails(Context context, SiteModel site, PostModel post) {
-        if (post == null) {
+        if (post == null || site == null) {
             return;
         }
-
-        StatsPostModel statsPostModel = new StatsPostModel(site.getSiteId(), String.valueOf(post.getRemotePostId()),
-                post.getTitle(), post.getLink(), StatsConstants.ITEM_TYPE_POST);
-        viewStatsSinglePostDetails(context, statsPostModel);
+        StatsDetailActivity.Companion
+                .start(context, site, post.getRemotePostId(), StatsConstants.ITEM_TYPE_POST, post.getTitle(),
+                        post.getLink());
     }
 
     public static void viewStatsSinglePostDetails(Context context, StatsPostModel post) {
         if (post == null) {
             return;
         }
+
         Intent statsPostViewIntent = new Intent(context, StatsSingleItemDetailsActivity.class);
         statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_REMOTE_BLOG_ID, post.getBlogID());
         statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_REMOTE_ITEM_ID, post.getItemID());

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
@@ -12,7 +12,6 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Divider
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.NavigationAction
@@ -74,7 +73,6 @@ class PostAverageViewsPerDayUseCase(
                         string.stats_months_and_years_views_label
                 )
         )
-        items.add(Divider)
         val shownYears = domainModel.yearsAverage.sortedByDescending { it.year }.takeLast(itemsToLoad)
         val yearList = postDetailMapper.mapYears(shownYears, uiState, this::onUiState)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDetailMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDetailMapper.kt
@@ -26,12 +26,17 @@ class PostDetailMapper
         onUiState: (ExpandedYearUiState) -> Unit
     ): List<BlockListItem> {
         val yearList = mutableListOf<BlockListItem>()
+
         shownYears.forEachIndexed { index, year ->
+            val isNextNotExpanded = shownYears.getOrNull(index + 1)?.year != expandedYearUiState.expandedYear
             if (year.months.isNotEmpty()) {
                 val isExpanded = year.year == expandedYearUiState.expandedYear
+                if (isExpanded) {
+                    yearList.add(Divider)
+                }
                 yearList.add(
                         ExpandableItem(
-                                mapYear(year, index, shownYears.size), isExpanded = isExpanded
+                                mapYear(year, index, shownYears.size, isNextNotExpanded), isExpanded = isExpanded
                         ) { changedExpandedState ->
                             val expandedYear = if (changedExpandedState) year.year else null
                             onUiState(expandedYearUiState.copy(expandedYear = expandedYear))
@@ -49,7 +54,7 @@ class PostDetailMapper
                 }
             } else {
                 yearList.add(
-                        mapYear(year, index, shownYears.size)
+                        mapYear(year, index, shownYears.size, isNextNotExpanded)
                 )
             }
         }
@@ -59,12 +64,13 @@ class PostDetailMapper
     private fun mapYear(
         year: Year,
         index: Int,
-        size: Int
+        size: Int,
+        isNextNotExpanded: Boolean
     ): ListItemWithIcon {
         return ListItemWithIcon(
                 text = year.year.toString(),
                 value = year.value.toFormattedString(locale = localeManagerWrapper.getLocale()),
-                showDivider = index < size - 1
+                showDivider = isNextNotExpanded && index < size - 1
         )
     }
 
@@ -83,11 +89,15 @@ class PostDetailMapper
             WeekUiModel(firstDay, lastDay, descendingDays, week.average)
         }.sortedByDescending { it.firstDay }.take(visibleCount)
         visibleWeeks.forEachIndexed { index, week ->
+            val isNextNotExpanded = visibleWeeks.getOrNull(index + 1)?.firstDay != uiState.expandedWeekFirstDay
             if (week.days.isNotEmpty()) {
                 val isExpanded = week.firstDay == uiState.expandedWeekFirstDay
+                if (isExpanded) {
+                    weekList.add(Divider)
+                }
                 weekList.add(
                         ExpandableItem(
-                                mapWeek(week, index, visibleWeeks.size), isExpanded = isExpanded
+                                mapWeek(week, index, visibleWeeks.size, isNextNotExpanded), isExpanded = isExpanded
                         ) { changedExpandedState ->
                             val expandedFirstDay = if (changedExpandedState) week.firstDay else null
                             onUiState(uiState.copy(expandedWeekFirstDay = expandedFirstDay))
@@ -106,7 +116,7 @@ class PostDetailMapper
                     weekList.add(Divider)
                 }
             } else {
-                weekList.add(mapWeek(week, index, visibleWeeks.size))
+                weekList.add(mapWeek(week, index, visibleWeeks.size, isNextNotExpanded))
             }
         }
         return weekList
@@ -121,7 +131,7 @@ class PostDetailMapper
         val weekAverage: Int
     )
 
-    private fun mapWeek(week: WeekUiModel, index: Int, size: Int): ListItemWithIcon {
+    private fun mapWeek(week: WeekUiModel, index: Int, size: Int, isNextNotExpanded: Boolean): ListItemWithIcon {
         val lastDay = week.lastDay
         val label = if (lastDay != null) {
             statsDateFormatter.printWeek(week.firstDay, lastDay)
@@ -131,7 +141,7 @@ class PostDetailMapper
         return ListItemWithIcon(
                 text = label,
                 value = week.weekAverage.toFormattedString(locale = localeManagerWrapper.getLocale()),
-                showDivider = index < size - 1
+                showDivider = isNextNotExpanded && index < size - 1
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCase.kt
@@ -12,7 +12,6 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Divider
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.NavigationAction
@@ -74,7 +73,6 @@ class PostMonthsAndYearsUseCase(
                         string.stats_months_and_years_views_label
                 )
         )
-        items.add(Divider)
         val shownYears = domainModel.yearsTotal.sortedByDescending { it.year }.takeLast(itemsToLoad)
         val yearList = postDetailMapper.mapYears(shownYears, uiState, this::onUiState)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCase.kt
@@ -12,7 +12,6 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Divider
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.NavigationAction
@@ -74,7 +73,6 @@ class PostRecentWeeksUseCase(
                         string.stats_months_and_years_views_label
                 )
         )
-        items.add(Divider)
         val yearList = postDetailMapper.mapWeeks(domainModel.weekViews, itemsToLoad, uiState, this::onUiState)
 
         items.addAll(yearList)

--- a/WordPress/src/main/res/layout/stats_block_referred_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_referred_item.xml
@@ -21,7 +21,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
         android:ellipsize="end"
-        android:lines="1"
+        android:lines="2"
         android:text="@string/unknown"/>
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/stats_block_referred_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_referred_item.xml
@@ -4,6 +4,7 @@
               android:layout_height="wrap_content"
               android:minHeight="@dimen/two_line_list_item_height"
               android:layout_marginStart="@dimen/margin_extra_large"
+              android:layout_marginEnd="@dimen/margin_extra_large"
               android:orientation="vertical">
 
     <TextView

--- a/WordPress/src/main/res/values/stats_styles.xml
+++ b/WordPress/src/main/res/values/stats_styles.xml
@@ -215,5 +215,7 @@
     <style name="StatsReferredItemTitle" parent="TextAppearance.AppCompat.Body2">
         <item name="android:textColor">@color/grey_dark</item>
         <item name="android:textSize">@dimen/text_sz_large</item>
+        <item name="android:fontFamily">serif</item>
+        <item name="android:textStyle">bold</item>
     </style>
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCaseTest.kt
@@ -26,7 +26,6 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.Us
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.ERROR
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.SUCCESS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Divider
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ExpandableItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
@@ -108,8 +107,7 @@ class PostAverageViewsPerDayUseCaseTest : BaseUnitTest() {
     ): ExpandableItem {
         assertTitle(this[0])
         assertHeader(this[1])
-        assertThat(this[2]).isEqualTo(Divider)
-        return assertYear(this[3], year.year.toString(), year.value)
+        return assertYear(this[2], year.year.toString(), year.value)
     }
 
     private fun List<BlockListItem>.assertExpandedList(
@@ -118,9 +116,8 @@ class PostAverageViewsPerDayUseCaseTest : BaseUnitTest() {
         val month = year.months.first()
         assertTitle(this[0])
         assertHeader(this[1])
-        assertThat(this[2]).isEqualTo(Divider)
-        assertYear(this[3], year.year.toString(), year.value)
-        assertMonth(this[4], "Jan", month.count.toString())
+        assertYear(this[2], year.year.toString(), year.value)
+        assertMonth(this[3], "Jan", month.count.toString())
     }
 
     @Test
@@ -151,12 +148,11 @@ class PostAverageViewsPerDayUseCaseTest : BaseUnitTest() {
 
         assertThat(result.state).isEqualTo(SUCCESS)
         result.data!!.apply {
-            assertThat(this).hasSize(5)
+            assertThat(this).hasSize(4)
             assertTitle(this[0])
             assertHeader(this[1])
-            assertThat(this[2]).isEqualTo(Divider)
-            assertYear(this[3], year.year.toString(), year.value)
-            assertLink(this[4])
+            assertYear(this[2], year.year.toString(), year.value)
+            assertLink(this[3])
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDetailMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDetailMapperTest.kt
@@ -65,24 +65,25 @@ class PostDetailMapperTest : BaseUnitTest() {
         val february = Month(2, 40)
         val years = listOf(PostDetailStatsModel.Year(2019, listOf(january, february), 100))
         val result = postDetailMapper.mapYears(years, ExpandedYearUiState(expandedYear = 2019)) { }
-        assertThat(result).hasSize(4)
-        (result[0] as ExpandableItem).apply {
+        assertThat(result).hasSize(5)
+        assertThat(result[0] is Divider).isTrue()
+        (result[1] as ExpandableItem).apply {
             assertThat(this.isExpanded).isTrue()
             assertThat(this.header.text).isEqualTo("2019")
             assertThat(this.header.value).isEqualTo("100")
             assertThat(this.header.showDivider).isFalse()
         }
-        (result[1] as ListItemWithIcon).apply {
+        (result[2] as ListItemWithIcon).apply {
             assertThat(this.text).isEqualTo("Feb")
             assertThat(this.value).isEqualTo("40")
             assertThat(this.showDivider).isFalse()
         }
-        (result[2] as ListItemWithIcon).apply {
+        (result[3] as ListItemWithIcon).apply {
             assertThat(this.text).isEqualTo("Jan")
             assertThat(this.value).isEqualTo("50")
             assertThat(this.showDivider).isFalse()
         }
-        assertThat(result[3] is Divider).isTrue()
+        assertThat(result[4] is Divider).isTrue()
     }
 
     @Test
@@ -139,23 +140,24 @@ class PostDetailMapperTest : BaseUnitTest() {
 
         val result = postDetailMapper.mapWeeks(weeks, 1, ExpandedWeekUiState(firstDay)) {}
 
-        assertThat(result).hasSize(4)
-        (result[0] as ExpandableItem).apply {
+        assertThat(result).hasSize(5)
+        assertThat(result[0] is Divider).isTrue()
+        (result[1] as ExpandableItem).apply {
             assertThat(this.isExpanded).isTrue()
             assertThat(this.header.text).isEqualTo(weekLabel)
             assertThat(this.header.value).isEqualTo("350")
             assertThat(this.header.showDivider).isFalse()
         }
-        (result[1] as ListItemWithIcon).apply {
+        (result[2] as ListItemWithIcon).apply {
             assertThat(this.text).isEqualTo("Jan 16")
             assertThat(this.value).isEqualTo("400")
             assertThat(this.showDivider).isFalse()
         }
-        (result[2] as ListItemWithIcon).apply {
+        (result[3] as ListItemWithIcon).apply {
             assertThat(this.text).isEqualTo("Jan 9")
             assertThat(this.value).isEqualTo("300")
             assertThat(this.showDivider).isFalse()
         }
-        assertThat(result[3] is Divider).isTrue()
+        assertThat(result[4] is Divider).isTrue()
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCaseTest.kt
@@ -26,7 +26,6 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.Us
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.ERROR
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.SUCCESS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Divider
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ExpandableItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
@@ -108,8 +107,7 @@ class PostMonthsAndYearsUseCaseTest : BaseUnitTest() {
     ): ExpandableItem {
         assertTitle(this[0])
         assertHeader(this[1])
-        assertThat(this[2]).isEqualTo(Divider)
-        return assertYear(this[3], year.year.toString(), year.value)
+        return assertYear(this[2], year.year.toString(), year.value)
     }
 
     private fun List<BlockListItem>.assertExpandedList(
@@ -118,9 +116,8 @@ class PostMonthsAndYearsUseCaseTest : BaseUnitTest() {
         val month = year.months.first()
         assertTitle(this[0])
         assertHeader(this[1])
-        assertThat(this[2]).isEqualTo(Divider)
-        assertYear(this[3], year.year.toString(), year.value)
-        assertMonth(this[4], "Jan", month.count.toString())
+        assertYear(this[2], year.year.toString(), year.value)
+        assertMonth(this[3], "Jan", month.count.toString())
     }
 
     @Test
@@ -151,12 +148,11 @@ class PostMonthsAndYearsUseCaseTest : BaseUnitTest() {
 
         assertThat(result.state).isEqualTo(SUCCESS)
         result.data!!.apply {
-            assertThat(this).hasSize(5)
+            assertThat(this).hasSize(4)
             assertTitle(this[0])
             assertHeader(this[1])
-            assertThat(this[2]).isEqualTo(Divider)
-            assertYear(this[3], year.year.toString(), year.value)
-            assertLink(this[4])
+            assertYear(this[2], year.year.toString(), year.value)
+            assertLink(this[3])
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCaseTest.kt
@@ -26,7 +26,6 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.Us
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.ERROR
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.SUCCESS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Divider
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ExpandableItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
@@ -116,17 +115,15 @@ class PostRecentWeeksUseCaseTest : BaseUnitTest() {
     private fun List<BlockListItem>.assertNonExpandedList(): ExpandableItem {
         assertTitle(this[0])
         assertHeader(this[1])
-        assertThat(this[2]).isEqualTo(Divider)
-        return assertWeek(this[3], "Mar 18 - Mar 24, 2019", 150)
+        return assertWeek(this[2], "Mar 18 - Mar 24, 2019", 150)
     }
 
     private fun List<BlockListItem>.assertExpandedList() {
         assertTitle(this[0])
         assertHeader(this[1])
-        assertThat(this[2]).isEqualTo(Divider)
-        assertWeek(this[3], "Mar 18 - Mar 24, 2019", 150)
-        assertDay(this[4], "Mar 18", "50")
-        assertDay(this[5], "Mar 24", "100")
+        assertWeek(this[2], "Mar 18 - Mar 24, 2019", 150)
+        assertDay(this[3], "Mar 18", "50")
+        assertDay(this[4], "Mar 24", "100")
     }
 
     @Test
@@ -160,12 +157,11 @@ class PostRecentWeeksUseCaseTest : BaseUnitTest() {
 
         assertThat(result.state).isEqualTo(SUCCESS)
         result.data!!.apply {
-            assertThat(this).hasSize(5)
+            assertThat(this).hasSize(4)
             assertTitle(this[0])
             assertHeader(this[1])
-            assertThat(this[2]).isEqualTo(Divider)
-            assertWeek(this[3], "Mar 18 - Mar 24, 2019", 150)
-            assertLink(this[4])
+            assertWeek(this[2], "Mar 18 - Mar 24, 2019", 150)
+            assertLink(this[3])
         }
     }
 


### PR DESCRIPTION
Fixes following items:
- Title of a post is now `serif`
- Title of the post has now a 16dp right margin
- There is now top and bottom full-width divider around an expanded item
- The Blog posts screen now redirects to the refreshed post detail screen

To test:
* Go to Stats/DWMY/Posts and Pages block
* Click on a Post
* The post title in the "Showing stats for" block:
  * is now `serif` and bold
  * has a 16dp right margin (when the post title is long)
* When expanding an item, it now has top and bottom full-width dividers

To test 2: 
* Go to Blog posts
* Click on `Stats` on a blog post
* The refreshed stats detail screen is opened instead of the old screen

![Screenshot_1552917759](https://user-images.githubusercontent.com/1079756/54536342-d8078300-4990-11e9-81a7-0c3f382168f9.png)
![Screenshot_1552917764](https://user-images.githubusercontent.com/1079756/54536344-d8078300-4990-11e9-9b92-5e866dacb4a9.png)


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
