### PR TITLE
Add .blog subdomain support to new site creation flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 12.2
 -----
+* Adds support for .blog subdomains for the new site creation flow
 
 12.1
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/NewSiteCreationActivity.kt
@@ -159,7 +159,11 @@ class NewSiteCreationActivity : AppCompatActivity(),
                         screenTitle,
                         target.wizardState.segmentId!!
                 )
-            DOMAINS -> NewSiteCreationDomainsFragment.newInstance(screenTitle, target.wizardState.siteTitle)
+            DOMAINS -> NewSiteCreationDomainsFragment.newInstance(
+                    screenTitle,
+                    target.wizardState.siteTitle,
+                    target.wizardState.segmentId!!
+            )
             SITE_INFO -> NewSiteCreationSiteInfoFragment.newInstance(screenTitle)
             SITE_PREVIEW -> NewSiteCreationPreviewFragment.newInstance(screenTitle, target.wizardState)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/NewSiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/NewSiteCreationDomainsFragment.kt
@@ -136,7 +136,7 @@ class NewSiteCreationDomainsFragment : NewSiteCreationBaseFormFragment() {
         viewModel.onHelpClicked.observe(this, Observer {
             helpClickedListener.onHelpClicked(HelpActivity.Origin.NEW_SITE_CREATION_DOMAINS)
         })
-        viewModel.start(getSiteTitleFromArguments())
+        viewModel.start(getSiteTitleFromArguments(), getSegmentIdFromArguments())
     }
 
     private fun updateContentUiState(contentState: DomainsUiContentState) {
@@ -151,14 +151,22 @@ class NewSiteCreationDomainsFragment : NewSiteCreationBaseFormFragment() {
         return arguments?.getString(EXTRA_SITE_TITLE)
     }
 
+    private fun getSegmentIdFromArguments(): Long {
+        return requireNotNull(arguments?.getLong(EXTRA_SEGMENT_ID)) {
+            "SegmentId is missing. Have you created the fragment using NewSiteCreationDomainsFragment.newInstance(..)?"
+        }
+    }
+
     companion object {
         const val TAG = "site_creation_domains_fragment_tag"
         const val EXTRA_SITE_TITLE = "extra_site_title"
+        private const val EXTRA_SEGMENT_ID = "extra_segment_id"
 
-        fun newInstance(screenTitle: String, siteTitle: String?): NewSiteCreationDomainsFragment {
+        fun newInstance(screenTitle: String, siteTitle: String?, segmentId: Long): NewSiteCreationDomainsFragment {
             val fragment = NewSiteCreationDomainsFragment()
             val bundle = Bundle()
             bundle.putString(NewSiteCreationBaseFormFragment.EXTRA_SCREEN_TITLE, screenTitle)
+            bundle.putLong(EXTRA_SEGMENT_ID, segmentId)
             siteTitle?.let { bundle.putString(EXTRA_SITE_TITLE, siteTitle) }
             fragment.arguments = bundle
             return fragment

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/NewSiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/NewSiteCreationDomainsViewModel.kt
@@ -56,6 +56,7 @@ class NewSiteCreationDomainsViewModel @Inject constructor(
     override val coroutineContext: CoroutineContext
         get() = bgDispatcher + job
     private var isStarted = false
+    private var segmentId by Delegates.notNull<Long>()
 
     private val _uiState: MutableLiveData<DomainsUiState> = MutableLiveData()
     val uiState: LiveData<DomainsUiState> = _uiState
@@ -86,10 +87,11 @@ class NewSiteCreationDomainsViewModel @Inject constructor(
         dispatcher.unregister(fetchDomainsUseCase)
     }
 
-    fun start(siteTitle: String?) {
+    fun start(siteTitle: String?, segmentId: Long) {
         if (isStarted) {
             return
         }
+        this.segmentId = segmentId
         isStarted = true
         tracker.trackDomainsAccessed()
         // isNullOrBlank not smart-casting for some reason..
@@ -140,7 +142,7 @@ class NewSiteCreationDomainsViewModel @Inject constructor(
             updateUiStateToContent(query, Loading(Ready(emptyList()), false))
             fetchDomainsJob = launch {
                 delay(THROTTLE_DELAY)
-                val onSuggestedDomains = fetchDomainsUseCase.fetchDomains(query.value)
+                val onSuggestedDomains = fetchDomainsUseCase.fetchDomains(query.value, segmentId)
                 withContext(mainDispatcher) {
                     onDomainsFetched(query, onSuggestedDomains)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/NewSitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/NewSitePreviewViewModel.kt
@@ -33,6 +33,9 @@ import org.wordpress.android.ui.sitecreation.services.NewSiteCreationServiceStat
 import org.wordpress.android.ui.sitecreation.services.NewSiteCreationServiceState.NewSiteCreationStep.FAILURE
 import org.wordpress.android.ui.sitecreation.services.NewSiteCreationServiceState.NewSiteCreationStep.IDLE
 import org.wordpress.android.ui.sitecreation.services.NewSiteCreationServiceState.NewSiteCreationStep.SUCCESS
+import org.wordpress.android.ui.sitecreation.usecases.isWordPressComSubDomain
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.UrlUtilsWrapper
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -230,7 +233,12 @@ class NewSitePreviewViewModel @Inject constructor(
             }
         }
         // Load the newly created site in the webview
-        _preloadPreview.postValue(urlUtils.addUrlSchemeIfNeeded(urlWithoutScheme, true))
+        val urlToLoad = urlUtils.addUrlSchemeIfNeeded(
+                url = urlWithoutScheme,
+                addHttps = isWordPressComSubDomain(urlWithoutScheme)
+        )
+        AppLog.v(T.SITE_CREATION, "Site preview will load for url: $urlToLoad")
+        _preloadPreview.postValue(urlToLoad)
     }
 
     fun onUrlLoaded() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/NewSitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/NewSitePreviewViewModel.kt
@@ -120,7 +120,7 @@ class NewSitePreviewViewModel @Inject constructor(
                         verticalId,
                         siteTitle,
                         siteTagLine,
-                        urlUtils.extractSubDomain(urlWithoutScheme)
+                        urlWithoutScheme
                 )
                 _startCreateSiteService.value = SitePreviewStartServiceData(serviceData, previousState)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.store.SiteStore.OnNewSiteCreated
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility.PUBLIC
 import org.wordpress.android.ui.sitecreation.services.NewSiteCreationServiceData
+import org.wordpress.android.util.UrlUtilsWrapper
 import javax.inject.Inject
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
@@ -20,7 +21,8 @@ import kotlin.coroutines.suspendCoroutine
  */
 class CreateSiteUseCase @Inject constructor(
     private val dispatcher: Dispatcher,
-    @Suppress("unused") private val siteStore: SiteStore
+    @Suppress("unused") private val siteStore: SiteStore,
+    private val urlUtilsWrapper: UrlUtilsWrapper
 ) {
     private var continuation: Continuation<OnNewSiteCreated>? = null
 
@@ -33,9 +35,21 @@ class CreateSiteUseCase @Inject constructor(
         if (continuation != null) {
             throw IllegalStateException("Create site request has already been sent.")
         }
+        /*
+         * To create a site with WordPress.com sub-domain, we need to pass the domain name without the "wordpress.com"
+         * whereas to create a site with other domains, we need to pass the full url. This issue is addressed
+         * in this use case since it's closest to the network layer.
+         *
+         * Ideally API wouldn't work like this or if it does FluxC is the one that handles the issue. However, at the
+         * time of this comment, changing FluxC's Payload might end up affecting the old site creation flow,
+         * so the workaround is applied here instead.
+         */
+        val domain = if (siteData.domain.endsWith(".wordpress.com")) {
+            urlUtilsWrapper.extractSubDomain(siteData.domain)
+        } else siteData.domain
         return suspendCoroutine { cont ->
             val newSitePayload = NewSitePayload(
-                    siteData.domain,
+                    domain,
                     siteData.siteTitle ?: "",
                     languageWordPressId,
                     siteVisibility,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
@@ -44,7 +44,7 @@ class CreateSiteUseCase @Inject constructor(
          * time of this comment, changing FluxC's Payload might end up affecting the old site creation flow,
          * so the workaround is applied here instead.
          */
-        val domain = if (siteData.domain.endsWith(".wordpress.com")) {
+        val domain = if (isWordPressComSubDomain(siteData.domain)) {
             urlUtilsWrapper.extractSubDomain(siteData.domain)
         } else siteData.domain
         return suspendCoroutine { cont ->
@@ -70,3 +70,5 @@ class CreateSiteUseCase @Inject constructor(
         continuation = null
     }
 }
+
+fun isWordPressComSubDomain(url: String) = url.endsWith(".wordpress.com")

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCase.kt
@@ -12,9 +12,6 @@ import javax.inject.Inject
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 
-private const val FETCH_DOMAINS_SHOULD_ONLY_FETCH_WORDPRESS_COM_DOMAINS = true
-private const val FETCH_DOMAINS_SHOULD_INCLUDE_WORDPRESS_COM_DOMAINS = true
-private const val FETCH_DOMAINS_SHOULD_INCLUDE_DOT_BLOG_SUB_DOMAINS = false
 private const val FETCH_DOMAINS_SHOULD_INCLUDE_DOT_BLOG_VENDOR = false
 private const val FETCH_DOMAINS_SIZE = 20
 
@@ -36,17 +33,13 @@ class FetchDomainsUseCase @Inject constructor(
 
     suspend fun fetchDomains(
         query: String,
-        onlyWordPressCom: Boolean = FETCH_DOMAINS_SHOULD_ONLY_FETCH_WORDPRESS_COM_DOMAINS,
-        includeWordPressCom: Boolean = FETCH_DOMAINS_SHOULD_INCLUDE_WORDPRESS_COM_DOMAINS,
-        includeDotBlogSubdomain: Boolean = FETCH_DOMAINS_SHOULD_INCLUDE_DOT_BLOG_SUB_DOMAINS,
+        segmentId: Long,
         includeVendorDot: Boolean = FETCH_DOMAINS_SHOULD_INCLUDE_DOT_BLOG_VENDOR,
         size: Int = FETCH_DOMAINS_SIZE
     ): OnSuggestedDomains {
         val payload = SuggestDomainsPayload(
                 query,
-                onlyWordPressCom,
-                includeWordPressCom,
-                includeDotBlogSubdomain,
+                segmentId,
                 size,
                 includeVendorDot
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/CreateSiteUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/CreateSiteUseCaseTest.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility
 import org.wordpress.android.test
 import org.wordpress.android.ui.sitecreation.services.NewSiteCreationServiceData
 import org.wordpress.android.ui.sitecreation.usecases.CreateSiteUseCase
+import org.wordpress.android.util.UrlUtilsWrapper
 
 private val DUMMY_SITE_DATA: NewSiteCreationServiceData = NewSiteCreationServiceData(
         123,
@@ -37,14 +38,15 @@ class CreateSiteUseCaseTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
 
-    @Mock lateinit var dispatcher: Dispatcher
-    @Mock lateinit var store: SiteStore
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var store: SiteStore
+    @Mock private lateinit var urlUtilsWrapper: UrlUtilsWrapper
     private lateinit var useCase: CreateSiteUseCase
     private lateinit var event: OnNewSiteCreated
 
     @Before
     fun setUp() {
-        useCase = CreateSiteUseCase(dispatcher, store)
+        useCase = CreateSiteUseCase(dispatcher, store, urlUtilsWrapper)
         event = OnNewSiteCreated()
         event.newSiteRemoteId = 123
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/NewSitePreviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/NewSitePreviewViewModelTest.kt
@@ -42,7 +42,7 @@ import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.UrlUtilsWrapper
 
 private const val SUB_DOMAIN = "test"
-private const val DOMAIN = ".com"
+private const val DOMAIN = ".wordpress.com"
 private const val URL = "$SUB_DOMAIN$DOMAIN"
 private const val REMOTE_SITE_ID = 1L
 private const val LOCAL_SITE_ID = 2

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCaseTest.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
 import org.wordpress.android.test
 
 private const val SEARCH_QUERY = "test"
+private const val SEGMENT_ID = 123L
 
 @RunWith(MockitoJUnitRunner::class)
 class FetchDomainsUseCaseTest {
@@ -43,7 +44,7 @@ class FetchDomainsUseCaseTest {
     fun coroutineResumedWhenResultEventDispatched() = test {
         whenever(dispatcher.dispatch(any())).then { useCase.onSuggestedDomains(event) }
 
-        val resultEvent = useCase.fetchDomains(SEARCH_QUERY)
+        val resultEvent = useCase.fetchDomains(SEARCH_QUERY, SEGMENT_ID)
 
         verify(dispatcher).dispatch(dispatchCaptor.capture())
         assertEquals(dispatchCaptor.lastValue.payload.query, SEARCH_QUERY)

--- a/build.gradle
+++ b/build.gradle
@@ -104,5 +104,5 @@ buildScan {
 }
 
 ext {
-    fluxCVersion = '7b5f25c60a5defd7b98717e762f4d4788b5eb34c'
+    fluxCVersion = 'cc7d6d7515127c2bb14f5af32e8133e73c666431'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -104,5 +104,5 @@ buildScan {
 }
 
 ext {
-    fluxCVersion = 'cc7d6d7515127c2bb14f5af32e8133e73c666431'
+    fluxCVersion = '2526f3919165a82be86ba66854b4dfae984c4e7e'
 }


### PR DESCRIPTION
This is a copy of #9499 which targeted the release branch to add the .blog subdomain support. I've opted to create a fresh PR for this because that branch had some commits that were not yet merged to `develop`. The original PR was already approved by @malinajirka and the only differences in this PR are the addition for the release notes and the FluxC hash update which now points to the latest `develop` commit. Below are the details copied from the original PR:

---

This PR adds .blog subdomain support for the new site creation flow. We didn't originally add this support to the new flow because we didn't want to add a hacky way to check if the current segment should support .blog subdomains. Recently the `/domains/suggestions` endpoint has been updated to accept a segment id which is implemented in FluxC in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1197. This PR updates the new site creation flow to take advantage of said change.

To test:
* Test both old and new site creation flows for WordPress.com and .blog subdomains. So, the reviewer should create at least 4 sites before merging this in. (I've tested it with the current FluxC hash and all of them worked fine)