### PR TITLE
Post settings / publish save issues

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3960,10 +3960,11 @@ public class EditPostActivity extends AppCompatActivity implements
         // the same conditions as per `getSaveButtonText()` apply:
         //  if status is DRAFT and isNewPost() && mPost.isLocalDraft() --> PUBLISH;
         //  else if UNKNOWN and mPost.isLocalDraft() --> PUBLISH
-        //  else if SAVE/UPDATE
         PostStatus status = PostStatus.fromPost(mPost);
         if (AppPrefs.isAsyncPromoRequired() && userCanPublishPosts()
             && ((status == PostStatus.DRAFT || status == PostStatus.PUBLISHED) && isNewPost() && mPost.isLocalDraft()
+                // we also check for PUBLISHED posts here because the user can have a isNewPost() and
+                // they may edit the Post settings and change the status to Publish
                 || status == PostStatus.UNKNOWN && mPost.isLocalDraft())) {
             return true;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1356,9 +1356,10 @@ public class EditPostActivity extends AppCompatActivity implements
                         return false;
                     }
 
-                    if (status == PostStatus.SCHEDULED) {
+                    if (status == PostStatus.SCHEDULED || status == PostStatus.PUBLISHED) {
                         if (isNewPost()) {
-                            // if user pressed `Save as draft` on a new, Scheduled Post, re-convert it to draft.
+                            // if user pressed `Save as draft` on a new, Scheduled (or set to Publish) Post,
+                            // so re-convert it to draft.
                             if (mEditPostSettingsFragment != null) {
                                 mEditPostSettingsFragment.updatePostStatus(PostStatus.DRAFT.toString());
                                 ToastUtils.showToast(EditPostActivity.this,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3960,15 +3960,23 @@ public class EditPostActivity extends AppCompatActivity implements
         // the same conditions as per `getSaveButtonText()` apply:
         //  if status is DRAFT and isNewPost() && mPost.isLocalDraft() --> PUBLISH;
         //  else if UNKNOWN and mPost.isLocalDraft() --> PUBLISH
-        PostStatus status = PostStatus.fromPost(mPost);
-        if (AppPrefs.isAsyncPromoRequired() && userCanPublishPosts()
-            && ((status == PostStatus.DRAFT || status == PostStatus.PUBLISHED) && isNewPost() && mPost.isLocalDraft()
-                // we also check for PUBLISHED posts here because the user can have a isNewPost() and
+        if (!AppPrefs.isAsyncPromoRequired() || !userCanPublishPosts()) return false;
+
+        switch (PostStatus.fromPost(mPost)) {
+            case DRAFT:
+            case PUBLISHED:
+                // we check for both DRAFT _AND_ PUBLISHED posts here because the user can have a isNewPost() and
                 // they may edit the Post settings and change the status to Publish
-                || status == PostStatus.UNKNOWN && mPost.isLocalDraft())) {
-            return true;
+                return isNewPost() && mPost.isLocalDraft();
+            case UNKNOWN:
+                return mPost.isLocalDraft();
+            case SCHEDULED:
+            case PRIVATE:
+            case PENDING:
+            case TRASHED:
+            default:
+                return false;
         }
-        return false;
     }
 
     private void showAsyncPromoDialog(boolean isPage, boolean isScheduled) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1355,12 +1355,18 @@ public class EditPostActivity extends AppCompatActivity implements
                         return false;
                     }
 
-                    if (status == PostStatus.SCHEDULED && isNewPost()) {
-                        // if user pressed `Save as draft` on a new, Scheduled Post, re-convert it to draft.
-                        if (mEditPostSettingsFragment != null) {
-                            mEditPostSettingsFragment.updatePostStatus(PostStatus.DRAFT.toString());
-                            ToastUtils.showToast(EditPostActivity.this,
-                                    getString(R.string.editor_post_converted_back_to_draft), Duration.SHORT);
+                    if (status == PostStatus.SCHEDULED) {
+                        if (isNewPost()) {
+                            // if user pressed `Save as draft` on a new, Scheduled Post, re-convert it to draft.
+                            if (mEditPostSettingsFragment != null) {
+                                mEditPostSettingsFragment.updatePostStatus(PostStatus.DRAFT.toString());
+                                ToastUtils.showToast(EditPostActivity.this,
+                                        getString(R.string.editor_post_converted_back_to_draft), Duration.SHORT);
+                            }
+                        } else {
+                            // user pressed `Publish Now` on a non-new, Scheduled Post. Let's confirm and publish!
+                            showPublishConfirmationDialog();
+                            return false;
                         }
                     }
                     UploadUtils.showSnackbar(findViewById(R.id.editor_activity), R.string.editor_uploading_post);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -177,6 +177,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -2020,6 +2021,10 @@ public class EditPostActivity extends AppCompatActivity implements
                 if (isPublishConfirmed) {
                     // now set status to PUBLISHED - only do this AFTER we have run the isFirstTimePublish() check,
                     // otherwise we'd have an incorrect value
+                    // also re-set the published date in case it was SCHEDULED and they want to publish NOW
+                    if (PostStatus.fromPost(mPost) == PostStatus.SCHEDULED) {
+                        mPost.setDateCreated(DateTimeUtils.iso8601FromDate(new Date()));
+                    }
                     mPost.setStatus(PostStatus.PUBLISHED.toString());
                     mPostEditorAnalyticsSession.setOutcome(Outcome.PUBLISH);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1492,7 +1492,7 @@ public class EditPostActivity extends AppCompatActivity implements
             showPublishConfirmationDialog();
         } else {
             // otherwise, if they're updating a Post, just go ahead and save it to the server
-            publishPost();
+            publishPost(false);
         }
     }
 
@@ -1967,10 +1967,6 @@ public class EditPostActivity extends AppCompatActivity implements
         i.putExtra(STATE_KEY_EDITOR_SESSION_DATA, mPostEditorAnalyticsSession);
         i.putExtra(EXTRA_IS_NEW_POST, mIsNewPost);
         setResult(RESULT_OK, i);
-    }
-
-    private void publishPost() {
-        publishPost(false);
     }
 
     private void publishPost(final boolean isPublishConfirmed) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3946,10 +3946,9 @@ public class EditPostActivity extends AppCompatActivity implements
     private boolean shouldShowAsyncPromoDialog() {
         // To make sure the behavior matches what we're communicating to the user as available options,
         // the same conditions as per `getSaveButtonText()` apply:
-        //
-        //if status is DRAFT and isNewPost() && mPost.isLocalDraft() --> PUBLISH;
-        //else if UNKNOWN and mPost.isLocalDraft() --> PUBLISH
-        //else if SAVE/UPDATE
+        //  if status is DRAFT and isNewPost() && mPost.isLocalDraft() --> PUBLISH;
+        //  else if UNKNOWN and mPost.isLocalDraft() --> PUBLISH
+        //  else if SAVE/UPDATE
         PostStatus status = PostStatus.fromPost(mPost);
         if (AppPrefs.isAsyncPromoRequired() && userCanPublishPosts()
             && ((status == PostStatus.DRAFT || status == PostStatus.PUBLISHED) && isNewPost() && mPost.isLocalDraft()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1741,7 +1741,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 mZendeskHelper.createNewTicket(this, Origin.DISCARD_CHANGES, mSite);
                 break;
             case TAG_PUBLISH_CONFIRMATION_DIALOG:
-                publishPost(PostStatus.fromPost(mPost) == PostStatus.DRAFT);
+                publishPost(true);
                 AppRatingDialog.INSTANCE
                         .incrementInteractions(APP_REVIEWS_EVENT_INCREMENTED_BY_PUBLISHING_POST_OR_PAGE);
                 break;
@@ -1750,7 +1750,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 mEditorFragment.removeAllFailedMediaUploads();
                 break;
             case ASYNC_PROMO_DIALOG_TAG:
-                publishPost(PostStatus.fromPost(mPost) == PostStatus.DRAFT);
+                publishPost(true);
                 break;
             case TAG_GB_INFORMATIVE_DIALOG:
                 // no op
@@ -1973,7 +1973,7 @@ public class EditPostActivity extends AppCompatActivity implements
         publishPost(false);
     }
 
-    private void publishPost(final boolean isDraftToPublish) {
+    private void publishPost(final boolean isPublishConfirmed) {
         AccountModel account = mAccountStore.getAccount();
         // prompt user to verify e-mail before publishing
         if (!account.getEmailVerified()) {
@@ -2017,7 +2017,7 @@ public class EditPostActivity extends AppCompatActivity implements
             @Override
             public void run() {
                 boolean isFirstTimePublish = isFirstTimePublish();
-                if (isDraftToPublish) {
+                if (isPublishConfirmed) {
                     // now set status to PUBLISHED - only do this AFTER we have run the isFirstTimePublish() check,
                     // otherwise we'd have an incorrect value
                     mPost.setStatus(PostStatus.PUBLISHED.toString());


### PR DESCRIPTION
Fixes #9652, #9658, #9659, #9660 

While addressing #9652, the reviewers found several other problems with Post settings / publish and save operations, that makes it really hard to test just one path and make sure it has or hasn't any relationship with the code at hand.
For this, I decided to create one PR that fixes all the reported issues, so it's easier to smoke test the paths from a manual testing POV without running into other problems that are difficult to separate one another.
At the same time, for the ease of reviewing the code, I'm splitting problems into commits and making sure to update the description in this PR with the references to which specific commits are fixing which specific issues, so you can always focus on reviewing each of the paths in code (while not making it painful to manually test on a device as you'd have to switch branches, build, etc, and it's difficult to compare paths that way).

So, this PR has fixes for various problems in publishing:

- [x] can't publish pending review Post https://github.com/wordpress-mobile/WordPress-Android/issues/9652 fix in b195a8c2a00816be03c8253b781eca59ac3e5cf6 _(note: I first [backed from going with this solution after seeing the other issues being reported](https://github.com/wordpress-mobile/WordPress-Android/pull/9655#issuecomment-484181336), but once I took the time to consider each of the issues separately I decided this was still a proper solution for #9652 so I decided to stick with it, hence taking the commits from the original PR #9655 in here)_
- [x] Async promo dialog being shown for first post that is not a draft https://github.com/wordpress-mobile/WordPress-Android/issues/9658 fix in def726cd69
- [x] "Publish Now" button doesn't work for Scheduled posts https://github.com/wordpress-mobile/WordPress-Android/issues/9659 fix in 8018996069 and 0cb4a074ae
- [x] New post: setting status to Published then tapping on "Save as draft" doesn't work https://github.com/wordpress-mobile/WordPress-Android/issues/9660, fix in 9cad625bf006432c9518dfc375f0001e29390d73


### To test:
#### PUBLISH A POST PENDING REVIEW (#9652)
To test:
1. start a draft post, enter some title and body
2. tap on the overflow menu icon and tap `Settings` 
3. set the status to `Pending review`
4. tap back twice (once to go back to editing, another one to exit the editor)
5. observe the Post gets saved and reflects on the Posts list as `Pending review`
6. open it again
7. open the menu and tap on `Publish Now`
8. accept the confirmation dialog
9. observe the Post gets published.

Also, test that a new Draft still gets published:
1. start a draft post, enter some title and body
2. tap PUBLISH on the action bar
3. accept the confirmation dialog
4. observe the Post gets published.

And finally, a saved Draft:
1. start a draft post, enter some title and body
2. exit the editor so it gets saved as a Draft
3. open it again
4. tap on the overflow menu icon and tap `Publish Now`
5. accept the confirmation dialog
6. observe the Post gets published.


#### ASYNC PROMO DIALOG TEST CASES (#9658)

1. delete app data
2. login and start a new draft, enter title and some text
3. tap post settings
4. change status to Pending review
5. tap on SAVE
6. observe the dialog doesn't show
7. open the post again, and repeat steps 3 to 6 with statuses `private`, `draft`.

8. now, start a new draft, enter some title, some text
9. tap on PUBLISH
10. observe the async promo dialog is shown. Tap Publish, or Keep editing.
11. repeat steps 8-10, and observe this time the async promo dialog is not shown anymore (the publish confirmation dialog is shown).


#### Tapping Publish Now on a `scheduled` Post doesn't do anything (#9659)
fix in 8018996069 and 0cb4a074ae
TEST A (the fix):
1. tap on an existing, scheduled Post in the Post list to open it
2. open the overflow menu and tap `Publish Now`
3. observe that now, instead of showing a snackbar and doing nothing else, it shows the Publish confirmation dialog
4. tap on Publish, and observe the post actually gets published (post list updated, post is published on the web, etc.)

TEST B:
1. tap on an existing, scheduled Post in the Post list to open it
2. tap on SCHEDULE (main action button on the navigation bar)
3. it should just update the Post on the server (as nothing changed, it'll remain scheduled as it already was)

#### New post: setting status to Published then tapping on "Save as draft" doesn't work (#9660) 
fix in 9cad625bf006432c9518dfc375f0001e29390d73
TEST A: New posts, setting=Publish, but tap `Save as draft`
1. start a new draft
2. enter something in title and body
3. tap on the menu icon and tap on Settings
4. change the post status from Draft to Published
5. go back to editing
6. now open the overflow menu again
7. tap `Save as draft`
8. observe a snackbar is shown "Your post is uploading", toast is shown "Post converted back to draft" and it effectively gets uploaded as a Draft.

TEST B: Existing local draft, tap PUBLISH.
1. start a draft, enter title and text
2. post settings -> change status from `Draft` to  `Publish`
3. exit the editor
4. observe it's been saved as a Local Draft (that's fine)
5. ok so, open it again
6. tap on PUBLISH
7. observe the Post gets uploaded and published

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
