### PR TITLE
 Fix #9730: Improve failed media error in Aztec

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1252,6 +1252,8 @@
     <string name="visual_editor_disabled">Visual Editor disabled</string>
     <string name="new_editor_reflection_error">Visual editor is not compatible with your device. It was
         automatically disabled.</string>
+    <string name="editor_failed_to_insert_media_tap_to_retry">Failed to insert media.\nPlease tap to retry.</string>
+    <string name="editor_failed_to_insert_media_tap_for_options">Failed to insert media.\nPlease tap for options.</string>
 
     <string name="async_promo_title_publish">Publish with Confidence</string>
     <string name="async_promo_title_schedule">Schedule with Confidence</string>
@@ -2612,7 +2614,7 @@
     <string name="gutenberg_mobile_gutenberg_packages_block_library_src_image_edit_native_js_198" tools:ignore="UnusedResources">WordPress Media Library</string>
     <string name="gutenberg_mobile_gutenberg_packages_block_library_src_image_edit_native_js_273" tools:ignore="UnusedResources">Alt Text</string>
     <string name="gutenberg_mobile_gutenberg_packages_block_library_src_image_edit_native_js_280" tools:ignore="UnusedResources">Clear All Settings</string>
-    <string name="gutenberg_mobile_gutenberg_packages_block_library_src_image_edit_native_js_374" tools:ignore="UnusedResources">Failed to insert media.\nPlease tap for options.</string>
+    <string name="gutenberg_mobile_gutenberg_packages_block_library_src_image_edit_native_js_374" translatable="false" tools:ignore="UnusedResources">@string/editor_failed_to_insert_media_tap_for_options</string>
     <string name="gutenberg_mobile_gutenberg_packages_editor_src_components_media_placeholder_index_native_js_26" tools:ignore="UnusedResources">CHOOSE IMAGE</string>
     <string name="gutenberg_mobile_gutenberg_packages_editor_src_components_url_input_index_native_js_27" tools:ignore="UnusedResources">Paste URL</string>
     <string name="gutenberg_mobile_src_block_types_unsupported_block_index_js_21" tools:ignore="UnusedResources">Unsupported Block</string>

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1671,12 +1671,14 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                             AttributesWithClass attributesWithClass = getAttributesWithClass(
                                     mContent.getElementAttributes(mTappedMediaPredicate));
 
-                            // remove the failed class
+                            // add or remove the failed class depending on whether the media was uploaded or not
                             attributesWithClass = addFailedStatusToMediaIfLocalSrcPresent(attributesWithClass);
+
+                            // clear overlays
+                            mContent.clearOverlays(mTappedMediaPredicate);
 
                             if (!attributesWithClass.hasClass(ATTR_STATUS_FAILED)) {
                                 // just save the item and leave
-                                mContent.clearOverlays(mTappedMediaPredicate);
                                 mContent.resetAttributedMediaSpan(mTappedMediaPredicate);
                                 return;
                             }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -899,8 +899,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         // Divide icon height by 2 and shift the text vertically (note: both elements are vertically centered)
         textDrawable.setTranslateY(iconDrawable.getIntrinsicHeight() / 2);
 
-        mContent.setOverlay(localMediaIdPredicate, 0, iconDrawable, Gravity.CENTER);
-        mContent.setOverlay(localMediaIdPredicate, 1, textDrawable, Gravity.CENTER);
+        mContent.setOverlay(localMediaIdPredicate, 0,
+                new ColorDrawable(getResources().getColor(R.color.media_shade_overlay_color)),
+                Gravity.FILL);
+        mContent.setOverlay(localMediaIdPredicate, 1, iconDrawable, Gravity.CENTER);
+        mContent.setOverlay(localMediaIdPredicate, 2, textDrawable, Gravity.CENTER);
         mContent.updateElementAttributes(localMediaIdPredicate, new AztecAttributes(attributes));
     }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1687,17 +1687,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                             }
 
                             // set intermediate shade overlay
-                            mContent.setOverlay(mTappedMediaPredicate, 0, new ColorDrawable(
-                                    getResources().getColor(R.color.media_shade_overlay_color)), Gravity.FILL);
+                            overlayProgressingMedia(mTappedMediaPredicate);
 
-                            Drawable progressDrawable = getResources().getDrawable(
-                                    android.R.drawable.progress_horizontal);
-                            // set the height of the progress bar to 2
-                            // (it's in dp since the drawable will be adjusted by the span)
-                            progressDrawable.setBounds(0, 0, 0, 4);
-
-                            mContent.setOverlay(mTappedMediaPredicate, 1, progressDrawable,
-                                                Gravity.FILL_HORIZONTAL | Gravity.TOP);
                             mContent.updateElementAttributes(mTappedMediaPredicate,
                                                              attributesWithClass.getAttributes());
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -891,12 +891,16 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     private void overlayFailedMedia(String localMediaId, Attributes attributes) {
         // set intermediate shade overlay
         AztecText.AttributePredicate localMediaIdPredicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
-        mContent.setOverlay(localMediaIdPredicate, 0,
-                            new ColorDrawable(getResources().getColor(R.color.media_shade_overlay_error_color)),
-                            Gravity.FILL);
 
-        Drawable alertDrawable = getResources().getDrawable(R.drawable.media_retry_image);
-        mContent.setOverlay(localMediaIdPredicate, 1, alertDrawable, Gravity.CENTER);
+        Drawable iconDrawable = getResources().getDrawable(R.drawable.media_retry_image);
+        float textSize = getResources().getDimension(R.dimen.text_header);
+        TextDrawable textDrawable = new TextDrawable(getResources(),
+                getString(R.string.editor_failed_to_insert_media_tap_to_retry), textSize);
+        // Divide icon height by 2 and shift the text vertically (note: both elements are vertically centered)
+        textDrawable.setTranslateY(iconDrawable.getIntrinsicHeight() / 2);
+
+        mContent.setOverlay(localMediaIdPredicate, 0, iconDrawable, Gravity.CENTER);
+        mContent.setOverlay(localMediaIdPredicate, 1, textDrawable, Gravity.CENTER);
         mContent.updateElementAttributes(localMediaIdPredicate, new AztecAttributes(attributes));
     }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/TextDrawable.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/TextDrawable.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Imported and modified from:
+ * https://android.googlesource.com/platform/packages/apps/Camera/+/master/src/com/android/camera/drawable
+ * /TextDrawable.java
+ *
+ */
+package org.wordpress.android.editor;
+
+import android.content.res.Resources;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.ColorFilter;
+import android.graphics.Paint;
+import android.graphics.Paint.Align;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.ColorInt;
+import android.text.Layout.Alignment;
+import android.text.StaticLayout;
+import android.text.TextPaint;
+
+
+public class TextDrawable extends Drawable {
+    private static final int DEFAULT_COLOR = Color.WHITE;
+    private TextPaint mPaint;
+    private CharSequence mText;
+    private int mIntrinsicWidth;
+    private int mIntrinsicHeight;
+    private int mTranslateX;
+    private int mTranslateY;
+    private StaticLayout mTextLayout;
+
+    public TextDrawable(Resources res, CharSequence text, float textSize) {
+        mText = text;
+        mPaint = new TextPaint(Paint.ANTI_ALIAS_FLAG);
+        mPaint.setColor(DEFAULT_COLOR);
+        mPaint.setTextAlign(Align.CENTER);
+        mPaint.setTextSize(textSize);
+        mIntrinsicWidth = (int) (mPaint.measureText(mText, 0, mText.length()) + .5);
+        mIntrinsicHeight = mPaint.getFontMetricsInt(null);
+        mTextLayout = new StaticLayout(mText, mPaint, mIntrinsicWidth, Alignment.ALIGN_NORMAL, 1.0f, 0.0f, false);
+    }
+
+    @Override
+    public void draw(Canvas canvas) {
+        Rect bounds = getBounds();
+        canvas.translate(bounds.centerX() + mTranslateX, bounds.centerY() + mTranslateY);
+        mTextLayout.draw(canvas);
+    }
+
+    @Override
+    public int getOpacity() {
+        return mPaint.getAlpha();
+    }
+
+    @Override
+    public int getIntrinsicWidth() {
+        return mIntrinsicWidth;
+    }
+
+    @Override
+    public int getIntrinsicHeight() {
+        return mIntrinsicHeight;
+    }
+
+    @Override
+    public void setAlpha(int alpha) {
+        mPaint.setAlpha(alpha);
+    }
+
+    @Override
+    public void setColorFilter(ColorFilter filter) {
+        mPaint.setColorFilter(filter);
+    }
+
+    public void setColor(@ColorInt int color) {
+        mPaint.setColor(color);
+    }
+
+    /**
+     * Shift the text on the x axis by @param x pixels.
+     */
+    public void setTranslateX(int x) {
+        mTranslateX = x;
+    }
+    /**
+     * Shift the text on the y axis by @param y pixels.
+     */
+    public void setTranslateY(int y) {
+        mTranslateY = y;
+    }
+}

--- a/libs/editor/WordPressEditor/src/main/res/values/colors.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/colors.xml
@@ -28,5 +28,6 @@
     <color name="quote_background">@color/wp_grey_lighten_30</color>
     <color name="text">@color/wp_grey_darken_30</color>
 
-    <color name="media_shade_overlay_color">#50000000</color>
+    <color name="black_translucent_50">#80000000</color>
+    <color name="media_shade_overlay_color">@color/black_translucent_50</color>
 </resources>

--- a/libs/editor/WordPressEditor/src/main/res/values/colors.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/colors.xml
@@ -29,5 +29,4 @@
     <color name="text">@color/wp_grey_darken_30</color>
 
     <color name="media_shade_overlay_color">#50000000</color>
-    <color name="media_shade_overlay_error_color">#50FF0000</color>
 </resources>

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -106,6 +106,8 @@
     <string name="editor_dropped_title_images_not_allowed">Dropping images in the Title is not allowed</string>
     <string name="editor_dropped_html_images_not_allowed">Dropping images while in HTML mode is not allowed</string>
     <string name="editor_dropped_unsupported_files">Warning: not all dropped items are supported!</string>
+    <string name="editor_failed_to_insert_media_tap_to_retry">Failed to insert media.\nPlease tap to retry.</string>
+    <string name="editor_failed_to_insert_media_tap_for_options">Failed to insert media.\nPlease tap for options.</string>
 
     <!-- Aztec -->
     <string name="editor_content_hint">Share your story here&#8230;</string>


### PR DESCRIPTION
Fix #9730: Improve failed media error in Aztec

## To test:
- In Airplane mode.
- Create a new post with Aztec.
- Add a local image -> you should see a less scary overlay and an error message.


![res](https://user-images.githubusercontent.com/40213/57530820-5bfa3d80-7338-11e9-8e27-d2d406e60bab.png)

(I made sure the text size was changing after changing the device text/display size in accessibility options)

## Design

I wanted to remove the overlay completely but the error text won't be visible if the user uploads an image with a white background. If we really want to remove the overlay, we'll need some to check the contrast ratio or only add a contract box around the error message.

cc @iamthomasbishop and @marecar3 that might be something to fix [in Gutenberg Mobile](https://github.com/WordPress/gutenberg/blob/94d48e09dcfb547ad1b142d137a51a378d57077f/packages/block-library/src/image/edit.native.js#L390-L393) - here is a [demo with a white background image](https://bia.is/s/ylts/gutenberg-failed-upload.png).

Last note: IMO, the current experience in Aztec is not great, it's a only a "tap to retry" action, I much prefer the Gutenberg way, it opens a dialog with different options:

![Screenshot_1557495031](https://user-images.githubusercontent.com/40213/57530920-982d9e00-7338-11e9-883c-f991859e0b50.png)

We can open a new ticket if we think Aztec needs it.

## Implementation

I took a `TextDrawable` implementation from [here](https://android.googlesource.com/platform/packages/apps/Camera/+/master/src/com/android/camera/drawable/TextDrawable.java) and modified it to support multiline strings and xy shifts.

It feels a bit hacky, but I think this is a less invasive approach. Another option would be adding support for text overlays in Aztec.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
