### PR TITLE
Update screenshots localization and status bar

### DIFF
--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -116,7 +116,7 @@ msgstr ""
 #. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
 msgctxt "enhanced_app_store_screenshot_1"
 msgid ""
-"<strong>Create </strong>beautiful\n"
+"<strong>Create</strong> beautiful\n"
 "posts and pages\n"
 msgstr ""
 
@@ -124,7 +124,7 @@ msgstr ""
 #. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
 msgctxt "enhanced_app_store_screenshot_2"
 msgid ""
-"<strong>Track </strong> what your\n"
+"<strong>Track</strong> what your\n"
 "visitors love\n"
 msgstr ""
 
@@ -132,15 +132,15 @@ msgstr ""
 #. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
 msgctxt "enhanced_app_store_screenshot_3"
 msgid ""
-"<strong>Check </strong>what's\n"
-"happening in real time\n"
+"<strong>Check</strong> what's\n"
+"happening in real-time\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
 #. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
 msgctxt "enhanced_app_store_screenshot_4"
 msgid ""
-"<strong>Share </strong>\n"
+"<strong>Share</strong>\n"
 "from anywhere\n"
 msgstr ""
 
@@ -148,7 +148,7 @@ msgstr ""
 #. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
 msgctxt "enhanced_app_store_screenshot_5"
 msgid ""
-"<strong>Capture </strong>ideas\n"
+"<strong>Capture</strong> ideas\n"
 "on the go\n"
 msgstr ""
 
@@ -156,5 +156,13 @@ msgstr ""
 #. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
 msgctxt "enhanced_app_store_screenshot_6"
 msgid "<strong>Write</strong> without compromises"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
+#. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
+msgctxt "enhanced_app_store_screenshot_7"
+msgid ""
+"<strong>Build</strong> and manage\n"
+"your website\n"
 msgstr ""
 

--- a/WordPress/metadata/enhanced_screenshot_1.html
+++ b/WordPress/metadata/enhanced_screenshot_1.html
@@ -1,2 +1,2 @@
-<strong>Create </strong>beautiful
+<strong>Create</strong> beautiful
 posts and pages

--- a/WordPress/metadata/enhanced_screenshot_2.html
+++ b/WordPress/metadata/enhanced_screenshot_2.html
@@ -1,2 +1,2 @@
-<strong>Track </strong> what your
+<strong>Track</strong> what your
 visitors love

--- a/WordPress/metadata/enhanced_screenshot_3.html
+++ b/WordPress/metadata/enhanced_screenshot_3.html
@@ -1,2 +1,2 @@
-<strong>Check </strong>what's
-happening in real time
+<strong>Check</strong> what's
+happening in real-time

--- a/WordPress/metadata/enhanced_screenshot_4.html
+++ b/WordPress/metadata/enhanced_screenshot_4.html
@@ -1,2 +1,2 @@
-<strong>Share </strong>
+<strong>Share</strong>
 from anywhere

--- a/WordPress/metadata/enhanced_screenshot_5.html
+++ b/WordPress/metadata/enhanced_screenshot_5.html
@@ -1,2 +1,2 @@
-<strong>Capture </strong>ideas
+<strong>Capture</strong> ideas
 on the go

--- a/WordPress/metadata/enhanced_screenshot_7.html
+++ b/WordPress/metadata/enhanced_screenshot_7.html
@@ -1,0 +1,2 @@
+<strong>Build</strong> and manage
+your website

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/DemoModeEnabler.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/DemoModeEnabler.kt
@@ -1,0 +1,54 @@
+package org.wordpress.android.support
+
+import android.os.ParcelFileDescriptor
+import android.os.ParcelFileDescriptor.AutoCloseInputStream
+import android.support.test.InstrumentationRegistry
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+// Adapted From https://gist.github.com/hvisser/e716105f4e3cf2908ea463dbdb50679c with minor adjustments
+class DemoModeEnabler {
+    fun enable() {
+        executeShellCommand("settings put global sysui_demo_allowed 1")
+        sendCommand("exit")
+        sendCommand("enter")
+
+        // Notifications Off
+        sendCommand("notifications", "visible" to "false")
+
+        // Set up the wifi icon
+        sendCommand("network", "wifi" to "show", "level" to "4")
+
+        // Set up the cellular icon
+        sendCommand("network", "mobile" to "show", "level" to "4")
+
+        // Battery full, not plugged in
+        sendCommand("battery", "level" to "100", "plugged" to "false")
+
+        // 11:37 seems to be the most standard "Android time" (?)
+        sendCommand("clock", "hhmm" to "1137")
+    }
+
+    fun disable() {
+        sendCommand("exit")
+    }
+
+    private fun sendCommand(command: String, vararg extras: Pair<String, Any>) {
+        val exec = StringBuilder("am broadcast -a com.android.systemui.demo -e command $command")
+        for ((key, value) in extras) {
+            exec.append(" -e $key $value")
+        }
+        executeShellCommand(exec.toString())
+    }
+
+    private fun executeShellCommand(command: String) {
+        waitForCompletion(InstrumentationRegistry.getInstrumentation().uiAutomation.executeShellCommand(command))
+    }
+
+    private fun waitForCompletion(descriptor: ParcelFileDescriptor) {
+        val reader = BufferedReader(InputStreamReader(AutoCloseInputStream(descriptor)))
+        reader.use {
+            it.readText()
+        }
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -12,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.wordpress.android.R;
 import org.wordpress.android.e2e.pages.PostsListPage;
 import org.wordpress.android.support.BaseTest;
+import org.wordpress.android.support.DemoModeEnabler;
 import org.wordpress.android.ui.WPLaunchActivity;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -42,6 +43,8 @@ public class WPScreenshotTest extends BaseTest {
     public ActivityTestRule<WPLaunchActivity> mActivityTestRule = new ActivityTestRule<>(WPLaunchActivity.class,
             false, false);
 
+    private DemoModeEnabler mDemoModeEnabler = new DemoModeEnabler();
+
     @Test
     public void wPScreenshotTest() {
         mActivityTestRule.launchActivity(null);
@@ -50,12 +53,18 @@ public class WPScreenshotTest extends BaseTest {
         // Never show the Gutenberg dialog when opening a post
         AppPrefs.setGutenbergInformativeDialogDisabled(true);
 
+        // Enable Demo Mode
+        mDemoModeEnabler.enable();
+
         wpLogin();
 
         editBlogPost();
         manageMedia();
         navigateStats();
         navigateNotifications();
+
+        // Turn Demo Mode off on the emulator when we're done
+        mDemoModeEnabler.disable();
     }
 
     private void editBlogPost() {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -97,6 +97,7 @@ ENV[GHHELPER_REPO="wordpress-mobile/WordPress-Android"]
       enhanced_app_store_screenshot_4: prj_folder + "/WordPress/metadata/enhanced_screenshot_4.html",
       enhanced_app_store_screenshot_5: prj_folder + "/WordPress/metadata/enhanced_screenshot_5.html",
       enhanced_app_store_screenshot_6: prj_folder + "/WordPress/metadata/enhanced_screenshot_6.html",
+      enhanced_app_store_screenshot_7: prj_folder + "/WordPress/metadata/enhanced_screenshot_7.html",
     }
 
     android_update_metadata_source(po_file_path: prj_folder + "/WordPress/metadata/PlayStoreStrings.po", 


### PR DESCRIPTION
Adds an additional localization key and adds a more reliable demo mode.

**How to Test:**

1. Open this branch in Android Studio
2. Run the `wPScreenshotTest()` configuration. It should pass, and if you watch the emulator while it's running, you'll see it sets the time, and only shows Wifi, Cellular (both at full bars), and battery (not plugged in).