### PR TITLE
Fix for lag when saving long posts in GB-HTML editor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1997,12 +1997,6 @@ public class EditPostActivity extends AppCompatActivity implements
             return;
         }
 
-        boolean postUpdateSuccessful = updatePostObject();
-        if (!postUpdateSuccessful) {
-            // just return, since the only case updatePostObject() can fail is when the editor
-            // fragment is not added to the activity
-            return;
-        }
 
         // Update post, save to db and publish in its own Thread, because 1. update can be pretty slow with a lot of
         // text 2. better not to call `updatePostObject()` from the UI thread due to weird thread blocking behavior

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1997,6 +1997,9 @@ public class EditPostActivity extends AppCompatActivity implements
             return;
         }
 
+        // Loading the content from the GB HTML editor can take time on long posts.
+        // Let's show a progress dialog for now. Ref: https://github.com/wordpress-mobile/gutenberg-mobile/issues/713
+        mEditorFragment.showSavingProgressDialogIfNeeded();
 
         // Update post, save to db and publish in its own Thread, because 1. update can be pretty slow with a lot of
         // text 2. better not to call `updatePostObject()` from the UI thread due to weird thread blocking behavior
@@ -2010,6 +2013,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 if (!postUpdateSuccessful) {
                     // just return, since the only case updatePostObject() can fail is when the editor
                     // fragment is not added to the activity
+                    mEditorFragment.hideSavingProgressDialog();
                     return;
                 }
 
@@ -2018,6 +2022,8 @@ public class EditPostActivity extends AppCompatActivity implements
                 // if post was modified or has unsaved local changes and is publishable, save it
                 saveResult(isPublishable, false, false);
 
+                // Hide the progress dialog now
+                mEditorFragment.hideSavingProgressDialog();
                 if (isPublishable) {
                     if (NetworkUtils.isNetworkAvailable(getBaseContext())) {
                         // Show an Alert Dialog asking the user if they want to remove all failed media before upload

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1124,6 +1124,16 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
+    public boolean showSavingProgressDialogIfNeeded() {
+        return false;
+    }
+
+    @Override
+    public boolean hideSavingProgressDialog() {
+        return false;
+    }
+
+    @Override
     public void onMediaUploadReattached(String localId, float currentProgress) {
         mUploadingMediaProgressMax.put(localId, currentProgress);
         overlayProgressingMediaForMediaId(localId);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1127,6 +1127,16 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     @Override
+    public boolean showSavingProgressDialogIfNeeded() {
+        return false;
+    }
+
+    @Override
+    public boolean hideSavingProgressDialog() {
+        return false;
+    }
+
+    @Override
     public void onMediaUploadReattached(String localId, float currentProgress) {
         // no op (no reattachment in Visual Editor)
     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -37,6 +37,8 @@ public abstract class EditorFragmentAbstract extends Fragment {
     public abstract void removeMedia(String mediaId);
     public abstract void setTitlePlaceholder(CharSequence text);
     public abstract void setContentPlaceholder(CharSequence text);
+    public abstract boolean showSavingProgressDialogIfNeeded();
+    public abstract boolean hideSavingProgressDialog();
 
     // TODO: remove this as soon as we can (we'll need to drop the legacy editor or fix html2spanned translation)
     public abstract Spanned getSpannedContent();

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.editor;
 
 import android.app.Activity;
+import android.app.ProgressDialog;
 import android.arch.lifecycle.LiveData;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -80,6 +81,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     private boolean mIsNewPost;
 
     private boolean mEditorDidMount;
+
+    private ProgressDialog mSavingContentProgressDialog;
 
     public static GutenbergEditorFragment newInstance(String title,
                                                       String content,
@@ -661,6 +664,38 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void setContentPlaceholder(CharSequence placeholderText) {
+    }
+
+    // Getting the content from the HTML editor can take time and the UI seems to be unresponsive.
+    // Show a progress dialog for now. Ref: https://github.com/wordpress-mobile/gutenberg-mobile/issues/713
+    @Override
+    public boolean showSavingProgressDialogIfNeeded() {
+        if (!isAdded()) {
+            return false;
+        }
+
+        if (!mHtmlModeEnabled) return false;
+
+        if (mSavingContentProgressDialog != null && mSavingContentProgressDialog.isShowing()) {
+            // Already on the screen? no need to show it again.
+            return true;
+        }
+
+        mSavingContentProgressDialog = new ProgressDialog(getActivity());
+        mSavingContentProgressDialog.setCancelable(false);
+        mSavingContentProgressDialog.setIndeterminate(true);
+        mSavingContentProgressDialog.setMessage(getActivity().getString(R.string.long_post_dlg_saving));
+        mSavingContentProgressDialog.show();
+       return true;
+    }
+
+    @Override
+    public boolean hideSavingProgressDialog() {
+        if (mSavingContentProgressDialog != null && mSavingContentProgressDialog.isShowing()) {
+            mSavingContentProgressDialog.dismiss();
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -681,10 +681,12 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
             return true;
         }
 
-        mSavingContentProgressDialog = new ProgressDialog(getActivity());
-        mSavingContentProgressDialog.setCancelable(false);
-        mSavingContentProgressDialog.setIndeterminate(true);
-        mSavingContentProgressDialog.setMessage(getActivity().getString(R.string.long_post_dlg_saving));
+        if (mSavingContentProgressDialog == null) {
+            mSavingContentProgressDialog = new ProgressDialog(getActivity());
+            mSavingContentProgressDialog.setCancelable(false);
+            mSavingContentProgressDialog.setIndeterminate(true);
+            mSavingContentProgressDialog.setMessage(getActivity().getString(R.string.long_post_dlg_saving));
+        }
         mSavingContentProgressDialog.show();
        return true;
     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
@@ -1211,6 +1211,16 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
     public void setContentPlaceholder(CharSequence text) { }
 
     @Override
+    public boolean showSavingProgressDialogIfNeeded() {
+        return false;
+    }
+
+    @Override
+    public boolean hideSavingProgressDialog() {
+        return false;
+    }
+
+    @Override
     public boolean isActionInProgress() {
         return false;
     }

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -133,5 +133,7 @@
     <string name="retry_failed_upload_remove">Remove</string>
     <string name="retry_failed_upload_retry_all">Retry all</string>
 
+    <string name="long_post_dlg_saving">Saving</string>
+
 
 </resources>


### PR DESCRIPTION
There is a brief moment in which the Gutenberg HTML editor seems to be hanging there, unresponsive, when you hit the `Update/Save` button.

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/713

**Test 1**

1. Use the content in (it's basically the demo Gutenberg content pasted several times) https://selfhostedmario.mystagingwebsite.com/2019/03/welcome-to-the-gutenberg-editor/
2. Open in Gutenberg
3. Tap on the overflow menu icon and choose HTML mode
4. Modify the content (don't break any blocks, for example just add some text within the pre-existing text in some paragraph block)
4. Tap UPDATE or, tap BACK after modifying 
5. Observe the progress dialog on the screen for a couple of secs.

**Test 2**
- Repeat the steps above on Visual mode, and make sure the dialog is not there, since the saving is fast. 

**Test 3**
1. Open the same long post of Test_1 and Test_2 
2. Tap on the overflow menu icon and choose Classic
3. Aztec should be there
4. Change the title or a block without braking the structure
5. Tap save
The Progress dialog should not be there


Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
