### PR TITLE
Split PostListViewModel into several files

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -1,0 +1,260 @@
+package org.wordpress.android.ui.posts
+
+import android.content.Intent
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.PostActionBuilder
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
+import org.wordpress.android.ui.notifications.utils.PendingDraftsNotificationsUtils
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.posts.CriticalPostActionTracker.CriticalPostAction.DELETING_POST
+import org.wordpress.android.ui.posts.CriticalPostActionTracker.CriticalPostAction.RESTORING_POST
+import org.wordpress.android.ui.posts.CriticalPostActionTracker.CriticalPostAction.TRASHING_POST
+import org.wordpress.android.ui.posts.PostListAction.DismissPendingNotification
+import org.wordpress.android.ui.posts.PostListAction.PreviewPost
+import org.wordpress.android.ui.posts.PostListAction.RetryUpload
+import org.wordpress.android.ui.posts.PostListAction.ViewPost
+import org.wordpress.android.ui.posts.PostListAction.ViewStats
+import org.wordpress.android.ui.posts.PostUploadAction.CancelPostAndMediaUpload
+import org.wordpress.android.ui.posts.PostUploadAction.EditPostResult
+import org.wordpress.android.ui.posts.PostUploadAction.PublishPost
+import org.wordpress.android.ui.uploads.UploadService
+import org.wordpress.android.util.ToastUtils.Duration
+import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
+import org.wordpress.android.widgets.PostListButtonType
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_BACK
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_EDIT
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_MORE
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_PREVIEW
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_PUBLISH
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_RESTORE
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_RETRY
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_STATS
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_SUBMIT
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_SYNC
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_TRASH
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_VIEW
+
+class PostActionHandler(
+    private val dispatcher: Dispatcher,
+    private val site: SiteModel,
+    private val postStore: PostStore,
+    private val postListDialogHelper: PostListDialogHelper,
+    private val postConflictResolver: PostConflictResolver,
+    private val triggerPostListAction: (PostListAction) -> Unit,
+    private val triggerPostUploadAction: (PostUploadAction) -> Unit,
+    private val invalidateList: () -> Unit,
+    private val checkNetworkConnection: () -> Boolean,
+    private val showSnackbar: (SnackbarMessageHolder) -> Unit,
+    private val showToast: (ToastMessageHolder) -> Unit
+) {
+    private val criticalPostActionTracker = CriticalPostActionTracker(listener = {
+        invalidateList.invoke()
+    })
+
+    fun handlePostButton(buttonType: PostListButtonType, post: PostModel) {
+        when (buttonType) {
+            BUTTON_EDIT -> editPostButtonAction(site, post)
+            BUTTON_RETRY -> triggerPostListAction.invoke(RetryUpload(post))
+            BUTTON_RESTORE -> {
+                restorePost(post)
+            }
+            BUTTON_SUBMIT, BUTTON_SYNC, BUTTON_PUBLISH -> {
+                postListDialogHelper.showPublishConfirmationDialog(post)
+            }
+            BUTTON_VIEW -> triggerPostListAction.invoke(ViewPost(site, post))
+            BUTTON_PREVIEW -> triggerPostListAction.invoke(PreviewPost(site, post))
+            BUTTON_STATS -> triggerPostListAction.invoke(ViewStats(site, post))
+            BUTTON_TRASH -> {
+                trashPost(post)
+            }
+            BUTTON_DELETE -> {
+                postListDialogHelper.showDeletePostConfirmationDialog(post)
+            }
+            BUTTON_MORE -> {
+            } // do nothing - ui will show a popup window
+            BUTTON_BACK -> TODO("will be removed during PostViewHolder refactoring")
+        }
+    }
+
+    fun newPost() {
+        triggerPostListAction(PostListAction.NewPost(site))
+    }
+
+    fun handleEditPostResult(data: Intent?) {
+        val localPostId = data?.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0)
+        if (localPostId == null || localPostId == 0) {
+            return
+        }
+        val post = postStore.getPostByLocalPostId(localPostId)
+        if (post != null) {
+            triggerPostUploadAction(EditPostResult(site, post, data) { publishPost(localPostId) })
+        }
+    }
+
+    fun publishPost(localPostId: Int) {
+        val post = postStore.getPostByLocalPostId(localPostId)
+        if (post != null) {
+            triggerPostUploadAction.invoke(PublishPost(dispatcher, site, post))
+        }
+    }
+
+    private fun restorePost(post: PostModel) {
+        // We need network connection to restore a post
+        if (!checkNetworkConnection.invoke()) {
+            return
+        }
+
+        criticalPostActionTracker.add(localPostId = LocalId(post.id), criticalPostAction = RESTORING_POST)
+        dispatcher.dispatch(PostActionBuilder.newRestorePostAction(RemotePostPayload(post, site)))
+    }
+
+    fun handlePostRestored(localPostId: LocalId, isError: Boolean) {
+        if (criticalPostActionTracker.get(localPostId) != RESTORING_POST) {
+            /*
+             * This is an unexpected action and either it has already been handled or another critical action has
+             * been performed. In either case, safest action is to just ignore it.
+             */
+            return
+        }
+        val removeFromTracker = {
+            criticalPostActionTracker.remove(localPostId = localPostId, criticalPostAction = RESTORING_POST)
+        }
+        if (isError) {
+            removeFromTracker.invoke()
+            showToast.invoke(ToastMessageHolder(R.string.error_restoring_post, Duration.SHORT))
+            return
+        }
+        val snackBarHolder = SnackbarMessageHolder(
+                messageRes = R.string.post_restored,
+                buttonTitleRes = R.string.undo,
+                buttonAction = {
+                    val post = postStore.getPostByLocalPostId(localPostId.value)
+                    if (post != null) {
+                        removeFromTracker.invoke()
+                        trashPost(post)
+                        showSnackbar.invoke(SnackbarMessageHolder(R.string.post_trashing))
+                    }
+                },
+                onDismissAction = {
+                    removeFromTracker.invoke()
+                }
+        )
+        showSnackbar.invoke(snackBarHolder)
+    }
+
+    private fun editPostButtonAction(site: SiteModel, post: PostModel) {
+        // first of all, check whether this post is in Conflicted state.
+        if (postConflictResolver.doesPostHaveUnhandledConflict(post)) {
+            postListDialogHelper.showConflictedPostResolutionDialog(post)
+            return
+        }
+
+        editPost(site, post)
+    }
+
+    private fun editPost(site: SiteModel, post: PostModel) {
+        if (UploadService.isPostUploadingOrQueued(post)) {
+            // If the post is uploading media, allow the media to continue uploading, but don't upload the
+            // post itself when they finish (since we're about to edit it again)
+            UploadService.cancelQueuedPostUpload(post)
+        }
+        triggerPostListAction.invoke(PostListAction.EditPost(site, post))
+    }
+
+    fun deletePost(localPostId: Int) {
+        // If post doesn't exist, nothing else to do
+        val post = postStore.getPostByLocalPostId(localPostId) ?: return
+        criticalPostActionTracker.add(LocalId(post.id), DELETING_POST)
+
+        when {
+            post.isLocalDraft -> {
+                val pushId = PendingDraftsNotificationsUtils.makePendingDraftNotificationId(post.id)
+                triggerPostListAction(DismissPendingNotification(pushId))
+                dispatcher.dispatch(PostActionBuilder.newRemovePostAction(post))
+            }
+            else -> {
+                dispatcher.dispatch(PostActionBuilder.newDeletePostAction(RemotePostPayload(post, site)))
+            }
+        }
+    }
+
+    /**
+     * This function handles a post being deleted and removed. Since deleting remote posts will trigger both delete
+     * and remove actions we only want to remove the critical action when the post is actually successfully removed.
+     *
+     * It's possible to separate these into two methods that handles delete and remove. However, the fact that they
+     * follow the same approach and the tricky nature of delete action makes combining the actions like so makes our
+     * expectations clearer.
+     */
+    fun handlePostDeletedOrRemoved(localPostId: LocalId, isRemoved: Boolean, isError: Boolean) {
+        if (criticalPostActionTracker.get(localPostId) != DELETING_POST) {
+            /*
+             * This is an unexpected action and either it has already been handled or another critical action has
+             * been performed. In either case, safest action is to just ignore it.
+             */
+            return
+        }
+        if (isError) {
+            showToast.invoke(ToastMessageHolder(R.string.error_deleting_post, Duration.SHORT))
+        }
+        if (isRemoved) {
+            criticalPostActionTracker.remove(localPostId = localPostId, criticalPostAction = DELETING_POST)
+        }
+    }
+
+    private fun trashPost(post: PostModel) {
+        // We need network connection to trash a post
+        if (!checkNetworkConnection()) {
+            return
+        }
+
+        criticalPostActionTracker.add(localPostId = LocalId(post.id), criticalPostAction = TRASHING_POST)
+
+        triggerPostUploadAction.invoke(CancelPostAndMediaUpload(post))
+        dispatcher.dispatch(PostActionBuilder.newDeletePostAction(RemotePostPayload(post, site)))
+    }
+
+    fun handlePostTrashed(localPostId: LocalId, isError: Boolean) {
+        if (criticalPostActionTracker.get(localPostId) != TRASHING_POST) {
+            /*
+             * This is an unexpected action and either it has already been handled or another critical action has
+             * been performed. In either case, safest action is to just ignore it.
+             */
+            return
+        }
+        val removeFromTracker = {
+            criticalPostActionTracker.remove(localPostId = localPostId, criticalPostAction = TRASHING_POST)
+        }
+        if (isError) {
+            removeFromTracker.invoke()
+            showToast.invoke(ToastMessageHolder(R.string.error_deleting_post, Duration.SHORT))
+            return
+        }
+        val snackBarHolder = SnackbarMessageHolder(
+                messageRes = R.string.post_trashed,
+                buttonTitleRes = R.string.undo,
+                buttonAction = {
+                    val post = postStore.getPostByLocalPostId(localPostId.value)
+                    if (post != null) {
+                        removeFromTracker.invoke()
+                        restorePost(post)
+                        showSnackbar.invoke(SnackbarMessageHolder(R.string.post_restoring))
+                    }
+                },
+                onDismissAction = {
+                    removeFromTracker.invoke()
+                }
+        )
+        showSnackbar.invoke(snackBarHolder)
+    }
+
+    fun isPerformingCriticalAction(localPostId: LocalId): Boolean {
+        return criticalPostActionTracker.contains(localPostId)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -40,6 +40,10 @@ import org.wordpress.android.widgets.PostListButtonType.BUTTON_SYNC
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_TRASH
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_VIEW
 
+/**
+ * This is a temporary class to make the PostListViewModel more manageable. Please feel free to refactor it any way
+ * you see fit.
+ */
 class PostActionHandler(
     private val dispatcher: Dispatcher,
     private val site: SiteModel,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostConflictResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostConflictResolver.kt
@@ -111,5 +111,4 @@ class PostConflictResolver(
         )
         showSnackbar.invoke(snackBarHolder)
     }
-
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostConflictResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostConflictResolver.kt
@@ -1,0 +1,115 @@
+package org.wordpress.android.ui.posts
+
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.PostActionBuilder
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.util.ToastUtils.Duration
+import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
+
+/**
+ * This is a temporary class to make the PostListViewModel more manageable. Please feel free to refactor it any way
+ * you see fit.
+ */
+class PostConflictResolver(
+    private val dispatcher: Dispatcher,
+    private val postStore: PostStore,
+    private val site: SiteModel,
+    private val invalidateList: () -> Unit,
+    private val checkNetworkConnection: () -> Boolean,
+    private val showSnackbar: (SnackbarMessageHolder) -> Unit,
+    private val showToast: (ToastMessageHolder) -> Unit
+) {
+    private var originalPostCopyForConflictUndo: PostModel? = null
+    private var localPostIdForFetchingRemoteVersionOfConflictedPost: Int? = null
+
+    fun updateConflictedPostWithRemoteVersion(localPostId: Int) {
+        // We need network connection to load a remote post
+        if (!checkNetworkConnection()) {
+            return
+        }
+
+        val post = postStore.getPostByLocalPostId(localPostId)
+        if (post != null) {
+            originalPostCopyForConflictUndo = post.clone()
+            dispatcher.dispatch(PostActionBuilder.newFetchPostAction(RemotePostPayload(post, site)))
+            showToast.invoke(ToastMessageHolder(R.string.toast_conflict_updating_post, Duration.SHORT))
+        }
+    }
+
+    fun updateConflictedPostWithLocalVersion(localPostId: Int) {
+        // We need network connection to push local version to remote
+        if (!checkNetworkConnection()) {
+            return
+        }
+
+        // Keep a reference to which post is being updated with the local version so we can avoid showing the conflicted
+        // label during the undo snackBar.
+        localPostIdForFetchingRemoteVersionOfConflictedPost = localPostId
+        invalidateList.invoke()
+
+        val post = postStore.getPostByLocalPostId(localPostId) ?: return
+
+        // and now show a snackBar, acting as if the Post was pushed, but effectively push it after the snackbar is gone
+        var isUndoed = false
+        val undoAction = {
+            isUndoed = true
+
+            // Remove the reference for the post being updated and re-show the conflicted label on undo
+            localPostIdForFetchingRemoteVersionOfConflictedPost = null
+            invalidateList.invoke()
+        }
+
+        val onDismissAction = {
+            if (!isUndoed) {
+                localPostIdForFetchingRemoteVersionOfConflictedPost = null
+                PostUtils.trackSavePostAnalytics(post, site)
+                dispatcher.dispatch(PostActionBuilder.newPushPostAction(RemotePostPayload(post, site)))
+            }
+        }
+        val snackBarHolder = SnackbarMessageHolder(
+                R.string.snackbar_conflict_web_version_discarded,
+                R.string.snackbar_conflict_undo, undoAction, onDismissAction
+        )
+        showSnackbar.invoke(snackBarHolder)
+    }
+
+    fun doesPostHaveUnhandledConflict(post: PostModel): Boolean {
+        // If we are fetching the remote version of a conflicted post, it means it's already being handled
+        val isFetchingConflictedPost = localPostIdForFetchingRemoteVersionOfConflictedPost != null &&
+                localPostIdForFetchingRemoteVersionOfConflictedPost == post.id
+        return !isFetchingConflictedPost && PostUtils.isPostInConflictWithRemote(post)
+    }
+
+    fun onPostSuccessfullyUpdated() {
+        originalPostCopyForConflictUndo?.id?.let {
+            val updatedPost = postStore.getPostByLocalPostId(it)
+            // Conflicted post has been successfully updated with its remote version
+            if (!PostUtils.isPostInConflictWithRemote(updatedPost)) {
+                conflictedPostUpdatedWithRemoteVersion()
+            }
+        }
+    }
+
+    private fun conflictedPostUpdatedWithRemoteVersion() {
+        val undoAction = {
+            // here replace the post with whatever we had before, again
+            if (originalPostCopyForConflictUndo != null) {
+                dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(originalPostCopyForConflictUndo))
+            }
+        }
+        val onDismissAction = {
+            originalPostCopyForConflictUndo = null
+        }
+        val snackBarHolder = SnackbarMessageHolder(
+                R.string.snackbar_conflict_local_version_discarded,
+                R.string.snackbar_conflict_undo, undoAction, onDismissAction
+        )
+        showSnackbar.invoke(snackBarHolder)
+    }
+
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListActionTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListActionTracker.kt
@@ -1,0 +1,36 @@
+package org.wordpress.android.ui.posts
+
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.util.analytics.AnalyticsUtils
+import org.wordpress.android.widgets.PostListButtonType
+
+fun trackPostListAction(site: SiteModel, buttonType: PostListButtonType, postData: PostModel, statsEvent: Stat) {
+    val properties = HashMap<String, Any?>()
+    if (!postData.isLocalDraft) {
+        properties["post_id"] = postData.remotePostId
+    }
+
+    properties["action"] = when (buttonType) {
+        PostListButtonType.BUTTON_EDIT -> {
+            properties[AnalyticsUtils.HAS_GUTENBERG_BLOCKS_KEY] = PostUtils
+                    .contentContainsGutenbergBlocks(postData.content)
+            "edit"
+        }
+        PostListButtonType.BUTTON_RETRY -> "retry"
+        PostListButtonType.BUTTON_SUBMIT -> "submit"
+        PostListButtonType.BUTTON_VIEW -> "view"
+        PostListButtonType.BUTTON_PREVIEW -> "preview"
+        PostListButtonType.BUTTON_STATS -> "stats"
+        PostListButtonType.BUTTON_TRASH -> "trash"
+        PostListButtonType.BUTTON_DELETE -> "delete"
+        PostListButtonType.BUTTON_PUBLISH -> "publish"
+        PostListButtonType.BUTTON_SYNC -> "sync"
+        PostListButtonType.BUTTON_MORE -> "more"
+        PostListButtonType.BUTTON_BACK -> "back"
+        PostListButtonType.BUTTON_RESTORE -> "restore"
+    }
+
+    AnalyticsUtils.trackWithSiteDetails(statsEvent, site, properties)
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
@@ -74,7 +74,7 @@ class PostListDialogHelper(
         instanceTag: String,
         deletePost: (Int) -> Unit,
         publishPost: (Int) -> Unit,
-        updateConflictedPostWithItsRemoteVersion: (Int) -> Unit
+        updateConflictedPostWithRemoteVersion: (Int) -> Unit
     ) {
         when (instanceTag) {
             CONFIRM_DELETE_POST_DIALOG_TAG -> localPostIdForDeleteDialog?.let {
@@ -88,7 +88,7 @@ class PostListDialogHelper(
             CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG -> localPostIdForConflictResolutionDialog?.let {
                 localPostIdForConflictResolutionDialog = null
                 // here load version from remote
-                updateConflictedPostWithItsRemoteVersion(it)
+                updateConflictedPostWithRemoteVersion(it)
             }
             else -> throw IllegalArgumentException("Dialog's positive button click is not handled: $instanceTag")
         }
@@ -96,13 +96,13 @@ class PostListDialogHelper(
 
     fun onNegativeClickedForBasicDialog(
         instanceTag: String,
-        updateConflictedPostWithItsLocalVersion: (Int) -> Unit
+        updateConflictedPostWithLocalVersion: (Int) -> Unit
     ) {
         when (instanceTag) {
             CONFIRM_DELETE_POST_DIALOG_TAG -> localPostIdForDeleteDialog = null
             CONFIRM_PUBLISH_POST_DIALOG_TAG -> localPostIdForPublishDialog = null
             CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG -> localPostIdForConflictResolutionDialog?.let {
-                updateConflictedPostWithItsLocalVersion(it)
+                updateConflictedPostWithLocalVersion(it)
             }
             else -> throw IllegalArgumentException("Dialog's negative button click is not handled: $instanceTag")
         }
@@ -110,14 +110,14 @@ class PostListDialogHelper(
 
     fun onDismissByOutsideTouchForBasicDialog(
         instanceTag: String,
-        updateConflictedPostWithItsLocalVersion: (Int) -> Unit
+        updateConflictedPostWithLocalVersion: (Int) -> Unit
     ) {
         // Cancel and outside touch dismiss works the same way for all, except for conflict resolution dialog,
         // for which tapping outside and actively tapping the "edit local" have different meanings
         if (instanceTag != CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG) {
             onNegativeClickedForBasicDialog(
                     instanceTag = instanceTag,
-                    updateConflictedPostWithItsLocalVersion = updateConflictedPostWithItsLocalVersion
+                    updateConflictedPostWithLocalVersion = updateConflictedPostWithLocalVersion
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
@@ -1,0 +1,125 @@
+package org.wordpress.android.ui.posts
+
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.viewmodel.helpers.DialogHolder
+
+private const val CONFIRM_DELETE_POST_DIALOG_TAG = "CONFIRM_DELETE_POST_DIALOG_TAG"
+private const val CONFIRM_PUBLISH_POST_DIALOG_TAG = "CONFIRM_PUBLISH_POST_DIALOG_TAG"
+private const val CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG = "CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG"
+
+/**
+ * This is a temporary class to make the PostListViewModel more manageable. Please feel free to refactor it any way
+ * you see fit.
+ */
+class PostListDialogHelper(
+    private val showDialog: (DialogHolder) -> Unit,
+    private val checkNetworkConnection: () -> Boolean
+) {
+    // Since we are using DialogFragments we need to hold onto which post will be published or trashed / resolved
+    private var localPostIdForDeleteDialog: Int? = null
+    private var localPostIdForPublishDialog: Int? = null
+    private var localPostIdForConflictResolutionDialog: Int? = null
+
+    fun showDeletePostConfirmationDialog(post: PostModel) {
+        // We need network connection to delete a remote post, but not a local draft
+        if (!post.isLocalDraft && !checkNetworkConnection.invoke()) {
+            return
+        }
+        val dialogHolder = DialogHolder(
+                tag = CONFIRM_DELETE_POST_DIALOG_TAG,
+                title = UiStringRes(R.string.delete_post),
+                message = UiStringRes(R.string.dialog_confirm_delete_permanently_post),
+                positiveButton = UiStringRes(R.string.delete),
+                negativeButton = UiStringRes(R.string.cancel)
+        )
+        localPostIdForDeleteDialog = post.id
+        showDialog.invoke(dialogHolder)
+    }
+
+    fun showPublishConfirmationDialog(post: PostModel) {
+        if (localPostIdForPublishDialog != null) {
+            // We can only handle one publish dialog at once
+            return
+        }
+        if (!checkNetworkConnection.invoke()) {
+            return
+        }
+        val dialogHolder = DialogHolder(
+                tag = CONFIRM_PUBLISH_POST_DIALOG_TAG,
+                title = UiStringRes(R.string.dialog_confirm_publish_title),
+                message = UiStringRes(R.string.dialog_confirm_publish_message_post),
+                positiveButton = UiStringRes(R.string.dialog_confirm_publish_yes),
+                negativeButton = UiStringRes(R.string.cancel)
+        )
+        localPostIdForPublishDialog = post.id
+        showDialog.invoke(dialogHolder)
+    }
+
+    fun showConflictedPostResolutionDialog(post: PostModel) {
+        val dialogHolder = DialogHolder(
+                tag = CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG,
+                title = UiStringRes(R.string.dialog_confirm_load_remote_post_title),
+                message = UiStringText(PostUtils.getConflictedPostCustomStringForDialog(post)),
+                positiveButton = UiStringRes(R.string.dialog_confirm_load_remote_post_discard_local),
+                negativeButton = UiStringRes(R.string.dialog_confirm_load_remote_post_discard_web)
+        )
+        localPostIdForConflictResolutionDialog = post.id
+        showDialog.invoke(dialogHolder)
+    }
+
+    fun onPositiveClickedForBasicDialog(
+        instanceTag: String,
+        deletePost: (Int) -> Unit,
+        publishPost: (Int) -> Unit,
+        updateConflictedPostWithItsRemoteVersion: (Int) -> Unit
+    ) {
+        when (instanceTag) {
+            CONFIRM_DELETE_POST_DIALOG_TAG -> localPostIdForDeleteDialog?.let {
+                localPostIdForDeleteDialog = null
+                deletePost(it)
+            }
+            CONFIRM_PUBLISH_POST_DIALOG_TAG -> localPostIdForPublishDialog?.let {
+                localPostIdForPublishDialog = null
+                publishPost(it)
+            }
+            CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG -> localPostIdForConflictResolutionDialog?.let {
+                localPostIdForConflictResolutionDialog = null
+                // here load version from remote
+                updateConflictedPostWithItsRemoteVersion(it)
+            }
+            else -> throw IllegalArgumentException("Dialog's positive button click is not handled: $instanceTag")
+        }
+    }
+
+    fun onNegativeClickedForBasicDialog(
+        instanceTag: String,
+        updateConflictedPostWithItsLocalVersion: (Int) -> Unit
+    ) {
+        when (instanceTag) {
+            CONFIRM_DELETE_POST_DIALOG_TAG -> localPostIdForDeleteDialog = null
+            CONFIRM_PUBLISH_POST_DIALOG_TAG -> localPostIdForPublishDialog = null
+            CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG -> localPostIdForConflictResolutionDialog?.let {
+                updateConflictedPostWithItsLocalVersion(it)
+            }
+            else -> throw IllegalArgumentException("Dialog's negative button click is not handled: $instanceTag")
+        }
+    }
+
+    fun onDismissByOutsideTouchForBasicDialog(
+        instanceTag: String,
+        updateConflictedPostWithItsLocalVersion: (Int) -> Unit
+    ) {
+        // Cancel and outside touch dismiss works the same way for all, except for conflict resolution dialog,
+        // for which tapping outside and actively tapping the "edit local" have different meanings
+        if (instanceTag != CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG) {
+            onNegativeClickedForBasicDialog(
+                    instanceTag = instanceTag,
+                    updateConflictedPostWithItsLocalVersion = updateConflictedPostWithItsLocalVersion
+            )
+        }
+    }
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
@@ -122,4 +122,3 @@ class PostListDialogHelper(
         }
     }
 }
-

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListEventListener.kt
@@ -1,0 +1,230 @@
+package org.wordpress.android.ui.posts
+
+import android.arch.lifecycle.Lifecycle
+import android.arch.lifecycle.LifecycleObserver
+import android.arch.lifecycle.OnLifecycleEvent
+import de.greenrobot.event.EventBus
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.CauseOfOnPostChanged
+import org.wordpress.android.fluxc.model.CauseOfOnPostChanged.DeletePost
+import org.wordpress.android.fluxc.model.CauseOfOnPostChanged.RemovePost
+import org.wordpress.android.fluxc.model.CauseOfOnPostChanged.RestorePost
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged
+import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
+import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded
+import org.wordpress.android.fluxc.store.PostStore.PostDeleteActionType.DELETE
+import org.wordpress.android.fluxc.store.PostStore.PostDeleteActionType.TRASH
+import org.wordpress.android.ui.posts.PostUploadAction.MediaUploadedSnackbar
+import org.wordpress.android.ui.posts.PostUploadAction.PostUploadedSnackbar
+import org.wordpress.android.ui.uploads.PostEvents
+import org.wordpress.android.ui.uploads.UploadService
+import org.wordpress.android.ui.uploads.VideoOptimizer
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+
+fun listenForPostListEvents(
+    lifecycle: Lifecycle,
+    dispatcher: Dispatcher,
+    postStore: PostStore,
+    site: SiteModel,
+    postConflictResolver: PostConflictResolver,
+    postActionHandler: PostActionHandler,
+    refreshList: () -> Unit,
+    triggerPostUploadAction: (PostUploadAction) -> Unit,
+    invalidateUploadStatus: (List<Int>) -> Unit,
+    invalidateFeaturedMedia: (List<Long>) -> Unit
+) {
+    PostListEventListener(
+            lifecycle = lifecycle,
+            dispatcher = dispatcher,
+            postStore = postStore,
+            site = site,
+            postConflictResolver = postConflictResolver,
+            postActionHandler = postActionHandler,
+            refreshList = refreshList,
+            triggerPostUploadAction = triggerPostUploadAction,
+            invalidateUploadStatus = invalidateUploadStatus,
+            invalidateFeaturedMedia = invalidateFeaturedMedia
+    )
+}
+
+/**
+ * This is a temporary class to make the PostListViewModel more manageable. Please feel free to refactor it any way
+ * you see fit.
+ */
+private class PostListEventListener(
+    private val lifecycle: Lifecycle,
+    private val dispatcher: Dispatcher,
+    private val postStore: PostStore,
+    private val site: SiteModel,
+    private val postConflictResolver: PostConflictResolver,
+    private val postActionHandler: PostActionHandler,
+    private val refreshList: () -> Unit,
+    private val triggerPostUploadAction: (PostUploadAction) -> Unit,
+    private val invalidateUploadStatus: (List<Int>) -> Unit,
+    private val invalidateFeaturedMedia: (List<Long>) -> Unit
+) : LifecycleObserver {
+    init {
+        dispatcher.register(this)
+        EventBus.getDefault().register(this)
+        lifecycle.addObserver(this)
+    }
+
+    /**
+     * Handles the [Lifecycle.Event.ON_DESTROY] event to cleanup the registration for dispatcher and removing the
+     * observer for lifecycle.
+     */
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    private fun onDestroy() {
+        lifecycle.removeObserver(this)
+        dispatcher.unregister(this)
+        EventBus.getDefault().unregister(this)
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.BACKGROUND)
+    fun onPostChanged(event: OnPostChanged) {
+        when (event.causeOfChange) {
+            // Fetched post list event will be handled by OnListChanged
+            is CauseOfOnPostChanged.UpdatePost -> {
+                if (event.isError) {
+                    AppLog.e(
+                            T.POSTS,
+                            "Error updating the post with type: ${event.error.type} and message: ${event.error.message}"
+                    )
+                } else {
+                    postConflictResolver.onPostSuccessfullyUpdated()
+                }
+            }
+            is CauseOfOnPostChanged.DeletePost -> {
+                val deletePostCauseOfChange = event.causeOfChange as DeletePost
+                val localPostId = LocalId(deletePostCauseOfChange.localPostId)
+                when (deletePostCauseOfChange.postDeleteActionType) {
+                    TRASH -> postActionHandler.handlePostTrashed(localPostId = localPostId, isError = event.isError)
+                    DELETE -> postActionHandler.handlePostDeletedOrRemoved(
+                            localPostId = localPostId,
+                            isRemoved = false,
+                            isError = event.isError
+                    )
+                }
+            }
+            is CauseOfOnPostChanged.RestorePost -> {
+                val localPostId = LocalId((event.causeOfChange as RestorePost).localPostId)
+                postActionHandler.handlePostRestored(localPostId = localPostId, isError = event.isError)
+            }
+            is CauseOfOnPostChanged.RemovePost -> {
+                val localPostId = LocalId((event.causeOfChange as RemovePost).localPostId)
+                postActionHandler.handlePostDeletedOrRemoved(
+                        localPostId = localPostId,
+                        isRemoved = true,
+                        isError = event.isError
+                )
+            }
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.BACKGROUND)
+    fun onMediaChanged(event: OnMediaChanged) {
+        if (!event.isError && event.mediaList != null) {
+            featuredMediaChanged(*event.mediaList.map { it.mediaId }.toLongArray())
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.BACKGROUND)
+    fun onPostUploaded(event: OnPostUploaded) {
+        if (event.post != null && event.post.localSiteId == site.id) {
+            triggerPostUploadAction.invoke(PostUploadedSnackbar(dispatcher, site, event.post, event.isError, null))
+            uploadStatusChanged(event.post.id)
+            // If a post is successfully uploaded, we need to fetch the list again so it's id is added to ListStore
+            if (!event.isError) {
+                refreshList.invoke()
+            }
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.BACKGROUND)
+    fun onMediaUploaded(event: OnMediaUploaded) {
+        if (event.isError || event.canceled) {
+            return
+        }
+        if (event.media == null || event.media.localPostId == 0 || site.id != event.media.localSiteId) {
+            // Not interested in media not attached to posts or not belonging to the current site
+            return
+        }
+        featuredMediaChanged(event.media.mediaId)
+    }
+
+    // EventBus Events
+
+    @Suppress("unused")
+    fun onEventBackgroundThread(event: UploadService.UploadErrorEvent) {
+        EventBus.getDefault().removeStickyEvent(event)
+        if (event.post != null) {
+            triggerPostUploadAction.invoke(PostUploadedSnackbar(dispatcher, site, event.post, true, event.errorMessage))
+        } else if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
+            triggerPostUploadAction.invoke(MediaUploadedSnackbar(site, event.mediaModelList, true, event.errorMessage))
+        }
+    }
+
+    @Suppress("unused")
+    fun onEventBackgroundThread(event: UploadService.UploadMediaSuccessEvent) {
+        EventBus.getDefault().removeStickyEvent(event)
+        if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
+            triggerPostUploadAction.invoke(
+                    MediaUploadedSnackbar(site, event.mediaModelList, false, event.successMessage)
+            )
+        }
+    }
+
+    /**
+     * Upload started, reload so correct status on uploading post appears
+     */
+    @Suppress("unused")
+    fun onEventBackgroundThread(event: PostEvents.PostUploadStarted) {
+        if (site.id == event.post.localSiteId) {
+            uploadStatusChanged(event.post.id)
+        }
+    }
+
+    /**
+     * Upload cancelled (probably due to failed media), reload so correct status on uploading post appears
+     */
+    @Suppress("unused")
+    fun onEventBackgroundThread(event: PostEvents.PostUploadCanceled) {
+        if (site.id == event.post.localSiteId) {
+            uploadStatusChanged(event.post.id)
+        }
+    }
+
+    @Suppress("unused")
+    fun onEventBackgroundThread(event: VideoOptimizer.ProgressEvent) {
+        uploadStatusChanged(event.media.id)
+    }
+
+    @Suppress("unused")
+    fun onEventBackgroundThread(event: UploadService.UploadMediaRetryEvent) {
+        if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
+            // if there' a Post to which the retried media belongs, clear their status
+            val postsToRefresh = PostUtils.getPostsThatIncludeAnyOfTheseMedia(postStore, event.mediaModelList)
+            // now that we know which Posts to refresh, let's do it
+            uploadStatusChanged(*postsToRefresh.map { it.id }.toIntArray())
+        }
+    }
+
+    private fun uploadStatusChanged(vararg localPostIds: Int) {
+        invalidateUploadStatus.invoke(localPostIds.toList())
+    }
+
+    private fun featuredMediaChanged(vararg featuredImageIds: Long) {
+        invalidateFeaturedMedia.invoke(featuredImageIds.toList())
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFeaturedImageTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFeaturedImageTracker.kt
@@ -1,0 +1,43 @@
+package org.wordpress.android.ui.posts
+
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.MediaActionBuilder
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.MediaStore
+import org.wordpress.android.fluxc.store.MediaStore.MediaPayload
+import org.wordpress.android.ui.reader.utils.ReaderImageScanner
+import org.wordpress.android.util.SiteUtils
+
+/**
+ * This is a temporary class to make the PostListViewModel more manageable. Please feel free to refactor it any way
+ * you see fit.
+ */
+class PostListFeaturedImageTracker(private val dispatcher: Dispatcher, private val mediaStore: MediaStore) {
+    private val featuredImageMap = HashMap<Long, String>()
+
+    fun getFeaturedImageUrl(site: SiteModel, featuredImageId: Long, postContent: String): String? {
+        if (featuredImageId == 0L) {
+            return ReaderImageScanner(postContent, !SiteUtils.isPhotonCapable(site)).largestImage
+        }
+        featuredImageMap[featuredImageId]?.let { return it }
+        mediaStore.getSiteMediaWithId(site, featuredImageId)?.let { media ->
+            // This should be a pretty rare case, but some media seems to be missing url
+            return if (media.url != null) {
+                featuredImageMap[featuredImageId] = media.url
+                media.url
+            } else null
+        }
+        // Media is not in the Store, we need to download it
+        val mediaToDownload = MediaModel()
+        mediaToDownload.mediaId = featuredImageId
+        mediaToDownload.localSiteId = site.id
+        val payload = MediaPayload(site, mediaToDownload)
+        dispatcher.dispatch(MediaActionBuilder.newFetchMediaAction(payload))
+        return null
+    }
+
+    fun invalidateFeaturedMedia(featuredImageIds: List<Long>) {
+        featuredImageIds.forEach { featuredImageMap.remove(it) }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -36,9 +36,9 @@ import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
 import org.wordpress.android.viewmodel.posts.PagedPostList
+import org.wordpress.android.viewmodel.posts.PostListEmptyUiState
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.LocalPostId
 import org.wordpress.android.viewmodel.posts.PostListViewModel
-import org.wordpress.android.viewmodel.posts.PostListViewModel.PostListEmptyUiState
 import org.wordpress.android.widgets.RecyclerItemDecoration
 import javax.inject.Inject
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -27,11 +27,6 @@ import org.wordpress.android.ui.posts.PostListType.PUBLISHED
 import org.wordpress.android.ui.posts.PostListType.SCHEDULED
 import org.wordpress.android.ui.posts.PostListType.TRASHED
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
-import org.wordpress.android.ui.utils.UiString
-import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.util.image.ImageType
-import org.wordpress.android.util.image.ImageType.AVATAR_WITH_BACKGROUND
-import org.wordpress.android.util.image.ImageType.MULTI_USER_AVATAR_GREY_BACKGROUND
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.LocalPostId
 import javax.inject.Inject
@@ -167,34 +162,4 @@ class PostListMainViewModel @Inject constructor(
         }
     }
 
-    class PostListMainViewState(
-        val isFabVisible: Boolean,
-        val isAuthorFilterVisible: Boolean,
-        val authorFilterSelection: AuthorFilterSelection,
-        val authorFilterItems: List<AuthorFilterListItemUIState>
-    )
-
-    sealed class AuthorFilterListItemUIState(
-        val id: Long,
-        val text: UiString,
-        val avatarUrl: String?,
-        val imageType: ImageType,
-        @ColorRes val dropDownBackground: Int
-    ) {
-        class Everyone(@ColorRes dropDownBackground: Int) : AuthorFilterListItemUIState(
-                id = AuthorFilterSelection.EVERYONE.id,
-                text = UiStringRes(R.string.post_list_author_everyone),
-                avatarUrl = null,
-                imageType = MULTI_USER_AVATAR_GREY_BACKGROUND,
-                dropDownBackground = dropDownBackground
-        )
-
-        class Me(avatarUrl: String?, @ColorRes dropDownBackground: Int) : AuthorFilterListItemUIState(
-                id = AuthorFilterSelection.ME.id,
-                text = UiStringRes(R.string.post_list_author_me),
-                avatarUrl = avatarUrl,
-                imageType = AVATAR_WITH_BACKGROUND,
-                dropDownBackground = dropDownBackground
-        )
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -161,5 +161,4 @@ class PostListMainViewModel @Inject constructor(
             _updatePostsPager.value = authorFilterSelection
         }
     }
-
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewState.kt
@@ -1,0 +1,40 @@
+package org.wordpress.android.ui.posts
+
+import android.support.annotation.ColorRes
+import org.wordpress.android.R
+import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.image.ImageType
+import org.wordpress.android.util.image.ImageType.AVATAR_WITH_BACKGROUND
+import org.wordpress.android.util.image.ImageType.MULTI_USER_AVATAR_GREY_BACKGROUND
+
+class PostListMainViewState(
+    val isFabVisible: Boolean,
+    val isAuthorFilterVisible: Boolean,
+    val authorFilterSelection: AuthorFilterSelection,
+    val authorFilterItems: List<AuthorFilterListItemUIState>
+)
+
+sealed class AuthorFilterListItemUIState(
+    val id: Long,
+    val text: UiString,
+    val avatarUrl: String?,
+    val imageType: ImageType,
+    @ColorRes val dropDownBackground: Int
+) {
+    class Everyone(@ColorRes dropDownBackground: Int) : AuthorFilterListItemUIState(
+            id = AuthorFilterSelection.EVERYONE.id,
+            text = UiStringRes(R.string.post_list_author_everyone),
+            avatarUrl = null,
+            imageType = MULTI_USER_AVATAR_GREY_BACKGROUND,
+            dropDownBackground = dropDownBackground
+    )
+
+    class Me(avatarUrl: String?, @ColorRes dropDownBackground: Int) : AuthorFilterListItemUIState(
+            id = AuthorFilterSelection.ME.id,
+            text = UiStringRes(R.string.post_list_author_me),
+            avatarUrl = avatarUrl,
+            imageType = AVATAR_WITH_BACKGROUND,
+            dropDownBackground = dropDownBackground
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListUploadStatusTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListUploadStatusTracker.kt
@@ -1,0 +1,37 @@
+package org.wordpress.android.ui.posts
+
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.store.UploadStore
+import org.wordpress.android.ui.uploads.UploadService
+import org.wordpress.android.viewmodel.posts.PostListItemUploadStatus
+
+/**
+ * This is a temporary class to make the PostListViewModel more manageable. Please feel free to refactor it any way
+ * you see fit.
+ */
+class PostListUploadStatusTracker(private val uploadStore: UploadStore) {
+    private val uploadStatusMap = HashMap<Int, PostListItemUploadStatus>()
+
+    fun getUploadStatus(post: PostModel): PostListItemUploadStatus {
+        uploadStatusMap[post.id]?.let { return it }
+        val uploadError = uploadStore.getUploadErrorForPost(post)
+        val isUploadingOrQueued = UploadService.isPostUploadingOrQueued(post)
+        val hasInProgressMediaUpload = UploadService.hasInProgressMediaUploadsForPost(post)
+        val newStatus = PostListItemUploadStatus(
+                uploadError = uploadError,
+                mediaUploadProgress = Math.round(UploadService.getMediaUploadProgressForPost(post) * 100),
+                isUploading = UploadService.isPostUploading(post),
+                isUploadingOrQueued = isUploadingOrQueued,
+                isQueued = UploadService.isPostQueued(post),
+                isUploadFailed = uploadStore.isFailedPost(post),
+                hasInProgressMediaUpload = hasInProgressMediaUpload,
+                hasPendingMediaUpload = UploadService.hasPendingMediaUploadsForPost(post)
+        )
+        uploadStatusMap[post.id] = newStatus
+        return newStatus
+    }
+
+    fun invalidateUploadStatus(localPostIds: List<Int>) {
+        localPostIds.forEach { uploadStatusMap.remove(it) }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/AuthorSelectionAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/AuthorSelectionAdapter.kt
@@ -12,8 +12,8 @@ import android.widget.SpinnerAdapter
 import androidx.annotation.CallSuper
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.ui.posts.AuthorFilterListItemUIState
 import org.wordpress.android.ui.posts.AuthorFilterSelection
-import org.wordpress.android.ui.posts.PostListMainViewModel.AuthorFilterListItemUIState
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.GravatarUtils
 import org.wordpress.android.util.image.ImageManager

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListEmptyUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListEmptyUiState.kt
@@ -1,0 +1,49 @@
+package org.wordpress.android.viewmodel.posts
+
+import android.support.annotation.DrawableRes
+import org.wordpress.android.R
+import org.wordpress.android.R.string
+import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+
+sealed class PostListEmptyUiState(
+    val title: UiString? = null,
+    @DrawableRes val imgResId: Int? = null,
+    val buttonText: UiString? = null,
+    val onButtonClick: (() -> Unit)? = null,
+    val emptyViewVisible: Boolean = true
+) {
+    class EmptyList(
+        title: UiString,
+        buttonText: UiString? = null,
+        onButtonClick: (() -> Unit)? = null
+    ) : PostListEmptyUiState(
+            title = title,
+            imgResId = R.drawable.img_illustration_posts_75dp,
+            buttonText = buttonText,
+            onButtonClick = onButtonClick
+    )
+
+    object DataShown : PostListEmptyUiState(emptyViewVisible = false)
+
+    object Loading : PostListEmptyUiState(
+            title = UiStringRes(string.posts_fetching),
+            imgResId = R.drawable.img_illustration_posts_75dp
+    )
+
+    class RefreshError(
+        title: UiString,
+        buttonText: UiString? = null,
+        onButtonClick: (() -> Unit)? = null
+    ) : PostListEmptyUiState(
+            title = title,
+            imgResId = R.drawable.img_illustration_empty_results_216dp,
+            buttonText = buttonText,
+            onButtonClick = onButtonClick
+    )
+
+    object PermissionsError : PostListEmptyUiState(
+            title = UiStringRes(R.string.error_refresh_unauthorized_posts),
+            imgResId = R.drawable.img_illustration_posts_75dp
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListEmptyUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListEmptyUiState.kt
@@ -3,6 +3,13 @@ package org.wordpress.android.viewmodel.posts
 import android.support.annotation.DrawableRes
 import org.wordpress.android.R
 import org.wordpress.android.R.string
+import org.wordpress.android.fluxc.store.ListStore.ListError
+import org.wordpress.android.fluxc.store.ListStore.ListErrorType.PERMISSION_ERROR
+import org.wordpress.android.ui.posts.PostListType
+import org.wordpress.android.ui.posts.PostListType.DRAFTS
+import org.wordpress.android.ui.posts.PostListType.PUBLISHED
+import org.wordpress.android.ui.posts.PostListType.SCHEDULED
+import org.wordpress.android.ui.posts.PostListType.TRASHED
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 
@@ -46,4 +53,70 @@ sealed class PostListEmptyUiState(
             title = UiStringRes(R.string.error_refresh_unauthorized_posts),
             imgResId = R.drawable.img_illustration_posts_75dp
     )
+}
+
+fun createEmptyUiState(
+    postListType: PostListType,
+    isNetworkAvailable: Boolean,
+    isFetchingFirstPage: Boolean,
+    isListEmpty: Boolean,
+    error: ListError?,
+    fetchFirstPage: () -> Unit,
+    newPost: () -> Unit
+): PostListEmptyUiState {
+    return if (isListEmpty) {
+        when {
+            error != null -> createErrorListUiState(
+                    isNetworkAvailable = isNetworkAvailable,
+                    error = error,
+                    fetchFirstPage = fetchFirstPage
+            )
+            isFetchingFirstPage -> PostListEmptyUiState.Loading
+            else -> createEmptyListUiState(postListType = postListType, newPost = newPost)
+        }
+    } else {
+        PostListEmptyUiState.DataShown
+    }
+}
+
+private fun createErrorListUiState(
+    isNetworkAvailable: Boolean,
+    error: ListError,
+    fetchFirstPage: () -> Unit
+): PostListEmptyUiState {
+    return if (error.type == PERMISSION_ERROR) {
+        PostListEmptyUiState.PermissionsError
+    } else {
+        val errorText = if (isNetworkAvailable) {
+            UiStringRes(R.string.error_refresh_posts)
+        } else {
+            UiStringRes(R.string.no_network_message)
+        }
+        PostListEmptyUiState.RefreshError(
+                errorText,
+                UiStringRes(R.string.retry),
+                fetchFirstPage
+        )
+    }
+}
+
+private fun createEmptyListUiState(postListType: PostListType, newPost: () -> Unit): PostListEmptyUiState.EmptyList {
+    return when (postListType) {
+        PUBLISHED -> PostListEmptyUiState.EmptyList(
+                UiStringRes(R.string.posts_published_empty),
+                UiStringRes(R.string.posts_empty_list_button),
+                newPost
+        )
+        DRAFTS -> PostListEmptyUiState.EmptyList(
+                UiStringRes(R.string.posts_draft_empty),
+                UiStringRes(R.string.posts_empty_list_button),
+                newPost
+        )
+        SCHEDULED -> PostListEmptyUiState.EmptyList(
+                UiStringRes(R.string.posts_scheduled_empty),
+                UiStringRes(R.string.posts_empty_list_button),
+                newPost
+        )
+        TRASHED -> PostListEmptyUiState.EmptyList(UiStringRes(R.string.posts_trashed_empty))
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -207,7 +207,6 @@ class PostListViewModel @Inject constructor(
         result
     }
 
-    private var isNetworkAvailable: Boolean = true
     private val lifecycleRegistry = LifecycleRegistry(this)
     override fun getLifecycle(): Lifecycle = lifecycleRegistry
 
@@ -215,7 +214,6 @@ class PostListViewModel @Inject constructor(
 
     init {
         connectionStatus.observe(this, Observer {
-            isNetworkAvailable = it?.isConnected == true
             retryOnConnectionAvailableAfterRefreshError()
         })
         lifecycleRegistry.markState(Lifecycle.State.CREATED)
@@ -277,7 +275,7 @@ class PostListViewModel @Inject constructor(
     }
 
     private fun retryOnConnectionAvailableAfterRefreshError() {
-        val connectionAvailableAfterRefreshError = isNetworkAvailable &&
+        val connectionAvailableAfterRefreshError = networkUtilsWrapper.isNetworkAvailable() &&
                 emptyViewState.value is RefreshError
 
         if (connectionAvailableAfterRefreshError) {
@@ -904,7 +902,7 @@ class PostListViewModel @Inject constructor(
     }
 
     private fun checkNetworkConnection(): Boolean =
-            if (isNetworkAvailable) {
+            if (networkUtilsWrapper.isNetworkAvailable()) {
                 true
             } else {
                 _toastMessage.postValue(ToastMessageHolder(R.string.no_network_message, Duration.SHORT))

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -9,7 +9,6 @@ import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModel
 import android.arch.paging.PagedList
 import android.content.Intent
-import android.support.annotation.DrawableRes
 import de.greenrobot.event.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -79,7 +78,6 @@ import org.wordpress.android.ui.reader.utils.ReaderImageScanner
 import org.wordpress.android.ui.uploads.PostEvents
 import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.uploads.VideoOptimizer
-import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
@@ -92,9 +90,9 @@ import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus
 import org.wordpress.android.viewmodel.helpers.DialogHolder
 import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
+import org.wordpress.android.viewmodel.posts.PostListEmptyUiState.RefreshError
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.LocalPostId
 import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
-import org.wordpress.android.viewmodel.posts.PostListViewModel.PostListEmptyUiState.RefreshError
 import org.wordpress.android.widgets.PostListButtonType
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_BACK
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE
@@ -264,48 +262,6 @@ class PostListViewModel @Inject constructor(
             )
             TRASHED -> PostListEmptyUiState.EmptyList(UiStringRes(R.string.posts_trashed_empty))
         }
-    }
-
-    sealed class PostListEmptyUiState(
-        val title: UiString? = null,
-        @DrawableRes val imgResId: Int? = null,
-        val buttonText: UiString? = null,
-        val onButtonClick: (() -> Unit)? = null,
-        val emptyViewVisible: Boolean = true
-    ) {
-        class EmptyList(
-            title: UiString,
-            buttonText: UiString? = null,
-            onButtonClick: (() -> Unit)? = null
-        ) : PostListEmptyUiState(
-                title = title,
-                imgResId = R.drawable.img_illustration_posts_75dp,
-                buttonText = buttonText,
-                onButtonClick = onButtonClick
-        )
-
-        object DataShown : PostListEmptyUiState(emptyViewVisible = false)
-
-        object Loading : PostListEmptyUiState(
-                title = UiStringRes(R.string.posts_fetching),
-                imgResId = R.drawable.img_illustration_posts_75dp
-        )
-
-        class RefreshError(
-            title: UiString,
-            buttonText: UiString? = null,
-            onButtonClick: (() -> Unit)? = null
-        ) : PostListEmptyUiState(
-                title = title,
-                imgResId = R.drawable.img_illustration_empty_results_216dp,
-                buttonText = buttonText,
-                onButtonClick = onButtonClick
-        )
-
-        object PermissionsError : PostListEmptyUiState(
-                title = UiStringRes(R.string.error_refresh_unauthorized_posts),
-                imgResId = R.drawable.img_illustration_posts_75dp
-        )
     }
 
     private var isNetworkAvailable: Boolean = true


### PR DESCRIPTION
This PR attempts to split the `PostListViewModel` into several files to make it more manageable. We needed to do something like this already, but it was actually done to be able to move the common post list logic to `PostListMainViewModel`. When I attempted to make that move without these changes, I didn't make much progress simply because there is too much going on in the `PostListViewModel`.

Please note that the new components are considered temporary and they were NOT designed as reusable components. I just threw in similar functions into several components for now. Having said that, I _think_ this move will make it much easier to refactor these components and make them more useful. I simply don't have the time to do that right now, but even if I did, I think this is how I'd have started.

**To review:**

I haven't made any functionality changes in this PR, so aside from adding some extra parameters, there really is not much changed. I think this one would be easier to review commit by commit. The commits are not super clean, but they are close enough. Sometimes I have fixed some checkstyle issues and added a few comments in other files, but generally they are very well contained. Please let me know if I can help with the review in any way.

**To test:**

Pretty much everything in the post list needs to be tested.

**To merge:**
1. Review and merge #9588
2. Update the base branch to `feature/master-post-filters`
3. Mark the PR as ready for review
