### PR TITLE
Add WordPress Android version to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,4 +7,4 @@
 ### Steps to reproduce the behavior
 
 
-##### Tested on [device], Android [version]
+##### WordPress Android [version], Tested on [device], Android [version]

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,4 +7,4 @@
 ### Steps to reproduce the behavior
 
 
-##### WordPress Android [version], Tested on [device], Android [version]
+##### Tested on [device], Android [version], WPAndroid [version]


### PR DESCRIPTION
It would be helpful to have the app's version as part of the issue template.