### PR TITLE
Use global scope for global operation in insights management

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementViewModel.kt
@@ -4,6 +4,7 @@ import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import androidx.annotation.StringRes
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.StatsStore
@@ -74,11 +75,12 @@ class InsightsManagementViewModel @Inject constructor(
     }
 
     fun onSaveInsights() {
-        launch {
+        // This has to be GlobalScope because otherwise the coroutine gets killed with the ViewModel
+        GlobalScope.launch {
             val addedTypes = insights.filter { it.type == ADDED }.map { it.insightType }
             statsStore.updateTypes(siteProvider.siteModel, addedTypes)
 
-            insightsUseCase.refreshData(true)
+            insightsUseCase.loadData()
         }
         _closeInsightsManagement.call()
     }


### PR DESCRIPTION
There was a bug when adding a new block to insights for the first time, it would get stuck in an infinite loading state. This was caused by the coroutine getting stopped because the ViewModel was closed when we have saved the Insights management activity (activity finish triggers ViewModel clean which cancels the coroutine). To fix this I'm replacing a coroutine with a local scope with the one with global scope. This guarantees that the coroutine will always finish.

To test:
* Go to Stats/Insights
* Scroll down to "Edit"
* Click on "Edit"
* Add a new block to insights
* Click "Save"
* You go back to Insights and the block is loaded
