### PR TITLE
Inflate post list menu item from xml instead of adding it dynamically

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -63,8 +63,6 @@ class PostsListActivity : AppCompatActivity(),
     private lateinit var pager: ViewPager
     private lateinit var fab: FloatingActionButton
 
-    private var toggleViewLayoutMenuItem: MenuItem? = null
-
     private var onPageChangeListener: OnPageChangeListener = object : OnPageChangeListener {
         override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {}
 
@@ -207,11 +205,6 @@ class PostsListActivity : AppCompatActivity(),
                 pager.addOnPageChangeListener(onPageChangeListener)
             }
         })
-        viewModel.viewLayoutMenuIcon.observe(this, Observer {
-            it?.let { icon ->
-                updateMenuIconForViewLayoutType(icon)
-            }
-        })
         viewModel.selectTab.observe(this, Observer { tabIndex ->
             tabIndex?.let {
                 tabLayout.getTabAt(tabIndex)?.select()
@@ -296,7 +289,7 @@ class PostsListActivity : AppCompatActivity(),
         if (item.itemId == android.R.id.home) {
             onBackPressed()
             return true
-        } else if (item.itemId == R.id.post_menu_item_view_layout_type) {
+        } else if (item.itemId == R.id.toggle_post_list_item_layout) {
             viewModel.toggleViewLayout()
             return true
         }
@@ -305,13 +298,14 @@ class PostsListActivity : AppCompatActivity(),
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         super.onCreateOptionsMenu(menu)
-        menu?.clear()
-        menu?.add(Menu.FIRST, R.id.post_menu_item_view_layout_type, 3, "")?.let { item ->
-            item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
-            toggleViewLayoutMenuItem = item
-            viewModel.viewLayoutMenuIcon.value?.let {
-                updateMenuIconForViewLayoutType(it)
-            }
+        menu?.let {
+            menuInflater.inflate(R.menu.posts_list_toggle_view_layout, it)
+            val toggleViewLayoutMenuItem = it.findItem(R.id.toggle_post_list_item_layout)
+            viewModel.viewLayoutMenuIcon.observe(this, Observer { iconRes ->
+                iconRes?.let { icon ->
+                    updateMenuIconForViewLayoutType(toggleViewLayoutMenuItem, icon)
+                }
+            })
         }
         return true
     }
@@ -337,9 +331,9 @@ class PostsListActivity : AppCompatActivity(),
 
     // Menu PostListViewLayoutType handling
 
-    private fun updateMenuIconForViewLayoutType(@DrawableRes iconId: Int) {
+    private fun updateMenuIconForViewLayoutType(menuItem: MenuItem, @DrawableRes iconId: Int) {
         getDrawable(iconId)?.let { drawable ->
-            toggleViewLayoutMenuItem?.setIcon(drawable)
+            menuItem.setIcon(drawable)
         }
     }
 }

--- a/WordPress/src/main/res/menu/posts_list_toggle_view_layout.xml
+++ b/WordPress/src/main/res/menu/posts_list_toggle_view_layout.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/toggle_post_list_item_layout"
+        android:icon="@drawable/ic_view_post_compact_white_24dp"
+        android:title="@string/post_list_toggle_item_view_layout"
+        app:showAsAction="always"/>
+</menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -256,6 +256,7 @@
     <string name="posts_draft_empty">You don\'t have any draft posts</string>
     <string name="posts_trashed_empty">You don\'t have any binned posts</string>
     <string name="multiple_status_label_delimiter" translatable="false">\u0020·\u0020</string>
+    <string name="post_list_toggle_item_view_layout">toggle rows view</string>
 
     <!-- buttons on post cards -->
     <string name="button_edit">Edit</string>


### PR DESCRIPTION
Fixes #9725 

Inflate the "toggle posts list item view layout" button on the post list screen from the xml instead of adding the button dynamically using Kotlin.

To test:
1. My Site
2. Blog Posts
3. Click on the "toggle rows view" button -> the compact version of the post list items is displayed
4. Go back to My Site
5. Blog Posts - make sure the compact version of the post list items is still being displayed + the menu icon is in correct state

![toggle-compact](https://user-images.githubusercontent.com/2261188/56969846-47fb5280-6b66-11e9-84b8-b1039bc4060b.gif)

Update release notes:

- There is no need to update the release-notes as the feature hasn't been merged into develop yet



Note - This code was mostly developed by @onepointsixtwo in https://github.com/wordpress-mobile/WordPress-Android/pull/9732, but the fork of the repo was deleted before we merged the PR.