### PR TITLE
Minor fixes in post list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/CriticalPostActionTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/CriticalPostActionTracker.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.posts
 
+import com.crashlytics.android.Crashlytics
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.util.AppLog
@@ -24,6 +25,8 @@ class CriticalPostActionTracker(
             AppLog.e(T.POSTS, errorMessage)
             if (shouldCrashOnUnexpectedAction) {
                 throw IllegalStateException(errorMessage)
+            } else {
+                Crashlytics.log(errorMessage)
             }
         }
         map[localPostId] = criticalPostAction

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/CriticalPostActionTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/CriticalPostActionTracker.kt
@@ -7,8 +7,7 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 
 class CriticalPostActionTracker(
-    // TODO: Find a better name than listener
-    private val listener: () -> Unit,
+    private val onStateChanged: () -> Unit,
     private val shouldCrashOnUnexpectedAction: Boolean = BuildConfig.DEBUG
 ) {
     enum class CriticalPostAction {
@@ -30,7 +29,7 @@ class CriticalPostActionTracker(
             }
         }
         map[localPostId] = criticalPostAction
-        listener.invoke()
+        onStateChanged.invoke()
     }
 
     fun contains(localPostId: LocalId): Boolean = map.containsKey(localPostId)
@@ -40,7 +39,7 @@ class CriticalPostActionTracker(
     fun remove(localPostId: LocalId, criticalPostAction: CriticalPostAction) {
         if (map[localPostId] == criticalPostAction) {
             map.remove(localPostId)
-            listener.invoke()
+            onStateChanged.invoke()
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -58,7 +58,7 @@ class PostActionHandler(
     private val showSnackbar: (SnackbarMessageHolder) -> Unit,
     private val showToast: (ToastMessageHolder) -> Unit
 ) {
-    private val criticalPostActionTracker = CriticalPostActionTracker(listener = {
+    private val criticalPostActionTracker = CriticalPostActionTracker(onStateChanged = {
         invalidateList.invoke()
     })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -28,7 +28,6 @@ import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
 import org.wordpress.android.widgets.PostListButtonType
-import org.wordpress.android.widgets.PostListButtonType.BUTTON_BACK
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_EDIT
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_MORE
@@ -84,7 +83,6 @@ class PostActionHandler(
             }
             BUTTON_MORE -> {
             } // do nothing - ui will show a popup window
-            BUTTON_BACK -> TODO("will be removed during PostViewHolder refactoring")
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListActionTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListActionTracker.kt
@@ -28,7 +28,6 @@ fun trackPostListAction(site: SiteModel, buttonType: PostListButtonType, postDat
         PostListButtonType.BUTTON_PUBLISH -> "publish"
         PostListButtonType.BUTTON_SYNC -> "sync"
         PostListButtonType.BUTTON_MORE -> "more"
-        PostListButtonType.BUTTON_BACK -> "back"
         PostListButtonType.BUTTON_MOVE_TO_DRAFT -> "move_to_draft"
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -52,7 +52,6 @@ class PostListFragment : Fragment() {
     private var progressLoadMore: ProgressBar? = null
 
     private lateinit var nonNullActivity: FragmentActivity
-    // TODO: We can get rid of SiteModel in the Fragment once we remove the `isPhotonCapable`
     private lateinit var site: SiteModel
 
     private val postViewHolderConfig: PostViewHolderConfig by lazy {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -18,10 +18,10 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.ImageUtils
 import org.wordpress.android.util.image.ImageType
-import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
 import org.wordpress.android.viewmodel.posts.PostListItemAction
 import org.wordpress.android.viewmodel.posts.PostListItemAction.MoreItem
 import org.wordpress.android.viewmodel.posts.PostListItemAction.SingleItem
+import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
 import org.wordpress.android.widgets.PostListButton
 import org.wordpress.android.widgets.WPTextView
 
@@ -110,7 +110,6 @@ class PostListItemViewHolder(
     }
 
     private fun showFeaturedImage(imageUrl: String?) {
-        // TODO move part of this logic to VM
         if (imageUrl == null) {
             featuredImageView.visibility = View.GONE
             config.imageManager.cancelRequestAndClearImageView(featuredImageView)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListType.kt
@@ -22,10 +22,9 @@ enum class PostListType(val postStatuses: List<PostStatus>) {
         fun fromPostStatus(status: PostStatus): PostListType {
             return when (status) {
                 PostStatus.PUBLISHED, PRIVATE -> PUBLISHED
-                PostStatus.DRAFT, PostStatus.PENDING -> DRAFTS
+                PostStatus.DRAFT, PostStatus.PENDING, PostStatus.UNKNOWN -> DRAFTS
                 PostStatus.TRASHED -> TRASHED
                 PostStatus.SCHEDULED -> SCHEDULED
-                PostStatus.UNKNOWN -> TODO()
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -54,7 +54,6 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         statsSupported: Boolean,
         featuredImageUrl: String?,
         formattedDate: String,
-        // TODO: Add a unit test for performing critical action property
         performingCriticalAction: Boolean,
         onAction: (PostModel, PostListButtonType, AnalyticsTracker.Stat) -> Unit
     ): PostListItemUiState {
@@ -67,7 +66,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
                         title = getTitle(post = post),
                         excerpt = getExcerpt(post = post),
                         imageUrl = featuredImageUrl,
-                        dateAndAuthor = UiStringText(text = formattedDate), // TODO Get name of the author
+                        dateAndAuthor = UiStringText(text = formattedDate),
                         statuses = getStatuses(
                                 postStatus = postStatus,
                                 isLocalDraft = post.isLocalDraft,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -189,7 +189,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         uploadStatus: PostListItemUploadStatus,
         hasUnhandledConflicts: Boolean
     ): Int? {
-        val isError = uploadStatus.uploadError != null && !uploadStatus.hasInProgressMediaUpload ||
+        val isError = (uploadStatus.uploadError != null && !uploadStatus.hasInProgressMediaUpload) ||
                 hasUnhandledConflicts
         val isProgressInfo = uploadStatus.isQueued || uploadStatus.hasPendingMediaUpload ||
                 uploadStatus.hasInProgressMediaUpload || uploadStatus.isUploading

--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
@@ -21,10 +21,9 @@ enum class PostListButtonType constructor(
     BUTTON_PUBLISH(7, R.string.button_publish, R.drawable.ic_reader_white_24dp, R.color.neutral_500),
     BUTTON_SYNC(8, R.string.button_sync, R.drawable.ic_reader_white_24dp, R.color.neutral_500),
     BUTTON_MORE(9, R.string.button_more, R.drawable.ic_ellipsis_white_24dp, R.color.neutral_500),
-    BUTTON_BACK(10, R.string.button_back, R.drawable.ic_chevron_left_white_24dp, R.color.neutral_500),
-    BUTTON_SUBMIT(11, R.string.submit_for_review, R.drawable.ic_reader_white_24dp, R.color.neutral_500),
-    BUTTON_RETRY(12, R.string.button_retry, R.drawable.ic_refresh_white_24dp, R.color.error),
-    BUTTON_MOVE_TO_DRAFT(13, R.string.button_move_to_draft, R.drawable.ic_refresh_white_24dp, R.color.neutral_500);
+    BUTTON_SUBMIT(10, R.string.submit_for_review, R.drawable.ic_reader_white_24dp, R.color.neutral_500),
+    BUTTON_RETRY(11, R.string.button_retry, R.drawable.ic_refresh_white_24dp, R.color.error),
+    BUTTON_MOVE_TO_DRAFT(12, R.string.button_move_to_draft, R.drawable.ic_refresh_white_24dp, R.color.neutral_500);
 
     companion object {
         fun fromInt(value: Int): PostListButtonType? = values().firstOrNull { it.value == value }

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -92,10 +92,9 @@
             <enum name="publish" value="7" />
             <enum name="sync" value="8" />
             <enum name="more" value="9" />
-            <enum name="back" value="10" />
-            <enum name="submit" value="11" />
-            <enum name="retry" value="12" />
-            <enum name="restore" value="13" />
+            <enum name="submit" value="10" />
+            <enum name="retry" value="11" />
+            <enum name="moveToDraft" value="12" />
         </attr>
     </declare-styleable>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -267,7 +267,6 @@
     <string name="button_trash">Trash</string>
     <string name="button_delete" translatable="false">@string/delete</string>
     <string name="button_more" translatable="false">@string/more</string>
-    <string name="button_back">Back</string>
     <string name="button_discard">Discard</string>
     <string name="button_discard_changes">Discard Changes</string>
     <string name="button_retry">Retry</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -182,6 +182,48 @@ class PostListItemUiStateHelperTest {
         assertThat(state.data.statuses).contains(UiStringRes(R.string.post_status_post_private))
     }
 
+    @Test
+    fun `show progress when performing critical action`() {
+        val state = createPostListItemUiState(performingCriticalAction = true)
+        assertThat(state.data.showProgress).isTrue()
+    }
+
+    @Test
+    fun `show progress when post is uploading or queued`() {
+        val state = createPostListItemUiState(uploadStatus = createUploadStatus(isUploadingOrQueued = true))
+        assertThat(state.data.showProgress).isTrue()
+    }
+
+    @Test
+    fun `show progress when uploading media`() {
+        val state = createPostListItemUiState(uploadStatus = createUploadStatus(hasInProgressMediaUpload = true))
+        assertThat(state.data.showProgress).isTrue()
+    }
+
+    @Test
+    fun `do not show progress when upload failed`() {
+        val state = createPostListItemUiState(
+                uploadStatus = createUploadStatus(
+                        isUploadFailed = true,
+                        isUploadingOrQueued = true,
+                        hasInProgressMediaUpload = true
+                )
+        )
+        assertThat(state.data.showProgress).isFalse()
+    }
+
+    @Test
+    fun `show overlay when performing critical action`() {
+        val state = createPostListItemUiState(performingCriticalAction = true)
+        assertThat(state.data.showOverlay).isTrue()
+    }
+
+    @Test
+    fun `show overlay when uploading post`() {
+        val state = createPostListItemUiState(uploadStatus = createUploadStatus(isUploading = true))
+        assertThat(state.data.showOverlay).isTrue()
+    }
+
     private fun createPostModel(
         status: String = POST_STATE_PUBLISH,
         isLocalDraft: Boolean = false,
@@ -202,6 +244,7 @@ class PostListItemUiStateHelperTest {
         statsSupported: Boolean = false,
         featuredImageUrl: String? = null,
         formattedDate: String = FORMATTER_DATE,
+        performingCriticalAction: Boolean = false,
         onAction: (PostModel, PostListButtonType, AnalyticsTracker.Stat) -> Unit = { _, _, _ -> }
     ): PostListItemUiState = helper.createPostListItemUiState(
             post = post,
@@ -212,7 +255,7 @@ class PostListItemUiStateHelperTest {
             featuredImageUrl = featuredImageUrl,
             formattedDate = formattedDate,
             onAction = onAction,
-            performingCriticalAction = false
+            performingCriticalAction = performingCriticalAction
     )
 
     private fun createUploadStatus(


### PR DESCRIPTION
Fixes #9605

- Fixes #9605 (Post List - Increase severity of an error in CriticalPostActionTracker) in https://github.com/wordpress-mobile/WordPress-Android/commit/23e45a50b73487b0ec1f32c483c6c9c2abc52134

- Removes "// TODO Get name of the author" in https://github.com/wordpress-mobile/WordPress-Android/commit/9a295ab2961684bb5e7002e774304e82355501ec as it has its own issue #9576 

- Fixes "// TODO: Add a unit test for performing critical action property" in https://github.com/wordpress-mobile/WordPress-Android/commit/9a295ab2961684bb5e7002e774304e82355501ec

- Minor change in condition in https://github.com/wordpress-mobile/WordPress-Android/commit/40f0d2788b8eb0ca42f9990f027b10819655b916

- Removes BUTTON_BACK and replaces "restore" with "moveToDrafts" in attrs.xml  in https://github.com/wordpress-mobile/WordPress-Android/commit/f0871f9b3f1ca138b0465197a62fd073b25e29f2

- Fixes Unknown post handling in https://github.com/wordpress-mobile/WordPress-Android/commit/aa9fc4c3be8793ce4b2f140ab817d5135f33f1ab -> I've decided to show posts with Unknown status in drafts as based on the code [here](https://github.com/wordpress-mobile/WordPress-Android/blob/43dbc82d0001f69a9eb08a7c53bf9bf6eb04e846/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L1490) and [here](https://github.com/wordpress-mobile/WordPress-Android/blob/43dbc82d0001f69a9eb08a7c53bf9bf6eb04e846/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L2165) it looks like the right choice. We can improve in the future.

- Removes more TODOs in https://github.com/wordpress-mobile/WordPress-Android/commit/97b76dbcfd9be78d6012504eae37b0bddc4ed3b2 as they have their own issue #9639 

- Fixes "// TODO: Find a better name than listener" in https://github.com/wordpress-mobile/WordPress-Android/commit/b2228a77633a927b8046847af803eaab6b7d653d


To test:
We'll test the post list screen anyway, so I don't think it's necessary to test these changes.

Update release notes:

- We'll update the release notes when we merge `feature/master-post-filters` into `develop`
