### PR TITLE
Fix crash in all time stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AllTimeStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AllTimeStatsUseCase.kt
@@ -66,13 +66,18 @@ class AllTimeStatsUseCase
                             Column(string.stats_visitors, domainModel.visitors.toFormattedString())
                     )
             )
+            val tooltip = if (domainModel.viewsBestDay.isNotEmpty()) {
+                statsDateFormatter.printDate(domainModel.viewsBestDay)
+            } else {
+                null
+            }
             items.add(
                     QuickScanItem(
                             Column(string.posts, domainModel.posts.toFormattedString()),
                             Column(
                                     string.stats_insights_best_ever,
                                     domainModel.viewsBestDayTotal.toFormattedString(),
-                                    statsDateFormatter.printDate(domainModel.viewsBestDay)
+                                    tooltip
                             )
                     )
             )

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AllTimeStatsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AllTimeStatsUseCaseTest.kt
@@ -131,7 +131,7 @@ class AllTimeStatsUseCaseTest : BaseUnitTest() {
     fun `best day is null when it's empty`() = test {
         val forced = false
         val refresh = true
-        val model = InsightsAllTimeModel(1L, null,  1, 0, 0, "", 0)
+        val model = InsightsAllTimeModel(1L, null, 1, 0, 0, "", 0)
         whenever(insightsStore.getAllTimeInsights(site)).thenReturn(model)
         whenever(
                 insightsStore.fetchAllTimeInsights(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AllTimeStatsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AllTimeStatsUseCaseTest.kt
@@ -127,6 +127,32 @@ class AllTimeStatsUseCaseTest : BaseUnitTest() {
         }
     }
 
+    @Test
+    fun `best day is null when it's empty`() = test {
+        val forced = false
+        val refresh = true
+        val model = InsightsAllTimeModel(1L, null,  1, 0, 0, "", 0)
+        whenever(insightsStore.getAllTimeInsights(site)).thenReturn(model)
+        whenever(
+                insightsStore.fetchAllTimeInsights(
+                        site,
+                        forced
+                )
+        ).thenReturn(OnStatsFetched(model))
+
+        val result = loadAllTimeInsights(refresh, forced)
+
+        assertThat(result.state).isEqualTo(UseCaseState.SUCCESS)
+        assertThat(result.type).isEqualTo(InsightsTypes.ALL_TIME_STATS)
+        val items = result.data!!
+        assertEquals(items.size, 3)
+        assertTrue(items[0] is Title)
+        assertEquals((items[0] as Title).textResource, R.string.stats_insights_all_time_stats)
+        (items[2] as QuickScanItem).apply {
+            assertThat(this.rightColumn.tooltip).isNull()
+        }
+    }
+
     private suspend fun loadAllTimeInsights(refresh: Boolean, forced: Boolean): UseCaseModel {
         var result: UseCaseModel? = null
         useCase.liveData.observeForever { result = it }


### PR DESCRIPTION
Fixes #8886 

Sometimes the `viewsBestDay` seems to be empty. The date parses cannot handle this use case. I'm changing the code so we only parse a non-empty date. If it's empty, we don't show the tooltip.

I've added a test to cover this scenario

To test:
* Go to Stats/Insights on an empty Site
* The App doesn't crash
