### PR TITLE
Release 12.4-rc3 with Gutenberg mobile fix for crashes on image blocks

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -44,7 +44,7 @@ android {
 
     defaultConfig {
         applicationId "org.wordpress.android"
-        versionName "12.4-rc-2"
+        versionName "12.4-rc-3"
         versionCode 725
         minSdkVersion 21
         targetSdkVersion 26

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -45,7 +45,7 @@ android {
     defaultConfig {
         applicationId "org.wordpress.android"
         versionName "12.4-rc-3"
-        versionCode 725
+        versionCode 726
         minSdkVersion 21
         targetSdkVersion 26
 


### PR DESCRIPTION
This PR prepares the 12.4-rc3 and includes a fix for #9768

Note: This point to GB-mobile v1.4.1.
Note 2: Updated `versionCode` to 726, but it's the same of current `develop` not sure if this leads to problems.

To test, follow steps here: #9768 (comment)

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
