### PR TITLE
Issue/9286 post list error screens

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -376,8 +376,9 @@ class PostListViewModel @Inject constructor(
         val connectionAvailableAfterError = isNetworkAvailable &&
                 pagedListWrapper.isFetchingFirstPage.value != true &&
                 pagedListWrapper.listError.value?.type == GENERIC_ERROR
+        val listIsEmpty = pagedListWrapper.isEmpty.value == true
 
-        if (connectionAvailableAfterError) {
+        if (connectionAvailableAfterError && listIsEmpty) {
             fetchFirstPage()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -34,7 +34,6 @@ import org.wordpress.android.fluxc.model.list.datastore.PostListDataStore
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.ListStore
 import org.wordpress.android.fluxc.store.ListStore.ListError
-import org.wordpress.android.fluxc.store.ListStore.ListErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.ListStore.ListErrorType.PERMISSION_ERROR
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload
@@ -84,6 +83,7 @@ import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus
 import org.wordpress.android.viewmodel.helpers.DialogHolder
 import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
+import org.wordpress.android.viewmodel.posts.PostListViewModel.PostListEmptyUiState.RefreshError
 import org.wordpress.android.widgets.PostListButtonType
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_BACK
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE
@@ -318,7 +318,7 @@ class PostListViewModel @Inject constructor(
     init {
         connectionStatus.observe(this, Observer {
             isNetworkAvailable = it?.isConnected == true
-            retryOnConnectionAvailableAfterError()
+            retryOnConnectionAvailableAfterRefreshError()
         })
         lifecycleRegistry.markState(Lifecycle.State.CREATED)
     }
@@ -372,13 +372,11 @@ class PostListViewModel @Inject constructor(
         _postListAction.postValue(PostListAction.NewPost(site))
     }
 
-    private fun retryOnConnectionAvailableAfterError() {
-        val connectionAvailableAfterError = isNetworkAvailable &&
-                pagedListWrapper.isFetchingFirstPage.value != true &&
-                pagedListWrapper.listError.value?.type == GENERIC_ERROR
-        val listIsEmpty = pagedListWrapper.isEmpty.value == true
+    private fun retryOnConnectionAvailableAfterRefreshError() {
+        val connectionAvailableAfterRefreshError = isNetworkAvailable &&
+                emptyViewState.value is RefreshError
 
-        if (connectionAvailableAfterError && listIsEmpty) {
+        if (connectionAvailableAfterRefreshError) {
             fetchFirstPage()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -232,11 +232,16 @@ class PostListViewModel @Inject constructor(
         return if (error.type == PERMISSION_ERROR) {
             PostListEmptyUiState.PermissionsError
         } else {
-            if (networkUtilsWrapper.isNetworkAvailable()) {
-                PostListEmptyUiState.RefreshError(UiStringRes(R.string.error_refresh_posts))
+            val errorText = if (networkUtilsWrapper.isNetworkAvailable()) {
+                UiStringRes(R.string.error_refresh_posts)
             } else {
-                PostListEmptyUiState.RefreshError(UiStringRes(R.string.no_network_message))
+                UiStringRes(R.string.no_network_message)
             }
+            PostListEmptyUiState.RefreshError(
+                    errorText,
+                    UiStringRes(R.string.retry),
+                    this::fetchFirstPage
+            )
         }
     }
 
@@ -286,9 +291,15 @@ class PostListViewModel @Inject constructor(
                 imgResId = R.drawable.img_illustration_posts_75dp
         )
 
-        class RefreshError(title: UiString) : PostListEmptyUiState(
+        class RefreshError(
+            title: UiString,
+            buttonText: UiString? = null,
+            onButtonClick: (() -> Unit)? = null
+        ) : PostListEmptyUiState(
                 title = title,
-                imgResId = R.drawable.img_illustration_posts_75dp
+                imgResId = R.drawable.img_illustration_empty_results_216dp,
+                buttonText = buttonText,
+                onButtonClick = onButtonClick
         )
 
         object PermissionsError : PostListEmptyUiState(

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -34,7 +34,7 @@ import org.wordpress.android.fluxc.model.list.datastore.PostListDataStore
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.ListStore
 import org.wordpress.android.fluxc.store.ListStore.ListError
-import org.wordpress.android.fluxc.store.ListStore.ListErrorType
+import org.wordpress.android.fluxc.store.ListStore.ListErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.ListStore.ListErrorType.PERMISSION_ERROR
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload
@@ -319,12 +319,7 @@ class PostListViewModel @Inject constructor(
     init {
         connectionStatus.distinct().observe(this, Observer {
             isNetworkAvailable = it?.isConnected == true
-            val connectionAvailableAfterError = isNetworkAvailable &&
-                    pagedListWrapper.isFetchingFirstPage.value != true &&
-                    pagedListWrapper.listError.value?.type == ListErrorType.GENERIC_ERROR
-            if (connectionAvailableAfterError) {
-                fetchFirstPage()
-            }
+            retryOnConnectionAvailableAfterError()
         })
         lifecycleRegistry.markState(Lifecycle.State.CREATED)
     }
@@ -376,6 +371,16 @@ class PostListViewModel @Inject constructor(
 
     fun newPost() {
         _postListAction.postValue(PostListAction.NewPost(site))
+    }
+
+    private fun retryOnConnectionAvailableAfterError() {
+        val connectionAvailableAfterError = isNetworkAvailable &&
+                pagedListWrapper.isFetchingFirstPage.value != true &&
+                pagedListWrapper.listError.value?.type == GENERIC_ERROR
+
+        if (connectionAvailableAfterError) {
+            fetchFirstPage()
+        }
     }
 
     // Private List Actions

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -80,7 +80,6 @@ import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.util.analytics.AnalyticsUtils
-import org.wordpress.android.util.distinct
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus
 import org.wordpress.android.viewmodel.helpers.DialogHolder
@@ -317,7 +316,7 @@ class PostListViewModel @Inject constructor(
     // Lifecycle
 
     init {
-        connectionStatus.distinct().observe(this, Observer {
+        connectionStatus.observe(this, Observer {
             isNetworkAvailable = it?.isConnected == true
             retryOnConnectionAvailableAfterError()
         })


### PR DESCRIPTION
Fixes #9286 

- adds retry button to error screen on `RefreshError`
- adds automatic retry when the internet connection becomes available after `RefreshError`

To test:
1. Clear app data and login
2. Turn on Airplane mode
3. Go to My Site -> Blog Posts
4. Make sure the "connection error" screen is shown and the retry button tries to fetch the data
5. Change tabs and make sure the error screen is shown on all the tabs
6. Turn the airplane mode off
7. The data should be automatically fetched -> the user doesn't need to click on retry

Update release notes:
- We'll update release notes when we merge `feature/master-post-filters` into `develop` 
