### PR TITLE
Fix crash in stats detail

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,5 +104,5 @@ buildScan {
 }
 
 ext {
-    fluxCVersion = '8c78b7cb3c3960525a34d8af9125ca261cf50977'
+    fluxCVersion = '7b5f25c60a5defd7b98717e762f4d4788b5eb34c'
 }


### PR DESCRIPTION
Updates FluxC hash to https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1189

This fix fixes a broken DB migration. 

To test:
* Go to Stats/DWMY/Posts and Pages
* Click on a Post/Page
* The app doesn't crash
