### PR TITLE
Update success message of the Jetpack remote install flow

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -823,7 +823,7 @@
     <string name="installing_jetpack">Installing Jetpack</string>
     <string name="installing_jetpack_message">Installing Jetpack on your site. This can take up to a few minutes to complete</string>
     <string name="jetpack_installed">Jetpack installed</string>
-    <string name="jetpack_installed_message">You have Jetpack installed on your site. Congratulations!</string>
+    <string name="jetpack_installed_message">Now that Jetpack is installed, we just need to get you set up. This will only take a minute.</string>
     <string name="jetpack_installation_problem">There was a problem</string>
     <string name="jetpack_installation_problem_message">Jetpack could not be installed at this time</string>
     <string name="install_jetpack_continue">Continue</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -826,7 +826,7 @@
     <string name="jetpack_installed_message">Now that Jetpack is installed, we just need to get you set up. This will only take a minute.</string>
     <string name="jetpack_installation_problem">There was a problem</string>
     <string name="jetpack_installation_problem_message">Jetpack could not be installed at this time</string>
-    <string name="install_jetpack_continue">Continue</string>
+    <string name="install_jetpack_continue">Set up</string>
     <string name="install_jetpack_retry">Retry</string>
     <string name="login_to_to_connect_jetpack">Log in to the WordPress.com account you used to connect Jetpack.</string>
 


### PR DESCRIPTION
In this PR I'm updating the Jetpack remote install success message to match iOS and be a bit more expressive. It's now explaining that installing Jetpack isn't enough, the uses still has to set it up to make everything work.

Matching iOS issue - https://github.com/wordpress-mobile/WordPress-iOS/issues/11525#issuecomment-486218319

* Log in with a self-hosted site without Jetpack
* Go to Stats
* Finish Jetpack remote install
* The success screen has following properties:
  * Title: Jetpack installed
  * Body: Now that Jetpack is installed, we just need to get you set up. This will only take a minute.
  * Button: Set up

![Screenshot_1556177730](https://user-images.githubusercontent.com/1079756/56717685-81365b80-673d-11e9-8880-3ae0fab01352.png)

Only one developer is required for this review