### PR TITLE
display snackbar when trying to update a post while offline

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1808,8 +1808,11 @@ public class EditPostActivity extends AppCompatActivity implements
     private synchronized void savePostToDb() {
         mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(mPost));
 
-        // update the original post object, so we'll know of new changes
-        mOriginalPost = mPost.clone();
+        // if it's the first time creating a new post mOriginalPost will be null
+        // otherwise it gets initialized on initializePostObject()
+        if (mOriginalPost == null) {
+            mOriginalPost = mPost.clone();
+        }
 
         if (mShowAztecEditor) {
             // update the list of uploading ids


### PR DESCRIPTION
Displays Snackbar once #9805 gets merged

Fixes #9567

So the bug here is actually that `PostUtils.postHasEdits(mOriginalPost, mPost)` currently always returns false. This method is also used to set one of the intent extras value that helps determine if we should display a snackbar/toast once we return to the previous screen. 

When creating a new Post, the app will go through the `newPostSetup()` and the `savePostToDb()` methods on `EditPostActivity` class.
Initially `mOriginalPost` is set to null because it's a brand new post.
Currently every time we call  `savePostToDb()` we are  always cloning the contents of `mPost`(current post) into ` mOriginalPost`. 
`savePostToDb()` gets called every time the user makes any modifications (text insert, deletion etc...), to the post which causes `mOriginalPost` to always have the same contents as `mPost`.
When we exit or try to publish the post we go through the `shouldSavePost()` method. 
Inside this method we always check if the current post has any changes from the post that we started with by calling `PostUtils.postHasEdits(mOriginalPost, mPost)`. This currently always returns false due to the cloning that happened every time on `savePostToDb()`.
In this scenario `shouldSavePost()` only returns true if `mIsNewPost` boolean is  true and if it’s a `publishablePost` condition is true.

Now, if we repeat the same process but try to edit an existing post the app will now go through the  `initializePostObject()` method on `EditPostActivity`.
In that method, since we are viewing an existing post, we clone its contents into `mOriginalPost`.
After this, the app behaves the same way as mentioned above. Any type of modification to the post makes a call to the `savePostToDB()` which clones the contents of the current post into `mOriginalPost`. 
Once again when we try to exit or publish a post we run into the same issue of those two instances containing the same content therefore causing `PostUtils.postHasEdits(mOriginalPost, mPost)` to always return false.
Currently in this scenario the method `shouldSavePost()` only returns true when `hasUnpublishedLocalDraftChanges` condition is true  even though the two posts may have been different.

This change makes it so that we only clone contents of `mPost`(current post) into `mOriginalPost` if it is null, which only happens on a fresh new Post. If it's an existing Post `mOriginalPost` gets initialized with the contents of the current post in `initializePostObject()`.

This way we will actually be comparing an old post content to a new post content and `PostUtils.postHasEdits(mOriginalPost, mPost)` will return the correct value, which is sometimes also being used as an intent extra to determine if we should display a toast or snackbar.

Before:
![offlineupdate](https://user-images.githubusercontent.com/4370019/57386085-af765b00-7181-11e9-87bd-7d82e79624a6.gif)

After:
![offline-post-update](https://user-images.githubusercontent.com/4370019/57386226-f06e6f80-7181-11e9-9dd8-ba8345c87dd8.gif)


To test:
1.Enter Airplane Mode
2.Go to Blog Posts
3.Press edit on a existing post under the "Published" Tab
4.Make modifications to the post content
5.Click on the "Update" menu button option


