### PR TITLE
Post List: Move to Draft

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/CriticalPostActionTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/CriticalPostActionTracker.kt
@@ -11,7 +11,7 @@ class CriticalPostActionTracker(
     private val shouldCrashOnUnexpectedAction: Boolean = BuildConfig.DEBUG
 ) {
     enum class CriticalPostAction {
-        DELETING_POST, RESTORING_POST, TRASHING_POST
+        DELETING_POST, RESTORING_POST, TRASHING_POST, MOVING_POST_TO_DRAFT
     }
     private val map = HashMap<LocalId, CriticalPostAction>()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -123,19 +123,11 @@ class PostActionHandler(
 
         val localPostId = LocalId(post.id)
         criticalPostActionTracker.add(localPostId, MOVING_POST_TO_DRAFT)
-        val removeFromCriticalPostActionTracker = {
-            criticalPostActionTracker.remove(localPostId, MOVING_POST_TO_DRAFT)
-        }
 
         val snackBarHolder = SnackbarMessageHolder(
                 messageRes = R.string.post_moving_to_draft,
-                buttonTitleRes = R.string.undo,
-                buttonAction = {
-                    removeFromCriticalPostActionTracker.invoke()
-                    trashPost(post)
-                },
                 onDismissAction = {
-                    removeFromCriticalPostActionTracker.invoke()
+                    criticalPostActionTracker.remove(localPostId, MOVING_POST_TO_DRAFT)
                 }
         )
         showSnackbar.invoke(snackBarHolder)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -232,9 +232,10 @@ class PostActionHandler(
 
     private fun restorePost(post: PostModel) {
         // We need network connection to restore a post
-        if (checkNetworkConnection.invoke()) {
+        if (!checkNetworkConnection.invoke()) {
             return
         }
+        showSnackbar.invoke(SnackbarMessageHolder(messageRes = R.string.post_restoring))
         criticalPostActionTracker.add(localPostId = LocalId(post.id), criticalPostAction = RESTORING_POST)
         dispatcher.dispatch(PostActionBuilder.newRestorePostAction(RemotePostPayload(post, site)))
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.generated.PostActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus.DRAFT
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
 import org.wordpress.android.ui.notifications.utils.PendingDraftsNotificationsUtils
@@ -30,9 +31,9 @@ import org.wordpress.android.widgets.PostListButtonType.BUTTON_BACK
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_EDIT
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_MORE
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_MOVE_TO_DRAFT
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_PREVIEW
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_PUBLISH
-import org.wordpress.android.widgets.PostListButtonType.BUTTON_RESTORE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_RETRY
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_STATS
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_SUBMIT
@@ -65,8 +66,8 @@ class PostActionHandler(
         when (buttonType) {
             BUTTON_EDIT -> editPostButtonAction(site, post)
             BUTTON_RETRY -> triggerPostListAction.invoke(RetryUpload(post))
-            BUTTON_RESTORE -> {
-                restorePost(post)
+            BUTTON_MOVE_TO_DRAFT -> {
+                moveTrashedPostToDraft(post)
             }
             BUTTON_SUBMIT, BUTTON_SYNC, BUTTON_PUBLISH -> {
                 postListDialogHelper.showPublishConfirmationDialog(post)
@@ -108,45 +109,22 @@ class PostActionHandler(
         }
     }
 
-    private fun restorePost(post: PostModel) {
-        // We need network connection to restore a post
+    private fun moveTrashedPostToDraft(post: PostModel) {
+        /*
+         * We need network connection to move a post to remote draft. We can technically move it to the local drafts
+         * but that'll leave the trashed post in the remote which can be confusing.
+         */
         if (!checkNetworkConnection.invoke()) {
             return
         }
+        post.status = DRAFT.toString()
+        dispatcher.dispatch(PostActionBuilder.newPushPostAction(RemotePostPayload(post, site)))
 
-        criticalPostActionTracker.add(localPostId = LocalId(post.id), criticalPostAction = RESTORING_POST)
-        dispatcher.dispatch(PostActionBuilder.newRestorePostAction(RemotePostPayload(post, site)))
-    }
-
-    fun handlePostRestored(localPostId: LocalId, isError: Boolean) {
-        if (criticalPostActionTracker.get(localPostId) != RESTORING_POST) {
-            /*
-             * This is an unexpected action and either it has already been handled or another critical action has
-             * been performed. In either case, safest action is to just ignore it.
-             */
-            return
-        }
-        val removeFromTracker = {
-            criticalPostActionTracker.remove(localPostId = localPostId, criticalPostAction = RESTORING_POST)
-        }
-        if (isError) {
-            removeFromTracker.invoke()
-            showToast.invoke(ToastMessageHolder(R.string.error_restoring_post, Duration.SHORT))
-            return
-        }
         val snackBarHolder = SnackbarMessageHolder(
-                messageRes = R.string.post_restored,
+                messageRes = R.string.post_moving_to_draft,
                 buttonTitleRes = R.string.undo,
                 buttonAction = {
-                    val post = postStore.getPostByLocalPostId(localPostId.value)
-                    if (post != null) {
-                        removeFromTracker.invoke()
-                        trashPost(post)
-                        showSnackbar.invoke(SnackbarMessageHolder(R.string.post_trashing))
-                    }
-                },
-                onDismissAction = {
-                    removeFromTracker.invoke()
+                    trashPost(post)
                 }
         )
         showSnackbar.invoke(snackBarHolder)
@@ -218,6 +196,7 @@ class PostActionHandler(
             return
         }
 
+        showSnackbar.invoke(SnackbarMessageHolder(R.string.post_trashing))
         criticalPostActionTracker.add(localPostId = LocalId(post.id), criticalPostAction = TRASHING_POST)
 
         triggerPostUploadAction.invoke(CancelPostAndMediaUpload(post))
@@ -232,30 +211,48 @@ class PostActionHandler(
              */
             return
         }
-        val removeFromTracker = {
-            criticalPostActionTracker.remove(localPostId = localPostId, criticalPostAction = TRASHING_POST)
-        }
+        criticalPostActionTracker.remove(localPostId = localPostId, criticalPostAction = TRASHING_POST)
         if (isError) {
-            removeFromTracker.invoke()
             showToast.invoke(ToastMessageHolder(R.string.error_deleting_post, Duration.SHORT))
+        } else {
+            showSnackbar.invoke(SnackbarMessageHolder(messageRes = R.string.post_trashed))
+            val snackBarHolder = SnackbarMessageHolder(
+                    messageRes = R.string.post_trashed,
+                    buttonTitleRes = R.string.undo,
+                    buttonAction = {
+                        val post = postStore.getPostByLocalPostId(localPostId.value)
+                        if (post != null) {
+                            restorePost(post)
+                        }
+                    }
+            )
+            showSnackbar.invoke(snackBarHolder)
+        }
+    }
+
+    private fun restorePost(post: PostModel) {
+        // We need network connection to restore a post
+        if (checkNetworkConnection.invoke()) {
             return
         }
-        val snackBarHolder = SnackbarMessageHolder(
-                messageRes = R.string.post_trashed,
-                buttonTitleRes = R.string.undo,
-                buttonAction = {
-                    val post = postStore.getPostByLocalPostId(localPostId.value)
-                    if (post != null) {
-                        removeFromTracker.invoke()
-                        restorePost(post)
-                        showSnackbar.invoke(SnackbarMessageHolder(R.string.post_restoring))
-                    }
-                },
-                onDismissAction = {
-                    removeFromTracker.invoke()
-                }
-        )
-        showSnackbar.invoke(snackBarHolder)
+        criticalPostActionTracker.add(localPostId = LocalId(post.id), criticalPostAction = RESTORING_POST)
+        dispatcher.dispatch(PostActionBuilder.newRestorePostAction(RemotePostPayload(post, site)))
+    }
+
+    fun handlePostRestored(localPostId: LocalId, isError: Boolean) {
+        if (criticalPostActionTracker.get(localPostId) != RESTORING_POST) {
+            /*
+             * This is an unexpected action and either it has already been handled or another critical action has
+             * been performed. In either case, safest action is to just ignore it.
+             */
+            return
+        }
+        criticalPostActionTracker.remove(localPostId = localPostId, criticalPostAction = RESTORING_POST)
+        if (isError) {
+            showToast.invoke(ToastMessageHolder(R.string.error_restoring_post, Duration.SHORT))
+        } else {
+            showSnackbar.invoke(SnackbarMessageHolder(messageRes = R.string.post_restored))
+        }
     }
 
     fun isPerformingCriticalAction(localPostId: LocalId): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListActionTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListActionTracker.kt
@@ -29,7 +29,7 @@ fun trackPostListAction(site: SiteModel, buttonType: PostListButtonType, postDat
         PostListButtonType.BUTTON_SYNC -> "sync"
         PostListButtonType.BUTTON_MORE -> "more"
         PostListButtonType.BUTTON_BACK -> "back"
-        PostListButtonType.BUTTON_RESTORE -> "restore"
+        PostListButtonType.BUTTON_MOVE_TO_DRAFT -> "move_to_draft"
     }
 
     AnalyticsUtils.trackWithSiteDetails(statsEvent, site, properties)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -149,7 +149,7 @@ class PostListMainViewModel @Inject constructor(
                 postActionHandler = postActionHandler,
                 handlePostUpdatedWithoutError = postConflictResolver::onPostSuccessfullyUpdated,
                 handlePostUploadedWithoutError = {
-                    // TODO("Fetch the first page of the lists so their id is added to the ListStore")
+                    refreshAllLists()
                 },
                 triggerPostUploadAction = { _postUploadAction.postValue(it) },
                 invalidateUploadStatus = {
@@ -177,7 +177,10 @@ class PostListMainViewModel @Inject constructor(
         super.onCleared()
     }
 
-    // TODO: We shouldn't need to pass the AuthorFilterSelection to fragments and get it back, we have that info already
+    /*
+     * FUTURE_REFACTOR: We shouldn't need to pass the AuthorFilterSelection to fragments and get it back, we have that
+     * info already
+     */
     fun getPostListViewModelConnector(
         authorFilter: AuthorFilterSelection,
         postListType: PostListType
@@ -285,6 +288,11 @@ class PostListMainViewModel @Inject constructor(
     }
 
     private fun invalidateAllLists() {
+        val listTypeIdentifier = PostListDescriptor.calculateTypeIdentifier(site.id)
+        dispatcher.dispatch(ListActionBuilder.newListDataInvalidatedAction(listTypeIdentifier))
+    }
+
+    private fun refreshAllLists() {
         val listTypeIdentifier = PostListDescriptor.calculateTypeIdentifier(site.id)
         dispatcher.dispatch(ListActionBuilder.newListRequiresRefreshAction(listTypeIdentifier))
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -260,7 +260,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
             isLocalDraft -> buttonTypes.add(PostListButtonType.BUTTON_DELETE)
             postStatus == PostStatus.TRASHED -> {
                 buttonTypes.add(PostListButtonType.BUTTON_DELETE)
-                buttonTypes.add(PostListButtonType.BUTTON_RESTORE)
+                buttonTypes.add(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
             }
             postStatus != PostStatus.TRASHED -> buttonTypes.add(PostListButtonType.BUTTON_TRASH)
         }

--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
@@ -24,7 +24,7 @@ enum class PostListButtonType constructor(
     BUTTON_BACK(10, R.string.button_back, R.drawable.ic_chevron_left_white_24dp, R.color.neutral_500),
     BUTTON_SUBMIT(11, R.string.submit_for_review, R.drawable.ic_reader_white_24dp, R.color.neutral_500),
     BUTTON_RETRY(12, R.string.button_retry, R.drawable.ic_refresh_white_24dp, R.color.error_500),
-    BUTTON_RESTORE(13, R.string.button_restore, R.drawable.ic_refresh_white_24dp, R.color.neutral_500);
+    BUTTON_MOVE_TO_DRAFT(13, R.string.button_move_to_draft, R.drawable.ic_refresh_white_24dp, R.color.neutral_500);
 
     companion object {
         fun fromInt(value: Int): PostListButtonType? = values().firstOrNull { it.value == value }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -271,7 +271,7 @@
     <string name="button_discard">Discard</string>
     <string name="button_discard_changes">Discard Changes</string>
     <string name="button_retry">Retry</string>
-    <string name="button_restore">Restore</string>
+    <string name="button_move_to_draft">Move to Draft</string>
 
     <!-- post uploads -->
     <string name="upload_failed_param">Upload failed for \"%s\"</string>
@@ -441,6 +441,7 @@
     <string name="post_trashing">Post is being trashed</string>
     <string name="post_restored">Post restored</string>
     <string name="post_restoring">Post is being restored</string>
+    <string name="post_moving_to_draft">Post is being moved to draft</string>
 
     <string name="share_link">Share link</string>
     <string name="view_in_browser">View in browser</string>

--- a/build.gradle
+++ b/build.gradle
@@ -104,5 +104,5 @@ buildScan {
 }
 
 ext {
-    fluxCVersion = '451775497c35bb72ade2cadc1cc166b9fe82406d'
+    fluxCVersion = 'b4b581f8dc00d6bac48eac04d521668d981af7ad'
 }


### PR DESCRIPTION
Fixes #9602 #9603 #9571. This PR introduces `Move to Draft` action for the trashed posts while fixing a few minor issues. With these changes:

* When a post is trashed, we'll show a "Post is being trashed" snackbar first and then "Post sent to trash" snackbar with an undo button which will restore the post. Note that we don't push the previous post again but instead rely on the `RESTORE_POST` FluxC action.
* In trashed posts, posts can be moved to draft. This currently requires a network connection, because without it if we move it to a local draft, the trashed post will stay in remote which might be confusing for the user. It's a good issue to handle in the offline support project, although I am not really sure how. cc @diegoreymendez 
* While the post is being moved to drafts, we'll briefly add it to the critical action list while we show the Snackbar that says "Post is being moved to draft". As soon as this Snackbar is dismissed it'll be removed from the critical action list.
* When the post is moved to drafts, it'll show our regular snackbar that says "Draft saved online" with the "Publish" button. I did not add this as part of this PR, but I think it works well enough in this case. When this new snackbar is shown the previous snackbar that said "Post is being moved to draft" will be dismissed which means it'll no longer be in the critical action list.
* We don't have specific error handling for this action for now.

---

This PR also fixes the `PostListMainViewModel` not invalidating the lists correctly. We were accidentally refreshing the list instead of invalidating it and wasn't refreshing it when we needed to. This issue was introduced in the last PR for post filters #9600 and had a TODO for it. I've included this fix in this PR because I was not able to properly test it without it.

---

To test:
* Try trashing, undoing and moving to draft actions in wp.com, Jetpack and self-hosted sites
* Try it again with slow connection.
