### PR TITLE
replace toast with snackbar when publishing a post while offline

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -1,5 +1,13 @@
 package org.wordpress.android.ui.uploads;
 
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
+import android.text.TextUtils;
+import android.view.View;
+
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
@@ -23,14 +31,6 @@ import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.widgets.WPSnackbar;
-
-import android.app.Activity;
-import android.content.Context;
-import android.content.Intent;
-import android.support.annotation.NonNull;
-import android.support.design.widget.Snackbar;
-import android.text.TextUtils;
-import android.view.View;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -1,13 +1,5 @@
 package org.wordpress.android.ui.uploads;
 
-import android.app.Activity;
-import android.content.Context;
-import android.content.Intent;
-import android.support.annotation.NonNull;
-import android.support.design.widget.Snackbar;
-import android.text.TextUtils;
-import android.view.View;
-
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
@@ -31,6 +23,14 @@ import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.widgets.WPSnackbar;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
+import android.text.TextUtils;
+import android.view.View;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -118,8 +118,7 @@ public class UploadUtils {
         boolean savedLocally = data.getBooleanExtra(EditPostActivity.EXTRA_SAVED_AS_LOCAL_DRAFT, false);
         if (savedLocally && !NetworkUtils.isNetworkAvailable(activity)) {
             // The network is not available, we can't do anything
-            ToastUtils.showToast(activity, R.string.error_publish_no_network,
-                                 ToastUtils.Duration.SHORT);
+            showSnackbar(snackbarAttachView, R.string.error_publish_no_network);
             return;
         }
 

--- a/WordPress/src/main/res/layout/main_activity.xml
+++ b/WordPress/src/main/res/layout/main_activity.xml
@@ -20,6 +20,12 @@
         android:layout_alignParentBottom="true"
         android:orientation="vertical">
 
+        <!-- this coordinator exists only for snackbars -->
+        <android.support.design.widget.CoordinatorLayout
+            android:id="@+id/coordinator"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/connection_bar"
             android:layout_width="match_parent"
@@ -34,12 +40,6 @@
             android:textSize="@dimen/text_sz_small"
             android:visibility="gone"
             tools:visibility="visible"/>
-
-        <!-- this coordinator exists only for snackbars -->
-        <android.support.design.widget.CoordinatorLayout
-            android:id="@+id/coordinator"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"/>
 
         <View
             android:id="@+id/navbar_separator"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1481,7 +1481,7 @@
     <string name="error_publish_empty_post">Can\'t publish an empty post</string>
     <string name="error_publish_empty_page">Can\'t publish an empty page</string>
     <string name="error_save_empty_draft">Can\'t save an empty draft</string>
-    <string name="error_publish_no_network">Device is offline. Post saved as a draft.</string>
+    <string name="error_publish_no_network">Device is offline. Post saved locally.</string>
     <string name="error_upload_post_param">There was an error uploading this post: %s.</string>
     <string name="error_upload_page_param">There was an error uploading this page: %s.</string>
     <string name="error_upload_post_media_param">There was an error uploading the media in this post: %s.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1481,7 +1481,7 @@
     <string name="error_publish_empty_post">Can\'t publish an empty post</string>
     <string name="error_publish_empty_page">Can\'t publish an empty page</string>
     <string name="error_save_empty_draft">Can\'t save an empty draft</string>
-    <string name="error_publish_no_network">Device is offline. Changes saved locally.</string>
+    <string name="error_publish_no_network">Device is offline. Post saved as a draft.</string>
     <string name="error_upload_post_param">There was an error uploading this post: %s.</string>
     <string name="error_upload_page_param">There was an error uploading this page: %s.</string>
     <string name="error_upload_post_media_param">There was an error uploading the media in this post: %s.</string>


### PR DESCRIPTION
Fixes #9565 

- Replaces toast with snackbar
- snackbar message - "Device is offline. Post saved as a draft."

Before: 
![before](https://user-images.githubusercontent.com/4370019/57268143-b6ea1700-7050-11e9-9179-6d1dc06a1d7e.gif)


After:
![offlinepublishing](https://user-images.githubusercontent.com/4370019/57267230-4db4d480-704d-11e9-8cb4-0b300b50e2ee.gif)

To test:

1. Go to Blog Posts
2. Put the device on "Airplane Mode"
3. Create a new post while on Airplane mode and try to publish it.
4. A snackbar should appear with the "Device is offline. Post saved as a draft"


Other possible error message suggestions that i thought about:
-Unable to connect to internet. Post saved to drafts.
-A network error occurred. Post saved to drafts.
-Unable to publish due to a network error. Post saved to drafts


