### PR TITLE
Fixes an issue which can result in gaps in the Reader

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,7 @@
 * The Site → Blog Posts → View WebView will no longer show any Calypso UI
 * Fixed an issue with Twitter publicize connections
 * Fixed an issue where the site icon wasn't updating correctly after switching to another site
-* Fixes an issue which can result in creating gaps in Reader
+* Fixes an issue which can result in missing posts in the Reader
 
 12.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * The Site → Blog Posts → View WebView will no longer show any Calypso UI
 * Fixed an issue with Twitter publicize connections
 * Fixed an issue where the site icon wasn't updating correctly after switching to another site
+* Fixes an issue which can result in creating gaps in Reader
 
 12.2
 -----

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -376,6 +376,14 @@ public class ReaderPostTable {
                                      args);
     }
 
+    private static boolean postExistsForReaderTag(long blogId, long postId, ReaderTag readerTag) {
+        String[] args = {Long.toString(blogId), Long.toString(postId), readerTag.getTagSlug(),
+                Integer.toString(readerTag.tagType.toInt())};
+        return SqlUtils.boolForQuery(ReaderDatabase.getReadableDb(),
+                "SELECT 1 FROM tbl_posts WHERE blog_id=? AND post_id=? AND tag_name=? AND tag_type=?",
+                args);
+    }
+
     /*
      * returns whether any of the passed posts are new or changed - used after posts are retrieved
      */
@@ -398,11 +406,11 @@ public class ReaderPostTable {
     }
 
     /*
-     * returns true if any posts in the passed list exist in this list
+     * returns true if any posts in the passed list exist in this list for the given tag
      */
-    public static boolean hasOverlap(ReaderPostList posts) {
+    public static boolean hasOverlap(ReaderPostList posts, ReaderTag tag) {
         for (ReaderPost post : posts) {
-            if (postExists(post.blogId, post.postId)) {
+            if (ReaderPostTable.postExistsForReaderTag(post.blogId, post.postId, tag)) {
                 return true;
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -410,7 +410,7 @@ public class ReaderPostTable {
      */
     public static boolean hasOverlap(ReaderPostList posts, ReaderTag tag) {
         for (ReaderPost post : posts) {
-            if (ReaderPostTable.postExistsForReaderTag(post.blogId, post.postId, tag)) {
+            if (postExistsForReaderTag(post.blogId, post.postId, tag)) {
                 return true;
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostLogic.java
@@ -232,7 +232,7 @@ public class ReaderPostLogic {
                                 int numServerPosts = serverPosts.size();
                                 if (numServerPosts >= 2
                                     && ReaderPostTable.getNumPostsWithTag(tag) > 0
-                                    && !ReaderPostTable.hasOverlap(serverPosts)) {
+                                    && !ReaderPostTable.hasOverlap(serverPosts, tag)) {
                                     // treat the second to last server post as having a gap
                                     postWithGap = serverPosts.get(numServerPosts - 2);
                                     // remove the last server post to deal with the edge case of


### PR DESCRIPTION
Fixes #5491. This PR fixes an issue which can sometimes result in a gap in the Reader. Note that while investigating #5491 this is one of the first issues I found, but I wouldn't be surprised if there is another issue that can result in a gap as I didn't audit the whole feature.

When we fetch the first page of the reader feed, we compare it to the existing posts in the DB and if at least one matches, we assume we fetched all the posts and there is no gap. The problem is that a post might be fetched as part of a different list and we'll act as if there is no gap even though there might be. The fix is fairly straightforward, we just check if the post exists for the given reader tag.

Please note that this PR will not fix the existing gaps in the Reader. These gaps will auto-resolve themselves fairly quickly, so I think resetting the table to fix the gaps is necessary.

---
**To test**
I think it's worth reproducing this issue first in `develop` and trying this branch again to check if the fix worked. Here are the steps to reproduce the issue:
1. Go to reader and refresh the list
2. Follow some random sites from another client, but make sure they’ll have at least 20 posts (in total) published before the first post in your list
3. Switch to the discover list
4. Follow at least one site you weren’t following before (the more you follow the bigger the gap will be)
5. Switch back to following list
6. It’ll auto refresh, but if it doesn’t, pull to refresh
7. Scroll 19 posts
8. Notice that there is a gap between the first post you got in `Step 1` and the 20th post in your list

---

The easiest way to test this would be to either create a new account or update the existing account and remove all the sites you're following and only follow `oguzkocertest.wordpress.com` whose last post is from a while back, so once you go into `Discover` and start following different sites, it'll be very easy to ensure at least 20 posts will be on top of the last post and check the gap.

Here is a gif of me reproducing this issue: https://cloudup.com/crG9Caq-GLH and here is the gif of the same steps after the fix: https://cloudup.com/cV8mgczYEBC

---
Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
