### PR TITLE
Do not crash when the annual model is empty

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AnnualSiteStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AnnualSiteStatsUseCase.kt
@@ -24,7 +24,8 @@ class AnnualSiteStatsUseCase
     private val statsSiteProvider: StatsSiteProvider
 ) : StatelessUseCase<YearsInsightsModel>(ANNUAL_SITE_STATS, mainDispatcher) {
     override suspend fun loadCachedData(): YearsInsightsModel? {
-        return mostPopularStore.getYearsInsights(statsSiteProvider.siteModel)
+        val dbModel = mostPopularStore.getYearsInsights(statsSiteProvider.siteModel)
+        return if (dbModel?.years?.isNotEmpty() == true) dbModel else null
     }
 
     override suspend fun fetchRemoteData(forced: Boolean): State<YearsInsightsModel> {
@@ -34,7 +35,7 @@ class AnnualSiteStatsUseCase
 
         return when {
             error != null -> State.Error(error.message ?: error.type.name)
-            model != null -> State.Data(model)
+            model != null && model.years.isNotEmpty() -> State.Data(model)
             else -> State.Empty()
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AnnualSiteStatsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AnnualSiteStatsUseCaseTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.stats.insights.MostPopularInsightsStore
 import org.wordpress.android.test
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.ERROR
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.SUCCESS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
@@ -97,6 +98,25 @@ class AnnualSiteStatsUseCaseTest : BaseUnitTest() {
                     "53k"
             )
         }
+    }
+
+    @Test
+    fun `maps empty result to UI model`() = test {
+        val forced = false
+        val refresh = true
+        val model = YearsInsightsModel(
+                listOf()
+        )
+        whenever(insightsStore.getYearsInsights(site)).thenReturn(model)
+        whenever(insightsStore.fetchYearsInsights(site, forced)).thenReturn(
+                OnStatsFetched(
+                        model
+                )
+        )
+
+        val result = loadMostPopularInsights(refresh, forced)
+
+        Assertions.assertThat(result.state).isEqualTo(UseCaseState.EMPTY)
     }
 
     @Test


### PR DESCRIPTION
Fixes #9746 on release 12.3
This was already fixed in develop in this PR - https://github.com/wordpress-mobile/WordPress-Android/pull/9787

Now I'm only applying it to the release branch.

To test:
* Create a new fresh site
* Go to Stats/Insights
* The app doesn't crash

