### PR TITLE
Issue/9490 post list retry status

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -27,6 +27,10 @@ import org.wordpress.android.util.AppLog.T.POSTS
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.LocalPostId
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.RemotePostId
 import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
+import org.wordpress.android.viewmodel.posts.PostListItemUiStateHelper.PostUploadUiState.NothingToUpload
+import org.wordpress.android.viewmodel.posts.PostListItemUiStateHelper.PostUploadUiState.UploadQueued
+import org.wordpress.android.viewmodel.posts.PostListItemUiStateHelper.PostUploadUiState.UploadingMedia
+import org.wordpress.android.viewmodel.posts.PostListItemUiStateHelper.PostUploadUiState.UploadingPost
 import org.wordpress.android.widgets.PostListButtonType
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_EDIT
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_PREVIEW
@@ -58,7 +62,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         onAction: (PostModel, PostListButtonType, AnalyticsTracker.Stat) -> Unit
     ): PostListItemUiState {
         val postStatus: PostStatus = PostStatus.fromPost(post)
-
+        val uploadUiState = createUploadUiState(uploadStatus)
         return PostListItemUiState(
                 data = PostListItemUiStateData(
                         remotePostId = RemotePostId(RemoteId(post.remotePostId)),
@@ -71,23 +75,23 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
                                 postStatus = postStatus,
                                 isLocalDraft = post.isLocalDraft,
                                 isLocallyChanged = post.isLocallyChanged,
-                                uploadStatus = uploadStatus,
+                                uploadUiState = uploadUiState,
                                 hasUnhandledConflicts = unhandledConflicts
                         ),
                         statusesColor = getStatusesColor(
                                 postStatus = postStatus,
                                 isLocalDraft = post.isLocalDraft,
                                 isLocallyChanged = post.isLocallyChanged,
-                                uploadStatus = uploadStatus,
+                                uploadUiState = uploadUiState,
                                 hasUnhandledConflicts = unhandledConflicts
                         ),
                         statusesDelimiter = UiStringRes(R.string.multiple_status_label_delimiter),
                         showProgress = shouldShowProgress(
-                                uploadStatus = uploadStatus,
+                                uploadUiState = uploadUiState,
                                 performingCriticalAction = performingCriticalAction
                         ),
                         showOverlay = shouldShowOverlay(
-                                uploadStatus = uploadStatus,
+                                uploadUiState = uploadUiState,
                                 performingCriticalAction = performingCriticalAction
                         )
                 ),
@@ -95,7 +99,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
                         postStatus = postStatus,
                         isLocalDraft = post.isLocalDraft,
                         isLocallyChanged = post.isLocallyChanged,
-                        uploadStatus = uploadStatus,
+                        uploadUiState = uploadUiState,
                         siteHasCapabilitiesToPublish = capabilitiesToPublish,
                         statsSupported = statsSupported,
                         onButtonClicked = { btnType -> onAction.invoke(post, btnType, POST_LIST_BUTTON_PRESSED) }
@@ -119,29 +123,26 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
                     ?.let { PostUtils.collapseShortcodes(it) }
                     ?.let { UiStringText(it) }
 
-    private fun shouldShowProgress(uploadStatus: PostListItemUploadStatus, performingCriticalAction: Boolean): Boolean {
-        return performingCriticalAction || (!uploadStatus.isUploadFailed &&
-                (uploadStatus.isUploadingOrQueued || uploadStatus.hasInProgressMediaUpload))
+    private fun shouldShowProgress(uploadUiState: PostUploadUiState, performingCriticalAction: Boolean): Boolean {
+        return performingCriticalAction || uploadUiState is UploadingPost || uploadUiState is UploadingMedia ||
+                uploadUiState is UploadQueued
     }
 
     private fun getStatuses(
         postStatus: PostStatus,
         isLocalDraft: Boolean,
         isLocallyChanged: Boolean,
-        uploadStatus: PostListItemUploadStatus,
+        uploadUiState: PostUploadUiState,
         hasUnhandledConflicts: Boolean
     ): List<UiString> {
         val labels: MutableList<UiString> = ArrayList()
-
-        val isError = uploadStatus.uploadError != null && !uploadStatus.hasInProgressMediaUpload
-
         when {
-            isError && uploadStatus.uploadError != null -> {
-                getErrorLabel(uploadStatus.uploadError)?.let { labels.add(it) }
+            uploadUiState is PostUploadUiState.UploadFailed -> {
+                getErrorLabel(uploadUiState.error)?.let { labels.add(it) }
             }
-            uploadStatus.isUploading -> labels.add(UiStringRes(string.post_uploading))
-            uploadStatus.hasInProgressMediaUpload -> labels.add(UiStringRes(string.uploading_media))
-            uploadStatus.isQueued || uploadStatus.hasPendingMediaUpload -> labels.add(UiStringRes(string.post_queued))
+            uploadUiState is UploadingPost -> labels.add(UiStringRes(string.post_uploading))
+            uploadUiState is UploadingMedia -> labels.add(UiStringRes(string.uploading_media))
+            uploadUiState is UploadQueued -> labels.add(UiStringRes(string.post_queued))
             hasUnhandledConflicts -> labels.add(UiStringRes(string.local_post_is_conflicted))
         }
 
@@ -186,13 +187,12 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         postStatus: PostStatus,
         isLocalDraft: Boolean,
         isLocallyChanged: Boolean,
-        uploadStatus: PostListItemUploadStatus,
+        uploadUiState: PostUploadUiState,
         hasUnhandledConflicts: Boolean
     ): Int? {
-        val isError = (uploadStatus.uploadError != null && !uploadStatus.hasInProgressMediaUpload) ||
-                hasUnhandledConflicts
-        val isProgressInfo = uploadStatus.isQueued || uploadStatus.hasPendingMediaUpload ||
-                uploadStatus.hasInProgressMediaUpload || uploadStatus.isUploading
+        val isError = uploadUiState is PostUploadUiState.UploadFailed || hasUnhandledConflicts
+        val isProgressInfo = uploadUiState is UploadingPost || uploadUiState is UploadingMedia ||
+                uploadUiState is UploadQueued
         val isStateInfo = isLocalDraft || isLocallyChanged || postStatus == PRIVATE || postStatus == PENDING
 
         return when {
@@ -203,24 +203,24 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         }
     }
 
-    private fun shouldShowOverlay(uploadStatus: PostListItemUploadStatus, performingCriticalAction: Boolean): Boolean {
+    private fun shouldShowOverlay(uploadUiState: PostUploadUiState, performingCriticalAction: Boolean): Boolean {
         // show overlay when post upload is in progress or (media upload is in progress and the user is not using Aztec)
         return performingCriticalAction ||
-                (uploadStatus.isUploading ||
-                        (!appPrefsWrapper.isAztecEditorEnabled && uploadStatus.isUploadingOrQueued))
+                (uploadUiState is UploadingPost ||
+                        (!appPrefsWrapper.isAztecEditorEnabled && uploadUiState is UploadingMedia))
     }
 
     private fun createActions(
         postStatus: PostStatus,
         isLocalDraft: Boolean,
         isLocallyChanged: Boolean,
-        uploadStatus: PostListItemUploadStatus,
+        uploadUiState: PostUploadUiState,
         siteHasCapabilitiesToPublish: Boolean,
         statsSupported: Boolean,
         onButtonClicked: (PostListButtonType) -> Unit
     ): List<PostListItemAction> {
-        val canRetryUpload = uploadStatus.uploadError != null && !uploadStatus.hasInProgressMediaUpload
-        val canPublishPost = !uploadStatus.isUploadingOrQueued &&
+        val canRetryUpload = uploadUiState is PostUploadUiState.UploadFailed
+        val canPublishPost = (canRetryUpload || uploadUiState is NothingToUpload) &&
                 (isLocallyChanged || isLocalDraft || postStatus == PostStatus.DRAFT)
         val canShowStats = statsSupported &&
                 postStatus == PostStatus.PUBLISHED &&
@@ -281,6 +281,25 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
             visibleItems.plus(PostListItemAction.MoreItem(itemsUnderMore, onButtonClicked))
         } else {
             buttonTypes.map(createSinglePostListItem)
+        }
+    }
+
+    private sealed class PostUploadUiState {
+        object UploadingMedia : PostUploadUiState()
+        object UploadingPost : PostUploadUiState()
+        data class UploadFailed(val error: UploadError) : PostUploadUiState()
+        object UploadQueued : PostUploadUiState()
+        object NothingToUpload : PostUploadUiState()
+    }
+
+    private fun createUploadUiState(status: PostListItemUploadStatus): PostUploadUiState {
+        return when {
+            status.hasInProgressMediaUpload -> UploadingMedia
+            status.isUploading -> UploadingPost
+            // the upload error is not null on retry -> it needs to be evaluated after UploadingMedia and UploadingPost
+            status.uploadError != null -> PostUploadUiState.UploadFailed(status.uploadError)
+            status.hasPendingMediaUpload || status.isQueued || status.isUploadingOrQueued -> UploadQueued
+            else -> NothingToUpload
         }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -201,7 +201,7 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `do not show progress when upload failed`() {
+    fun `show progress when upload failed and retrying`() {
         val state = createPostListItemUiState(
                 uploadStatus = createUploadStatus(
                         isUploadFailed = true,
@@ -209,7 +209,7 @@ class PostListItemUiStateHelperTest {
                         hasInProgressMediaUpload = true
                 )
         )
-        assertThat(state.data.showProgress).isFalse()
+        assertThat(state.data.showProgress).isTrue()
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -201,6 +201,16 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
+    fun `do not show progress when upload failed`() {
+        val state = createPostListItemUiState(
+                uploadStatus = createUploadStatus(
+                        isUploadFailed = true
+                )
+        )
+        assertThat(state.data.showProgress).isFalse()
+    }
+
+    @Test
     fun `show progress when upload failed and retrying`() {
         val state = createPostListItemUiState(
                 uploadStatus = createUploadStatus(


### PR DESCRIPTION
Fixes #9490 

~**Note: The branch is based on #9705 - it shouldn't be merged before #9705 is reviewed.**~

I've decided to introduce `UploadUiState` to make the conditions in the PostListUiHelper more readable. Moreover, I wanted to make sure the various permutations of fields in PostListItemUploadStatus always result in a single consistent UiState - even if the state won't be correct due to a bug, I believe it'll be much easier to find the bug and fix it. Ideally we'd get rid of the `PostListItemUploadStatus`, but it'd break all our tests and I don't think it's worth it at the moment. 

[I've also moved the evaluation](https://github.com/wordpress-mobile/WordPress-Android/blob/05641e275c0dd225da4a89d5f8427c4c60c4705b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt#L300) of "Error" state after "Uploading in progress" state as the `PostListItemUploadStatus.uploadError` is not cleared when the user clicks on Retry -> it resulted in the issue described here #9490.


To test:
- ideally try all different scenarios + try at least some of them on slow connection
1. Publish a draft
2. Update a published post
3. Schedule a post
4. Publish a post and kill the app before upload finished -> try to retry the upload
4. Publish a post with pending media upload
5. Publish a post with pending media upload and kill the app -> try to retry the upload (sometimes results in this issue #9704)


Note: It seems the retry media upload sometimes doesn't work as expected #9704 

Update release notes:

- I haven't updated the release notes as this issue will be released along with the Post Filters project
