### PR TITLE
Fix first publish analytics

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1741,9 +1741,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 mZendeskHelper.createNewTicket(this, Origin.DISCARD_CHANGES, mSite);
                 break;
             case TAG_PUBLISH_CONFIRMATION_DIALOG:
-                mPost.setStatus(PostStatus.PUBLISHED.toString());
-                mPostEditorAnalyticsSession.setOutcome(Outcome.PUBLISH);
-                publishPost();
+                publishPost(PostStatus.fromPost(mPost) == PostStatus.DRAFT);
                 AppRatingDialog.INSTANCE
                         .incrementInteractions(APP_REVIEWS_EVENT_INCREMENTED_BY_PUBLISHING_POST_OR_PAGE);
                 break;
@@ -1752,7 +1750,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 mEditorFragment.removeAllFailedMediaUploads();
                 break;
             case ASYNC_PROMO_DIALOG_TAG:
-                publishPost();
+                publishPost(PostStatus.fromPost(mPost) == PostStatus.DRAFT);
                 break;
             case TAG_GB_INFORMATIVE_DIALOG:
                 // no op
@@ -1972,6 +1970,10 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private void publishPost() {
+        publishPost(false);
+    }
+
+    private void publishPost(final boolean isDraftToPublish) {
         AccountModel account = mAccountStore.getAccount();
         // prompt user to verify e-mail before publishing
         if (!account.getEmailVerified()) {
@@ -2015,6 +2017,12 @@ public class EditPostActivity extends AppCompatActivity implements
             @Override
             public void run() {
                 boolean isFirstTimePublish = isFirstTimePublish();
+                if (isDraftToPublish) {
+                    // now set status to PUBLISHED - only do this AFTER we have run the isFirstTimePublish() check,
+                    // otherwise we'd have an incorrect value
+                    mPost.setStatus(PostStatus.PUBLISHED.toString());
+                    mPostEditorAnalyticsSession.setOutcome(Outcome.PUBLISH);
+                }
 
                 boolean postUpdateSuccessful = updatePostObject();
                 if (!postUpdateSuccessful) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -252,8 +252,7 @@ public class UploadUtils {
         }
 
         PostUtils.updatePublishDateIfShouldBePublishedImmediately(post);
-        boolean isFirstTimePublish = PostStatus.fromPost(post) == PostStatus.DRAFT
-                                     || (PostStatus.fromPost(post) == PostStatus.PUBLISHED && post.isLocalDraft());
+        boolean isFirstTimePublish = PostUtils.isFirstTimePublish(post);
         post.setStatus(PostStatus.PUBLISHED.toString());
 
         // save the post in the DB so the UploadService will get the latest change


### PR DESCRIPTION
This PR fixes a problem in Tracks first spot by @elibud 

**tl;dr:** when you tap PUBLISH, we were setting the status of the Post to `published` immediately and checking _only after_ whether it was a first time publish. Thus, the check returned `false` because it wasn't a DRAFT anymore.

In previous code, when you tap on PUBLISH, the Post's status was being changed immediately to `PUBLISHED` and then being sent to the UploadService, with the problem that checks being performed for Tracks implied that the Post was not a DRAFT being published anymore, but rather looked like an update of an already published Post.
So this PR changes things a bit and only sets the Posts' new status  (PUBLISHED) after making the `isFirstTimePublished()` checks which we need to correctly track fresh / new posts.

To test:
1. start a draft
2. type something (Title/body)
3. tap on PUBLISH on the navigation bar
4. if you put a breakpoint , observe the Tracks code being called is `UploadService.uploadPostAndTrackAnalytics` in https://github.com/wordpress-mobile/WordPress-Android/compare/release/12.2...try/fix-first-publish-analytics?expand=1#diff-38b6aea9cfff5f3e0e4b7389b44de602R1895

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
