### PR TITLE
Added RN DevSettingsActivity

### DIFF
--- a/WordPress/src/debug/AndroidManifest.xml
+++ b/WordPress/src/debug/AndroidManifest.xml
@@ -8,7 +8,10 @@
         tools:replace="android:name,android:supportsRtl"
         android:name=".WordPressDebug"
         android:supportsRtl="true"
-        />
+        >
+
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    </application>
 
     <!-- 
         The below permissions are required by Fastlane for taking screenshots.


### PR DESCRIPTION
This PR adds React Native's `DevSettingsActivity` to the `debug` manifest for accessing debugging settings while debugging WPAndroid+Gutenberg integration

To test:
1. build `ZalphaDebug` or for the case, any debug flavor
2. make sure to have Gutenberg enabled in App Settings (use Block Editor for new posts)
3. start a new draft to launch GB
4. tap on the overflow menu icon, then Debug Menu
5. in the RN's debug menu, select `Dev Settings`.
6. observe the app doesn't crash

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
