### PR TITLE
Update menu item title on post list screen to improve accessibility

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.wordpress.android.R
 import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_AUTHOR_FILTER_CHANGED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_TAB_CHANGED
@@ -36,6 +35,8 @@ import org.wordpress.android.ui.posts.PostListType.SCHEDULED
 import org.wordpress.android.ui.posts.PostListType.TRASHED
 import org.wordpress.android.ui.posts.PostListViewLayoutType.COMPACT
 import org.wordpress.android.ui.posts.PostListViewLayoutType.STANDARD
+import org.wordpress.android.ui.posts.PostListViewLayoutTypeMenuUiState.CompactViewLayoutTypeMenuUiState
+import org.wordpress.android.ui.posts.PostListViewLayoutTypeMenuUiState.StandardViewLayoutTypeMenuUiState
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.ToastUtils.Duration
@@ -106,8 +107,8 @@ class PostListMainViewModel @Inject constructor(
     private val _viewLayoutType = MutableLiveData<PostListViewLayoutType>()
     val viewLayoutType: LiveData<PostListViewLayoutType> = _viewLayoutType
 
-    private val _viewLayoutMenuIcon = MutableLiveData<Int>()
-    val viewLayoutMenuIcon: LiveData<Int> = _viewLayoutMenuIcon
+    private val _viewLayoutTypeMenuUiState = MutableLiveData<PostListViewLayoutTypeMenuUiState>()
+    val viewLayoutTypeMenuUiState: LiveData<PostListViewLayoutTypeMenuUiState> = _viewLayoutTypeMenuUiState
 
     private val uploadStatusTracker = PostListUploadStatusTracker(uploadStore = uploadStore)
     private val featuredImageTracker = PostListFeaturedImageTracker(dispatcher = dispatcher, mediaStore = mediaStore)
@@ -372,11 +373,9 @@ class PostListMainViewModel @Inject constructor(
 
     private fun setViewLayoutAndIcon(layout: PostListViewLayoutType) {
         _viewLayoutType.value = layout
-        _viewLayoutMenuIcon.value = iconForViewLayout(layout)
-    }
-
-    private fun iconForViewLayout(layout: PostListViewLayoutType) = when (layout) {
-        STANDARD -> R.drawable.ic_view_post_compact_white_24dp
-        COMPACT -> R.drawable.ic_view_post_full_white_24dp
+        _viewLayoutTypeMenuUiState.value = when (layout) {
+            STANDARD -> StandardViewLayoutTypeMenuUiState
+            COMPACT -> CompactViewLayoutTypeMenuUiState
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewState.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.posts
 
 import android.support.annotation.ColorRes
+import android.support.annotation.DrawableRes
 import org.wordpress.android.R
 import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
 import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
@@ -16,6 +17,18 @@ class PostListMainViewState(
     val authorFilterSelection: AuthorFilterSelection,
     val authorFilterItems: List<AuthorFilterListItemUIState>
 )
+
+sealed class PostListViewLayoutTypeMenuUiState(@DrawableRes val iconRes: Int, val title: UiString) {
+    object StandardViewLayoutTypeMenuUiState : PostListViewLayoutTypeMenuUiState(
+            iconRes = R.drawable.ic_view_post_compact_white_24dp,
+            title = UiStringRes(R.string.post_list_toggle_item_layout_list_view)
+    )
+
+    object CompactViewLayoutTypeMenuUiState : PostListViewLayoutTypeMenuUiState(
+            iconRes = R.drawable.ic_view_post_full_white_24dp,
+            title = UiStringRes(R.string.post_list_toggle_item_layout_cards_view)
+    )
+}
 
 sealed class AuthorFilterListItemUIState(
     val id: Long,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -7,6 +7,7 @@ import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.support.annotation.DrawableRes
 import android.support.design.widget.FloatingActionButton
 import android.support.design.widget.Snackbar
 import android.support.design.widget.TabLayout
@@ -21,7 +22,6 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.AdapterView
 import android.widget.Toast
-import androidx.annotation.DrawableRes
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
@@ -35,6 +35,7 @@ import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogOnDismissBy
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface
 import org.wordpress.android.ui.posts.adapters.AuthorSelectionAdapter
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.LocaleManager
 import org.wordpress.android.widgets.WPSnackbar
@@ -301,9 +302,10 @@ class PostsListActivity : AppCompatActivity(),
         menu?.let {
             menuInflater.inflate(R.menu.posts_list_toggle_view_layout, it)
             val toggleViewLayoutMenuItem = it.findItem(R.id.toggle_post_list_item_layout)
-            viewModel.viewLayoutMenuIcon.observe(this, Observer { iconRes ->
-                iconRes?.let { icon ->
-                    updateMenuIconForViewLayoutType(toggleViewLayoutMenuItem, icon)
+            viewModel.viewLayoutTypeMenuUiState.observe(this, Observer {menuUiState ->
+                menuUiState?.let {
+                    updateMenuIcon(menuUiState.iconRes, toggleViewLayoutMenuItem)
+                    updateMenuTitle(menuUiState.title, toggleViewLayoutMenuItem)
                 }
             })
         }
@@ -331,9 +333,13 @@ class PostsListActivity : AppCompatActivity(),
 
     // Menu PostListViewLayoutType handling
 
-    private fun updateMenuIconForViewLayoutType(menuItem: MenuItem, @DrawableRes iconId: Int) {
-        getDrawable(iconId)?.let { drawable ->
+    private fun updateMenuIcon(@DrawableRes iconRes: Int, menuItem: MenuItem) {
+        getDrawable(iconRes)?.let { drawable ->
             menuItem.setIcon(drawable)
         }
+    }
+
+    private fun updateMenuTitle(title: UiString, menuItem: MenuItem): MenuItem? {
+        return menuItem.setTitle(uiHelpers.getTextOfUiString(this@PostsListActivity, title))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -302,7 +302,7 @@ class PostsListActivity : AppCompatActivity(),
         menu?.let {
             menuInflater.inflate(R.menu.posts_list_toggle_view_layout, it)
             val toggleViewLayoutMenuItem = it.findItem(R.id.toggle_post_list_item_layout)
-            viewModel.viewLayoutTypeMenuUiState.observe(this, Observer {menuUiState ->
+            viewModel.viewLayoutTypeMenuUiState.observe(this, Observer { menuUiState ->
                 menuUiState?.let {
                     updateMenuIcon(menuUiState.iconRes, toggleViewLayoutMenuItem)
                     updateMenuTitle(menuUiState.title, toggleViewLayoutMenuItem)

--- a/WordPress/src/main/res/menu/posts_list_toggle_view_layout.xml
+++ b/WordPress/src/main/res/menu/posts_list_toggle_view_layout.xml
@@ -4,6 +4,6 @@
     <item
         android:id="@+id/toggle_post_list_item_layout"
         android:icon="@drawable/ic_view_post_compact_white_24dp"
-        android:title="@string/post_list_toggle_item_view_layout"
+        android:title="@string/post_list_toggle_item_layout_list_view"
         app:showAsAction="always"/>
 </menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -256,7 +256,8 @@
     <string name="posts_draft_empty">You don\'t have any draft posts</string>
     <string name="posts_trashed_empty">You don\'t have any binned posts</string>
     <string name="multiple_status_label_delimiter" translatable="false">\u0020·\u0020</string>
-    <string name="post_list_toggle_item_view_layout">toggle rows view</string>
+    <string name="post_list_toggle_item_layout_cards_view">Switch to cards view</string>
+    <string name="post_list_toggle_item_layout_list_view">Switch to list view</string>
 
     <!-- buttons on post cards -->
     <string name="button_edit">Edit</string>


### PR DESCRIPTION
Updates toggle view layout type menu icon on post list screen as suggested by @maxme [here](https://github.com/wordpress-mobile/WordPress-Android/pull/9764#discussion_r280410755).

To Test
1. My Site
2. Blog Posts
3. Long press the "toggle view layout" toolbar menu item
4. Make sure the correct title is displayed
5. Toggle the view layout
6. Make sure the correct title is displayed
