### PR TITLE
Minor color scheme fixes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -38,9 +38,9 @@ import org.wordpress.android.widgets.PostListButtonType.BUTTON_VIEW
 import javax.inject.Inject
 
 private const val MAX_NUMBER_OF_VISIBLE_ACTIONS = 3
-const val ERROR_COLOR = R.color.error_500
+const val ERROR_COLOR = R.color.error
 const val PROGRESS_INFO_COLOR = R.color.neutral_500
-const val STATE_INFO_COLOR = R.color.warning_700
+const val STATE_INFO_COLOR = R.color.warning_dark
 
 /**
  * Helper class which encapsulates logic for creating UiStates for items in the PostsList.

--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
@@ -23,7 +23,7 @@ enum class PostListButtonType constructor(
     BUTTON_MORE(9, R.string.button_more, R.drawable.ic_ellipsis_white_24dp, R.color.neutral_500),
     BUTTON_BACK(10, R.string.button_back, R.drawable.ic_chevron_left_white_24dp, R.color.neutral_500),
     BUTTON_SUBMIT(11, R.string.submit_for_review, R.drawable.ic_reader_white_24dp, R.color.neutral_500),
-    BUTTON_RETRY(12, R.string.button_retry, R.drawable.ic_refresh_white_24dp, R.color.error_500),
+    BUTTON_RETRY(12, R.string.button_retry, R.drawable.ic_refresh_white_24dp, R.color.error),
     BUTTON_RESTORE(13, R.string.button_restore, R.drawable.ic_refresh_white_24dp, R.color.neutral_500);
 
     companion object {


### PR DESCRIPTION
Fixed minor issue with colors introduced in #9607 more specifically implements some of the suggestions mentioned [here](https://github.com/wordpress-mobile/WordPress-Android/pull/9607#issuecomment-482761261). 

The changes are so minor that I don't think we need to test it. Moreover, we are merging it  into a working branch and we'll perform several tests before we merge the branch into develop.