### PR TITLE
Issue/jetpack install punctuation

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -830,13 +830,13 @@
     <!-- Jetpack install -->
     <string name="jetpack">Jetpack</string>
     <string name="install_jetpack">Install Jetpack</string>
-    <string name="install_jetpack_message">Your website credentials will not be stored and are used only for the purpose of installing Jetpack</string>
+    <string name="install_jetpack_message">Your website credentials will not be stored and are used only for the purpose of installing Jetpack.</string>
     <string name="installing_jetpack">Installing Jetpack</string>
-    <string name="installing_jetpack_message">Installing Jetpack on your site. This can take up to a few minutes to complete</string>
+    <string name="installing_jetpack_message">Installing Jetpack on your site. This can take up to a few minutes to complete.</string>
     <string name="jetpack_installed">Jetpack installed</string>
     <string name="jetpack_installed_message">Now that Jetpack is installed, we just need to get you set up. This will only take a minute.</string>
     <string name="jetpack_installation_problem">There was a problem</string>
-    <string name="jetpack_installation_problem_message">Jetpack could not be installed at this time</string>
+    <string name="jetpack_installation_problem_message">Jetpack could not be installed at this time.</string>
     <string name="install_jetpack_continue">Set up</string>
     <string name="install_jetpack_retry">Retry</string>
     <string name="login_to_to_connect_jetpack">Log in to the WordPress.com account you used to connect Jetpack.</string>


### PR DESCRIPTION
### Fix
Add missing punctuation to the Jetpack remote install string resources for consistency with other messages in the flow and to match the iOS implementation.  See the screenshots below for illustration.

Before|After|iOS
-|-|-
![jetpack_install_punctuation_01_before](https://user-images.githubusercontent.com/3827611/56761312-ded4a300-6751-11e9-822b-e2e8f184b6bd.png)|![jetpack_install_punctuation_01_after](https://user-images.githubusercontent.com/3827611/56761316-e1cf9380-6751-11e9-8d81-ac6749d2dd44.png)|![jetpack_install_punctuation_01_ios](https://user-images.githubusercontent.com/3827611/56761326-e72cde00-6751-11e9-8d5c-9032344b1795.png)
![jetpack_install_punctuation_02_before](https://user-images.githubusercontent.com/3827611/56761387-15122280-6752-11e9-9eb3-62312cb138df.png)|![jetpack_install_punctuation_02_after](https://user-images.githubusercontent.com/3827611/56761395-1ba09a00-6752-11e9-8046-5e33689124d7.png)|![jetpack_install_punctuation_02_ios](https://user-images.githubusercontent.com/3827611/56761416-22c7a800-6752-11e9-8023-8a255e206786.png)
![jetpack_install_punctuation_03_before](https://user-images.githubusercontent.com/3827611/56761427-265b2f00-6752-11e9-8b7e-25c659130dfd.png)|![jetpack_install_punctuation_03_after](https://user-images.githubusercontent.com/3827611/56761434-28bd8900-6752-11e9-900f-bbb7a3567a60.png)|![jetpack_install_punctuation_03_ios](https://user-images.githubusercontent.com/3827611/56761451-2eb36a00-6752-11e9-923e-753dcf3ecb6d.png)
![jetpack_install_punctuation_04_before](https://user-images.githubusercontent.com/3827611/56761610-a08bb380-6752-11e9-86ee-b4b7aae9d410.png)|![jetpack_install_punctuation_04_after](https://user-images.githubusercontent.com/3827611/56761613-a2557700-6752-11e9-85eb-98718b6a038d.png)|![jetpack_install_punctuation_04_ios](https://user-images.githubusercontent.com/3827611/56761620-a41f3a80-6752-11e9-81bb-8b94febae6e9.png)
![jetpack_install_punctuation_05_before](https://user-images.githubusercontent.com/3827611/56761625-a5e8fe00-6752-11e9-90c6-0c251750100c.png)|![jetpack_install_punctuation_05_after](https://user-images.githubusercontent.com/3827611/56761627-a7b2c180-6752-11e9-91d5-460f570f08df.png)|![jetpack_install_punctuation_05_ios](https://user-images.githubusercontent.com/3827611/56761630-a97c8500-6752-11e9-8c1b-80ec761564ae.png)


### Test
0. Log in with only self-hosted site without Jetpack.
1. Go to ***Sites*** tab.
2. Tap ***Stats*** item.
3. Notice punctuation in message.
4. Tap ***Install Jetpack*** button.
5. Notice punctuation in message.
6. Enable airplane mode.
7. Tap ***Set Up*** button.
8. Notice punctuation in message.
9. Wait for install to fail.
10. Notice punctuation in message.
11. Disable airplane mode.
12. Tap ***Retry*** button.
13. Wait for install to pass.
14. Notice punctuation in message

### Review
Only one developer is required to review these changes, but anyone can perform the review.