### PR TITLE
Fix issue with snackbar being dismissed by invisible WPMainActivity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -110,6 +110,7 @@ import javax.inject.Inject;
 
 import de.greenrobot.event.EventBus;
 
+import static android.arch.lifecycle.Lifecycle.State.STARTED;
 import static org.wordpress.android.WordPress.SITE;
 import static org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartVariant.NEXT_STEPS;
 import static org.wordpress.android.ui.JetpackConnectionSource.NOTIFICATIONS;
@@ -1094,16 +1095,18 @@ public class WPMainActivity extends AppCompatActivity implements
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPostUploaded(OnPostUploaded event) {
-        SiteModel site = getSelectedSite();
-        if (site != null && event.post != null && event.post.getLocalSiteId() == site.getId()) {
-            UploadUtils.onPostUploadedSnackbarHandler(
-                    this,
-                    findViewById(R.id.coordinator),
-                    event.isError(),
-                    event.post,
-                    null,
-                    site,
-                    mDispatcher);
+        if (getLifecycle().getCurrentState().isAtLeast(STARTED)) {
+            SiteModel site = getSelectedSite();
+            if (site != null && event.post != null && event.post.getLocalSiteId() == site.getId()) {
+                UploadUtils.onPostUploadedSnackbarHandler(
+                        this,
+                        findViewById(R.id.coordinator),
+                        event.isError(),
+                        event.post,
+                        null,
+                        site,
+                        mDispatcher);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #9604

Fixes an issue with snackbar - sometimes WPMainActivity invoked Snackbar.show(..) even though the activity wasn't visible. This could have pretty nasty side-effect -> it may dismiss another Snackbar shown by other activity/fragment. More info [here](https://github.com/wordpress-mobile/WordPress-Android/issues/9604#issuecomment-482760389)

To test:
1. Go to Post List
2. Drafts
3. Publish a post
4. Wait until the upload completes
5. Make sure snackbar with "Post published" message and "View" action is shown
6. Go to Me section
7. Create and publish a post using "+New Post" button in the bottom navigation bar
8. Wait until the upload completes
9. Make sure snackbar with "Post published" message and "View" action is shown

Update release notes:

- We'll update the release notes when we merge master-post-filters branch into develop
