### PR TITLE
Update Aztec to v1.3.24 and Gutenberg to v1.2.1

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     ext {
-        aztecVersion = 'v1.3.24'
+        aztecVersion = 'v1.3.25'
     }
 
     repositories {


### PR DESCRIPTION
This PR updates the gutenberg-mobile reference to point to the latest patch release, v1.2.1 and updating Aztec.

The reference is currently pointing to the `release/1.2.1` branch on https://github.com/wordpress-mobile/gutenberg-mobile.

#### ToDo

- [x] When that gets merged to gutenberg-mobile master, I'll update the ref here to point to the merge commit.

To test:
The block editor should work as normal.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
