### PR TITLE
Moved Fabric initialization up

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -222,6 +222,10 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         mContext = this;
         long startDate = SystemClock.elapsedRealtime();
 
+        if (CrashlyticsUtils.shouldEnableCrashlytics(this)) {
+            Fabric.with(this, new Crashlytics());
+        }
+
         // Init WellSql
         WellSql.init(new WellSqlConfig(getApplicationContext()));
 
@@ -234,10 +238,6 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         sRequestQueue = mRequestQueue;
         sImageLoader = mImageLoader;
         sOAuthAuthenticator = mOAuthAuthenticator;
-
-        if (CrashlyticsUtils.shouldEnableCrashlytics(this)) {
-            Fabric.with(this, new Crashlytics());
-        }
 
         ProfilingUtils.start("App Startup");
         // Enable log recording


### PR DESCRIPTION
h/t @hypest  who first suggested this could be a problem, as we were getting reports of crashes when the app starts and could not see anything on Fabric. 

This PR moves the initialization code for Fabric up, as the first thing on onCreate() to also get crashes with potential SQL initialization

To test:
1. try to make the app crash (maybe by artificially adding an exception in code temporarily, or by trying to reproduce an existing known crash)
2. observe crashes are sent to Fabric

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
