### PR TITLE
Issue/9447 stats page spacing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -75,6 +75,7 @@ class StatsFragment : DaggerFragment() {
     private fun initializeViews(activity: FragmentActivity) {
         statsPager.adapter = StatsPagerAdapter(activity, childFragmentManager)
         tabLayout.setupWithViewPager(statsPager)
+        statsPager.pageMargin = resources.getDimensionPixelSize(R.dimen.margin_extra_large)
         statsPager.setCurrentItem(viewModel.getSelectedSection().ordinal, false)
         tabLayout.addOnTabSelectedListener(object : OnTabSelectedListener {
             override fun onTabReselected(tab: Tab?) {


### PR DESCRIPTION
### Fix
Add margin between pages of tabs in ***Stats*** as described in https://github.com/wordpress-mobile/WordPress-Android/issues/9447.  See the screenshots below for illustration.

![stats_page_spacing](https://user-images.githubusercontent.com/3827611/54711274-cea02700-4b06-11e9-9dd0-3706347af6c7.png)

### Test
1. Go to ***Sites*** tab.
2. Tap ***Stats*** item.
3. Swipe between ***Insights***, ***Days***, ***Weeks***, ***Months***, and ***Years*** tabs.
4. Notice spacing between pages.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.