### PR TITLE
Update login subtree

### DIFF
--- a/libs/login/.idea/checkstyle-idea.xml
+++ b/libs/login/.idea/checkstyle-idea.xml
@@ -3,12 +3,12 @@
   <component name="CheckStyle-IDEA">
     <option name="configuration">
       <map>
-        <entry key="active-configuration" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
+        <entry key="active-configuration" value="LOCAL_FILE:$PROJECT_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="checkstyle-version" value="8.2" />
         <entry key="copy-libs" value="false" />
         <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
-        <entry key="location-2" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
+        <entry key="location-2" value="LOCAL_FILE:$PROJECT_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="scan-before-checkin" value="false" />
         <entry key="scanscope" value="AllSourcesWithTests" />
         <entry key="suppress-errors" value="false" />

--- a/libs/login/.idea/codeStyles/Project.xml
+++ b/libs/login/.idea/codeStyles/Project.xml
@@ -46,6 +46,7 @@
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="IMPORT_NESTED_CLASSES" value="true" />
       <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
+      <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="1" />
     </JetCodeStyleSettings>
     <Objective-C-extensions>
       <file>
@@ -264,6 +265,17 @@
       <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
       <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="CALL_PARAMETERS_WRAP" value="5" />
+      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_WRAP" value="5" />
+      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="EXTENDS_LIST_WRAP" value="5" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+      <option name="METHOD_ANNOTATION_WRAP" value="1" />
+      <option name="FIELD_ANNOTATION_WRAP" value="1" />
+      <option name="ENUM_CONSTANTS_WRAP" value="5" />
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -51,7 +51,7 @@ dependencies {
             exclude group: "org.wordpress", module: "utils"
         }
     } else {
-        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:7c4fa0333cef380aa80b92adbb5e4803b90dd7e5") {
+        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:8cdbf03cf3d595ef904bab3c1dc207e39242c882") {
             exclude group: "com.android.support"
             exclude group: "org.wordpress", module: "utils"
         }

--- a/libs/login/config/checkstyle.xml
+++ b/libs/login/config/checkstyle.xml
@@ -34,15 +34,6 @@
 
     <!-- Miscellaneous other checks.                   -->
     <!-- See http://checkstyle.sf.net/config_misc.html -->
-    <module name="RegexpSingleline">
-       <property name="format" value="\s+$"/>
-       <property name="minimum" value="0"/>
-       <property name="maximum" value="0"/>
-       <property name="message" value="Line has trailing spaces."/>
-       <property name="severity" value="error"/>
-    </module>
-
-
     <module name="RegexpMultiline">
       <property name="format"
                 value="(\n|\r\n)[\t ]*(\n|\r\n)[\t ]*\}"/>
@@ -154,7 +145,9 @@
         <!-- Checks for imports                              -->
         <!-- See http://checkstyle.sf.net/config_import.html -->
         <module name="AvoidStarImport"/>
-        <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+        <module name="IllegalImport">
+            <property name="illegalClasses" value="android.app.Fragment"/>
+        </module>
         <module name="RedundantImport"/>
         <module name="UnusedImports">
             <property name="processJavadoc" value="true"/>
@@ -181,6 +174,7 @@
           <property name="tokens" value="METHOD_DEF"/>
           <!-- TODO: We should set this value around 40 or 50 -->
           <property name="max" value="200"/>
+          <property name="severity" value="warning"/>
         </module>
 
         <!-- Checks for whitespace                               -->

--- a/libs/login/gradle/wrapper/gradle-wrapper.properties
+++ b/libs/login/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip


### PR DESCRIPTION
Pulls in the latest changes from the login subtree, and updates the default FluxC hash the login library uses when built standalone.

To test:

No applicable changes to the WP app.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
