### PR TITLE
Add the new StatsActivity to the locale manager

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
@@ -1,10 +1,12 @@
 package org.wordpress.android.ui.stats.refresh
 
+import android.content.Context
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
 import kotlinx.android.synthetic.main.toolbar.*
 import org.wordpress.android.R
+import org.wordpress.android.util.LocaleManager
 
 class StatsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -17,6 +19,10 @@ class StatsActivity : AppCompatActivity() {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)
         }
+    }
+
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(LocaleManager.setLocale(newBase))
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {


### PR DESCRIPTION
This enables the StatsActivity to receive notifications when the app locale changes and adjust its translations accordingly

**To test:**
This has caused issues when generating screenshots, as the stats activity wasn't responding to changes in the system language. Separate from the screenshots, it may be difficult to test this. 

However, it's fairly straightforward code, mirrored from here: 

https://github.com/wordpress-mobile/WordPress-Android/blob/da5af1173cd925c5f175528255639ca81ab94b4e/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java#L28-L30