### PR TITLE
Use the Gutenberg fix for Enter at end of list block

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     ext {
-        aztecVersion = '3a6ab4ffde163ec2f2ebd3732a20013ebd8723a4'
+        aztecVersion = '1400adb886ca9372211f06b62dd24fbbbd252f42'
     }
 
     repositories {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     ext {
-        aztecVersion = 'v1.3.24'
+        aztecVersion = '3a6ab4ffde163ec2f2ebd3732a20013ebd8723a4'
     }
 
     repositories {


### PR DESCRIPTION
This PR brings in a newer version of Aztec, to include the fix for the list block writing flow. See [the gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/868) for details.

To test:
* In a post with blocks, use a list block and follow the steps in the gutenberg-mobile PR

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
