### PR TITLE
Gutenberg mobile hotfix v1.4.1

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 * Fixed an issue with Twitter publicize connections
 * Fixed an issue where the site icon wasn't updating correctly after switching to another site
 * Fixes an issue which can result in missing posts in the Reader
+* Fixed crash when editing a post with a previously cancelled image upload
 
 12.2
 -----


### PR DESCRIPTION
Fixes #9768

This PR updates the gutenberg-mobile reference to point to the latest hotfix, `v1.4.1`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/976.

To test, follow steps here: https://github.com/wordpress-mobile/WordPress-Android/issues/9768#issuecomment-490852531

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
