### PR TITLE
Post list name refactoring

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -31,13 +31,13 @@ class PostListItemViewHolder(
     private val config: PostViewHolderConfig,
     private val uiHelpers: UiHelpers
 ) : RecyclerView.ViewHolder(LayoutInflater.from(parentView.context).inflate(layout, parentView, false)) {
-    private val ivImageFeatured: ImageView = itemView.findViewById(R.id.image_featured)
-    private val tvTitle: WPTextView = itemView.findViewById(R.id.title)
-    private val tvExcerpt: WPTextView = itemView.findViewById(R.id.excerpt)
-    private val tvDateAndAuthor: WPTextView = itemView.findViewById(R.id.date_and_author)
+    private val featuredImageView: ImageView = itemView.findViewById(R.id.image_featured)
+    private val titleTextView: WPTextView = itemView.findViewById(R.id.title)
+    private val excerptTextView: WPTextView = itemView.findViewById(R.id.excerpt)
+    private val dateAndAuthorTextView: WPTextView = itemView.findViewById(R.id.date_and_author)
     private val statusesLabelTextView: WPTextView = itemView.findViewById(R.id.statuses_label)
-    private val pbProgress: ProgressBar = itemView.findViewById(R.id.progress)
-    private val flDisabledOverlay: FrameLayout = itemView.findViewById(R.id.disabled_overlay)
+    private val progressProgressBar: ProgressBar = itemView.findViewById(R.id.progress)
+    private val disabledOverlay: FrameLayout = itemView.findViewById(R.id.disabled_overlay)
     private val actionButtons: List<PostListButton> = listOf(
             itemView.findViewById(R.id.btn_primary),
             itemView.findViewById(R.id.btn_secondary),
@@ -46,16 +46,16 @@ class PostListItemViewHolder(
 
     fun onBind(item: PostListItemUiState) {
         showFeaturedImage(item.data.imageUrl)
-        setTextOrHide(tvTitle, item.data.title)
-        setTextOrHide(tvExcerpt, item.data.excerpt)
-        setTextOrHide(tvDateAndAuthor, item.data.dateAndAuthor)
+        setTextOrHide(titleTextView, item.data.title)
+        setTextOrHide(excerptTextView, item.data.excerpt)
+        setTextOrHide(dateAndAuthorTextView, item.data.dateAndAuthor)
         uiHelpers.updateVisibility(statusesLabelTextView, item.data.statuses.isNotEmpty())
         updateStatusesLabel(statusesLabelTextView, item.data.statuses, item.data.statusesDelimiter)
         if (item.data.statusesColor != null) {
             statusesLabelTextView.setTextColor(ContextCompat.getColor(statusesLabelTextView.context, item.data.statusesColor))
         }
-        uiHelpers.updateVisibility(pbProgress, item.data.showProgress)
-        uiHelpers.updateVisibility(flDisabledOverlay, item.data.showOverlay)
+        uiHelpers.updateVisibility(progressProgressBar, item.data.showProgress)
+        uiHelpers.updateVisibility(disabledOverlay, item.data.showOverlay)
         itemView.setOnClickListener { item.onSelected.invoke() }
 
         actionButtons.forEachIndexed { index, button ->
@@ -107,24 +107,24 @@ class PostListItemViewHolder(
     private fun showFeaturedImage(imageUrl: String?) {
         // TODO move part of this logic to VM
         if (imageUrl == null) {
-            ivImageFeatured.visibility = View.GONE
-            config.imageManager.cancelRequestAndClearImageView(ivImageFeatured)
+            featuredImageView.visibility = View.GONE
+            config.imageManager.cancelRequestAndClearImageView(featuredImageView)
         } else if (imageUrl.startsWith("http")) {
             val photonUrl = ReaderUtils.getResizedImageUrl(
                     imageUrl, config.photonWidth, config.photonHeight, !config.isPhotonCapable
             )
-            ivImageFeatured.visibility = View.VISIBLE
-            config.imageManager.load(ivImageFeatured, ImageType.PHOTO, photonUrl, ScaleType.CENTER_CROP)
+            featuredImageView.visibility = View.VISIBLE
+            config.imageManager.load(featuredImageView, ImageType.PHOTO, photonUrl, ScaleType.CENTER_CROP)
         } else {
             val bmp = ImageUtils.getWPImageSpanThumbnailFromFilePath(
-                    ivImageFeatured.context, imageUrl, config.photonWidth
+                    featuredImageView.context, imageUrl, config.photonWidth
             )
             if (bmp != null) {
-                ivImageFeatured.visibility = View.VISIBLE
-                config.imageManager.load(ivImageFeatured, bmp)
+                featuredImageView.visibility = View.VISIBLE
+                config.imageManager.load(featuredImageView, bmp)
             } else {
-                ivImageFeatured.visibility = View.GONE
-                config.imageManager.cancelRequestAndClearImageView(ivImageFeatured)
+                featuredImageView.visibility = View.GONE
+                config.imageManager.cancelRequestAndClearImageView(featuredImageView)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -36,7 +36,7 @@ class PostListItemViewHolder(
     private val excerptTextView: WPTextView = itemView.findViewById(R.id.excerpt)
     private val dateAndAuthorTextView: WPTextView = itemView.findViewById(R.id.date_and_author)
     private val statusesLabelTextView: WPTextView = itemView.findViewById(R.id.statuses_label)
-    private val progressProgressBar: ProgressBar = itemView.findViewById(R.id.progress)
+    private val uploadProgressBar: ProgressBar = itemView.findViewById(R.id.upload_progress)
     private val disabledOverlay: FrameLayout = itemView.findViewById(R.id.disabled_overlay)
     private val actionButtons: List<PostListButton> = listOf(
             itemView.findViewById(R.id.btn_primary),
@@ -52,9 +52,14 @@ class PostListItemViewHolder(
         uiHelpers.updateVisibility(statusesLabelTextView, item.data.statuses.isNotEmpty())
         updateStatusesLabel(statusesLabelTextView, item.data.statuses, item.data.statusesDelimiter)
         if (item.data.statusesColor != null) {
-            statusesLabelTextView.setTextColor(ContextCompat.getColor(statusesLabelTextView.context, item.data.statusesColor))
+            statusesLabelTextView.setTextColor(
+                    ContextCompat.getColor(
+                            statusesLabelTextView.context,
+                            item.data.statusesColor
+                    )
+            )
         }
-        uiHelpers.updateVisibility(progressProgressBar, item.data.showProgress)
+        uiHelpers.updateVisibility(uploadProgressBar, item.data.showProgress)
         uiHelpers.updateVisibility(disabledOverlay, item.data.showOverlay)
         itemView.setOnClickListener { item.onSelected.invoke() }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -35,7 +35,7 @@ class PostListItemViewHolder(
     private val tvTitle: WPTextView = itemView.findViewById(R.id.title)
     private val tvExcerpt: WPTextView = itemView.findViewById(R.id.excerpt)
     private val tvDateAndAuthor: WPTextView = itemView.findViewById(R.id.date_and_author)
-    private val tvStatusLabels: WPTextView = itemView.findViewById(R.id.status_labels)
+    private val statusesLabelTextView: WPTextView = itemView.findViewById(R.id.statuses_label)
     private val pbProgress: ProgressBar = itemView.findViewById(R.id.progress)
     private val flDisabledOverlay: FrameLayout = itemView.findViewById(R.id.disabled_overlay)
     private val actionButtons: List<PostListButton> = listOf(
@@ -49,10 +49,10 @@ class PostListItemViewHolder(
         setTextOrHide(tvTitle, item.data.title)
         setTextOrHide(tvExcerpt, item.data.excerpt)
         setTextOrHide(tvDateAndAuthor, item.data.dateAndAuthor)
-        uiHelpers.updateVisibility(tvStatusLabels, item.data.statusLabels.isNotEmpty())
-        updateStatusLabels(tvStatusLabels, item.data.statusLabels, item.data.statusLabelsDelimiter)
-        if (item.data.statusLabelsColor != null) {
-            tvStatusLabels.setTextColor(ContextCompat.getColor(tvStatusLabels.context, item.data.statusLabelsColor))
+        uiHelpers.updateVisibility(statusesLabelTextView, item.data.statuses.isNotEmpty())
+        updateStatusesLabel(statusesLabelTextView, item.data.statuses, item.data.statusesDelimiter)
+        if (item.data.statusesColor != null) {
+            statusesLabelTextView.setTextColor(ContextCompat.getColor(statusesLabelTextView.context, item.data.statusesColor))
         }
         uiHelpers.updateVisibility(pbProgress, item.data.showProgress)
         uiHelpers.updateVisibility(flDisabledOverlay, item.data.showOverlay)
@@ -63,9 +63,9 @@ class PostListItemViewHolder(
         }
     }
 
-    private fun updateStatusLabels(view: WPTextView, statusLabels: List<UiString>, delimiter: UiString) {
+    private fun updateStatusesLabel(view: WPTextView, statuses: List<UiString>, delimiter: UiString) {
         val separator = uiHelpers.getTextOfUiString(view.context, delimiter)
-        view.text = statusLabels.joinToString(separator) { uiHelpers.getTextOfUiString(view.context, it) }
+        view.text = statuses.joinToString(separator) { uiHelpers.getTextOfUiString(view.context, it) }
     }
 
     private fun updateMenuItem(postListButton: PostListButton, action: PostListItemAction?) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiState.kt
@@ -17,9 +17,9 @@ data class PostListItemUiStateData(
     val excerpt: UiString?,
     val imageUrl: String?,
     val dateAndAuthor: UiString?,
-    @ColorRes val statusLabelsColor: Int?,
-    val statusLabels: List<UiString>,
-    val statusLabelsDelimiter: UiString,
+    @ColorRes val statusesColor: Int?,
+    val statuses: List<UiString>,
+    val statusesDelimiter: UiString,
     val showProgress: Boolean,
     val showOverlay: Boolean
 )

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -60,21 +60,21 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
                         excerpt = getExcerpt(post = post),
                         imageUrl = featuredImageUrl,
                         dateAndAuthor = UiStringText(text = formattedDate), // TODO Get name of the author
-                        statusLabels = getStatusLabels(
+                        statuses = getStatuses(
                                 postStatus = postStatus,
                                 isLocalDraft = post.isLocalDraft,
                                 isLocallyChanged = post.isLocallyChanged,
                                 uploadStatus = uploadStatus,
                                 hasUnhandledConflicts = unhandledConflicts
                         ),
-                        statusLabelsColor = getStatusLabelsColor(
+                        statusesColor = getStatusesColor(
                                 postStatus = postStatus,
                                 isLocalDraft = post.isLocalDraft,
                                 isLocallyChanged = post.isLocallyChanged,
                                 uploadStatus = uploadStatus,
                                 hasUnhandledConflicts = unhandledConflicts
                         ),
-                        statusLabelsDelimiter = UiStringRes(R.string.multiple_status_label_delimiter),
+                        statusesDelimiter = UiStringRes(R.string.multiple_status_label_delimiter),
                         showProgress = shouldShowProgress(uploadStatus = uploadStatus),
                         showOverlay = shouldShowOverlay(uploadStatus = uploadStatus)
                 ),
@@ -111,7 +111,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
                 (uploadStatus.isUploadingOrQueued || uploadStatus.hasInProgressMediaUpload)
     }
 
-    private fun getStatusLabels(
+    private fun getStatuses(
         postStatus: PostStatus,
         isLocalDraft: Boolean,
         isLocallyChanged: Boolean,
@@ -169,7 +169,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         }
     }
 
-    @ColorRes private fun getStatusLabelsColor(
+    @ColorRes private fun getStatusesColor(
         postStatus: PostStatus,
         isLocalDraft: Boolean,
         isLocallyChanged: Boolean,

--- a/WordPress/src/main/res/layout/post_list_item.xml
+++ b/WordPress/src/main/res/layout/post_list_item.xml
@@ -86,7 +86,7 @@
             android:layout_height="wrap_content"
             android:clickable="false"
             android:orientation="horizontal"
-            app:layout_constraintBottom_toTopOf="@+id/progress"
+            app:layout_constraintBottom_toTopOf="@+id/upload_progress"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/statuses_label">
@@ -144,7 +144,7 @@
             tools:text="Private · Local Changes Private · Local Changes Private · Local Changes Private · Local Changes Private · Local Changes "/>
 
         <ProgressBar
-            android:id="@+id/progress"
+            android:id="@+id/upload_progress"
             style="?android:attr/progressBarStyleHorizontal"
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/post_list_item.xml
+++ b/WordPress/src/main/res/layout/post_list_item.xml
@@ -89,7 +89,7 @@
             app:layout_constraintBottom_toTopOf="@+id/progress"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/status_labels">
+            app:layout_constraintTop_toBottomOf="@+id/statuses_label">
 
             <org.wordpress.android.widgets.PostListButton
                 android:id="@+id/btn_primary"
@@ -126,7 +126,7 @@
             app:layout_constraintTop_toTopOf="parent"/>
 
         <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/status_labels"
+            android:id="@+id/statuses_label"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/margin_extra_large"

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -48,7 +48,7 @@ class PostListItemUiStateHelperTest {
     @Test
     fun `label has error color on upload error`() {
         val state = createPostListItemUiState(uploadStatus = createUploadStatus(uploadError = createGenericError()))
-        assertThat(state.data.statusLabelsColor).isEqualTo(ERROR_COLOR)
+        assertThat(state.data.statusesColor).isEqualTo(ERROR_COLOR)
     }
 
     @Test
@@ -59,90 +59,90 @@ class PostListItemUiStateHelperTest {
                         hasInProgressMediaUpload = true
                 )
         )
-        assertThat(state.data.statusLabelsColor).isEqualTo(PROGRESS_INFO_COLOR)
+        assertThat(state.data.statusesColor).isEqualTo(PROGRESS_INFO_COLOR)
     }
 
     @Test
     fun `label has progress color when post queued`() {
         val state = createPostListItemUiState(uploadStatus = createUploadStatus(isQueued = true))
-        assertThat(state.data.statusLabelsColor).isEqualTo(PROGRESS_INFO_COLOR)
+        assertThat(state.data.statusesColor).isEqualTo(PROGRESS_INFO_COLOR)
     }
 
     @Test
     fun `label has progress color when media queued`() {
         val state = createPostListItemUiState(uploadStatus = createUploadStatus(hasPendingMediaUpload = true))
-        assertThat(state.data.statusLabelsColor).isEqualTo(PROGRESS_INFO_COLOR)
+        assertThat(state.data.statusesColor).isEqualTo(PROGRESS_INFO_COLOR)
     }
 
     @Test
     fun `label has progress color when uploading media`() {
         val state = createPostListItemUiState(uploadStatus = createUploadStatus(hasInProgressMediaUpload = true))
-        assertThat(state.data.statusLabelsColor).isEqualTo(PROGRESS_INFO_COLOR)
+        assertThat(state.data.statusesColor).isEqualTo(PROGRESS_INFO_COLOR)
     }
 
     @Test
     fun `label has progress color when uploading post`() {
         val state = createPostListItemUiState(uploadStatus = createUploadStatus(isUploading = true))
-        assertThat(state.data.statusLabelsColor).isEqualTo(PROGRESS_INFO_COLOR)
+        assertThat(state.data.statusesColor).isEqualTo(PROGRESS_INFO_COLOR)
     }
 
     fun `label has error color on version conflict`() {
         val state = createPostListItemUiState(unhandledConflicts = true)
-        assertThat(state.data.statusLabelsColor).isEqualTo(ERROR_COLOR)
+        assertThat(state.data.statusesColor).isEqualTo(ERROR_COLOR)
     }
 
     @Test
     fun `private label shown for private posts`() {
         val state = createPostListItemUiState(post = createPostModel(status = POST_STATE_PRIVATE))
-        assertThat(state.data.statusLabels).contains(UiStringRes(R.string.post_status_post_private))
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.post_status_post_private))
     }
 
     @Test
     fun `pending review label shown for posts pending review`() {
         val state = createPostListItemUiState(post = createPostModel(status = POST_STATE_PENDING))
-        assertThat(state.data.statusLabels).contains(UiStringRes(R.string.post_status_pending_review))
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.post_status_pending_review))
     }
 
     @Test
     fun `local draft label shown for local posts`() {
         val state = createPostListItemUiState(post = createPostModel(isLocalDraft = true))
-        assertThat(state.data.statusLabels).contains(UiStringRes(R.string.local_draft))
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.local_draft))
     }
 
     @Test
     fun `locally changed label shown for locally changed posts`() {
         val state = createPostListItemUiState(post = createPostModel(isLocallyChanged = true))
-        assertThat(state.data.statusLabels).contains(UiStringRes(R.string.local_changes))
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.local_changes))
     }
 
     @Test
     fun `version conflict label shown for posts with version conflict`() {
         val state = createPostListItemUiState(unhandledConflicts = true)
-        assertThat(state.data.statusLabels).contains(UiStringRes(R.string.local_post_is_conflicted))
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.local_post_is_conflicted))
     }
 
     @Test
     fun `uploading post label shown when the post is being uploaded`() {
         val state = createPostListItemUiState(uploadStatus = createUploadStatus(isUploading = true))
-        assertThat(state.data.statusLabels).contains(UiStringRes(R.string.post_uploading))
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.post_uploading))
     }
 
     @Test
     fun `uploading media label shown when the post's media is being uploaded`() {
         val state = createPostListItemUiState(uploadStatus = createUploadStatus(hasInProgressMediaUpload = true))
-        assertThat(state.data.statusLabels).contains(UiStringRes(R.string.uploading_media))
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.uploading_media))
     }
 
     @Test
     fun `queued post label shown when the post has pending media uploads`() {
         val state = createPostListItemUiState(uploadStatus = createUploadStatus(hasPendingMediaUpload = true))
-        assertThat(state.data.statusLabels).contains(UiStringRes(R.string.post_queued))
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.post_queued))
     }
 
     @Test
     fun `queued post label shown when the post is queued for upload`() {
         val state = createPostListItemUiState(uploadStatus = createUploadStatus(isQueued = true))
-        assertThat(state.data.statusLabels).contains(UiStringRes(R.string.post_queued))
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.post_queued))
     }
 
     @Test
@@ -150,7 +150,7 @@ class PostListItemUiStateHelperTest {
         val state = createPostListItemUiState(
                 uploadStatus = createUploadStatus(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
         )
-        assertThat(state.data.statusLabels).contains(UiStringRes(R.string.error_media_recover_post))
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.error_media_recover_post))
     }
 
     @Test
@@ -159,7 +159,7 @@ class PostListItemUiStateHelperTest {
         val state = createPostListItemUiState(
                 uploadStatus = createUploadStatus(uploadError = UploadError(PostError(GENERIC_ERROR, errorMsg)))
         )
-        assertThat(state.data.statusLabels).contains(UiStringText(errorMsg))
+        assertThat(state.data.statuses).contains(UiStringText(errorMsg))
     }
 
     @Test
@@ -168,8 +168,8 @@ class PostListItemUiStateHelperTest {
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_PRIVATE),
                 uploadStatus = createUploadStatus(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
         )
-        assertThat(state.data.statusLabels).contains(UiStringRes(R.string.error_media_recover_post))
-        assertThat(state.data.statusLabels).hasSize(1)
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.error_media_recover_post))
+        assertThat(state.data.statuses).hasSize(1)
     }
 
     @Test
@@ -177,8 +177,8 @@ class PostListItemUiStateHelperTest {
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_PRIVATE)
         )
-        assertThat(state.data.statusLabels).contains(UiStringRes(R.string.local_changes))
-        assertThat(state.data.statusLabels).contains(UiStringRes(R.string.post_status_post_private))
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.local_changes))
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.post_status_post_private))
     }
 
     private fun createPostModel(


### PR DESCRIPTION
Follow-up to [this](https://github.com/wordpress-mobile/WordPress-Android/pull/9491#discussion_r270838712) discussion.

Minor refactoring of names in PostListViewHolder and related classes.


To test:
1. Open the post list
2. Make sure statuses label is being correctly displayed (eg. when you make changes to a post while offline, yellow "Local changes" status is shown)
