### PR TITLE
Fix infinite item decoration in posting activity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
@@ -82,20 +82,22 @@ class ActivityViewHolder(val parent: ViewGroup) : BlockListItemViewHolder(
                     false
             )
         }
-        val offsets = recyclerView.resources.getDimensionPixelSize(R.dimen.stats_activity_spacing)
-        recyclerView.addItemDecoration(
-                object : RecyclerView.ItemDecoration() {
-                    override fun getItemOffsets(
-                        outRect: Rect,
-                        view: View,
-                        parent: RecyclerView,
-                        state: RecyclerView.State
-                    ) {
-                        super.getItemOffsets(outRect, view, parent, state)
-                        outRect.set(offsets, offsets, offsets, offsets)
+        if (recyclerView.itemDecorationCount == 0) {
+            val offsets = recyclerView.resources.getDimensionPixelSize(R.dimen.stats_activity_spacing)
+            recyclerView.addItemDecoration(
+                    object : RecyclerView.ItemDecoration() {
+                        override fun getItemOffsets(
+                            outRect: Rect,
+                            view: View,
+                            parent: RecyclerView,
+                            state: RecyclerView.State
+                        ) {
+                            super.getItemOffsets(outRect, view, parent, state)
+                            outRect.set(offsets, offsets, offsets, offsets)
+                        }
                     }
-                }
-        )
+            )
+        }
         (recyclerView.adapter as MonthActivityAdapter).update(boxes)
     }
 }


### PR DESCRIPTION
Fixes #9550 
This fixes a bug in Posting activity block in Stats Insights

To test:
* Go to Stats/Insights
* Scroll down to Posting activity 
* Scroll back to the top
* Repeat several times
* The gap between Posting activity boxes doesn't change
