### PR TITLE
Set baselineAlign in different layouts from StatsActivity

### DIFF
--- a/WordPress/src/main/res/layout-sw720dp/stats_activity.xml
+++ b/WordPress/src/main/res/layout-sw720dp/stats_activity.xml
@@ -108,7 +108,8 @@
 
                         <LinearLayout
                             android:layout_width="match_parent"
-                            android:layout_height="wrap_content">
+                            android:layout_height="wrap_content"
+                            android:baselineAligned="false">
 
                             <!-- Left column -->
                             <LinearLayout
@@ -169,7 +170,8 @@
 
                         <LinearLayout
                             android:layout_width="match_parent"
-                            android:layout_height="wrap_content">
+                            android:layout_height="wrap_content"
+                            android:baselineAligned="false">
 
                             <!-- Left column -->
                             <LinearLayout

--- a/WordPress/src/main/res/layout/stats_insights_latest_post_item.xml
+++ b/WordPress/src/main/res/layout/stats_insights_latest_post_item.xml
@@ -32,7 +32,8 @@
         android:id="@+id/stats_latest_post_tabs"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:baselineAligned="false">
         <!-- VIEWS tab-->
         <include
             layout="@layout/stats_visitors_and_views_tab"

--- a/WordPress/src/main/res/layout/stats_insights_today_item.xml
+++ b/WordPress/src/main/res/layout/stats_insights_today_item.xml
@@ -10,7 +10,8 @@
         android:id="@+id/stats_post_tabs"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:baselineAligned="false">
 
         <!-- VIEWS tab-->
         <include

--- a/WordPress/src/main/res/layout/stats_visitors_and_views_fragment.xml
+++ b/WordPress/src/main/res/layout/stats_visitors_and_views_fragment.xml
@@ -18,7 +18,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:visibility="gone" >
+            android:visibility="gone"
+            android:baselineAligned="false" >
 
             <!-- VIEWS tab-->
             <include
@@ -107,7 +108,8 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:gravity="center_vertical"
-            android:layout_marginBottom="@dimen/margin_medium">
+            android:layout_marginBottom="@dimen/margin_medium"
+            android:baselineAligned="false">
             <LinearLayout
                 android:focusable="false"
                 android:orientation="horizontal"

--- a/WordPress/src/main/res/layout/stats_widget_layout.xml
+++ b/WordPress/src/main/res/layout/stats_widget_layout.xml
@@ -48,7 +48,8 @@
         android:minHeight="@dimen/stats_widget_main_container_min_size"
         android:layout_width="match_parent"
         android:gravity="center_vertical"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:baselineAligned="false">
 
         <!-- Views -->
         <LinearLayout


### PR DESCRIPTION
Fixes # This PR is supposed to improve performance in StatsActivity by setting baselineAlign to false in some layouts from this activity, following Android Lint recommendations for performance.

To test: Measure use of memory in StatsActivity, while navegating by all tabs. By our tests with @VivianGomez, we measure an improvement between ~5MB and almost ~20MB.

   1. Go to Stats in My Site tab
   2. Scroll on first tap
   3. Navigate and scroll in all taps
   4. Navigate directlly from last tap (Years) to first (Insights)

Update release notes: Improvement memory usage in StatsActivity
#9837 #9837 