### PR TITLE
Treat response.pagination field as nullable

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/giphy/GiphyPickerDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/giphy/GiphyPickerDataSource.kt
@@ -77,7 +77,11 @@ class GiphyPickerDataSource(
 
         apiClient.search(searchQuery, gif, params.requestedLoadSize, startPosition, null, null) { response, error ->
             if (response != null) {
-                callback.onResult(response.data.toGiphyMediaViewModels(), startPosition, response.pagination.totalCount)
+                callback.onResult(
+                        response.data.toGiphyMediaViewModels(),
+                        startPosition,
+                        response.pagination?.totalCount ?: response.data.size
+                )
             } else {
                 initialLoadError = error
                 callback.onResult(emptyList(), startPosition, 0)


### PR DESCRIPTION
Fixes #8977 
The `response.pagination` field in the Giphy response is nullable and we have to treat it as such. I'm adding a fallback to `response.data.size` when the `pagination` object is null.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
