### PR TITLE
Proposal: Keep scroll position of post list on insert when necessary

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -37,6 +37,7 @@ import javax.inject.Inject
 
 private const val EXTRA_POST_LIST_AUTHOR_FILTER = "post_list_author_filter"
 private const val EXTRA_POST_LIST_TYPE = "post_list_type"
+private const val MAX_INDEX_FOR_VISIBLE_ITEM_TO_KEEP_SCROLL_POSITION = 2
 
 class PostListFragment : Fragment() {
     @Inject internal lateinit var imageManager: ImageManager
@@ -155,8 +156,30 @@ class PostListFragment : Fragment() {
         return view
     }
 
+    /**
+     * Updates the data for the adapter while retaining visible item in certain cases.
+     *
+     * PagedList tries to keep the visible item by adding new items outside of the screen while modifying the scroll
+     * position. In most cases, this works out great because it doesn't interrupt to the user. However, after a new
+     * item is inserted at the top while the list is showing the very first items, it feels very weird to not have the
+     * inserted item shown. For example, if a new draft is added there is no indication of it except for the flash
+     * of the scroll bar which is not noticeable unless user is paying attention to it.
+     *
+     * In these cases, we try to keep the scroll position the same instead of keeping the visible item the same by
+     * first saving the state and re-applying it after the data updates are completed. Since `PagedListAdapter` uses
+     * bg thread to calculate the changes, we need to post the change in the bg thread as well so that it'll be applied
+     * after changes are reflected.
+     */
     private fun updatePagedListData(pagedListData: PagedPostList) {
+        val recyclerViewState = recyclerView?.layoutManager?.onSaveInstanceState()
         postListAdapter.submitList(pagedListData)
+        recyclerView?.post {
+            (recyclerView?.layoutManager as? LinearLayoutManager)?.let { layoutManager ->
+                if (layoutManager.findFirstVisibleItemPosition() < MAX_INDEX_FOR_VISIBLE_ITEM_TO_KEEP_SCROLL_POSITION) {
+                    layoutManager.onRestoreInstanceState(recyclerViewState)
+                }
+            }
+        }
     }
 
     private fun updateEmptyViewForState(state: PostListEmptyUiState) {


### PR DESCRIPTION
Fixes #9146. This is a proposal for fixing the scroll position issue in the post list. As explained in the code comment as well, `PagedList` tries to keep the visible item the same at all times. However, this looks very weird when the user is already at the top of the list.

In this PR, I've implemented a similar logic we had from before we introduced the `PagedList` by saving the scroll position and retaining it. This didn't work when I tried it before because I wasn't taking into account that the `PagedList` will calculate the changes in the bg thread and only apply it once it's done. So, when we kept the scroll position in the main thread, nothing would have changed because the changes wouldn't have been applied. By using `recyclerView.post` we can get around that issue.

I also feel that the visible item shouldn't change if the user has already scrolled, so maybe a solution such as [this proposal](https://github.com/wordpress-mobile/WordPress-Android/issues/9146#issuecomment-483783785) would work better in this case. So, currently I added a check to only keep the scroll position if we are near the top of the list. We can modify this condition any way we fit, this is just a proposal.

_I don't think this PR gets us exactly where we would like to be with this issue, but hopefully it gets us one step closer and gives us some ideas about how to go about this issue._

**To test:**

* Go to Post List
* Switch to Drafts
* Don't scroll (stay at the very top)
* Add a new draft by tapping on the new post floating button
* Notice that draft shows up at the top without having to scroll (new behavior)

My test: https://cloudup.com/crS2hx49rJy

---

* Go to Post List
* Switch to Drafts
* Scroll a few items
* Add a new draft by tapping on the new post floating button
* Notice that the list refreshes, but scroll position is kept the same (old behavior)

My test: https://cloudup.com/clAZtBMT27H

---

More tests can be done in other tabs, but their results should be the same. It's up to the reviewer whether to test different cases or not.

**Update release notes:**

~- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.~ I don't think a release note is necessary for this change.

_P.S: @mzorz I only just saw that you assigned this issue to yourself yesterday. I had an inspiration while working on something else and didn't think to check if anyone else assigned it to themselves. Really sorry about that, hope you don't mind me opening this proposal._
