### PR TITLE
Only show failure/success notifications for actions triggered from within the NotificationsProcessingService

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -663,9 +663,9 @@ public class NotificationsProcessingService extends Service {
                 }
             }
 
-            // now remove any localIds for already processed actions
-            for (Long localId : eventChangedCommentsRemoteIds) {
-                mActionedCommentsRemoteIds.remove(localId);
+            // now remove any remoteIds for already processed actions
+            for (Long remoteId : eventChangedCommentsRemoteIds) {
+                mActionedCommentsRemoteIds.remove(remoteId);
             }
         } else if (event.causeOfChange == CommentAction.LIKE_COMMENT) {
             if (event.isError()) {

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -646,7 +646,7 @@ public class NotificationsProcessingService extends Service {
             return;
         }
 
-        if (!Collections.disjoint(event.changedCommentsLocalIds, mActionedCommentsLocalIds)) {
+        if (Collections.disjoint(event.changedCommentsLocalIds, mActionedCommentsLocalIds)) {
             // exit if these FluxC events have nothing to do with what has been triggered from this Service
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -533,8 +533,8 @@ public class NotificationsProcessingService extends Service {
 
             SiteModel site = mSiteStore.getSiteBySiteId(mNote.getSiteId());
             if (site != null) {
-                // keep the local CommentId, we'll use it later to know whether to trigger the end processing notification
-                // or not
+                // keep the local CommentId, we'll use it later to know whether to trigger the end processing
+                // notification or not
                 keepLocalCommentIdForPostProcessing(site, mNote.getCommentId());
 
                 mDispatcher.dispatch(CommentActionBuilder.newLikeCommentAction(

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -50,7 +50,6 @@ import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.QuickActionTrackPropertyValue;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 


### PR DESCRIPTION
Fixes #8947

Comes from https://github.com/wordpress-mobile/WordPress-Android/issues/8947#issuecomment-486267765

#### Analysis
The only place where `Comment approved!` message notification is shown in code is (supposedly) when a notification's quick action has been triggered and [has completed](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java#L397).
I can think of the following situation as a possible case:
If the `NotificationsProcessingService` (used mainly for notifications quick actions processing) is running, which also means the class has been [registered with FluxC's dispatcher](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java#L148) and as such [`onCommentChanged()` subscription callback gets called not only for actions triggered from the service but also for any kind of actions on the FluxC database](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java#L620). If the network is slow enough, this could mean something you do to [moderate (approve/spam) a comment on the app's Notifications tab](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java#L529), after already having approved a comment as a quick action, will also get collected by the registered callback.
Furthermore, the callback assumes there are only effectively `like/reply/approve`  actions (as that's the design for quick actions), and maps [a successful FluxC level action `CommentAction.PUSH_COMMENT` to be equal to approving](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java#L624-L629), when it might actually not be the case.
Hence, tapping on a quick action and then opening the app while the action is taking place, and spaming something there can lead to this situation. Difficult to reproduce, but still plausible. There are still other reasons why the Service could still exist in memory even if not really running, and given it hasn't been destroyed it will still be "listening" to FluxC events, producing these notifications as well.

#### Solution
Been looking into FluxC's code to see if we can match the API responses to which notifications quick action triggered them, and it seems we do have `event.changedCommentsLocalIds` in the response's payload, so in theory it should suffice to be able to compare triggered actions and responses by their Comment's local ids to make sense of what to notify the user about and what not (that is, for the time being, we should only produce notifications for quick action buttons-triggered actions within the `NotificationsProcessingService`, and none in particular for handling those that are triggered from the app's main screens).


To test:

TEST A:
This test goes through the code path that compares Comment ids to make sure it needs to show the success notification for comment moderation (approval)
1. create 2 comment notification (make comments that should need approval - make the user a Contributor and go to site settings -> Discussion -> check "Comment must be manually approved")
2. dismiss one of the notifications, this will provoke the Service to get created (because of the notification dismiss PEndingIntent) and make the Service registered to FluxC
3. now, tap on the APPROVE notification quick action for the remaining notification
4. observe the comment gets approved and a final success notification is shown "Comment approved!"

TEST B:
This test goes through the same path as TEST A, but makes sure the action is _not_ from a quick action
1. create 2 comment notification (make comments that should need approval)
2. dismiss one of the notifications, this will provoke the Service to get created (because of the notification dismiss PEndingIntent) and make the Service registered to FluxC
3. now, open the app on the Notifications tab screen
4. open the any comment
5. mark it as spam
6. observe the there is no "Comment approved!" successnotification

TEST C:
This test goes through a different path that doesn't test moderation
1. create 2 comment notification (make comments that should NOT need approval, so the LIKE quick action is shown).
2. dismiss one of the notifications, this will provoke the Service to get created (because of the notification dismiss PEndingIntent) and make the Service registered to FluxC
3. now, tap on the LIKE notification quick action for the remaining notification
4. observe the comment gets liked without a problem.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
