### PR TITLE
Adds descriptive introductory paragraph to Domain Suggestions screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -78,6 +78,11 @@ class DomainSuggestionsFragment : Fragment() {
     }
 
     private fun setupObservers() {
+        viewModel.isIntroVisible.observe(this, Observer {
+            it?.let { isIntroVisible ->
+                introduction_container.visibility = if (isIntroVisible) View.VISIBLE else View.GONE
+            }
+        })
         viewModel.suggestionsLiveData.observe(this, Observer { listState ->
             if (listState != null) {
                 val isLoading = listState is ListState.Loading<*>

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModel.kt
@@ -131,9 +131,10 @@ class DomainSuggestionsViewModel @Inject constructor(
     }
 
     fun updateSearchQuery(query: String) {
+        _isIntroVisible.value = query.isEmpty()
+
         if (!TextUtils.isEmpty(query)) {
             searchQuery = query
-            _isIntroVisible.value = false
         } else if (searchQuery != site.name) {
             // Only reinitialize the search query, if it has changed.
             initializeDefaultSuggestions()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModel.kt
@@ -50,6 +50,10 @@ class DomainSuggestionsViewModel @Inject constructor(
     val selectedPosition: LiveData<Int>
         get() = _selectedPosition
 
+    private val _isIntroVisible = MutableLiveData<Boolean>().apply { value = true }
+    val isIntroVisible: LiveData<Boolean>
+        get() = _isIntroVisible
+
     private var searchQuery: String by Delegates.observable("") { _, oldValue, newValue ->
         if (newValue != oldValue) {
             debouncer.debounce(Void::class.java, {
@@ -129,6 +133,7 @@ class DomainSuggestionsViewModel @Inject constructor(
     fun updateSearchQuery(query: String) {
         if (!TextUtils.isEmpty(query)) {
             searchQuery = query
+            _isIntroVisible.value = false
         } else if (searchQuery != site.name) {
             // Only reinitialize the search query, if it has changed.
             initializeDefaultSuggestions()

--- a/WordPress/src/main/res/layout/domain_suggestion_list_item.xml
+++ b/WordPress/src/main/res/layout/domain_suggestion_list_item.xml
@@ -23,6 +23,6 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/margin_extra_medium_large"
         android:textColor="@color/neutral_700"
-        android:textSize="@dimen/text_sz_medium"/>
+        android:textSize="@dimen/text_sz_large"/>
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/domain_suggestion_list_item.xml
+++ b/WordPress/src/main/res/layout/domain_suggestion_list_item.xml
@@ -10,6 +10,7 @@
 
     <RadioButton
         android:id="@+id/domain_selection_radio_button"
+        android:buttonTint="@color/neutral_100_primary_400_selector"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/margin_small_medium"

--- a/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
+++ b/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
@@ -31,10 +31,10 @@
         android:layout_below="@id/introduction_container"
         android:gravity="center_vertical"
         android:orientation="horizontal"
-        android:paddingBottom="@dimen/margin_extra_large"
+        android:paddingBottom="@dimen/margin_large"
         android:paddingEnd="@dimen/margin_extra_large"
         android:paddingStart="@dimen/margin_large"
-        android:paddingTop="@dimen/margin_extra_large">
+        android:paddingTop="@dimen/margin_large">
 
         <FrameLayout
             android:layout_width="wrap_content"

--- a/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
+++ b/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
@@ -7,11 +7,27 @@
                 android:background="@android:color/white">
 
     <LinearLayout
+        android:id="@+id/introduction_container"
+        style="@style/DomainSuggestionsFormIntroductionContainer"
+        android:layout_alignParentTop="true"
+        android:orientation="vertical">
+
+        <TextView
+            style="@style/DomainSuggestionsFormIntroductionTitle"
+            android:text="@string/domains_suggestions_intro_title"/>
+
+        <TextView
+            style="@style/DomainSuggestionsFormIntroductionDescription"
+            android:text="@string/domains_suggestions_intro_description"/>
+
+    </LinearLayout>
+
+    <LinearLayout
         android:id="@+id/search_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true"
+        android:layout_below="@id/introduction_container"
         android:layout_marginTop="@dimen/margin_extra_small"
         android:gravity="center_vertical"
         android:orientation="horizontal"

--- a/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
+++ b/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
@@ -29,7 +29,6 @@
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
         android:layout_below="@id/introduction_container"
-        android:layout_marginTop="@dimen/margin_extra_small"
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:paddingBottom="@dimen/margin_extra_large"
@@ -82,7 +81,7 @@
         android:layout_below="@+id/search_container"
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:layout_marginStart="@dimen/margin_extra_large"
-        android:background="@color/divider"
+        android:background="@color/gray_0"
        />
 
     <RelativeLayout

--- a/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
+++ b/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
@@ -47,7 +47,7 @@
                 android:layout_marginStart="@dimen/margin_extra_extra_small"
                 android:contentDescription="@null"
                 android:src="@drawable/ic_search_white_24dp"
-                android:tint="@color/neutral"/>
+                android:tint="@color/neutral_300"/>
 
             <ProgressBar
                 android:id="@+id/suggestion_progress_bar"

--- a/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
+++ b/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
@@ -4,6 +4,7 @@
                 xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:animateLayoutChanges="true"
                 android:background="@android:color/white">
 
     <LinearLayout

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -418,4 +418,9 @@
 
     <dimen name="icon_size_075">18dp</dimen>
 
+    <!-- domain suggestions screen -->
+    <dimen name="domain_suggestions_intro_vertical_padding">24dp</dimen>
+    <dimen name="domain_suggestions_intro_horizontal_padding">16dp</dimen>
+    <dimen name="domain_suggestions_intro_header_bottom_padding">8dp</dimen>
+
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1966,6 +1966,8 @@
     <string name="register_domain">Register Domain</string>
     <string name="domains_suggestions_choose_domain">Choose Domain</string>
     <string name="domains_suggestions_empty_list">No suggestions found</string>
+    <string name="domains_suggestions_intro_title">Choose a premium domain name</string>
+    <string name="domains_suggestions_intro_description">This is where people will find you on the internet.</string>
     <string name="domain_suggestions_search_hint">Type a keyword for more ideas</string>
     <string name="domain_suggestions_fetch_error">Domain suggestions couldn\'t be loaded</string>
     <string name="domain_registration_contact_form_input_error">Please enter a valid %s</string>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -870,17 +870,17 @@
     <style name="DomainSuggestionsFormIntroductionContainer">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:paddingStart">@dimen/margin_extra_large</item>
-        <item name="android:paddingTop">@dimen/margin_dialog</item>
-        <item name="android:paddingEnd">@dimen/margin_extra_large</item>
-        <item name="android:paddingBottom">@dimen/margin_extra_large</item>
+        <item name="android:paddingStart">@dimen/domain_suggestions_intro_horizontal_padding</item>
+        <item name="android:paddingTop">@dimen/domain_suggestions_intro_vertical_padding</item>
+        <item name="android:paddingEnd">@dimen/domain_suggestions_intro_horizontal_padding</item>
+        <item name="android:paddingBottom">@dimen/domain_suggestions_intro_vertical_padding</item>
         <item name="android:background">@color/neutral_0</item>
     </style>
 
     <style name="DomainSuggestionsFormIntroductionTitle">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:paddingBottom">@dimen/margin_medium</item>
+        <item name="android:paddingBottom">@dimen/domain_suggestions_intro_header_bottom_padding</item>
         <item name="android:fontFamily">sans-serif-medium</item>
         <item name="android:textColor">@color/neutral_600</item>
         <item name="android:text">@dimen/text_sz_large</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -867,4 +867,32 @@
         <item name="android:layout_marginBottom">@dimen/margin_large</item>
     </style>
 
+    <style name="DomainSuggestionsFormIntroductionContainer">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:paddingStart">@dimen/margin_extra_large</item>
+        <item name="android:paddingTop">@dimen/margin_dialog</item>
+        <item name="android:paddingEnd">@dimen/margin_extra_large</item>
+        <item name="android:paddingBottom">@dimen/margin_extra_large</item>
+        <item name="android:background">@color/neutral_0</item>
+    </style>
+
+    <style name="DomainSuggestionsFormIntroductionTitle">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:paddingBottom">@dimen/margin_medium</item>
+        <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="android:textColor">@color/neutral_600</item>
+        <item name="android:text">@dimen/text_sz_large</item>
+        <item name="android:gravity">center_horizontal</item>
+    </style>
+
+    <style name="DomainSuggestionsFormIntroductionDescription">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:textColor">@color/neutral_400</item>
+        <item name="android:text">@dimen/text_sz_large</item>
+        <item name="android:gravity">center_horizontal</item>
+    </style>
+
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
@@ -40,7 +40,7 @@ class DomainSuggestionsViewModelTest {
     }
 
     @Test
-    fun isIntroVisibleIsSetToFalseWhenSearchQueryIsFirstSetToNonBlankValue() {
+    fun isIntroVisibleIsSetToFalseWhenSearchQueryIsSetToNonBlankValue() {
         viewModel.updateSearchQuery("Hello World")
 
         assertNotNull(viewModel.isIntroVisible.value)
@@ -50,13 +50,13 @@ class DomainSuggestionsViewModelTest {
     }
 
     @Test
-    fun isIntroVisibleNeverGetsSetBackToTrue() {
+    fun isIntroVisibleIsSetToTrueWhenSearchQueryIsCleared() {
         viewModel.updateSearchQuery("Hello World")
         viewModel.updateSearchQuery("")
 
         assertNotNull(viewModel.isIntroVisible.value)
         viewModel.isIntroVisible.value?.let { isIntroVisible ->
-            assertFalse(isIntroVisible)
+            assert(isIntroVisible)
         }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
@@ -1,0 +1,62 @@
+package org.wordpress.android.viewmodel.domains
+
+import android.arch.core.executor.testing.InstantTaskExecutorRule
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.util.helpers.Debouncer
+
+@RunWith(MockitoJUnitRunner::class)
+class DomainSuggestionsViewModelTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    @Mock lateinit var dispatcher: Dispatcher
+    @Mock lateinit var debouncer: Debouncer
+
+    private lateinit var site: SiteModel
+    private lateinit var viewModel: DomainSuggestionsViewModel
+
+    @Before
+    fun setUp() {
+        site = SiteModel().also { it.name = "Test Site" }
+        viewModel = DomainSuggestionsViewModel(dispatcher, debouncer)
+        viewModel.start(site)
+    }
+
+    @Test
+    fun isIntroVisibleIsInitializedToTrue() {
+        assertNotNull(viewModel.isIntroVisible.value)
+        viewModel.isIntroVisible.value?.let { isIntroVisible ->
+            assert(isIntroVisible)
+        }
+    }
+
+    @Test
+    fun isIntroVisibleIsSetToFalseWhenSearchQueryIsFirstSetToNonBlankValue() {
+        viewModel.updateSearchQuery("Hello World")
+
+        assertNotNull(viewModel.isIntroVisible.value)
+        viewModel.isIntroVisible.value?.let { isIntroVisible ->
+            assertFalse(isIntroVisible)
+        }
+    }
+
+    @Test
+    fun isIntroVisibleNeverGetsSetBackToTrue() {
+        viewModel.updateSearchQuery("Hello World")
+        viewModel.updateSearchQuery("")
+
+        assertNotNull(viewModel.isIntroVisible.value)
+        viewModel.isIntroVisible.value?.let { isIntroVisible ->
+            assertFalse(isIntroVisible)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #9815 Subtask: Add descriptive introductory paragraph to Domain Suggestions screen

This PR adds an introduction paragraph to the Domain Suggestions screen. The paragraph will disappear when the user starts typing into the search box. It will not reappear if they clear the search box, since it really only needs to be read once. If this behaviour is not correct, please let me know.

To test:
1. Install the wasabi build.
2. Switch to a site on a business plan with unclaimed domain credit (let me know if you need help with this).
3. Navigate to Plugins screen, and from there to details of any plugin (like Woocommerce).
4. Tap on Install button.
5. In the dialog tap on "REGISTER DOMAIN".
6. View the introduction paragraph on the Domain Suggestions screen
7. Start typing in the search box, the introduction paragraph should disappear

![Screenshot3](https://user-images.githubusercontent.com/897223/57746901-6f870a80-7690-11e9-9452-8f1666dc4cd9.png)



