### PR TITLE
Themes: Hide no search results text when showing themes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 12.7
 -----
 * Show upload in progress notification when retrying
+* Fixed issue where text appeared behind list of themes on the theme screen
 
 12.6
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserAdapter.java
@@ -89,6 +89,10 @@ class ThemeBrowserAdapter extends BaseAdapter implements Filterable {
         return mFilteredThemes.size();
     }
 
+    public int getUnfilteredCount() {
+        return mAllThemes.size();
+    }
+
     @Override
     public Object getItem(int position) {
         return mFilteredThemes.get(position);

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -92,14 +92,14 @@ public class ThemeBrowserFragment extends Fragment
     private String mLastSearch;
 
     private HeaderGridView mGridView;
-    private RelativeLayout mNoThemesView;
-    private ActionableEmptyView mNoMatchesView;
+    private RelativeLayout mEmptyView;
+    private ActionableEmptyView mActionableEmptyView;
     private TextView mCurrentThemeTextView;
     private View mHeaderCustomizeButton;
 
     private ThemeBrowserAdapter mAdapter;
     private boolean mShouldRefreshOnStart;
-    private TextView mNoThemesText;
+    private TextView mEmptyTextView;
     private SiteModel mSite;
 
     private MenuItem mSearchMenuItem;
@@ -155,9 +155,9 @@ public class ThemeBrowserFragment extends Fragment
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.theme_browser_fragment, container, false);
 
-        mNoMatchesView = view.findViewById(R.id.no_matches_view);
-        mNoThemesText = view.findViewById(R.id.no_themes_text);
-        mNoThemesView = view.findViewById(R.id.no_themes_view);
+        mActionableEmptyView = view.findViewById(R.id.actionable_empty_view);
+        mEmptyTextView = view.findViewById(R.id.text_empty);
+        mEmptyView = view.findViewById(R.id.empty_view);
 
         configureGridView(inflater, view);
         configureSwipeToRefresh(view);
@@ -307,7 +307,7 @@ public class ThemeBrowserFragment extends Fragment
                         }
                         if (!NetworkUtils.checkConnection(getActivity())) {
                             mSwipeToRefreshHelper.setRefreshing(false);
-                            mNoThemesText.setText(R.string.no_network_title);
+                            mEmptyTextView.setText(R.string.no_network_title);
                             return;
                         }
                         setRefreshing(true);
@@ -395,12 +395,12 @@ public class ThemeBrowserFragment extends Fragment
         boolean hasVisibleThemes = getAdapter().getCount() > 0;
         boolean hasNoMatchingThemes = hasThemes && !hasVisibleThemes;
 
-        mNoThemesView.setVisibility(!hasThemes ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
+        mEmptyView.setVisibility(!hasThemes ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
         if (!hasThemes && !NetworkUtils.isNetworkAvailable(getActivity())) {
-            mNoThemesText.setText(R.string.no_network_title);
+            mEmptyTextView.setText(R.string.no_network_title);
         }
         mGridView.setVisibility(hasVisibleThemes ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
-        mNoMatchesView.setVisibility(hasNoMatchingThemes ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
+        mActionableEmptyView.setVisibility(hasNoMatchingThemes ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
     }
 
     private List<ThemeModel> fetchThemes() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -395,12 +395,12 @@ public class ThemeBrowserFragment extends Fragment
         boolean hasVisibleThemes = getAdapter().getCount() > 0;
         boolean hasNoMatchingThemes = hasThemes && !hasVisibleThemes;
 
-        mEmptyView.setVisibility(!hasThemes ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
+        mEmptyView.setVisibility(!hasThemes ? View.VISIBLE : View.GONE);
         if (!hasThemes && !NetworkUtils.isNetworkAvailable(getActivity())) {
             mEmptyTextView.setText(R.string.no_network_title);
         }
-        mGridView.setVisibility(hasVisibleThemes ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
-        mActionableEmptyView.setVisibility(hasNoMatchingThemes ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
+        mGridView.setVisibility(hasVisibleThemes ? View.VISIBLE : View.GONE);
+        mActionableEmptyView.setVisibility(hasNoMatchingThemes ? View.VISIBLE : View.GONE);
     }
 
     private List<ThemeModel> fetchThemes() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.themes;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.database.DataSetObserver;
 import android.os.Bundle;
 import android.text.Spannable;
 import android.text.TextUtils;
@@ -222,7 +223,6 @@ public class ThemeBrowserFragment extends Fragment
         super.onActivityCreated(savedInstanceState);
 
         getAdapter().setThemeList(fetchThemes());
-        setEmptyViewVisible(getAdapter().getCount() == 0);
         mGridView.setAdapter(getAdapter());
     }
 
@@ -386,14 +386,21 @@ public class ThemeBrowserFragment extends Fragment
         }
     }
 
-    private void setEmptyViewVisible(boolean visible) {
+    private void updateDisplay() {
         if (!isAdded() || getView() == null) {
             return;
         }
-        mEmptyView.setVisibility(visible ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
-        mActionableEmptyView.setVisibility(visible ? View.GONE : View.VISIBLE);
-        mGridView.setVisibility(visible ? View.GONE : View.VISIBLE);
-        if (visible && !NetworkUtils.isNetworkAvailable(getActivity())) {
+
+        boolean hasFetchedAnyThemes = getAdapter().getUnfilteredCount() > 0;
+        boolean isShowingAnyThemes = getAdapter().getCount() > 0;
+
+        boolean showEmptyView = !isShowingAnyThemes && !hasFetchedAnyThemes;
+        boolean showActionableEmptyView = !isShowingAnyThemes && hasFetchedAnyThemes;
+
+        mEmptyView.setVisibility(showEmptyView ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
+        mActionableEmptyView.setVisibility(showActionableEmptyView ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
+        mGridView.setVisibility(isShowingAnyThemes ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
+        if (showEmptyView && !NetworkUtils.isNetworkAvailable(getActivity())) {
             mEmptyTextView.setText(R.string.no_network_title);
         }
     }
@@ -413,13 +420,13 @@ public class ThemeBrowserFragment extends Fragment
     private ThemeBrowserAdapter getAdapter() {
         if (mAdapter == null) {
             mAdapter = new ThemeBrowserAdapter(getActivity(), mSite.getPlanId(), mCallback, mImageManager);
+            mAdapter.registerDataSetObserver(new ThemeDataSetObserver());
         }
         return mAdapter;
     }
 
     protected void refreshView() {
         getAdapter().setThemeList(fetchThemes());
-        setEmptyViewVisible(getAdapter().getCount() == 0);
     }
 
     private List<ThemeModel> getSortedWpComThemes() {
@@ -526,5 +533,15 @@ public class ThemeBrowserFragment extends Fragment
     @Override public void onStop() {
         super.onStop();
         EventBus.getDefault().unregister(this);
+    }
+
+    private class ThemeDataSetObserver extends DataSetObserver {
+        @Override public void onChanged() {
+            updateDisplay();
+        }
+
+        @Override public void onInvalidated() {
+            updateDisplay();
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -92,14 +92,14 @@ public class ThemeBrowserFragment extends Fragment
     private String mLastSearch;
 
     private HeaderGridView mGridView;
-    private RelativeLayout mEmptyView;
-    private ActionableEmptyView mActionableEmptyView;
+    private RelativeLayout mNoThemesView;
+    private ActionableEmptyView mNoMatchesView;
     private TextView mCurrentThemeTextView;
     private View mHeaderCustomizeButton;
 
     private ThemeBrowserAdapter mAdapter;
     private boolean mShouldRefreshOnStart;
-    private TextView mEmptyTextView;
+    private TextView mNoThemesText;
     private SiteModel mSite;
 
     private MenuItem mSearchMenuItem;
@@ -155,9 +155,9 @@ public class ThemeBrowserFragment extends Fragment
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.theme_browser_fragment, container, false);
 
-        mActionableEmptyView = view.findViewById(R.id.actionable_empty_view);
-        mEmptyTextView = view.findViewById(R.id.text_empty);
-        mEmptyView = view.findViewById(R.id.empty_view);
+        mNoMatchesView = view.findViewById(R.id.no_matches_view);
+        mNoThemesText = view.findViewById(R.id.no_themes_text);
+        mNoThemesView = view.findViewById(R.id.no_themes_view);
 
         configureGridView(inflater, view);
         configureSwipeToRefresh(view);
@@ -307,7 +307,7 @@ public class ThemeBrowserFragment extends Fragment
                         }
                         if (!NetworkUtils.checkConnection(getActivity())) {
                             mSwipeToRefreshHelper.setRefreshing(false);
-                            mEmptyTextView.setText(R.string.no_network_title);
+                            mNoThemesText.setText(R.string.no_network_title);
                             return;
                         }
                         setRefreshing(true);
@@ -391,18 +391,16 @@ public class ThemeBrowserFragment extends Fragment
             return;
         }
 
-        boolean hasFetchedAnyThemes = getAdapter().getUnfilteredCount() > 0;
-        boolean isShowingAnyThemes = getAdapter().getCount() > 0;
+        boolean hasThemes = getAdapter().getUnfilteredCount() > 0;
+        boolean hasVisibleThemes = getAdapter().getCount() > 0;
+        boolean hasNoMatchingThemes = hasThemes && !hasVisibleThemes;
 
-        boolean showEmptyView = !isShowingAnyThemes && !hasFetchedAnyThemes;
-        boolean showActionableEmptyView = !isShowingAnyThemes && hasFetchedAnyThemes;
-
-        mEmptyView.setVisibility(showEmptyView ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
-        mActionableEmptyView.setVisibility(showActionableEmptyView ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
-        mGridView.setVisibility(isShowingAnyThemes ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
-        if (showEmptyView && !NetworkUtils.isNetworkAvailable(getActivity())) {
-            mEmptyTextView.setText(R.string.no_network_title);
+        mNoThemesView.setVisibility(!hasThemes ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
+        if (!hasThemes && !NetworkUtils.isNetworkAvailable(getActivity())) {
+            mNoThemesText.setText(R.string.no_network_title);
         }
+        mGridView.setVisibility(hasVisibleThemes ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
+        mNoMatchesView.setVisibility(hasNoMatchingThemes ? RelativeLayout.VISIBLE : RelativeLayout.GONE);
     }
 
     private List<ThemeModel> fetchThemes() {

--- a/WordPress/src/main/res/layout/theme_browser_fragment.xml
+++ b/WordPress/src/main/res/layout/theme_browser_fragment.xml
@@ -8,7 +8,7 @@
                 android:layout_height="match_parent">
 
     <org.wordpress.android.ui.ActionableEmptyView
-        android:id="@+id/no_matches_view"
+        android:id="@+id/actionable_empty_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_theme_browser_top"
@@ -36,7 +36,7 @@
     </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
     <RelativeLayout
-        android:id="@+id/no_themes_view"
+        android:id="@+id/empty_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_centerHorizontal="true"
@@ -53,7 +53,7 @@
             android:src="@drawable/drake_empty_results_400dp"/>
 
         <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/no_themes_text"
+            android:id="@+id/text_empty"
             style="@style/WordPress.EmptyList.Title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/theme_browser_fragment.xml
+++ b/WordPress/src/main/res/layout/theme_browser_fragment.xml
@@ -8,7 +8,7 @@
                 android:layout_height="match_parent">
 
     <org.wordpress.android.ui.ActionableEmptyView
-        android:id="@+id/actionable_empty_view"
+        android:id="@+id/no_matches_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_theme_browser_top"
@@ -36,7 +36,7 @@
     </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
     <RelativeLayout
-        android:id="@+id/empty_view"
+        android:id="@+id/no_themes_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_centerHorizontal="true"
@@ -53,7 +53,7 @@
             android:src="@drawable/drake_empty_results_400dp"/>
 
         <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/text_empty"
+            android:id="@+id/no_themes_text"
             style="@style/WordPress.EmptyList.Title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
## Overview

This PR prevents the "No themes matching your search" text from being visible in the gaps between the items in the list of themes in `ThemeBrowserFragment`.

![output](https://user-images.githubusercontent.com/4656348/57113512-e9270c00-6d12-11e9-9668-9636322098b8.gif)

## Background

There are 3 overlapping views from `ThemeBrowserFragment` that are relevant to this PR:

New Name | Previous Name | Description
------------ | ------------- | --------------
mNoThemesView | mEmptyView | Informs the user that no themes have been retrieved (either due to a fetch currently in progress or no internet connection)
mNoMatchesView | mActionableEmptyView | Informs the user that there are "No themes matching your search"
mGridView | [no change] | Displays the list of (possibly filtered) themes to the user

Before this PR, there were only two states for visibility of these views:

View | No Themes Downloaded Visibility | Themes Downloaded Visibility
------------ | ------------- | --------------
mNoThemesView | VISIBLE | GONE
mNoMatchesView | GONE | VISIBLE
mGridView | GONE | VISIBLE

Because `mGridView` and `mNoMatchesView` overlap each other, and `mGridView` is higher on the z-axis, any themes that are displayed will (mostly) obscure `mNoMatchesView`'s "No themes matching your search" text. If the user performs a search doesn't match any of the themes (so no themes are displayed), then the `mNoMatchesView` is uncovered, and it becomes fully visible to the user.

But the `mNoMatchesView` is visible beneath the list of themes even when themes are being displayed. Therefore, the "No themes matching your search" text can be seen in the gap between the top two visible themes. It is most noticeable in landscape:

![output_landscape1](https://user-images.githubusercontent.com/4656348/57090323-90388300-6cd4-11e9-9d69-f304fe93948d.gif)

## Changes in this PR

This PR changes the handling of these views so that instead of two possible states (themes-not-downloaded and themes-downloaded), there are now three states, with only one view visible in each state:

State | Visible View
---- | -----
No themes have been downloaded | mNoThemesView
Themes have been downloaded, and at least one theme is displayed | mGridView
Themes have been downloaded, and no themes are displayed due to a user search | mNoMatchesView

Before this PR, we were not updating the visibility of these views when the filter changed. That is why both `mNoMatchesView` and `mGridView` had to be visible any time we had downloaded themes—we were not updating the views based on whether any of those downloaded themes were being displayed. This PR detects any changes to the adapter's data set (including changes caused by the user's search) by adding [a data set observer](https://github.com/mchowning/WordPress-Android/blob/08beddebf57cd9e86c3fdb21c827dda74e7ade54/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java#L433) to the adapter. Any time the adapter's data set changes, including when the user's search changes, that observer is triggered. We then check which of the three possible states we are in, and update the views accordingly. 

## Test Steps

1. Log into a fresh install of the app (or any install of the app that has not already downloaded the themes)
2. Tap on 'Themes' from the 'My Site' tab
3. Observe the screen display "Fetching themes..." below an image of a Drake while the themes are being downloaded.
4. Once the themes are downloaded, observe that the list of themes is displayed.
5. Scroll the list up and down so that the gap between the themes crosses the entire screen and confirm that neither the (a) "Fetching themes..."; or (b) "No themes matching your search" text is visible in the gaps between the themes.
6. Execute a search that filters all of the themes (i.e., 'asd')
7. Observe the "No themes matching your search" text is visible
8. Shorten the previous search so that some themes are displayed again (i.e., 'as')
9. Again confirm that there are no views visible underneath the list of themes.

## Update release notes

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
