### PR TITLE
Issue/remove load drawable

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -66,7 +66,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
         if (!context.isAvailable()) return
         GlideApp.with(context)
                 .load(imgUrl)
-                .addFallback(context, imageType)
+                .addFallback(imageType)
                 .addPlaceholder(context, imageType)
                 .applyScaleType(scaleType)
                 .into(imageView)
@@ -89,7 +89,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
         if (!context.isAvailable()) return
         GlideApp.with(context)
                 .load(imgUrl)
-                .addFallback(context, imageType)
+                .addFallback(imageType)
                 .addPlaceholder(context, imageType)
                 .circleCrop()
                 .attachRequestListener(requestListener)
@@ -117,7 +117,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
         if (!context.isAvailable()) return
         GlideApp.with(context)
                 .load(imgUrl)
-                .addFallback(context, imageType)
+                .addFallback(imageType)
                 .addPlaceholder(context, imageType)
                 .addThumbnail(context, thumbnailUrl, requestListener)
                 .attachRequestListener(requestListener)
@@ -179,7 +179,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
         if (!context.isAvailable()) return
         GlideApp.with(context)
                 .load(imgUrl)
-                .addFallback(context, imageType)
+                .addFallback(imageType)
                 .addPlaceholder(context, imageType)
                 .into(viewTarget)
                 .clearOnDetach()
@@ -248,7 +248,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
         }
     }
 
-    private fun <T : Any> GlideRequest<T>.addFallback(context: Context, imageType: ImageType): GlideRequest<T> {
+    private fun <T : Any> GlideRequest<T>.addFallback(imageType: ImageType): GlideRequest<T> {
         val errorImageRes = placeholderManager.getErrorResource(imageType)
         return if (errorImageRes == null) {
             this

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -7,7 +7,6 @@ import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.support.annotation.DrawableRes
 import android.support.v4.app.FragmentActivity
-import android.support.v7.content.res.AppCompatResources
 import android.text.TextUtils
 import android.widget.ImageView
 import android.widget.ImageView.ScaleType
@@ -245,7 +244,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
         return if (placeholderImageRes == null) {
             this
         } else {
-            this.placeholder(loadDrawable(context, placeholderImageRes))
+            this.placeholder(placeholderImageRes)
         }
     }
 
@@ -254,7 +253,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
         return if (errorImageRes == null) {
             this
         } else {
-            this.error(loadDrawable(context, errorImageRes))
+            this.error(errorImageRes)
         }
     }
 
@@ -268,12 +267,6 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
             this.signature(ObjectKey(signature))
         }
     }
-
-    /**
-     * Load drawable using AppCompatResource to prevent the app from crashing when loading vector drawables on api < 21.
-     * May be removed when https://github.com/bumptech/glide/issues/3086 is fixed.
-     */
-    fun loadDrawable(context: Context, imgRes: Int) = AppCompatResources.getDrawable(context, imgRes)
 
     private fun GlideRequest<Drawable>.addThumbnail(
         context: Context,

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -67,7 +67,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
         GlideApp.with(context)
                 .load(imgUrl)
                 .addFallback(imageType)
-                .addPlaceholder(context, imageType)
+                .addPlaceholder(imageType)
                 .applyScaleType(scaleType)
                 .into(imageView)
                 .clearOnDetach()
@@ -90,7 +90,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
         GlideApp.with(context)
                 .load(imgUrl)
                 .addFallback(imageType)
-                .addPlaceholder(context, imageType)
+                .addPlaceholder(imageType)
                 .circleCrop()
                 .attachRequestListener(requestListener)
                 .addSignature(version)
@@ -118,7 +118,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
         GlideApp.with(context)
                 .load(imgUrl)
                 .addFallback(imageType)
-                .addPlaceholder(context, imageType)
+                .addPlaceholder(imageType)
                 .addThumbnail(context, thumbnailUrl, requestListener)
                 .attachRequestListener(requestListener)
                 .into(imageView)
@@ -180,7 +180,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
         GlideApp.with(context)
                 .load(imgUrl)
                 .addFallback(imageType)
-                .addPlaceholder(context, imageType)
+                .addPlaceholder(imageType)
                 .into(viewTarget)
                 .clearOnDetach()
     }
@@ -239,7 +239,7 @@ class ImageManager @Inject constructor(val placeholderManager: ImagePlaceholderM
         }
     }
 
-    private fun <T : Any> GlideRequest<T>.addPlaceholder(context: Context, imageType: ImageType): GlideRequest<T> {
+    private fun <T : Any> GlideRequest<T>.addPlaceholder(imageType: ImageType): GlideRequest<T> {
         val placeholderImageRes = placeholderManager.getPlaceholderResource(imageType)
         return if (placeholderImageRes == null) {
             this


### PR DESCRIPTION
### Fix
Remove the `loadDrawable` method from the `ImageManager` class and update associated methods since the app no longer supports API less than 21.

### Test
In order to see the placeholder and error images, it's best to clear the app cache before testing and enable airplane mode while testing.

1. Go to ***Sites*** tab.
2. Notice site icon placeholder and error image (if applicable).
3. Tap ***Plan*** item.
4. Tap ***View Plans Anyway*** button.
5. Notice plan icon placeholder and error images (if applicable).
6. Tap back arrow.
7. Go to ***Notifications*** tab.
8. Notice user icon placeholder and error images (if applicable).