### PR TITLE
Fix #9562: Fix slug edition in Post Settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -200,6 +200,7 @@ public class PostUtils {
                                     && StringUtils.equals(oldPost.getPassword(), newPost.getPassword())
                                     && StringUtils.equals(oldPost.getPostFormat(), newPost.getPostFormat())
                                     && StringUtils.equals(oldPost.getDateCreated(), newPost.getDateCreated())
+                                    && StringUtils.equals(oldPost.getSlug(), newPost.getSlug())
                                     && oldPost.getFeaturedImageId() == newPost.getFeaturedImageId()
                                     && oldPost.getTagNameList().containsAll(newPost.getTagNameList())
                                     && newPost.getTagNameList().containsAll(oldPost.getTagNameList())


### PR DESCRIPTION
Fix #9562: Fix slug edition in Post Settings, check if the slug field has been modified in `PostUtils.postHasEdits`

### Before the patch: 

- Edit a post
- Go to post settings -> edit slug
- Back to leave the settings
- Back to leave the post
- Re-open the post then post settings and notice the slug wasn't modified 😿 

### After the patch

- Edit a post
- Go to post settings -> edit slug
- Back to leave the settings
- Back to leave the post
- Re-open the post then post settings and notice the slug was modified  😸 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
