### PR TITLE
Fix #9804: Make sure we call registerPostModel even if it's already registered

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -209,9 +209,8 @@ public class UploadService extends Service {
         if (mediaList != null && !mediaList.isEmpty()) {
             Set<PostModel> postsToRefresh = PostUtils.getPostsThatIncludeAnyOfTheseMedia(mPostStore, mediaList);
             for (PostModel post : postsToRefresh) {
-                if (!mUploadStore.isRegisteredPostModel(post)) {
-                    mUploadStore.registerPostModel(post, mediaList);
-                }
+                // If the post is already registered, the new media will be added to its list
+                mUploadStore.registerPostModel(post, mediaList);
             }
 
             if (isRetry) {


### PR DESCRIPTION
Fix #9804: Make sure we call registerPostModel even if it's already registered. This is required to add new media to the Post associated media ids set.

I also double checked on the FluxC side that the [set was correctly updated ](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/2b0b8f97c2d2a3f11dbfde36180c4872e09faa6f/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java#L140-L143)(and not overridden, I'll probably open a follow up PR on FluxC to add a new method `UploadModel.addMediaToAssociatedMediaIdSet` cc @mzorz)

Also I wonder if we should rename `registerPostModel` to something else or split it into `registerPostModel` + `addAssociatedMedia` for more clarity.

## Debugging Story

- When multiple media files are added from the editor, [`UploadService.uploadMedia`](https://github.com/wordpress-mobile/WordPress-Android/blob/87b949b27d9d4efb95e066bafe672693481da947/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java#L360-L368) is called sequentially.
- `UploadService.uploadMedia` [enqueues the media to upload and associate the media to the post](https://github.com/wordpress-mobile/WordPress-Android/blob/87b949b27d9d4efb95e066bafe672693481da947/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java#L199-L203).
- The problem was in the "associate the media to the post" part, only the first media was added.


## Wrong track

We first thought the problem was coming from [this](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/2b0b8f97c2d2a3f11dbfde36180c4872e09faa6f/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java#L250-L270) but we misunderstood it. Failed or cancelled post uploads are removed from the queue: they won't be retried automatically. When the user taps "retry" or do another publishing actions, which will call the `UploadService` again and creates a new `PostUploadModel` and do the whole dance (get associated medias, upload them, etc.).

## To test


- Go offline
- Create a draft post
- Add 2 images to the post
- Exit the editor
- Go online
- Tap on the Retry button.
- Enjoy your uploaded draft 🍸 
