### PR TITLE
Post List: Move common logic to the main ViewModel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -49,7 +49,7 @@ class PostActionHandler(
     private val site: SiteModel,
     private val postStore: PostStore,
     private val postListDialogHelper: PostListDialogHelper,
-    private val postConflictResolver: PostConflictResolver,
+    private val doesPostHaveUnhandledConflict: (PostModel) -> Boolean,
     private val triggerPostListAction: (PostListAction) -> Unit,
     private val triggerPostUploadAction: (PostUploadAction) -> Unit,
     private val invalidateList: () -> Unit,
@@ -154,7 +154,7 @@ class PostActionHandler(
 
     private fun editPostButtonAction(site: SiteModel, post: PostModel) {
         // first of all, check whether this post is in Conflicted state.
-        if (postConflictResolver.doesPostHaveUnhandledConflict(post)) {
+        if (doesPostHaveUnhandledConflict.invoke(post)) {
             postListDialogHelper.showConflictedPostResolutionDialog(post)
             return
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -1,11 +1,11 @@
 package org.wordpress.android.ui.posts
 
-import android.app.Activity
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProvider
 import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentActivity
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
@@ -51,7 +51,7 @@ class PostListFragment : Fragment() {
     private var actionableEmptyView: ActionableEmptyView? = null
     private var progressLoadMore: ProgressBar? = null
 
-    private lateinit var nonNullActivity: Activity
+    private lateinit var nonNullActivity: FragmentActivity
     private lateinit var site: SiteModel
 
     private val postViewHolderConfig: PostViewHolderConfig by lazy {
@@ -101,9 +101,12 @@ class PostListFragment : Fragment() {
         val authorFilter: AuthorFilterSelection = requireNotNull(arguments)
                 .getSerializable(EXTRA_POST_LIST_AUTHOR_FILTER) as AuthorFilterSelection
         val postListType = requireNotNull(arguments).getSerializable(EXTRA_POST_LIST_TYPE) as PostListType
+        val mainViewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
+                .get(PostListMainViewModel::class.java)
+
         viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get<PostListViewModel>(PostListViewModel::class.java)
-        viewModel.start(site, authorFilter, postListType)
+        viewModel.start(mainViewModel.getPostListViewModelConnector(authorFilter, postListType))
         viewModel.pagedListData.observe(this, Observer {
             it?.let { pagedListData -> updatePagedListData(pagedListData) }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -52,6 +52,7 @@ class PostListFragment : Fragment() {
     private var progressLoadMore: ProgressBar? = null
 
     private lateinit var nonNullActivity: FragmentActivity
+    // TODO: We can get rid of SiteModel in the Fragment once we remove the `isPhotonCapable`
     private lateinit var site: SiteModel
 
     private val postViewHolderConfig: PostViewHolderConfig by lazy {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -4,9 +4,7 @@ import android.app.Activity
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProvider
 import android.arch.lifecycle.ViewModelProviders
-import android.content.Intent
 import android.os.Bundle
-import android.support.design.widget.Snackbar
 import android.support.v4.app.Fragment
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
@@ -19,14 +17,9 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActionableEmptyView
-import org.wordpress.android.ui.ActivityLauncher
-import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.adapters.PostListAdapter
-import org.wordpress.android.ui.uploads.UploadService
-import org.wordpress.android.ui.uploads.UploadUtils
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.ui.utils.UiString
-import org.wordpress.android.util.AccessibilityUtils
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.SiteUtils
@@ -123,95 +116,11 @@ class PostListFragment : Fragment() {
         viewModel.isLoadingMore.observe(this, Observer {
             progressLoadMore?.visibility = if (it == true) View.VISIBLE else View.GONE
         })
-        viewModel.postListAction.observe(this, Observer {
-            it?.let { action -> handlePostListAction(requireActivity(), action) }
-        })
-        viewModel.postUploadAction.observe(this, Observer {
-            it?.let { uploadAction -> handleUploadAction(uploadAction) }
-        })
-        viewModel.toastMessage.observe(this, Observer {
-            it?.show(nonNullActivity)
-        })
-        viewModel.snackBarAction.observe(this, Observer {
-            it?.let { snackBarHolder -> showSnackBar(snackBarHolder) }
-        })
-        viewModel.dialogAction.observe(this, Observer {
-            val fragmentManager = requireNotNull(fragmentManager) { "FragmentManager can't be null at this point" }
-            it?.show(nonNullActivity, fragmentManager, uiHelpers)
-        })
         viewModel.scrollToPosition.observe(this, Observer {
             it?.let { index ->
                 recyclerView?.scrollToPosition(index)
             }
         })
-    }
-
-    private fun showSnackBar(holder: SnackbarMessageHolder) {
-        nonNullActivity.findViewById<View>(R.id.coordinator)?.let { parent ->
-            val message = getString(holder.messageRes)
-            val duration = AccessibilityUtils.getSnackbarDuration(nonNullActivity)
-            val snackBar = Snackbar.make(parent, message, duration)
-            if (holder.buttonTitleRes != null) {
-                snackBar.setAction(getString(holder.buttonTitleRes)) {
-                    holder.buttonAction()
-                }
-            }
-            snackBar.addCallback(object : Snackbar.Callback() {
-                override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
-                    holder.onDismissAction()
-                    super.onDismissed(transientBottomBar, event)
-                }
-            })
-            snackBar.show()
-        }
-    }
-
-    private fun handleUploadAction(action: PostUploadAction) {
-        when (action) {
-            is PostUploadAction.EditPostResult -> {
-                UploadUtils.handleEditPostResultSnackbars(
-                        nonNullActivity,
-                        nonNullActivity.findViewById(R.id.coordinator),
-                        action.data,
-                        action.post,
-                        action.site
-                ) {
-                    action.publishAction()
-                }
-            }
-            is PostUploadAction.PublishPost -> {
-                UploadUtils.publishPost(
-                        nonNullActivity,
-                        action.post,
-                        action.site,
-                        action.dispatcher
-                )
-            }
-            is PostUploadAction.PostUploadedSnackbar -> {
-                UploadUtils.onPostUploadedSnackbarHandler(
-                        nonNullActivity,
-                        nonNullActivity.findViewById(R.id.coordinator),
-                        action.isError,
-                        action.post,
-                        action.errorMessage,
-                        action.site,
-                        action.dispatcher
-                )
-            }
-            is PostUploadAction.MediaUploadedSnackbar -> {
-                UploadUtils.onMediaUploadedSnackbarHandler(
-                        nonNullActivity,
-                        nonNullActivity.findViewById(R.id.coordinator),
-                        action.isError,
-                        action.mediaList,
-                        action.site,
-                        action.message
-                )
-            }
-            is PostUploadAction.CancelPostAndMediaUpload -> {
-                UploadService.cancelQueuedPostUploadAndRelatedMedia(nonNullActivity, action.post)
-            }
-        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -243,22 +152,6 @@ class PostListFragment : Fragment() {
         return view
     }
 
-    fun handleEditPostResult(resultCode: Int, data: Intent?) {
-        if (resultCode == Activity.RESULT_OK) {
-            if (data != null && EditPostActivity.checkToRestart(data)) {
-                ActivityLauncher.editPostOrPageForResult(
-                        data, nonNullActivity, site,
-                        data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0)
-                )
-
-                // a restart will happen so, no need to continue here
-                return
-            }
-
-            viewModel.handleEditPostResult(data)
-        }
-    }
-
     private fun updatePagedListData(pagedListData: PagedPostList) {
         postListAdapter.submitList(pagedListData)
     }
@@ -283,18 +176,6 @@ class PostListFragment : Fragment() {
     ) {
         uiHelpers.setTextOrHide(buttonView, text)
         buttonView.setOnClickListener { onButtonClick?.invoke() }
-    }
-
-    fun onPositiveClickedForBasicDialog(instanceTag: String) {
-        viewModel.onPositiveClickedForBasicDialog(instanceTag)
-    }
-
-    fun onNegativeClickedForBasicDialog(instanceTag: String) {
-        viewModel.onNegativeClickedForBasicDialog(instanceTag)
-    }
-
-    fun onDismissByOutsideTouchForBasicDialog(instanceTag: String) {
-        viewModel.onDismissByOutsideTouchForBasicDialog(instanceTag)
     }
 
     fun scrollToTargetPost(localPostId: LocalPostId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -7,14 +7,12 @@ import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
 import android.content.Intent
-import android.support.annotation.ColorRes
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.wordpress.android.R
 import org.wordpress.android.R.string
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.ListActionBuilder
@@ -173,7 +171,7 @@ class PostListMainViewModel @Inject constructor(
                 postActionHandler = postActionHandler,
                 handlePostUpdatedWithoutError = postConflictResolver::onPostSuccessfullyUpdated,
                 handlePostUploadedWithoutError = {
-                    TODO("Fetch the first page of the lists so their id is added to the ListStore")
+                    // TODO("Fetch the first page of the lists so their id is added to the ListStore")
                 },
                 triggerPostUploadAction = { _postUploadAction.postValue(it) },
                 invalidateUploadStatus = {
@@ -192,7 +190,7 @@ class PostListMainViewModel @Inject constructor(
                 isFabVisible = FAB_VISIBLE_POST_LIST_PAGES.contains(POST_LIST_PAGES.first()),
                 isAuthorFilterVisible = site.isUsingWpComRestApi,
                 authorFilterSelection = authorFilterSelection,
-                authorFilterItems = getAuthorFilterItems(authorFilterSelection)
+                authorFilterItems = getAuthorFilterItems(authorFilterSelection, accountStore.account?.avatarUrl)
         )
         lifecycleRegistry.markState(Lifecycle.State.STARTED)
     }
@@ -203,6 +201,7 @@ class PostListMainViewModel @Inject constructor(
         super.onCleared()
     }
 
+    // TODO: We shouldn't need to pass the AuthorFilterSelection to fragments and get it back, we have that info already
     fun getPostListViewModelConnector(
         authorFilter: AuthorFilterSelection,
         postListType: PostListType
@@ -239,7 +238,7 @@ class PostListMainViewModel @Inject constructor(
 
         updateViewStateTriggerPagerChange(
                 authorFilterSelection = selection,
-                authorFilterItems = getAuthorFilterItems(selection)
+                authorFilterItems = getAuthorFilterItems(selection, accountStore.account?.avatarUrl)
         )
         prefs.postListAuthorSelection = selection
     }
@@ -296,19 +295,6 @@ class PostListMainViewModel @Inject constructor(
         )
     }
 
-    private fun getAuthorFilterItems(selection: AuthorFilterSelection): List<AuthorFilterListItemUIState> {
-        return AuthorFilterSelection.values().map { value ->
-            @ColorRes val backgroundColorRes: Int =
-                    if (selection == value) R.color.grey_lighten_30_translucent_50
-                    else R.color.transparent
-
-            when (value) {
-                ME -> AuthorFilterListItemUIState.Me(accountStore.account?.avatarUrl, backgroundColorRes)
-                EVERYONE -> AuthorFilterListItemUIState.Everyone(backgroundColorRes)
-            }
-        }
-    }
-
     /**
      * Only the non-null variables will be changed in the current state
      */
@@ -334,7 +320,6 @@ class PostListMainViewModel @Inject constructor(
         }
     }
 
-    // TODO: This might not be the best way to invalidate lists
     private fun invalidateAllLists() {
         val listTypeIdentifier = PostListDescriptor.calculateTypeIdentifier(site.id)
         dispatcher.dispatch(ListActionBuilder.newListRequiresRefreshAction(listTypeIdentifier))

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.helpers.DialogHolder
 import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.LocalPostId
+import org.wordpress.android.viewmodel.posts.PostListViewModelConnector
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
@@ -116,7 +117,7 @@ class PostListMainViewModel @Inject constructor(
                 refreshList = this::invalidateAllLists,
                 triggerPostUploadAction = { _postUploadAction.postValue(it) },
                 invalidateUploadStatus = {
-                    uploadStatesTracker.invalidateUploadStatus(it)
+                    uploadStatusTracker.invalidateUploadStatus(it)
                     invalidateAllLists()
                 },
                 invalidateFeaturedMedia = {
@@ -218,7 +219,7 @@ class PostListMainViewModel @Inject constructor(
     /**
      */
 
-    private val uploadStatesTracker = PostListUploadStatusTracker(uploadStore = uploadStore)
+    private val uploadStatusTracker = PostListUploadStatusTracker(uploadStore = uploadStore)
     private val featuredImageTracker = PostListFeaturedImageTracker(dispatcher = dispatcher, mediaStore = mediaStore)
 
     private val postListDialogHelper: PostListDialogHelper by lazy {
@@ -257,7 +258,7 @@ class PostListMainViewModel @Inject constructor(
     }
 
     private fun invalidateAllLists() {
-        TODO()
+//        TODO()
     }
 
     private fun checkNetworkConnection(): Boolean =
@@ -294,6 +295,25 @@ class PostListMainViewModel @Inject constructor(
         postListDialogHelper.onDismissByOutsideTouchForBasicDialog(
                 instanceTag = instanceTag,
                 updateConflictedPostWithLocalVersion = postConflictResolver::updateConflictedPostWithLocalVersion
+        )
+    }
+
+    /**
+     *
+     */
+
+    fun getPostListViewModelConnector(
+        authorFilter: AuthorFilterSelection,
+        postListType: PostListType
+    ): PostListViewModelConnector {
+        return PostListViewModelConnector(
+                site = site,
+                postListType = postListType,
+                authorFilter = authorFilter,
+                postActionHandler = postActionHandler,
+                featuredImageTracker = featuredImageTracker,
+                uploadStatusTracker = uploadStatusTracker,
+                postConflictResolver = postConflictResolver
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -21,9 +21,13 @@ import org.wordpress.android.fluxc.generated.ListActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.list.AuthorFilter
 import org.wordpress.android.fluxc.model.list.PostListDescriptor
+import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescriptorForRestSite
+import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescriptorForXmlRpcSite
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.ListStore
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.UploadStore
@@ -43,6 +47,7 @@ import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.helpers.DialogHolder
 import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
+import org.wordpress.android.viewmodel.posts.PostListItemDataSource
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.LocalPostId
 import org.wordpress.android.viewmodel.posts.PostListItemUiStateHelper
 import org.wordpress.android.viewmodel.posts.PostListViewModelConnector
@@ -58,6 +63,7 @@ class PostListMainViewModel @Inject constructor(
     private val dispatcher: Dispatcher,
     private val postStore: PostStore,
     private val accountStore: AccountStore,
+    private val listStore: ListStore,
     uploadStore: UploadStore,
     mediaStore: MediaStore,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
@@ -144,14 +150,20 @@ class PostListMainViewModel @Inject constructor(
         SiteUtils.isAccessedViaWPComRest(site) && site.hasCapabilityViewStats
     }
 
+    private val postListItemDataSource: PostListItemDataSource by lazy {
+        PostListItemDataSource(
+            dispatcher = dispatcher,
+            postStore = postStore,
+            transform = this::transformPostModelToPostListItemUiState
+        )
+    }
+
     init {
         lifecycleRegistry.markState(Lifecycle.State.CREATED)
     }
 
     fun start(site: SiteModel) {
         this.site = site
-
-        val authorFilterSelection: AuthorFilterSelection = prefs.postListAuthorSelection
 
         listenForPostListEvents(
                 lifecycle = lifecycle,
@@ -173,6 +185,8 @@ class PostListMainViewModel @Inject constructor(
                     invalidateAllLists()
                 }
         )
+
+        val authorFilterSelection: AuthorFilterSelection = prefs.postListAuthorSelection
         _updatePostsPager.value = authorFilterSelection
         _viewState.value = PostListMainViewState(
                 isFabVisible = FAB_VISIBLE_POST_LIST_PAGES.contains(POST_LIST_PAGES.first()),
@@ -193,12 +207,26 @@ class PostListMainViewModel @Inject constructor(
         authorFilter: AuthorFilterSelection,
         postListType: PostListType
     ): PostListViewModelConnector {
+        val listDescriptor = if (site.isUsingWpComRestApi) {
+            val author: AuthorFilter = when (authorFilter) {
+                ME -> AuthorFilter.SpecificAuthor(accountStore.account.userId)
+                EVERYONE -> AuthorFilter.Everyone
+            }
+
+            PostListDescriptorForRestSite(
+                    site = site,
+                    statusList = postListType.postStatuses,
+                    author = author
+            )
+        } else {
+            PostListDescriptorForXmlRpcSite(site = site, statusList = postListType.postStatuses)
+        }
         return PostListViewModelConnector(
-                site = site,
                 postListType = postListType,
-                authorFilter = authorFilter,
                 newPost = postActionHandler::newPost,
-                transformPostModelToPostListItemUiState = this::transformPostModelToPostListItemUiState
+                createPagedListWrapper = {
+                    listStore.getList(listDescriptor, postListItemDataSource, lifecycle)
+                }
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -150,10 +150,11 @@ class PostListMainViewModel @Inject constructor(
                 dispatcher = dispatcher,
                 postStore = postStore,
                 site = site,
-                postConflictResolver = postConflictResolver,
                 postActionHandler = postActionHandler,
-                // TODO: Do we have to refresh all lists
-                refreshList = this::invalidateAllLists,
+                handlePostUpdatedWithoutError = postConflictResolver::onPostSuccessfullyUpdated,
+                handlePostUploadedWithoutError = {
+                    TODO("Fetch the first page of the lists so their id is added to the ListStore")
+                },
                 triggerPostUploadAction = { _postUploadAction.postValue(it) },
                 invalidateUploadStatus = {
                     uploadStatusTracker.invalidateUploadStatus(it)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewState.kt
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.posts
 
 import android.support.annotation.ColorRes
 import org.wordpress.android.R
+import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
+import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.image.ImageType
@@ -37,4 +39,20 @@ sealed class AuthorFilterListItemUIState(
             imageType = AVATAR_WITH_BACKGROUND,
             dropDownBackground = dropDownBackground
     )
+}
+
+fun getAuthorFilterItems(
+    selection: AuthorFilterSelection,
+    avatarUrl: String?
+): List<AuthorFilterListItemUIState> {
+    return AuthorFilterSelection.values().map { value ->
+        @ColorRes val backgroundColorRes: Int =
+                if (selection == value) R.color.grey_lighten_30_translucent_50
+                else R.color.transparent
+
+        when (value) {
+            ME -> AuthorFilterListItemUIState.Me(avatarUrl, backgroundColorRes)
+            EVERYONE -> AuthorFilterListItemUIState.Everyone(backgroundColorRes)
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadAction.kt
@@ -88,4 +88,3 @@ fun handleUploadAction(action: PostUploadAction, activity: Activity, snackbarAtt
         }
     }
 }
-

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadAction.kt
@@ -1,10 +1,14 @@
 package org.wordpress.android.ui.posts
 
+import android.app.Activity
 import android.content.Intent
+import android.view.View
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.uploads.UploadService
+import org.wordpress.android.ui.uploads.UploadUtils
 
 sealed class PostUploadAction {
     class EditPostResult(
@@ -36,3 +40,52 @@ sealed class PostUploadAction {
      */
     class CancelPostAndMediaUpload(val post: PostModel) : PostUploadAction()
 }
+
+fun handleUploadAction(action: PostUploadAction, activity: Activity, snackbarAttachView: View) {
+    when (action) {
+        is PostUploadAction.EditPostResult -> {
+            UploadUtils.handleEditPostResultSnackbars(
+                    activity,
+                    snackbarAttachView,
+                    action.data,
+                    action.post,
+                    action.site
+            ) {
+                action.publishAction()
+            }
+        }
+        is PostUploadAction.PublishPost -> {
+            UploadUtils.publishPost(
+                    activity,
+                    action.post,
+                    action.site,
+                    action.dispatcher
+            )
+        }
+        is PostUploadAction.PostUploadedSnackbar -> {
+            UploadUtils.onPostUploadedSnackbarHandler(
+                    activity,
+                    snackbarAttachView,
+                    action.isError,
+                    action.post,
+                    action.errorMessage,
+                    action.site,
+                    action.dispatcher
+            )
+        }
+        is PostUploadAction.MediaUploadedSnackbar -> {
+            UploadUtils.onMediaUploadedSnackbarHandler(
+                    activity,
+                    snackbarAttachView,
+                    action.isError,
+                    action.mediaList,
+                    action.site,
+                    action.message
+            )
+        }
+        is PostUploadAction.CancelPostAndMediaUpload -> {
+            UploadService.cancelQueuedPostUploadAndRelatedMedia(activity, action.post)
+        }
+    }
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -59,10 +59,6 @@ class PostsListActivity : AppCompatActivity(),
     private lateinit var pager: ViewPager
     private lateinit var fab: FloatingActionButton
 
-    // TODO: Remove this
-    private val currentFragment: PostListFragment?
-        get() = postsPagerAdapter.getItemAtPosition(pager.currentItem)
-
     private var onPageChangeListener: OnPageChangeListener = object : OnPageChangeListener {
         override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {}
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.posts
 
+import android.app.Activity
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProvider
 import android.arch.lifecycle.ViewModelProviders
@@ -22,14 +23,16 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.ActivityId
+import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogNegativeClickInterface
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogOnDismissByOutsideTouchInterface
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface
 import org.wordpress.android.ui.posts.adapters.AuthorSelectionAdapter
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.AccessibilityUtils
 import org.wordpress.android.util.AppLog
-import org.wordpress.android.util.CrashlyticsUtils
 import org.wordpress.android.util.LocaleManager
 import javax.inject.Inject
 
@@ -56,6 +59,7 @@ class PostsListActivity : AppCompatActivity(),
     private lateinit var pager: ViewPager
     private lateinit var fab: FloatingActionButton
 
+    // TODO: Remove this
     private val currentFragment: PostListFragment?
         get() = postsPagerAdapter.getItemAtPosition(pager.currentItem)
 
@@ -204,14 +208,43 @@ class PostsListActivity : AppCompatActivity(),
             }
         })
         viewModel.snackBarMessage.observe(this, Observer {
-            it?.let { uiString ->
-                Snackbar.make(
-                        findViewById(R.id.coordinator),
-                        getString(it.messageRes),
-                        Snackbar.LENGTH_LONG
-                ).show()
+            it?.let { snackBarHolder -> showSnackBar(snackBarHolder) }
+        })
+        viewModel.dialogAction.observe(this, Observer {
+            it?.show(this, supportFragmentManager, uiHelpers)
+        })
+        viewModel.toastMessage.observe(this, Observer {
+            it?.show(this)
+        })
+        viewModel.postUploadAction.observe(this, Observer {
+            it?.let { uploadAction ->
+                handleUploadAction(
+                        uploadAction,
+                        this@PostsListActivity,
+                        findViewById(R.id.coordinator)
+                )
             }
         })
+    }
+
+    private fun showSnackBar(holder: SnackbarMessageHolder) {
+        findViewById<View>(R.id.coordinator)?.let { parent ->
+            val message = getString(holder.messageRes)
+            val duration = AccessibilityUtils.getSnackbarDuration(this)
+            val snackBar = Snackbar.make(parent, message, duration)
+            if (holder.buttonTitleRes != null) {
+                snackBar.setAction(getString(holder.buttonTitleRes)) {
+                    holder.buttonAction()
+                }
+            }
+            snackBar.addCallback(object : Snackbar.Callback() {
+                override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
+                    holder.onDismissAction()
+                    super.onDismissed(transientBottomBar, event)
+                }
+            })
+            snackBar.show()
+        }
     }
 
     private fun loadIntentData(intent: Intent) {
@@ -229,8 +262,18 @@ class PostsListActivity : AppCompatActivity(),
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
 
-        if (requestCode == RequestCodes.EDIT_POST) {
-            currentFragment?.handleEditPostResult(resultCode, data) ?: logFragmentNullError()
+        if (requestCode == RequestCodes.EDIT_POST && resultCode == Activity.RESULT_OK) {
+            if (data != null && EditPostActivity.checkToRestart(data)) {
+                ActivityLauncher.editPostOrPageForResult(
+                        data, this, site,
+                        data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0)
+                )
+
+                // a restart will happen so, no need to continue here
+                return
+            }
+
+            viewModel.handleEditPostResult(data)
         }
     }
 
@@ -250,19 +293,14 @@ class PostsListActivity : AppCompatActivity(),
     // BasicDialogFragment Callbacks
 
     override fun onPositiveClicked(instanceTag: String) {
-        currentFragment?.onPositiveClickedForBasicDialog(instanceTag) ?: logFragmentNullError()
+        viewModel.onPositiveClickedForBasicDialog(instanceTag)
     }
 
     override fun onNegativeClicked(instanceTag: String) {
-        currentFragment?.onNegativeClickedForBasicDialog(instanceTag) ?: logFragmentNullError()
+        viewModel.onNegativeClickedForBasicDialog(instanceTag)
     }
 
     override fun onDismissByOutsideTouch(instanceTag: String) {
-        currentFragment?.onDismissByOutsideTouchForBasicDialog(instanceTag) ?: logFragmentNullError()
-    }
-
-    private fun logFragmentNullError() {
-        AppLog.e(AppLog.T.POSTS, "CurrentFragment should never be null.")
-        CrashlyticsUtils.log("${PostsListActivity::class.java}: CurrentFragment should never be null.")
+        viewModel.onDismissByOutsideTouchForBasicDialog(instanceTag)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -187,17 +187,6 @@ class PostListViewModel @Inject constructor(
         }?.index
     }
 
-    private val dummyUploadStatus = PostListItemUploadStatus(
-            uploadError = null,
-            mediaUploadProgress = 0,
-            isUploading = false,
-            isUploadingOrQueued = false,
-            isQueued = false,
-            isUploadFailed = false,
-            hasInProgressMediaUpload = false,
-            hasPendingMediaUpload = false
-    )
-
     private fun transformPostModelToPostListItemUiState(post: PostModel) =
             listItemUiStateHelper.createPostListItemUiState(
                     post = post,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -8,10 +8,7 @@ import android.arch.lifecycle.MediatorLiveData
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModel
 import android.arch.paging.PagedList
-import android.content.Intent
-import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.list.AuthorFilter
@@ -21,32 +18,18 @@ import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescrip
 import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescriptorForXmlRpcSite
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.ListStore
-import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.PostStore
-import org.wordpress.android.fluxc.store.UploadStore
-import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
 import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
-import org.wordpress.android.ui.posts.PostActionHandler
-import org.wordpress.android.ui.posts.PostConflictResolver
-import org.wordpress.android.ui.posts.PostListAction
-import org.wordpress.android.ui.posts.PostListDialogHelper
-import org.wordpress.android.ui.posts.PostListFeaturedImageTracker
 import org.wordpress.android.ui.posts.PostListType
-import org.wordpress.android.ui.posts.PostListUploadStatusTracker
-import org.wordpress.android.ui.posts.PostUploadAction
 import org.wordpress.android.ui.posts.PostUtils
-import org.wordpress.android.ui.posts.listenForPostListEvents
 import org.wordpress.android.ui.posts.trackPostListAction
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.SiteUtils
-import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus
-import org.wordpress.android.viewmodel.helpers.DialogHolder
-import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
 import org.wordpress.android.viewmodel.posts.PostListEmptyUiState.RefreshError
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.LocalPostId
 import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
@@ -57,8 +40,6 @@ typealias PagedPostList = PagedList<PostListItemType>
 class PostListViewModel @Inject constructor(
     private val dispatcher: Dispatcher,
     private val listStore: ListStore,
-    uploadStore: UploadStore,
-    mediaStore: MediaStore,
     private val postStore: PostStore,
     private val accountStore: AccountStore,
     private val listItemUiStateHelper: PostListItemUiStateHelper,
@@ -73,25 +54,7 @@ class PostListViewModel @Inject constructor(
     private lateinit var site: SiteModel
     private lateinit var postListType: PostListType
 
-    private val uploadStatesTracker = PostListUploadStatusTracker(uploadStore = uploadStore)
-    private val featuredImageTracker = PostListFeaturedImageTracker(dispatcher = dispatcher, mediaStore = mediaStore)
-
     private var scrollToLocalPostId: LocalPostId? = null
-
-    private val _postListAction = SingleLiveEvent<PostListAction>()
-    val postListAction: LiveData<PostListAction> = _postListAction
-
-    private val _postUploadAction = SingleLiveEvent<PostUploadAction>()
-    val postUploadAction: LiveData<PostUploadAction> = _postUploadAction
-
-    private val _toastMessage = SingleLiveEvent<ToastMessageHolder>()
-    val toastMessage: LiveData<ToastMessageHolder> = _toastMessage
-
-    private val _dialogAction = SingleLiveEvent<DialogHolder>()
-    val dialogAction: LiveData<DialogHolder> = _dialogAction
-
-    private val _snackBarAction = SingleLiveEvent<SnackbarMessageHolder>()
-    val snackBarAction: LiveData<SnackbarMessageHolder> = _snackBarAction
 
     private val _scrollToPosition = SingleLiveEvent<Int>()
     val scrollToPosition: LiveData<Int> = _scrollToPosition
@@ -131,7 +94,8 @@ class PostListViewModel @Inject constructor(
                     isListEmpty = pagedListWrapper.isEmpty.value ?: true,
                     error = pagedListWrapper.listError.value,
                     fetchFirstPage = this::fetchFirstPage,
-                    newPost = postActionHandler::newPost
+                    // TODO!!!
+                    newPost = {}//postActionHandler::newPost
             )
         }
         result.addSource(pagedListWrapper.isEmpty) { result.value = update() }
@@ -140,45 +104,8 @@ class PostListViewModel @Inject constructor(
         result
     }
 
-    private val postListDialogHelper: PostListDialogHelper by lazy {
-        PostListDialogHelper(
-                showDialog = { _dialogAction.postValue(it) },
-                checkNetworkConnection = this::checkNetworkConnection
-        )
-    }
-
-    private val postConflictResolver: PostConflictResolver by lazy {
-        PostConflictResolver(
-                dispatcher = dispatcher,
-                postStore = postStore,
-                site = site,
-                invalidateList = { pagedListWrapper.invalidateData() },
-                checkNetworkConnection = this::checkNetworkConnection,
-                showSnackbar = { _snackBarAction.postValue(it) },
-                showToast = { _toastMessage.postValue(it) }
-        )
-    }
-
-    private val postActionHandler: PostActionHandler by lazy {
-        PostActionHandler(
-                dispatcher = dispatcher,
-                site = site,
-                postStore = postStore,
-                postListDialogHelper = postListDialogHelper,
-                postConflictResolver = postConflictResolver,
-                triggerPostListAction = { _postListAction.postValue(it) },
-                triggerPostUploadAction = { _postUploadAction.postValue(it) },
-                invalidateList = { pagedListWrapper.invalidateData() },
-                checkNetworkConnection = this::checkNetworkConnection,
-                showSnackbar = { _snackBarAction.postValue(it) },
-                showToast = { _toastMessage.postValue(it) }
-        )
-    }
-
     private val lifecycleRegistry = LifecycleRegistry(this)
     override fun getLifecycle(): Lifecycle = lifecycleRegistry
-
-    // Lifecycle
 
     init {
         connectionStatus.observe(this, Observer {
@@ -205,24 +132,6 @@ class PostListViewModel @Inject constructor(
             PostListDescriptorForXmlRpcSite(site = site, statusList = postListType.postStatuses)
         }
 
-        listenForPostListEvents(
-                lifecycle = lifecycle,
-                dispatcher = dispatcher,
-                postStore = postStore,
-                site = site,
-                postConflictResolver = postConflictResolver,
-                postActionHandler = postActionHandler,
-                refreshList = { pagedListWrapper.invalidateData() },
-                triggerPostUploadAction = { _postUploadAction.postValue(it) },
-                invalidateUploadStatus = {
-                    uploadStatesTracker.invalidateUploadStatus(it)
-                    pagedListWrapper.invalidateData()
-                },
-                invalidateFeaturedMedia = {
-                    featuredImageTracker.invalidateFeaturedMedia(it)
-                    pagedListWrapper.invalidateData()
-                }
-        )
         isStarted = true
         lifecycleRegistry.markState(Lifecycle.State.STARTED)
         fetchFirstPage()
@@ -239,10 +148,6 @@ class PostListViewModel @Inject constructor(
         pagedListWrapper.fetchFirstPage()
     }
 
-    fun handleEditPostResult(data: Intent?) {
-        postActionHandler.handleEditPostResult(data)
-    }
-
     fun scrollToPost(localPostId: LocalPostId) {
         val data = pagedListData.value
         if (data != null) {
@@ -251,31 +156,6 @@ class PostListViewModel @Inject constructor(
             // store the target post id and scroll there when the data is loaded
             scrollToLocalPostId = localPostId
         }
-    }
-
-    // BasicFragmentDialog Events
-
-    fun onPositiveClickedForBasicDialog(instanceTag: String) {
-        postListDialogHelper.onPositiveClickedForBasicDialog(
-                instanceTag = instanceTag,
-                deletePost = postActionHandler::deletePost,
-                publishPost = postActionHandler::publishPost,
-                updateConflictedPostWithRemoteVersion = postConflictResolver::updateConflictedPostWithRemoteVersion
-        )
-    }
-
-    fun onNegativeClickedForBasicDialog(instanceTag: String) {
-        postListDialogHelper.onNegativeClickedForBasicDialog(
-                instanceTag = instanceTag,
-                updateConflictedPostWithLocalVersion = postConflictResolver::updateConflictedPostWithLocalVersion
-        )
-    }
-
-    fun onDismissByOutsideTouchForBasicDialog(instanceTag: String) {
-        postListDialogHelper.onDismissByOutsideTouchForBasicDialog(
-                instanceTag = instanceTag,
-                updateConflictedPostWithLocalVersion = postConflictResolver::updateConflictedPostWithLocalVersion
-        )
     }
 
     // Utils
@@ -305,23 +185,35 @@ class PostListViewModel @Inject constructor(
         }?.index
     }
 
+    private val dummyUploadStatus = PostListItemUploadStatus(
+            uploadError = null,
+            mediaUploadProgress = 0,
+            isUploading = false,
+            isUploadingOrQueued = false,
+            isQueued = false,
+            isUploadFailed = false,
+            hasInProgressMediaUpload = false,
+            hasPendingMediaUpload = false
+    )
+
     private fun transformPostModelToPostListItemUiState(post: PostModel) =
+    // TODO!!!
             listItemUiStateHelper.createPostListItemUiState(
                     post = post,
-                    uploadStatus = uploadStatesTracker.getUploadStatus(post),
-                    unhandledConflicts = postConflictResolver.doesPostHaveUnhandledConflict(post),
+                    uploadStatus = dummyUploadStatus,//uploadStatesTracker.getUploadStatus(post),
+                    unhandledConflicts = false, //postConflictResolver.doesPostHaveUnhandledConflict(post),
                     capabilitiesToPublish = site.hasCapabilityPublishPosts,
                     statsSupported = isStatsSupported,
-                    featuredImageUrl = featuredImageTracker.getFeaturedImageUrl(
-                            site = site,
-                            featuredImageId = post.featuredImageId,
-                            postContent = post.content
-                    ),
+                    featuredImageUrl = null, //featuredImageTracker.getFeaturedImageUrl(
+//                            site = site,
+//                            featuredImageId = post.featuredImageId,
+//                            postContent = post.content
+//                    ),
                     formattedDate = PostUtils.getFormattedDate(post),
-                    performingCriticalAction = postActionHandler.isPerformingCriticalAction(LocalId(post.id))
+                    performingCriticalAction = false //postActionHandler.isPerformingCriticalAction(LocalId(post.id))
             ) { postModel, buttonType, statEvent ->
                 trackPostListAction(site, buttonType, postModel, statEvent)
-                postActionHandler.handlePostButton(buttonType, postModel)
+//                postActionHandler.handlePostButton(buttonType, postModel)
             }
 
     private fun retryOnConnectionAvailableAfterRefreshError() {
@@ -332,12 +224,4 @@ class PostListViewModel @Inject constructor(
             fetchFirstPage()
         }
     }
-
-    private fun checkNetworkConnection(): Boolean =
-            if (networkUtilsWrapper.isNetworkAvailable()) {
-                true
-            } else {
-                _toastMessage.postValue(ToastMessageHolder(R.string.no_network_message, Duration.SHORT))
-                false
-            }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -8,24 +8,9 @@ import android.arch.lifecycle.MediatorLiveData
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModel
 import android.arch.paging.PagedList
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
-import org.wordpress.android.fluxc.model.PostModel
-import org.wordpress.android.fluxc.model.list.AuthorFilter
 import org.wordpress.android.fluxc.model.list.PagedListWrapper
-import org.wordpress.android.fluxc.model.list.PostListDescriptor
-import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescriptorForRestSite
-import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescriptorForXmlRpcSite
-import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.fluxc.store.ListStore
-import org.wordpress.android.fluxc.store.PostStore
-import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
-import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
-import org.wordpress.android.ui.posts.PostUtils
-import org.wordpress.android.ui.posts.trackPostListAction
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
-import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus
 import org.wordpress.android.viewmodel.posts.PostListEmptyUiState.RefreshError
@@ -36,15 +21,10 @@ import javax.inject.Inject
 typealias PagedPostList = PagedList<PostListItemType>
 
 class PostListViewModel @Inject constructor(
-    private val dispatcher: Dispatcher,
-    private val listStore: ListStore,
-    private val postStore: PostStore,
-    private val accountStore: AccountStore,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     connectionStatus: LiveData<ConnectionStatus>
 ) : ViewModel(), LifecycleOwner {
     private var isStarted: Boolean = false
-    private var listDescriptor: PostListDescriptor? = null
     private lateinit var connector: PostListViewModelConnector
 
     private var scrollToLocalPostId: LocalPostId? = null
@@ -53,15 +33,7 @@ class PostListViewModel @Inject constructor(
     val scrollToPosition: LiveData<Int> = _scrollToPosition
 
     private val pagedListWrapper: PagedListWrapper<PostListItemType> by lazy {
-        val listDescriptor = requireNotNull(listDescriptor) {
-            "ListDescriptor needs to be initialized before this is observed!"
-        }
-        val dataSource = PostListItemDataSource(
-                dispatcher = dispatcher,
-                postStore = postStore,
-                transform = connector.transformPostModelToPostListItemUiState
-        )
-        listStore.getList(listDescriptor, dataSource, lifecycle)
+        connector.createPagedListWrapper(lifecycle)
     }
 
     val isFetchingFirstPage: LiveData<Boolean> by lazy { pagedListWrapper.isFetchingFirstPage }
@@ -111,21 +83,6 @@ class PostListViewModel @Inject constructor(
             return
         }
         connector = postListViewModelConnector
-
-        this.listDescriptor = if (connector.site.isUsingWpComRestApi) {
-            val author: AuthorFilter = when (postListViewModelConnector.authorFilter) {
-                ME -> AuthorFilter.SpecificAuthor(accountStore.account.userId)
-                EVERYONE -> AuthorFilter.Everyone
-            }
-
-            PostListDescriptorForRestSite(
-                    site = connector.site,
-                    statusList = connector.postListType.postStatuses,
-                    author = author
-            )
-        } else {
-            PostListDescriptorForXmlRpcSite(site = connector.site, statusList = connector.postListType.postStatuses)
-        }
 
         isStarted = true
         lifecycleRegistry.markState(Lifecycle.State.STARTED)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -11,7 +11,6 @@ import android.arch.paging.PagedList
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.PostModel
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.list.AuthorFilter
 import org.wordpress.android.fluxc.model.list.PagedListWrapper
 import org.wordpress.android.fluxc.model.list.PostListDescriptor
@@ -20,10 +19,8 @@ import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescrip
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.ListStore
 import org.wordpress.android.fluxc.store.PostStore
-import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
 import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
-import org.wordpress.android.ui.posts.PostListType
 import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.ui.posts.trackPostListAction
 import org.wordpress.android.util.AppLog

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
@@ -1,11 +1,15 @@
 package org.wordpress.android.viewmodel.posts
 
-import android.arch.lifecycle.Lifecycle
-import org.wordpress.android.fluxc.model.list.PagedListWrapper
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.PostListType
+import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
 
 class PostListViewModelConnector(
+    val site: SiteModel,
     val postListType: PostListType,
+    val authorFilter: AuthorFilterSelection,
     val newPost: () -> Unit,
-    val createPagedListWrapper: (Lifecycle) -> PagedListWrapper<PostListItemType>
+    val transformPostModelToPostListItemUiState: (PostModel) -> PostListItemUiState
 )

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
@@ -3,13 +3,19 @@ package org.wordpress.android.viewmodel.posts
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.AuthorFilterSelection
+import org.wordpress.android.ui.posts.PostActionHandler
 import org.wordpress.android.ui.posts.PostListType
-import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
 
 class PostListViewModelConnector(
     val site: SiteModel,
     val postListType: PostListType,
     val authorFilter: AuthorFilterSelection,
-    val newPost: () -> Unit,
-    val transformPostModelToPostListItemUiState: (PostModel) -> PostListItemUiState
-)
+    val postActionHandler: PostActionHandler,
+    val getUploadStatus: (PostModel) -> PostListItemUploadStatus,
+    val doesPostHaveUnhandledConflict: (PostModel) -> Boolean,
+    private val getFeaturedImageUrl: (site: SiteModel, featuredImageId: Long, postContent: String) -> String?
+) {
+    fun getFeaturedImageUrl(featuredImageId: Long, postContent: String): String? {
+        return getFeaturedImageUrl.invoke(site, featuredImageId, postContent)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
@@ -1,19 +1,15 @@
 package org.wordpress.android.viewmodel.posts
 
+import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.AuthorFilterSelection
-import org.wordpress.android.ui.posts.PostActionHandler
-import org.wordpress.android.ui.posts.PostConflictResolver
-import org.wordpress.android.ui.posts.PostListFeaturedImageTracker
 import org.wordpress.android.ui.posts.PostListType
-import org.wordpress.android.ui.posts.PostListUploadStatusTracker
+import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
 
 class PostListViewModelConnector(
     val site: SiteModel,
     val postListType: PostListType,
     val authorFilter: AuthorFilterSelection,
-    val postActionHandler: PostActionHandler,
-    val featuredImageTracker: PostListFeaturedImageTracker,
-    val uploadStatusTracker: PostListUploadStatusTracker,
-    val postConflictResolver: PostConflictResolver
+    val newPost: () -> Unit,
+    val transformPostModelToPostListItemUiState: (PostModel) -> PostListItemUiState
 )

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
@@ -1,15 +1,11 @@
 package org.wordpress.android.viewmodel.posts
 
-import org.wordpress.android.fluxc.model.PostModel
-import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.ui.posts.AuthorFilterSelection
+import android.arch.lifecycle.Lifecycle
+import org.wordpress.android.fluxc.model.list.PagedListWrapper
 import org.wordpress.android.ui.posts.PostListType
-import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
 
 class PostListViewModelConnector(
-    val site: SiteModel,
     val postListType: PostListType,
-    val authorFilter: AuthorFilterSelection,
     val newPost: () -> Unit,
-    val transformPostModelToPostListItemUiState: (PostModel) -> PostListItemUiState
+    val createPagedListWrapper: (Lifecycle) -> PagedListWrapper<PostListItemType>
 )

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.viewmodel.posts
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.posts.AuthorFilterSelection
+import org.wordpress.android.ui.posts.PostActionHandler
+import org.wordpress.android.ui.posts.PostConflictResolver
+import org.wordpress.android.ui.posts.PostListFeaturedImageTracker
+import org.wordpress.android.ui.posts.PostListType
+import org.wordpress.android.ui.posts.PostListUploadStatusTracker
+
+class PostListViewModelConnector(
+    val site: SiteModel,
+    val postListType: PostListType,
+    val authorFilter: AuthorFilterSelection,
+    val postActionHandler: PostActionHandler,
+    val featuredImageTracker: PostListFeaturedImageTracker,
+    val uploadStatusTracker: PostListUploadStatusTracker,
+    val postConflictResolver: PostConflictResolver
+)


### PR DESCRIPTION
This PR moves the common logic for post list from the `PostListViewModel` to the `PostListMainViewModel`. It does so by introducing a connector between them `PostListViewModelConnector`. I only had a few hours to come up with a solution and implement it, so I am not sure if this approach is the best idea, but it simplified things quite a bit and it gives us an opportunity to improve things even more. 

I think this PR fixed #9598. I don't know why #9590 broke it, but when I try to publish a draft in this branch it disappears from the post list as expected. It even shows up in the Published section, but I am confused as to why :) We normally need to fetch the first page of the list after a successful upload which is not implemented in this branch yet. I've left a todo for this and we can figure out why it's already working there.

I believe this PR also fixed #9145, it was a simple (read stupid) mistake I made a while back [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt#L506-L509).
```
@Suppress("unused")
    fun onEventBackgroundThread(event: VideoOptimizer.ProgressEvent) {
        invalidateUploadStatusAndPagedListData(event.media.id)
}
```
Instead of the `media.id` it should have been passing the `media.localPostId` which is fixed in this PR.

**To test:**
Similar to #9590, we need to test everything which we can postpone again until we do the full test we'll do very soon.
