### PR TITLE
Make ConnectionStatusLiveData distinct

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -54,7 +54,7 @@ public abstract class ApplicationModule {
     }
 
     @Provides
-    public static LiveData<ConnectionStatus> provideConnectionStatusLiveData(Context context) {
-        return new ConnectionStatusLiveData(context);
+    static LiveData<ConnectionStatus> provideConnectionStatusLiveData(Context context) {
+        return new ConnectionStatusLiveData.Factory(context).create();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/helpers/ConnectionStatusLiveData.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/helpers/ConnectionStatusLiveData.kt
@@ -6,8 +6,11 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.net.ConnectivityManager
+import org.wordpress.android.util.distinct
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus.AVAILABLE
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus.UNAVAILABLE
+import org.wordpress.android.viewmodel.helpers.ConnectionStatusLiveData.Factory
+import javax.inject.Inject
 
 enum class ConnectionStatus {
     AVAILABLE,
@@ -17,11 +20,12 @@ enum class ConnectionStatus {
 /**
  * A LiveData instance that can be injected to keep track of the network availability.
  *
- * This only emits if the network availability changes and not when the user switches between cellular and wi-fi.
+ * Use [Factory] to create an instance. The Factory guarantees that this only emits if the network availability
+ * changes and not when the user switches between cellular and wi-fi.
  *
  * IMPORTANT: It needs to be observed for the changes to be posted.
  */
-class ConnectionStatusLiveData(private val context: Context) : LiveData<ConnectionStatus>() {
+class ConnectionStatusLiveData private constructor(private val context: Context) : LiveData<ConnectionStatus>() {
     override fun onActive() {
         super.onActive()
         val intentFilter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
@@ -37,11 +41,14 @@ class ConnectionStatusLiveData(private val context: Context) : LiveData<Connecti
         override fun onReceive(context: Context, intent: Intent) {
             val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager?
             val networkInfo = connectivityManager?.activeNetworkInfo
-
             val nextValue: ConnectionStatus = if (networkInfo?.isConnected == true) AVAILABLE else UNAVAILABLE
             if (value != nextValue) {
                 postValue(nextValue)
             }
         }
+    }
+
+    class Factory @Inject constructor(private val context: Context) {
+        fun create() = ConnectionStatusLiveData(context).distinct()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/helpers/ConnectionStatusLiveData.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/helpers/ConnectionStatusLiveData.kt
@@ -6,15 +6,18 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.net.ConnectivityManager
+import org.wordpress.android.viewmodel.helpers.ConnectionStatus.AVAILABLE
+import org.wordpress.android.viewmodel.helpers.ConnectionStatus.UNAVAILABLE
 
-/**
- * A wrapper class for the network connection status. It can be extended to provide more details about the current
- * network connection.
- */
-class ConnectionStatus(val isConnected: Boolean)
+enum class ConnectionStatus {
+    AVAILABLE,
+    UNAVAILABLE
+}
 
 /**
  * A LiveData instance that can be injected to keep track of the network availability.
+ *
+ * This only emits if the network availability changes and not when the user switches between cellular and wi-fi.
  *
  * IMPORTANT: It needs to be observed for the changes to be posted.
  */
@@ -34,7 +37,11 @@ class ConnectionStatusLiveData(private val context: Context) : LiveData<Connecti
         override fun onReceive(context: Context, intent: Intent) {
             val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager?
             val networkInfo = connectivityManager?.activeNetworkInfo
-            postValue(ConnectionStatus(networkInfo?.isConnected == true))
+
+            val nextValue: ConnectionStatus = if (networkInfo?.isConnected == true) AVAILABLE else UNAVAILABLE
+            if (value != nextValue) {
+                postValue(nextValue)
+            }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/helpers/ConnectionStatusLiveData.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/helpers/ConnectionStatusLiveData.kt
@@ -41,10 +41,9 @@ class ConnectionStatusLiveData private constructor(private val context: Context)
         override fun onReceive(context: Context, intent: Intent) {
             val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager?
             val networkInfo = connectivityManager?.activeNetworkInfo
+
             val nextValue: ConnectionStatus = if (networkInfo?.isConnected == true) AVAILABLE else UNAVAILABLE
-            if (value != nextValue) {
-                postValue(nextValue)
-            }
+            postValue(nextValue)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -32,6 +32,7 @@ import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus
+import org.wordpress.android.viewmodel.helpers.ConnectionStatus.AVAILABLE
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -74,7 +75,7 @@ class HistoryViewModel @Inject constructor(
         lifecycleRegistry.markState(Lifecycle.State.CREATED)
         dispatcher.register(this)
         connectionStatus.observe(this, Observer {
-            if (it?.isConnected == true) {
+            if (it == AVAILABLE) {
                 fetchRevisions()
             }
         })

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/helpers/ConnectionStatusLiveDataTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/helpers/ConnectionStatusLiveDataTest.kt
@@ -1,0 +1,95 @@
+package org.wordpress.android.viewmodel.helpers
+
+import android.arch.core.executor.testing.InstantTaskExecutorRule
+import android.arch.lifecycle.LiveData
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkInfo
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.wordpress.android.viewmodel.helpers.ConnectionStatus.AVAILABLE
+import org.wordpress.android.viewmodel.helpers.ConnectionStatus.UNAVAILABLE
+
+class ConnectionStatusLiveDataTest {
+    @get:Rule val rule = InstantTaskExecutorRule()
+
+    private lateinit var connectionStatusLiveData: LiveData<ConnectionStatus>
+    private lateinit var broadcastReceiver: BroadcastReceiver
+
+    @Before
+    fun setUp() {
+        val captor = argumentCaptor<BroadcastReceiver>()
+        val context = mock<Context> {
+            on { registerReceiver(captor.capture(), any()) } doReturn mock()
+        }
+
+        connectionStatusLiveData = ConnectionStatusLiveData(context)
+        // Start observing to capture the broadcastReceiver
+        connectionStatusLiveData.observeForever { }
+
+        broadcastReceiver = captor.firstValue
+    }
+
+    @Test
+    fun `it emits a value when receiving a network info change`() {
+        assertThat(connectionStatusLiveData.value).isNull()
+
+        broadcastReceiver.onReceive(mockedBroadcastReceiverContext(connectedNetwork = false), mock())
+
+        assertThat(connectionStatusLiveData.value).isEqualTo(UNAVAILABLE)
+    }
+
+    @Test
+    fun `it emits a value when the network availability changes`() {
+        // Arrange
+        broadcastReceiver.onReceive(mockedBroadcastReceiverContext(connectedNetwork = true), mock())
+        assertThat(connectionStatusLiveData.value).isEqualTo(AVAILABLE)
+
+        // Act
+        broadcastReceiver.onReceive(mockedBroadcastReceiverContext(connectedNetwork = false), mock())
+
+        // Assert
+        assertThat(connectionStatusLiveData.value).isEqualTo(UNAVAILABLE)
+    }
+
+    @Test
+    fun `it does not emit a value when the network available didn't change`() {
+        // Arrange
+        var emitCount = 0
+
+        connectionStatusLiveData.observeForever {
+            emitCount += 1
+        }
+
+        broadcastReceiver.onReceive(mockedBroadcastReceiverContext(connectedNetwork = true), mock())
+
+        // Act
+        repeat(3) {
+            broadcastReceiver.onReceive(mockedBroadcastReceiverContext(connectedNetwork = true), mock())
+        }
+
+        // Assert
+        assertThat(emitCount).isEqualTo(1)
+        assertThat(connectionStatusLiveData.value).isEqualTo(AVAILABLE)
+    }
+
+    private fun mockedBroadcastReceiverContext(connectedNetwork: Boolean): Context {
+        val networkInfo = mock<NetworkInfo> {
+            on { isConnected } doReturn connectedNetwork
+        }
+        val connectivityManager = mock<ConnectivityManager> {
+            on { activeNetworkInfo } doReturn networkInfo
+        }
+
+        return mock<Context> {
+            on { getSystemService(any()) } doReturn connectivityManager
+        }
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/helpers/ConnectionStatusLiveDataTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/helpers/ConnectionStatusLiveDataTest.kt
@@ -30,7 +30,7 @@ class ConnectionStatusLiveDataTest {
             on { registerReceiver(captor.capture(), any()) } doReturn mock()
         }
 
-        connectionStatusLiveData = ConnectionStatusLiveData(context)
+        connectionStatusLiveData = ConnectionStatusLiveData.Factory(context).create()
         // Start observing to capture the broadcastReceiver
         connectionStatusLiveData.observeForever { }
 
@@ -88,7 +88,7 @@ class ConnectionStatusLiveDataTest {
             on { activeNetworkInfo } doReturn networkInfo
         }
 
-        return mock<Context> {
+        return mock {
             on { getSystemService(any()) } doReturn connectivityManager
         }
     }


### PR DESCRIPTION
This was started by [this discussion](https://github.com/wordpress-mobile/WordPress-Android/pull/9774#discussion_r280401657) in #9774. 

This changes `ConnectionStatusLiveData` so it will not emit values when the availability doesn't change. For example, a network change from LTE to wi-fi will not cause `ConnectionStatusLiveData` to emit a value. Most of the time, this is the behavior that we want. It's also the least dangerous since we rely on this `LiveData` to trigger network requests and we would probably forget about using `getDistinct()`. 

I have also simplified `ConnectionStatus` by changing it to an `enum` for now. 

## Testing

Adding a breakpoint in one of the observers of `LiveData<ConnectionStatus>` would probably be the easiest way to test this. Please verify that:

- Changing between wi-fi and cellular will not emit new events
- Switching between available and unavailable internet connections still work

## Release Notes

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
