### PR TITLE
Issue/site creation button

### DIFF
--- a/WordPress/src/main/res/layout-land/new_site_creation_preview_screen.xml
+++ b/WordPress/src/main/res/layout-land/new_site_creation_preview_screen.xml
@@ -25,6 +25,7 @@
             android:id="@+id/sitePreviewTitleAndButtonContainer"
             android:layout_width="@dimen/new_site_creation_preview_landscape_title_and_button_container_width"
             android:layout_height="match_parent"
+            android:clipToPadding="false"
             android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
             android:gravity="center"

--- a/WordPress/src/main/res/layout-land/new_site_creation_preview_screen.xml
+++ b/WordPress/src/main/res/layout-land/new_site_creation_preview_screen.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -35,10 +34,13 @@
 
             <include layout="@layout/new_site_creation_preview_header_item"/>
 
-            <Button
+            <android.support.v7.widget.AppCompatButton
                 android:id="@+id/okButton"
-                style="@style/SitePreviewOkButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_extra_large"
+                android:text="@string/dialog_button_ok"
+                android:theme="@style/WordPress.Button.Primary"
                 tools:ignore="InconsistentLayout"/>
         </LinearLayout>
 

--- a/WordPress/src/main/res/layout/new_site_creation_preview_screen_default.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_preview_screen_default.xml
@@ -52,10 +52,15 @@
             app:cardElevation="@dimen/new_site_creation_container_elevation"
             tools:ignore="InconsistentLayout">
 
-            <Button
+            <android.support.v7.widget.AppCompatButton
                 android:id="@+id/okButton"
-                style="@style/SitePreviewOkButton"
-                android:layout_margin="@dimen/margin_extra_large"/>
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginEnd="@dimen/margin_extra_large"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:text="@string/dialog_button_ok"
+                android:theme="@style/WordPress.Button.Primary"/>
         </android.support.v7.widget.CardView>
     </RelativeLayout>
 </RelativeLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -390,7 +390,6 @@
     <dimen name="new_site_creation_preview_skeleton_mid_size_width">174dp</dimen>
     <dimen name="new_site_creation_preview_skeleton_large_block_height">136dp</dimen>
     <dimen name="new_site_creation_preview_landscape_title_and_button_container_width">220dp</dimen>
-    <dimen name="new_site_creation_preview_ok_button_height">36dp</dimen>
 
     <!-- stats -->
     <dimen name="stats_header_height">32dp</dimen>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -835,14 +835,6 @@
         <item name="android:text">@string/new_site_creation_preview_subtitle</item>
     </style>
 
-    <style name="SitePreviewOkButton">
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">@dimen/new_site_creation_preview_ok_button_height</item>
-        <item name="android:background">@color/primary_400</item>
-        <item name="android:text">@string/dialog_button_ok</item>
-        <item name="android:textColor">@android:color/white</item>
-    </style>
-
     <style name="SitePreviewSkeletonView">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_marginTop">@dimen/margin_large</item>


### PR DESCRIPTION
### Fix
Update the ***OK*** button color and style on the site creation preview screen to follow the updated design described in https://github.com/wordpress-mobile/WordPress-Android/issues/9545 and https://github.com/wordpress-mobile/WordPress-Android/pull/9546.  See the screenshots below for illustration.

![site_creation_preview_portrait](https://user-images.githubusercontent.com/3827611/56600889-a5affd80-65ae-11e9-8d66-945317a18f54.png)

![site_creation_preview_landscape](https://user-images.githubusercontent.com/3827611/56600896-a779c100-65ae-11e9-9970-570a6d659dc2.png)

### Test
1. Go to ***Sites*** tab.
2. Tap ***Switch Site*** button in top card view.
3. Tap ***Add New Site*** button in top app bar.
4. Tap ***Create WordPress.com Site*** option in dialog.
5. Tap any segment on ***Create Site*** screen.
6. Tap ***Skip*** button in ***1 of 3*** screen.
7. Tap ***Skip*** button in ***2 of 3*** screen.
8. Enter text in ***Search Domains*** field.
9. Tap domain in list.
10. Tap ***Create Site*** button.
11. Notice ***OK*** button is pink.
12. Long-press ***OK*** button.
13. Notice shadow is not clipped.
14. Rotate device.
15. Notice ***OK*** button is pink.
16. Long-press ***OK*** button.
17. Notice shadow is not clipped.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.