### PR TITLE
[GM/issues/605]Honors OS font size scale in GM editor

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -60,7 +60,8 @@ public class GutenbergContainerFragment extends Fragment {
 
     @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         boolean isNewPost = getArguments() != null && getArguments().getBoolean(ARG_IS_NEW_POST);
         String localeString = getArguments().getString(ARG_LOCALE);
         Bundle translations = getArguments().getBundle(ARG_TRANSLATIONS);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -1,7 +1,11 @@
 package org.wordpress.android.editor;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode;
@@ -47,12 +51,20 @@ public class GutenbergContainerFragment extends Fragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        mWPAndroidGlueCode = new WPAndroidGlueCode();
+        mWPAndroidGlueCode.onCreate(getContext());
+
+        // clear the content initialization flag since a new ReactRootView has been created;
+        mHasReceivedAnyContent = false;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         boolean isNewPost = getArguments() != null && getArguments().getBoolean(ARG_IS_NEW_POST);
         String localeString = getArguments().getString(ARG_LOCALE);
         Bundle translations = getArguments().getBundle(ARG_TRANSLATIONS);
 
-        mWPAndroidGlueCode = new WPAndroidGlueCode();
-        mWPAndroidGlueCode.onCreate(getContext());
         mWPAndroidGlueCode.onCreateView(
                 getContext(),
                 mHtmlModeEnabled,
@@ -63,8 +75,7 @@ public class GutenbergContainerFragment extends Fragment {
                 localeString,
                 translations);
 
-        // clear the content initialization flag since a new ReactRootView has been created;
-        mHasReceivedAnyContent = false;
+        return super.onCreateView(inflater, container, savedInstanceState);
     }
 
     @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -53,9 +53,6 @@ public class GutenbergContainerFragment extends Fragment {
 
         mWPAndroidGlueCode = new WPAndroidGlueCode();
         mWPAndroidGlueCode.onCreate(getContext());
-
-        // clear the content initialization flag since a new ReactRootView has been created;
-        mHasReceivedAnyContent = false;
     }
 
     @Nullable
@@ -75,6 +72,9 @@ public class GutenbergContainerFragment extends Fragment {
                 isNewPost,
                 localeString,
                 translations);
+
+        // clear the content initialization flag since a new ReactRootView has been created;
+        mHasReceivedAnyContent = false;
 
         return super.onCreateView(inflater, container, savedInstanceState);
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/605

## Overview

This PR fixes gutenberg editor screen to honor OS font size when fontScale is changed(The issue is reported at [gutenberg-mobile/issues/605](https://github.com/wordpress-mobile/gutenberg-mobile/issues/605).

Since `GutenbergContainerFragment` is initialized with `setRetainInstance(true)` I just moved `WPAndroidGlueCode#onCreateView` in `Fragment#onCreateView` which can be called even if retainInstance is true.

### Links

- Original commit: https://github.com/wordpress-mobile/WordPress-Android/commit/98940ebc95a567909ad53e43beda0ba2623329d5
- PR: https://github.com/wordpress-mobile/WordPress-Android/pull/9030
- https://developer.android.com/reference/android/app/Fragment.html#setRetainInstance(boolean)

### Screenshots

| Before | After |
| ----------- | ----------- |
|<img src="https://user-images.githubusercontent.com/471318/55091536-58965400-50f4-11e9-9978-a4d16f5aa869.gif" width="250" /> |<img src="https://user-images.githubusercontent.com/471318/55128599-78ab2f00-5157-11e9-9f7a-c891eb3372db.gif" width="250" />|

### To test

- Turn on `Use Block Editor` from app setting
- Open editor screen and type something
- Go to OS setting(Accessibility→Font Size) and change font size
- Back to editor screen and confirm content font size has been changed

### Update release notes

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
