### PR TITLE
Aztec - Log NumberFormatException in CleaningUtils

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -596,9 +596,21 @@ public class EditPostActivity extends AppCompatActivity implements
             mOriginalPostHadLocalChangesOnOpen = mOriginalPost.isLocallyChanged();
             mPost = UploadService.updatePostWithCurrentlyCompletedUploads(mPost);
             if (mShowAztecEditor) {
-                mMediaMarkedUploadingOnStartIds =
-                        AztecEditorFragment.getMediaMarkedUploadingInPostContent(this, mPost.getContent());
-                Collections.sort(mMediaMarkedUploadingOnStartIds);
+                try {
+                    mMediaMarkedUploadingOnStartIds =
+                            AztecEditorFragment.getMediaMarkedUploadingInPostContent(this, mPost.getContent());
+                    Collections.sort(mMediaMarkedUploadingOnStartIds);
+                } catch (NumberFormatException err) {
+                    // see: https://github.com/wordpress-mobile/AztecEditor-Android/issues/805
+                    if (getSite() != null && getSite().isWPCom() && !getSite().isPrivate()
+                            && TextUtils.isEmpty(mPost.getPassword())
+                            && !PostStatus.PRIVATE.toString().equals(mPost.getStatus())) {
+                        AppLog.e(T.EDITOR, "There was an error initializing post object!");
+                        AppLog.e(AppLog.T.EDITOR, "HTML content of the post before the crash:");
+                        AppLog.e(AppLog.T.EDITOR, mPost.getContent());
+                        throw err;
+                    }
+                }
             }
             mIsPage = mPost.isPage();
 


### PR DESCRIPTION
I think i've found a quick way to log the content of the editor (when privacy conditions are met) in case of this weird crash happening in clean utils of Aztec - wordpress-mobile/AztecEditor-Android#805

(_This time with the correct base branch!_)

Update release notes:

[ x ] If there are user facing changes, I have added an item to RELEASE-NOTES.txt.
