### PR TITLE
Update the block spacing in Stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -18,7 +18,6 @@ import kotlinx.android.synthetic.main.stats_date_selector.*
 import kotlinx.android.synthetic.main.stats_error_view.*
 import kotlinx.android.synthetic.main.stats_list_fragment.*
 import org.wordpress.android.R
-import org.wordpress.android.R.dimen
 import org.wordpress.android.ui.stats.refresh.StatsListItemDecoration
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel
@@ -81,11 +80,11 @@ class StatsListFragment : DaggerFragment() {
         recyclerView.layoutManager = this.layoutManager
         recyclerView.addItemDecoration(
                 StatsListItemDecoration(
-                        resources.getDimensionPixelSize(dimen.stats_list_card_horizontal_spacing),
-                        resources.getDimensionPixelSize(dimen.stats_list_card_top_spacing),
-                        resources.getDimensionPixelSize(dimen.stats_list_card_bottom_spacing),
-                        resources.getDimensionPixelSize(dimen.stats_list_card_first_spacing),
-                        resources.getDimensionPixelSize(dimen.stats_list_card_last_spacing),
+                        resources.getDimensionPixelSize(R.dimen.stats_list_card_horizontal_spacing),
+                        resources.getDimensionPixelSize(R.dimen.stats_list_card_top_spacing),
+                        resources.getDimensionPixelSize(R.dimen.stats_list_card_bottom_spacing),
+                        resources.getDimensionPixelSize(R.dimen.stats_list_card_first_spacing),
+                        resources.getDimensionPixelSize(R.dimen.stats_list_card_last_spacing),
                         columns
                 )
         )

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -397,9 +397,9 @@
     <dimen name="stats_block_icon_size">24dp</dimen>
     <dimen name="stats_list_card_horizontal_spacing">0dp</dimen>
     <dimen name="stats_list_card_top_spacing">0dp</dimen>
-    <dimen name="stats_list_card_bottom_spacing">16dp</dimen>
+    <dimen name="stats_list_card_bottom_spacing">8dp</dimen>
     <dimen name="stats_list_card_first_spacing">0dp</dimen>
-    <dimen name="stats_list_card_last_spacing">16dp</dimen>
+    <dimen name="stats_list_card_last_spacing">8dp</dimen>
     <dimen name="stats_list_item_left_margin">56dp</dimen>
     <dimen name="stats_activity_spacing">1dp</dimen>
 


### PR DESCRIPTION
Fixes #9433.

This PR changes the spacing between blocks and at the bottom from 16dp to 8dp.

![image](https://user-images.githubusercontent.com/1522856/54707686-f06acf80-4b41-11e9-92a8-34bcc97a829c.png)
