### PR TITLE
Issue/update uihelpers v2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -6,11 +6,9 @@ import android.arch.lifecycle.ViewModelProvider
 import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.support.v4.app.Fragment
-import android.text.Spannable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import kotlinx.android.synthetic.main.activity_log_item_detail.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -19,6 +17,7 @@ import org.wordpress.android.fluxc.tools.FormattableRange
 import org.wordpress.android.ui.notifications.utils.FormattableContentClickHandler
 import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
 import org.wordpress.android.ui.posts.BasicFragmentDialog
+import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.AVATAR_WITH_BACKGROUND
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_ID_KEY
@@ -31,6 +30,7 @@ class ActivityLogDetailFragment : Fragment() {
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var notificationsUtilsWrapper: NotificationsUtilsWrapper
     @Inject lateinit var formattableContentClickHandler: FormattableContentClickHandler
+    @Inject lateinit var uiHelpers: UiHelpers
 
     private lateinit var viewModel: ActivityLogDetailViewModel
 
@@ -68,8 +68,8 @@ class ActivityLogDetailFragment : Fragment() {
 
             viewModel.activityLogItem.observe(this, Observer { activityLogModel ->
                 setActorIcon(activityLogModel?.actorIconUrl, activityLogModel?.showJetpackIcon)
-                activityActorName.setTextOrHide(activityLogModel?.actorName)
-                activityActorRole.setTextOrHide(activityLogModel?.actorRole)
+                uiHelpers.setTextOrHide(activityActorName, activityLogModel?.actorName)
+                uiHelpers.setTextOrHide(activityActorRole, activityLogModel?.actorRole)
 
                 val spannable = activityLogModel?.content?.let {
                     notificationsUtilsWrapper.getSpannableContentForRanges(it, activityMessage, { range ->
@@ -77,8 +77,8 @@ class ActivityLogDetailFragment : Fragment() {
                     }, false)
                 }
 
-                activityMessage.setTextOrHide(spannable)
-                activityType.setTextOrHide(activityLogModel?.summary)
+                uiHelpers.setTextOrHide(activityMessage, spannable)
+                uiHelpers.setTextOrHide(activityType, activityLogModel?.summary)
 
                 activityCreatedDate.text = activityLogModel?.createdDate
                 activityCreatedTime.text = activityLogModel?.createdTime
@@ -140,24 +140,6 @@ class ActivityLogDetailFragment : Fragment() {
                 activityActorIcon.visibility = View.GONE
                 activityJetpackActorIcon.visibility = View.GONE
             }
-        }
-    }
-
-    private fun TextView.setTextOrHide(text: String?) {
-        if (text != null) {
-            this.text = text
-            this.visibility = View.VISIBLE
-        } else {
-            this.visibility = View.GONE
-        }
-    }
-
-    private fun TextView.setTextOrHide(text: Spannable?) {
-        if (text != null) {
-            this.text = text
-            this.visibility = View.VISIBLE
-        } else {
-            this.visibility = View.GONE
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/NewSiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/NewSiteCreationPreviewFragment.kt
@@ -208,14 +208,14 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment(),
 
     private fun updateLoadingLayout(progressUiState: SitePreviewFullscreenProgressUiState) {
         progressUiState.apply {
-            setTextOrHide(fullscreenProgressLayout.findViewById(R.id.progress_text), loadingTextResId)
+            uiHelpers.setTextOrHide(fullscreenProgressLayout.findViewById(R.id.progress_text), loadingTextResId)
         }
     }
 
     private fun updateErrorLayout(errorUiStateState: SitePreviewFullscreenErrorUiState) {
         errorUiStateState.apply {
-            setTextOrHide(fullscreenErrorLayout.findViewById(R.id.error_title), titleResId)
-            setTextOrHide(fullscreenErrorLayout.findViewById(R.id.error_subtitle), subtitleResId)
+            uiHelpers.setTextOrHide(fullscreenErrorLayout.findViewById(R.id.error_title), titleResId)
+            uiHelpers.setTextOrHide(fullscreenErrorLayout.findViewById(R.id.error_subtitle), subtitleResId)
             uiHelpers.updateVisibility(
                     fullscreenErrorLayout.findViewById(R.id.contact_support),
                     errorUiStateState.showContactSupport
@@ -224,13 +224,6 @@ class NewSiteCreationPreviewFragment : NewSiteCreationBaseFormFragment(),
                     fullscreenErrorLayout.findViewById(R.id.cancel_wizard_button),
                     errorUiStateState.showCancelWizardButton
             )
-        }
-    }
-
-    private fun setTextOrHide(textView: TextView, resId: Int?) {
-        textView.visibility = if (resId == null) View.GONE else View.VISIBLE
-        resId?.let {
-            textView.text = resources.getString(resId)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/NewSiteCreationSegmentsFragment.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.ui.sitecreation.NewSiteCreationBaseFormFragment
 import org.wordpress.android.ui.sitecreation.misc.OnHelpClickedListener
 import org.wordpress.android.ui.sitecreation.segments.SegmentsUiState.SegmentsContentUiState
 import org.wordpress.android.ui.sitecreation.segments.SegmentsUiState.SegmentsErrorUiState
+import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
 
@@ -36,6 +37,7 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment() {
 
     @Inject internal lateinit var imageManager: ImageManager
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject internal lateinit var uiHelpers: UiHelpers
 
     private lateinit var helpClickedListener: OnHelpClickedListener
     private lateinit var segmentsScreenListener: SegmentsScreenListener
@@ -113,15 +115,8 @@ class NewSiteCreationSegmentsFragment : NewSiteCreationBaseFormFragment() {
     }
 
     private fun updateErrorLayout(errorUiStateState: SegmentsErrorUiState) {
-        setTextOrHide(errorTitle, errorUiStateState.titleResId)
-        setTextOrHide(errorSubtitle, errorUiStateState.subtitleResId)
-    }
-
-    private fun setTextOrHide(textView: TextView, resId: Int?) {
-        textView.visibility = if (resId == null) View.GONE else View.VISIBLE
-        resId?.let {
-            textView.text = resources.getString(resId)
-        }
+        uiHelpers.setTextOrHide(errorTitle, errorUiStateState.titleResId)
+        uiHelpers.setTextOrHide(errorSubtitle, errorUiStateState.subtitleResId)
     }
 
     private fun initRetryButton(rootView: ViewGroup) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/NewSiteCreationVerticalsFragment.kt
@@ -10,10 +10,8 @@ import android.support.annotation.LayoutRes
 import android.support.v4.app.FragmentActivity
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
-import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.TextView
 import kotlinx.android.synthetic.main.site_creation_error_with_retry.view.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -179,15 +177,8 @@ class NewSiteCreationVerticalsFragment : NewSiteCreationBaseFormFragment() {
     }
 
     private fun updateErrorLayout(errorLayout: ViewGroup, errorUiStateState: VerticalsFullscreenErrorUiState) {
-        setTextOrHide(errorLayout.error_title, errorUiStateState.titleResId)
-        setTextOrHide(errorLayout.error_subtitle, errorUiStateState.subtitleResId)
-    }
-
-    private fun setTextOrHide(textView: TextView, resId: Int?) {
-        textView.visibility = if (resId == null) View.GONE else View.VISIBLE
-        resId?.let {
-            textView.text = resources.getString(resId)
-        }
+        uiHelpers.setTextOrHide(errorLayout.error_title, errorUiStateState.titleResId)
+        uiHelpers.setTextOrHide(errorLayout.error_subtitle, errorUiStateState.subtitleResId)
     }
 
     override fun onHelp() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -1,7 +1,9 @@
 package org.wordpress.android.ui.utils
 
 import android.content.Context
+import android.support.annotation.StringRes
 import android.view.View
+import android.widget.TextView
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import javax.inject.Inject
@@ -15,5 +17,17 @@ class UiHelpers @Inject constructor() {
 
     fun updateVisibility(view: View, visible: Boolean) {
         view.visibility = if (visible) View.VISIBLE else View.GONE
+    }
+
+    fun setTextOrHide(view: TextView, @StringRes resId: Int?) {
+        val text = resId?.let { view.context.getString(resId) }
+        setTextOrHide(view, text)
+    }
+
+    fun setTextOrHide(view: TextView, text: CharSequence?) {
+        updateVisibility(view, text != null)
+        text?.let {
+            view.text = text
+        }
     }
 }


### PR DESCRIPTION
Moves setTextOrHide to UiHelpers.

Note: I haven't refactored BlockListItemViewHolder since they use two variables (resId: Int?, text: String?) instead of UiString. We might want to consider refactoring that as well in the future. Wdyt?

To test:
- open activity log
- walk through site creation flow

Update release notes:

[ x ] If there are user facing changes, I have added an item to RELEASE-NOTES.txt.

Note: We'll want to create another PR for `feature/master-post-filters` when this is merged. The changes can be just cherry-picked from `issue/update-uihelpers` (https://github.com/wordpress-mobile/WordPress-Android/pull/9471)