### PR TITLE
Make network mock for self hosted tests more flexible

### DIFF
--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/self-hosted/rest_v11_sites_self-hosted.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/self-hosted/rest_v11_sites_self-hosted.json
@@ -1,7 +1,7 @@
 {
     "request": {
         "method": "GET",
-        "urlPattern": "/rest/v1.1/sites/([0-9]+(\\.[0-9]+)+|localhost)%3A[0-9]*/.*"
+        "urlPattern": "/rest/v1.1/sites/([0-9]+(\\.[0-9]+)+|localhost|.*.mystagingwebsite.com)(%3A[0-9]*)?/.*"
     },
     "response": {
         "status": 403,


### PR DESCRIPTION
Following the merge of https://github.com/wordpress-mobile/WordPress-Android/pull/9422, this fixes a small issue that would cause the self hosted login test to fail if you are using `gradle.properties` values other than those in `gradle.properties-example`.

To test:

- `cp ~/.mobile-secrets/android/WPAndroid/gradle.properties gradle.properties`
- `./gradlew WordPress:connectedVanillaDebugAndroidTest --stacktrace`

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
