### PR TITLE
Fixes site icon not updating correctly after switch site

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * Updated primary button color to pink
 * Redirect to username/password login when WordPress.com reports email login not allowed
 * Updated snackbar design to Material guidelines
+* Fixed an issue where the site icon wasn't updating correctly after switching to another site
 
 12.2
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -193,7 +193,9 @@ public abstract class SiteSettingsInterface {
         SiteSettingsTable.saveSettings(mSettings);
     }
 
-    public int getLocalSiteId() { return mSite.getId(); }
+    public int getLocalSiteId() {
+        return mSite.getId();
+    }
 
     public @NonNull String getTitle() {
         return mSettings.title == null ? "" : mSettings.title;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -193,6 +193,8 @@ public abstract class SiteSettingsInterface {
         SiteSettingsTable.saveSettings(mSettings);
     }
 
+    public int getLocalSiteId() { return mSite.getId(); }
+
     public @NonNull String getTitle() {
         return mSettings.title == null ? "" : mSettings.title;
     }


### PR DESCRIPTION
Fixes #9554. This PR fixes the site icon not updating/removing correctly after the selected site is changed. This was happening because the site settings handler in the `MySiteFragment` would be created once and would not be updated ever again. So, when the site icon was removed or replaced, it'd actually try to replace it for another site. In most cases, I assume this wouldn't work because the media is uploaded to the current site, so the media id used to update the other site would not exist, but I am sure in some cases the other site's icon would be updated to something weird.

This is a pretty sad bug and I imagine it's been there since the implementation of site icons. It's also another example why relying on global properties is a bad practice. (I have not changed this in this PR unfortunately because changing it properly would require more refactoring than I am willing to do right now and without that refactor, removing the global property would have a performance cost attached to it)

In this PR, I made 2 changes:
1. The site settings property will be checked and initialized in `onResume`. We'll first check if the site settings handler is cached and whether the site has changed. If it did, we'll force a refresh of the handler. If the site settings handler is `null`, we'll try to get it and initialize it if it's there. This second part is exactly the same from the previous implementation.
2. I have introduced a helper method for updating the site icon so it's all in one place and easy to find. Before I found the source of the bug, I attempted to figure out the media upload logic which was not necessary in this case. If we had this method from the start, I imagine I'd start there. (Hard to say that in hindsight though 🤷‍♂️ )

To test:
* Go to `My Site`, add/change/remove the site icon
* Switch site, add/change/remove the site icon
* Create a new site, add/change/remove the site icon

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
