### PR TITLE
Issue/9599 notifications empty flash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -103,7 +103,6 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
 
     public void setFilter(FILTERS newFilter) {
         mCurrentFilter = newFilter;
-        myNotifyDatasetChanged();
     }
 
     public FILTERS getCurrentFilter() {


### PR DESCRIPTION
### Fix
Remove notifying the `NotesAdapter` that the data set changed when setting the notification type filter in order to fix the empty view flash as described in https://github.com/wordpress-mobile/WordPress-Android/issues/9599.  The `NotificationsListFragmentPage.onDataLoaded` method is causing the empty view to be shown just before the notifications list is populated due to the `myNotifyDatasetChanged()` statement in the `NotesAdapter.setFilter(FILTERS)` method.  The `myNotifyDatasetChanged()` statement was previously needed in the `NotesAdapter.setFilter(FILTERS)` method when mutually exclusive filters could be applied to the single notifications list so that the list would be updated when the filter changed.  The new tab implementation now uses a single filter with a single list for each tab and that filter cannot be changed.  Since the filter cannot be changed once it has been set, the `myNotifyDatasetChanged()` statement is no longer necessary.

### Test
1. Go to ***Notifications*** tab.
2. Select ***All***, ***Unread***, ***Comments***, ***Follows***, or ***Likes*** filter with at least one notification.
3. Go to ***Sites***, ***Reader***, or ***Me*** tab.
4. Go to ***Notifications*** tab.
5. Notice empty view does not flash on screen before notification(s) are loaded.

### Review
Only one developer is required to review these changes, but anyone can perform the review.  I requested @rachelmcr as a reviewer for additional testing help to make sure this solution fixes the issue.