### PR TITLE
Issue/9724 post filters toggle fixes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -89,7 +89,7 @@ sealed class PostListItemViewHolder(
     class Compact(
         parent: ViewGroup,
         config: PostViewHolderConfig,
-        uiHelpers: UiHelpers
+        private val uiHelpers: UiHelpers
     ) : PostListItemViewHolder(R.layout.post_list_item_compact, parent, config, uiHelpers) {
         private val moreButton: ImageButton = itemView.findViewById(R.id.more_button)
 
@@ -97,10 +97,8 @@ sealed class PostListItemViewHolder(
             setBasicValues(item.data)
 
             itemView.setOnClickListener { item.onSelected.invoke() }
-
-            if (item.compactActions.actions.isNotEmpty()) {
-                moreButton.setOnClickListener { onMoreClicked(item.compactActions.actions, moreButton) }
-            }
+            uiHelpers.updateVisibility(moreButton, item.compactActions.actions.isNotEmpty())
+            moreButton.setOnClickListener { onMoreClicked(item.compactActions.actions, moreButton) }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -315,10 +315,9 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         buttonTypes: List<PostListButtonType>,
         onButtonClicked: (PostListButtonType) -> Unit
     ): MoreItem {
-        val createSinglePostListItem = { buttonType: PostListButtonType ->
+        val allItems = buttonTypes.map { buttonType: PostListButtonType ->
             PostListItemAction.SingleItem(buttonType, onButtonClicked)
         }
-        val allItems = buttonTypes.map(createSinglePostListItem)
         return PostListItemAction.MoreItem(allItems, onButtonClicked)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -24,7 +24,6 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.POSTS
-import org.wordpress.android.viewmodel.posts.PostListItemAction.MoreItem
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.LocalPostId
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.RemotePostId
 import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
@@ -314,7 +313,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
     private fun createCompactViewActions(
         buttonTypes: List<PostListButtonType>,
         onButtonClicked: (PostListButtonType) -> Unit
-    ): MoreItem {
+    ): PostListItemAction.MoreItem {
         val allItems = buttonTypes.map { buttonType: PostListButtonType ->
             PostListItemAction.SingleItem(buttonType, onButtonClicked)
         }


### PR DESCRIPTION
Fixes #9724 

This PR fixes three issues still present after #9724 and can be seen in the comments for that issue. These are:

1. Do not have an if branch in the PostListItemViewHolder with no else branch as this could lead to odd bugs such as a leftover listener not associated with the current item. The fix for this has been simply to always set the click handler, but to use the UiHelpers object to show / hide the button as appropriate (i.e. on the basis of whether there are any available actions). The fix for this is in the first commit - c118237
2. Do not have a closure stored to a variable when it is only used once, and on the next line. Fixed in 7a26885
3. Do not use MoreItem and PostListItemAction.MoreItem interchangeably within PostListItemUiStateHelper.kt - just use the fully qualified name. Fixed in 5efd390

To test:

- Nothing beyond the original issue. Changes are purely code related and not user-visible.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
