### PR TITLE
Issue/update contributing drawables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Please use the following naming convention for drawables:
 `ic_reply_white_24dp` (white reply icon 24dp)  
 `ic_stats_black_32dp` (black stats icon 32dp)
 #### Invalid
-`reply_black` (missing `ic_` and width)  
+`reply_white` (missing `ic_` and width)  
 `ic_confetti_284dp` (uses `ic_`, but should use `img_`)  
 `img_confetti_98dp` (uses height, but should use width)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,8 @@ Please use the following naming convention for drawables:
 * Use the width in dp (example: `ic_reply_white_24dp`).
 
 #### Valid
-`ic_reply_white_24dp` (black reply icon 24dp)  
-`ic_stats_black_32dp` (white stats icon 32dp)
+`ic_reply_white_24dp` (white reply icon 24dp)  
+`ic_stats_black_32dp` (black stats icon 32dp)
 #### Invalid
 `reply_black` (missing `ic_` and width)  
 `ic_confetti_284dp` (uses `ic_`, but should use `img_`)  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,16 +104,16 @@ Please use the following naming convention for drawables:
 
 * Use `ic_` for icons (i.e. simple, usually single color, usually square shape) and `img_` for images (i.e. complex, usually multiple colors).
 * Use the [gridicon](http://automattic.github.io/gridicons/) name if applicable (examples: `ic_my_sites` or `ic_reply`).
-* Use the color to icons (example: `ic_reply_grey`).
-* Use the width in dp (example: `ic_reply_grey_32dp`).
+* Use the color to icons (example: `ic_reply_white`).
+* Use the width in dp (example: `ic_reply_white_24dp`).
 
 #### Valid
-`ic_reply_grey_32dp` (grey reply icon 32dp)
-`ic_reply_white_24dp` (white reply icon 24dp).
+`ic_reply_white_24dp` (black reply icon 24dp)  
+`ic_stats_black_32dp` (white stats icon 32dp)
 #### Invalid
-`reply_blue` (missing `ic_` and width)
-`ic_confetti_284dp` (uses `ic_`, but should use `img_`)
-`img_confetti_98dp` (uses height, but should use width).
+`reply_black` (missing `ic_` and width)  
+`ic_confetti_284dp` (uses `ic_`, but should use `img_`)  
+`img_confetti_98dp` (uses height, but should use width)
 
 # Subtree'd projects
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ To help ease the translation process we ask that you mark alias string resources
 
 # Drawable Resources
 
-Adding a vector drawable (to `WordPress/src/main/res/drawable/`) should be the first option when adding assets. Only if a vector drawable is not available should PNG files be added to the project. Also make sure to use `android:src` in place of `app:srcCompat` in XML files.
+Adding a vector drawable (to `WordPress/src/main/res/drawable/`) should be the first option when adding assets. Only if a vector drawable is not available should PNG files be added to the project. Also make sure to use `android:src` in place of `app:srcCompat` in XML files. Use existing white 24dp variations of vector drawables (i.e. `ic_*_white_24dp`) and tint the drawables statically (i.e. XML) or dynamically (i.e. Java or Kotlin) as necessary. Set values for `android:height` and `android:width` attributes for views with icons to scale the 24dp icon for that view.
 
 Some vector drawables may come from a SVG file and they are not the easiest file type to edit. If the SVG file is specific to the WPAndroid project (like a banner image or unlike a gridicon), then add the SVG source in `WordPress/src/future/svg/`. This will make sure we can find and edit the SVG file and then export it in vector drawable format.
 


### PR DESCRIPTION
### Fix
Add instructions for using white icons and tinting drawables to **_Drawable Resources_** section of `CONTRIBUTING.md` file.  The icons used as examples were updated also.

### Test
Open `CONTRIBUTING.md` file and review **_Drawable Resources_** section.