### PR TITLE
Issue/jetpack install tint

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
@@ -5,8 +5,10 @@ import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProvider
 import android.arch.lifecycle.ViewModelProviders
 import android.content.Intent
+import android.content.res.ColorStateList
 import android.os.Bundle
 import android.support.v4.app.Fragment
+import android.support.v4.content.ContextCompat
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -48,6 +50,12 @@ class JetpackRemoteInstallFragment : Fragment() {
                         AppLog.e(AppLog.T.JETPACK_REMOTE_INSTALL, "An error occurred while installing Jetpack")
                     }
                     jetpack_install_icon.setImageResource(viewState.icon)
+                    if (viewState.iconTint != null) {
+                        jetpack_install_icon.imageTintList = ColorStateList.valueOf(ContextCompat.getColor(
+                                jetpack_install_icon.context, viewState.iconTint))
+                    } else {
+                        jetpack_install_icon.imageTintList = null
+                    }
                     jetpack_install_title.setText(viewState.titleResource)
                     jetpack_install_message.setText(viewState.messageResource)
                     if (viewState.buttonResource != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallViewState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallViewState.kt
@@ -1,7 +1,9 @@
 package org.wordpress.android.ui
 
+import android.support.annotation.ColorRes
 import android.support.annotation.DrawableRes
 import android.support.annotation.StringRes
+import org.wordpress.android.R.color
 import org.wordpress.android.R.drawable
 import org.wordpress.android.R.string
 import org.wordpress.android.ui.JetpackRemoteInstallViewState.Type.ERROR
@@ -14,6 +16,7 @@ sealed class JetpackRemoteInstallViewState(
     @StringRes val titleResource: Int,
     @StringRes val messageResource: Int,
     @DrawableRes val icon: Int,
+    @ColorRes val iconTint: Int? = null,
     @StringRes val buttonResource: Int? = null,
     open val onClick: () -> Unit = {},
     val progressBarVisible: Boolean = false
@@ -23,6 +26,7 @@ sealed class JetpackRemoteInstallViewState(
             string.install_jetpack,
             string.install_jetpack_message,
             icon = drawable.ic_plans_white_24dp,
+            iconTint = color.jetpack,
             buttonResource = string.install_jetpack_continue,
             onClick = onClick
     )
@@ -32,6 +36,7 @@ sealed class JetpackRemoteInstallViewState(
             string.installing_jetpack,
             string.installing_jetpack_message,
             icon = drawable.ic_plans_white_24dp,
+            iconTint = color.jetpack,
             progressBarVisible = true
     )
 
@@ -41,6 +46,7 @@ sealed class JetpackRemoteInstallViewState(
             string.jetpack_installed_message,
             icon = drawable.ic_plans_white_24dp,
             buttonResource = string.install_jetpack_continue,
+            iconTint = color.jetpack,
             onClick = onClick
     )
 

--- a/WordPress/src/main/res/layout/jetpack_remote_install_fragment.xml
+++ b/WordPress/src/main/res/layout/jetpack_remote_install_fragment.xml
@@ -26,7 +26,7 @@
                 android:layout_marginTop="@dimen/margin_extra_large"
                 android:contentDescription="@string/content_description_people_looking_charts"
                 android:src="@drawable/ic_plans_white_24dp"
-                android:tint="@color/jetpack"/>
+                tools:tint="@color/jetpack"/>
 
             <TextView
                 android:id="@+id/jetpack_install_title"


### PR DESCRIPTION
### Fix
Update the icon tint in the Jetpack remote install flow to be `jetpack` (`#00be28`) for the [`START`](https://github.com/wordpress-mobile/WordPress-Android/blob/e39a5da718877047367bb06a1379578ecaf38af0/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallViewState.kt#L24-L32), [`INSTALLING`](https://github.com/wordpress-mobile/WordPress-Android/blob/e39a5da718877047367bb06a1379578ecaf38af0/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallViewState.kt#L34-L41), and [`INSTALLED`](https://github.com/wordpress-mobile/WordPress-Android/blob/e39a5da718877047367bb06a1379578ecaf38af0/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallViewState.kt#L43-L51) states and none for the [`ERROR`](https://github.com/wordpress-mobile/WordPress-Android/blob/e39a5da718877047367bb06a1379578ecaf38af0/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallViewState.kt#L53-L60) state.  See the animations below for illustration.

Before|After
-|-
<a href="https://user-images.githubusercontent.com/3827611/56591788-3b8f5c80-659e-11e9-8ed7-fb41fccd6d8c.gif"><img src="https://user-images.githubusercontent.com/3827611/56591788-3b8f5c80-659e-11e9-8ed7-fb41fccd6d8c.gif" width="320"></a>|<a href="https://user-images.githubusercontent.com/3827611/56591795-3e8a4d00-659e-11e9-885c-f806175beb15.gif"><img src="https://user-images.githubusercontent.com/3827611/56591795-3e8a4d00-659e-11e9-885c-f806175beb15.gif" width="320"></a>

### Test
0. Log in with only self-hosted site without Jetpack.
1. Go to ***Sites*** tab.
2. Tap ***Stats*** item.
3. Tap ***Install Jetpack*** button.
4. Enable airplane mode.
5. Tap ***Continue*** button.
6. Notice info outline image is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.