### PR TITLE
DRAFT - Try/use aztec content re creation fix

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -66,9 +66,13 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'org.wordpress:utils:1.22'
 
-    api ("com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:$aztecVersion")
-    api ("com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:$aztecVersion")
-    api ("com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:$aztecVersion")
+//    api ("com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:$aztecVersion")
+//    api ("com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:$aztecVersion")
+//    api ("com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:$aztecVersion")
+
+    api ("com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:try~fix-dynamic-layout-crash2-SNAPSHOT")
+    api ("com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:try~fix-dynamic-layout-crash2-SNAPSHOT")
+    api ("com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:try~fix-dynamic-layout-crash2-SNAPSHOT")
 
     if (rootProject.ext.buildGutenbergFromSource) {
         implementation (project(':react-native-gutenberg-bridge')) {


### PR DESCRIPTION
Fixes #8828 

This is a draft PR to allow testing of the fix in https://github.com/wordpress-mobile/AztecEditor-Android/pull/813/ in the WordPress Android app on various Posts.

To test:

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
