### PR TITLE
Localize Terms of Service URL

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/Constants.java
+++ b/WordPress/src/main/java/org/wordpress/android/Constants.java
@@ -1,7 +1,7 @@
 package org.wordpress.android;
 
 public class Constants {
-    public static final String URL_TOS = "https://en.wordpress.com/tos";
+    public static final String URL_TOS = "https://wordpress.com/tos";
     public static final String URL_AUTOMATTIC = "https://automattic.com";
     public static final String URL_PRIVACY_POLICY = "https://automattic.com/privacy";
     public static final String URL_DATETIME_FORMAT_HELP = "https://codex.wordpress.org/Formatting_Date_and_Time";

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -62,13 +62,13 @@ import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarte
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.CrashlyticsUtils;
-import org.wordpress.android.util.LanguageUtils;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SelfSignedSSLUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
+import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.widgets.WPSnackbar;
 
 import java.util.ArrayList;
@@ -406,13 +406,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     @Override
     public void onSignupSheetTermsOfServiceClicked() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_TERMS_OF_SERVICE_TAPPED);
-        // Get device locale and remove region to pass only language.
-        String locale = LanguageUtils.getPatchedCurrentDeviceLanguage(this);
-        int pos = locale.indexOf("_");
-        if (pos > -1) {
-            locale = locale.substring(0, pos);
-        }
-        ActivityLauncher.openUrlExternal(this, getResources().getString(R.string.wordpresscom_tos_url, locale));
+        ActivityLauncher.openUrlExternal(this, WPUrlUtils.buildTermsOfServiceUrl(this));
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -39,6 +39,7 @@ import org.wordpress.android.ui.notifications.services.NotificationsUpdateServic
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.widgets.WPViewPager;
 
 import java.util.HashMap;
@@ -52,7 +53,6 @@ import static org.wordpress.android.analytics.AnalyticsTracker.NOTIFICATIONS_SEL
 import static org.wordpress.android.ui.JetpackConnectionSource.NOTIFICATIONS;
 import static org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter.IS_TAPPED_ON_NOTIFICATION;
 import static org.wordpress.android.ui.stats.StatsConnectJetpackActivity.FAQ_URL;
-import static org.wordpress.android.ui.stats.StatsConnectJetpackActivity.TERMS_URL;
 
 public class NotificationsListFragment extends Fragment implements MainToolbarFragment {
     public static final String NOTE_ID_EXTRA = "noteId";
@@ -156,7 +156,7 @@ public class NotificationsListFragment extends Fragment implements MainToolbarFr
         TextView jetpackTermsAndConditions = view.findViewById(R.id.jetpack_terms_and_conditions);
         jetpackTermsAndConditions.setOnClickListener(new OnClickListener() {
             @Override public void onClick(View view) {
-                WPWebViewActivity.openURL(requireContext(), TERMS_URL);
+                WPWebViewActivity.openURL(requireContext(), WPUrlUtils.buildTermsOfServiceUrl(getContext()));
             }
         });
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AboutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AboutActivity.java
@@ -13,6 +13,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.util.LocaleManager;
+import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.widgets.WPTextView;
 
 import java.util.Calendar;
@@ -64,7 +65,7 @@ public class AboutActivity extends AppCompatActivity implements OnClickListener 
         if (id == R.id.about_url) {
             url = Constants.URL_AUTOMATTIC;
         } else if (id == R.id.about_tos) {
-            url = Constants.URL_TOS;
+            url = WPUrlUtils.buildTermsOfServiceUrl(this);
         } else if (id == R.id.about_privacy) {
             url = Constants.URL_PRIVACY_POLICY;
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.java
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.LocaleManager;
+import org.wordpress.android.util.WPUrlUtils;
 
 import javax.inject.Inject;
 
@@ -40,7 +41,6 @@ import static org.wordpress.android.ui.JetpackConnectionSource.STATS;
 public class StatsConnectJetpackActivity extends AppCompatActivity {
     public static final String ARG_CONTINUE_JETPACK_CONNECT = "ARG_CONTINUE_JETPACK_CONNECT";
     public static final String FAQ_URL = "https://wordpress.org/plugins/jetpack/#faq";
-    public static final String TERMS_URL = "https://en.wordpress.com/tos/";
 
     private boolean mIsJetpackConnectStarted;
 
@@ -98,7 +98,8 @@ public class StatsConnectJetpackActivity extends AppCompatActivity {
         View jetpackTermsAndConditions = findViewById(R.id.jetpack_terms_and_conditions);
         jetpackTermsAndConditions.setOnClickListener(new OnClickListener() {
             @Override public void onClick(View v) {
-                WPWebViewActivity.openURL(StatsConnectJetpackActivity.this, TERMS_URL);
+                WPWebViewActivity.openURL(StatsConnectJetpackActivity.this,
+                        WPUrlUtils.buildTermsOfServiceUrl(StatsConnectJetpackActivity.this));
             }
         });
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPUrlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPUrlUtils.java
@@ -1,5 +1,9 @@
 package org.wordpress.android.util;
 
+import android.content.Context;
+
+import org.wordpress.android.Constants;
+
 import java.net.URI;
 import java.net.URL;
 
@@ -39,5 +43,9 @@ public class WPUrlUtils {
             return false;
         }
         return url.getHost().equals("gravatar.com") || url.getHost().endsWith(".gravatar.com");
+    }
+
+    public static String buildTermsOfServiceUrl(Context context) {
+        return Constants.URL_TOS + "?locale=" + LanguageUtils.getPatchedCurrentDeviceLanguage(context);
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1412,7 +1412,6 @@
     <string name="copyright_with_year_and_company_params">© %1$d %2$s</string>
     <string name="automattic_inc" translatable="false">Automattic, Inc</string>
     <string name="automattic_url" translatable="false">automattic.com</string>
-    <string name="wordpresscom_tos_url" translatable="false">https://%s.wordpress.com/tos</string>
     <string name="version">Version</string>
     <string name="version_with_name_param">Version %s</string>
     <string name="tos">Terms of Service</string>


### PR DESCRIPTION
Fixes #8068. With supported added to `https://wordpress.com/tos` for a `locale` parameter (thanks @akirk!), we can now specify the device locale when loading the locale.

I updated all references to the ToS URL in the app to append the `locale` parameter (also switched the signup screen's usage to this from the language subdomain implementation it previously used).

### To test:
Test opening the ToS page for various device languages (many don't have a translated ToS page, so it should just load in English).

Also check that it's working on all the screens that link to the ToS:
* Me > App Settings > WordPress for Android > Terms of Service
* The link on the bottom sheet when signing up using the app (launch a clean install of the app to get this screen)
* When the active site is a non-Jetpack self-hosted site, the link on the stats screen (some of the text will be missing - see #9726 - but tapping on the text will still work)
* Same as above, but the notifications list

#### Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

(Doesn't really seem worth mentioning to me - if you disagree I'm happy to add a note.)
