### PR TITLE
Fix #9826: make sure we Play Services are available before running the email hint picker.

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -27,6 +27,7 @@ import com.google.android.gms.auth.api.credentials.Credential;
 import com.google.android.gms.auth.api.credentials.CredentialPickerConfig;
 import com.google.android.gms.auth.api.credentials.HintRequest;
 import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.common.api.GoogleApiClient.ConnectionCallbacks;
 import com.google.android.gms.common.api.GoogleApiClient.OnConnectionFailedListener;
@@ -424,6 +425,12 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     }
 
     public void getEmailHints() {
+        GoogleApiAvailability googleApiAvailability = GoogleApiAvailability.getInstance();
+        if (getContext() == null
+            || googleApiAvailability.isGooglePlayServicesAvailable(getContext()) != ConnectionResult.SUCCESS) {
+            AppLog.w(T.NUX, LOG_TAG + ": Couldn't start hint picker - Play Services unavailable");
+            return;
+        }
         HintRequest hintRequest = new HintRequest.Builder()
                 .setHintPickerConfig(new CredentialPickerConfig.Builder()
                         .setShowCancelButton(true)

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupEmailFragment.java
@@ -24,6 +24,7 @@ import com.google.android.gms.auth.api.credentials.Credential;
 import com.google.android.gms.auth.api.credentials.CredentialPickerConfig;
 import com.google.android.gms.auth.api.credentials.HintRequest;
 import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.common.api.GoogleApiClient.ConnectionCallbacks;
 import com.google.android.gms.common.api.GoogleApiClient.OnConnectionFailedListener;
@@ -296,6 +297,12 @@ public class SignupEmailFragment extends LoginBaseFormFragment<LoginListener> im
     }
 
     public void getEmailHints() {
+        GoogleApiAvailability googleApiAvailability = GoogleApiAvailability.getInstance();
+        if (getContext() == null
+            || googleApiAvailability.isGooglePlayServicesAvailable(getContext()) != ConnectionResult.SUCCESS) {
+            AppLog.w(T.NUX, LOG_TAG + ": Couldn't start hint picker - Play Services unavailable");
+            return;
+        }
         HintRequest hintRequest = new HintRequest.Builder()
                 .setHintPickerConfig(new CredentialPickerConfig.Builder()
                         .setShowCancelButton(true)


### PR DESCRIPTION
Fix #9826: make sure we Play Services are available before running the email hint picker.

The app won't crash, but there is some known limitations:
- Users can't sign in/sign up with Google (but they get an error dialog).
- Users won't receive push notification (and we don't tell them about it)

Note: I checked did a quick check of places where `GoogleApiClient` was used and I also ran the app and do a manual check of most features.