### PR TITLE
Fixes broken Images on private sites in local preview

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2225,7 +2225,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 case 3:
                     return HistoryListFragment.Companion.newInstance(mPost, mSite);
                 default:
-                    return EditPostPreviewFragment.newInstance(mPost);
+                    return EditPostPreviewFragment.newInstance(mPost, mSite);
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPreviewFragment.java
@@ -51,12 +51,6 @@ public class EditPostPreviewFragment extends Fragment {
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
-        outState.putSerializable(WordPress.SITE, mSite);
-        super.onSaveInstanceState(outState);
-    }
-
-    @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) requireActivity().getApplication()).component().inject(this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPreviewFragment.java
@@ -16,8 +16,11 @@ import android.webkit.WebView;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.WPWebViewClient;
 
 import javax.inject.Inject;
 
@@ -26,12 +29,15 @@ public class EditPostPreviewFragment extends Fragment {
     private WebView mWebView;
     private int mLocalPostId;
     private LoadPostPreviewTask mLoadTask;
+    private SiteModel mSite;
 
     @Inject PostStore mPostStore;
+    @Inject AccountStore mAccountStore;
 
-    public static EditPostPreviewFragment newInstance(@NonNull PostModel post) {
+    public static EditPostPreviewFragment newInstance(@NonNull PostModel post, SiteModel site) {
         EditPostPreviewFragment fragment = new EditPostPreviewFragment();
         Bundle bundle = new Bundle();
+        bundle.putSerializable(WordPress.SITE, site);
         bundle.putInt(ARG_LOCAL_POST_ID, post.getId());
         fragment.setArguments(bundle);
         return fragment;
@@ -41,6 +47,13 @@ public class EditPostPreviewFragment extends Fragment {
     public void setArguments(Bundle args) {
         super.setArguments(args);
         mLocalPostId = args.getInt(ARG_LOCAL_POST_ID);
+        mSite = (SiteModel) args.getSerializable(WordPress.SITE);
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        outState.putSerializable(WordPress.SITE, mSite);
+        super.onSaveInstanceState(outState);
     }
 
     @Override
@@ -54,6 +67,8 @@ public class EditPostPreviewFragment extends Fragment {
         ViewGroup rootView = (ViewGroup) inflater
                 .inflate(R.layout.edit_post_preview_fragment, container, false);
         mWebView = rootView.findViewById(R.id.post_preview_web_view);
+        WPWebViewClient client = new WPWebViewClient(mSite, mAccountStore.getAccessToken());
+        mWebView.setWebViewClient(client);
         mWebView.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
             @Override
             public void onGlobalLayout() {


### PR DESCRIPTION
Fixes # https://github.com/wordpress-mobile/WordPress-Android/issues/8964

Initial problem was that `EditPreviewPostFragment` wasn't using `WPWebViewClient` as a client in `WebView` which exposed an issue https://github.com/wordpress-mobile/WordPress-Android/issues/8964. (Missing logic for inserting the token when fetching private site image)

To test:

### Steps to reproduce the behavior

**Test A:**
1. Select a WordPress.com Simple site and set it to Private.
2. Start a new post.
3. Add an image to the post. (Wait for it to upload or select an image from the site's media library.)
4. Preview the post. Result: The local draft shows an image.
5. Back to the post, add some content
6. Preview the post. Result: It should have the latest changes
7. Rotate device. Result: Content should be there

Update release notes:

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.
xt`.
