### PR TITLE
Issue/6836 enable back dating drafts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -711,12 +711,12 @@ public class EditPostSettingsFragment extends Fragment {
 
     private void updatePublishDate(Calendar calendar) {
         getPost().setDateCreated(DateTimeUtils.iso8601FromDate(calendar.getTime()));
-        // Posts that are scheduled have a `future` date for REST but their status should be set to `published` as
-        // there is no `future` entry in XML-RPC (see PostStatus in FluxC for more info)
         PostStatus initialPostStatus = PostStatus.fromPost(getPost());
         boolean isPublishDateInTheFuture = PostUtils.isPublishDateInTheFuture(getPost());
         PostStatus finalPostStatus = initialPostStatus;
         if (initialPostStatus == PostStatus.DRAFT && isPublishDateInTheFuture) {
+            // Posts that are scheduled have a `future` date for REST but their status should be set to `published` as
+            // there is no `future` entry in XML-RPC (see PostStatus in FluxC for more info)
             finalPostStatus = PostStatus.PUBLISHED;
         } else if (initialPostStatus == PostStatus.PUBLISHED && getPost().isLocalDraft()) {
             // if user was changing dates for a local draft (not saved yet), only way to have it set to PUBLISH

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -71,6 +71,7 @@ import org.wordpress.android.util.GeocoderUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
 
@@ -724,6 +725,8 @@ public class EditPostSettingsFragment extends Fragment {
             // The other option was to make it published immediately but, let the user actively do that rather than
             // having the app be smart about it - we don't want to accidentally publish a post.
             updatePostStatus(PostStatus.DRAFT.toString());
+            ToastUtils.showToast(getActivity(),
+                    getString(R.string.editor_post_converted_back_to_draft), Duration.SHORT);
         }
         updatePublishDateTextView();
         updateSaveButton();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -15,6 +15,7 @@ import android.support.v7.widget.PopupMenu;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
 import android.view.ContextMenu;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -725,8 +726,9 @@ public class EditPostSettingsFragment extends Fragment {
             // The other option was to make it published immediately but, let the user actively do that rather than
             // having the app be smart about it - we don't want to accidentally publish a post.
             updatePostStatus(PostStatus.DRAFT.toString());
+            // show toast only once, when time is shown
             ToastUtils.showToast(getActivity(),
-                    getString(R.string.editor_post_converted_back_to_draft), Duration.SHORT);
+                    getString(R.string.editor_post_converted_back_to_draft), Duration.SHORT, Gravity.TOP);
         }
         updatePublishDateTextView();
         updateSaveButton();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -713,6 +713,11 @@ public class EditPostSettingsFragment extends Fragment {
         // there is no `future` entry in XML-RPC (see PostStatus in FluxC for more info)
         if (PostStatus.fromPost(getPost()) == PostStatus.DRAFT && PostUtils.isPublishDateInTheFuture(getPost())) {
             updatePostStatus(PostStatus.PUBLISHED.toString());
+        } else if (PostStatus.fromPost(getPost()) == PostStatus.PUBLISHED && getPost().isLocalDraft()) {
+            // if user was changing dates for a local draft (not saved yet), only way to have it set to PUBLISH
+            // is by running into the if case above. So, if they're updating the date again by calling
+            // `updatePublishDate()`, get it back to DRAFT.
+            updatePostStatus(PostStatus.DRAFT.toString());
         }
         updatePublishDateTextView();
         updateSaveButton();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -718,6 +718,12 @@ public class EditPostSettingsFragment extends Fragment {
             // is by running into the if case above. So, if they're updating the date again by calling
             // `updatePublishDate()`, get it back to DRAFT.
             updatePostStatus(PostStatus.DRAFT.toString());
+        } else if (PostStatus.fromPost(getPost()) == PostStatus.SCHEDULED
+                   && !PostUtils.isPublishDateInTheFuture(getPost())) {
+            // if this is an SCHEDULED post and the user is trying to Back-date it now, let's update it to DRAFT.
+            // The other option was to make it published immediately but, let the user actively do that rather than
+            // having the app be smart about it - we don't want to accidentally publish a post.
+            updatePostStatus(PostStatus.DRAFT.toString());
         }
         updatePublishDateTextView();
         updateSaveButton();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.java
@@ -151,11 +151,6 @@ public class PostDatePickerDialogFragment extends DialogFragment {
                                         now);
                             }
                         });
-                if (mCanPublishImmediately) {
-                    // We shouldn't let the user pick a past date since we'll just override it to Immediately if they do
-                    // We can't set the min date to now, so we need to subtract some amount of time
-                    datePickerDialog.getDatePicker().setMinDate(System.currentTimeMillis() - 1000);
-                }
                 return datePickerDialog;
 
             case TIME_PICKER:

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -281,6 +281,13 @@ public class PostUtils {
         return pubDate == null || !pubDate.after(now);
     }
 
+    static boolean isPublishDateInTheFuture(PostModel postModel) {
+        Date pubDate = DateTimeUtils.dateFromIso8601(postModel.getDateCreated());
+        Date now = new Date();
+        // Publish immediately for posts that don't have any date set yet and drafts with publish dates in the past
+        return pubDate != null && pubDate.after(now);
+    }
+
     // Only drafts should have the option to publish immediately to avoid user confusion
     static boolean shouldPublishImmediatelyOptionBeAvailable(PostModel postModel) {
         return PostStatus.fromPost(postModel) == PostStatus.DRAFT;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -284,7 +284,6 @@ public class PostUtils {
     static boolean isPublishDateInTheFuture(PostModel postModel) {
         Date pubDate = DateTimeUtils.dateFromIso8601(postModel.getDateCreated());
         Date now = new Date();
-        // Publish immediately for posts that don't have any date set yet and drafts with publish dates in the past
         return pubDate != null && pubDate.after(now);
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1235,6 +1235,11 @@
     <string name="publish_date">Publish</string>
     <string name="immediately">Immediately</string>
     <string name="now">Now</string>
+    <string name="scheduled_for">Scheduled for: %s</string>
+    <string name="published_on">Published on: %s</string>
+    <string name="schedule_for">Schedule for: %s</string>
+    <string name="publish_on">Publish on: %s</string>
+
 
     <!-- location -->
     <string name="post_settings_location">Location</string>

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ToastUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ToastUtils.java
@@ -30,9 +30,13 @@ public class ToastUtils {
     }
 
     public static Toast showToast(Context context, String text, Duration duration) {
+        return showToast(context, text, duration, Gravity.CENTER);
+    }
+
+    public static Toast showToast(Context context, String text, Duration duration, int gravity) {
         Toast toast = Toast.makeText(context, text,
-                                     (duration == Duration.SHORT ? Toast.LENGTH_SHORT : Toast.LENGTH_LONG));
-        toast.setGravity(Gravity.CENTER, 0, 0);
+                (duration == Duration.SHORT ? Toast.LENGTH_SHORT : Toast.LENGTH_LONG));
+        toast.setGravity(gravity, 0, 0);
         toast.show();
         return toast;
     }


### PR DESCRIPTION
Fixes #6836 

This PR aims at bringing the Posts's date handling as closest to par as possible with wp-admin/Calypso.

*Note:* we can change the labels an as we wish, I only copied them in our strings here so it's easier to follow the code as per the wp-admin reference.


To test:
Using Classic/Gutenberg editors should be the same for these tests.

Update release notes:
CASE A: draft, no saves
1. start a draft
2.  do not enter anything (no title, no body)
3. tap on overflow menu icon and go to Post Settings
4. Observe it reads "Publish: Immediately"

CASE B.1: draft, enter data
1. start a draft
2. enter a title and/or something in the body
3. tap on overflow menu icon and go to Post Settings
4. Observe it reads "Publish: Immediately"


CASE B.2: draft, save
1. start a draft
2. enter a title and/or something in the body
3. tap back so the draft saves
4. open the draft in the Editor again
5. tap on overflow menu icon and go to Post Settings
6. Observe it reads ~"Publish: Immediately"~ "Publish on: <date>"

CASE C: draft, change publish date in the future (do not tap Schedule)
1. start a draft
1.b (test both entering a title and text and also test leaving everything empty)
2. tap on the overflow menu icon and go to Post settings
3. change publish date in the future (i.e. tomorrow)
4. observe it changes to show the date as expected, and the button on the action bar changes to `SCHEDULE`


CASE D: draft, change publish date in the past, publish
1. start a draft
1.b (test both entering a title and text and also test leaving everything empty)
2. tap on the overflow menu icon and go to Post settings
3. change publish date in the past (i.e. yesterday)
4. observe it shows "Publish immediately" (as the draft has not been saved);  the button on the action bar reads `PUBLISH`.
5. tapping PUBLISH will trigger the publish dialog (promo dialog first time,  or confirmation dialog other times), and if you continue publishing it will be published with the chosen date (note the Posts list will be sorted by date, so, find your Post there)



~CASE E: draft, change publish date in the past, save draft
Repeat steps 1-4 of above case D.~

~6. tapping BACK instead, or tapping "Save as draft" in the menu will save the back-dated draft (will show as "Draft" in the Posts list, look for it among the posts of previous days).
7. verify going to Posts settings will show Publish "Immediately" and main action  "UPDATE".
8. verify opening the overflow menu shows "Publish now".
9. If you tap UPDATE, note it will save your changes but will be kept as draft.
10. if you tap "Publish now "  on the overflow menu icon, it will show the publish confirmation dialog (and publish if you confirm).~



CASE E: draft, change publish date in the past, save draft
Repeat steps 1-4 of above case D.

6. tapping BACK instead, or tapping "Save as draft" in the menu will save the back-dated draft (will show as "Draft" in the Posts list, look for it among the posts of previous days).

CASE F: edit back-dated draft
1. open the recently saved Post in CASE E.
2. verify going to Posts settings will show "Publish on <date>" and main action  "UPDATE".
3. verify opening the overflow menu shows "Publish now".
4. If you tap UPDATE, note it will save your changes but will be kept as draft.
5. if you tap "Publish now "  on the overflow menu icon, it will show the publish confirmation dialog (and publish if you confirm).



- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
