### PR TITLE
Introduce PostFetcher - prevent duplicate requests

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -37,6 +37,7 @@ import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.helpers.DialogHolder
 import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
+import org.wordpress.android.viewmodel.posts.PostFetcher
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.LocalPostId
 import org.wordpress.android.viewmodel.posts.PostListViewModelConnector
 import javax.inject.Inject
@@ -96,6 +97,10 @@ class PostListMainViewModel @Inject constructor(
 
     private val uploadStatusTracker = PostListUploadStatusTracker(uploadStore = uploadStore)
     private val featuredImageTracker = PostListFeaturedImageTracker(dispatcher = dispatcher, mediaStore = mediaStore)
+
+    private val postFetcher by lazy {
+        PostFetcher(lifecycle, dispatcher)
+    }
 
     private val postListDialogHelper: PostListDialogHelper by lazy {
         PostListDialogHelper(
@@ -192,7 +197,8 @@ class PostListMainViewModel @Inject constructor(
                 postActionHandler = postActionHandler,
                 getUploadStatus = uploadStatusTracker::getUploadStatus,
                 doesPostHaveUnhandledConflict = postConflictResolver::doesPostHaveUnhandledConflict,
-                getFeaturedImageUrl = featuredImageTracker::getFeaturedImageUrl
+                getFeaturedImageUrl = featuredImageTracker::getFeaturedImageUrl,
+                postFetcher = postFetcher
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostFetcher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostFetcher.kt
@@ -1,0 +1,64 @@
+package org.wordpress.android.viewmodel.posts
+
+import android.arch.lifecycle.Lifecycle
+import android.arch.lifecycle.LifecycleObserver
+import android.arch.lifecycle.OnLifecycleEvent
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.PostActionBuilder
+import org.wordpress.android.fluxc.model.CauseOfOnPostChanged.UpdatePost
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
+import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
+
+/**
+ * Class which takes care of dispatching fetch post events while ignoring duplicate requests.
+ */
+class PostFetcher constructor(
+    private val lifecycle: Lifecycle,
+    private val dispatcher: Dispatcher
+) : LifecycleObserver {
+    private val ongoingRequests = HashSet<RemoteId>()
+
+    init {
+        dispatcher.register(this)
+        lifecycle.addObserver(this)
+    }
+
+    /**
+     * Handles the [Lifecycle.Event.ON_DESTROY] event to cleanup the registration for dispatcher and removing the
+     * observer for lifecycle.
+     */
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    private fun onDestroy() {
+        lifecycle.removeObserver(this)
+        dispatcher.unregister(this)
+    }
+
+    // TODO: We should implement batch fetching when it's available in the API
+    fun fetchPosts(site: SiteModel, remoteItemIds: List<RemoteId>) {
+        remoteItemIds
+                .filter {
+                    val isDuplicate = ongoingRequests.contains(it)
+                    !isDuplicate
+                }
+                .forEach { remoteId ->
+                    ongoingRequests.add(remoteId)
+
+                    val postToFetch = PostModel()
+                    postToFetch.remotePostId = remoteId.value
+                    dispatcher.dispatch(PostActionBuilder.newFetchPostAction(RemotePostPayload(postToFetch, site)))
+                }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.BACKGROUND)
+    fun onPostChanged(event: OnPostChanged) {
+        (event.causeOfChange as? UpdatePost)?.let {
+            ongoingRequests.remove(RemoteId((event.causeOfChange as UpdatePost).remotePostId))
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostFetcher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostFetcher.kt
@@ -42,8 +42,8 @@ class PostFetcher constructor(
     fun fetchPosts(site: SiteModel, remoteItemIds: List<RemoteId>) {
         remoteItemIds
                 .filter {
-                    val isDuplicate = ongoingRequests.contains(it)
-                    !isDuplicate
+                    // ignore duplicate requests
+                    !ongoingRequests.contains(it)
                 }
                 .forEach { remoteId ->
                     ongoingRequests.add(remoteId)
@@ -57,8 +57,8 @@ class PostFetcher constructor(
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     fun onPostChanged(event: OnPostChanged) {
-        (event.causeOfChange as? UpdatePost)?.let {
-            ongoingRequests.remove(RemoteId((event.causeOfChange as UpdatePost).remotePostId))
+        (event.causeOfChange as? UpdatePost)?.let { updatePostCauseOfChange ->
+            ongoingRequests.remove(RemoteId(updatePostCauseOfChange.remotePostId))
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -63,6 +63,7 @@ class PostListViewModel @Inject constructor(
         val dataSource = PostListItemDataSource(
                 dispatcher = dispatcher,
                 postStore = postStore,
+                postFetcher = connector.postFetcher,
                 transform = this::transformPostModelToPostListItemUiState
         )
         listStore.getList(listDescriptor, dataSource, lifecycle)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
@@ -13,6 +13,7 @@ class PostListViewModelConnector(
     val postActionHandler: PostActionHandler,
     val getUploadStatus: (PostModel) -> PostListItemUploadStatus,
     val doesPostHaveUnhandledConflict: (PostModel) -> Boolean,
+    val postFetcher: PostFetcher,
     private val getFeaturedImageUrl: (site: SiteModel, featuredImageId: Long, postContent: String) -> String?
 ) {
     fun getFeaturedImageUrl(featuredImageId: Long, postContent: String): String? {


### PR DESCRIPTION
Introduces a simple PostFetcher which takes care of preventing the Post List from sending duplicate requests for fetching a post.

This solution is far from an ideal one, but introducing a robust mechanism in FluxC is beyond the scope of this project.

To test:
1. Clear app data
2. Log in 
3. Open Stetho's network tab
4. Open Post List (make sure you have enough posts so you can load several pages)
5. Scroll up and down as the posts are being fetched
6. When all the posts are loaded check in Stetho that there is a single request for each post (I randomly picked several postIds and used the search input)
7. Repeat steps 1-7 on an emulator with a slow connection

Update release notes:

- We'll update the release notes when we merge `feature/master-post-filters` into `develop`
