### PR TITLE
Issue/site creation search

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SearchInputWithHeader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SearchInputWithHeader.kt
@@ -36,7 +36,6 @@ class SearchInputWithHeader(private val uiHelpers: UiHelpers, rootView: View, on
         clearButtonDrawable?.setTint(greyColor)
         clearAllButton.background = clearButtonDrawable
 
-        val clearAllLayout = rootView.findViewById<View>(R.id.clear_all_layout)
         clearAllLayout.setOnClickListener {
             onClear()
         }

--- a/WordPress/src/main/res/layout/new_site_creation_search_input_item.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_search_input_item.xml
@@ -27,6 +27,8 @@
         android:textAlignment="viewStart"
         android:textColor="@color/neutral_700"
         android:textColorHint="@color/neutral_300"
+        tools:drawableStart="@drawable/ic_search_white_24dp"
+        tools:drawableTint="@color/neutral_300"
         tools:hint="@string/site_creation_domain_keywords_hint"
         tools:ignore="RtlSymmetry"
         tools:targetApi="o">

--- a/WordPress/src/main/res/layout/new_site_creation_search_input_item.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_search_input_item.xml
@@ -63,7 +63,8 @@
             android:layout_width="@dimen/site_creation_verticals_clear_search_icon_size"
             android:layout_height="@dimen/site_creation_verticals_clear_search_icon_size"
             android:background="@drawable/ic_close_white_24dp"
-            android:contentDescription="@string/new_site_creation_clear_all_content_description"/>
+            android:contentDescription="@string/new_site_creation_clear_all_content_description"
+            tools:backgroundTint="@color/neutral_300"/>
 
     </LinearLayout>
 

--- a/WordPress/src/main/res/layout/new_site_creation_search_input_item.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_search_input_item.xml
@@ -55,6 +55,7 @@
         android:layout_alignBottom="@+id/input"
         android:layout_alignParentEnd="true"
         android:layout_alignTop="@+id/input"
+        android:background="?attr/selectableItemBackgroundBorderless"
         android:gravity="center">
 
         <View

--- a/WordPress/src/main/res/layout/new_site_creation_search_input_item.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_search_input_item.xml
@@ -39,7 +39,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
-        android:background="@android:color/white">
+        android:background="@android:color/white"
+        tools:visibility="invisible">
 
         <ProgressBar
             android:layout_width="@dimen/site_creation_verticals_search_progress_size"

--- a/WordPress/src/main/res/layout/new_site_creation_search_input_item.xml
+++ b/WordPress/src/main/res/layout/new_site_creation_search_input_item.xml
@@ -42,7 +42,7 @@
         <ProgressBar
             android:layout_width="@dimen/site_creation_verticals_search_progress_size"
             android:layout_height="@dimen/site_creation_verticals_search_progress_size"
-            android:layout_marginStart="@dimen/margin_large"/>
+            android:layout_marginStart="@dimen/margin_extra_large"/>
     </FrameLayout>
 
     <LinearLayout

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -384,9 +384,9 @@
     <dimen name="new_site_creation_preview_web_view_side_margin">40dp</dimen>
     <dimen name="new_site_creation_preview_ok_button_container_height">68dp</dimen>
     <dimen name="new_site_creation_container_elevation">6dp</dimen>
-    <dimen name="new_site_creation_verticals_search_input_text_padding">24dp</dimen>
+    <dimen name="new_site_creation_verticals_search_input_text_padding">32dp</dimen>
 
-    <dimen name="new_site_creation_domains_radio_button_padding_start">20dp</dimen>
+    <dimen name="new_site_creation_domains_radio_button_padding_start">28dp</dimen>
 
     <dimen name="new_site_creation_preview_skeleton_mid_size_width">174dp</dimen>
     <dimen name="new_site_creation_preview_skeleton_large_block_height">136dp</dimen>


### PR DESCRIPTION
### Fix
Update the left/start margin of the progress view from 12dp to 16dp in the `SearchInputWithHeader` class, which is used in the site creation flow.  This left-aligns the view to the 16dp keyline, which is vertically aligned with the radio buttons below it shown after the search completes.  Also, this allows the progress view to completely cover the search icon to the left/start of the input field text.  It currently shows a small part of the search icon while the progress view is animating.  It's hard to see, but it's easier if the screenshots below are opened in a new tab/window and the image is zoomed to full-size.  These changes also include adding touch feedback when tapping the clear button, which doesn't exist currently.  See the screenshots below for illustration.

![site_creation_search](https://user-images.githubusercontent.com/3827611/56835387-edda5480-6828-11e9-8a1d-f4e33ad73622.png)

### Test
1. Go to ***Sites*** tab.
2. Tap ***Switch Site*** button in top card view.
3. Tap ***Add New Site*** button in top app bar.
4. Tap ***Create WordPress.com Site*** option in dialog.
5. Tap any segment on ***Create Site*** screen.
6. Enter text in ***e.g. Fashion, travel, design, plumbing*** field.
7. Notice progress view covers search icon completely.
8. Tap ***Clear*** button to right.
9. Notice touch feedback.
10. Tap ***Skip*** button.
11. Tap ***Skip*** button.
12. Enter text in ***Search Domains*** field.
13. Notice progress view covers search icon completely.
14. Tap ***Clear*** button.
15. Notice touch feedback.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.