### PR TITLE
Issue/9745 post list author selection fix

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewState.kt
@@ -1,14 +1,12 @@
 package org.wordpress.android.ui.posts
 
 import android.support.annotation.ColorRes
+import android.support.annotation.DrawableRes
 import org.wordpress.android.R
 import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
 import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.util.image.ImageType
-import org.wordpress.android.util.image.ImageType.AVATAR_WITH_BACKGROUND
-import org.wordpress.android.util.image.ImageType.MULTI_USER_AVATAR_GREY_BACKGROUND
 
 class PostListMainViewState(
     val isFabVisible: Boolean,
@@ -20,25 +18,21 @@ class PostListMainViewState(
 sealed class AuthorFilterListItemUIState(
     val id: Long,
     val text: UiString,
-    val avatarUrl: String?,
-    val imageType: ImageType,
-    @ColorRes val dropDownBackground: Int
+    @ColorRes open val dropDownBackground: Int
 ) {
-    class Everyone(@ColorRes dropDownBackground: Int) : AuthorFilterListItemUIState(
-            id = AuthorFilterSelection.EVERYONE.id,
-            text = UiStringRes(R.string.post_list_author_everyone),
-            avatarUrl = null,
-            imageType = MULTI_USER_AVATAR_GREY_BACKGROUND,
-            dropDownBackground = dropDownBackground
-    )
+    data class Everyone(@ColorRes override val dropDownBackground: Int, @DrawableRes val imageRes: Int) :
+            AuthorFilterListItemUIState(
+                    id = AuthorFilterSelection.EVERYONE.id,
+                    text = UiStringRes(R.string.post_list_author_everyone),
+                    dropDownBackground = dropDownBackground
+            )
 
-    class Me(avatarUrl: String?, @ColorRes dropDownBackground: Int) : AuthorFilterListItemUIState(
-            id = AuthorFilterSelection.ME.id,
-            text = UiStringRes(R.string.post_list_author_me),
-            avatarUrl = avatarUrl,
-            imageType = AVATAR_WITH_BACKGROUND,
-            dropDownBackground = dropDownBackground
-    )
+    data class Me(val avatarUrl: String?, @ColorRes override val dropDownBackground: Int) :
+            AuthorFilterListItemUIState(
+                    id = AuthorFilterSelection.ME.id,
+                    text = UiStringRes(R.string.post_list_author_me),
+                    dropDownBackground = dropDownBackground
+            )
 }
 
 fun getAuthorFilterItems(
@@ -52,7 +46,10 @@ fun getAuthorFilterItems(
 
         when (value) {
             ME -> AuthorFilterListItemUIState.Me(avatarUrl, backgroundColorRes)
-            EVERYONE -> AuthorFilterListItemUIState.Everyone(backgroundColorRes)
+            EVERYONE -> AuthorFilterListItemUIState.Everyone(
+                    backgroundColorRes,
+                    R.drawable.bg_oval_neutral_300_multiple_users_white_40dp
+            )
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/AuthorSelectionAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/AuthorSelectionAdapter.kt
@@ -1,14 +1,13 @@
 package org.wordpress.android.ui.posts.adapters
 
 import android.content.Context
-import android.database.DataSetObserver
 import android.support.v4.content.ContextCompat
 import android.support.v7.widget.AppCompatImageView
 import android.support.v7.widget.AppCompatTextView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.SpinnerAdapter
+import android.widget.BaseAdapter
 import androidx.annotation.CallSuper
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -17,21 +16,17 @@ import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.GravatarUtils
 import org.wordpress.android.util.image.ImageManager
-import java.lang.ref.WeakReference
 import javax.inject.Inject
 
-class AuthorSelectionAdapter(context: Context) : SpinnerAdapter {
+class AuthorSelectionAdapter(context: Context) : BaseAdapter() {
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var uiHelpers: UiHelpers
 
-    private var observers: MutableList<WeakReference<DataSetObserver>> = mutableListOf()
     private val items = mutableListOf<AuthorFilterListItemUIState>()
 
     init {
         (context.applicationContext as WordPress).component().inject(this)
     }
-
-    override fun getCount(): Int = items.count()
 
     override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
         var view: View? = convertView
@@ -51,11 +46,7 @@ class AuthorSelectionAdapter(context: Context) : SpinnerAdapter {
         return view!!
     }
 
-    override fun getItem(position: Int): AuthorFilterListItemUIState = items[position]
-
     override fun getItemId(position: Int): Long = items[position].id
-
-    override fun getItemViewType(position: Int): Int = 0
 
     fun getIndexOfSelection(selection: AuthorFilterSelection): Int? {
         for ((index, item) in items.withIndex()) {
@@ -85,35 +76,16 @@ class AuthorSelectionAdapter(context: Context) : SpinnerAdapter {
         return view!!
     }
 
-    override fun getViewTypeCount(): Int = 1
     override fun hasStableIds(): Boolean = true
-    override fun isEmpty(): Boolean = false
 
-    fun notifyDataSetChanged() {
-        for (observer in observers) {
-            observer.get()?.onChanged()
-        }
-    }
+    override fun getItem(position: Int): Any = items[position]
 
-    override fun registerDataSetObserver(observer: DataSetObserver) {
-        if (!observers.mapNotNull { it.get() }.contains(observer)) {
-            observers.add(WeakReference(observer))
-        }
-    }
+    override fun getCount(): Int = items.count()
 
     fun updateItems(newItems: List<AuthorFilterListItemUIState>) {
         items.clear()
         items.addAll(newItems)
         notifyDataSetChanged()
-    }
-
-    override fun unregisterDataSetObserver(observer: DataSetObserver) {
-        for ((index, currentRef) in observers.withIndex()) {
-            if (observer == currentRef.get()) {
-                observers.removeAt(index)
-                return
-            }
-        }
     }
 
     private open class NormalViewHolder(protected val itemView: View) {
@@ -134,9 +106,7 @@ class AuthorSelectionAdapter(context: Context) : SpinnerAdapter {
         override fun bind(state: AuthorFilterListItemUIState, imageManager: ImageManager, uiHelpers: UiHelpers) {
             super.bind(state, imageManager, uiHelpers)
             val context = itemView.context
-
             text.text = uiHelpers.getTextOfUiString(context, state.text)
-
             itemView.setBackgroundColor(ContextCompat.getColor(context, state.dropDownBackground))
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
@@ -20,7 +20,7 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.UNKNOWN -> R.drawable.ic_notice_white_24dp
             ImageType.VIDEO -> R.color.neutral_0
             ImageType.ICON -> R.drawable.bg_rectangle_neutral_0_radius_2dp
-            ImageType.MULTI_USER_AVATAR_GREY_BACKGROUND -> R.drawable.bg_oval_neutral_300_multiple_users_white_40dp
+            ImageType.NO_PLACEHOLDER -> null
         }
     }
 
@@ -38,7 +38,7 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.UNKNOWN -> R.drawable.legacy_dashicon_format_image_big_grey
             ImageType.VIDEO -> R.color.neutral_0
             ImageType.ICON -> R.drawable.bg_rectangle_neutral_0_radius_2dp
-            ImageType.MULTI_USER_AVATAR_GREY_BACKGROUND -> R.drawable.bg_oval_neutral_300_multiple_users_white_40dp
+            ImageType.NO_PLACEHOLDER -> null
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
@@ -18,5 +18,5 @@ enum class ImageType {
     UNKNOWN,
     VIDEO,
     ICON,
-    MULTI_USER_AVATAR_GREY_BACKGROUND
+    NO_PLACEHOLDER
 }


### PR DESCRIPTION
Fixes #9745 

`onBind` method of the AuthorSelectionAdapter was being called in an infinite loop. 

It seems getView method always returns convertView == null when used with Spinner. When we invoke imageManager.load..(url..) in the view holder and the 'url' is empty or the requests fails an error/placeholder drawable is used. However, this results in another layout/measure phase -> getView(..) is called again. However, since the convertView == null we inflate a new view and imageManager.load..(..) is invoked again - this goes on forever. In order to prevent this issue we don't use placeholder/error drawables in this case. The cost of this solution is that an empty circle is shown if we don't have the avatar in the cache and the request fails.

I've also made a couple of updates to the code while fixing this issue
- I've replaced SpinnerAdapter with BaseAdapter to remove unnecessary code in https://github.com/wordpress-mobile/WordPress-Android/commit/8356fc06827845a25f98782d45cf71fa759ab1c1
- I've fixed the issue and refactored `AuthorFilterListItemUIState` a bit in https://github.com/wordpress-mobile/WordPress-Android/commit/421ca65004420259a5d67c3074a889b02ed9a71a

Note: I recommend reviewing the two commits separately

To test:
1. Go to Post List
2. Change author selection a couple of times and make sure the correct image is always being displayed
3. Put a debugger in the `NormalViewHolder.onBind` method and make sure it's not called from an infinite loop
4. Turn on airplane mode
5. Kill the app and clears it's cache
6. Open Posts List and notice an empty circle is shown for the "My" avatar (verify the app works as expected)

Update release notes:

- This feature hasn't been released yet, so there is no reason to update the release notes.
