### PR TITLE
Remove primary 500 transparent

### DIFF
--- a/WordPress/src/main/res/drawable-ldrtl/tab_layout_gradient.xml
+++ b/WordPress/src/main/res/drawable-ldrtl/tab_layout_gradient.xml
@@ -2,6 +2,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient
         android:endColor="@color/primary_500"
-        android:startColor="@color/primary_500_transparent"
+        android:startColor="@android:color/transparent"
         android:angle="180"/>
 </shape>

--- a/WordPress/src/main/res/drawable/tab_layout_gradient.xml
+++ b/WordPress/src/main/res/drawable/tab_layout_gradient.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient
         android:endColor="@color/primary_500"
-        android:startColor="@color/primary_500_transparent"/>
+        android:startColor="@android:color/transparent"/>
 </shape>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -83,7 +83,6 @@
     <color name="primary_900">@color/blue_900</color>
     <color name="primary_dark">@color/blue_700</color>
     <color name="primary_light">@color/blue_300</color>
-    <color name="primary_500_transparent">@color/blue_500_transparent</color>
     <color name="success">@color/hot_green_500</color>
     <color name="success_0">@color/hot_green_0</color>
     <color name="success_100">@color/hot_green_100</color>
@@ -300,8 +299,4 @@
     <color name="grey_lighten_30_translucent_50">#80e9eff3</color> <!-- Use for old Stats.  Will be removed soon. -->
     <color name="white_translucent_40">#66ffffff</color>
     <color name="white_translucent_65">#a6ffffff</color>
-
-    <!-- TRANSPARENT -->
-    <color name="blue_500_transparent">#000087be</color>
-
 </resources>


### PR DESCRIPTION
Remove unnecessary transparent color from colors.xml as suggested per Tyler's comment [here](https://github.com/wordpress-mobile/WordPress-Android/pull/9607#issuecomment-482761261)

To test:
1. My Site
2. Blog Posts
3. Make sure the author filter looks ok

Update release notes:

- [ x ] We'll update the release notes when we merge "feature/master-post-filters" into develop
