### PR TITLE
issue/9616-reader-audio

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * Added support for displaying posts in tabs based on their status
 * Added ability to filter posts by their author
 * Fixed several bugs on the blog posts screen
+* Fixed bug that prevented audio playing in the reader
 
 12.3
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -95,6 +95,7 @@ public class ReaderWebView extends WebView {
             this.setWebChromeClient(mReaderChromeClient);
             this.setWebViewClient(new ReaderWebViewClient(this));
             this.getSettings().setUserAgentString(WordPress.getUserAgent());
+            this.getSettings().setMediaPlaybackRequiresUserGesture(false);
 
             // Enable third-party cookies since they are disabled by default;
             // we need third-party cookies to support authenticated images


### PR DESCRIPTION
Fixes #9616 - adds `webSettings.setMediaPlaybackRequiresUserGesture(false)` to the reader's WebView to enable playing embedded audio.

To test:
* On the web, like [this post](https://nickbradbury.com/music-by-nick-bradbury/) which contains embedded audio
* Open the Android reader to "My Likes" and tap that post
* Ensure embedded audio plays when tapped

Hat tip to [this SO post](https://stackoverflow.com/a/48543264/1673548) for the solution.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
