### PR TITLE
Call publishPost(true) when confirmation dialog is accepted

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1492,7 +1492,7 @@ public class EditPostActivity extends AppCompatActivity implements
             showPublishConfirmationDialog();
         } else {
             // otherwise, if they're updating a Post, just go ahead and save it to the server
-            publishPost();
+            publishPost(false);
         }
     }
 
@@ -1967,10 +1967,6 @@ public class EditPostActivity extends AppCompatActivity implements
         i.putExtra(STATE_KEY_EDITOR_SESSION_DATA, mPostEditorAnalyticsSession);
         i.putExtra(EXTRA_IS_NEW_POST, mIsNewPost);
         setResult(RESULT_OK, i);
-    }
-
-    private void publishPost() {
-        publishPost(false);
     }
 
     private void publishPost(final boolean isPublishConfirmed) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1741,7 +1741,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 mZendeskHelper.createNewTicket(this, Origin.DISCARD_CHANGES, mSite);
                 break;
             case TAG_PUBLISH_CONFIRMATION_DIALOG:
-                publishPost(PostStatus.fromPost(mPost) == PostStatus.DRAFT);
+                publishPost(true);
                 AppRatingDialog.INSTANCE
                         .incrementInteractions(APP_REVIEWS_EVENT_INCREMENTED_BY_PUBLISHING_POST_OR_PAGE);
                 break;
@@ -1750,7 +1750,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 mEditorFragment.removeAllFailedMediaUploads();
                 break;
             case ASYNC_PROMO_DIALOG_TAG:
-                publishPost(PostStatus.fromPost(mPost) == PostStatus.DRAFT);
+                publishPost(true);
                 break;
             case TAG_GB_INFORMATIVE_DIALOG:
                 // no op
@@ -1973,7 +1973,7 @@ public class EditPostActivity extends AppCompatActivity implements
         publishPost(false);
     }
 
-    private void publishPost(final boolean isDraftToPublish) {
+    private void publishPost(final boolean isPublishConfirmed) {
         AccountModel account = mAccountStore.getAccount();
         // prompt user to verify e-mail before publishing
         if (!account.getEmailVerified()) {
@@ -2017,7 +2017,7 @@ public class EditPostActivity extends AppCompatActivity implements
             @Override
             public void run() {
                 boolean isFirstTimePublish = isFirstTimePublish();
-                if (isDraftToPublish) {
+                if (isPublishConfirmed) {
                     // now set status to PUBLISHED - only do this AFTER we have run the isFirstTimePublish() check,
                     // otherwise we'd have an incorrect value
                     mPost.setStatus(PostStatus.PUBLISHED.toString());


### PR DESCRIPTION
Fixes #9652

The problem being reported in #9652 was due to not having the `PENDING` status of Posts into account when moving the code to change status to `PUBLISHED` in #9544 (thanks for narrowing down the occurrence and opening an issue @hypest @malinajirka ).

This PR just changes the meaning of the `publishPost(boolean isDraftToPublish)` parameter from `isDraftToPublish` to `isPublishConfirmed`. The reality is all checks for Post statuses should have been made _before_ the publish confirmation dialog appears, hence this is all we need to know (whether the user was shown the publish confirmation dialog and they pressed OK). This way, we'll cover both the `DRAFT` _and_ `PENDING` statuses (or any other "future" statues that make the transition to `PUBLISHED` possible).


To test:
1. start a draft post, enter some title and body
2. tap on the overflow menu icon and tap `Settings` 
3. set the status to `Pending review`
4. tap back twice (once to go back to editing, another one to exit the editor)
5. observe the Post gets saved and reflects on the Posts list as `Pending review`
6. open it again
7. open the menu and tap on `Publish Now`
8. accept the confirmation dialog
9. observe the Post gets published.

Also, test that a new Draft still gets published:
1. start a draft post, enter some title and body
2. tap PUBLISH on the action bar
3. accept the confirmation dialog
4. observe the Post gets published.

And finally, a saved Draft:
1. start a draft post, enter some title and body
2. exit the editor so it gets saved as a Draft
3. open it again
4. tap on the overflow menu icon and tap `Publish Now`
5. accept the confirmation dialog
6. observe the Post gets published.


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

cc @jtreanor @jkmassel 