### PR TITLE
Lowercased Block editor for core convention

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,7 @@
 * Added swiping between tabs in Notifications
 * Refreshed View all Stats screens, when digging into stats data
 * Visual update to Today's stats, All-time stats and Most popular stats blocks
-* Now sharing pictures to WordPress opens the Block editor
+* Now sharing pictures to WordPress opens the block editor
 
 12.0
 -----


### PR DESCRIPTION
To follow the lead in core am lowercasing Block editor to block editor.
Reference - https://make.wordpress.org/core/handbook/best-practices/spelling/