### PR TITLE
Fix uploading media label not shown on post list screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListEventListener.kt
@@ -134,7 +134,7 @@ private class PostListEventListener(
     fun onMediaChanged(event: OnMediaChanged) {
         if (!event.isError && event.mediaList != null) {
             featuredMediaChanged(*event.mediaList.map { it.mediaId }.toLongArray())
-            uploadStatusChanged(*event.mediaList.map{it.localPostId}.toIntArray())
+            uploadStatusChanged(*event.mediaList.map { it.localPostId }.toIntArray())
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListEventListener.kt
@@ -134,6 +134,7 @@ private class PostListEventListener(
     fun onMediaChanged(event: OnMediaChanged) {
         if (!event.isError && event.mediaList != null) {
             featuredMediaChanged(*event.mediaList.map { it.mediaId }.toLongArray())
+            uploadStatusChanged(*event.mediaList.map{it.localPostId}.toIntArray())
         }
     }
 


### PR DESCRIPTION
Fixes #9691 

The "uploading media" label is shown when the media upload is in progress.

To test:

1. Open a published post
2. Open local media library
3. Set "Edge" connection type on the emulator
4. Add images to the post
5. Select "add individually"
6. Right after you add them, publish the post
7. Notice "Uploading media" label is shown


Update release notes:
- I haven't updated the release notes as this issue will be released along with the Post Filters project
