### PR TITLE
Add UiDimen wrapper class

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiDimen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiDimen.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.ui.utils
+
+import android.support.annotation.DimenRes
+
+/**
+ * [UiDimen] is a utility sealed class that represents a dimension to be used in the UI. It allows a dimension to be
+ * represented as both dimen resource and integer.
+ */
+
+sealed class UiDimen {
+    data class UIDimenRes(@DimenRes val dimenRes: Int) : UiDimen()
+    data class UIDimenDPInt(val dimensionDP: Int) : UiDimen()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -4,11 +4,20 @@ import android.content.Context
 import android.support.annotation.StringRes
 import android.view.View
 import android.widget.TextView
+import org.wordpress.android.ui.utils.UiDimen.UIDimenDPInt
+import org.wordpress.android.ui.utils.UiDimen.UIDimenRes
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
 
 class UiHelpers @Inject constructor() {
+    fun getPxOfUiDimen(context: Context, uiDimen: UiDimen): Int =
+            when (uiDimen) {
+                is UIDimenRes -> context.resources.getDimensionPixelSize(uiDimen.dimenRes)
+                is UIDimenDPInt -> DisplayUtils.dpToPx(context, uiDimen.dimensionDP)
+            }
+
     fun getTextOfUiString(context: Context, uiString: UiString): String =
             when (uiString) {
                 is UiStringRes -> context.getString(uiString.stringRes)


### PR DESCRIPTION
This adds a UiDimen class similar to that of UiString, which allows the declaration of a dimen as either a res or a DP value. There is also the injectable helper function to get the PX value for use in UI code.

Suggested by @oguzkocer in a [comment on a different PR](https://github.com/wordpress-mobile/WordPress-Android/pull/9484#issuecomment-478046546), implemented separately so that it can get into develop sooner and benefit other developers.

To test:
No direct way to test this code without using it in some new code, however hopefully the implementation is simple enough to test it out quickly.