### PR TITLE
Fix RTL in refreshed stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -17,8 +17,8 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM_WITH_ICON
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LOADING_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.MAP
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.REFERRED_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.QUICK_SCAN_ITEM
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.REFERRED_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TABS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TEXT
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
@@ -101,7 +101,7 @@ sealed class BlockListItem(val type: Type) {
         }
     }
 
-    data class QuickScanItem(val leftColumn: Column, val rightColumn: Column) : BlockListItem(QUICK_SCAN_ITEM) {
+    data class QuickScanItem(val startColumn: Column, val endColumn: Column) : BlockListItem(QUICK_SCAN_ITEM) {
         data class Column(@StringRes val label: Int, val value: String, val tooltip: String? = null)
     }
 
@@ -158,7 +158,7 @@ sealed class BlockListItem(val type: Type) {
             get() = tabs.hashCode()
     }
 
-    data class Header(@StringRes val leftLabel: Int, @StringRes val rightLabel: Int) : BlockListItem(HEADER)
+    data class Header(@StringRes val startLabel: Int, @StringRes val endLabel: Int) : BlockListItem(HEADER)
 
     data class ExpandableItem(
         val header: ListItemWithIcon,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/HeaderViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/HeaderViewHolder.kt
@@ -10,10 +10,10 @@ class HeaderViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         parent,
         layout.stats_block_header_item
 ) {
-    private val leftLabel = itemView.findViewById<TextView>(id.left_label)
-    private val rightLabel = itemView.findViewById<TextView>(id.right_label)
+    private val startLabel = itemView.findViewById<TextView>(id.start_label)
+    private val endLabel = itemView.findViewById<TextView>(id.end_label)
     fun bind(item: Header) {
-        leftLabel.setText(item.leftLabel)
-        rightLabel.setText(item.rightLabel)
+        startLabel.setText(item.startLabel)
+        endLabel.setText(item.endLabel)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/QuickScanItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/QuickScanItemViewHolder.kt
@@ -12,14 +12,14 @@ class QuickScanItemViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         parent,
         layout.stats_quick_scan_item
 ) {
-    private val leftLabel = itemView.findViewById<TextView>(id.left_label)
-    private val leftValue = itemView.findViewById<TextView>(id.left_value)
-    private val rightLabel = itemView.findViewById<TextView>(id.right_label)
-    private val rightValue = itemView.findViewById<TextView>(id.right_value)
+    private val startLabel = itemView.findViewById<TextView>(id.start_label)
+    private val startValue = itemView.findViewById<TextView>(id.start_value)
+    private val endLabel = itemView.findViewById<TextView>(id.end_label)
+    private val endValue = itemView.findViewById<TextView>(id.end_value)
 
     fun bind(item: QuickScanItem) {
-        bindColumn(item.leftColumn, leftLabel, leftValue)
-        bindColumn(item.rightColumn, rightLabel, rightValue)
+        bindColumn(item.startColumn, startLabel, startValue)
+        bindColumn(item.endColumn, endLabel, endValue)
     }
 
     private fun bindColumn(column: Column, label: TextView, value: TextView) {

--- a/WordPress/src/main/res/layout/stats_block_activity_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_activity_item.xml
@@ -64,7 +64,6 @@
         android:gravity="center_vertical"
         android:text="@string/stats_fewer_posts"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/very_low_box"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/third_activity"
@@ -73,9 +72,9 @@
     <View
         android:id="@+id/very_low_box"
         style="@style/StatsActivityBox"
+        android:layout_marginStart="8dp"
         android:background="@color/neutral_100"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/low_box"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/fewer_posts_label"
         app:layout_constraintTop_toTopOf="@+id/fewer_posts_label"/>
@@ -85,7 +84,6 @@
         style="@style/StatsActivityBox"
         android:background="@color/stats_activity_low"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/medium_box"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/very_low_box"
         app:layout_constraintTop_toTopOf="@+id/fewer_posts_label"/>
@@ -95,7 +93,6 @@
         style="@style/StatsActivityBox"
         android:background="@color/stats_activity_medium"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/high_box"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/low_box"
         app:layout_constraintTop_toTopOf="@+id/fewer_posts_label"/>
@@ -105,7 +102,6 @@
         style="@style/StatsActivityBox"
         android:background="@color/stats_activity_high"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/very_high_box"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/medium_box"
         app:layout_constraintTop_toTopOf="@+id/fewer_posts_label"/>
@@ -115,7 +111,6 @@
         style="@style/StatsActivityBox"
         android:background="@color/neutral_700"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/more_posts_label"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/high_box"
         app:layout_constraintTop_toTopOf="@+id/fewer_posts_label"/>

--- a/WordPress/src/main/res/layout/stats_block_header_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_header_item.xml
@@ -9,7 +9,7 @@
               android:orientation="horizontal">
 
     <TextView
-        android:id="@+id/left_label"
+        android:id="@+id/start_label"
         style="@style/StatsBlockLabel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -22,7 +22,7 @@
         android:layout_height="match_parent"/>
 
     <TextView
-        android:id="@+id/right_label"
+        android:id="@+id/end_label"
         style="@style/StatsBlockLabel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/stats_block_referred_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_referred_item.xml
@@ -18,7 +18,7 @@
     <TextView
         android:id="@+id/title"
         style="@style/StatsReferredItemTitle"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
         android:ellipsize="end"

--- a/WordPress/src/main/res/layout/stats_block_tabs_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_tabs_item.xml
@@ -8,15 +8,17 @@
 
     <android.support.design.widget.TabLayout
         android:id="@+id/tab_layout"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="top"
-        app:tabGravity="center"
+        app:tabGravity="fill"
         app:tabIndicatorColor="@color/primary"
-        app:tabSelectedTextColor="@color/primary"
-        app:tabPaddingStart="@dimen/margin_extra_large"
+        app:tabMode="scrollable"
         app:tabPaddingEnd="@dimen/margin_extra_large"
-        app:tabTextColor="@color/neutral_500"/>
+        app:tabPaddingStart="@dimen/margin_extra_large"
+        app:tabSelectedTextColor="@color/primary"
+        app:tabTextColor="@color/neutral_500"
+        app:theme="@style/Base.Widget.Design.TabLayout"/>
 
     <View
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/stats_quick_scan_item.xml
+++ b/WordPress/src/main/res/layout/stats_quick_scan_item.xml
@@ -9,19 +9,19 @@
 
 
     <TextView
-        android:id="@+id/left_label"
+        android:id="@+id/start_label"
         style="@style/StatsBlockQuickScanLabel"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="16dp"
         android:layout_marginStart="16dp"
         android:text="@string/unknown"
-        app:layout_constraintBottom_toTopOf="@id/left_value"
+        app:layout_constraintBottom_toTopOf="@id/start_value"
         app:layout_constraintEnd_toStartOf="@+id/horizontal_divider"
         app:layout_constraintStart_toStartOf="parent"/>
 
     <TextView
-        android:id="@+id/left_value"
+        android:id="@+id/start_value"
         style="@style/StatsBlockQuickScanValue"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -45,19 +45,19 @@
 
 
     <TextView
-        android:id="@+id/right_label"
+        android:id="@+id/end_label"
         style="@style/StatsBlockQuickScanLabel"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="16dp"
         android:layout_marginStart="16dp"
         android:text="@string/unknown"
-        app:layout_constraintBottom_toTopOf="@id/right_value"
+        app:layout_constraintBottom_toTopOf="@id/end_value"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/horizontal_divider"/>
 
     <TextView
-        android:id="@+id/right_value"
+        android:id="@+id/end_value"
         style="@style/StatsBlockQuickScanValue"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/values/stats_styles.xml
+++ b/WordPress/src/main/res/values/stats_styles.xml
@@ -203,7 +203,7 @@
     <style name="StatsActivityBox">
         <item name="android:layout_width">@dimen/stats_activity_box_size</item>
         <item name="android:layout_height">@dimen/stats_activity_box_size</item>
-        <item name="android:layout_marginEnd">@dimen/stats_activity_box_end_margin</item>
+        <item name="android:layout_marginStart">@dimen/stats_activity_box_end_margin</item>
     </style>
 
     <style name="StatsReferredItemLabel" parent="TextAppearance.AppCompat.Body1">

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCaseTest.kt
@@ -182,8 +182,8 @@ class PostAverageViewsPerDayUseCaseTest : BaseUnitTest() {
 
     private fun assertHeader(item: BlockListItem) {
         assertThat(item.type).isEqualTo(HEADER)
-        assertThat((item as Header).leftLabel).isEqualTo(R.string.stats_months_and_years_period_label)
-        assertThat(item.rightLabel).isEqualTo(R.string.stats_months_and_years_views_label)
+        assertThat((item as Header).startLabel).isEqualTo(R.string.stats_months_and_years_period_label)
+        assertThat(item.endLabel).isEqualTo(R.string.stats_months_and_years_views_label)
     }
 
     private fun assertMonth(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCaseTest.kt
@@ -182,8 +182,8 @@ class PostMonthsAndYearsUseCaseTest : BaseUnitTest() {
 
     private fun assertHeader(item: BlockListItem) {
         assertThat(item.type).isEqualTo(HEADER)
-        assertThat((item as Header).leftLabel).isEqualTo(R.string.stats_months_and_years_period_label)
-        assertThat(item.rightLabel).isEqualTo(R.string.stats_months_and_years_views_label)
+        assertThat((item as Header).startLabel).isEqualTo(R.string.stats_months_and_years_period_label)
+        assertThat(item.endLabel).isEqualTo(R.string.stats_months_and_years_views_label)
     }
 
     private fun assertMonth(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCaseTest.kt
@@ -191,8 +191,8 @@ class PostRecentWeeksUseCaseTest : BaseUnitTest() {
 
     private fun assertHeader(item: BlockListItem) {
         assertThat(item.type).isEqualTo(HEADER)
-        assertThat((item as Header).leftLabel).isEqualTo(R.string.stats_months_and_years_period_label)
-        assertThat(item.rightLabel).isEqualTo(R.string.stats_months_and_years_views_label)
+        assertThat((item as Header).startLabel).isEqualTo(R.string.stats_months_and_years_period_label)
+        assertThat(item.endLabel).isEqualTo(R.string.stats_months_and_years_views_label)
     }
 
     private fun assertDay(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCaseTest.kt
@@ -220,8 +220,8 @@ class AuthorsUseCaseTest : BaseUnitTest() {
 
     private fun assertLabel(item: BlockListItem) {
         assertThat(item.type).isEqualTo(HEADER)
-        assertThat((item as Header).leftLabel).isEqualTo(R.string.stats_author_label)
-        assertThat(item.rightLabel).isEqualTo(R.string.stats_author_views_label)
+        assertThat((item as Header).startLabel).isEqualTo(R.string.stats_author_label)
+        assertThat(item.endLabel).isEqualTo(R.string.stats_author_views_label)
     }
 
     private fun assertSingleItem(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCaseTest.kt
@@ -216,8 +216,8 @@ class ClicksUseCaseTest : BaseUnitTest() {
 
     private fun assertHeader(item: BlockListItem) {
         assertThat(item.type).isEqualTo(HEADER)
-        assertThat((item as Header).leftLabel).isEqualTo(R.string.stats_clicks_link_label)
-        assertThat(item.rightLabel).isEqualTo(R.string.stats_clicks_label)
+        assertThat((item as Header).startLabel).isEqualTo(R.string.stats_clicks_link_label)
+        assertThat(item.endLabel).isEqualTo(R.string.stats_clicks_label)
     }
 
     private fun assertSingleItem(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCaseTest.kt
@@ -177,8 +177,8 @@ class CountryViewsUseCaseTest : BaseUnitTest() {
 
     private fun assertLabel(item: BlockListItem) {
         assertThat(item.type).isEqualTo(HEADER)
-        assertThat((item as Header).leftLabel).isEqualTo(R.string.stats_country_label)
-        assertThat(item.rightLabel).isEqualTo(R.string.stats_country_views_label)
+        assertThat((item as Header).startLabel).isEqualTo(R.string.stats_country_label)
+        assertThat(item.endLabel).isEqualTo(R.string.stats_country_views_label)
     }
 
     private fun assertItem(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCaseTest.kt
@@ -330,8 +330,8 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
 
     private fun assertHeader(item: BlockListItem) {
         assertThat(item.type).isEqualTo(HEADER)
-        assertThat((item as Header).leftLabel).isEqualTo(R.string.stats_posts_and_pages_title_label)
-        assertThat(item.rightLabel).isEqualTo(R.string.stats_posts_and_pages_views_label)
+        assertThat((item as Header).startLabel).isEqualTo(R.string.stats_posts_and_pages_title_label)
+        assertThat(item.endLabel).isEqualTo(R.string.stats_posts_and_pages_views_label)
     }
 
     private suspend fun loadData(refresh: Boolean, forced: Boolean): UseCaseModel {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCaseTest.kt
@@ -203,8 +203,8 @@ class ReferrersUseCaseTest : BaseUnitTest() {
 
     private fun assertLabel(item: BlockListItem) {
         assertThat(item.type).isEqualTo(HEADER)
-        assertThat((item as Header).leftLabel).isEqualTo(R.string.stats_referrer_label)
-        assertThat(item.rightLabel).isEqualTo(R.string.stats_referrer_views_label)
+        assertThat((item as Header).startLabel).isEqualTo(R.string.stats_referrer_label)
+        assertThat(item.endLabel).isEqualTo(R.string.stats_referrer_views_label)
     }
 
     private fun assertSingleItem(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCaseTest.kt
@@ -207,8 +207,8 @@ class SearchTermsUseCaseTest : BaseUnitTest() {
 
     private fun assertHeader(item: BlockListItem) {
         assertThat(item.type).isEqualTo(HEADER)
-        assertThat((item as Header).leftLabel).isEqualTo(R.string.stats_search_terms_label)
-        assertThat(item.rightLabel).isEqualTo(R.string.stats_search_terms_views_label)
+        assertThat((item as Header).startLabel).isEqualTo(R.string.stats_search_terms_label)
+        assertThat(item.endLabel).isEqualTo(R.string.stats_search_terms_views_label)
     }
 
     private fun assertItem(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCaseTest.kt
@@ -177,8 +177,8 @@ class VideoPlaysUseCaseTest : BaseUnitTest() {
 
     private fun assertHeader(item: BlockListItem) {
         assertThat(item.type).isEqualTo(HEADER)
-        assertThat((item as Header).leftLabel).isEqualTo(R.string.stats_videos_title_label)
-        assertThat(item.rightLabel).isEqualTo(R.string.stats_videos_views_label)
+        assertThat((item as Header).startLabel).isEqualTo(R.string.stats_videos_title_label)
+        assertThat(item.endLabel).isEqualTo(R.string.stats_videos_views_label)
     }
 
     private fun assertItem(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AllTimeStatsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AllTimeStatsUseCaseTest.kt
@@ -113,17 +113,17 @@ class AllTimeStatsUseCaseTest : BaseUnitTest() {
         assertTrue(items[0] is Title)
         assertEquals((items[0] as Title).textResource, R.string.stats_insights_all_time_stats)
         (items[1] as QuickScanItem).apply {
-            assertThat(this.leftColumn.label).isEqualTo(R.string.stats_views)
-            assertThat(this.leftColumn.value).isEqualTo(views.toString())
-            assertThat(this.rightColumn.label).isEqualTo(R.string.stats_visitors)
-            assertThat(this.rightColumn.value).isEqualTo(visitors.toString())
+            assertThat(this.startColumn.label).isEqualTo(R.string.stats_views)
+            assertThat(this.startColumn.value).isEqualTo(views.toString())
+            assertThat(this.endColumn.label).isEqualTo(R.string.stats_visitors)
+            assertThat(this.endColumn.value).isEqualTo(visitors.toString())
         }
         (items[2] as QuickScanItem).apply {
-            assertThat(this.leftColumn.label).isEqualTo(R.string.posts)
-            assertThat(this.leftColumn.value).isEqualTo(posts.toString())
-            assertThat(this.rightColumn.label).isEqualTo(R.string.stats_insights_best_ever)
-            assertThat(this.rightColumn.value).isEqualTo(viewsBestDayTotal.toString())
-            assertThat(this.rightColumn.tooltip).isEqualTo(bestDayTransformed)
+            assertThat(this.startColumn.label).isEqualTo(R.string.posts)
+            assertThat(this.startColumn.value).isEqualTo(posts.toString())
+            assertThat(this.endColumn.label).isEqualTo(R.string.stats_insights_best_ever)
+            assertThat(this.endColumn.value).isEqualTo(viewsBestDayTotal.toString())
+            assertThat(this.endColumn.tooltip).isEqualTo(bestDayTransformed)
         }
     }
 
@@ -149,7 +149,7 @@ class AllTimeStatsUseCaseTest : BaseUnitTest() {
         assertTrue(items[0] is Title)
         assertEquals((items[0] as Title).textResource, R.string.stats_insights_all_time_stats)
         (items[2] as QuickScanItem).apply {
-            assertThat(this.rightColumn.tooltip).isNull()
+            assertThat(this.endColumn.tooltip).isNull()
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCaseTest.kt
@@ -228,8 +228,8 @@ class CommentsUseCaseTest : BaseUnitTest() {
 
         val headerItem = this[2]
         assertThat(headerItem.type).isEqualTo(HEADER)
-        assertThat((headerItem as Header).leftLabel).isEqualTo(R.string.stats_comments_title_label)
-        assertThat(headerItem.rightLabel).isEqualTo(R.string.stats_comments_label)
+        assertThat((headerItem as Header).startLabel).isEqualTo(R.string.stats_comments_title_label)
+        assertThat(headerItem.endLabel).isEqualTo(R.string.stats_comments_label)
 
         val userItem = this[3]
         assertThat(userItem.type).isEqualTo(LIST_ITEM)
@@ -251,8 +251,8 @@ class CommentsUseCaseTest : BaseUnitTest() {
 
         val headerItem = this[2]
         assertThat(headerItem.type).isEqualTo(HEADER)
-        assertThat((headerItem as Header).leftLabel).isEqualTo(R.string.stats_comments_author_label)
-        assertThat(headerItem.rightLabel).isEqualTo(R.string.stats_comments_label)
+        assertThat((headerItem as Header).startLabel).isEqualTo(R.string.stats_comments_author_label)
+        assertThat(headerItem.endLabel).isEqualTo(R.string.stats_comments_label)
 
         val userItem = this[3]
         assertThat(userItem.type).isEqualTo(LIST_ITEM_WITH_ICON)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/MostPopularInsightsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/MostPopularInsightsUseCaseTest.kt
@@ -115,12 +115,12 @@ class MostPopularInsightsUseCaseTest : BaseUnitTest() {
     private fun assertDayAndHour(blockListItem: BlockListItem) {
         assertThat(blockListItem.type).isEqualTo(QUICK_SCAN_ITEM)
         val item = blockListItem as QuickScanItem
-        assertThat(item.leftColumn.label).isEqualTo(R.string.stats_insights_best_day)
-        assertThat(item.leftColumn.value).isEqualTo(dayString)
-        assertThat(item.leftColumn.tooltip).isEqualTo("${highestDayPercent.roundToInt()}% of views")
-        assertThat(item.rightColumn.label).isEqualTo(R.string.stats_insights_best_hour)
-        assertThat(item.rightColumn.value).isEqualTo(hourString)
-        assertThat(item.rightColumn.tooltip).isEqualTo("${highestHourPercent.roundToInt()}% of views")
+        assertThat(item.startColumn.label).isEqualTo(R.string.stats_insights_best_day)
+        assertThat(item.startColumn.value).isEqualTo(dayString)
+        assertThat(item.startColumn.tooltip).isEqualTo("${highestDayPercent.roundToInt()}% of views")
+        assertThat(item.endColumn.label).isEqualTo(R.string.stats_insights_best_hour)
+        assertThat(item.endColumn.value).isEqualTo(hourString)
+        assertThat(item.endColumn.tooltip).isEqualTo("${highestHourPercent.roundToInt()}% of views")
     }
 
     private suspend fun loadMostPopularInsights(refresh: Boolean, forced: Boolean): UseCaseModel {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCaseTest.kt
@@ -78,8 +78,8 @@ class PublicizeUseCaseTest : BaseUnitTest() {
             assertThat(this).hasSize(3)
             assertTitle(this[0])
             val header = this[1] as Header
-            assertThat(header.leftLabel).isEqualTo(R.string.stats_publicize_service_label)
-            assertThat(header.rightLabel).isEqualTo(R.string.stats_publicize_followers_label)
+            assertThat(header.startLabel).isEqualTo(R.string.stats_publicize_service_label)
+            assertThat(header.endLabel).isEqualTo(R.string.stats_publicize_followers_label)
             assertThat(this[2]).isEqualTo(mockedItem)
         }
     }
@@ -109,8 +109,8 @@ class PublicizeUseCaseTest : BaseUnitTest() {
             assertThat(this).hasSize(4)
             assertTitle(this[0])
             val header = this[1] as Header
-            assertThat(header.leftLabel).isEqualTo(R.string.stats_publicize_service_label)
-            assertThat(header.rightLabel).isEqualTo(R.string.stats_publicize_followers_label)
+            assertThat(header.startLabel).isEqualTo(R.string.stats_publicize_service_label)
+            assertThat(header.endLabel).isEqualTo(R.string.stats_publicize_followers_label)
             assertThat(this[2]).isEqualTo(mockedItem)
             assertLink(this[3])
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCaseTest.kt
@@ -183,8 +183,8 @@ class TagsAndCategoriesUseCaseTest : BaseUnitTest() {
 
     private fun assertHeader(item: BlockListItem) {
         assertThat(item.type).isEqualTo(HEADER)
-        assertThat((item as Header).leftLabel).isEqualTo(R.string.stats_tags_and_categories_title_label)
-        assertThat(item.rightLabel).isEqualTo(R.string.stats_tags_and_categories_views_label)
+        assertThat((item as Header).startLabel).isEqualTo(R.string.stats_tags_and_categories_title_label)
+        assertThat(item.endLabel).isEqualTo(R.string.stats_tags_and_categories_views_label)
     }
 
     private fun assertSingleTag(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TodayStatsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TodayStatsUseCaseTest.kt
@@ -112,19 +112,19 @@ class TodayStatsUseCaseTest : BaseUnitTest() {
     private fun assertViewsAndVisitors(blockListItem: BlockListItem) {
         assertThat(blockListItem.type).isEqualTo(QUICK_SCAN_ITEM)
         val item = blockListItem as QuickScanItem
-        assertThat(item.leftColumn.label).isEqualTo(R.string.stats_views)
-        assertThat(item.leftColumn.value).isEqualTo(views.toString())
-        assertThat(item.rightColumn.label).isEqualTo(R.string.stats_visitors)
-        assertThat(item.rightColumn.value).isEqualTo(visitors.toString())
+        assertThat(item.startColumn.label).isEqualTo(R.string.stats_views)
+        assertThat(item.startColumn.value).isEqualTo(views.toString())
+        assertThat(item.endColumn.label).isEqualTo(R.string.stats_visitors)
+        assertThat(item.endColumn.value).isEqualTo(visitors.toString())
     }
 
     private fun assertLikesAndComments(blockListItem: BlockListItem) {
         assertThat(blockListItem.type).isEqualTo(QUICK_SCAN_ITEM)
         val item = blockListItem as QuickScanItem
-        assertThat(item.leftColumn.label).isEqualTo(R.string.stats_likes)
-        assertThat(item.leftColumn.value).isEqualTo(likes.toString())
-        assertThat(item.rightColumn.label).isEqualTo(R.string.stats_comments)
-        assertThat(item.rightColumn.value).isEqualTo(comments.toString())
+        assertThat(item.startColumn.label).isEqualTo(R.string.stats_likes)
+        assertThat(item.startColumn.value).isEqualTo(likes.toString())
+        assertThat(item.endColumn.label).isEqualTo(R.string.stats_comments)
+        assertThat(item.endColumn.value).isEqualTo(comments.toString())
     }
 
     private suspend fun loadTodayStats(refresh: Boolean, forced: Boolean): UseCaseModel {


### PR DESCRIPTION
Fixes #9542 
This PR fixes RTL in several parts of the refreshed stats:
* The Tabs on top of Comments/Followers are now aligned to the start
* The Header on the Post detail stats is fixed
* The posting activity label is now fixed
* I've renamed all the left/right fields to start/end to make it more clear

To test:
* Go to Stats in LTR
* The TabLayout on top of Comments/Followers didn't change
* The posting activity label didn't change
* Go to DWMY/Posts and Pages
* Click on a Post
* The first card ("Showing stats for") didn't change
* Change to RTL (either change language to something like Hebrew or force RTL in developer options)
* The TabLayout on top of Comments/Followers is aligned to the right
* The posting activity label works as expected (and starts from the right side)
* Go to DWMY/Posts and Pages
* Click on a Post
* The first card ("Showing stats for") is aligned to the right

![Screenshot_1554994473](https://user-images.githubusercontent.com/1079756/55967681-ffddc400-5c7a-11e9-980e-afb418e6009e.png)
![Screenshot_1554994447](https://user-images.githubusercontent.com/1079756/55967682-ffddc400-5c7a-11e9-9aea-c06c9e34a3a0.png)


