### PR TITLE
Add margins to post list for tablets

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -11,6 +11,7 @@ import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewGroup.MarginLayoutParams
 import android.widget.Button
 import android.widget.ProgressBar
 import org.wordpress.android.R
@@ -114,10 +115,18 @@ class PostListFragment : Fragment() {
                     STANDARD -> {
                         recyclerView?.removeItemDecoration(itemDecorationCompactLayout)
                         recyclerView?.addItemDecoration(itemDecorationStandardLayout)
+                        (recyclerView?.layoutParams as? MarginLayoutParams)?.let {
+                            it.marginStart = nonNullActivity.resources.getDimensionPixelSize(R.dimen.post_list_content_margin)
+                            it.marginEnd = nonNullActivity.resources.getDimensionPixelSize(R.dimen.post_list_content_margin)
+                        }
                     }
                     COMPACT -> {
                         recyclerView?.removeItemDecoration(itemDecorationStandardLayout)
                         recyclerView?.addItemDecoration(itemDecorationCompactLayout)
+                        (recyclerView?.layoutParams as? MarginLayoutParams)?.let {
+                            it.marginStart = 0
+                            it.marginEnd = 0
+                        }
                     }
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -115,21 +115,22 @@ class PostListFragment : Fragment() {
                     STANDARD -> {
                         recyclerView?.removeItemDecoration(itemDecorationCompactLayout)
                         recyclerView?.addItemDecoration(itemDecorationStandardLayout)
-                        (recyclerView?.layoutParams as? MarginLayoutParams)?.let {
-                            it.marginStart = nonNullActivity.resources
-                                    .getDimensionPixelSize(R.dimen.post_list_content_margin)
-                            it.marginEnd = nonNullActivity.resources
-                                    .getDimensionPixelSize(R.dimen.post_list_content_margin)
-                        }
                     }
                     COMPACT -> {
                         recyclerView?.removeItemDecoration(itemDecorationStandardLayout)
                         recyclerView?.addItemDecoration(itemDecorationCompactLayout)
-                        (recyclerView?.layoutParams as? MarginLayoutParams)?.let {
-                            it.marginStart = 0
-                            it.marginEnd = 0
-                        }
                     }
+                }
+
+                val contentMargin = when (layoutType) {
+                    STANDARD -> nonNullActivity.resources
+                            .getDimensionPixelSize(R.dimen.post_list_content_margin_standard)
+                    COMPACT -> nonNullActivity.resources
+                            .getDimensionPixelSize(R.dimen.post_list_content_margin_compact)
+                }
+                (recyclerView?.layoutParams as? MarginLayoutParams)?.let {
+                    it.marginStart = contentMargin
+                    it.marginEnd = contentMargin
                 }
 
                 recyclerView?.scrollToPosition(0)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -116,8 +116,10 @@ class PostListFragment : Fragment() {
                         recyclerView?.removeItemDecoration(itemDecorationCompactLayout)
                         recyclerView?.addItemDecoration(itemDecorationStandardLayout)
                         (recyclerView?.layoutParams as? MarginLayoutParams)?.let {
-                            it.marginStart = nonNullActivity.resources.getDimensionPixelSize(R.dimen.post_list_content_margin)
-                            it.marginEnd = nonNullActivity.resources.getDimensionPixelSize(R.dimen.post_list_content_margin)
+                            it.marginStart = nonNullActivity.resources
+                                    .getDimensionPixelSize(R.dimen.post_list_content_margin)
+                            it.marginEnd = nonNullActivity.resources
+                                    .getDimensionPixelSize(R.dimen.post_list_content_margin)
                         }
                     }
                     COMPACT -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -11,7 +11,6 @@ import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewGroup.MarginLayoutParams
 import android.widget.Button
 import android.widget.ProgressBar
 import org.wordpress.android.R
@@ -120,17 +119,6 @@ class PostListFragment : Fragment() {
                         recyclerView?.removeItemDecoration(itemDecorationStandardLayout)
                         recyclerView?.addItemDecoration(itemDecorationCompactLayout)
                     }
-                }
-
-                val contentMargin = when (layoutType) {
-                    STANDARD -> nonNullActivity.resources
-                            .getDimensionPixelSize(R.dimen.post_list_content_margin_standard)
-                    COMPACT -> nonNullActivity.resources
-                            .getDimensionPixelSize(R.dimen.post_list_content_margin_compact)
-                }
-                (recyclerView?.layoutParams as? MarginLayoutParams)?.let {
-                    it.marginStart = contentMargin
-                    it.marginEnd = contentMargin
                 }
 
                 recyclerView?.scrollToPosition(0)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -167,7 +167,7 @@ sealed class PostListItemViewHolder(
     }
 
     private fun showFeaturedImage(imageUrl: String?) {
-        if (imageUrl == loadedFeaturedImgUrl) {
+        if (!imageUrl.isNullOrBlank() && imageUrl == loadedFeaturedImgUrl) {
             // Suppress blinking as the media upload progresses
             return
         }

--- a/WordPress/src/main/res/layout/post_list_item.xml
+++ b/WordPress/src/main/res/layout/post_list_item.xml
@@ -5,6 +5,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/post_list_content_margin_standard"
+    android:layout_marginEnd="@dimen/post_list_content_margin_standard"
     android:background="@color/white">
 
     <android.support.constraint.ConstraintLayout

--- a/WordPress/src/main/res/layout/post_list_item_compact.xml
+++ b/WordPress/src/main/res/layout/post_list_item_compact.xml
@@ -6,6 +6,8 @@
     android:id="@+id/background"
     android:layout_width="match_parent"
     android:layout_height="@dimen/posts_list_compact_row_height"
+    android:layout_marginEnd="@dimen/post_list_content_margin_compact"
+    android:layout_marginStart="@dimen/post_list_content_margin_compact"
     android:background="@color/white">
 
     <android.support.constraint.ConstraintLayout
@@ -41,9 +43,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/page_item_horizontal_padding"
+            android:layout_marginTop="@dimen/margin_extra_small"
             android:ellipsize="end"
             android:maxLines="1"
-            android:layout_marginTop="@dimen/margin_extra_small"
             android:textColor="@color/neutral_500"
             android:textSize="@dimen/text_sz_medium"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/WordPress/src/main/res/layout/post_list_item_skeleton.xml
+++ b/WordPress/src/main/res/layout/post_list_item_skeleton.xml
@@ -5,6 +5,8 @@
     xmlns:wp="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginEnd="@dimen/post_list_content_margin_standard"
+    android:layout_marginStart="@dimen/post_list_content_margin_standard"
     android:background="@color/white">
 
     <com.facebook.shimmer.ShimmerFrameLayout

--- a/WordPress/src/main/res/layout/post_list_item_skeleton_compact.xml
+++ b/WordPress/src/main/res/layout/post_list_item_skeleton_compact.xml
@@ -4,6 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/post_list_content_margin_compact"
+    android:layout_marginEnd="@dimen/post_list_content_margin_compact"
     android:background="@color/white">
 
     <com.facebook.shimmer.ShimmerFrameLayout

--- a/WordPress/src/main/res/values-w600dp/dimens.xml
+++ b/WordPress/src/main/res/values-w600dp/dimens.xml
@@ -9,6 +9,6 @@
     <dimen name="reader_detail_margin">@dimen/reader_detail_margin_tablet</dimen>
     <dimen name="notifications_content_margin">@dimen/content_margin_tablet</dimen>
     <dimen name="site_creation_content_margin">@dimen/content_margin_tablet</dimen>
-    <dimen name="post_list_content_margin">@dimen/content_margin_tablet</dimen>
+    <dimen name="post_list_content_margin_standard">@dimen/content_margin_tablet</dimen>
 
 </resources>

--- a/WordPress/src/main/res/values-w600dp/dimens.xml
+++ b/WordPress/src/main/res/values-w600dp/dimens.xml
@@ -9,5 +9,6 @@
     <dimen name="reader_detail_margin">@dimen/reader_detail_margin_tablet</dimen>
     <dimen name="notifications_content_margin">@dimen/content_margin_tablet</dimen>
     <dimen name="site_creation_content_margin">@dimen/content_margin_tablet</dimen>
+    <dimen name="post_list_content_margin">@dimen/content_margin_tablet</dimen>
 
 </resources>

--- a/WordPress/src/main/res/values-w720dp/dimens.xml
+++ b/WordPress/src/main/res/values-w720dp/dimens.xml
@@ -9,6 +9,6 @@
     <dimen name="reader_detail_margin">@dimen/reader_detail_margin_tablet_big</dimen>
     <dimen name="notifications_content_margin">@dimen/content_margin_tablet_big</dimen>
     <dimen name="site_creation_content_margin">@dimen/content_margin_tablet_big</dimen>
-    <dimen name="post_list_content_margin">@dimen/content_margin_tablet_big</dimen>
+    <dimen name="post_list_content_margin_standard">@dimen/content_margin_tablet_big</dimen>
 
 </resources>

--- a/WordPress/src/main/res/values-w720dp/dimens.xml
+++ b/WordPress/src/main/res/values-w720dp/dimens.xml
@@ -9,5 +9,6 @@
     <dimen name="reader_detail_margin">@dimen/reader_detail_margin_tablet_big</dimen>
     <dimen name="notifications_content_margin">@dimen/content_margin_tablet_big</dimen>
     <dimen name="site_creation_content_margin">@dimen/content_margin_tablet_big</dimen>
+    <dimen name="post_list_content_margin">@dimen/content_margin_tablet_big</dimen>
 
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -61,8 +61,9 @@
     <dimen name="content_margin_site_row_start_tablet">60dp</dimen>
     <dimen name="content_margin_site_row_start_tablet_big">108dp</dimen>
 
-    <dimen name="site_creation_content_margin_normal">0dp</dimen>
-    <dimen name="site_creation_content_margin">@dimen/site_creation_content_margin_normal</dimen>
+    <dimen name="content_margin_none">0dp</dimen>
+    <dimen name="site_creation_content_margin">@dimen/content_margin_none</dimen>
+    <dimen name="post_list_content_margin">@dimen/content_margin_none</dimen>
 
     <!--
         native reader dimens

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -63,7 +63,8 @@
 
     <dimen name="content_margin_none">0dp</dimen>
     <dimen name="site_creation_content_margin">@dimen/content_margin_none</dimen>
-    <dimen name="post_list_content_margin">@dimen/content_margin_none</dimen>
+    <dimen name="post_list_content_margin_standard">@dimen/content_margin_none</dimen>
+    <dimen name="post_list_content_margin_compact">@dimen/content_margin_none</dimen>
 
     <!--
         native reader dimens


### PR DESCRIPTION
Adds start/end margin to Standard (card) layout type on the post list screen.

@SylvesterWilmott I wasn't sure if the margin should be applied even to the FAB.

![maxwidth](https://user-images.githubusercontent.com/2261188/57223288-d7d94a80-7005-11e9-94df-eea26fcbb6d3.jpg)


To test:
Test on phone and tablet
1. My Site
2. Blog posts
3. Click on the "Switch layout type" button in the toolbar
4. Make sure the margin is present only for the standard(card) view + only when the display size is wide enough

Update release notes:

- The improvement is too minor.
