### PR TITLE
Update snackbar msg text from uploading post to uploading draft

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -170,7 +170,7 @@ public class UploadUtils {
                 } else {
                     if (UploadService.hasPendingOrInProgressMediaUploadsForPost(post)
                         || UploadService.isPostUploadingOrQueued(post)) {
-                        showSnackbar(snackbarAttachView, R.string.editor_uploading_post);
+                        showSnackbar(snackbarAttachView, R.string.editor_uploading_draft);
                     } else {
                         showSnackbarSuccessAction(snackbarAttachView, R.string.editor_draft_saved_online,
                                                   R.string.button_publish,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -356,7 +356,9 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
             uploadStatus.isUploading -> UploadingPost(postStatus == PostStatus.DRAFT)
             // the upload error is not null on retry -> it needs to be evaluated after UploadingMedia and UploadingPost
             uploadStatus.uploadError != null -> PostUploadUiState.UploadFailed(uploadStatus.uploadError)
-            uploadStatus.hasPendingMediaUpload || uploadStatus.isQueued || uploadStatus.isUploadingOrQueued -> UploadQueued
+            uploadStatus.hasPendingMediaUpload ||
+                    uploadStatus.isQueued ||
+                    uploadStatus.isUploadingOrQueued -> UploadQueued
             else -> NothingToUpload
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -4,7 +4,6 @@ import android.support.annotation.ColorRes
 import org.apache.commons.text.StringEscapeUtils
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
-import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_BUTTON_PRESSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_ITEM_SELECTED
@@ -63,7 +62,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         onAction: (PostModel, PostListButtonType, AnalyticsTracker.Stat) -> Unit
     ): PostListItemUiState {
         val postStatus: PostStatus = PostStatus.fromPost(post)
-        val uploadUiState = createUploadUiState(uploadStatus)
+        val uploadUiState = createUploadUiState(uploadStatus, postStatus == PostStatus.DRAFT)
 
         val onButtonClicked = { buttonType: PostListButtonType ->
             onAction.invoke(post, buttonType, POST_LIST_BUTTON_PRESSED)
@@ -132,7 +131,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
     private fun getTitle(post: PostModel): UiString {
         return if (post.title.isNotBlank()) {
             UiStringText(StringEscapeUtils.unescapeHtml4(post.title))
-        } else UiStringRes(string.untitled_in_parentheses)
+        } else UiStringRes(R.string.untitled_in_parentheses)
     }
 
     private fun getExcerpt(post: PostModel): UiString? =
@@ -174,25 +173,29 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
             uploadUiState is PostUploadUiState.UploadFailed -> {
                 getErrorLabel(uploadUiState.error)?.let { labels.add(it) }
             }
-            uploadUiState is UploadingPost -> labels.add(UiStringRes(string.post_uploading))
-            uploadUiState is UploadingMedia -> labels.add(UiStringRes(string.uploading_media))
-            uploadUiState is UploadQueued -> labels.add(UiStringRes(string.post_queued))
-            hasUnhandledConflicts -> labels.add(UiStringRes(string.local_post_is_conflicted))
+            uploadUiState is UploadingPost -> if (uploadUiState.isDraft) {
+                labels.add(UiStringRes(R.string.post_uploading_draft))
+            } else {
+                labels.add(UiStringRes(R.string.post_uploading))
+            }
+            uploadUiState is UploadingMedia -> labels.add(UiStringRes(R.string.uploading_media))
+            uploadUiState is UploadQueued -> labels.add(UiStringRes(R.string.post_queued))
+            hasUnhandledConflicts -> labels.add(UiStringRes(R.string.local_post_is_conflicted))
         }
 
         // we want to show either single error/progress label or 0-n info labels.
         if (labels.isEmpty()) {
             if (isLocalDraft) {
-                labels.add(UiStringRes(string.local_draft))
+                labels.add(UiStringRes(R.string.local_draft))
             }
             if (isLocallyChanged) {
-                labels.add(UiStringRes(string.local_changes))
+                labels.add(UiStringRes(R.string.local_changes))
             }
             if (postStatus == PRIVATE) {
-                labels.add(UiStringRes(string.post_status_post_private))
+                labels.add(UiStringRes(R.string.post_status_post_private))
             }
             if (postStatus == PENDING) {
-                labels.add(UiStringRes(string.post_status_pending_review))
+                labels.add(UiStringRes(R.string.post_status_pending_review))
             }
         }
         return labels
@@ -200,7 +203,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
 
     private fun getErrorLabel(uploadError: UploadError): UiString? {
         return when {
-            uploadError.mediaError != null -> UiStringRes(string.error_media_recover_post)
+            uploadError.mediaError != null -> UiStringRes(R.string.error_media_recover_post)
             uploadError.postError != null -> UploadUtils.getErrorMessageResIdFromPostError(
                     false,
                     uploadError.postError
@@ -263,7 +266,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         val canShowPublishButton = canRetryUpload || canPublishPost
         val buttonTypes = ArrayList<PostListButtonType>()
 
-        buttonTypes.add(PostListButtonType.BUTTON_EDIT)
+        buttonTypes.add(BUTTON_EDIT)
         if (canShowPublishButton) {
             buttonTypes.add(
                     if (!siteHasCapabilitiesToPublish) {
@@ -338,16 +341,19 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
 
     private sealed class PostUploadUiState {
         data class UploadingMedia(val progress: Int) : PostUploadUiState()
-        object UploadingPost : PostUploadUiState()
+        data class UploadingPost(val isDraft: Boolean) : PostUploadUiState()
         data class UploadFailed(val error: UploadError) : PostUploadUiState()
         object UploadQueued : PostUploadUiState()
         object NothingToUpload : PostUploadUiState()
     }
 
-    private fun createUploadUiState(status: PostListItemUploadStatus): PostUploadUiState {
+    private fun createUploadUiState(
+        status: PostListItemUploadStatus,
+        isDraft: Boolean
+    ): PostUploadUiState {
         return when {
             status.hasInProgressMediaUpload -> UploadingMedia(status.mediaUploadProgress)
-            status.isUploading -> UploadingPost
+            status.isUploading -> UploadingPost(isDraft)
             // the upload error is not null on retry -> it needs to be evaluated after UploadingMedia and UploadingPost
             status.uploadError != null -> PostUploadUiState.UploadFailed(status.uploadError)
             status.hasPendingMediaUpload || status.isQueued || status.isUploadingOrQueued -> UploadQueued

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -62,7 +62,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         onAction: (PostModel, PostListButtonType, AnalyticsTracker.Stat) -> Unit
     ): PostListItemUiState {
         val postStatus: PostStatus = PostStatus.fromPost(post)
-        val uploadUiState = createUploadUiState(uploadStatus, postStatus == PostStatus.DRAFT)
+        val uploadUiState = createUploadUiState(uploadStatus, postStatus)
 
         val onButtonClicked = { buttonType: PostListButtonType ->
             onAction.invoke(post, buttonType, POST_LIST_BUTTON_PRESSED)
@@ -348,15 +348,15 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
     }
 
     private fun createUploadUiState(
-        status: PostListItemUploadStatus,
-        isDraft: Boolean
+        uploadStatus: PostListItemUploadStatus,
+        postStatus: PostStatus
     ): PostUploadUiState {
         return when {
-            status.hasInProgressMediaUpload -> UploadingMedia(status.mediaUploadProgress)
-            status.isUploading -> UploadingPost(isDraft)
+            uploadStatus.hasInProgressMediaUpload -> UploadingMedia(uploadStatus.mediaUploadProgress)
+            uploadStatus.isUploading -> UploadingPost(postStatus == PostStatus.DRAFT)
             // the upload error is not null on retry -> it needs to be evaluated after UploadingMedia and UploadingPost
-            status.uploadError != null -> PostUploadUiState.UploadFailed(status.uploadError)
-            status.hasPendingMediaUpload || status.isQueued || status.isUploadingOrQueued -> UploadQueued
+            uploadStatus.uploadError != null -> PostUploadUiState.UploadFailed(uploadStatus.uploadError)
+            uploadStatus.hasPendingMediaUpload || uploadStatus.isQueued || uploadStatus.isUploadingOrQueued -> UploadQueued
             else -> NothingToUpload
         }
     }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -247,6 +247,7 @@
     <string name="untitled_in_parentheses">(Untitled)</string>
     <string name="local_draft">Local draft</string>
     <string name="post_uploading">Uploading post</string>
+    <string name="post_uploading_draft">Uploading draft</string>
     <string name="post_queued">Queued post</string>
     <string name="posts_empty_list">No posts yet. Why not create one?</string>
     <string name="posts_empty_list_button">Create a post</string>
@@ -1245,6 +1246,7 @@
     <string name="editor_draft_saved_locally">Draft saved on device</string>
     <string name="editor_post_saved_locally_failed_media">The post has failed media uploads and has been saved locally</string>
     <string name="editor_uploading_post">Your post is uploading</string>
+    <string name="editor_uploading_draft">Your draft is uploading</string>
     <string name="editor_post_converted_back_to_draft">Post converted back to draft</string>
     <string name="visual_editor_enabled">Visual Editor enabled</string>
     <string name="visual_editor_disabled">Visual Editor disabled</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -27,6 +27,7 @@ private const val FORMATTER_DATE = "January 1st, 1:35pm"
 private val POST_STATE_PUBLISH = PostStatus.PUBLISHED.toString()
 private val POST_STATE_PRIVATE = PostStatus.PRIVATE.toString()
 private val POST_STATE_PENDING = PostStatus.PENDING.toString()
+private val POST_STATE_DRAFT = PostStatus.DRAFT.toString()
 
 @RunWith(MockitoJUnitRunner::class)
 class PostListItemUiStateHelperTest {
@@ -126,6 +127,15 @@ class PostListItemUiStateHelperTest {
     fun `uploading post label shown when the post is being uploaded`() {
         val state = createPostListItemUiState(uploadStatus = createUploadStatus(isUploading = true))
         assertThat(state.data.statuses).contains(UiStringRes(R.string.post_uploading))
+    }
+
+    @Test
+    fun `uploading draft label shown when the draft is being uploaded`() {
+        val state = createPostListItemUiState(
+                uploadStatus = createUploadStatus(isUploading = true),
+                post = createPostModel(status = POST_STATE_DRAFT)
+        )
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.post_uploading_draft))
     }
 
     @Test


### PR DESCRIPTION
Fixes #9790 

This PR updates text of:
- post list item label - "uploading post" replaced with "uploading draft"
- snackbar message - "your post is uploading" replaced with "your draft is uploading"

![uploading-draft](https://user-images.githubusercontent.com/2261188/57227288-4f60a700-7011-11e9-9148-b54c69765293.gif)

To test:
1. My Site
2. Blog Posts
3. Drafts tab
4. Click on a draft
4. Edit title/content
5. Click on back button or update button in the toolbar
6. Notice correct message is displayed on both post list item and snackbar msg ("uploading draft" and "your draft is uploading")
------------------------
1. My Site
2. Blog Posts
3. Drafts tab
4. Click on a draft
4. Edit title/content
5. Click on toolbar overflow menu -> publish now -> confirm dialog
6. Notice correct message is displayed on both post list item and snackbar msg ("uploading post" and "your post is uploading")



Update release notes:

- Too minor change.


