### PR TITLE
Do not start Jetpack flow when leaving Connect activity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.java
@@ -137,12 +137,14 @@ public class StatsConnectJetpackActivity extends AppCompatActivity {
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onAccountChanged(OnAccountChanged event) {
-        if (event.isError()) {
-            AppLog.e(T.API, "StatsConnectJetpackActivity.onAccountChanged error: "
-                            + event.error.type + " - " + event.error.message);
-        } else if (!mIsJetpackConnectStarted && event.causeOfChange == AccountAction.FETCH_ACCOUNT
-                   && !TextUtils.isEmpty(mAccountStore.getAccount().getUserName())) {
-            startJetpackConnectionFlow((SiteModel) getIntent().getSerializableExtra(SITE));
+        if (!isFinishing()) {
+            if (event.isError()) {
+                AppLog.e(T.API, "StatsConnectJetpackActivity.onAccountChanged error: "
+                                + event.error.type + " - " + event.error.message);
+            } else if (!mIsJetpackConnectStarted && event.causeOfChange == AccountAction.FETCH_ACCOUNT
+                       && !TextUtils.isEmpty(mAccountStore.getAccount().getUserName())) {
+                startJetpackConnectionFlow((SiteModel) getIntent().getSerializableExtra(SITE));
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #8434 

The `WPMainActivity` triggers account update in onResume. At that time the `StatsConnectJetpackActivity` is not yet finished so it receives the `OnAccountChanged` event and starts the Jetpack connection flow in the WebView. This PR introduces a check that checks whether the app is not finishing when we receive the event. 

To test:
* Create a fresh self-hosted site without Jetpack
* Go to Stats
* Click "Back" on the screen that tells you to install Jetpack
* You go back to the Main activity

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
