### PR TITLE
Issue/8475 post list skeleton

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
@@ -12,19 +12,19 @@ enum class PostListButtonType constructor(
     @DrawableRes val iconResId: Int,
     @ColorRes val colorResId: Int
 ) {
-    BUTTON_EDIT(1, R.string.button_edit, R.drawable.ic_pencil_white_24dp, R.color.blue_wordpress),
-    BUTTON_VIEW(2, R.string.button_view, R.drawable.ic_external_white_24dp, R.color.blue_wordpress),
-    BUTTON_PREVIEW(3, R.string.button_preview, R.drawable.ic_external_white_24dp, R.color.blue_wordpress),
-    BUTTON_STATS(4, R.string.button_stats, R.drawable.ic_stats_alt_white_24dp, R.color.blue_wordpress),
-    BUTTON_TRASH(5, R.string.button_trash, R.drawable.ic_trash_white_24dp, R.color.blue_wordpress),
-    BUTTON_DELETE(6, R.string.button_delete, R.drawable.ic_trash_white_24dp, R.color.blue_wordpress),
-    BUTTON_PUBLISH(7, R.string.button_publish, R.drawable.ic_reader_white_24dp, R.color.blue_wordpress),
-    BUTTON_SYNC(8, R.string.button_sync, R.drawable.ic_reader_white_24dp, R.color.blue_wordpress),
-    BUTTON_MORE(9, R.string.button_more, R.drawable.ic_ellipsis_white_24dp, R.color.blue_wordpress),
-    BUTTON_BACK(10, R.string.button_back, R.drawable.ic_chevron_left_white_24dp, R.color.blue_wordpress),
-    BUTTON_SUBMIT(11, R.string.submit_for_review, R.drawable.ic_reader_white_24dp, R.color.blue_wordpress),
+    BUTTON_EDIT(1, R.string.button_edit, R.drawable.ic_pencil_white_24dp, R.color.grey_darken_20),
+    BUTTON_VIEW(2, R.string.button_view, R.drawable.ic_external_white_24dp, R.color.grey_darken_20),
+    BUTTON_PREVIEW(3, R.string.button_preview, R.drawable.ic_external_white_24dp, R.color.grey_darken_20),
+    BUTTON_STATS(4, R.string.button_stats, R.drawable.ic_stats_alt_white_24dp, R.color.grey_darken_20),
+    BUTTON_TRASH(5, R.string.button_trash, R.drawable.ic_trash_white_24dp, R.color.grey_darken_20),
+    BUTTON_DELETE(6, R.string.button_delete, R.drawable.ic_trash_white_24dp, R.color.grey_darken_20),
+    BUTTON_PUBLISH(7, R.string.button_publish, R.drawable.ic_reader_white_24dp, R.color.grey_darken_20),
+    BUTTON_SYNC(8, R.string.button_sync, R.drawable.ic_reader_white_24dp, R.color.grey_darken_20),
+    BUTTON_MORE(9, R.string.button_more, R.drawable.ic_ellipsis_white_24dp, R.color.grey_darken_20),
+    BUTTON_BACK(10, R.string.button_back, R.drawable.ic_chevron_left_white_24dp, R.color.grey_darken_20),
+    BUTTON_SUBMIT(11, R.string.submit_for_review, R.drawable.ic_reader_white_24dp, R.color.grey_darken_20),
     BUTTON_RETRY(12, R.string.button_retry, R.drawable.ic_refresh_white_24dp, R.color.alert_red),
-    BUTTON_RESTORE(13, R.string.button_restore, R.drawable.ic_refresh_white_24dp, R.color.blue_wordpress);
+    BUTTON_RESTORE(13, R.string.button_restore, R.drawable.ic_refresh_white_24dp, R.color.grey_darken_20);
 
     companion object {
         fun fromInt(value: Int): PostListButtonType? = values().firstOrNull { it.value == value }

--- a/WordPress/src/main/res/layout/post_list_item.xml
+++ b/WordPress/src/main/res/layout/post_list_item.xml
@@ -88,6 +88,7 @@
             android:orientation="horizontal"
             app:layout_constraintBottom_toTopOf="@+id/upload_progress"
             app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginTop="@dimen/margin_extra_large"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/statuses_label">
 

--- a/WordPress/src/main/res/layout/post_list_item_skeleton.xml
+++ b/WordPress/src/main/res/layout/post_list_item_skeleton.xml
@@ -14,8 +14,7 @@
         <android.support.constraint.ConstraintLayout
             android:id="@+id/skeleton_container"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?selectableItemBackground">
+            android:layout_height="wrap_content">
 
             <View
                 android:id="@+id/skeleton_title"

--- a/WordPress/src/main/res/layout/post_list_item_skeleton.xml
+++ b/WordPress/src/main/res/layout/post_list_item_skeleton.xml
@@ -72,24 +72,15 @@
                 app:layout_constraintTop_toBottomOf="@+id/skeleton_date_and_author">
 
                 <org.wordpress.android.widgets.PostListButton
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="center"
+                    style="@style/PostListRowSkeletonButton"
                     wp:wpPostButtonType="edit"/>
 
                 <org.wordpress.android.widgets.PostListButton
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="center"
+                    style="@style/PostListRowSkeletonButton"
                     wp:wpPostButtonType="view"/>
 
                 <org.wordpress.android.widgets.PostListButton
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="center"
+                    style="@style/PostListRowSkeletonButton"
                     wp:wpPostButtonType="more"/>
             </LinearLayout>
         </android.support.constraint.ConstraintLayout>

--- a/WordPress/src/main/res/layout/post_list_item_skeleton.xml
+++ b/WordPress/src/main/res/layout/post_list_item_skeleton.xml
@@ -1,67 +1,98 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<android.support.v7.widget.CardView
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:wp="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    card_view:cardCornerRadius="@dimen/default_cardview_radius"
-    card_view:cardElevation="@dimen/card_elevation">
+    android:background="@color/white">
 
     <com.facebook.shimmer.ShimmerFrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <LinearLayout
+        <android.support.constraint.ConstraintLayout
+            android:id="@+id/skeleton_container"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical">
+            android:layout_height="wrap_content"
+            android:background="?selectableItemBackground">
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
+            <View
+                android:id="@+id/skeleton_title"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/post_list_row_skeleton_view_title_height"
                 android:layout_marginEnd="@dimen/margin_extra_large"
                 android:layout_marginStart="@dimen/margin_extra_large"
-                android:orientation="vertical">
+                android:layout_marginTop="@dimen/margin_extra_large"
+                android:background="@color/wp_grey_lighten_30"
+                app:layout_constraintBottom_toTopOf="@+id/skeleton_excerpt"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintWidth_percent="0.60"/>
 
-                <View
-                    android:layout_width="@dimen/post_list_row_skeleton_view_title_width"
-                    android:layout_height="@dimen/post_list_row_skeleton_view_title_height"
-                    android:layout_marginTop="@dimen/margin_extra_large"
-                    android:background="@color/light_gray"/>
+            <View
+                android:id="@+id/skeleton_excerpt"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/post_list_row_skeleton_view_excerpt_height"
+                android:layout_marginEnd="@dimen/margin_extra_large"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:layout_marginTop="@dimen/margin_medium"
+                android:background="@color/wp_grey_lighten_30"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/skeleton_title"
+                app:layout_constraintWidth_percent="0.85"/>
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="@dimen/post_list_row_skeleton_view_excerpt_height"
-                    android:layout_marginTop="@dimen/margin_medium"
-                    android:background="@color/light_gray"/>
-
-                <View
-                    android:layout_width="@dimen/post_list_row_skeleton_view_date_width"
-                    android:layout_height="@dimen/post_list_row_skeleton_view_date_height"
-                    android:layout_marginTop="@dimen/margin_medium"
-                    android:background="@color/light_gray"/>
-            </LinearLayout>
+            <View
+                android:id="@+id/skeleton_date_and_author"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/post_list_row_skeleton_view_date_height"
+                android:layout_marginEnd="@dimen/margin_extra_large"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:layout_marginTop="@dimen/margin_medium"
+                android:background="@color/wp_grey_lighten_30"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/skeleton_excerpt"
+                app:layout_constraintWidth_percent="0.75"/>
 
             <LinearLayout
-                android:layout_width="match_parent"
+                android:id="@+id/skeleton_layout_buttons"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_large"
-                android:orientation="horizontal">
+                android:layout_marginTop="@dimen/margin_extra_large"
+                android:clickable="false"
+                android:orientation="horizontal"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/skeleton_date_and_author">
 
                 <org.wordpress.android.widgets.PostListButton
-                    style="@style/PostListRowSkeletonButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
                     wp:wpPostButtonType="edit"/>
 
                 <org.wordpress.android.widgets.PostListButton
-                    style="@style/PostListRowSkeletonButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
                     wp:wpPostButtonType="view"/>
 
                 <org.wordpress.android.widgets.PostListButton
-                    style="@style/PostListRowSkeletonButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
                     wp:wpPostButtonType="more"/>
             </LinearLayout>
-        </LinearLayout>
+        </android.support.constraint.ConstraintLayout>
     </com.facebook.shimmer.ShimmerFrameLayout>
-</android.support.v7.widget.CardView>
+</FrameLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -357,11 +357,9 @@
     <dimen name="quota_bar_text_minimum_height">36dp</dimen>
 
     <!--post skeleton-->
-    <dimen name="post_list_row_skeleton_view_title_width">160dp</dimen>
-    <dimen name="post_list_row_skeleton_view_title_height">@dimen/margin_extra_medium_large</dimen>
-    <dimen name="post_list_row_skeleton_view_excerpt_height">@dimen/margin_extra_medium_large</dimen>
-    <dimen name="post_list_row_skeleton_view_date_width">80dp</dimen>
-    <dimen name="post_list_row_skeleton_view_date_height">@dimen/margin_extra_large</dimen>
+    <dimen name="post_list_row_skeleton_view_title_height">20dp</dimen>
+    <dimen name="post_list_row_skeleton_view_excerpt_height">16dp</dimen>
+    <dimen name="post_list_row_skeleton_view_date_height">16dp</dimen>
 
     <!--posts list-->
     <dimen name="posts_list_spinner_width">56dp</dimen>


### PR DESCRIPTION
Fixes #8475 

Updates design of the loading skeleton on Post List screen.

![5770d7c1966a71d3b892528189a18287](https://user-images.githubusercontent.com/2261188/55728305-23530580-5a14-11e9-8bbf-70237abed8ad.gif)


Note: I've also update two minor design issue on loaded list items
- top margin
- color of action buttons

To test:
1. Clear app data (or switch to a site for which you haven't loaded the posts yet)
2. My Site
3. Blog Posts
4. Make sure the loading skeleton matches the proposed design

Update release notes:

- will be updated when `master-post-filters` is merged into `develop`
