### PR TITLE
Post List trash/restore/delete actions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/CriticalPostActionTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/CriticalPostActionTracker.kt
@@ -1,0 +1,41 @@
+package org.wordpress.android.ui.posts
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+
+class CriticalPostActionTracker(
+    // TODO: Find a better name than listener
+    private val listener: () -> Unit,
+    private val shouldCrashOnUnexpectedAction: Boolean = BuildConfig.DEBUG
+) {
+    enum class CriticalPostAction {
+        RESTORING_POST, TRASHING_POST
+    }
+    private val map = HashMap<LocalId, CriticalPostAction>()
+
+    fun add(localPostId: LocalId, criticalPostAction: CriticalPostAction) {
+        if (map.containsKey(localPostId)) {
+            val currentActionName = map[localPostId]?.name
+            val newActionName = criticalPostAction.name
+            val errorMessage = "We should not perform more than one critical post action. Current action is " +
+                    "($currentActionName), new action is ($newActionName)"
+            AppLog.e(T.POSTS, errorMessage)
+            if (shouldCrashOnUnexpectedAction) {
+                throw IllegalStateException(errorMessage)
+            }
+        }
+        map[localPostId] = criticalPostAction
+        listener.invoke()
+    }
+
+    fun contains(localPostId: LocalId): Boolean = map.containsKey(localPostId)
+
+    fun get(localPostId: LocalId): CriticalPostAction? = map[localPostId]
+
+    fun remove(localPostId: LocalId) {
+        map.remove(localPostId)
+        listener.invoke()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/CriticalPostActionTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/CriticalPostActionTracker.kt
@@ -11,7 +11,7 @@ class CriticalPostActionTracker(
     private val shouldCrashOnUnexpectedAction: Boolean = BuildConfig.DEBUG
 ) {
     enum class CriticalPostAction {
-        RESTORING_POST, TRASHING_POST
+        DELETING_POST, RESTORING_POST, TRASHING_POST
     }
     private val map = HashMap<LocalId, CriticalPostAction>()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/CriticalPostActionTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/CriticalPostActionTracker.kt
@@ -34,8 +34,10 @@ class CriticalPostActionTracker(
 
     fun get(localPostId: LocalId): CriticalPostAction? = map[localPostId]
 
-    fun remove(localPostId: LocalId) {
-        map.remove(localPostId)
-        listener.invoke()
+    fun remove(localPostId: LocalId, criticalPostAction: CriticalPostAction) {
+        if (map[localPostId] == criticalPostAction) {
+            map.remove(localPostId)
+            listener.invoke()
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemType.kt
@@ -8,7 +8,6 @@ import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.RemotePostId
 import org.wordpress.android.widgets.PostListButtonType
 
 sealed class PostListItemType {
-    // TODO: Can we find a better name for this now that it's a PostListItemType?
     class PostListItemUiState(
         val data: PostListItemUiStateData,
         val actions: List<PostListItemAction>,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -54,7 +54,8 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         statsSupported: Boolean,
         featuredImageUrl: String?,
         formattedDate: String,
-        performingAction: Boolean,
+        // TODO: Add a unit test for performing critical action property
+        performingCriticalAction: Boolean,
         onAction: (PostModel, PostListButtonType, AnalyticsTracker.Stat) -> Unit
     ): PostListItemUiState {
         val postStatus: PostStatus = PostStatus.fromPost(post)
@@ -84,11 +85,11 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
                         statusesDelimiter = UiStringRes(R.string.multiple_status_label_delimiter),
                         showProgress = shouldShowProgress(
                                 uploadStatus = uploadStatus,
-                                performingAction = performingAction
+                                performingCriticalAction = performingCriticalAction
                         ),
                         showOverlay = shouldShowOverlay(
                                 uploadStatus = uploadStatus,
-                                performingAction = performingAction
+                                performingCriticalAction = performingCriticalAction
                         )
                 ),
                 actions = createActions(
@@ -119,8 +120,8 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
                     ?.let { PostUtils.collapseShortcodes(it) }
                     ?.let { UiStringText(it) }
 
-    private fun shouldShowProgress(uploadStatus: PostListItemUploadStatus, performingAction: Boolean): Boolean {
-        return performingAction || (!uploadStatus.isUploadFailed &&
+    private fun shouldShowProgress(uploadStatus: PostListItemUploadStatus, performingCriticalAction: Boolean): Boolean {
+        return performingCriticalAction || (!uploadStatus.isUploadFailed &&
                 (uploadStatus.isUploadingOrQueued || uploadStatus.hasInProgressMediaUpload))
     }
 
@@ -203,9 +204,9 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         }
     }
 
-    private fun shouldShowOverlay(uploadStatus: PostListItemUploadStatus, performingAction: Boolean): Boolean {
+    private fun shouldShowOverlay(uploadStatus: PostListItemUploadStatus, performingCriticalAction: Boolean): Boolean {
         // show overlay when post upload is in progress or (media upload is in progress and the user is not using Aztec)
-        return performingAction ||
+        return performingCriticalAction ||
                 (uploadStatus.isUploading ||
                         (!appPrefsWrapper.isAztecEditorEnabled && uploadStatus.isUploadingOrQueued))
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -54,6 +54,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         statsSupported: Boolean,
         featuredImageUrl: String?,
         formattedDate: String,
+        performingAction: Boolean,
         onAction: (PostModel, PostListButtonType, AnalyticsTracker.Stat) -> Unit
     ): PostListItemUiState {
         val postStatus: PostStatus = PostStatus.fromPost(post)
@@ -81,8 +82,14 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
                                 hasUnhandledConflicts = unhandledConflicts
                         ),
                         statusesDelimiter = UiStringRes(R.string.multiple_status_label_delimiter),
-                        showProgress = shouldShowProgress(uploadStatus = uploadStatus),
-                        showOverlay = shouldShowOverlay(uploadStatus = uploadStatus)
+                        showProgress = shouldShowProgress(
+                                uploadStatus = uploadStatus,
+                                performingAction = performingAction
+                        ),
+                        showOverlay = shouldShowOverlay(
+                                uploadStatus = uploadStatus,
+                                performingAction = performingAction
+                        )
                 ),
                 actions = createActions(
                         postStatus = postStatus,
@@ -112,9 +119,9 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
                     ?.let { PostUtils.collapseShortcodes(it) }
                     ?.let { UiStringText(it) }
 
-    private fun shouldShowProgress(uploadStatus: PostListItemUploadStatus): Boolean {
-        return !uploadStatus.isUploadFailed &&
-                (uploadStatus.isUploadingOrQueued || uploadStatus.hasInProgressMediaUpload)
+    private fun shouldShowProgress(uploadStatus: PostListItemUploadStatus, performingAction: Boolean): Boolean {
+        return performingAction || (!uploadStatus.isUploadFailed &&
+                (uploadStatus.isUploadingOrQueued || uploadStatus.hasInProgressMediaUpload))
     }
 
     private fun getStatuses(
@@ -196,9 +203,11 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         }
     }
 
-    private fun shouldShowOverlay(uploadStatus: PostListItemUploadStatus): Boolean {
+    private fun shouldShowOverlay(uploadStatus: PostListItemUploadStatus, performingAction: Boolean): Boolean {
         // show overlay when post upload is in progress or (media upload is in progress and the user is not using Aztec)
-        return uploadStatus.isUploading || (!appPrefsWrapper.isAztecEditorEnabled && uploadStatus.isUploadingOrQueued)
+        return performingAction ||
+                (uploadStatus.isUploading ||
+                        (!appPrefsWrapper.isAztecEditorEnabled && uploadStatus.isUploadingOrQueued))
     }
 
     private fun createActions(
@@ -246,11 +255,13 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
             )
         }
 
-        if (postStatus != PostStatus.TRASHED) {
-            buttonTypes.add(PostListButtonType.BUTTON_TRASH)
-        } else {
-            buttonTypes.add(PostListButtonType.BUTTON_DELETE)
-            buttonTypes.add(PostListButtonType.BUTTON_RESTORE)
+        when {
+            isLocalDraft -> buttonTypes.add(PostListButtonType.BUTTON_DELETE)
+            postStatus == PostStatus.TRASHED -> {
+                buttonTypes.add(PostListButtonType.BUTTON_DELETE)
+                buttonTypes.add(PostListButtonType.BUTTON_RESTORE)
+            }
+            postStatus != PostStatus.TRASHED -> buttonTypes.add(PostListButtonType.BUTTON_TRASH)
         }
 
         if (canShowStats) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -414,10 +414,20 @@ class PostListViewModel @Inject constructor(
     }
 
     private fun showDeletePostConfirmationDialog(post: PostModel) {
+        // We need network connection to delete a remote post, but not a local draft
+        if (!post.isLocalDraft && !checkNetworkConnection()) {
+            return
+        }
+        val messageRes = if (!UploadService.isPostUploadingOrQueued(post)) {
+            R.string.dialog_confirm_delete_permanently_post
+        } else {
+            // TODO Can this ever happen? - delete action is disabled when an upload is in progress
+            R.string.dialog_confirm_cancel_post_media_uploading
+        }
         val dialogHolder = DialogHolder(
                 tag = CONFIRM_DELETE_POST_DIALOG_TAG,
                 title = UiStringRes(R.string.delete_post),
-                message = UiStringRes(R.string.dialog_confirm_delete_permanently_post),
+                message = UiStringRes(messageRes),
                 positiveButton = UiStringRes(R.string.delete),
                 negativeButton = UiStringRes(R.string.cancel)
         )

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -489,8 +489,11 @@ class PostListViewModel @Inject constructor(
              */
             return
         }
+        val removeFromTracker = {
+            criticalPostActionTracker.remove(localPostId = localPostId, criticalPostAction = RESTORING_POST)
+        }
         if (isError) {
-            criticalPostActionTracker.remove(localPostId = localPostId)
+            removeFromTracker.invoke()
             _toastMessage.postValue(ToastMessageHolder(R.string.error_restoring_post, Duration.SHORT))
             return
         }
@@ -500,12 +503,13 @@ class PostListViewModel @Inject constructor(
                 buttonAction = {
                     val post = postStore.getPostByLocalPostId(localPostId.value)
                     if (post != null) {
+                        removeFromTracker.invoke()
                         trashPost(post)
                         _snackBarAction.postValue(SnackbarMessageHolder(R.string.post_trashing))
                     }
                 },
                 onDismissAction = {
-                    criticalPostActionTracker.remove(localPostId = localPostId)
+                    removeFromTracker.invoke()
                 }
         )
         _snackBarAction.postValue(snackBarHolder)
@@ -572,7 +576,7 @@ class PostListViewModel @Inject constructor(
             _toastMessage.postValue(ToastMessageHolder(R.string.error_deleting_post, Duration.SHORT))
         }
         if (isRemoved) {
-            criticalPostActionTracker.remove(localPostId = localPostId)
+            criticalPostActionTracker.remove(localPostId = localPostId, criticalPostAction = DELETING_POST)
         }
     }
 
@@ -596,8 +600,11 @@ class PostListViewModel @Inject constructor(
              */
             return
         }
+        val removeFromTracker = {
+            criticalPostActionTracker.remove(localPostId = localPostId, criticalPostAction = TRASHING_POST)
+        }
         if (isError) {
-            criticalPostActionTracker.remove(localPostId = localPostId)
+            removeFromTracker.invoke()
             _toastMessage.postValue(ToastMessageHolder(R.string.error_deleting_post, Duration.SHORT))
             return
         }
@@ -607,12 +614,13 @@ class PostListViewModel @Inject constructor(
                 buttonAction = {
                     val post = postStore.getPostByLocalPostId(localPostId.value)
                     if (post != null) {
+                        removeFromTracker.invoke()
                         restorePost(post)
                         _snackBarAction.postValue(SnackbarMessageHolder(R.string.post_restoring))
                     }
                 },
                 onDismissAction = {
-                    criticalPostActionTracker.remove(localPostId = localPostId)
+                    removeFromTracker.invoke()
                 }
         )
         _snackBarAction.postValue(snackBarHolder)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -469,6 +469,11 @@ class PostListViewModel @Inject constructor(
     }
 
     private fun restorePost(post: PostModel) {
+        // We need network connection to restore a post
+        if (!checkNetworkConnection()) {
+            return
+        }
+
         postsBeingTrashedOrRestored.add(LocalId(post.id))
         pagedListWrapper.invalidateData()
         dispatcher.dispatch(PostActionBuilder.newRestorePostAction(RemotePostPayload(post, site)))
@@ -533,6 +538,11 @@ class PostListViewModel @Inject constructor(
     }
 
     private fun trashPost(post: PostModel) {
+        // We need network connection to trash a post
+        if (!checkNetworkConnection()) {
+            return
+        }
+
         postsBeingTrashedOrRestored.add(LocalId(post.id))
         pagedListWrapper.invalidateData()
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -418,16 +418,10 @@ class PostListViewModel @Inject constructor(
         if (!post.isLocalDraft && !checkNetworkConnection()) {
             return
         }
-        val messageRes = if (!UploadService.isPostUploadingOrQueued(post)) {
-            R.string.dialog_confirm_delete_permanently_post
-        } else {
-            // TODO Can this ever happen? - delete action is disabled when an upload is in progress
-            R.string.dialog_confirm_cancel_post_media_uploading
-        }
         val dialogHolder = DialogHolder(
                 tag = CONFIRM_DELETE_POST_DIALOG_TAG,
                 title = UiStringRes(R.string.delete_post),
-                message = UiStringRes(messageRes),
+                message = UiStringRes(R.string.dialog_confirm_delete_permanently_post),
                 positiveButton = UiStringRes(R.string.delete),
                 negativeButton = UiStringRes(R.string.cancel)
         )

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -408,20 +408,10 @@ class PostListViewModel @Inject constructor(
     }
 
     private fun showDeletePostConfirmationDialog(post: PostModel) {
-        // We need network connection to delete a remote post, but not a local draft
-        if (!post.isLocalDraft && !checkNetworkConnection()) {
-            return
-        }
-        val messageRes = if (!UploadService.isPostUploadingOrQueued(post)) {
-            R.string.dialog_confirm_delete_permanently_post
-        } else {
-            // TODO Can this ever happen? - delete action is disabled when an upload is in progress
-            R.string.dialog_confirm_cancel_post_media_uploading
-        }
         val dialogHolder = DialogHolder(
                 tag = CONFIRM_DELETE_POST_DIALOG_TAG,
                 title = UiStringRes(R.string.delete_post),
-                message = UiStringRes(messageRes),
+                message = UiStringRes(R.string.dialog_confirm_delete_permanently_post),
                 positiveButton = UiStringRes(R.string.delete),
                 negativeButton = UiStringRes(R.string.cancel)
         )

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -166,13 +166,9 @@ class PostListViewModel @Inject constructor(
         val listDescriptor = requireNotNull(listDescriptor) {
             "ListDescriptor needs to be initialized before this is observed!"
         }
-        val performGetItemIdsToHide = { postListDescriptor: PostListDescriptor ->
-            null
-        }
         val dataSource = PostListItemDataSource(
                 dispatcher = dispatcher,
                 postStore = postStore,
-                performGetItemIdsToHide = performGetItemIdsToHide,
                 transform = this::transformPostModelToPostListItemUiState
         )
         listStore.getList(listDescriptor, dataSource, lifecycle)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -13,7 +13,6 @@ import android.support.annotation.DrawableRes
 import de.greenrobot.event.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
@@ -76,7 +75,6 @@ import org.wordpress.android.ui.posts.PostUploadAction.MediaUploadedSnackbar
 import org.wordpress.android.ui.posts.PostUploadAction.PostUploadedSnackbar
 import org.wordpress.android.ui.posts.PostUploadAction.PublishPost
 import org.wordpress.android.ui.posts.PostUtils
-import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.reader.utils.ReaderImageScanner
 import org.wordpress.android.ui.uploads.PostEvents
 import org.wordpress.android.ui.uploads.UploadService
@@ -375,8 +373,7 @@ class PostListViewModel @Inject constructor(
         }
     }
 
-    // TODO: Can this be a private method?
-    fun newPost() {
+    private fun newPost() {
         _postListAction.postValue(PostListAction.NewPost(site))
     }
 
@@ -515,11 +512,6 @@ class PostListViewModel @Inject constructor(
         _snackBarAction.postValue(snackBarHolder)
     }
 
-    // TODO: This method doesn't seem to be used, we should remove it if it's not necessary
-    private fun isGutenbergEnabled(): Boolean {
-        return BuildConfig.OFFER_GUTENBERG && AppPrefs.isGutenbergEditorEnabled()
-    }
-
     private fun editPostButtonAction(site: SiteModel, post: PostModel) {
         // first of all, check whether this post is in Conflicted state.
         if (doesPostHaveUnhandledConflict(post)) {
@@ -628,6 +620,7 @@ class PostListViewModel @Inject constructor(
 
     // FluxC Events
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     fun onPostChanged(event: OnPostChanged) {
         when (event.causeOfChange) {
@@ -671,6 +664,7 @@ class PostListViewModel @Inject constructor(
         }
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     fun onMediaChanged(event: OnMediaChanged) {
         if (!event.isError && event.mediaList != null) {
@@ -678,8 +672,8 @@ class PostListViewModel @Inject constructor(
         }
     }
 
-    // TODO: Why is this in the MAIN thread?
-    @Subscribe(threadMode = ThreadMode.MAIN)
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.BACKGROUND)
     fun onPostUploaded(event: OnPostUploaded) {
         if (event.post != null && event.post.localSiteId == site.id) {
             _postUploadAction.postValue(PostUploadedSnackbar(dispatcher, site, event.post, event.isError, null))
@@ -691,6 +685,7 @@ class PostListViewModel @Inject constructor(
         }
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     fun onMediaUploaded(event: OnMediaUploaded) {
         if (event.isError || event.canceled) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1434,6 +1434,7 @@
     <string name="error_refresh_stats">Stats couldn\'t be refreshed at this time</string>
     <string name="error_refresh_media">Media couldn\'t be refreshed at this time</string>
     <string name="error_deleting_post">An error occurred while deleting the post</string>
+    <string name="error_restoring_post">An error occurred while restoring the post</string>
 
     <string name="error_refresh_unauthorized_comments">You don\'t have permission to view or edit comments</string>
     <string name="error_refresh_unauthorized_pages">You don\'t have permission to view or edit pages</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -317,12 +317,10 @@
     <string name="width">Width</string>
     <string name="featured_in_post">Include image in post content</string>
     <string name="file_not_found">Couldn\'t find the file for upload. Was it deleted or moved?</string>
-    <string name="dialog_confirm_cancel_post_media_uploading">Are you sure? Deleting this post will also cancel the media upload.</string>
     <string name="delete_post">Delete post?</string>
     <string name="delete_page">Delete page?</string>
     <string name="posts_fetching">Fetching posts…</string>
     <string name="pages_fetching">Fetching pages…</string>
-    <string name="dialog_confirm_delete_post">This post will be deleted and sent to Trash</string>
     <string name="dialog_confirm_publish_title">Ready to Publish?</string>
     <string name="dialog_confirm_publish_message_post">This post will be published immediately.</string>
     <string name="dialog_confirm_publish_message_page">This page will be published immediately.</string>
@@ -439,7 +437,6 @@
 
     <!-- post actions -->
     <string name="preview_post">Preview post</string>
-    <string name="post_deleted">Post deleted</string>
     <string name="post_trashed">Post sent to trash</string>
     <string name="post_trashing">Post is being trashed</string>
     <string name="post_restored">Post restored</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -441,6 +441,10 @@
     <string name="preview_post">Preview post</string>
     <string name="post_deleted">Post deleted</string>
     <string name="post_trashed">Post sent to trash</string>
+    <string name="post_trashing">Post is being trashed</string>
+    <string name="post_restored">Post restored</string>
+    <string name="post_restoring">Post is being restored</string>
+
     <string name="share_link">Share link</string>
     <string name="view_in_browser">View in browser</string>
     <string name="preview">Preview</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -211,7 +211,8 @@ class PostListItemUiStateHelperTest {
             statsSupported = statsSupported,
             featuredImageUrl = featuredImageUrl,
             formattedDate = formattedDate,
-            onAction = onAction
+            onAction = onAction,
+            performingCriticalAction = false
     )
 
     private fun createUploadStatus(

--- a/build.gradle
+++ b/build.gradle
@@ -104,5 +104,5 @@ buildScan {
 }
 
 ext {
-    fluxCVersion = '0ff9b94db30f636384ed690741553d6f0cc5a027'
+    fluxCVersion = '2edf9153820237a3f0183dd143eaf71baccb2c71'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -104,5 +104,5 @@ buildScan {
 }
 
 ext {
-    fluxCVersion = '2edf9153820237a3f0183dd143eaf71baccb2c71'
+    fluxCVersion = '5f6840fdcadaf60c51222d6e08bad8a289b4223e'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -104,5 +104,5 @@ buildScan {
 }
 
 ext {
-    fluxCVersion = 'eeb663fd2fc1c88098e94b4872f65b36f84c89a1'
+    fluxCVersion = '0ff9b94db30f636384ed690741553d6f0cc5a027'
 }


### PR DESCRIPTION
Fixes #9181 #8592. It's a follow up to the draft PR #9577.

Here is when these actions are enabled:

* A post can be trashed if it exists in remote.
* A post can be deleted if it's either a local draft or it's already trashed.
* A post can be restored if it's in trash

Here is how they are implemented:

* When a post is being trashed/deleted/restored we mark them as taking a critical action
* If a post is taking a critical action it's temporarily disabled for interaction by an overlay
* Once the action completes, regardless of whether there is an error or not, we remove the mark and make the post available for interaction again.
* Posts can be trashed or restored without a dialog, but once these actions are completed it'll show a snackbar with an undo button. Even if the user misses the snackbar, they can undo the action by restoring it or trashing it, so it's not a big deal.
* If a post is being deleted, we'll show a confirmation dialog, but there won't be an undo action anymore.

**CriticalPostActionTracker**

This is a new component that makes it easier to keep track of what critical action is being taken for a post. It's far from perfect and I strongly believe we need a state tracking solution not only for critical actions, but actions such as fetching/pushing etc as well. However, instead of having the tracking logic in the post view models, I believe this component at least brings some structure to it.

I don't think it's possible to take multiple critical actions at the same time, so the app will crash in `DEBUG` builds if it's ever the case. We also log this issue just in case. This is both for our peace of mind and also convey our intended usage of this component for other developers.

**To test:**
Go to `Blog Posts` page and try to trash/delete/restore posts for:

- [x] Local Draft
- [x] Locally Changed Post
- [x] Remote Draft
- [x] Published Post
- [x] Scheduled Post
- [x] Trashed Post

There is not really a difference between these actions for a lot of these states, but hopefully these testing instructions will help us catch a difference we might not have thought of so far.

Here is a partial gif of my test: https://cloudup.com/cC90rgyARbd