### PR TITLE
Point to latest gutenberg-mobile release v1.1.1

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * Added swiping between tabs in Notifications
 * Refreshed View all Stats screens, when digging into stats data
 * Visual update to Today's stats, All-time stats and Most popular stats blocks
+* Now sharing pictures to WordPress opens the Block editor
 
 12.0
 -----

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     ext {
-        aztecVersion = 'v1.3.21'
+        aztecVersion = 'v1.3.22'
     }
 
     repositories {


### PR DESCRIPTION
This PR updates the gutenberg-mobile reference to point to the latest release, v1.1.1 and updating Aztec.

The reference is currently pointing to the `release/1.1.1` branch on https://github.com/wordpress-mobile/gutenberg-mobile.

~~When that gets merged to gutenberg-mobile master, I'll update the ref here to point to the merge commit.~~ Updated with merge commit.

To test:
The block editor should work as normal.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
