### PR TITLE
Gb/update aztec gutenberg mobile hotfix v1.1.3

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * Refreshed View all Stats screens, when digging into stats data
 * Visual update to Today's stats, All-time stats and Most popular stats blocks
 * Now sharing pictures to WordPress opens the Block editor
+* Fixed crash when inserting text right before an Image
 
 12.0
 -----

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     ext {
-        aztecVersion = 'v1.3.22'
+        aztecVersion = 'v1.3.23'
     }
 
     repositories {


### PR DESCRIPTION
This PR updates the gutenberg-mobile reference to point to the latest hotfix, v1.1.3 and updating Aztec.

The reference is currently pointing to the `hotfix/1.1.3` branch on https://github.com/wordpress-mobile/gutenberg-mobile.

#### ToDo

- [x] ~When that gets merged to gutenberg-mobile master, I'll update the ref here to point to the merge commit.~  updated hash in 7d8b3051d3

To test:
The block editor should work as normal.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
