### PR TITLE
Fix empty view on post list shown for 0.1s

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListEmptyUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListEmptyUiState.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.viewmodel.posts
 
 import android.support.annotation.DrawableRes
 import org.wordpress.android.R
-import org.wordpress.android.R.string
 import org.wordpress.android.fluxc.store.ListStore.ListError
 import org.wordpress.android.fluxc.store.ListStore.ListErrorType.PERMISSION_ERROR
 import org.wordpress.android.ui.posts.PostListType
@@ -34,7 +33,7 @@ sealed class PostListEmptyUiState(
     object DataShown : PostListEmptyUiState(emptyViewVisible = false)
 
     object Loading : PostListEmptyUiState(
-            title = UiStringRes(string.posts_fetching),
+            title = UiStringRes(R.string.posts_fetching),
             imgResId = R.drawable.img_illustration_posts_75dp
     )
 
@@ -58,7 +57,7 @@ sealed class PostListEmptyUiState(
 fun createEmptyUiState(
     postListType: PostListType,
     isNetworkAvailable: Boolean,
-    isFetchingFirstPage: Boolean,
+    isLoadingData: Boolean,
     isListEmpty: Boolean,
     error: ListError?,
     fetchFirstPage: () -> Unit,
@@ -71,7 +70,7 @@ fun createEmptyUiState(
                     error = error,
                     fetchFirstPage = fetchFirstPage
             )
-            isFetchingFirstPage -> PostListEmptyUiState.Loading
+            isLoadingData -> PostListEmptyUiState.Loading
             else -> createEmptyListUiState(postListType = postListType, newPost = newPost)
         }
     } else {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -88,7 +88,8 @@ class PostListViewModel @Inject constructor(
             createEmptyUiState(
                     postListType = connector.postListType,
                     isNetworkAvailable = networkUtilsWrapper.isNetworkAvailable(),
-                    isFetchingFirstPage = pagedListWrapper.isFetchingFirstPage.value ?: false,
+                    isLoadingData = pagedListWrapper.isFetchingFirstPage.value ?: false ||
+                            pagedListWrapper.data.value == null,
                     isListEmpty = pagedListWrapper.isEmpty.value ?: true,
                     error = pagedListWrapper.listError.value,
                     fetchFirstPage = this::fetchFirstPage,


### PR DESCRIPTION
Fixes #9717 

Note: If #9785 is merged first, update the target branch to `develop`

Fix issue when empty view was being shown while we were loading data from the local database.

To test:
1. Restart the app
2. My Site
3. Blog Posts
4. Notice only "Fetching posts" view is shown before the data are loaded

Before
![empty-view-post-list](https://user-images.githubusercontent.com/2261188/57126362-05678f00-6d8d-11e9-877b-65269239f5bd.gif)

After
![empty-view-after](https://user-images.githubusercontent.com/2261188/57126352-000a4480-6d8d-11e9-914c-c22e21b41d2f.gif)



Update release notes:

- The feature hasn't been released yet, so there is no need to update the release notes


Note:
I've created a PR in FluxC so we can fix this issue in the correct layer - https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/1244