### PR TITLE
Fix crash with missing view in StatsViewAllFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -83,7 +83,7 @@ class StatsViewAllFragment : DaggerFragment() {
         super.onSaveInstanceState(outState)
     }
 
-        private fun initializeViews(savedInstanceState: Bundle?) {
+    private fun initializeViews(savedInstanceState: Bundle?) {
         val layoutManager = LinearLayoutManager(activity, LinearLayoutManager.VERTICAL, false)
 
         savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
@@ -225,8 +225,16 @@ class StatsViewAllFragment : DaggerFragment() {
         })
 
         viewModel.toolbarHasShadow.observe(this, Observer { hasShadow ->
-            val elevation = if (hasShadow == true) resources.getDimension(R.dimen.appbar_elevation) else 0f
-            app_bar_layout.postDelayed({ ViewCompat.setElevation(app_bar_layout, elevation) }, 100)
+            app_bar_layout.postDelayed({
+                if (app_bar_layout != null) {
+                    val elevation = if (hasShadow == true) {
+                        resources.getDimension(R.dimen.appbar_elevation)
+                    } else {
+                        0f
+                    }
+                    ViewCompat.setElevation(app_bar_layout, elevation)
+                }
+            }, 100)
         })
     }
 


### PR DESCRIPTION
Fixes #9750 
This was already fixed in the `StatsFragment`. When we do the `postDelayed` to hide/show the toolbar shadow, it's possible that the view is already gone (when the activity is killed). We need to check whether we're still showing the layout before setting the shadow.

To test:
* Go to a site with lot of stats
* Go to Insights/Comments card
* Click on "View more"
* The top toolbar ("Comments") doesn't have a shadow
* The tabs toolbar ("Authors" and "Posts and Pages") does have a shadow
* Go to Insights/Tags and Categories
* Click on "View more"
* The top toolbar (Tags & Categories) does have a shadow

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
