### PR TITLE
Add Total Comments Tab in Stats Insights

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCase.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.stats.CommentsModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.CommentsRestClient
 import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.COMMENTS
 import org.wordpress.android.fluxc.store.stats.insights.CommentsStore
 import org.wordpress.android.modules.UI_THREAD
@@ -28,6 +29,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.insights.InsightUse
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import zendesk.support.CommentsResponse
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -75,7 +77,7 @@ class CommentsUseCase
         if (model.authors.isNotEmpty() || model.posts.isNotEmpty()) {
             items.add(
                     TabsItem(
-                            listOf(R.string.stats_comments_authors, R.string.stats_comments_posts_and_pages, R.string.stats_comments_totals),
+                            listOf(R.string.stats_comments_authors, R.string.stats_comments_posts_and_pages),
                             uiState
                     ) { selectedTabPosition -> onUiState(selectedTabPosition) }
             )
@@ -84,8 +86,6 @@ class CommentsUseCase
                 items.addAll(buildAuthorsTab(model.authors))
             } else if (uiState == 1){
                 items.addAll(buildPostsTab(model.posts))
-            } else if (uiState == 2){
-                items.addAll(buildTotalsTab(model.posts))
             }
 
             if (model.hasMoreAuthors && uiState == 0 || model.hasMorePosts && uiState == 1) {
@@ -123,8 +123,9 @@ class CommentsUseCase
 
     private fun buildPostsTab(posts: List<CommentsModel.Post>): List<BlockListItem> {
         val mutableItems = mutableListOf<BlockListItem>()
+        val totalComments = posts.mapIndexed { index, post -> post.comments }.sum()
         if (posts.isNotEmpty()) {
-            mutableItems.add(Header(R.string.stats_comments_title_label, R.string.stats_comments_label))
+            mutableItems.add(Information("Total Comments : " + totalComments))
             mutableItems.addAll(posts.mapIndexed { index, post ->
                 ListItem(
                         post.name,
@@ -132,19 +133,6 @@ class CommentsUseCase
                         index < posts.size - 1
                 )
             })
-        } else {
-            mutableItems.add(Empty())
-        }
-        return mutableItems
-    }
-
-    private fun buildTotalsTab(posts: List<CommentsModel.Post>): List<BlockListItem> {
-        val mutableItems = mutableListOf<BlockListItem>()
-        val totalComments = posts.mapIndexed { index, post -> post.comments }.sum()
-        if (posts.isNotEmpty()) {
-            mutableItems.add(
-                    Information( "Total Comments : " + totalComments)
-            )
         } else {
             mutableItems.add(Empty())
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCase.kt
@@ -6,7 +6,6 @@ import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.stats.CommentsModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
-import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.CommentsRestClient
 import org.wordpress.android.fluxc.store.StatsStore.InsightsTypes.COMMENTS
 import org.wordpress.android.fluxc.store.stats.insights.CommentsStore
 import org.wordpress.android.modules.UI_THREAD
@@ -125,7 +124,7 @@ class CommentsUseCase
         val mutableItems = mutableListOf<BlockListItem>()
         val totalComments = posts.mapIndexed { index, post -> post.comments }.sum()
         if (posts.isNotEmpty()) {
-            mutableItems.add(Information("Total Comments : " + totalComments))
+            mutableItems.add(Information("Total Comments : " + totalComments))//Introducing a Total Comments(counter) indicator.
             mutableItems.addAll(posts.mapIndexed { index, post ->
                 ListItem(
                         post.name,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCase.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.Us
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Information
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
@@ -74,15 +75,17 @@ class CommentsUseCase
         if (model.authors.isNotEmpty() || model.posts.isNotEmpty()) {
             items.add(
                     TabsItem(
-                            listOf(R.string.stats_comments_authors, R.string.stats_comments_posts_and_pages),
+                            listOf(R.string.stats_comments_authors, R.string.stats_comments_posts_and_pages, R.string.stats_comments_totals),
                             uiState
                     ) { selectedTabPosition -> onUiState(selectedTabPosition) }
             )
 
             if (uiState == 0) {
                 items.addAll(buildAuthorsTab(model.authors))
-            } else {
+            } else if (uiState == 1){
                 items.addAll(buildPostsTab(model.posts))
+            } else if (uiState == 2){
+                items.addAll(buildTotalsTab(model.posts))
             }
 
             if (model.hasMoreAuthors && uiState == 0 || model.hasMorePosts && uiState == 1) {
@@ -129,6 +132,19 @@ class CommentsUseCase
                         index < posts.size - 1
                 )
             })
+        } else {
+            mutableItems.add(Empty())
+        }
+        return mutableItems
+    }
+
+    private fun buildTotalsTab(posts: List<CommentsModel.Post>): List<BlockListItem> {
+        val mutableItems = mutableListOf<BlockListItem>()
+        val totalComments = posts.mapIndexed { index, post -> post.comments }.sum()
+        if (posts.isNotEmpty()) {
+            mutableItems.add(
+                    Information( "Total Comments : " + totalComments)
+            )
         } else {
             mutableItems.add(Empty())
         }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -798,6 +798,7 @@
     <string name="stats_follower_since_label">Since</string>
     <string name="stats_comments_authors">Authors</string>
     <string name="stats_comments_posts_and_pages">Posts and pages</string>
+    <string name="stats_comments_totals">Total</string>
     <string name="stats_comments_author_label">Author</string>
     <string name="stats_comments_title_label">Title</string>
     <string name="stats_comments_label">Comments</string>


### PR DESCRIPTION
Fixes # 
Added a Total Comments Tab in Stats Insights. With this feature, the user will be able to have quick access to information about the number of the total comments in his site. 

In the 1st Screenshot you can see that i have 3 + 1 comments in my POSTS AND PAGES.

![56380155_2300282996697501_806057484765626368_n](https://user-images.githubusercontent.com/33027134/55514670-60fd0a80-5671-11e9-901a-0aaf3b2bdea1.png)

In the 2nd Screenshot you can see that i have (3 + 1 =) 4 total comments in my TOTAL tab.

![56201166_334255544104548_5293354825029779456_n](https://user-images.githubusercontent.com/33027134/55514672-60fd0a80-5671-11e9-9a2a-39593c211fad.png)



