### PR TITLE
Point to latest gutenberg-mobile release v1.2.0

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     ext {
-        aztecVersion = 'v1.3.23'
+        aztecVersion = 'v1.3.24'
     }
 
     repositories {


### PR DESCRIPTION
This PR updates the gutenberg-mobile reference to point to the latest release, v1.2.0. Aztec has also been updated `1.3.24`.

The reference is currently pointing to the `release/1.2` branch on https://github.com/wordpress-mobile/gutenberg-mobile. Relevant PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/833.

When that gets merged to gutenberg-mobile master, I'll update the ref here to point to the merge commit.

To test:
The block editor should work as normal.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.