### PR TITLE
Show warning dialog when trashing post with local changes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/CriticalPostActionTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/CriticalPostActionTracker.kt
@@ -11,7 +11,7 @@ class CriticalPostActionTracker(
     private val shouldCrashOnUnexpectedAction: Boolean = BuildConfig.DEBUG
 ) {
     enum class CriticalPostAction {
-        DELETING_POST, RESTORING_POST, TRASHING_POST, MOVING_POST_TO_DRAFT
+        DELETING_POST, RESTORING_POST, TRASHING_POST, TRASHING_POST_WITH_LOCAL_CHANGES, MOVING_POST_TO_DRAFT
     }
     private val map = HashMap<LocalId, CriticalPostAction>()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -209,7 +209,7 @@ class PostActionHandler(
         if (!checkNetworkConnection()) {
             return
         }
-        val criticalPostAction = if(hasLocalChanges){
+        val criticalPostAction = if (hasLocalChanges) {
             TRASHING_POST_WITH_LOCAL_CHANGES
         } else {
             TRASHING_POST

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.posts.CriticalPostActionTracker.CriticalPostActi
 import org.wordpress.android.ui.posts.CriticalPostActionTracker.CriticalPostAction.MOVING_POST_TO_DRAFT
 import org.wordpress.android.ui.posts.CriticalPostActionTracker.CriticalPostAction.RESTORING_POST
 import org.wordpress.android.ui.posts.CriticalPostActionTracker.CriticalPostAction.TRASHING_POST
+import org.wordpress.android.ui.posts.CriticalPostActionTracker.CriticalPostAction.TRASHING_POST_WITH_LOCAL_CHANGES
 import org.wordpress.android.ui.posts.PostListAction.DismissPendingNotification
 import org.wordpress.android.ui.posts.PostListAction.PreviewPost
 import org.wordpress.android.ui.posts.PostListAction.RetryUpload
@@ -77,7 +78,11 @@ class PostActionHandler(
             BUTTON_PREVIEW -> triggerPostListAction.invoke(PreviewPost(site, post))
             BUTTON_STATS -> triggerPostListAction.invoke(ViewStats(site, post))
             BUTTON_TRASH -> {
-                trashPost(post)
+                if (post.isLocallyChanged) {
+                    postListDialogHelper.showTrashPostWithLocalChangesConfirmationDialog(post)
+                } else {
+                    trashPost(post)
+                }
             }
             BUTTON_DELETE -> {
                 postListDialogHelper.showDeletePostConfirmationDialog(post)
@@ -193,42 +198,57 @@ class PostActionHandler(
         }
     }
 
-    private fun trashPost(post: PostModel) {
+    fun trashPostWithLocalChanges(localPostId: Int) {
+        // If post doesn't exist, nothing else to do
+        val post = postStore.getPostByLocalPostId(localPostId) ?: return
+        trashPost(post, true)
+    }
+
+    private fun trashPost(post: PostModel, hasLocalChanges: Boolean = false) {
         // We need network connection to trash a post
         if (!checkNetworkConnection()) {
             return
         }
+        val criticalPostAction = if(hasLocalChanges){
+            TRASHING_POST_WITH_LOCAL_CHANGES
+        } else {
+            TRASHING_POST
+        }
 
         showSnackbar.invoke(SnackbarMessageHolder(R.string.post_trashing))
-        criticalPostActionTracker.add(localPostId = LocalId(post.id), criticalPostAction = TRASHING_POST)
+        criticalPostActionTracker.add(localPostId = LocalId(post.id), criticalPostAction = criticalPostAction)
 
         triggerPostUploadAction.invoke(CancelPostAndMediaUpload(post))
         dispatcher.dispatch(PostActionBuilder.newDeletePostAction(RemotePostPayload(post, site)))
     }
 
     fun handlePostTrashed(localPostId: LocalId, isError: Boolean) {
-        if (criticalPostActionTracker.get(localPostId) != TRASHING_POST) {
+        val criticalAction = criticalPostActionTracker.get(localPostId)
+        if (criticalAction != TRASHING_POST && criticalAction != TRASHING_POST_WITH_LOCAL_CHANGES) {
             /*
              * This is an unexpected action and either it has already been handled or another critical action has
              * been performed. In either case, safest action is to just ignore it.
              */
             return
         }
-        criticalPostActionTracker.remove(localPostId = localPostId, criticalPostAction = TRASHING_POST)
+        criticalPostActionTracker.remove(localPostId = localPostId, criticalPostAction = criticalAction)
         if (isError) {
             showToast.invoke(ToastMessageHolder(R.string.error_deleting_post, Duration.SHORT))
         } else {
-            showSnackbar.invoke(SnackbarMessageHolder(messageRes = R.string.post_trashed))
-            val snackBarHolder = SnackbarMessageHolder(
-                    messageRes = R.string.post_trashed,
-                    buttonTitleRes = R.string.undo,
-                    buttonAction = {
-                        val post = postStore.getPostByLocalPostId(localPostId.value)
-                        if (post != null) {
-                            restorePost(post)
+            val snackBarHolder = when (criticalAction) {
+                TRASHING_POST -> SnackbarMessageHolder(
+                        messageRes = R.string.post_trashed,
+                        buttonTitleRes = R.string.undo,
+                        buttonAction = {
+                            val post = postStore.getPostByLocalPostId(localPostId.value)
+                            if (post != null) {
+                                restorePost(post)
+                            }
                         }
-                    }
-            )
+                )
+                TRASHING_POST_WITH_LOCAL_CHANGES -> SnackbarMessageHolder(messageRes = R.string.post_trashed)
+                else -> throw IllegalStateException("Unexpected action in handlePostTrashed(): $criticalAction")
+            }
             showSnackbar.invoke(snackBarHolder)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
@@ -68,8 +68,8 @@ class PostListDialogHelper(
                 tag = CONFIRM_TRASH_POST_WITH_LOCAL_CHANGES_DIALOG_TAG,
                 title = UiStringRes(R.string.dialog_confirm_trash_losing_local_changes_title),
                 message = UiStringRes(R.string.dialog_confirm_trash_losing_local_changes_message),
-                positiveButton = UiStringRes(R.string.trash_yes),
-                negativeButton = UiStringRes(R.string.trash_no)
+                positiveButton = UiStringRes(R.string.dialog_button_ok),
+                negativeButton = UiStringRes(R.string.dialog_button_cancel)
         )
         localPostIdForTrashPostWithLocalChangesDialog = post.id
         showDialog.invoke(dialogHolder)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -242,6 +242,7 @@ class PostListMainViewModel @Inject constructor(
     fun onPositiveClickedForBasicDialog(instanceTag: String) {
         postListDialogHelper.onPositiveClickedForBasicDialog(
                 instanceTag = instanceTag,
+                trashPostWithLocalChanges = postActionHandler::trashPostWithLocalChanges,
                 deletePost = postActionHandler::deletePost,
                 publishPost = postActionHandler::publishPost,
                 updateConflictedPostWithRemoteVersion = postConflictResolver::updateConflictedPostWithRemoteVersion

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -339,8 +339,8 @@
     <string name="snackbar_conflict_undo">Undo</string>
 
     <!-- trash post with local changes dialog -->
-    <string name="dialog_confirm_trash_losing_local_changes_title">Trash Post</string>
-    <string name="dialog_confirm_trash_losing_local_changes_message">You\'ll permanently lose your local changes.</string>
+    <string name="dialog_confirm_trash_losing_local_changes_title">Local changes</string>
+    <string name="dialog_confirm_trash_losing_local_changes_message">Trashing this post will discard local changes, are you sure you want to continue?</string>
 
     <!-- gutenberg informative dialog -->
     <string name="dialog_gutenberg_informative_title">Block Editor Enabled</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -338,6 +338,10 @@
     <string name="snackbar_conflict_web_version_discarded">Web version discarded</string>
     <string name="snackbar_conflict_undo">Undo</string>
 
+    <!-- trash post with local changes dialog -->
+    <string name="dialog_confirm_trash_losing_local_changes_title">Trash Post</string>
+    <string name="dialog_confirm_trash_losing_local_changes_message">You\'ll permanently lose your local changes.</string>
+
     <!-- gutenberg informative dialog -->
     <string name="dialog_gutenberg_informative_title">Block Editor Enabled</string>
     <string name="dialog_gutenberg_informative_description_post">This post was originally created in the Block Editor, so we\'ve also enabled it on this Post.


### PR DESCRIPTION
When a post has local changes we show a warning dialog when the user tries to trash it. When the user clicks on the positive button, the post is trashed and the local changes are discarded. The undo button is not supported in this scenario.

I'm not happy about this solution so I'm all ears.

To test:
1. My Site
2. Blog Posts
3. Trash a post and make sure post is trashed and the undo button works as expected
4. Turn on airplane mode
5. Open a post and change it's title
6. Close the post
7. Try to trash the post and notice a warning dialog is shown
8. Make sure both positive and negative buttons work as expected

Update release notes:

- We'll update the release notes when we merge `feature/master-post-filters` into `develop`
