### PR TITLE
Prevent NPE when session tracker has not been initialized

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -758,7 +758,9 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override
     protected void onDestroy() {
         if (!mIsConfigChange && (mRestartEditorOption == RestartEditorOptions.NO_RESTART)) {
-            mPostEditorAnalyticsSession.end();
+            if (mPostEditorAnalyticsSession != null) {
+                mPostEditorAnalyticsSession.end();
+            }
         }
         AnalyticsTracker.track(AnalyticsTracker.Stat.EDITOR_CLOSED);
         mDispatcher.unregister(this);


### PR DESCRIPTION

Fixes #9494 

Added null check as tracker may not have been initialized if site or Post were null in the first place and Editor was exited preemptively

To test:
1. artificially make `Post` or `Site` null in `onCreate()`, or add a call to `showErrorAndFinish()` before the call to `createPostEditorAnalyticsSessionTracker()`
2. run and open the Editor
3. observe it exits but doesn't crash

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
