### PR TITLE
Fix PENDING for review posts when SUBMIT button pressed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2026,8 +2026,8 @@ public class EditPostActivity extends AppCompatActivity implements
                     mPost.setStatus(PostStatus.PUBLISHED.toString());
                     mPostEditorAnalyticsSession.setOutcome(Outcome.PUBLISH);
                 } else {
-                    // particular case: if user is submitting for review (that is, can't publish posts directly to this site),
-                    // update the status
+                    // particular case: if user is submitting for review (that is,
+                    // can't publish posts directly to this site), update the status
                     if (!userCanPublishPosts()) {
                         mPost.setStatus(PostStatus.PENDING.toString());
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1498,6 +1498,13 @@ public class EditPostActivity extends AppCompatActivity implements
             showPublishConfirmationDialog();
         } else {
             // otherwise, if they're updating a Post, just go ahead and save it to the server
+
+            // particular case: if user is submitting for review (that is, can't publish posts directly to this site),
+            // update the status
+            if (!userCanPublishPosts()) {
+                mPost.setStatus(PostStatus.PENDING.toString());
+                mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
+            }
             publishPost(false);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1498,13 +1498,6 @@ public class EditPostActivity extends AppCompatActivity implements
             showPublishConfirmationDialog();
         } else {
             // otherwise, if they're updating a Post, just go ahead and save it to the server
-
-            // particular case: if user is submitting for review (that is, can't publish posts directly to this site),
-            // update the status
-            if (!userCanPublishPosts()) {
-                mPost.setStatus(PostStatus.PENDING.toString());
-                mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
-            }
             publishPost(false);
         }
     }
@@ -2032,6 +2025,13 @@ public class EditPostActivity extends AppCompatActivity implements
                     }
                     mPost.setStatus(PostStatus.PUBLISHED.toString());
                     mPostEditorAnalyticsSession.setOutcome(Outcome.PUBLISH);
+                } else {
+                    // particular case: if user is submitting for review (that is, can't publish posts directly to this site),
+                    // update the status
+                    if (!userCanPublishPosts()) {
+                        mPost.setStatus(PostStatus.PENDING.toString());
+                        mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
+                    }
                 }
 
                 boolean postUpdateSuccessful = updatePostObject();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2030,8 +2030,8 @@ public class EditPostActivity extends AppCompatActivity implements
                     // update the status
                     if (!userCanPublishPosts()) {
                         mPost.setStatus(PostStatus.PENDING.toString());
-                        mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
                     }
+                    mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
                 }
 
                 boolean postUpdateSuccessful = updatePostObject();
@@ -2060,11 +2060,9 @@ public class EditPostActivity extends AppCompatActivity implements
                                 }
                             });
                         } else {
-                            mPostEditorAnalyticsSession.setOutcome(Outcome.PUBLISH);
                             savePostOnlineAndFinishAsync(isFirstTimePublish, true);
                         }
                     } else {
-                        mPostEditorAnalyticsSession.setOutcome(Outcome.PUBLISH);
                         savePostLocallyAndFinishAsync(true);
                     }
                 } else {


### PR DESCRIPTION

Fixes #9718 

As the issue described, we weren't updating the Post status for drafts where the author had no permission to publish posts, and was pressing the SUBMIT action.

To test:
1. make yourself a `Contributor` of a site (edit Roles, you can do so if you first login as an Admin of a site and go to People -> choose user -> set Role to Contributor). Alternatively do this on wp-admin or Calypso.
2. login to the app as such Contributor user
3. make sure to switch to the test site of preference where you did the changes in step 1
4. start a draft, enter a title and some text
5. tap on the action bar main Action `SUBMIT`, alternatively you can open the overflow menu and choose `Submit` there.
6. observe the Post gets uploaded and has now `Pending review` status, instead of draft as it was before this fix.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
