### PR TITLE
Intercept image request to add access token when site is private

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -5,6 +5,7 @@ import android.support.v4.app.Fragment;
 import android.view.ViewGroup;
 
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode;
+import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnAuthHeaderRequestedListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnEditorMountListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnGetContentTimeout;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnMediaLibraryButtonListener;
@@ -38,9 +39,10 @@ public class GutenbergContainerFragment extends Fragment {
 
     public void attachToContainer(ViewGroup viewGroup, OnMediaLibraryButtonListener onMediaLibraryButtonListener,
                                   OnReattachQueryListener onReattachQueryListener,
-                                  OnEditorMountListener onEditorMountListener) {
+                                  OnEditorMountListener onEditorMountListener,
+                                  OnAuthHeaderRequestedListener onAuthHeaderRequestedListener) {
         mWPAndroidGlueCode.attachToContainer(viewGroup, onMediaLibraryButtonListener, onReattachQueryListener,
-                onEditorMountListener);
+                onEditorMountListener, onAuthHeaderRequestedListener);
     }
 
     @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -40,6 +40,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.aztec.IHistoryListener;
+import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnAuthHeaderRequestedListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnEditorMountListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnGetContentTimeout;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnMediaLibraryButtonListener;
@@ -262,8 +263,11 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                             }
                         });
                     }
-                }
-            );
+                }, new OnAuthHeaderRequestedListener() {
+                    @Override public String onAuthHeaderRequested(String url) {
+                        return mEditorFragmentListener.onAuthHeaderRequested(url);
+                    }
+                });
 
         // request dependency injection. Do this after setting min/max dimensions
         if (getActivity() instanceof EditorFragmentActivity) {


### PR DESCRIPTION
Fixes # https://github.com/wordpress-mobile/gutenberg-mobile/issues/376

Related gutenberg-mobile PR : https://github.com/wordpress-mobile/gutenberg-mobile/pull/788

To test:
1. Choose private site
2. Create new post
3. Upload image from device/camera

Result -> Image is presented
