### PR TITLE
Issue/update snackbar duration

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -35,7 +35,6 @@ import org.wordpress.android.ui.posts.BasicFragmentDialog;
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
-import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.ToastUtils;
@@ -271,8 +270,8 @@ public class CommentsActivity extends AppCompatActivity
                 }
             };
 
-            WPSnackbar snackbar = WPSnackbar.make(getListFragment().getView(), message,
-                    AccessibilityUtils.getSnackbarDuration(this)).setAction(R.string.undo, undoListener);
+            WPSnackbar snackbar = WPSnackbar.make(getListFragment().getView(), message, Snackbar.LENGTH_LONG)
+                    .setAction(R.string.undo, undoListener);
 
             // do the actual moderation once the undo bar has been hidden
             snackbar.setCallback(new Snackbar.Callback() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.PopupMenu;
@@ -71,7 +72,6 @@ import org.wordpress.android.ui.stats.service.StatsService;
 import org.wordpress.android.ui.themes.ThemeBrowserActivity;
 import org.wordpress.android.ui.uploads.UploadService;
 import org.wordpress.android.ui.uploads.UploadUtils;
-import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
@@ -254,8 +254,7 @@ public class MySiteFragment extends Fragment implements
                             WPDialogSnackbar.make(
                                     requireActivity().findViewById(R.id.coordinator),
                                     noticeMessage,
-                                    AccessibilityUtils.getSnackbarDuration(getActivity(),
-                                            getResources().getInteger(R.integer.quick_start_snackbar_duration_ms)));
+                                    getResources().getInteger(R.integer.quick_start_snackbar_duration_ms));
 
                     quickStartNoticeSnackBar.setTitle(noticeTitle);
 
@@ -1317,8 +1316,7 @@ public class MySiteFragment extends Fragment implements
                 mActiveTutorialPrompt.getIconId());
 
         WPDialogSnackbar promptSnackbar = WPDialogSnackbar.make(requireActivity().findViewById(R.id.coordinator),
-                shortQuickStartMessage, AccessibilityUtils.getSnackbarDuration(requireContext(),
-                        getResources().getInteger(R.integer.quick_start_snackbar_duration_ms)));
+                shortQuickStartMessage, getResources().getInteger(R.integer.quick_start_snackbar_duration_ms));
 
         ((WPMainActivity) getActivity()).showQuickStartSnackBar(promptSnackbar);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -9,7 +9,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.PopupMenu;

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -42,7 +42,6 @@ import org.wordpress.android.ui.pages.PageItem.Page
 import org.wordpress.android.ui.posts.BasicFragmentDialog
 import org.wordpress.android.ui.posts.EditPostActivity
 import org.wordpress.android.ui.quickstart.QuickStartEvent
-import org.wordpress.android.util.AccessibilityUtils
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.QuickStartUtils
 import org.wordpress.android.util.WPSwipeToRefreshHelper
@@ -384,10 +383,7 @@ class PagesFragment : Fragment() {
 
                 WPDialogSnackbar.make(
                         view!!.findViewById(R.id.coordinatorLayout), title,
-                        AccessibilityUtils.getSnackbarDuration(
-                                requireActivity(),
-                                resources.getInteger(R.integer.quick_start_snackbar_duration_ms)
-                        )
+                        resources.getInteger(R.integer.quick_start_snackbar_duration_ms)
                 ).show()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -69,7 +69,6 @@ import org.wordpress.android.fluxc.store.SiteStore.OnAutomatedTransferStatusChec
 import org.wordpress.android.fluxc.store.SiteStore.OnPlansFetched;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.ui.ActivityLauncher;
-import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -275,8 +274,8 @@ public class PluginDetailActivity extends AppCompatActivity {
         if (event.isError()) {
             AppLog.e(T.PLANS, PluginDetailActivity.class.getSimpleName() + ".onPlansFetched: "
                               + event.error.type + " - " + event.error.message);
-            WPSnackbar.make(mContainer, getString(R.string.plugin_check_domain_credit_error),
-                    AccessibilityUtils.getSnackbarDuration(this)).show();
+            WPSnackbar.make(mContainer, getString(R.string.plugin_check_domain_credit_error), Snackbar.LENGTH_LONG)
+                    .show();
         } else {
             // This should not happen
             if (event.plans == null) {
@@ -284,8 +283,8 @@ public class PluginDetailActivity extends AppCompatActivity {
                 if (BuildConfig.DEBUG) {
                     throw new IllegalStateException(errorMessage);
                 }
-                WPSnackbar.make(mContainer, getString(R.string.plugin_check_domain_credit_error),
-                        AccessibilityUtils.getSnackbarDuration(this)).show();
+                WPSnackbar.make(mContainer, getString(R.string.plugin_check_domain_credit_error), Snackbar.LENGTH_LONG)
+                        .show();
                 AppLog.e(T.PLANS, errorMessage);
                 return;
             }
@@ -856,8 +855,7 @@ public class PluginDetailActivity extends AppCompatActivity {
 
     private void showUpdateFailedSnackbar() {
         WPSnackbar.make(mContainer,
-                getString(R.string.plugin_updated_failed, mPlugin.getDisplayName()),
-                AccessibilityUtils.getSnackbarDuration(this))
+                getString(R.string.plugin_updated_failed, mPlugin.getDisplayName()), Snackbar.LENGTH_LONG)
                 .setAction(R.string.retry, new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
@@ -869,8 +867,7 @@ public class PluginDetailActivity extends AppCompatActivity {
 
     private void showInstallFailedSnackbar() {
         WPSnackbar.make(mContainer,
-                getString(R.string.plugin_installed_failed, mPlugin.getDisplayName()),
-                AccessibilityUtils.getSnackbarDuration(this))
+                getString(R.string.plugin_installed_failed, mPlugin.getDisplayName()), Snackbar.LENGTH_LONG)
                 .setAction(R.string.retry, new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -134,7 +134,6 @@ import org.wordpress.android.ui.uploads.PostEvents;
 import org.wordpress.android.ui.uploads.UploadService;
 import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.ui.uploads.VideoOptimizer;
-import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
@@ -1839,8 +1838,7 @@ public class EditPostActivity extends AppCompatActivity implements
         mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
         refreshEditorContent();
 
-        WPSnackbar.make(mViewPager, getString(R.string.history_loaded_revision),
-                AccessibilityUtils.getSnackbarDuration(EditPostActivity.this, 4000))
+        WPSnackbar.make(mViewPager, getString(R.string.history_loaded_revision), 4000)
                 .setAction(getString(R.string.undo), new OnClickListener() {
                     @Override
                     public void onClick(View view) {
@@ -3864,8 +3862,7 @@ public class EditPostActivity extends AppCompatActivity implements
                     refreshEditorContent();
 
                     if (mViewPager != null) {
-                        WPSnackbar.make(mViewPager, getString(R.string.local_changes_discarded),
-                                AccessibilityUtils.getSnackbarDuration(EditPostActivity.this, Snackbar.LENGTH_LONG))
+                        WPSnackbar.make(mViewPager, getString(R.string.local_changes_discarded), Snackbar.LENGTH_LONG)
                                 .setAction(getString(R.string.undo), new OnClickListener() {
                                     @Override public void onClick(View view) {
                                         AnalyticsTracker.track(Stat.EDITOR_DISCARDED_CHANGES_UNDO);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -29,7 +29,6 @@ import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.uploads.UploadUtils
 import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.util.AccessibilityUtils
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.NetworkUtils
@@ -187,7 +186,7 @@ class PostListFragment : Fragment() {
     private fun showSnackbar(holder: SnackbarMessageHolder) {
         nonNullActivity.findViewById<View>(R.id.coordinator)?.let { parent ->
             val message = getString(holder.messageRes)
-            val duration = AccessibilityUtils.getSnackbarDuration(nonNullActivity)
+            val duration = Snackbar.LENGTH_LONG
             val snackbar = WPSnackbar.make(parent, message, duration)
             if (holder.buttonTitleRes != null) {
                 snackbar.setAction(getString(holder.buttonTitleRes)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -389,8 +389,7 @@ public class PostPreviewActivity extends AppCompatActivity implements
                     refreshPreview();
 
                     if (mMessageView != null) {
-                        WPSnackbar.make(mMessageView, getString(R.string.local_changes_discarded),
-                                AccessibilityUtils.getSnackbarDuration(PostPreviewActivity.this, Snackbar.LENGTH_LONG))
+                        WPSnackbar.make(mMessageView, getString(R.string.local_changes_discarded), Snackbar.LENGTH_LONG)
                                 .setAction(getString(R.string.undo), new OnClickListener() {
                                     @Override public void onClick(View view) {
                                         AnalyticsTracker.track(Stat.EDITOR_DISCARDED_CHANGES_UNDO);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -40,7 +40,6 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.accounts.HelpActivity.Origin;
 import org.wordpress.android.ui.uploads.PostEvents;
 import org.wordpress.android.ui.uploads.UploadService;
-import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -24,7 +24,6 @@ import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter.OnAdapterLoadedListener;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter.OnServiceClickListener;
 import org.wordpress.android.ui.quickstart.QuickStartEvent;
-import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.QuickStartUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -132,8 +131,8 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
             Spannable title = QuickStartUtils.stylizeQuickStartPrompt(getActivity(),
                     R.string.quick_start_dialog_enable_sharing_message_short_connections);
 
-            WPDialogSnackbar.make(getView(), title, AccessibilityUtils.getSnackbarDuration(getActivity(),
-                    getResources().getInteger(R.integer.quick_start_snackbar_duration_ms))).show();
+            WPDialogSnackbar.make(getView(), title,
+                    getResources().getInteger(R.integer.quick_start_snackbar_duration_ms)).show();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -67,7 +67,6 @@ import org.wordpress.android.ui.reader.views.ReaderWebView;
 import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderCustomViewListener;
 import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderWebViewPageFinishedListener;
 import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderWebViewUrlClickListener;
-import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -448,7 +447,7 @@ public class ReaderPostDetailFragment extends Fragment
                     : blogName;
 
             WPSnackbar.make(view, Html.fromHtml(getString(R.string.reader_followed_blog_notifications,
-                    "<b>", blog, "</b>")), AccessibilityUtils.getSnackbarDuration(getActivity()))
+                    "<b>", blog, "</b>")), Snackbar.LENGTH_LONG)
                     .setAction(getString(R.string.reader_followed_blog_notifications_action),
                         new View.OnClickListener() {
                             @Override public void onClick(View view) {
@@ -566,15 +565,15 @@ public class ReaderPostDetailFragment extends Fragment
             return;
         }
 
-        WPSnackbar.make(getView(), R.string.reader_bookmark_snack_title,
-                AccessibilityUtils.getSnackbarDuration(getActivity())).setAction(R.string.reader_bookmark_snack_btn,
-                new View.OnClickListener() {
-                    @Override public void onClick(View view) {
-                        AnalyticsTracker
-                                .track(AnalyticsTracker.Stat.READER_SAVED_LIST_VIEWED_FROM_POST_DETAILS_NOTICE);
-                        ActivityLauncher.viewSavedPostsListInReader(getActivity());
-                    }
-                })
+        WPSnackbar.make(getView(), R.string.reader_bookmark_snack_title, Snackbar.LENGTH_LONG)
+                .setAction(R.string.reader_bookmark_snack_btn,
+                    new View.OnClickListener() {
+                        @Override public void onClick(View view) {
+                            AnalyticsTracker
+                                    .track(AnalyticsTracker.Stat.READER_SAVED_LIST_VIEWED_FROM_POST_DETAILS_NOTICE);
+                            ActivityLauncher.viewSavedPostsListInReader(getActivity());
+                        }
+                    })
                 .show();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -13,6 +13,7 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.design.widget.TabLayout;
 import android.support.design.widget.TabLayout.OnTabSelectedListener;
 import android.support.design.widget.TabLayout.Tab;
@@ -100,7 +101,6 @@ import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarte
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel;
 import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView;
-import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -551,9 +551,8 @@ public class ReaderPostListFragment extends Fragment
                     R.string.quick_start_dialog_follow_sites_message_short_search,
                     R.drawable.ic_search_white_24dp);
 
-            WPDialogSnackbar snackbar = WPDialogSnackbar.make(requireActivity().findViewById(R.id.coordinator),
-                    title, AccessibilityUtils.getSnackbarDuration(requireContext(),
-                            getResources().getInteger(R.integer.quick_start_snackbar_duration_ms)));
+            WPDialogSnackbar snackbar = WPDialogSnackbar.make(requireActivity().findViewById(R.id.coordinator), title,
+                    getResources().getInteger(R.integer.quick_start_snackbar_duration_ms));
 
             ((WPMainActivity) getActivity()).showQuickStartSnackBar(snackbar);
         }
@@ -1196,8 +1195,7 @@ public class ReaderPostListFragment extends Fragment
                 refreshPosts();
             }
         };
-        WPSnackbar.make(getSnackbarParent(), getString(R.string.reader_toast_blog_blocked),
-                AccessibilityUtils.getSnackbarDuration(getActivity()))
+        WPSnackbar.make(getSnackbarParent(), getString(R.string.reader_toast_blog_blocked), Snackbar.LENGTH_LONG)
                 .setAction(R.string.undo, undoListener)
                 .show();
     }
@@ -1490,18 +1488,18 @@ public class ReaderPostListFragment extends Fragment
             return;
         }
 
-        WPSnackbar.make(getView(), R.string.reader_bookmark_snack_title,
-                AccessibilityUtils.getSnackbarDuration(getActivity())).setAction(R.string.reader_bookmark_snack_btn,
-                new View.OnClickListener() {
-                    @Override public void onClick(View view) {
-                        AnalyticsTracker
-                                .track(AnalyticsTracker.Stat.READER_SAVED_LIST_VIEWED_FROM_POST_LIST_NOTICE);
-                        ActivityLauncher.viewSavedPostsListInReader(getActivity());
-                        if (getActivity() instanceof WPMainActivity) {
-                            getActivity().overridePendingTransition(0, 0);
+        WPSnackbar.make(getView(), R.string.reader_bookmark_snack_title, Snackbar.LENGTH_LONG)
+                .setAction(R.string.reader_bookmark_snack_btn,
+                    new View.OnClickListener() {
+                        @Override public void onClick(View view) {
+                            AnalyticsTracker
+                                    .track(AnalyticsTracker.Stat.READER_SAVED_LIST_VIEWED_FROM_POST_LIST_NOTICE);
+                            ActivityLauncher.viewSavedPostsListInReader(getActivity());
+                            if (getActivity() instanceof WPMainActivity) {
+                                getActivity().overridePendingTransition(0, 0);
+                            }
                         }
-                    }
-                })
+                    })
                 .show();
     }
 
@@ -2209,7 +2207,7 @@ public class ReaderPostListFragment extends Fragment
                 : blogName;
 
         WPSnackbar.make(getSnackbarParent(), Html.fromHtml(getString(R.string.reader_followed_blog_notifications,
-                "<b>", blog, "</b>")), AccessibilityUtils.getSnackbarDuration(getActivity()))
+                "<b>", blog, "</b>")), Snackbar.LENGTH_LONG)
                 .setAction(getString(R.string.reader_followed_blog_notifications_action),
                         new View.OnClickListener() {
                             @Override public void onClick(View view) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -34,12 +34,11 @@ import org.wordpress.android.fluxc.store.ThemeStore;
 import org.wordpress.android.ui.ActionableEmptyView;
 import org.wordpress.android.ui.plans.PlansConstants;
 import org.wordpress.android.ui.quickstart.QuickStartEvent;
-import org.wordpress.android.util.AccessibilityUtils;
-import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.QuickStartUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper.RefreshListener;
 import org.wordpress.android.util.image.ImageManager;
@@ -212,8 +211,7 @@ public class ThemeBrowserFragment extends Fragment
                             R.drawable.ic_customize_white_24dp);
 
                     WPDialogSnackbar.make(getView(), title,
-                            AccessibilityUtils.getSnackbarDuration(getActivity(),
-                                    getResources().getInteger(R.integer.quick_start_snackbar_duration_ms))).show();
+                            getResources().getInteger(R.integer.quick_start_snackbar_duration_ms)).show();
                 }
             });
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -23,7 +23,6 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.prefs.AppPrefs;
-import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -192,9 +191,7 @@ public class UploadUtils {
 
     private static void showSnackbarError(View view, String message, int buttonTitleRes,
                                           View.OnClickListener onClickListener) {
-        WPSnackbar.make(view, message,
-                AccessibilityUtils.getSnackbarDuration(view.getContext(), K_SNACKBAR_WAIT_TIME_MS))
-                .setAction(buttonTitleRes, onClickListener).show();
+        WPSnackbar.make(view, message, K_SNACKBAR_WAIT_TIME_MS).setAction(buttonTitleRes, onClickListener).show();
     }
 
     public static void showSnackbarError(View view, String message) {
@@ -203,32 +200,22 @@ public class UploadUtils {
 
     private static void showSnackbar(View view, int messageRes, int buttonTitleRes,
                                      View.OnClickListener onClickListener) {
-        WPSnackbar.make(view, messageRes,
-                AccessibilityUtils.getSnackbarDuration(view.getContext(), K_SNACKBAR_WAIT_TIME_MS))
-                .setAction(buttonTitleRes, onClickListener).show();
+        WPSnackbar.make(view, messageRes, K_SNACKBAR_WAIT_TIME_MS).setAction(buttonTitleRes, onClickListener).show();
     }
 
     public static void showSnackbarSuccessAction(View view, int messageRes, int buttonTitleRes,
                                                   View.OnClickListener onClickListener) {
-        WPSnackbar.make(view, messageRes,
-                AccessibilityUtils.getSnackbarDuration(view.getContext(), K_SNACKBAR_WAIT_TIME_MS))
-                .setAction(buttonTitleRes, onClickListener)
-                .show();
+        WPSnackbar.make(view, messageRes, K_SNACKBAR_WAIT_TIME_MS).setAction(buttonTitleRes, onClickListener).show();
     }
 
     private static void showSnackbarSuccessAction(View view, String message, int buttonTitleRes,
                                                   View.OnClickListener onClickListener) {
-        WPSnackbar.make(view, message,
-                AccessibilityUtils.getSnackbarDuration(view.getContext(), K_SNACKBAR_WAIT_TIME_MS))
-                .setAction(buttonTitleRes, onClickListener)
-                .show();
+        WPSnackbar.make(view, message, K_SNACKBAR_WAIT_TIME_MS).setAction(buttonTitleRes, onClickListener).show();
     }
 
     public static void showSnackbarSuccessActionOrange(View view, int messageRes, int buttonTitleRes,
                                                   View.OnClickListener onClickListener) {
-        WPSnackbar.make(view, messageRes, Snackbar.LENGTH_LONG)
-                .setAction(buttonTitleRes, onClickListener)
-                .show();
+        WPSnackbar.make(view, messageRes, Snackbar.LENGTH_LONG).setAction(buttonTitleRes, onClickListener).show();
     }
 
     public static void showSnackbar(View view, int messageRes) {

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AccessibilityUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AccessibilityUtils.java
@@ -15,13 +15,6 @@ public class AccessibilityUtils {
     }
 
     /**
-     * If the accessibility is enabled, returns increased snackbar duration, otherwise returns LENGTH_LONG duration.
-     */
-    public static int getSnackbarDuration(Context ctx) {
-        return getSnackbarDuration(ctx, Snackbar.LENGTH_LONG);
-    }
-
-    /**
      * If the default duration is LENGTH_INDEFINITE, ignore accessibility duration and return LENGTH_INDEFINITE.
      * If the accessibility is enabled, returns increased snackbar duration, otherwise returns defaultDuration.
      *


### PR DESCRIPTION
### Fix
Remove the `AccessibilityUtils. getSnackbarDuration` usages from the `WPDialogSnackbar` and `WPSnackbar` instances.  `WPDialogSnackbar` and `WPSnackbar` were updated in https://github.com/wordpress-mobile/WordPress-Android/pull/9574 to use the `AccessibilityUtils. getSnackbarDuration` within the class constructors.  Now developers will be able to set the duration parameter in `WPDialogSnackbar` and `WPSnackbar` instances the same way it's set in `Snackbar` instances (i.e. `Snackbar.LENGTH_LONG`, `Snackbar.LENGTH_SHORT`, `Snackbar.LENGTH_INDEFINITE`, or integer duration in milliseconds) and `AccessibilityUtils` will still be used.

### Test
There are no interface changes with this pull request.  Snackbars should maintain the same behavior.  The steps to test snackbars in the app described in https://github.com/wordpress-mobile/WordPress-Android/pull/9574 are included below for completeness.

#### Signup
0. Clear app data.
1. Tap ***Sign Up for WordPress.com*** button.
2. Tap ***Sign Up with Google*** button.
3. Tap email with existing WordPress.com account and two-factor authentication enabled.
4. Notice snackbar is show.

#### Stats
0. Enable airplane mode.
1. Go to ***Sites*** tab.
2. Tap ***Stats*** item.
3. Notice snackbar is shown.

#### Activity Log
0. Select site with rewind available.
1. Go to ***Sites*** tab.
2. Tap ***Activity*** item.
3. Tap event in list with rewind available.
4. Tap ***Rewind*** button in event detail.
5. Tap ***Rewind Site*** button in dialog.
6. Notice snackbar is displayed as shown below.
7. Wait for rewind to finish.
8. Notice snackbar is shown.

#### Site Pages
1. Go to ***Sites*** tab.
2. Tap ***Site Pages*** under ***Publish*** section.
3. Tap ellipsis button of page in list.
4. Tap ***Move to Trash*** item in menu.
5. Wait for page to be moved to trash.
6. Notice snackbar is shown.
7. Tap ***Undo*** action in snackbar.

#### Blog Posts
1. Go to ***Sites*** tab.
2. Tap ***Blog Posts*** under ***Publish*** section.
3. Tap ***Trash*** button in blog post.
4. Tap ***Delete*** button in dialog.
5. Notice snackbar is shown.
6. Tap ***Undo*** action in snackbar.

#### Revisions
1. Go to ***Sites*** tab.
2. Tap ***Blog Posts*** under ***Publish*** section.
3. Tap blog post in list with history.
4. Tap ellipsis button in top app bar.
5. Tap ***History*** item in menu.
6. Tap revision in list.
7. Tap ***Load*** button in top app bar.
8. Notice snackbar is shown.

#### Comments
1. Go to ***Sites*** tab.
2. Tap ***Comments*** under ***Publish*** section.
3. Tap comment in list.
4. Tap ***Trash*** button in comment footer.
5. Notice snackbar is shown.
6. Tap ***Undo*** action in snackbar.

#### Plugins
0. Select site with plugins available.
1. Go to ***Sites*** tab.
2. Tap ***Plugins*** under ***Configuration*** section.
3. Tap plugin with ***Needs update*** status.
4. Tap ***Update*** button in plugin detail.
5. Wait for plugin to update.
6. Notice snackbar is shown.

#### Export Content
1. Go to ***Sites*** tab.
2. Tap ***Settings*** under ***Configuration*** section.
3. Tap ***Export Content*** under ***Advanced*** section.
4. Tap ***Export Content*** button in dialog.
5. Wait for export content.
6. Notice snackbar is shown.

#### Save Posts
1. Go to ***Reader*** tab.
2. Tap ***Bookmark*** button in post.
3. Notice snackbar is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.