### PR TITLE
Point to gutenberg-mobile v1.4.0

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     ext {
-        aztecVersion = 'v1.3.25'
+        aztecVersion = 'v1.3.26'
     }
 
     repositories {


### PR DESCRIPTION
This PR updates the gutenberg-mobile reference to point to the latest release, v1.4.0. 

The reference is currently pointing to the release/1.4.0 branch on https://github.com/wordpress-mobile/gutenberg-mobile. Relevant PR: wordpress-mobile/gutenberg-mobile#951.

To test:
The block editor should work as normal.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
