### PR TITLE
[GB Mobile] Apply OS font size changes to the editor

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -205,6 +205,7 @@
             android:windowSoftInputMode="stateVisible" />
         <activity
             android:name=".ui.posts.EditPostActivity"
+            android:configChanges="fontScale"
             android:theme="@style/Calypso.ActionMode.Dark"
             android:windowSoftInputMode="stateHidden|adjustResize">
             <meta-data

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -342,6 +342,8 @@ public class EditPostActivity extends AppCompatActivity implements
     // for keeping the media uri while asking for permissions
     private ArrayList<Uri> mDroppedMediaUris;
 
+    private float mConfigurationFontSize;
+
     private boolean isModernEditor() {
         return mShowNewEditor || mShowAztecEditor || mShowGutenbergEditor;
     }
@@ -587,6 +589,8 @@ public class EditPostActivity extends AppCompatActivity implements
             }
         });
 
+        mConfigurationFontSize = getResources().getConfiguration().fontScale;
+
         ActivityId.trackLastActivity(ActivityId.POST_EDITOR);
     }
 
@@ -801,6 +805,7 @@ public class EditPostActivity extends AppCompatActivity implements
         outState.putBoolean(STATE_KEY_HTML_MODE_ON, mHtmlModeMenuStateOn);
         outState.putSerializable(WordPress.SITE, mSite);
         outState.putParcelable(STATE_KEY_REVISION, mRevision);
+        outState.putFloat("mConfigurationFontSize", mConfigurationFontSize);
 
         outState.putSerializable(STATE_KEY_EDITOR_SESSION_DATA, mPostEditorAnalyticsSession);
         mIsConfigChange = true; // don't call sessionData.end() in onDestroy() if this is an Android config change
@@ -822,11 +827,20 @@ public class EditPostActivity extends AppCompatActivity implements
         if (savedInstanceState.getBoolean(STATE_KEY_IS_PHOTO_PICKER_VISIBLE, false)) {
             showPhotoPicker();
         }
+
+        mConfigurationFontSize = savedInstanceState.getFloat("mConfigurationFontSize", 0f);
     }
 
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
+
+
+        if (newConfig.fontScale != mConfigurationFontSize && (mEditorFragment instanceof GutenbergEditorFragment)) {
+            GutenbergEditorFragment gbFragment = (GutenbergEditorFragment) mEditorFragment;
+            mConfigurationFontSize = newConfig.fontScale;
+            gbFragment.recreateReactContextInBackground();
+        }
 
         // resize the photo picker if the user rotated the device
         int orientation = newConfig.orientation;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -838,10 +838,10 @@ public class EditPostActivity extends AppCompatActivity implements
 
         if (newConfig.fontScale != mConfigurationFontSize && (mEditorFragment instanceof GutenbergEditorFragment)) {
             // Configuration has changed: Save the new fontScale and update the GB editor fragment(s).
-            // We can't rely on the Android and RN font scaling system, since we're using GB mobile in a retained fragment,
-            // and the configuration changed code is not called automatically.
+            // We can't rely on the Android and RN font scaling system, since we're using GB mobile
+            // in a retained fragment, and the configuration changed code is not called automatically.
             // `setRetainInstance(true)` was set here
-            // https://github.com/wordpress-mobile/WordPress-Android/pull/9030/files#diff-02f567e707c1df878dfea548cfec3da7R111
+            // https://github.com/wordpress-mobile/WordPress-Android/pull/9030
             // in order to fix a couple of issues: history lost, and device rotation issues.
             GutenbergEditorFragment gbFragment = (GutenbergEditorFragment) mEditorFragment;
             try {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -18,6 +18,8 @@ public class GutenbergContainerFragment extends Fragment {
     private static final String ARG_LOCALE = "param_locale";
     private static final String ARG_TRANSLATIONS = "param_translations";
 
+    private static final String KEY_HTML_MODE_ENABLED = "KEY_HTML_MODE_ENABLED";
+
     private boolean mHtmlModeEnabled;
     private boolean mHasReceivedAnyContent;
 
@@ -52,6 +54,10 @@ public class GutenbergContainerFragment extends Fragment {
         boolean isNewPost = getArguments() != null && getArguments().getBoolean(ARG_IS_NEW_POST);
         String localeString = getArguments().getString(ARG_LOCALE);
         Bundle translations = getArguments().getBundle(ARG_TRANSLATIONS);
+
+        if (savedInstanceState != null) {
+            mHtmlModeEnabled = savedInstanceState.getBoolean(KEY_HTML_MODE_ENABLED);
+        }
 
         mWPAndroidGlueCode = new WPAndroidGlueCode();
         mWPAndroidGlueCode.onCreate(getContext());
@@ -88,6 +94,11 @@ public class GutenbergContainerFragment extends Fragment {
         super.onDestroy();
 
         mWPAndroidGlueCode.onDestroy(getActivity());
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        outState.putBoolean(KEY_HTML_MODE_ENABLED, mHtmlModeEnabled);
     }
 
     public void setTitle(String title) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -145,4 +145,8 @@ public class GutenbergContainerFragment extends Fragment {
     public void clearMediaFileURL(final int mediaId) {
         mWPAndroidGlueCode.clearMediaFileURL(mediaId);
     }
+
+    public void recreateReactContextInBackground() {
+        mWPAndroidGlueCode.recreateReactContextInBackground();
+    }
 }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -148,7 +148,8 @@ public class GutenbergContainerFragment extends Fragment {
 
     /**
      * Recreate the react application and context.
-     * See: https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java#L350
+     * See: https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/
+     * react/ReactInstanceManager.java#L350
      */
     public void recreateReactContextInBackground() {
         mWPAndroidGlueCode.recreateReactContextInBackground();

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -146,6 +146,10 @@ public class GutenbergContainerFragment extends Fragment {
         mWPAndroidGlueCode.clearMediaFileURL(mediaId);
     }
 
+    /**
+     * Recreate the react application and context.
+     * See: https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java#L350
+     */
     public void recreateReactContextInBackground() {
         mWPAndroidGlueCode.recreateReactContextInBackground();
     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -59,6 +59,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         IHistoryListener {
     private static final String KEY_HTML_MODE_ENABLED = "KEY_HTML_MODE_ENABLED";
     private static final String KEY_EDITOR_DID_MOUNT = "KEY_EDITOR_DID_MOUNT";
+    private static final String KEY_TITLE_BEFORE_CONFIG_CHANGES = "KEY_TITLE_BEFORE_CONFIG_CHANGES";
+    private static final String KEY_CONTENT_BEFORE_CONFIG_CHANGES = "KEY_CONTENT_BEFORE_CONFIG_CHANGES";
     private static final String ARG_IS_NEW_POST = "param_is_new_post";
     private static final String ARG_LOCALE_SLUG = "param_locale_slug";
 
@@ -85,8 +87,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     private ProgressDialog mSavingContentProgressDialog;
 
-    private String mTitleAfterConfigChanged = null;
-    private String mContentAfterConfigChanged = null;
+    private String mTitleBeforeConfigChanged = null;
+    private String mContentBeforeConfigChanged = null;
 
     public static GutenbergEditorFragment newInstance(String title,
                                                       String content,
@@ -205,6 +207,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         if (savedInstanceState != null) {
             mHtmlModeEnabled = savedInstanceState.getBoolean(KEY_HTML_MODE_ENABLED);
             mEditorDidMount = savedInstanceState.getBoolean(KEY_EDITOR_DID_MOUNT);
+            mTitleBeforeConfigChanged = savedInstanceState.getString(KEY_TITLE_BEFORE_CONFIG_CHANGES, null);
+            mContentBeforeConfigChanged = savedInstanceState.getString(KEY_CONTENT_BEFORE_CONFIG_CHANGES, null);
         }
     }
 
@@ -263,13 +267,13 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                             @Override
                             public void run() {
                                 setEditorProgressBarVisibility(!mEditorDidMount);
-                                if (mTitleAfterConfigChanged != null) {
-                                    setTitle(mTitleAfterConfigChanged);
-                                    mTitleAfterConfigChanged = null;
+                                if (mTitleBeforeConfigChanged != null) {
+                                    setTitle(mTitleBeforeConfigChanged);
+                                    mTitleBeforeConfigChanged = null;
                                 }
-                                if (mContentAfterConfigChanged != null) {
-                                    setContent(mContentAfterConfigChanged);
-                                    mContentAfterConfigChanged = null;
+                                if (mContentBeforeConfigChanged != null) {
+                                    setContent(mContentBeforeConfigChanged);
+                                    mContentBeforeConfigChanged = null;
                                 }
                             }
                         });
@@ -463,6 +467,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     public void onSaveInstanceState(Bundle outState) {
         outState.putBoolean(KEY_HTML_MODE_ENABLED, mHtmlModeEnabled);
         outState.putBoolean(KEY_EDITOR_DID_MOUNT, mEditorDidMount);
+        outState.putString(KEY_TITLE_BEFORE_CONFIG_CHANGES, mTitleBeforeConfigChanged);
+        outState.putString(KEY_CONTENT_BEFORE_CONFIG_CHANGES, mContentBeforeConfigChanged);
     }
 
     @Override
@@ -787,10 +793,10 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     // Save a temporary copy of the content in GB mobile, and restore it when the editor is refreshed
-    // Note: History, block focused, and caret position is lost after this call!
+    // Note: History, block focused, scroll and caret position are lost after this call!
     public void updateEditorContentAndReload(String title, String content) {
-        mContentAfterConfigChanged = content;
-        mTitleAfterConfigChanged = title;
+        mContentBeforeConfigChanged = content;
+        mTitleBeforeConfigChanged = title;
         // set this to false otherwise the spinning dialog is not shown
         mEditorDidMount = false;
         setEditorProgressBarVisibility(mEditorDidMount);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -774,4 +774,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
         return true;
     }
+
+    public void recreateReactContextInBackground() {
+        mRetainedGutenbergContainerFragment.recreateReactContextInBackground();
+    }
 }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -85,8 +85,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     private ProgressDialog mSavingContentProgressDialog;
 
-    private String titleAfterConfigChanged = null;
-    private String contentAfterConfigChanged = null;
+    private String mTitleAfterConfigChanged = null;
+    private String mContentAfterConfigChanged = null;
 
     public static GutenbergEditorFragment newInstance(String title,
                                                       String content,
@@ -263,13 +263,13 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                             @Override
                             public void run() {
                                 setEditorProgressBarVisibility(!mEditorDidMount);
-                                if (titleAfterConfigChanged != null) {
-                                    setTitle(titleAfterConfigChanged);
-                                    titleAfterConfigChanged = null;
+                                if (mTitleAfterConfigChanged != null) {
+                                    setTitle(mTitleAfterConfigChanged);
+                                    mTitleAfterConfigChanged = null;
                                 }
-                                if (contentAfterConfigChanged != null) {
-                                    setContent(contentAfterConfigChanged);
-                                    contentAfterConfigChanged = null;
+                                if (mContentAfterConfigChanged != null) {
+                                    setContent(mContentAfterConfigChanged);
+                                    mContentAfterConfigChanged = null;
                                 }
                             }
                         });
@@ -789,8 +789,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     // Save a temporary copy of the content in GB mobile, and restore it when the editor is refreshed
     // Note: History, block focused, and caret position is lost after this call!
     public void updateEditorContentAndReload(String title, String content) {
-        contentAfterConfigChanged = content;
-        titleAfterConfigChanged = title;
+        mContentAfterConfigChanged = content;
+        mTitleAfterConfigChanged = title;
         // set this to false otherwise the spinning dialog is not shown
         mEditorDidMount = false;
         setEditorProgressBarVisibility(mEditorDidMount);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -85,6 +85,9 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     private ProgressDialog mSavingContentProgressDialog;
 
+    private String titleAfterConfigChanged = null;
+    private String contentAfterConfigChanged = null;
+
     public static GutenbergEditorFragment newInstance(String title,
                                                       String content,
                                                       boolean isNewPost,
@@ -260,6 +263,14 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                             @Override
                             public void run() {
                                 setEditorProgressBarVisibility(!mEditorDidMount);
+                                if (titleAfterConfigChanged != null) {
+                                    setTitle(titleAfterConfigChanged);
+                                    titleAfterConfigChanged = null;
+                                }
+                                if (contentAfterConfigChanged != null) {
+                                    setContent(contentAfterConfigChanged);
+                                    contentAfterConfigChanged = null;
+                                }
                             }
                         });
                     }
@@ -775,7 +786,14 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         return true;
     }
 
-    public void recreateReactContextInBackground() {
+    // Save a temporary copy of the content in GB mobile, and restore it when the editor is refreshed
+    // Note: History, block focused, and caret position is lost after this call!
+    public void updateEditorContentAndReload(String title, String content) {
+        contentAfterConfigChanged = content;
+        titleAfterConfigChanged = title;
+        // set this to false otherwise the spinning dialog is not shown
+        mEditorDidMount = false;
+        setEditorProgressBarVisibility(mEditorDidMount);
         mRetainedGutenbergContainerFragment.recreateReactContextInBackground();
     }
 }


### PR DESCRIPTION
Fixes #605 by reloading the RN context on system fontSize changes. 

**Description**
We can't rely on the Android and RN font scaling system, since we're using GB mobile in a retained fragment, and the configuration changed code is not called automatically.
`setRetainInstance(true)` was set [here](https://github.com/wordpress-mobile/WordPress-Android/pull/9030/files#diff-02f567e707c1df878dfea548cfec3da7R111) in order to fix a couple of issues: history, scroll position, focused block, and caret position lost, on activity restart. 

In this PR we're manually recreating the RN context when fontSize configurationChanged event is received in the app. 

**NOTE: History, focused block, and caret/scroll position, are all lost after the config changed event.** Since fontSize changes when the app is open on the editor is a kind of rare event, we're ok with not having the history for now.

_To test_
- Open a GB post in the app (better if it's the demo content)
- Change the title and the content a bit
- Go to system settings (Accessibility→Font Size) and change the default font size
- Go back to the app confirm font size has been changed on all blocks, and the content/title is correctly preserved


GB Mobile side PR available here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/808


Update release notes:

- [ X ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
