### PR TITLE
Issue/9725 inflate xml menu

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -17,7 +17,6 @@ import android.support.v7.widget.AppCompatSpinner
 import android.support.v7.widget.Toolbar
 import android.view.HapticFeedbackConstants
 import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.widget.AdapterView
@@ -306,11 +305,9 @@ class PostsListActivity : AppCompatActivity(),
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         super.onCreateOptionsMenu(menu)
-        menu?.clear()
         menu?.let {
-            val inflater = MenuInflater(this)
-            inflater.inflate(R.menu.posts_list_layout_change, it)
-            toggleViewLayoutMenuItem = menu.findItem(R.id.post_menu_item_view_layout_type)
+            menuInflater.inflate(R.menu.posts_list_layout_change, it)
+            toggleViewLayoutMenuItem = it.findItem(R.id.post_menu_item_view_layout_type)
         }
         return true
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -17,6 +17,7 @@ import android.support.v7.widget.AppCompatSpinner
 import android.support.v7.widget.Toolbar
 import android.view.HapticFeedbackConstants
 import android.view.Menu
+import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.widget.AdapterView
@@ -306,12 +307,10 @@ class PostsListActivity : AppCompatActivity(),
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         super.onCreateOptionsMenu(menu)
         menu?.clear()
-        menu?.add(Menu.FIRST, R.id.post_menu_item_view_layout_type, 3, "")?.let { item ->
-            item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
-            toggleViewLayoutMenuItem = item
-            viewModel.viewLayoutMenuIcon.value?.let {
-                updateMenuIconForViewLayoutType(it)
-            }
+        menu?.let {
+            val inflater = MenuInflater(this)
+            inflater.inflate(R.menu.posts_list_layout_change, it)
+            toggleViewLayoutMenuItem = menu.findItem(R.id.post_menu_item_view_layout_type)
         }
         return true
     }

--- a/WordPress/src/main/res/menu/posts_list_layout_change.xml
+++ b/WordPress/src/main/res/menu/posts_list_layout_change.xml
@@ -4,6 +4,6 @@
     <item
         android:id="@+id/post_menu_item_view_layout_type"
         android:icon="@drawable/ic_view_post_compact_white_24dp"
-        android:title="TEST"
+        android:title=""
         app:showAsAction="always"/>
 </menu>

--- a/WordPress/src/main/res/menu/posts_list_layout_change.xml
+++ b/WordPress/src/main/res/menu/posts_list_layout_change.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/post_menu_item_view_layout_type"
+        android:icon="@drawable/ic_view_post_compact_white_24dp"
+        android:title="TEST"
+        app:showAsAction="always"/>
+</menu>

--- a/WordPress/src/main/res/values/ids.xml
+++ b/WordPress/src/main/res/values/ids.xml
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <item type="id" name="row_post_id" />
-    <item type="id" name="drag_handle" />
-    <item type="id" name="click_remove" />
-    <item type="id" name="stats_tags" />
-    <item type="id" name="stats_geoviews" />
-    <item type="id" name="stats_comments" />
-    <item type="id" name="stats_referrers" />
-    <item type="id" name="stats_clicks" />
-    <item type="id" name="stats_search" />
-    <item type="id" name="stats_top_authors" />
-    <item type="id" name="stats_top_posts" />
-    <item type="id" name="note_block_tag_id" />
-    <item type="id" name="bottom_nav_reader_button" />
-    <item type="id" name="bottom_nav_new_post_button" />
-    <item type="id" name="media_grid_file_path_id" />
-    <item type="id" name="post_menu_item_view_layout_type" />
+    <item name="row_post_id" type="id"/>
+    <item name="drag_handle" type="id"/>
+    <item name="click_remove" type="id"/>
+    <item name="stats_tags" type="id"/>
+    <item name="stats_geoviews" type="id"/>
+    <item name="stats_comments" type="id"/>
+    <item name="stats_referrers" type="id"/>
+    <item name="stats_clicks" type="id"/>
+    <item name="stats_search" type="id"/>
+    <item name="stats_top_authors" type="id"/>
+    <item name="stats_top_posts" type="id"/>
+    <item name="note_block_tag_id" type="id"/>
+    <item name="bottom_nav_reader_button" type="id"/>
+    <item name="bottom_nav_new_post_button" type="id"/>
+    <item name="media_grid_file_path_id" type="id"/>
 </resources>


### PR DESCRIPTION
Fixes #9725 

This changes the way the menu created in PR #9184 is created using XML layout instead. As a note @malinajirka you were right - I needed to use the menu inflater property on the activity rather than creating one. Thanks :-)

Also, I know that the PR re-orders the name and type of IDs. I should note that I save save (CMD+S) mapped to actually perform both a save and a format automatically, so I assume this happened because I habitually hit save on the file. I assume this is the way around the current formatting we have present for the project expects it, but apologies that it creates a few more lines of diff than necessary.

To test:

- No functional changes from the original issue in theory - but should probably test that the menu on the top right hand corner of blog posts still works to switch between layout types.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
