### PR TITLE
Add digit to Overview and Latest post big value

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarCh
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ChartLegend
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Columns
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem
-import org.wordpress.android.ui.stats.refresh.utils.HUNDRED_THOUSAND
+import org.wordpress.android.ui.stats.refresh.utils.MILLION
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -47,7 +47,7 @@ class OverviewMapper
         }
 
         return ValueItem(
-                value = value.toFormattedString(HUNDRED_THOUSAND),
+                value = value.toFormattedString(MILLION),
                 unit = units[selectedPosition],
                 isFirst = true,
                 change = change,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCase.kt
@@ -22,7 +22,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListI
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.NavigationAction
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem
-import org.wordpress.android.ui.stats.refresh.utils.HUNDRED_THOUSAND
+import org.wordpress.android.ui.stats.refresh.utils.MILLION
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -72,7 +72,7 @@ class LatestPostSummaryUseCase
         if (domainModel != null && domainModel.hasData()) {
             items.add(
                     ValueItem(
-                            domainModel.postViewsCount.toFormattedString(startValue = HUNDRED_THOUSAND),
+                            domainModel.postViewsCount.toFormattedString(startValue = MILLION),
                             R.string.stats_views
                     )
             )


### PR DESCRIPTION
Fixes #9067 
This PR adds one digit to the Big numbers to the Overview card and to the Latest post summary card.

To test:
* Go to Stats
* In the Latest post summary card the N views gets cropped if it's > 999,999
* Go to DWMY
* The Overview card big number gets cropped after it's > 999,999
