### PR TITLE
Feature/9182 multiple labels

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -12,6 +12,7 @@ import android.widget.ImageView
 import android.widget.ImageView.ScaleType
 import android.widget.PopupMenu
 import android.widget.ProgressBar
+import org.apache.commons.lang3.StringUtils
 import org.wordpress.android.R
 import org.wordpress.android.ui.reader.utils.ReaderUtils
 import org.wordpress.android.ui.utils.UiHelpers
@@ -24,6 +25,8 @@ import org.wordpress.android.viewmodel.posts.PostListItemAction.SingleItem
 import org.wordpress.android.viewmodel.posts.PostListItemUiState
 import org.wordpress.android.widgets.PostListButton
 import org.wordpress.android.widgets.WPTextView
+
+private const val STATUS_LABEL_DELIMITER = " · "
 
 class PostListItemViewHolder(
     @LayoutRes layout: Int,
@@ -49,7 +52,8 @@ class PostListItemViewHolder(
         setTextOrHide(tvTitle, item.data.title)
         setTextOrHide(tvExcerpt, item.data.excerpt)
         setTextOrHide(tvDateAndAuthor, item.data.dateAndAuthor)
-        setTextOrHide(tvStatusLabels, item.data.statusLabels)
+        uiHelpers.updateVisibility(tvStatusLabels, item.data.statusLabels.isNotEmpty())
+        updateStatusLabels(tvStatusLabels, item.data.statusLabels)
         if (item.data.statusLabelsColor != null) {
             tvStatusLabels.setTextColor(ContextCompat.getColor(tvStatusLabels.context, item.data.statusLabelsColor))
         }
@@ -60,6 +64,13 @@ class PostListItemViewHolder(
         actionButtons.forEachIndexed { index, button ->
             updateMenuItem(button, item.actions.getOrNull(index))
         }
+    }
+
+    private fun updateStatusLabels(view: WPTextView, statusLabels: List<UiString>) {
+        view.text = StringUtils.join(
+                statusLabels.map { uiHelpers.getTextOfUiString(view.context, it) },
+                STATUS_LABEL_DELIMITER
+        )
     }
 
     private fun updateMenuItem(postListButton: PostListButton, action: PostListItemAction?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -12,7 +12,6 @@ import android.widget.ImageView
 import android.widget.ImageView.ScaleType
 import android.widget.PopupMenu
 import android.widget.ProgressBar
-import org.apache.commons.lang3.StringUtils
 import org.wordpress.android.R
 import org.wordpress.android.ui.reader.utils.ReaderUtils
 import org.wordpress.android.ui.utils.UiHelpers
@@ -65,10 +64,8 @@ class PostListItemViewHolder(
     }
 
     private fun updateStatusLabels(view: WPTextView, statusLabels: List<UiString>, delimiter: UiString) {
-        view.text = StringUtils.join(
-                statusLabels.map { uiHelpers.getTextOfUiString(view.context, it) },
-                uiHelpers.getTextOfUiString(view.context, delimiter)
-        )
+        val separator = uiHelpers.getTextOfUiString(view.context, delimiter)
+        view.text = statusLabels.joinToString(separator) { uiHelpers.getTextOfUiString(view.context, it) }
     }
 
     private fun updateMenuItem(postListButton: PostListButton, action: PostListItemAction?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -26,8 +26,6 @@ import org.wordpress.android.viewmodel.posts.PostListItemUiState
 import org.wordpress.android.widgets.PostListButton
 import org.wordpress.android.widgets.WPTextView
 
-private const val STATUS_LABEL_DELIMITER = " · "
-
 class PostListItemViewHolder(
     @LayoutRes layout: Int,
     parentView: ViewGroup,
@@ -53,7 +51,7 @@ class PostListItemViewHolder(
         setTextOrHide(tvExcerpt, item.data.excerpt)
         setTextOrHide(tvDateAndAuthor, item.data.dateAndAuthor)
         uiHelpers.updateVisibility(tvStatusLabels, item.data.statusLabels.isNotEmpty())
-        updateStatusLabels(tvStatusLabels, item.data.statusLabels)
+        updateStatusLabels(tvStatusLabels, item.data.statusLabels, item.data.statusLabelsDelimiter)
         if (item.data.statusLabelsColor != null) {
             tvStatusLabels.setTextColor(ContextCompat.getColor(tvStatusLabels.context, item.data.statusLabelsColor))
         }
@@ -66,10 +64,10 @@ class PostListItemViewHolder(
         }
     }
 
-    private fun updateStatusLabels(view: WPTextView, statusLabels: List<UiString>) {
+    private fun updateStatusLabels(view: WPTextView, statusLabels: List<UiString>, delimiter: UiString) {
         view.text = StringUtils.join(
                 statusLabels.map { uiHelpers.getTextOfUiString(view.context, it) },
-                STATUS_LABEL_DELIMITER
+                uiHelpers.getTextOfUiString(view.context, delimiter)
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiState.kt
@@ -19,6 +19,7 @@ data class PostListItemUiStateData(
     val dateAndAuthor: UiString?,
     @ColorRes val statusLabelsColor: Int?,
     val statusLabels: List<UiString>,
+    val statusLabelsDelimiter: UiString,
     val showProgress: Boolean,
     val showOverlay: Boolean
 )

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiState.kt
@@ -18,7 +18,7 @@ data class PostListItemUiStateData(
     val imageUrl: String?,
     val dateAndAuthor: UiString?,
     @ColorRes val statusLabelsColor: Int?,
-    val statusLabels: UiString?,
+    val statusLabels: List<UiString>,
     val showProgress: Boolean,
     val showOverlay: Boolean
 )

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -74,6 +74,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
                                 uploadStatus = uploadStatus,
                                 hasUnhandledConflicts = unhandledConflicts
                         ),
+                        statusLabelsDelimiter = UiStringRes(R.string.multiple_status_label_delimiter),
                         showProgress = shouldShowProgress(uploadStatus = uploadStatus),
                         showOverlay = shouldShowOverlay(uploadStatus = uploadStatus)
                 ),

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -177,8 +177,9 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
     ): Int? {
         val isError = uploadStatus.uploadError != null && !uploadStatus.hasInProgressMediaUpload
         val isProgressInfo = uploadStatus.isQueued || uploadStatus.hasPendingMediaUpload ||
-                uploadStatus.hasInProgressMediaUpload || uploadStatus.isUploading || hasUnhandledConflicts
+                uploadStatus.hasInProgressMediaUpload || uploadStatus.isUploading
         val isStateInfo = isLocalDraft || isLocallyChanged || postStatus == PRIVATE || postStatus == PENDING
+                || hasUnhandledConflicts
 
         return when {
             isError -> ERROR_COLOR

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -158,9 +158,11 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
                     uploadError.postError
             )
             else -> {
-                AppLog.e(POSTS, "MediaError and postError are both null.")
+                val errorMsg = "MediaError and postError are both null."
                 if (BuildConfig.DEBUG) {
-                    throw IllegalStateException()
+                    throw IllegalStateException(errorMsg)
+                } else {
+                    AppLog.e(POSTS, errorMsg)
                 }
                 UiStringRes(R.string.error_generic)
             }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -122,7 +122,6 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
 
         val isError = uploadStatus.uploadError != null && !uploadStatus.hasInProgressMediaUpload
 
-
         when {
             isError && uploadStatus.uploadError != null -> {
                 getErrorLabel(uploadStatus.uploadError)?.let { labels.add(it) }
@@ -178,8 +177,8 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         val isError = uploadStatus.uploadError != null && !uploadStatus.hasInProgressMediaUpload
         val isProgressInfo = uploadStatus.isQueued || uploadStatus.hasPendingMediaUpload ||
                 uploadStatus.hasInProgressMediaUpload || uploadStatus.isUploading
-        val isStateInfo = isLocalDraft || isLocallyChanged || postStatus == PRIVATE || postStatus == PENDING
-                || hasUnhandledConflicts
+        val isStateInfo = isLocalDraft || isLocallyChanged || postStatus == PRIVATE || postStatus == PENDING ||
+                hasUnhandledConflicts
 
         return when {
             isError -> ERROR_COLOR

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -174,11 +174,11 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         uploadStatus: PostListItemUploadStatus,
         hasUnhandledConflicts: Boolean
     ): Int? {
-        val isError = uploadStatus.uploadError != null && !uploadStatus.hasInProgressMediaUpload
+        val isError = uploadStatus.uploadError != null && !uploadStatus.hasInProgressMediaUpload ||
+                hasUnhandledConflicts
         val isProgressInfo = uploadStatus.isQueued || uploadStatus.hasPendingMediaUpload ||
                 uploadStatus.hasInProgressMediaUpload || uploadStatus.isUploading
-        val isStateInfo = isLocalDraft || isLocallyChanged || postStatus == PRIVATE || postStatus == PENDING ||
-                hasUnhandledConflicts
+        val isStateInfo = isLocalDraft || isLocallyChanged || postStatus == PRIVATE || postStatus == PENDING
 
         return when {
             isError -> ERROR_COLOR

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -255,7 +255,7 @@
     <string name="posts_scheduled_empty">You don\'t have any scheduled posts</string>
     <string name="posts_draft_empty">You don\'t have any draft posts</string>
     <string name="posts_trashed_empty">You don\'t have any binned posts</string>
-    <string name="multiple_status_label_delimiter" translatable="false"> · </string>
+    <string name="multiple_status_label_delimiter" translatable="false">\u0020·\u0020</string>
 
     <!-- buttons on post cards -->
     <string name="button_edit">Edit</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -255,6 +255,7 @@
     <string name="posts_scheduled_empty">You don\'t have any scheduled posts</string>
     <string name="posts_draft_empty">You don\'t have any draft posts</string>
     <string name="posts_trashed_empty">You don\'t have any binned posts</string>
+    <string name="multiple_status_label_delimiter" translatable="false"> · </string>
 
     <!-- buttons on post cards -->
     <string name="button_edit">Edit</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -163,13 +163,13 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `error label has precedence over info labels`() {
+    fun `given a mix of info and error statuses, only the error status is shown`() {
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_PRIVATE),
                 uploadStatus = createUploadStatus(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
         )
         assertThat(state.data.statusLabels).contains(UiStringRes(R.string.error_media_recover_post))
-        assertThat(state.data.statusLabels.size).isEqualTo(1)
+        assertThat(state.data.statusLabels).hasSize(1)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -82,8 +82,13 @@ class PostListItemUiStateHelperTest {
 
     @Test
     fun `label has progress color when uploading post`() {
-        val state = createPostListItemUiState(unhandledConflicts = true)
+        val state = createPostListItemUiState(uploadStatus = createUploadStatus(isUploading = true))
         assertThat(state.data.statusLabelsColor).isEqualTo(PROGRESS_INFO_COLOR)
+    }
+
+    fun `label has error color on version conflict`() {
+        val state = createPostListItemUiState(unhandledConflicts = true)
+        assertThat(state.data.statusLabelsColor).isEqualTo(ERROR_COLOR)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -10,6 +10,7 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.MediaStore.MediaError
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.AUTHORIZATION_REQUIRED
 import org.wordpress.android.fluxc.store.PostStore.PostError
@@ -22,10 +23,9 @@ import org.wordpress.android.widgets.PostListButtonType
 
 private const val FORMATTER_DATE = "January 1st, 1:35pm"
 
-// statuses are hardcoded in PostStatus.java
-private const val POST_STATE_PUBLISH = "publish"
-private const val POST_STATE_PRIVATE = "private"
-private const val POST_STATE_PENDING = "pending"
+private val POST_STATE_PUBLISH = PostStatus.PUBLISHED.toString()
+private val POST_STATE_PRIVATE = PostStatus.PRIVATE.toString()
+private val POST_STATE_PENDING = PostStatus.PENDING.toString()
 
 @RunWith(MockitoJUnitRunner::class)
 class PostListItemUiStateHelperTest {


### PR DESCRIPTION
Fixes #9182 

Adds support for displaying multiple status labels on the Post List items. I've also increased severity of "Version conflict" to error (it's red and always appears alone).

The logic is following:
Error (red) and Progress (grey) labels always appear alone.
Multiple Info labels (yellow) can be shown.

![Screenshot_2019-03-28_at_08_43_49](https://user-images.githubusercontent.com/2261188/55139332-c9aa2b80-5135-11e9-807f-c63fca7b080c.jpg)

To test:
- we decide we'd do a full test when we are about to be done with the project, I'd suggest following this approach even here.

1. Make local changes to a post and make sure the "Local changes" status label is displayed
2. Make local changes to a private post and make sure both "Local changes" and "Private" status labels are displayed
3. Add images to the post from the 2. step, click on publish and turn on airplane mode so the upload fails (you can check more detailed steps in #9490)
4. Make sure only the error status label is displayed (note: when you click on retry the correct status isn't displayed - #9490)


Notes: 
- I'm not sure about the last two tests as they test just one of the many combinations. We could probably come up with some rather complex solution which would test all the combinations, but I don't think it's worth it. Should I remove these tests completely? Wdyt?
~- The "Version conflict" label has yellow text color. I think it should be red, but I want to discuss it with Sylvester first.~

Update release notes:

- We'll update the release notes when we merge the `feature/master-post-filters` into `develop`
