### PR TITLE
[GB Mobile] Disable multiple photos popup from Aztec in GB mobile

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserType.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserType.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.media;
 public enum MediaBrowserType {
     BROWSER, // browse & manage media
     EDITOR_PICKER, // select multiple images or videos to insert into a post
+    GUTENBERG_EDITOR_PICKER, // select a single image to insert into a post
     AZTEC_EDITOR_PICKER, // select multiple images or videos to insert into a post, hide source bar in portrait
     FEATURED_IMAGE_PICKER, // select a single image as a featured image
     GRAVATAR_IMAGE_PICKER, // select a single image as a gravatar
@@ -17,7 +18,8 @@ public enum MediaBrowserType {
     }
 
     public boolean isSingleImagePicker() {
-        return this == FEATURED_IMAGE_PICKER || this == GRAVATAR_IMAGE_PICKER || this == SITE_ICON_PICKER;
+        return this == FEATURED_IMAGE_PICKER || this == GRAVATAR_IMAGE_PICKER
+               || this == SITE_ICON_PICKER || this == GUTENBERG_EDITOR_PICKER;
     }
 
     public boolean canMultiselect() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2973,6 +2973,7 @@ public class EditPostActivity extends AppCompatActivity implements
         if (data != null || ((requestCode == RequestCodes.TAKE_PHOTO || requestCode == RequestCodes.TAKE_VIDEO))) {
             switch (requestCode) {
                 case RequestCodes.MULTI_SELECT_MEDIA_PICKER:
+                case RequestCodes.SINGLE_SELECT_MEDIA_PICKER:
                     handleMediaPickerResult(data);
                     // No need to bump analytics here. Bumped later in
                     // handleMediaPickerResult -> addExistingMediaToEditorAndSave
@@ -3369,8 +3370,8 @@ public class EditPostActivity extends AppCompatActivity implements
         if (isPhotoPickerShowing()) {
             hidePhotoPicker();
         } else if (mShowGutenbergEditor) {
-            // show the WP media library only since that's the only mode integrated currently from Gutenberg-mobile
-            ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.EDITOR_PICKER);
+            // show the WP media library with pictures only, since that's the only mode integrated currently from Gutenberg-mobile
+            ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.GUTENBERG_EDITOR_PICKER);
         } else if (WPMediaUtils.currentUserCanUploadMedia(mSite)) {
             showPhotoPicker();
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3370,7 +3370,8 @@ public class EditPostActivity extends AppCompatActivity implements
         if (isPhotoPickerShowing()) {
             hidePhotoPicker();
         } else if (mShowGutenbergEditor) {
-            // show the WP media library with pictures only, since that's the only mode integrated currently from Gutenberg-mobile
+            // show the WP media library with pictures only, since that's the only mode currently
+            // integrated in Gutenberg-mobile
             ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.GUTENBERG_EDITOR_PICKER);
         } else if (WPMediaUtils.currentUserCanUploadMedia(mSite)) {
             showPhotoPicker();


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/933 by making sure multiple pictures selection is disabled on media library when launched in GB mobile.
(Also video selection is disabled at this stage of the GB project).

To test:
- Enable Block Editor
- Insert image block
- Choose: "WordPress Media Library"
- Try to select 2 or more images (It should not be possible)
- Tap on a picture
- The tapped picture should be added to the block

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
