### PR TITLE
Issue/post list snackbars

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -184,7 +184,7 @@ class PostListFragment : Fragment() {
     }
 
     private fun showSnackbar(holder: SnackbarMessageHolder) {
-        nonNullActivity.findViewById<View>(R.id.root_view)?.let { parent ->
+        nonNullActivity.findViewById<View>(R.id.coordinator)?.let { parent ->
             val message = getString(holder.messageRes)
             val duration = AccessibilityUtils.getSnackbarDuration(nonNullActivity)
             val snackbar = Snackbar.make(parent, message, duration)


### PR DESCRIPTION
### Fix
Update the target view used by snackbars in the `PostListFragment` class from the `RelativeLayout` to the `CoordinatorLayout` so that the snackbar will not overlap the floating action button.  See the screenshots below for illustration.

![snackbar_posts](https://user-images.githubusercontent.com/3827611/54558330-b13e5200-497a-11e9-86be-d1a34e17f040.png)

### Test
1. Go to ***Sites*** tab.
2. Tap ***Blog Posts*** under ***Publish*** section.
3. Tap ***Create*** button.
4. Enter title and/or content.
5. Tap back arrow.
6. Notice ***Your post is uploading*** snackbar does not overlap floating action button.
7. Wait for post to upload.
8. Notice ***Draft saved online*** snackbar does not overlap floating action button.
9. Tap ***Trash*** button on post.
10. Notice ***Post sent to trash*** snackbar does not overlap floating action button.

### Review
Only one developer is required to review these changes, but anyone can perform the review.