### PR TITLE
Fix crash - revert some of the changes made in 7c5243c and 22cc80c

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -247,7 +247,7 @@ class PostListMainViewModel @Inject constructor(
         AnalyticsUtils.trackWithSiteDetails(
                 POST_LIST_TAB_CHANGED,
                 site,
-                mapOf(TRACKS_SELECTED_TAB to currentPage.toString())
+                mutableMapOf(TRACKS_SELECTED_TAB to currentPage.toString() as Any)
         )
     }
 
@@ -325,7 +325,7 @@ class PostListMainViewModel @Inject constructor(
             AnalyticsUtils.trackWithSiteDetails(
                     POST_LIST_AUTHOR_FILTER_CHANGED,
                     site,
-                    mapOf(TRACKS_SELECTED_AUTHOR_FILTER to authorFilterSelection.toString())
+                    mutableMapOf(TRACKS_SELECTED_AUTHOR_FILTER to authorFilterSelection.toString() as Any)
             )
         }
     }


### PR DESCRIPTION
Fixes crash onTabChanged on post list screen.
- the `trackWithSiteDetails()` is putting some new elements into the map and therefore the map needs to be mutable



Update release notes:

- [ x ] We'll update the release not when the feature/master-post-filters is merged.
