### PR TITLE
Add loading skeleton for compact items in posts list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostListAdapter.kt
@@ -26,6 +26,7 @@ private const val VIEW_TYPE_POST = 0
 private const val VIEW_TYPE_POST_COMPACT = 1
 private const val VIEW_TYPE_ENDLIST_INDICATOR = 2
 private const val VIEW_TYPE_LOADING = 3
+private const val VIEW_TYPE_LOADING_COMPACT = 4
 
 class PostListAdapter(
     context: Context,
@@ -38,14 +39,18 @@ class PostListAdapter(
     override fun getItemViewType(position: Int): Int {
         return when (getItem(position)) {
             is EndListIndicatorItem -> VIEW_TYPE_ENDLIST_INDICATOR
-            is LoadingItem -> VIEW_TYPE_LOADING
             is PostListItemUiState -> {
-                return when (itemLayoutType) {
+                when (itemLayoutType) {
                     STANDARD -> VIEW_TYPE_POST
                     COMPACT -> VIEW_TYPE_POST_COMPACT
                 }
             }
-            null -> VIEW_TYPE_LOADING // Placeholder by paged list
+            is LoadingItem, null -> {
+                when (itemLayoutType) {
+                    STANDARD -> VIEW_TYPE_LOADING
+                    COMPACT -> VIEW_TYPE_LOADING_COMPACT
+                }
+            }
         }
     }
 
@@ -58,6 +63,10 @@ class PostListAdapter(
             }
             VIEW_TYPE_LOADING -> {
                 val view = layoutInflater.inflate(R.layout.post_list_item_skeleton, parent, false)
+                LoadingViewHolder(view)
+            }
+            VIEW_TYPE_LOADING_COMPACT -> {
+                val view = layoutInflater.inflate(R.layout.post_list_item_skeleton_compact, parent, false)
                 LoadingViewHolder(view)
             }
             VIEW_TYPE_POST -> {

--- a/WordPress/src/main/res/layout/post_list_item_skeleton_compact.xml
+++ b/WordPress/src/main/res/layout/post_list_item_skeleton_compact.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/white">
+
+    <com.facebook.shimmer.ShimmerFrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <android.support.constraint.ConstraintLayout
+            android:id="@+id/skeleton_container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <View
+                android:id="@+id/skeleton_title"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/post_list_row_skeleton_view_title_height"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:layout_marginTop="@dimen/margin_extra_large"
+                android:background="@color/neutral_50"
+                app:layout_constraintBottom_toTopOf="@+id/skeleton_excerpt"
+                app:layout_constraintEnd_toStartOf="@+id/more_button"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintWidth_percent="0.50"/>
+
+            <View
+                android:id="@+id/skeleton_excerpt"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/post_list_row_skeleton_view_excerpt_height"
+                android:layout_marginBottom="@dimen/margin_extra_large"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:layout_marginTop="@dimen/margin_medium"
+                android:background="@color/neutral_50"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/more_button"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/skeleton_title"
+                app:layout_constraintWidth_percent="0.75"/>
+
+            <ImageView
+                android:id="@+id/more_button"
+                android:layout_width="@dimen/posts_list_compact_menu_button_size"
+                android:layout_height="@dimen/posts_list_compact_menu_button_size"
+                android:layout_marginEnd="@dimen/margin_large"
+                android:layout_marginStart="8dp"
+                android:importantForAccessibility="no"
+                android:src="@drawable/ic_ellipsis_vertical_white_24dp"
+                android:tint="@color/neutral_600"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="1.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"/>
+
+        </android.support.constraint.ConstraintLayout>
+    </com.facebook.shimmer.ShimmerFrameLayout>
+</FrameLayout>


### PR DESCRIPTION
Fixes #9763  

Note: This branch is based on https://github.com/wordpress-mobile/WordPress-Android/pull/9764.
Merge instructions
1. Review and Merge https://github.com/wordpress-mobile/WordPress-Android/pull/9764
2. Update the target branch to `feature/post-filters-compat-view-toggle`
3. Review and Merge this PR

Updates the loading skeleton for the compact view layout type on post list screen.

To test: - you might want to change the network type to EDGE so it takes a while before the items are fetched
1. Clear app data or switch to a site for which you haven't loaded posts yet
2. My Site
3. Blog Posts
4. Notice loading skeletons are being displayed
5. Click on the "toggle rows layout" - change it to compact layout
6. Scroll and observe the compact version of the loading skeleton is being displayed

![compact-loading-skeleton](https://user-images.githubusercontent.com/2261188/56970340-39fa0180-6b67-11e9-9e90-91f111b085e6.gif)

Update release notes:

- There is no need to update the release-notes as the feature hasn't been released yet

Note - This code was mostly developed by @onepointsixtwo in https://github.com/wordpress-mobile/WordPress-Android/pull/9733, but the fork of the repo was deleted before we merged the PR.