### PR TITLE
Issue/9610 update keylines notifications

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * Updated primary button color to pink
 * Redirect to username/password login when WordPress.com reports email login not allowed
+* Updated notifications list to Material guidelines
 * Updated snackbar design to Material guidelines
 
 12.2

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -46,10 +46,10 @@
             <ImageView
                 android:id="@+id/note_avatar"
                 android:contentDescription="@null"
-                android:layout_height="@dimen/notifications_avatar_sz"
+                android:layout_height="@dimen/activity_log_icon_size"
                 android:layout_marginEnd="@dimen/activity_log_icon_margin"
                 android:layout_marginTop="@dimen/margin_small"
-                android:layout_width="@dimen/notifications_avatar_sz"
+                android:layout_width="@dimen/activity_log_icon_size"
                 tools:src="@drawable/bg_oval_neutral_300_user_32dp" >
             </ImageView>
 

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -58,8 +58,8 @@
                 android:background="@drawable/bg_oval_primary_400_stroke_notification_unread"
                 android:gravity="center"
                 android:layout_height="@dimen/note_icon_sz"
-                android:layout_marginStart="31dp"
-                android:layout_marginTop="35dp"
+                android:layout_marginStart="@dimen/notifications_note_icon_margin"
+                android:layout_marginTop="@dimen/notifications_note_icon_margin"
                 android:layout_width="@dimen/note_icon_sz"
                 android:textColor="@android:color/white"
                 android:textSize="14sp" >

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -183,6 +183,7 @@
     <dimen name="notifications_content_margin">0dp</dimen>
     <dimen name="notifications_avatar_sz">48dp</dimen>
     <dimen name="notifications_text_indent_sz">22dp</dimen>
+    <dimen name="notifications_note_icon_margin">28dp</dimen>
 
     <dimen name="progress_bar_height">3dp</dimen>
     <dimen name="activity_progress_bar_height">5dp</dimen>


### PR DESCRIPTION
### Fix
Update the ***Notifications*** list to match the 16dp and 72dp keylines from the [Material guidelines](https://material.io/design/layout/spacing-methods.html#spacing) as described in https://github.com/wordpress-mobile/WordPress-Android/issues/9610.  See the screenshots below for illustration.

![keylines_notifications](https://user-images.githubusercontent.com/3827611/56172995-a8a06200-5fa0-11e9-8536-bbb1cdba2be7.png)

### Test
1. Go to ***Notifications*** tab.
2. Notice avatar and text in list items match 16dp and 72dp keylines, respectively.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
The `RELEASE-NOTES.txt` document was updated in 61feb84a87 with the following:
> Updated notifications list to Material guidelines