### PR TITLE
Replace event/observeEvent with Event wrapper for single actions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/NavigationTarget.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/NavigationTarget.kt
@@ -2,11 +2,10 @@ package org.wordpress.android.ui.stats.refresh
 
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.ui.stats.StatsConstants
-import org.wordpress.android.util.Event
 import java.util.Date
 
-sealed class NavigationTarget : Event() {
-    class AddNewPost : NavigationTarget()
+sealed class NavigationTarget {
+    object AddNewPost : NavigationTarget()
     data class ViewPost(val postId: Long, val postUrl: String, val postType: String = StatsConstants.ITEM_TYPE_POST) :
             NavigationTarget()
 
@@ -19,9 +18,9 @@ sealed class NavigationTarget : Event() {
     ) : NavigationTarget()
 
     data class ViewFollowersStats(val selectedTab: Int) : NavigationTarget()
-    class ViewCommentsStats(val selectedTab: Int) : NavigationTarget()
-    class ViewTagsAndCategoriesStats : NavigationTarget()
-    class ViewPublicizeStats : NavigationTarget()
+    data class ViewCommentsStats(val selectedTab: Int) : NavigationTarget()
+    object ViewTagsAndCategoriesStats : NavigationTarget()
+    object ViewPublicizeStats : NavigationTarget()
     data class ViewTag(val link: String) : NavigationTarget()
     data class ViewPostsAndPages(val statsGranularity: StatsGranularity, val selectedDate: Date) : NavigationTarget()
     data class ViewReferrers(val statsGranularity: StatsGranularity, val selectedDate: Date) : NavigationTarget()
@@ -31,7 +30,7 @@ sealed class NavigationTarget : Event() {
     data class ViewSearchTerms(val statsGranularity: StatsGranularity, val selectedDate: Date) : NavigationTarget()
     data class ViewAuthors(val statsGranularity: StatsGranularity, val selectedDate: Date) : NavigationTarget()
     data class ViewUrl(val url: String) : NavigationTarget()
-    class ViewMonthsAndYearsStats : NavigationTarget()
-    class ViewDayAverageStats : NavigationTarget()
-    class ViewRecentWeeksStats : NavigationTarget()
+    object ViewMonthsAndYearsStats : NavigationTarget()
+    object ViewDayAverageStats : NavigationTarget()
+    object ViewRecentWeeksStats : NavigationTarget()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -38,7 +38,6 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsNavigator
 import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.util.image.ImageManager
-import org.wordpress.android.util.observeEvent
 import javax.inject.Inject
 
 class StatsViewAllFragment : DaggerFragment() {
@@ -158,15 +157,17 @@ class StatsViewAllFragment : DaggerFragment() {
             }
         })
 
-        viewModel.showSnackbarMessage.observe(this, Observer { holder ->
-            val parent = activity.findViewById<View>(R.id.coordinatorLayout)
-            if (holder != null && parent != null) {
-                if (holder.buttonTitleRes == null) {
-                    Snackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG).show()
-                } else {
-                    val snackbar = Snackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG)
-                    snackbar.setAction(getString(holder.buttonTitleRes)) { holder.buttonAction() }
-                    snackbar.show()
+        viewModel.showSnackbarMessage.observe(this, Observer { event ->
+            event?.getContentIfNotHandled()?.let { holder ->
+                val parent = activity.findViewById<View>(R.id.coordinatorLayout)
+                if (parent != null) {
+                    if (holder.buttonTitleRes == null) {
+                        Snackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG).show()
+                    } else {
+                        val snackbar = Snackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG)
+                        snackbar.setAction(getString(holder.buttonTitleRes)) { holder.buttonAction() }
+                        snackbar.show()
+                    }
                 }
             }
         })
@@ -192,11 +193,11 @@ class StatsViewAllFragment : DaggerFragment() {
                 }
             }
         })
-
-        viewModel.navigationTarget.observeEvent(this) { target ->
-            navigator.navigate(activity, target)
-            return@observeEvent true
-        }
+        viewModel.navigationTarget.observe(this, Observer { event ->
+            event?.getContentIfNotHandled()?.let { target ->
+                navigator.navigate(activity, target)
+            }
+        })
 
         viewModel.dateSelectorData.observe(this, Observer { dateSelectorUiModel ->
             val dateSelectorVisibility = if (dateSelectorUiModel?.isVisible == true) View.VISIBLE else View.GONE
@@ -214,15 +215,17 @@ class StatsViewAllFragment : DaggerFragment() {
             }
         })
 
-        viewModel.navigationTarget.observeEvent(this) { target ->
-            navigator.navigate(activity, target)
-            return@observeEvent true
-        }
+        viewModel.navigationTarget.observe(this, Observer { event ->
+            event?.getContentIfNotHandled()?.let { target ->
+                navigator.navigate(activity, target)
+            }
+        })
 
-        viewModel.selectedDate.observeEvent(this) {
-            viewModel.onDateChanged()
-            true
-        }
+        viewModel.selectedDate.observe(this, Observer { event ->
+            if (event?.hasBeenHandled == false) {
+                viewModel.onDateChanged()
+            }
+        })
 
         viewModel.toolbarHasShadow.observe(this, Observer { hasShadow ->
             val elevation = if (hasShadow == true) resources.getDimension(R.dimen.appbar_elevation) else 0f

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllViewModel.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.distinct
 import org.wordpress.android.util.map
 import org.wordpress.android.util.mapNullable
+import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 
 class StatsViewAllViewModel(
@@ -32,7 +33,7 @@ class StatsViewAllViewModel(
     private val dateSelector: StatsDateSelector,
     @StringRes val title: Int
 ) : ScopedViewModel(mainDispatcher) {
-    private val mutableSnackbarMessage = MutableLiveData<Int>()
+    private val mutableSnackbarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
 
     val selectedDate = dateSelector.selectedDate
 
@@ -40,7 +41,7 @@ class StatsViewAllViewModel(
         it ?: DateSelectorUiModel(false)
     }
 
-    val navigationTarget: LiveData<NavigationTarget> = useCase.navigationTarget
+    val navigationTarget: LiveData<Event<NavigationTarget>> = useCase.navigationTarget
 
     val data: LiveData<StatsBlock> = useCase.liveData.map { useCaseModel ->
         when (useCaseModel.state) {
@@ -54,9 +55,7 @@ class StatsViewAllViewModel(
     private val _isRefreshing = MutableLiveData<Boolean>()
     val isRefreshing: LiveData<Boolean> = _isRefreshing
 
-    val showSnackbarMessage: LiveData<SnackbarMessageHolder> = mutableSnackbarMessage.map {
-        SnackbarMessageHolder(it)
-    }
+    val showSnackbarMessage: LiveData<Event<SnackbarMessageHolder>> = mutableSnackbarMessage
 
     val toolbarHasShadow = dateSelectorData.map { !it.isVisible }
 
@@ -90,7 +89,7 @@ class StatsViewAllViewModel(
             if (statsSiteProvider.hasLoadedSite()) {
                 useCase.fetch(refresh, forced)
             } else {
-                mutableSnackbarMessage.postValue(R.string.stats_site_not_loaded_yet)
+                mutableSnackbarMessage.postValue(Event(SnackbarMessageHolder(R.string.stats_site_not_loaded_yet)))
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.util.combineMap
 import org.wordpress.android.util.distinct
 import org.wordpress.android.util.map
 import org.wordpress.android.util.mergeNotNull
+import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.SingleLiveEvent
 
 class BaseListUseCase(
@@ -48,7 +49,7 @@ class BaseListUseCase(
         }
     }.distinct()
 
-    val navigationTarget: LiveData<NavigationTarget> = mergeNotNull(
+    val navigationTarget: LiveData<Event<NavigationTarget>> = mergeNotNull(
             useCases.map { it.navigationTarget },
             distinct = false
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.ui.stats.refresh.lists.detail.DetailListViewModel
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsNavigator
 import org.wordpress.android.util.image.ImageManager
-import org.wordpress.android.util.observeEvent
 import javax.inject.Inject
 
 class StatsListFragment : DaggerFragment() {
@@ -170,15 +169,17 @@ class StatsListFragment : DaggerFragment() {
             }
         })
 
-        viewModel.navigationTarget.observeEvent(this) { target ->
-            navigator.navigate(activity, target)
-            return@observeEvent true
-        }
+        viewModel.navigationTarget.observe(this, Observer { event ->
+            event?.getContentIfNotHandled()?.let { target ->
+                navigator.navigate(activity, target)
+            }
+        })
 
-        viewModel.selectedDate.observeEvent(this) {
-            viewModel.onDateChanged()
-            true
-        }
+        viewModel.selectedDate.observe(this, Observer { event ->
+            if (event?.hasBeenHandled == false) {
+                viewModel.onDateChanged()
+            }
+        })
 
         viewModel.listSelected.observe(this, Observer {
             viewModel.onListSelected()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsDateSelector
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.mapNullable
 import org.wordpress.android.util.throttle
+import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -52,7 +53,7 @@ abstract class StatsListViewModel(
 
     val selectedDate = dateSelector.selectedDate
 
-    val navigationTarget: LiveData<NavigationTarget> = statsUseCase.navigationTarget
+    val navigationTarget: LiveData<Event<NavigationTarget>> = statsUseCase.navigationTarget
 
     val listSelected = statsUseCase.listSelected
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
@@ -89,7 +89,7 @@ class PostAverageViewsPerDayUseCase(
     }
 
     private fun onLinkClick() {
-        navigateTo(ViewDayAverageStats())
+        navigateTo(ViewDayAverageStats)
     }
 
     override fun buildLoadingItem(): List<BlockListItem> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCase.kt
@@ -89,7 +89,7 @@ class PostMonthsAndYearsUseCase(
     }
 
     private fun onLinkClick() {
-        navigateTo(ViewMonthsAndYearsStats())
+        navigateTo(ViewMonthsAndYearsStats)
     }
 
     override fun buildLoadingItem(): List<BlockListItem> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCase.kt
@@ -88,7 +88,7 @@ class PostRecentWeeksUseCase(
     }
 
     private fun onLinkClick() {
-        navigateTo(ViewRecentWeeksStats())
+        navigateTo(ViewRecentWeeksStats)
     }
 
     override fun buildLoadingItem(): List<BlockListItem> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
-import org.wordpress.android.util.observeEvent
 import javax.inject.Inject
 
 class StatsDetailFragment : DaggerFragment() {
@@ -77,10 +76,11 @@ class StatsDetailFragment : DaggerFragment() {
             }
         })
 
-        viewModel.selectedDateChanged.observeEvent(this) {
-            viewModel.onDateChanged()
-            true
-        }
+        viewModel.selectedDateChanged.observe(this, Observer { event ->
+            if (event?.hasBeenHandled == false) {
+                viewModel.onDateChanged()
+            }
+        })
 
         viewModel.showDateSelector.observe(this, Observer { dateSelectorUiModel ->
             val dateSelectorVisibility = if (dateSelectorUiModel?.isVisible == true) View.VISIBLE else View.GONE

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.Us
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.distinct
 import org.wordpress.android.util.merge
+import org.wordpress.android.viewmodel.Event
 
 /**
  * Do not override this class directly. Use StatefulUseCase or StatelessUseCase instead.
@@ -58,8 +59,8 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
         }
     }.distinct()
 
-    private val mutableNavigationTarget = MutableLiveData<NavigationTarget>()
-    val navigationTarget: LiveData<NavigationTarget> = mutableNavigationTarget
+    private val mutableNavigationTarget = MutableLiveData<Event<NavigationTarget>>()
+    val navigationTarget: LiveData<Event<NavigationTarget>> = mutableNavigationTarget
 
     /**
      * Fetches data either from a local cache or from remote API
@@ -154,7 +155,7 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
      * Passes a navigation target to the View layer which uses the context to open the correct activity.
      */
     fun navigateTo(target: NavigationTarget) {
-        mutableNavigationTarget.value = target
+        mutableNavigationTarget.value = Event(target)
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
@@ -9,8 +9,8 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSect
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.WEEKS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.YEARS
 import org.wordpress.android.ui.stats.refresh.utils.toStatsSection
-import org.wordpress.android.util.Event
 import org.wordpress.android.util.filter
+import org.wordpress.android.viewmodel.Event
 import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -25,15 +25,15 @@ class SelectedDateProvider
             YEARS to SelectedDate(loading = true)
     )
 
-    private val mutableSelectedDateChanged = MutableLiveData<SectionChange>()
-    val selectedDateChanged: LiveData<SectionChange> = mutableSelectedDateChanged
+    private val mutableSelectedDateChanged = MutableLiveData<Event<SectionChange>>()
+    val selectedDateChanged: LiveData<Event<SectionChange>> = mutableSelectedDateChanged
 
-    fun granularSelectedDateChanged(statsGranularity: StatsGranularity): LiveData<SectionChange> {
-        return selectedDateChanged.filter { it.selectedSection == statsGranularity.toStatsSection() }
+    fun granularSelectedDateChanged(statsGranularity: StatsGranularity): LiveData<Event<SectionChange>> {
+        return selectedDateChanged.filter { it.peekContent().selectedSection == statsGranularity.toStatsSection() }
     }
 
-    fun granularSelectedDateChanged(statsSection: StatsSection): LiveData<SectionChange> {
-        return selectedDateChanged.filter { it.selectedSection == statsSection }
+    fun granularSelectedDateChanged(statsSection: StatsSection): LiveData<Event<SectionChange>> {
+        return selectedDateChanged.filter { it.peekContent().selectedSection == statsSection }
     }
 
     fun selectDate(date: Date, statsSection: StatsSection) {
@@ -65,7 +65,7 @@ class SelectedDateProvider
     private fun updateSelectedDate(selectedDate: SelectedDate, statsSection: StatsSection) {
         if (mutableDates[statsSection] != selectedDate) {
             mutableDates[statsSection] = selectedDate
-            mutableSelectedDateChanged.postValue(SectionChange(statsSection))
+            mutableSelectedDateChanged.postValue(Event(SectionChange(statsSection)))
         }
     }
 
@@ -165,5 +165,5 @@ class SelectedDateProvider
         fun getDate(): Date = availableDates[index!!]
     }
 
-    data class SectionChange(val selectedSection: StatsSection) : Event()
+    data class SectionChange(val selectedSection: StatsSection)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCase.kt
@@ -130,7 +130,7 @@ class LatestPostSummaryUseCase
 
     private fun onAddNewPostClick() {
         analyticsTracker.track(STATS_LATEST_POST_SUMMARY_ADD_NEW_POST_TAPPED)
-        navigateTo(AddNewPost())
+        navigateTo(AddNewPost)
     }
 
     private fun onViewMore(params: ViewMoreParams) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCase.kt
@@ -93,7 +93,7 @@ class PublicizeUseCase
 
     private fun onLinkClick() {
         analyticsTracker.track(AnalyticsTracker.Stat.STATS_PUBLICIZE_VIEW_MORE_TAPPED)
-        return navigateTo(ViewPublicizeStats())
+        return navigateTo(ViewPublicizeStats)
     }
 
     class PublicizeUseCaseFactory

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCase.kt
@@ -167,7 +167,7 @@ class TagsAndCategoriesUseCase
 
     private fun onLinkClick() {
         analyticsTracker.track(AnalyticsTracker.Stat.STATS_TAGS_AND_CATEGORIES_VIEW_MORE_TAPPED)
-        navigateTo(ViewTagsAndCategoriesStats())
+        navigateTo(ViewTagsAndCategoriesStats)
     }
 
     private fun onTagClick(link: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
@@ -7,7 +7,6 @@ import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
-import org.wordpress.android.util.filter
 import org.wordpress.android.util.perform
 import javax.inject.Inject
 
@@ -20,8 +19,7 @@ constructor(
     private val _dateSelectorUiModel = MutableLiveData<DateSelectorUiModel>()
     val dateSelectorData: LiveData<DateSelectorUiModel> = _dateSelectorUiModel
 
-    val selectedDate = selectedDateProvider.selectedDateChanged
-            .filter { sectionChange -> sectionChange.selectedSection == this.statsSection }
+    val selectedDate = selectedDateProvider.granularSelectedDateChanged(this.statsSection)
             .perform {
                 if (!it.hasBeenHandled) {
                     updateDateSelector()

--- a/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
@@ -1,9 +1,7 @@
 package org.wordpress.android.util
 
-import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MediatorLiveData
-import android.arch.lifecycle.Observer
 import android.arch.lifecycle.Transformations
 import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.viewmodel.SingleMediatorLiveEvent
@@ -226,18 +224,3 @@ fun <T> LiveData<T>.filter(predicate: (T) -> Boolean): LiveData<T> {
     }
     return mediator
 }
-
-/**
- * Use this in order to observe an emission only once - for example for displaying a Snackbar message
- */
-fun <T : Event> LiveData<T>.observeEvent(owner: LifecycleOwner, observer: (T) -> Boolean) {
-    this.observe(owner, Observer {
-        if (it != null && !it.hasBeenHandled) {
-            if (observer(it)) {
-                it.hasBeenHandled = true
-            }
-        }
-    })
-}
-
-open class Event(var hasBeenHandled: Boolean = false)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/Event.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/Event.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.viewmodel
+
+/**
+ * Used as a wrapper for data that is exposed via a LiveData that represents an event.
+ */
+open class Event<out T>(private val content: T) {
+    var hasBeenHandled = false
+        private set // Allow external read but not write
+
+    /**
+     * Returns the content and prevents its use again.
+     */
+    fun getContentIfNotHandled(): T? {
+        return if (hasBeenHandled) {
+            null
+        } else {
+            hasBeenHandled = true
+            content
+        }
+    }
+
+    /**
+     * Returns the content, even if it's already been handled.
+     */
+    fun peekContent(): T = content
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCaseTest.kt
@@ -319,7 +319,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
         assertThat(items[3] is Link).isTrue()
 
         var navigationTarget: NavigationTarget? = null
-        useCase.navigationTarget.observeForever { navigationTarget = it }
+        useCase.navigationTarget.observeForever { navigationTarget = it?.getContentIfNotHandled() }
 
         (items[3] as Link).navigateAction.click()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCaseTest.kt
@@ -179,7 +179,7 @@ class LatestPostSummaryUseCaseTest : BaseUnitTest() {
 
     private fun Link.toNavigationTarget(): NavigationTarget? {
         var navigationTarget: NavigationTarget? = null
-        useCase.navigationTarget.observeForever { navigationTarget = it }
+        useCase.navigationTarget.observeForever { navigationTarget = it?.getContentIfNotHandled() }
         this.navigateAction.click()
         return navigationTarget
     }


### PR DESCRIPTION
This is an exploration related to this article - https://medium.com/androiddevelopers/livedata-with-snackbar-navigation-and-other-events-the-singleliveevent-case-ac2622673150

I'm replacing a parent `Event` and the `observeEvent` method with an `Event` wrapper. I think this approach makes it less error prone. You can define an event on the observable point of code and the observer has to call the correct method to get the value. It adds a bit of boilerplate code.

What do you think about this solution?

To test:
* Go to stats
* Click on View more on any block
* Go back
* Click on View more on the same block
* Go to DWMY
* Change date from date selector
* Change date from the Overview block
* Check that all works as expected