### PR TITLE
Fix metadata strings

### DIFF
--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -115,41 +115,46 @@ msgstr ""
 
 #. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
 #. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot_1"
-msgid "<strong>Create </strong>beautiful<br />posts and pages"
+msgctxt "enhanced_app_store_screenshot-1"
+msgid ""
+"<strong>Create</strong> beautiful\n"
+"posts and pages"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
 #. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot_2"
-msgid "<strong>Track </strong><span>what your<br />visitors love</span>
-"
+msgctxt "enhanced_app_store_screenshot-2"
+msgid ""
+"<strong>Track</strong> what your\n"
+"visitors love"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
 #. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot_3"
-msgid "<strong>Check </strong><span>what's<br />happening in real time</span>
-"
+msgctxt "enhanced_app_store_screenshot-3"
+msgid ""
+"<strong>Check</strong> what's\n"
+"happening in real time"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
 #. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot_4"
-msgid "<strong>Share </strong> from<br />anywhere
-"
+msgctxt "enhanced_app_store_screenshot-4"
+msgid ""
+"<strong>Share</strong> from\n"
+"anywhere"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
 #. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot_5"
-msgid "<strong>Capture </strong>ideas<br />on the go
-"
+msgctxt "enhanced_app_store_screenshot-5"
+msgid "<strong>Capture</strong> ideas\n"
+"on the go"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
 #. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot_6"
-msgid "<strong>Write</strong> without compromises"
+msgctxt "enhanced_app_store_screenshot-6"
+msgid ""
+"<strong>Write</strong> without compromises"
 msgstr ""
-


### PR DESCRIPTION
Fixes an issue with the metadata strings that fails the upload to GlotPress.
This is a temp fix pushed only to quickly upload the strings. A new PR with the source strings fixed will be pushed soon.
