### PR TITLE
Issue/9553 create custom snackbar

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 12.3
 -----
 * Updated primary button color to pink
+* Updated snackbar design to Material guidelines
 
 12.2
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -13,7 +13,6 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
-import android.widget.TextView;
 
 import com.google.android.gms.auth.api.credentials.Credential;
 import com.google.android.gms.common.ConnectionResult;
@@ -70,6 +69,7 @@ import org.wordpress.android.util.SelfSignedSSLUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
+import org.wordpress.android.widgets.WPSnackbar;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -742,11 +742,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
 
     @Override
     public void showSignupToLoginMessage() {
-        Snackbar snackbar =
-                Snackbar.make(findViewById(R.id.main_view), R.string.signup_user_exists, Snackbar.LENGTH_LONG);
-        TextView snackbarText = snackbar.getView().findViewById(android.support.design.R.id.snackbar_text);
-        snackbarText.setMaxLines(2);
-        snackbar.show();
+        WPSnackbar.make(findViewById(R.id.main_view), R.string.signup_user_exists, Snackbar.LENGTH_LONG).show();
     }
 
     // GoogleListener

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -11,7 +11,6 @@ import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import kotlinx.android.synthetic.main.activity_log_list_fragment.*
 import kotlinx.android.synthetic.main.activity_log_list_loading_item.*
 import org.wordpress.android.R
@@ -26,6 +25,7 @@ import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus.FETCHING
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus.LOADING_MORE
+import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
 
 class ActivityLogListFragment : Fragment() {
@@ -110,10 +110,7 @@ class ActivityLogListFragment : Fragment() {
         viewModel.showSnackbarMessage.observe(this, Observer { message ->
             val parent: View? = activity?.findViewById(android.R.id.content)
             if (message != null && parent != null) {
-                val snackbar = Snackbar.make(parent, message, Snackbar.LENGTH_LONG)
-                val snackbarText = snackbar.view.findViewById<TextView>(android.support.design.R.id.snackbar_text)
-                snackbarText.maxLines = 2
-                snackbar.show()
+                WPSnackbar.make(parent, message, Snackbar.LENGTH_LONG).show()
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -39,6 +39,7 @@ import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.widgets.WPSnackbar;
 
 import javax.inject.Inject;
 
@@ -270,9 +271,8 @@ public class CommentsActivity extends AppCompatActivity
                 }
             };
 
-            Snackbar snackbar = Snackbar.make(getListFragment().getView(), message,
-                    AccessibilityUtils.getSnackbarDuration(this))
-                                        .setAction(R.string.undo, undoListener);
+            WPSnackbar snackbar = WPSnackbar.make(getListFragment().getView(), message,
+                    AccessibilityUtils.getSnackbarDuration(this)).setAction(R.string.undo, undoListener);
 
             // do the actual moderation once the undo bar has been hidden
             snackbar.setCallback(new Snackbar.Callback() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -56,6 +56,7 @@ import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.SCHE
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.TRASHED
 import org.wordpress.android.viewmodel.pages.PagesViewModel
 import org.wordpress.android.widgets.WPDialogSnackbar
+import org.wordpress.android.widgets.WPSnackbar
 import java.lang.ref.WeakReference
 import javax.inject.Inject
 
@@ -256,9 +257,9 @@ class PagesFragment : Fragment() {
             val parent = activity.findViewById<View>(R.id.coordinatorLayout)
             if (holder != null && parent != null) {
                 if (holder.buttonTitleRes == null) {
-                    Snackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG).show()
+                    WPSnackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG).show()
                 } else {
-                    val snackbar = Snackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG)
+                    val snackbar = WPSnackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG)
                     snackbar.setAction(getString(holder.buttonTitleRes)) { _ -> holder.buttonAction() }
                     snackbar.show()
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -86,6 +86,7 @@ import org.wordpress.android.util.WPLinkMovementMethod;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
+import org.wordpress.android.widgets.WPSnackbar;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -274,7 +275,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         if (event.isError()) {
             AppLog.e(T.PLANS, PluginDetailActivity.class.getSimpleName() + ".onPlansFetched: "
                               + event.error.type + " - " + event.error.message);
-            Snackbar.make(mContainer, getString(R.string.plugin_check_domain_credit_error),
+            WPSnackbar.make(mContainer, getString(R.string.plugin_check_domain_credit_error),
                     AccessibilityUtils.getSnackbarDuration(this)).show();
         } else {
             // This should not happen
@@ -283,7 +284,7 @@ public class PluginDetailActivity extends AppCompatActivity {
                 if (BuildConfig.DEBUG) {
                     throw new IllegalStateException(errorMessage);
                 }
-                Snackbar.make(mContainer, getString(R.string.plugin_check_domain_credit_error),
+                WPSnackbar.make(mContainer, getString(R.string.plugin_check_domain_credit_error),
                         AccessibilityUtils.getSnackbarDuration(this)).show();
                 AppLog.e(T.PLANS, errorMessage);
                 return;
@@ -833,28 +834,28 @@ public class PluginDetailActivity extends AppCompatActivity {
     }
 
     private void showSuccessfulUpdateSnackbar() {
-        Snackbar.make(mContainer,
+        WPSnackbar.make(mContainer,
                 getString(R.string.plugin_updated_successfully, mPlugin.getDisplayName()),
                 Snackbar.LENGTH_LONG)
                 .show();
     }
 
     private void showSuccessfulInstallSnackbar() {
-        Snackbar.make(mContainer,
+        WPSnackbar.make(mContainer,
                 getString(R.string.plugin_installed_successfully, mPlugin.getDisplayName()),
                 Snackbar.LENGTH_LONG)
                 .show();
     }
 
     private void showSuccessfulPluginRemovedSnackbar() {
-        Snackbar.make(mContainer,
+        WPSnackbar.make(mContainer,
                 getString(R.string.plugin_removed_successfully, mPlugin.getDisplayName()),
                 Snackbar.LENGTH_LONG)
                 .show();
     }
 
     private void showUpdateFailedSnackbar() {
-        Snackbar.make(mContainer,
+        WPSnackbar.make(mContainer,
                 getString(R.string.plugin_updated_failed, mPlugin.getDisplayName()),
                 AccessibilityUtils.getSnackbarDuration(this))
                 .setAction(R.string.retry, new View.OnClickListener() {
@@ -867,7 +868,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     }
 
     private void showInstallFailedSnackbar() {
-        Snackbar.make(mContainer,
+        WPSnackbar.make(mContainer,
                 getString(R.string.plugin_installed_failed, mPlugin.getDisplayName()),
                 AccessibilityUtils.getSnackbarDuration(this))
                 .setAction(R.string.retry, new View.OnClickListener() {
@@ -880,7 +881,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     }
 
     private void showPluginRemoveFailedSnackbar() {
-        Snackbar.make(mContainer,
+        WPSnackbar.make(mContainer,
                 getString(R.string.plugin_remove_failed, mPlugin.getDisplayName()),
                 Snackbar.LENGTH_LONG)
                 .show();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -167,6 +167,7 @@ import org.wordpress.android.util.helpers.MediaGalleryImageSpan;
 import org.wordpress.android.util.helpers.WPImageSpan;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.widgets.AppRatingDialog;
+import org.wordpress.android.widgets.WPSnackbar;
 import org.wordpress.android.widgets.WPViewPager;
 import org.wordpress.aztec.AztecExceptionHandler;
 import org.wordpress.aztec.util.AztecLog;
@@ -1838,7 +1839,7 @@ public class EditPostActivity extends AppCompatActivity implements
         mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
         refreshEditorContent();
 
-        Snackbar.make(mViewPager, getString(R.string.history_loaded_revision),
+        WPSnackbar.make(mViewPager, getString(R.string.history_loaded_revision),
                 AccessibilityUtils.getSnackbarDuration(EditPostActivity.this, 4000))
                 .setAction(getString(R.string.undo), new OnClickListener() {
                     @Override
@@ -3863,7 +3864,7 @@ public class EditPostActivity extends AppCompatActivity implements
                     refreshEditorContent();
 
                     if (mViewPager != null) {
-                        Snackbar.make(mViewPager, getString(R.string.local_changes_discarded),
+                        WPSnackbar.make(mViewPager, getString(R.string.local_changes_discarded),
                                 AccessibilityUtils.getSnackbarDuration(EditPostActivity.this, Snackbar.LENGTH_LONG))
                                 .setAction(getString(R.string.undo), new OnClickListener() {
                                     @Override public void onClick(View view) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -48,6 +48,7 @@ import org.wordpress.android.viewmodel.posts.PostListEmptyViewState.PERMISSION_E
 import org.wordpress.android.viewmodel.posts.PostListEmptyViewState.REFRESH_ERROR
 import org.wordpress.android.viewmodel.posts.PostListViewModel
 import org.wordpress.android.widgets.RecyclerItemDecoration
+import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
 
 class PostListFragment : Fragment() {
@@ -187,7 +188,7 @@ class PostListFragment : Fragment() {
         nonNullActivity.findViewById<View>(R.id.coordinator)?.let { parent ->
             val message = getString(holder.messageRes)
             val duration = AccessibilityUtils.getSnackbarDuration(nonNullActivity)
-            val snackbar = Snackbar.make(parent, message, duration)
+            val snackbar = WPSnackbar.make(parent, message, duration)
             if (holder.buttonTitleRes != null) {
                 snackbar.setAction(getString(holder.buttonTitleRes)) {
                     holder.buttonAction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -48,6 +48,7 @@ import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.widgets.WPSnackbar;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -388,7 +389,7 @@ public class PostPreviewActivity extends AppCompatActivity implements
                     refreshPreview();
 
                     if (mMessageView != null) {
-                        Snackbar.make(mMessageView, getString(R.string.local_changes_discarded),
+                        WPSnackbar.make(mMessageView, getString(R.string.local_changes_discarded),
                                 AccessibilityUtils.getSnackbarDuration(PostPreviewActivity.this, Snackbar.LENGTH_LONG))
                                 .setAction(getString(R.string.undo), new OnClickListener() {
                                     @Override public void onClick(View view) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -77,6 +77,7 @@ import org.wordpress.android.util.ValidationUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPPrefUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.widgets.WPSnackbar;
 
 import java.util.HashMap;
 import java.util.List;
@@ -1726,7 +1727,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                         AnalyticsUtils.trackWithSiteDetails(
                                 AnalyticsTracker.Stat.SITE_SETTINGS_EXPORT_SITE_RESPONSE_OK, mSite);
                         dismissProgressDialog(progressDialog);
-                        Snackbar.make(getView(), R.string.export_email_sent, Snackbar.LENGTH_LONG).show();
+                        WPSnackbar.make(getView(), R.string.export_email_sent, Snackbar.LENGTH_LONG).show();
                     }
                 }
             }, new RestRequest.ErrorListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -41,7 +41,6 @@ import org.wordpress.android.ui.suggestion.adapters.SuggestionAdapter;
 import org.wordpress.android.ui.suggestion.service.SuggestionEvents;
 import org.wordpress.android.ui.suggestion.util.SuggestionServiceConnectionManager;
 import org.wordpress.android.ui.suggestion.util.SuggestionUtils;
-import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DisplayUtils;
@@ -50,10 +49,12 @@ import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
+import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 import org.wordpress.android.widgets.RecyclerItemDecoration;
 import org.wordpress.android.widgets.SuggestionAutoCompleteText;
+import org.wordpress.android.widgets.WPSnackbar;
 
 import java.util.List;
 import java.util.Locale;
@@ -440,7 +441,7 @@ public class ReaderCommentListActivity extends AppCompatActivity {
                 case COMMENT_LIKE:
                     getCommentAdapter().setHighlightCommentId(mCommentId, false);
                     if (!mAccountStore.hasAccessToken()) {
-                        Snackbar.make(mRecyclerView,
+                        WPSnackbar.make(mRecyclerView,
                                       R.string.reader_snackbar_err_cannot_like_post_logged_out,
                                       Snackbar.LENGTH_INDEFINITE)
                                 .setAction(R.string.sign_in, mSignInClickListener)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -82,6 +82,7 @@ import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 import org.wordpress.android.widgets.WPScrollView;
 import org.wordpress.android.widgets.WPScrollView.ScrollDirectionListener;
+import org.wordpress.android.widgets.WPSnackbar;
 import org.wordpress.android.widgets.WPTextView;
 
 import java.util.EnumSet;
@@ -446,7 +447,7 @@ public class ReaderPostDetailFragment extends Fragment
                     ? getString(R.string.reader_followed_blog_notifications_this)
                     : blogName;
 
-            Snackbar.make(view, Html.fromHtml(getString(R.string.reader_followed_blog_notifications,
+            WPSnackbar.make(view, Html.fromHtml(getString(R.string.reader_followed_blog_notifications,
                     "<b>", blog, "</b>")), AccessibilityUtils.getSnackbarDuration(getActivity()))
                     .setAction(getString(R.string.reader_followed_blog_notifications_action),
                         new View.OnClickListener() {
@@ -458,7 +459,6 @@ public class ReaderPostDetailFragment extends Fragment
                                 ReaderBlogTable.setNotificationsEnabledByBlogId(blogId, true);
                             }
                         })
-                    .setActionTextColor(getResources().getColor(R.color.accent))
                     .show();
         }
     }
@@ -566,7 +566,7 @@ public class ReaderPostDetailFragment extends Fragment
             return;
         }
 
-        Snackbar.make(getView(), R.string.reader_bookmark_snack_title,
+        WPSnackbar.make(getView(), R.string.reader_bookmark_snack_title,
                 AccessibilityUtils.getSnackbarDuration(getActivity())).setAction(R.string.reader_bookmark_snack_btn,
                 new View.OnClickListener() {
                     @Override public void onClick(View view) {
@@ -891,7 +891,7 @@ public class ReaderPostDetailFragment extends Fragment
         }
 
         if (!mAccountStore.hasAccessToken()) {
-            Snackbar.make(getView(), R.string.reader_snackbar_err_cannot_like_post_logged_out,
+            WPSnackbar.make(getView(), R.string.reader_snackbar_err_cannot_like_post_logged_out,
                     Snackbar.LENGTH_INDEFINITE)
                     .setAction(R.string.sign_in, mSignInClickListener).show();
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -13,7 +13,6 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.design.widget.Snackbar;
 import android.support.design.widget.TabLayout;
 import android.support.design.widget.TabLayout.OnTabSelectedListener;
 import android.support.design.widget.TabLayout.Tab;
@@ -117,6 +116,7 @@ import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.widgets.AppRatingDialog;
 import org.wordpress.android.widgets.RecyclerItemDecoration;
 import org.wordpress.android.widgets.WPDialogSnackbar;
+import org.wordpress.android.widgets.WPSnackbar;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -1196,7 +1196,7 @@ public class ReaderPostListFragment extends Fragment
                 refreshPosts();
             }
         };
-        Snackbar.make(getSnackbarParent(), getString(R.string.reader_toast_blog_blocked),
+        WPSnackbar.make(getSnackbarParent(), getString(R.string.reader_toast_blog_blocked),
                 AccessibilityUtils.getSnackbarDuration(getActivity()))
                 .setAction(R.string.undo, undoListener)
                 .show();
@@ -1490,7 +1490,7 @@ public class ReaderPostListFragment extends Fragment
             return;
         }
 
-        Snackbar.make(getView(), R.string.reader_bookmark_snack_title,
+        WPSnackbar.make(getView(), R.string.reader_bookmark_snack_title,
                 AccessibilityUtils.getSnackbarDuration(getActivity())).setAction(R.string.reader_bookmark_snack_btn,
                 new View.OnClickListener() {
                     @Override public void onClick(View view) {
@@ -2208,7 +2208,7 @@ public class ReaderPostListFragment extends Fragment
                 ? getString(R.string.reader_followed_blog_notifications_this)
                 : blogName;
 
-        Snackbar.make(getSnackbarParent(), Html.fromHtml(getString(R.string.reader_followed_blog_notifications,
+        WPSnackbar.make(getSnackbarParent(), Html.fromHtml(getString(R.string.reader_followed_blog_notifications,
                 "<b>", blog, "</b>")), AccessibilityUtils.getSnackbarDuration(getActivity()))
                 .setAction(getString(R.string.reader_followed_blog_notifications_action),
                         new View.OnClickListener() {
@@ -2220,7 +2220,6 @@ public class ReaderPostListFragment extends Fragment
                                 ReaderBlogTable.setNotificationsEnabledByBlogId(blogId, true);
                             }
                         })
-                .setActionTextColor(getResources().getColor(R.color.accent))
                 .show();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSect
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.YEARS
 import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
+import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
 
 private val statsSections = listOf(INSIGHTS, DAYS, WEEKS, MONTHS, YEARS)
@@ -144,9 +145,9 @@ class StatsFragment : DaggerFragment() {
             val parent = activity.findViewById<View>(R.id.coordinatorLayout)
             if (holder != null && parent != null) {
                 if (holder.buttonTitleRes == null) {
-                    Snackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG).show()
+                    WPSnackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG).show()
                 } else {
-                    val snackbar = Snackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG)
+                    val snackbar = WPSnackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG)
                     snackbar.setAction(getString(holder.buttonTitleRes)) { holder.buttonAction() }
                     snackbar.show()
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.observeEvent
+import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
 
 class StatsViewAllFragment : DaggerFragment() {
@@ -162,9 +163,9 @@ class StatsViewAllFragment : DaggerFragment() {
             val parent = activity.findViewById<View>(R.id.coordinatorLayout)
             if (holder != null && parent != null) {
                 if (holder.buttonTitleRes == null) {
-                    Snackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG).show()
+                    WPSnackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG).show()
                 } else {
-                    val snackbar = Snackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG)
+                    val snackbar = WPSnackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG)
                     snackbar.setAction(getString(holder.buttonTitleRes)) { holder.buttonAction() }
                     snackbar.show()
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -28,6 +28,7 @@ import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPMediaUtils;
+import org.wordpress.android.widgets.WPSnackbar;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -191,49 +192,47 @@ public class UploadUtils {
 
     private static void showSnackbarError(View view, String message, int buttonTitleRes,
                                           View.OnClickListener onClickListener) {
-        Snackbar.make(view, message, AccessibilityUtils.getSnackbarDuration(view.getContext(), K_SNACKBAR_WAIT_TIME_MS))
+        WPSnackbar.make(view, message,
+                AccessibilityUtils.getSnackbarDuration(view.getContext(), K_SNACKBAR_WAIT_TIME_MS))
                 .setAction(buttonTitleRes, onClickListener).show();
     }
 
     public static void showSnackbarError(View view, String message) {
-        Snackbar.make(view, message, K_SNACKBAR_WAIT_TIME_MS).show();
+        WPSnackbar.make(view, message, K_SNACKBAR_WAIT_TIME_MS).show();
     }
 
     private static void showSnackbar(View view, int messageRes, int buttonTitleRes,
                                      View.OnClickListener onClickListener) {
-        Snackbar.make(view, messageRes,
+        WPSnackbar.make(view, messageRes,
                 AccessibilityUtils.getSnackbarDuration(view.getContext(), K_SNACKBAR_WAIT_TIME_MS))
                 .setAction(buttonTitleRes, onClickListener).show();
     }
 
     public static void showSnackbarSuccessAction(View view, int messageRes, int buttonTitleRes,
                                                   View.OnClickListener onClickListener) {
-        Snackbar.make(view, messageRes,
+        WPSnackbar.make(view, messageRes,
                 AccessibilityUtils.getSnackbarDuration(view.getContext(), K_SNACKBAR_WAIT_TIME_MS))
-                .setAction(buttonTitleRes, onClickListener).
-                        setActionTextColor(view.getResources().getColor(R.color.primary_400))
+                .setAction(buttonTitleRes, onClickListener)
                 .show();
     }
 
     private static void showSnackbarSuccessAction(View view, String message, int buttonTitleRes,
                                                   View.OnClickListener onClickListener) {
-        Snackbar.make(view, message, AccessibilityUtils.getSnackbarDuration(view.getContext(), K_SNACKBAR_WAIT_TIME_MS))
+        WPSnackbar.make(view, message,
+                AccessibilityUtils.getSnackbarDuration(view.getContext(), K_SNACKBAR_WAIT_TIME_MS))
                 .setAction(buttonTitleRes, onClickListener)
-                .setActionTextColor(view.getResources().getColor(R.color.primary_400))
                 .show();
     }
 
     public static void showSnackbarSuccessActionOrange(View view, int messageRes, int buttonTitleRes,
                                                   View.OnClickListener onClickListener) {
-        Snackbar.make(view, messageRes, Snackbar.LENGTH_LONG)
-                .setAction(buttonTitleRes, onClickListener).
-                        setActionTextColor(view.getResources().getColor(R.color.accent))
+        WPSnackbar.make(view, messageRes, Snackbar.LENGTH_LONG)
+                .setAction(buttonTitleRes, onClickListener)
                 .show();
     }
 
     public static void showSnackbar(View view, int messageRes) {
-        Snackbar.make(view,
-                      messageRes, Snackbar.LENGTH_LONG).show();
+        WPSnackbar.make(view, messageRes, Snackbar.LENGTH_LONG).show();
     }
 
     public static void publishPost(Activity activity, final PostModel post, SiteModel site, Dispatcher dispatcher) {

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPDialogSnackbar.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPDialogSnackbar.java
@@ -1,29 +1,41 @@
 package org.wordpress.android.widgets;
 
+import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import android.support.design.widget.Snackbar.SnackbarLayout;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
+import org.wordpress.android.util.AccessibilityUtils;
 
 /**
- * {@link Snackbar} with {@link android.app.Dialog}-like layout.  The layout views include title, message,
- * positive button, and negative button.  Any empty or null view is hidden.  The only required view is message.
+ * {@link Snackbar} with {@link android.app.Dialog}-like layout mimicking the updated design pattern defined in the
+ * Material Design guidelines <a href="https://material.io/design/components/snackbars.html#spec">specifications</a>.
+ * The view include title, message, positive button, negative button, and neutral button.  Any empty or null view is
+ * hidden.  The only required view is message.
  */
 public class WPDialogSnackbar {
     private Snackbar mSnackbar;
     private View mContentView;
 
     private WPDialogSnackbar(@NonNull View view, @NonNull CharSequence text, int duration) {
-        mSnackbar = Snackbar.make(view, "", duration);
+        mSnackbar = Snackbar.make(view, "", AccessibilityUtils.getSnackbarDuration(view.getContext(), duration));
 
         // Set underlying snackbar layout.
         SnackbarLayout snackbarLayout = (SnackbarLayout) mSnackbar.getView();
+        ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) snackbarLayout.getLayoutParams();
+        Context context = view.getContext();
+        int margin = (int) context.getResources().getDimension(R.dimen.margin_medium);
+        params.setMargins(margin, margin, margin, margin);
+        snackbarLayout.setLayoutParams(params);
         snackbarLayout.setPadding(0, 0, 0, 0);
+        snackbarLayout.setBackground(context.getDrawable(R.drawable.bg_snackbar));
 
         // Hide underlying snackbar text and action.
         TextView snackbarText = snackbarLayout.findViewById(android.support.design.R.id.snackbar_text);
@@ -60,7 +72,7 @@ public class WPDialogSnackbar {
         return new WPDialogSnackbar(view, text, duration);
     }
 
-    private void setButtonTextAndVisibility(TextView button, CharSequence text, final View.OnClickListener listener) {
+    private void setButtonTextAndVisibility(Button button, CharSequence text, final View.OnClickListener listener) {
         // Hide button when text is empty or listener is null.
         if (TextUtils.isEmpty(text) || listener == null) {
             button.setVisibility(View.GONE);
@@ -79,17 +91,17 @@ public class WPDialogSnackbar {
     }
 
     public WPDialogSnackbar setNegativeButton(CharSequence text, View.OnClickListener listener) {
-        setButtonTextAndVisibility((TextView) mContentView.findViewById(R.id.button_negative), text, listener);
+        setButtonTextAndVisibility((Button) mContentView.findViewById(R.id.button_negative), text, listener);
         return this;
     }
 
     public WPDialogSnackbar setNeutralButton(CharSequence text, View.OnClickListener listener) {
-        setButtonTextAndVisibility((TextView) mContentView.findViewById(R.id.button_neutral), text, listener);
+        setButtonTextAndVisibility((Button) mContentView.findViewById(R.id.button_neutral), text, listener);
         return this;
     }
 
     public WPDialogSnackbar setPositiveButton(CharSequence text, View.OnClickListener listener) {
-        setButtonTextAndVisibility((TextView) mContentView.findViewById(R.id.button_positive), text, listener);
+        setButtonTextAndVisibility((Button) mContentView.findViewById(R.id.button_positive), text, listener);
         return this;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPSnackbar.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPSnackbar.java
@@ -1,0 +1,122 @@
+package org.wordpress.android.widgets;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
+import android.support.design.widget.Snackbar;
+import android.support.design.widget.Snackbar.SnackbarLayout;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+
+import org.wordpress.android.R;
+import org.wordpress.android.util.AccessibilityUtils;
+
+/**
+ * {@link Snackbar} with custom colors and layout mimicking the updated design pattern defined in the Material Design
+ * guidelines <a href="https://material.io/design/components/snackbars.html#spec">specifications</a>.  The views include
+ * message and action button.  Any empty or null view is hidden.  The only required view is message.
+ */
+public class WPSnackbar {
+    private Snackbar mSnackbar;
+    private View mContentView;
+
+    private WPSnackbar(@NonNull View view, @NonNull CharSequence text, int duration) {
+        mSnackbar = Snackbar.make(view, "", AccessibilityUtils.getSnackbarDuration(view.getContext(), duration));
+
+        // Set underlying snackbar layout.
+        SnackbarLayout snackbarLayout = (SnackbarLayout) mSnackbar.getView();
+        ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) snackbarLayout.getLayoutParams();
+        Context context = view.getContext();
+        int margin = (int) context.getResources().getDimension(R.dimen.margin_medium);
+        params.setMargins(margin, margin, margin, margin);
+        snackbarLayout.setLayoutParams(params);
+        snackbarLayout.setPadding(0, 0, 0, 0);
+        snackbarLayout.setBackground(context.getDrawable(R.drawable.bg_snackbar));
+
+        // Hide underlying snackbar text and action.
+        TextView snackbarText = snackbarLayout.findViewById(android.support.design.R.id.snackbar_text);
+        snackbarText.setVisibility(View.INVISIBLE);
+        TextView snackbarAction = snackbarLayout.findViewById(android.support.design.R.id.snackbar_action);
+        snackbarAction.setVisibility(View.INVISIBLE);
+
+        mContentView = LayoutInflater.from(context).inflate(R.layout.snackbar, null);
+
+        TextView message = mContentView.findViewById(R.id.message);
+
+        // Hide message view when text is empty.
+        if (TextUtils.isEmpty(text)) {
+            message.setVisibility(View.GONE);
+        } else {
+            message.setVisibility(View.VISIBLE);
+            message.setText(text);
+        }
+
+        snackbarLayout.addView(mContentView, 0);
+    }
+
+    public WPSnackbar addCallback(Snackbar.Callback callback) {
+        mSnackbar.addCallback(callback);
+        return this;
+    }
+
+    public void dismiss() {
+        if (mSnackbar != null) {
+            mSnackbar.dismiss();
+        }
+    }
+
+    public boolean isShowing() {
+        return mSnackbar != null && mSnackbar.isShown();
+    }
+
+    public static WPSnackbar make(@NonNull View view, @NonNull CharSequence text, int duration) {
+        return new WPSnackbar(view, text, duration);
+    }
+
+    public static WPSnackbar make(@NonNull View view, @StringRes int textRes, int duration) {
+        CharSequence text = view.getResources().getString(textRes);
+        return new WPSnackbar(view, text, duration);
+    }
+
+    private void setButtonTextAndVisibility(Button button, CharSequence text, final View.OnClickListener listener) {
+        // Hide button when text is empty or listener is null.
+        if (TextUtils.isEmpty(text) || listener == null) {
+            button.setVisibility(View.GONE);
+            button.setOnClickListener(null);
+        } else {
+            button.setVisibility(View.VISIBLE);
+            button.setText(text);
+            button.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    listener.onClick(view);
+                    dismiss();
+                }
+            });
+        }
+    }
+
+    public WPSnackbar setAction(CharSequence text, View.OnClickListener listener) {
+        setButtonTextAndVisibility((Button) mContentView.findViewById(R.id.action), text, listener);
+        return this;
+    }
+
+    public WPSnackbar setAction(@StringRes int textRes, View.OnClickListener listener) {
+        CharSequence text = mContentView.getResources().getString(textRes);
+        setButtonTextAndVisibility((Button) mContentView.findViewById(R.id.action), text, listener);
+        return this;
+    }
+
+    public WPSnackbar setCallback(Snackbar.Callback callback) {
+        mSnackbar.addCallback(callback);
+        return this;
+    }
+
+    public void show() {
+        mSnackbar.show();
+    }
+}

--- a/WordPress/src/main/res/drawable/bg_snackbar.xml
+++ b/WordPress/src/main/res/drawable/bg_snackbar.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid
+        android:color="@color/background_snackbar">
+    </solid>
+
+    <corners
+        android:radius="@dimen/snackbar_radius">
+    </corners>
+
+</shape>

--- a/WordPress/src/main/res/layout/dialog_snackbar.xml
+++ b/WordPress/src/main/res/layout/dialog_snackbar.xml
@@ -3,15 +3,16 @@
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/background_snackbar"
-    android:paddingBottom="@dimen/margin_medium">
+    android:layout_width="match_parent"
+    android:paddingBottom="@dimen/margin_medium"
+    tools:background="@drawable/bg_snackbar"
+    tools:layout_margin="@dimen/margin_medium">
 
     <RelativeLayout
         android:id="@+id/text"
-        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_width="match_parent"
         android:paddingBottom="@dimen/margin_medium"
         android:paddingEnd="@dimen/dialog_snackbar_content_padding"
         android:paddingStart="@dimen/dialog_snackbar_content_padding"
@@ -19,11 +20,11 @@
 
         <TextView
             android:id="@+id/title"
-            android:layout_width="match_parent"
+            android:fontFamily="sans-serif-medium"
             android:layout_height="wrap_content"
             android:layout_marginBottom="8dp"
-            android:fontFamily="sans-serif-medium"
-            android:textColor="@android:color/white"
+            android:layout_width="match_parent"
+            android:textColor="@color/white"
             android:textSize="@dimen/text_sz_large"
             android:visibility="gone"
             tools:text="Add social media account"
@@ -32,9 +33,9 @@
 
         <TextView
             android:id="@+id/message"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
             android:layout_below="@+id/title"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
             android:textColor="@color/neutral_50"
             android:textSize="@dimen/text_sz_medium"
             android:visibility="gone"
@@ -45,58 +46,58 @@
     </RelativeLayout>
 
     <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
         android:layout_below="@+id/text"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
         android:paddingEnd="@dimen/margin_medium"
         android:paddingStart="@dimen/margin_medium">
 
-        <android.support.v7.widget.AppCompatButton
+        <Button
             android:id="@+id/button_positive"
-            style="@style/Widget.AppCompat.Button.Borderless"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:layout_marginStart="@dimen/margin_medium"
             android:fontFamily="sans-serif-medium"
+            android:layout_alignParentEnd="true"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_medium"
+            android:layout_width="wrap_content"
             android:minHeight="@dimen/default_dialog_button_height"
             android:minWidth="@dimen/min_touch_target_sz"
-            android:textColor="@color/accent"
+            android:textColor="@color/accent_300"
             android:visibility="gone"
             tools:text="Yes, let's do it"
-            tools:visibility="visible">
-        </android.support.v7.widget.AppCompatButton>
+            tools:visibility="visible"
+            style="@android:style/Widget.Material.Button.Borderless">
+        </Button>
 
-        <android.support.v7.widget.AppCompatButton
+        <Button
             android:id="@+id/button_negative"
-            style="@style/Widget.AppCompat.Button.Borderless"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignWithParentIfMissing="true"
-            android:layout_toStartOf="@+id/button_positive"
             android:fontFamily="sans-serif-medium"
+            android:layout_alignWithParentIfMissing="true"
+            android:layout_height="wrap_content"
+            android:layout_toStartOf="@+id/button_positive"
+            android:layout_width="wrap_content"
             android:minHeight="@dimen/default_dialog_button_height"
             android:minWidth="@dimen/min_touch_target_sz"
-            android:textColor="@color/accent"
+            android:textColor="@color/accent_300"
             android:visibility="gone"
             tools:text="Not now"
-            tools:visibility="visible">
-        </android.support.v7.widget.AppCompatButton>
+            tools:visibility="visible"
+            style="@android:style/Widget.Material.Button.Borderless">
+        </Button>
 
-        <android.support.v7.widget.AppCompatButton
+        <Button
             android:id="@+id/button_neutral"
-            style="@style/Widget.AppCompat.Button.Borderless"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentStart="true"
             android:fontFamily="sans-serif-medium"
+            android:layout_alignParentStart="true"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
             android:minHeight="@dimen/default_dialog_button_height"
             android:minWidth="@dimen/min_touch_target_sz"
-            android:textColor="@color/accent"
+            android:textColor="@color/accent_300"
             android:visibility="gone"
             tools:text="Never ever"
-            tools:visibility="visible">
-        </android.support.v7.widget.AppCompatButton>
+            tools:visibility="visible"
+            style="@android:style/Widget.Material.Button.Borderless">
+        </Button>
 
     </RelativeLayout>
 

--- a/WordPress/src/main/res/layout/post_preview_activity.xml
+++ b/WordPress/src/main/res/layout/post_preview_activity.xml
@@ -19,12 +19,13 @@
         android:id="@+id/message_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@drawable/bg_snackbar"
         android:layout_alignParentBottom="true"
-        android:visibility="gone"
-        android:background="@color/background_snackbar"
-        tools:visibility="visible"
+        android:layout_margin="@dimen/content_margin"
+        android:paddingEnd="@dimen/content_margin"
         android:paddingStart="@dimen/content_margin"
-        android:paddingEnd="@dimen/content_margin">
+        android:visibility="gone"
+        tools:visibility="visible">
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/message_text"
@@ -57,7 +58,7 @@
                 android:paddingTop="@dimen/margin_medium"
                 android:text="@string/button_discard_changes"
                 android:textAllCaps="true"
-                android:textColor="@color/accent"
+                android:textColor="@color/accent_300"
                 android:textSize="@dimen/text_sz_small"
                 android:paddingStart="@dimen/margin_extra_large"
                 android:paddingEnd="@dimen/margin_extra_large"/>
@@ -72,7 +73,7 @@
                 android:paddingTop="@dimen/margin_medium"
                 android:text="@string/button_publish"
                 android:textAllCaps="true"
-                android:textColor="@color/accent"
+                android:textColor="@color/accent_300"
                 android:textSize="@dimen/text_sz_small"
                 android:paddingEnd="@dimen/margin_large"
                 android:paddingStart="@dimen/margin_large"/>

--- a/WordPress/src/main/res/layout/snackbar.xml
+++ b/WordPress/src/main/res/layout/snackbar.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
+    android:minHeight="@dimen/snackbar_height_minimum"
+    android:paddingEnd="@dimen/margin_medium"
+    android:paddingStart="@dimen/margin_medium"
+    tools:background="@drawable/bg_snackbar"
+    tools:layout_margin="@dimen/margin_medium">
+
+    <Button
+        android:id="@+id/action"
+        android:fontFamily="sans-serif-medium"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:minHeight="@dimen/min_touch_target_sz"
+        android:minWidth="@dimen/min_touch_target_sz"
+        android:textColor="@color/accent_300"
+        android:visibility="gone"
+        tools:text="Action"
+        tools:visibility="visible"
+        style="@android:style/Widget.Material.Button.Borderless">
+    </Button>
+
+    <TextView
+        android:id="@+id/message"
+        android:ellipsize="end"
+        android:gravity="center_vertical"
+        android:layout_alignParentStart="true"
+        android:layout_height="wrap_content"
+        android:layout_toStartOf="@+id/action"
+        android:layout_width="wrap_content"
+        android:maxLines="2"
+        android:paddingBottom="@dimen/margin_large"
+        android:paddingEnd="@dimen/margin_medium"
+        android:paddingStart="@dimen/margin_medium"
+        android:paddingTop="@dimen/margin_large"
+        android:textColor="@android:color/white"
+        android:textSize="@dimen/text_sz_medium"
+        android:visibility="gone"
+        tools:text="Message that is limited to two lines of text with an ellipsis is shown when there is more text"
+        tools:visibility="visible">
+    </TextView>
+
+</RelativeLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -26,6 +26,8 @@
 
     <dimen name="message_bar_elevation">2dp</dimen>
     <dimen name="tabs_elevation">4dp</dimen>
+    <dimen name="snackbar_height_minimum">48dp</dimen>
+    <dimen name="snackbar_radius">4dp</dimen>
 
     <dimen name="media_grid_progress_height">24dp</dimen>
     <dimen name="media_settings_margin_normal">@dimen/margin_extra_large</dimen>

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AccessibilityUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AccessibilityUtils.java
@@ -22,12 +22,14 @@ public class AccessibilityUtils {
     }
 
     /**
+     * If the default duration is LENGTH_INDEFINITE, ignore accessibility duration and return LENGTH_INDEFINITE.
      * If the accessibility is enabled, returns increased snackbar duration, otherwise returns defaultDuration.
      *
      * @param defaultDuration Either be one of the predefined lengths: LENGTH_SHORT, LENGTH_LONG, or a custom duration
      *                        in milliseconds.
      */
     public static int getSnackbarDuration(Context ctx, int defaultDuration) {
-        return isAccessibilityEnabled(ctx) ? SNACKBAR_WITH_ACTION_DURATION_IN_MILLIS : defaultDuration;
+        return defaultDuration == Snackbar.LENGTH_INDEFINITE ? Snackbar.LENGTH_INDEFINITE
+                : isAccessibilityEnabled(ctx) ? SNACKBAR_WITH_ACTION_DURATION_IN_MILLIS : defaultDuration;
     }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AccessibilityUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AccessibilityUtils.java
@@ -11,7 +11,7 @@ public class AccessibilityUtils {
 
     public static boolean isAccessibilityEnabled(Context ctx) {
         AccessibilityManager am = (AccessibilityManager) ctx.getSystemService(ACCESSIBILITY_SERVICE);
-        return am != null ? am.isEnabled() : false;
+        return am != null && am.isEnabled();
     }
 
     /**


### PR DESCRIPTION
### Fix
Create a snackbar with custom colors and layout as described in the [Material specification](https://material.io/design/components/snackbars.html#spec) as described in https://github.com/wordpress-mobile/WordPress-Android/issues/9553.  See the screenshots below for illustration.

#### Note
`WPDialogSnackbar` was updated to resemble the new snackbar design with these changes.  Also, the ***Preview*** screen contains a view used to mimic a snackbar, which was also updated to resemble the new snackbar design.  The pseudo-snackbar view should be updated in a subsequent pull request to use `WPDialogSnackbar`.  See the screenshots below for illustration.

![snackbar_preview](https://user-images.githubusercontent.com/3827611/55846562-fb8a9d00-5afa-11e9-9249-098fdfd4f15b.png)

These changes include updating the `AccessibilityUtils` class to account for the `Snackbar.LENGTH_INDEFINITE` duration constant.  The `WPDialogSnackbar` and `WPSnackbar` classes were made to use the `AccessibilityUtils.getSnackbarDuration` method so that developers do not have to remember to use `AccessibilityUtils` to get the duration for snackbar instances.  I'll update the usage of `AccessibilityUtils.getSnackbarDuration` in `WPDialogSnackbar` and `WPSnackbar` instances in a subsequent pull request.

### Test
#### Signup
0. Clear app data.
1. Tap ***Sign Up for WordPress.com*** button.
2. Tap ***Sign Up with Google*** button.
3. Tap email with existing WordPress.com account and two-factor authentication enabled.
4. Notice snackbar is displayed as shown below.

![snackbar_signup](https://user-images.githubusercontent.com/3827611/55846972-786a4680-5afc-11e9-9653-fae94befdc02.png)

#### Stats
0. Enable airplane mode.
1. Go to ***Sites*** tab.
2. Tap ***Stats*** item.
3. Notice snackbar is displayed as shown below.

![snackbar_stats](https://user-images.githubusercontent.com/3827611/55848287-427b9100-5b01-11e9-9654-14a9a46c45ca.png)

#### Activity Log
0. Select site with rewind available.
1. Go to ***Sites*** tab.
2. Tap ***Activity*** item.
3. Tap event in list with rewind available.
4. Tap ***Rewind*** button in event detail.
5. Tap ***Rewind Site*** button in dialog.
6. Notice snackbar is displayed as shown below.
7. Wait for rewind to finish.
8. Notice snackbar is displayed as shown below.

![snackbar_activity_rewinding](https://user-images.githubusercontent.com/3827611/55847618-d861ec80-5afe-11e9-83e5-c907af090c7b.png)

![snackbar_activity_rewound](https://user-images.githubusercontent.com/3827611/55847678-152de380-5aff-11e9-8b61-447790497963.png)

#### Site Pages
1. Go to ***Sites*** tab.
2. Tap ***Site Pages*** under ***Publish*** section.
3. Tap ellipsis button of page in list.
4. Tap ***Move to Trash*** item in menu.
5. Wait for page to be moved to trash.
6. Notice snackbar is displayed as shown below.
7. Tap ***Undo*** action in snackbar.

![snackbar_pages](https://user-images.githubusercontent.com/3827611/55848241-1b24c400-5b01-11e9-8767-e53236538baf.png)

#### Blog Posts
1. Go to ***Sites*** tab.
2. Tap ***Blog Posts*** under ***Publish*** section.
3. Tap ***Trash*** button in blog post.
4. Tap ***Delete*** button in dialog.
5. Notice snackbar is displayed as shown below.
6. Tap ***Undo*** action in snackbar.

![snackbar_posts](https://user-images.githubusercontent.com/3827611/55848253-2b3ca380-5b01-11e9-8900-e8aa0877fff0.png)

#### Revisions
1. Go to ***Sites*** tab.
2. Tap ***Blog Posts*** under ***Publish*** section.
3. Tap blog post in list with history.
4. Tap ellipsis button in top app bar.
5. Tap ***History*** item in menu.
6. Tap revision in list.
7. Tap ***Load*** button in top app bar.
8. Notice snackbar is displayed as shown below.

![snackbar_revisions](https://user-images.githubusercontent.com/3827611/55848249-22e46880-5b01-11e9-9920-cf1e0171490a.png)

#### Comments
1. Go to ***Sites*** tab.
2. Tap ***Comments*** under ***Publish*** section.
3. Tap comment in list.
4. Tap ***Trash*** button in comment footer.
5. Notice snackbar is displayed as shown below.
6. Tap ***Undo*** action in snackbar.

![snackbar_comments](https://user-images.githubusercontent.com/3827611/55848234-14964c80-5b01-11e9-939b-5945866124a7.png)

#### Plugins
0. Select site with plugins available.
1. Go to ***Sites*** tab.
2. Tap ***Plugins*** under ***Configuration*** section.
3. Tap plugin with ***Needs update*** status.
4. Tap ***Update*** button in plugin detail.
5. Wait for plugin to update.
6. Notice snackbar is displayed as shown below.

![snackbar_plugins](https://user-images.githubusercontent.com/3827611/55848242-1eb84b00-5b01-11e9-97e2-f218c9f90ece.png)

#### Export Content
1. Go to ***Sites*** tab.
2. Tap ***Settings*** under ***Configuration*** section.
3. Tap ***Export Content*** under ***Advanced*** section.
4. Tap ***Export Content*** button in dialog.
5. Wait for export content.
6. Notice snackbar is displayed as shown below.

![snackbar_export](https://user-images.githubusercontent.com/3827611/55848266-2e379400-5b01-11e9-8737-c84902ee19ce.png)

#### Save Posts
1. Go to ***Reader*** tab.
2. Tap ***Bookmark*** button in post.
3. Notice snackbar is displayed as shown below.

![snackbar_save](https://user-images.githubusercontent.com/3827611/55848274-38599280-5b01-11e9-8104-fbd160850f00.png)

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
The `RELEASE-NOTES.txt` document was updated in 11bbac42b8 with the following:
> Updated snackbar design to Material guidelines