### PR TITLE
Issue/9340 Swiping Between Unread Notifications Does Not Remove Unread Badge

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -200,6 +200,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
                     if (currentNote != null) {
                         setActionBarTitleForNote(currentNote);
                         markNoteAsRead(currentNote);
+                        NotificationsActions.updateSeenTimestamp(currentNote);
                     }
                 }
 


### PR DESCRIPTION
### Fixes #9340

Checked that the issue was not introduced in recent commits (went back to version tag 10.4 of 18th Jul 2018 and the issue was already present).

### Reproduced issue behavior
Using the steps reported in #9340 we are able to reproduce the issue as per below gif.

<img src="https://user-images.githubusercontent.com/47797566/54871754-c885a100-4db9-11e9-9b45-bf9027f7e8be.gif" width="300">

**Minor note:** I actually needed to swap step 1 and 2 reported in the issue description to get a consistent behavior since going to Notifications tab (step 1) actually reset the badge in current implementation (looking at the code logic this is the expected behavior and I do not think it is related to my setup but a confirmation from someone else would help). In any case, at least in my understanding, this seems a minor note.
Also in the gif I switched to the Reader tab instead of the Me tab to confirm that the issue does not depend on which tab you select.

### Analysis
The issue is due to the fact that in `NotificationsDetailActivity` the implemented `onPageSelected` method of the `ViewPager.OnPageChangeListener` interface calls the method `markNoteAsRead` (to mark the note as read if needed) but does not notify that the note has been seen. 
The fix adds the call to `NotificationsActions.updateSeenTimestamp` to align the behavior to what already happens in `NotificationsDetailActivity.updateUIAndNote`. 
_In this way a note that has been read by swiping has also been seen._

### Behavior after fix
Following the same steps as above after applying the fix we get the corrected behavior as per gif below.

<img src="https://user-images.githubusercontent.com/47797566/54872152-0a194a80-4dc0-11e9-979d-439de12fc113.gif" width="300">

_Tested on Xiaomi Redmi Note 5, Android 8.1.0_


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

### Side Notes
The above should fix the issue #9340. I would like to share some thoughts I had while looking into it hoping it can be useful in some way.
From fast looking into the code I understand that a notification can be READ/UNREAD and this is a status belonging to the single notification itself. On the other hand the User can have/not have UNSEEN notifications. This status belongs to the user and is regulated by a timestamp that collectively reports the timestamp of the more recent notification that the user should have “seen”.
Currently when a user that has unseen notifications (for example user is not in the Notifications tab and notification badge is visible) goes to the Notifications tab, the badge is removed since the User has “seen” the notifications, but the timestamp is not always updated until the user has read a notification in the `NotificationsDetailActivity` (see `markNoteAsRead` method). This can lead to conditions like in the following gif in which since the user has not read the details of the first notification the badge is made visible again even if we are seeing the notes (don’t know if it is expected since it is true that you have unread notes but you have already seen them; hope someone can feedback/clarify).

<img src="https://user-images.githubusercontent.com/47797566/54872615-f58c8080-4dc6-11e9-8d17-df5b32e281ba.gif" width="300">

For cross-check I looked into the iOS WordPress implementation where the function `NotificationsViewController.updateLastSeenTime` regulates the above timestamp and it is used also in the `viewWillAppear` of the `NotificationsViewController`. If that is the intended behavior, in a similar way could be enough to insert some logic to update seen timestamp in `NotificationsListFragment.onResume` event, but this would deserve further investigation and eventually a dedicated issue. 

Just my 2 cents; hope to not having been too verbose.
