### PR TITLE
Hide author selection filter on post list screen for jetpack sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -81,7 +81,7 @@ class PostListMainViewModel @Inject constructor(
         _updatePostsPager.value = authorFilterSelection
         _viewState.value = PostListMainViewState(
                 isFabVisible = FAB_VISIBLE_POST_LIST_PAGES.contains(POST_LIST_PAGES.first()),
-                isAuthorFilterVisible = site.isUsingWpComRestApi,
+                isAuthorFilterVisible = site.isWPCom,
                 authorFilterSelection = authorFilterSelection,
                 authorFilterItems = getAuthorFilterItems(authorFilterSelection)
         )


### PR DESCRIPTION
Fixes #9575 

Hides Author selection filter on Post List screen on self-hosted JetPack sites.

It seems filtering by author on self-hosted Jetpack sites isn't supported. I've checked with Calypso and the "me/everyone" filter is hidden there. 

To test:
1. Switch to a self-hosted Jetpack site
2. My Site
3. Blog Posts
4. Notice the Author selection filter is hidden
5. Switch to a WPcom site
6. My Site
7. Blog posts
8. Notice the Author selection filter is visible

Update release notes:

- We'll update the release notes when we merge "feature/master-post-filters" into develop.
