### PR TITLE
Back date post label

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -754,10 +754,14 @@ public class EditPostSettingsFragment extends Fragment {
                 labelToUse = getString(R.string.scheduled_for, formattedDate);
             } else if (status == PostStatus.PUBLISHED || status == PostStatus.PRIVATE) {
                 labelToUse = getString(R.string.published_on, formattedDate);
-            } else if (postModel.isLocalDraft() && PostUtils.shouldPublishImmediately(postModel)) {
-                // only show Publish "Immediate" label if it's a local draft. If it's also saved online,
-                // then show the back-date appropriately.
-                labelToUse = getString(R.string.immediately);
+            } else if (postModel.isLocalDraft()) {
+                if (PostUtils.isPublishDateInThePast(postModel)) {
+                    labelToUse = getString(R.string.backdated_for, formattedDate);
+                } else if (PostUtils.shouldPublishImmediately(postModel)) {
+                    labelToUse = getString(R.string.immediately);
+                } else {
+                    labelToUse = getString(R.string.publish_on, formattedDate);
+                }
             } else if (PostUtils.isPublishDateInTheFuture(postModel)) {
                 labelToUse = getString(R.string.schedule_for, formattedDate);
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -287,6 +287,12 @@ public class PostUtils {
         return pubDate != null && pubDate.after(now);
     }
 
+    static boolean isPublishDateInThePast(PostModel postModel) {
+        Date pubDate = DateTimeUtils.dateFromIso8601(postModel.getDateCreated());
+        Date now = new Date();
+        return pubDate != null && pubDate.before(now);
+    }
+
     // Only drafts should have the option to publish immediately to avoid user confusion
     static boolean shouldPublishImmediatelyOptionBeAvailable(PostModel postModel) {
         return PostStatus.fromPost(postModel) == PostStatus.DRAFT;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -26,6 +26,7 @@ import org.wordpress.android.util.helpers.MediaFile;
 
 import java.text.BreakIterator;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -289,8 +290,12 @@ public class PostUtils {
 
     static boolean isPublishDateInThePast(PostModel postModel) {
         Date pubDate = DateTimeUtils.dateFromIso8601(postModel.getDateCreated());
-        Date now = new Date();
-        return pubDate != null && pubDate.before(now);
+
+        // just use half an hour before now as a threshold to make sure this is backdated, to avoid false positives
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.MINUTE, -30);
+        Date halfHourBack = cal.getTime();
+        return pubDate != null && pubDate.before(halfHourBack);
     }
 
     // Only drafts should have the option to publish immediately to avoid user confusion

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1255,6 +1255,7 @@
     <string name="immediately">Immediately</string>
     <string name="now">Now</string>
     <string name="scheduled_for">Scheduled for: %s</string>
+    <string name="backdated_for">Backdated for: %s</string>
     <string name="published_on">Published on: %s</string>
     <string name="schedule_for">Schedule for: %s</string>
     <string name="publish_on">Publish on: %s</string>


### PR DESCRIPTION
Fixes #9573 

This PR implements the `Backdated: date` label solution as specified in https://github.com/wordpress-mobile/WordPress-Android/issues/9573#issuecomment-485914051 

Copying here so the PR contains the full description:

> I've not read all of the history of this issue, but at first glance I agree with something along the lines of @mattmiklic's assessment – an explicit label. Assuming we want to keep in-line with what exists for `scheduled` posts (screenshot below – `Scheduled for: [date], [time]`), backdated posts would be labeled as: `Backdated for: [date], [time]`. 

![image](https://user-images.githubusercontent.com/1200432/56605083-ecaaec80-65c8-11e9-8f7b-6f6fa465866a.png)

To test:
1. start a new draft
2. enter some title, text
3. tap on the overflow menu icon
4. tap on `Post settings`
5. under `Publish`, tap to choose a date
6. choose a date that is in the past
7. observe the label changed from `Immediately` to`Backdated for [date], [time]:`  

Note that this only applies to drafts that have not been saved yet - opening an already saved draft will show `Publish on: [date], [time]` - both situations can be seen on the gif below:

![backdate](https://user-images.githubusercontent.com/6597771/56610213-50431300-65e5-11e9-9b13-f8755c29c855.gif)


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
