### PR TITLE
Improve the error message for invalid site url in login flow

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -463,8 +463,7 @@
     <string name="uploading_media">Uploading media…</string>
 
     <!-- new account view -->
-    <string name="no_site_error">Couldn\'t connect to the WordPress site. There is no valid WordPress site at this
-        address. Check the site address (URL) you entered.</string>
+    <string name="no_site_error">The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.</string>
 
     <!-- category management -->
     <string name="categories">Categories</string>
@@ -2183,6 +2182,7 @@
     <string name="login_error_while_adding_site">Error while adding site. Error code: %s</string>
     <string name="login_log_in_for_deeplink">Log in to WordPress.com to access the post.</string>
     <string name="login_log_in_for_share_intent">Log in to WordPress.com to share the content.</string>
+    <string name="login_invalid_site_url">The site address you entered is invalid. Please re-enter it.</string>
     <string name="login_empty_site_url">Please enter a site address</string>
     <string name="login_empty_username">Please enter a username</string>
     <string name="login_empty_password">Please enter a password</string>

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -10,6 +10,7 @@ import android.support.annotation.Nullable;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
+import android.util.Patterns;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
@@ -146,12 +147,19 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
             return;
         }
 
-        if (TextUtils.isEmpty(mSiteAddressInput.getEditText().getText())) {
+        String cleanedSiteAddress = getCleanedSiteAddress();
+
+        if (TextUtils.isEmpty(cleanedSiteAddress)) {
             showError(R.string.login_empty_site_url);
             return;
         }
 
-        mRequestedSiteAddress = getCleanedSiteAddress();
+        if (!Patterns.WEB_URL.matcher(cleanedSiteAddress).matches()) {
+            showError(R.string.login_invalid_site_url);
+            return;
+        }
+
+        mRequestedSiteAddress = cleanedSiteAddress;
 
         String cleanedXmlrpcSuffix = UrlUtils.removeXmlrpcSuffix(mRequestedSiteAddress);
         mDispatcher.dispatch(SiteActionBuilder.newFetchWpcomSiteByUrlAction(cleanedXmlrpcSuffix));

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="login_log_in_for_deeplink">Log in to WordPress.com to access the post.</string>
     <string name="login_log_in_for_share_intent">Log in to WordPress.com to share the content.</string>
     <string name="login_empty_site_url">Please enter a site address</string>
+    <string name="login_invalid_site_url">The site address you entered is invalid. Please re-enter it.</string>
     <string name="login_empty_username">Please enter a username</string>
     <string name="login_empty_password">Please enter a password</string>
     <string name="login_empty_2fa">Please enter a verification code</string>
@@ -89,8 +90,7 @@
     <string name="logging_in">Logging in</string>
     <string name="forgot_password">Lost your password?</string>
     <string name="error_generic">An error occurred</string>
-    <string name="no_site_error">Couldn\'t connect to the WordPress site. There is no valid WordPress site at this
-        address. Check the site address (URL) you entered.</string>
+    <string name="no_site_error">The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.</string>
     <string name="invalid_site_url_message">Check that the site URL entered is valid</string>
     <string name="xmlrpc_missing_method_error">Couldn\'t connect. Required XML-RPC methods are missing on the server.</string>
     <string name="xmlrpc_post_blocked_error">Couldn\'t connect. Your host is blocking POST requests, and the app needs


### PR DESCRIPTION
Fixes #8460. This PR improves the error messages for invalid site url. Instead of relying on the FluxC callback to check if the input text is a valid url, we'll first do a pattern check and if it fails, we'll show `login_invalid_site_url` message. If the pattern matches a url, we'll let FluxC do it's thing and if finds that there are no sites at that url, it's more likely that it's not a WordPress site, so we show the updated `no_site_error` message.

There are several different ways to check if it's a valid url, but surprisingly out of all the options I tried, only one of them worked exactly how I want this to. Here are a couple issues:

* If we use `UrlUtils.isValidUrlAndHostNotNull`, we'll need to put in the scheme in which case it says it's a valid url when I enter `arst` (which will be converted to `http://arst`)
* `URLUtil.isValidUrl()` suffers from the same issue above

See: https://stackoverflow.com/a/5930532

---

**Copy Updates**

I've requested two different messages from editorial in an internal p2 post and they got back to me with the following messages:

**login_invalid_site_url:** The site address you entered is invalid. Please re-enter it.
**no_site_error:** The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.

I don't think it's necessary to do another editorial review.

---

**Design Review**

I brought up this issue on Slack and per @mattmiklic:

```
On the design side, we should fix the spacing so the error message lines up with the text field and fix the weird line break between “at this” and “address.”
```

I am not entirely sure why the line break issue was happening, but it seems to be working fine for me. For the spacing, I think it's correct right now, maybe the screenshot in the original issue is a wrong one. Here are screenshots of the updated message with and without the layout bounds:

![Screenshot_1555449776](https://user-images.githubusercontent.com/662023/56245382-482b2680-606d-11e9-8ef9-d2d58929af36.png)
![Screenshot_1555449768](https://user-images.githubusercontent.com/662023/56245385-4a8d8080-606d-11e9-8f30-4b3f2cf16c6c.png)

---

**To test**
Test the following cases:
1. Empty site url
2. Any text without `.`
3. Any text without a `.` but with a url scheme such as `http://`
4. A valid url that's not a WordPress site
5. A valid WordPress site url

Here are my tests: https://cloudup.com/coSPbKhY4lU

---

Update release notes:

~- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.~

I don't think this is big enough of a change to have in the release notes, but let me know if you feel otherwise.
