### PR TITLE
Issue/long press hint

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -35,9 +35,11 @@ import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
 import android.view.ContextThemeWrapper;
+import android.view.HapticFeedbackConstants;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.View.OnLongClickListener;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
@@ -46,6 +48,7 @@ import android.widget.ImageView;
 import android.widget.SeekBar;
 import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -304,9 +307,19 @@ public class MediaSettingsActivity extends AppCompatActivity
                     showFullScreen();
                 }
             };
-            mFabView.setOnClickListener(listener);
             mImageView.setOnClickListener(listener);
             mImagePlay.setOnClickListener(listener);
+            mFabView.setOnClickListener(listener);
+            mFabView.setOnLongClickListener(new OnLongClickListener() {
+                @Override public boolean onLongClick(View view) {
+                    if (view.isHapticFeedbackEnabled()) {
+                        view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
+                    }
+
+                    Toast.makeText(view.getContext(), R.string.button_preview, Toast.LENGTH_SHORT).show();
+                    return true;
+                }
+            });
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -14,6 +14,7 @@ import android.support.v4.app.FragmentManager
 import android.support.v4.app.FragmentPagerAdapter
 import android.support.v4.view.ViewPager.OnPageChangeListener
 import android.support.v7.widget.SearchView
+import android.view.HapticFeedbackConstants
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
@@ -23,6 +24,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import android.widget.Toast
 import de.greenrobot.event.EventBus
 import kotlinx.android.synthetic.main.pages_fragment.*
 import org.greenrobot.eventbus.Subscribe
@@ -150,6 +152,15 @@ class PagesFragment : Fragment() {
 
         newPageButton.setOnClickListener {
             viewModel.onNewPageButtonTapped()
+        }
+
+        newPageButton.setOnLongClickListener {
+            if (newPageButton.isHapticFeedbackEnabled) {
+                newPageButton.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+            }
+
+            Toast.makeText(newPageButton.context, R.string.pages_empty_list_button, Toast.LENGTH_SHORT).show()
+            return@setOnLongClickListener true
         }
 
         pagesPager.addOnPageChangeListener(object : OnPageChangeListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -11,10 +11,12 @@ import android.support.design.widget.Snackbar
 import android.support.v4.app.Fragment
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
+import android.view.HapticFeedbackConstants
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ProgressBar
+import android.widget.Toast
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.PostModel
@@ -290,6 +292,14 @@ class PostListFragment : Fragment() {
         // hide the fab so we can animate it
         fabView?.visibility = View.GONE
         fabView?.setOnClickListener { viewModel.newPost() }
+        fabView?.setOnLongClickListener {
+            if (fabView?.isHapticFeedbackEnabled == true) {
+                fabView?.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+            }
+
+            Toast.makeText(fabView?.context, R.string.posts_empty_list_button, Toast.LENGTH_SHORT).show()
+            return@setOnLongClickListener true
+        }
 
         swipeToRefreshHelper = buildSwipeToRefreshHelper(swipeRefreshLayout) {
             if (!NetworkUtils.isNetworkAvailable(nonNullActivity)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -18,6 +18,7 @@ import android.preference.PreferenceFragment;
 import android.preference.PreferenceScreen;
 import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
+import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
 import android.support.v4.util.SparseArrayCompat;
 import android.support.v7.widget.LinearLayoutManager;
@@ -32,6 +33,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.View.OnLongClickListener;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager.LayoutParams;
@@ -42,6 +44,7 @@ import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.NumberPicker.Formatter;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
@@ -65,7 +68,6 @@ import org.wordpress.android.support.ZendeskHelper;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.accounts.HelpActivity.Origin;
 import org.wordpress.android.ui.prefs.SiteSettingsFormatDialog.FormatType;
-import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.HtmlUtils;
 import org.wordpress.android.util.LocaleManager;
@@ -77,6 +79,7 @@ import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.ValidationUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPPrefUtils;
+import org.wordpress.android.util.analytics.AnalyticsUtils;
 
 import java.util.HashMap;
 import java.util.List;
@@ -1508,7 +1511,8 @@ public class SiteSettingsFragment extends PreferenceFragment
                         }
                 )
         );
-        view.findViewById(R.id.fab_button).setOnClickListener(new View.OnClickListener() {
+        FloatingActionButton button = view.findViewById(R.id.fab_button);
+        button.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 AlertDialog.Builder builder = new AlertDialog.Builder(
@@ -1565,6 +1569,16 @@ public class SiteSettingsFragment extends PreferenceFragment
                 if (negative != null) {
                     WPPrefUtils.layoutAsFlatButton(negative);
                 }
+            }
+        });
+        button.setOnLongClickListener(new OnLongClickListener() {
+            @Override public boolean onLongClick(View view) {
+                if (view.isHapticFeedbackEnabled()) {
+                    view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
+                }
+
+                Toast.makeText(view.getContext(), R.string.add, Toast.LENGTH_SHORT).show();
+                return true;
             }
         });
 


### PR DESCRIPTION
### Fix
Add a toast hint with haptic feedback when long-pressing floating action buttons.  This helps users understand what the action will do when the tap it if they are unsure.

### Test
#### Site Pages
1. Go to ***SItes*** tab.
2. Tap ***Site Pages*** under ***Publish*** section.
3. Long-press floating action button.
4. Notice ***Create a page*** hint is shown.

#### Blog Posts
1. Go to ***SItes*** tab.
2. Tap ***Media*** under ***Publish*** section.
3. Long-press floating action button.
4. Notice ***Create a post*** hint is shown.

#### Media
1. Go to ***SItes*** tab.
2. Tap ***Media*** under ***Publish*** section.
3. Tap any image item.
4. Long-press floating action button.
5. Notice ***Preview*** hint is shown.

#### Tags
1. Go to ***SItes*** tab.
2. Tap ***Settings*** under ***Configuration*** section.
3. Tap ***Tags*** under ***Writing*** section.
4. Add tag if empty.
5. Long-press floating action button.
6. Notice ***Create a tag*** hint is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.