### PR TITLE
LocalDraftUploadStarter: Upload from anywhere

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 12.5
 -----
-* Fixed local drafts not automatically pushed to the server.
+* Fixed local drafts not automatically pushed to the server. 
+* Local Drafts will be automatically uploaded to the server as soon as internet connection is available.
 
 12.4
 -----

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -76,12 +76,12 @@ import org.wordpress.android.ui.stats.datasets.StatsDatabaseHelper;
 import org.wordpress.android.ui.stats.datasets.StatsTable;
 import org.wordpress.android.ui.uploads.LocalDraftUploadStarter;
 import org.wordpress.android.ui.uploads.UploadService;
-import org.wordpress.android.util.CrashLoggingUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.AppLogListener;
 import org.wordpress.android.util.AppLog.LogLevel;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.BitmapLruCache;
+import org.wordpress.android.util.CrashLoggingUtils;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.LocaleManager;
@@ -279,7 +279,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
 
         // Make the UploadStarter observe the app process so it can auto-start uploads
-        ProcessLifecycleOwner.get().getLifecycle().addObserver(mLocalDraftUploadStarter.getProcessLifecycleObserver());
+        mLocalDraftUploadStarter.startAutoUploads((ProcessLifecycleOwner) ProcessLifecycleOwner.get());
 
         initAnalytics(SystemClock.elapsedRealtime() - startDate);
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -279,7 +279,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
 
         // Make the UploadStarter observe the app process so it can auto-start uploads
-        mLocalDraftUploadStarter.startAutoUploads((ProcessLifecycleOwner) ProcessLifecycleOwner.get());
+        mLocalDraftUploadStarter.activateAutoUploading((ProcessLifecycleOwner) ProcessLifecycleOwner.get());
 
         initAnalytics(SystemClock.elapsedRealtime() - startDate);
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -74,6 +74,7 @@ import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.stats.StatsWidgetProvider;
 import org.wordpress.android.ui.stats.datasets.StatsDatabaseHelper;
 import org.wordpress.android.ui.stats.datasets.StatsTable;
+import org.wordpress.android.ui.uploads.LocalDraftUploadStarter;
 import org.wordpress.android.ui.uploads.UploadService;
 import org.wordpress.android.util.CrashLoggingUtils;
 import org.wordpress.android.util.AppLog;
@@ -141,6 +142,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
     @Inject SiteStore mSiteStore;
     @Inject MediaStore mMediaStore;
     @Inject ZendeskHelper mZendeskHelper;
+    @Inject LocalDraftUploadStarter mLocalDraftUploadStarter;
 
     @Inject @Named("custom-ssl") RequestQueue mRequestQueue;
     public static RequestQueue sRequestQueue;
@@ -275,6 +277,9 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         // initialize our ApplicationLifecycleMonitor, which is the App's LifecycleObserver implementation
         mApplicationLifecycleMonitor = new ApplicationLifecycleMonitor();
         ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
+
+        // Make the UploadStarter observe the app process so it can auto-start uploads
+        ProcessLifecycleOwner.get().getLifecycle().addObserver(mLocalDraftUploadStarter.getProcessLifecycleObserver());
 
         initAnalytics(SystemClock.elapsedRealtime() - startDate);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ThreadModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ThreadModule.kt
@@ -12,6 +12,7 @@ const val UI_SCOPE = "UI_SCOPE"
 const val DEFAULT_SCOPE = "DEFAULT_SCOPE"
 const val UI_THREAD = "UI_THREAD"
 const val BG_THREAD = "BG_THREAD"
+const val IO_THREAD = "IO_THREAD"
 
 @Module
 class ThreadModule {
@@ -37,6 +38,12 @@ class ThreadModule {
     @Named(BG_THREAD)
     fun provideBackgroundDispatcher(): CoroutineDispatcher {
         return Dispatchers.Default
+    }
+
+    @Provides
+    @Named(IO_THREAD)
+    fun provideIoDispatcher(): CoroutineDispatcher {
+        return Dispatchers.IO
     }
 
     @Provides

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -5,7 +5,6 @@ import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.LifecycleRegistry
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
-import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModel
 import android.content.Intent
 import kotlinx.coroutines.CoroutineDispatcher
@@ -39,12 +38,10 @@ import org.wordpress.android.ui.posts.PostListViewLayoutType.STANDARD
 import org.wordpress.android.ui.posts.PostListViewLayoutTypeMenuUiState.CompactViewLayoutTypeMenuUiState
 import org.wordpress.android.ui.posts.PostListViewLayoutTypeMenuUiState.StandardViewLayoutTypeMenuUiState
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
-import org.wordpress.android.ui.uploads.LocalDraftUploadStarter
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.util.analytics.AnalyticsUtils
 import org.wordpress.android.viewmodel.SingleLiveEvent
-import org.wordpress.android.viewmodel.helpers.ConnectionStatus
 import org.wordpress.android.viewmodel.helpers.DialogHolder
 import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
 import org.wordpress.android.viewmodel.posts.PostFetcher
@@ -68,8 +65,6 @@ class PostListMainViewModel @Inject constructor(
     mediaStore: MediaStore,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val prefs: AppPrefsWrapper,
-    private val localDraftUploadStarter: LocalDraftUploadStarter,
-    private val connectionStatus: LiveData<ConnectionStatus>,
     private val postListEventListenerFactory: PostListEventListener.Factory,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
@@ -216,10 +211,6 @@ class PostListMainViewModel @Inject constructor(
                 authorFilterItems = getAuthorFilterItems(authorFilterSelection, accountStore.account?.avatarUrl)
         )
         lifecycleRegistry.markState(Lifecycle.State.STARTED)
-
-        connectionStatus.observe(this, Observer {
-            localDraftUploadStarter.queueUpload(site = site)
-        })
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -218,7 +218,7 @@ class PostListMainViewModel @Inject constructor(
         lifecycleRegistry.markState(Lifecycle.State.STARTED)
 
         connectionStatus.observe(this, Observer {
-            localDraftUploadStarter.uploadLocalDrafts(scope = this@PostListMainViewModel, site = site)
+            localDraftUploadStarter.queueUpload(site = site)
         })
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -214,7 +214,7 @@ class PostListMainViewModel @Inject constructor(
         )
         lifecycleRegistry.markState(Lifecycle.State.STARTED)
 
-        localDraftUploadStarter.queueUpload(site)
+        localDraftUploadStarter.queueUploadFromSite(site)
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -38,6 +38,7 @@ import org.wordpress.android.ui.posts.PostListViewLayoutType.STANDARD
 import org.wordpress.android.ui.posts.PostListViewLayoutTypeMenuUiState.CompactViewLayoutTypeMenuUiState
 import org.wordpress.android.ui.posts.PostListViewLayoutTypeMenuUiState.StandardViewLayoutTypeMenuUiState
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.uploads.LocalDraftUploadStarter
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.util.analytics.AnalyticsUtils
@@ -67,7 +68,8 @@ class PostListMainViewModel @Inject constructor(
     private val prefs: AppPrefsWrapper,
     private val postListEventListenerFactory: PostListEventListener.Factory,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
-    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+    private val localDraftUploadStarter: LocalDraftUploadStarter
 ) : ViewModel(), LifecycleOwner, CoroutineScope {
     private val lifecycleRegistry = LifecycleRegistry(this)
     override fun getLifecycle(): Lifecycle = lifecycleRegistry
@@ -211,6 +213,8 @@ class PostListMainViewModel @Inject constructor(
                 authorFilterItems = getAuthorFilterItems(authorFilterSelection, accountStore.account?.avatarUrl)
         )
         lifecycleRegistry.markState(Lifecycle.State.STARTED)
+
+        localDraftUploadStarter.queueUpload(site)
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.uploads
 
+import android.arch.lifecycle.LiveData
 import android.content.Context
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -11,6 +12,8 @@ import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.viewmodel.helpers.ConnectionStatus
+import org.wordpress.android.viewmodel.helpers.ConnectionStatus.AVAILABLE
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -31,11 +34,21 @@ class LocalDraftUploadStarter @Inject constructor(
      * The Coroutine dispatcher used for querying in FluxC.
      */
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
-    private val networkUtilsWrapper: NetworkUtilsWrapper
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
+    connectionStatus: LiveData<ConnectionStatus>
 ) : CoroutineScope {
     override val coroutineContext: CoroutineContext get() = bgDispatcher
 
-    fun queueUploadForAllSites() = launch {
+    init {
+        // Since this class is meant to be a Singleton, it should be fine (I think) to use observeForever in here.
+        connectionStatus.observeForever {
+            if (it == AVAILABLE) {
+                queueUploadForAllSites()
+            }
+        }
+    }
+
+    private fun queueUploadForAllSites() = launch {
         val sites = siteStore.sites
         // TODO there should be an actual queue instead of calling this directly
         upload(sites = sites)

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -10,10 +10,12 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.NetworkUtilsWrapper
 import javax.inject.Inject
 import javax.inject.Named
+import javax.inject.Singleton
 
 /**
  * Provides a way to find and upload all local drafts.
  */
+@Singleton
 class LocalDraftUploadStarter @Inject constructor(
     /**
      * The Application context

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.util.NetworkUtilsWrapper
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Provides a way to find and upload all local drafts.
@@ -27,7 +28,9 @@ class LocalDraftUploadStarter @Inject constructor(
      */
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val networkUtilsWrapper: NetworkUtilsWrapper
-) {
+) : CoroutineScope {
+    override val coroutineContext: CoroutineContext get() = bgDispatcher
+
     fun uploadLocalDrafts(scope: CoroutineScope, site: SiteModel) = scope.launch(bgDispatcher) {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return@launch

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.IO_THREAD
+import org.wordpress.android.util.CrashLoggingUtils
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.skip
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus
@@ -82,14 +83,22 @@ class LocalDraftUploadStarter @Inject constructor(
 
     private fun queueUploadFromAllSites() = launch {
         val sites = siteStore.sites
-        checkConnectionAndUpload(sites = sites)
+        try {
+            checkConnectionAndUpload(sites = sites)
+        } catch (e: Exception) {
+            CrashLoggingUtils.log(e)
+        }
     }
 
     /**
      * Upload all local drafts from the given [site].
      */
     fun queueUploadFromSite(site: SiteModel) = launch {
-        checkConnectionAndUpload(sites = listOf(site))
+        try {
+            checkConnectionAndUpload(sites = listOf(site))
+        } catch (e: Exception) {
+            CrashLoggingUtils.log(e)
+        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -1,6 +1,9 @@
 package org.wordpress.android.ui.uploads
 
+import android.arch.lifecycle.Lifecycle.Event
+import android.arch.lifecycle.LifecycleObserver
 import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.OnLifecycleEvent
 import android.content.Context
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -38,6 +41,13 @@ class LocalDraftUploadStarter @Inject constructor(
     connectionStatus: LiveData<ConnectionStatus>
 ) : CoroutineScope {
     override val coroutineContext: CoroutineContext get() = bgDispatcher
+
+    val processLifecycleObserver = object : LifecycleObserver {
+        @OnLifecycleEvent(Event.ON_START)
+        fun onAppComesFromBackground() {
+            queueUploadForAllSites()
+        }
+    }
 
     init {
         // Since this class is meant to be a Singleton, it should be fine (I think) to use observeForever in here.

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -42,6 +42,15 @@ class LocalDraftUploadStarter @Inject constructor(
 
     override val coroutineContext: CoroutineContext get() = job + bgDispatcher
 
+    /**
+     * The hook for making this class automatically launch uploads whenever the app is placed in the foreground.
+     *
+     * This must be attached during [org.wordpress.android.WordPress]' creation like so:
+     *
+     * ```
+     * ProcessLifecycleOwner.get().getLifecycle().addObserver(mLocalDraftUploadStarter.getProcessLifecycleObserver());
+     * ```
+     */
     val processLifecycleObserver = object : LifecycleObserver {
         @OnLifecycleEvent(Event.ON_START)
         fun onAppComesFromBackground() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -8,7 +8,6 @@ import android.arch.lifecycle.ProcessLifecycleOwner
 import android.content.Context
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -16,6 +15,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.modules.IO_THREAD
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.skip
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus
@@ -41,6 +41,7 @@ class LocalDraftUploadStarter @Inject constructor(
     private val postStore: PostStore,
     private val siteStore: SiteStore,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+    @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher,
     private val uploadServiceFacade: UploadServiceFacade,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val connectionStatus: LiveData<ConnectionStatus>
@@ -101,7 +102,7 @@ class LocalDraftUploadStarter @Inject constructor(
         }
     }
 
-    private fun upload(scope: CoroutineScope, site: SiteModel) = scope.launch(Dispatchers.IO) {
+    private fun upload(scope: CoroutineScope, site: SiteModel) = scope.launch(ioDispatcher) {
         postStore.getLocalDraftPosts(site)
                 .filterNot { uploadServiceFacade.isPostUploadingOrQueued(it) }
                 .forEach { localDraft ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -104,16 +104,16 @@ class LocalDraftUploadStarter @Inject constructor(
         }
 
         sites.forEach {
-            upload(scope = this, site = it)
+            launch(ioDispatcher) {
+                upload(site = it)
+            }
         }
     }
 
     /**
      * This is meant to be used by [checkConnectionAndUpload] only.
-     *
-     * @param scope The scope created by [checkConnectionAndUpload].
      */
-    private fun upload(scope: CoroutineScope, site: SiteModel) = scope.launch(ioDispatcher) {
+    private fun upload(site: SiteModel) {
         postStore.getLocalDraftPosts(site)
                 .filterNot { uploadServiceFacade.isPostUploadingOrQueued(it) }
                 .forEach { localDraft ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -30,7 +30,7 @@ import kotlin.coroutines.CoroutineContext
  * Auto-uploads happen when the app is placed in the foreground or when the internet connection is restored. In
  * addition to this, call sites can also request an immediate execution by calling [upload].
  *
- * The method [startAutoUploads] must be called once, preferably during app creation, for the auto-uploads to work.
+ * The method [activateAutoUploading] must be called once, preferably during app creation, for the auto-uploads to work.
  */
 @Singleton
 class LocalDraftUploadStarter @Inject constructor(
@@ -65,10 +65,10 @@ class LocalDraftUploadStarter @Inject constructor(
      * This must be called during [org.wordpress.android.WordPress]' creation like so:
      *
      * ```
-     * mLocalDraftUploadStarter.startAutoUploads(ProcessLifecycleOwner.get())
+     * mLocalDraftUploadStarter.activateAutoUploading(ProcessLifecycleOwner.get())
      * ```
      */
-    fun startAutoUploads(processLifecycleOwner: ProcessLifecycleOwner) {
+    fun activateAutoUploading(processLifecycleOwner: ProcessLifecycleOwner) {
         // Since this class is meant to be a Singleton, it should be fine (I think) to use observeForever in here.
         // We're skipping the first emitted value because the processLifecycleObserver below will also trigger an
         // immediate upload.

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.skip
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus
 import javax.inject.Inject
 import javax.inject.Named
@@ -60,7 +61,7 @@ class LocalDraftUploadStarter @Inject constructor(
 
     init {
         // Since this class is meant to be a Singleton, it should be fine (I think) to use observeForever in here.
-        connectionStatus.observeForever {
+        connectionStatus.skip(1).observeForever {
             queueUploadForAllSites()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -92,6 +92,12 @@ class LocalDraftUploadStarter @Inject constructor(
         checkConnectionAndUpload(sites = listOf(site))
     }
 
+    /**
+     * If there is an internet connection, uploads all local drafts belonging to [sites].
+     *
+     * This coroutine will suspend until all the [upload] operations have completed. If one of them fails, all query
+     * and queuing attempts ([upload]) will be canceled. The exception will be thrown by this method.
+     */
     private suspend fun checkConnectionAndUpload(sites: List<SiteModel>) = coroutineScope {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return@coroutineScope
@@ -102,6 +108,11 @@ class LocalDraftUploadStarter @Inject constructor(
         }
     }
 
+    /**
+     * This is meant to be used by [checkConnectionAndUpload] only.
+     *
+     * @param scope The scope created by [checkConnectionAndUpload].
+     */
     private fun upload(scope: CoroutineScope, site: SiteModel) = scope.launch(ioDispatcher) {
         postStore.getLocalDraftPosts(site)
                 .filterNot { uploadServiceFacade.isPostUploadingOrQueued(it) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -88,7 +88,7 @@ class LocalDraftUploadStarter @Inject constructor(
     /**
      * Upload all local drafts from the given [site].
      */
-    fun queueUpload(site: SiteModel) = launch {
+    fun queueUploadFromSite(site: SiteModel) = launch {
         checkConnectionAndUpload(sites = listOf(site))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.SiteModel
@@ -37,7 +38,9 @@ class LocalDraftUploadStarter @Inject constructor(
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     connectionStatus: LiveData<ConnectionStatus>
 ) : CoroutineScope {
-    override val coroutineContext: CoroutineContext get() = bgDispatcher
+    private val job = Job()
+
+    override val coroutineContext: CoroutineContext get() = job + bgDispatcher
 
     val processLifecycleObserver = object : LifecycleObserver {
         @OnLifecycleEvent(Event.ON_START)

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.ui.uploads
+
+import android.content.Context
+import org.wordpress.android.fluxc.model.PostModel
+import javax.inject.Inject
+
+/**
+ * An injectable class built on top of [UploadService].
+ *
+ * The main purpose of this is to provide testability for classes that use [UploadService]. This should never
+ * contain any static methods.
+ */
+class UploadServiceFacade @Inject constructor() {
+    fun uploadPost(context: Context, post: PostModel, trackAnalytics: Boolean, publish: Boolean, isRetry: Boolean) {
+        val intent = UploadService.getUploadPostServiceIntent(context, post, trackAnalytics, publish, isRetry)
+        context.startService(intent)
+    }
+
+    fun isPostUploadingOrQueued(post: PostModel) = UploadService.isPostUploadingOrQueued(post)
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
@@ -248,10 +248,8 @@ fun <T> LiveData<T>.skip(times: Int): LiveData<T> {
     mediator.addSource(this) { value ->
         skipped += 1
 
-        if (skipped <= times) {
-            return@addSource
-        } else {
-            mediator.postValue(value)
+        if (skipped > times) {
+            mediator.value = value
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.util
 
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MediatorLiveData
+import android.arch.lifecycle.Observer
 import android.arch.lifecycle.Transformations
 import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.viewmodel.SingleMediatorLiveEvent
@@ -222,5 +223,37 @@ fun <T> LiveData<T>.filter(predicate: (T) -> Boolean): LiveData<T> {
             mediator.value = it
         }
     }
+    return mediator
+}
+
+/**
+ * Suppresses the first n items by this [LiveData].
+ *
+ * Consider this for example:
+ *
+ * ```
+ * val connectionStatusLiveData = getConnectionStatusLiveData()
+ * connectionStatusLiveData.skip(1).observe(this, Observer {
+ *     refresh()
+ * })
+ * ```
+ *
+ * The first value emitted by `connectionStatusLiveData` would be ignored and [Observer] will nto be called.
+ */
+fun <T> LiveData<T>.skip(times: Int): LiveData<T> {
+    check(times > 0) { "The number of times to skip must be greater than 0" }
+
+    var skipped = 0
+    val mediator = MediatorLiveData<T>()
+    mediator.addSource(this) { value ->
+        skipped += 1
+
+        if (skipped <= times) {
+            return@addSource
+        } else {
+            mediator.postValue(value)
+        }
+    }
+
     return mediator
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
@@ -238,7 +238,7 @@ fun <T> LiveData<T>.filter(predicate: (T) -> Boolean): LiveData<T> {
  * })
  * ```
  *
- * The first value emitted by `connectionStatusLiveData` would be ignored and [Observer] will nto be called.
+ * The first value emitted by `connectionStatusLiveData` would be ignored and [Observer] will not be called.
  */
 fun <T> LiveData<T>.skip(times: Int): LiveData<T> {
     check(times > 0) { "The number of times to skip must be greater than 0" }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -154,7 +154,7 @@ class PostListViewModel @Inject constructor(
     // Public Methods
 
     fun swipeToRefresh() {
-        localDraftUploadStarter.uploadLocalDrafts(scope = this, site = connector.site)
+        localDraftUploadStarter.queueUpload(site = connector.site)
         fetchFirstPage()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -7,8 +7,8 @@ import android.arch.lifecycle.LifecycleRegistry
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MediatorLiveData
 import android.arch.lifecycle.Observer
+import android.arch.lifecycle.ViewModel
 import android.arch.paging.PagedList
-import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.PostModel
@@ -20,7 +20,6 @@ import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescrip
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.ListStore
 import org.wordpress.android.fluxc.store.PostStore
-import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
 import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
 import org.wordpress.android.ui.posts.PostUtils
@@ -29,14 +28,12 @@ import org.wordpress.android.ui.uploads.LocalDraftUploadStarter
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.SiteUtils
-import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus
 import org.wordpress.android.viewmodel.posts.PostListEmptyUiState.RefreshError
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.LocalPostId
 import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
 import javax.inject.Inject
-import javax.inject.Named
 
 typealias PagedPostList = PagedList<PostListItemType>
 
@@ -49,9 +46,8 @@ class PostListViewModel @Inject constructor(
     private val listItemUiStateHelper: PostListItemUiStateHelper,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val localDraftUploadStarter: LocalDraftUploadStarter,
-    connectionStatus: LiveData<ConnectionStatus>,
-    @Named(BG_THREAD) bgDispatcher: CoroutineDispatcher
-) : ScopedViewModel(bgDispatcher), LifecycleOwner {
+    connectionStatus: LiveData<ConnectionStatus>
+) : ViewModel(), LifecycleOwner {
     private val isStatsSupported: Boolean by lazy {
         SiteUtils.isAccessedViaWPComRest(connector.site) && connector.site.hasCapabilityViewStats
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -150,7 +150,7 @@ class PostListViewModel @Inject constructor(
     // Public Methods
 
     fun swipeToRefresh() {
-        localDraftUploadStarter.queueUpload(site = connector.site)
+        localDraftUploadStarter.queueUploadFromSite(connector.site)
         fetchFirstPage()
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
@@ -37,7 +37,7 @@ class PostListMainViewModelTest {
         viewModel.start(site = site)
 
         // Then
-        verify(localDraftUploadStarter, times(1)).uploadLocalDrafts(scope = eq(viewModel), site = eq(site))
+        verify(localDraftUploadStarter, times(1)).queueUpload(site = eq(site))
     }
 
     @Test
@@ -60,7 +60,7 @@ class PostListMainViewModelTest {
         // Then
         // The upload should be executed 3 times because we have 2 connections status changes plus the auto-upload
         // during `viewModel.start()`.
-        verify(localDraftUploadStarter, times(3)).uploadLocalDrafts(scope = eq(viewModel), site = eq(site))
+        verify(localDraftUploadStarter, times(3)).queueUpload(site = eq(site))
     }
 
     private companion object {
@@ -80,8 +80,6 @@ class PostListMainViewModelTest {
                     mediaStore = mock(),
                     networkUtilsWrapper = mock(),
                     prefs = prefs,
-                    localDraftUploadStarter = localDraftUploadStarter,
-                    connectionStatus = connectionStatus,
                     mainDispatcher = mock(),
                     bgDispatcher = mock(),
                     postListEventListenerFactory = mock()

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
@@ -28,7 +28,7 @@ class PostListMainViewModelTest {
         viewModel.start(site = site)
 
         // Then
-        verify(localDraftUploadStarter, times(1)).queueUpload(site = eq(site))
+        verify(localDraftUploadStarter, times(1)).queueUploadFromSite(eq(site))
     }
 
     private companion object {

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
@@ -1,8 +1,6 @@
 package org.wordpress.android.ui.posts
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
-import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
@@ -14,9 +12,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.PostListViewLayoutType.STANDARD
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.uploads.LocalDraftUploadStarter
-import org.wordpress.android.viewmodel.helpers.ConnectionStatus
-import org.wordpress.android.viewmodel.helpers.ConnectionStatus.AVAILABLE
-import org.wordpress.android.viewmodel.helpers.ConnectionStatus.UNAVAILABLE
 
 class PostListMainViewModelTest {
     @get:Rule val rule = InstantTaskExecutorRule()
@@ -26,12 +21,8 @@ class PostListMainViewModelTest {
         // Given
         val site = SiteModel()
         val localDraftUploadStarter = mock<LocalDraftUploadStarter>()
-        val connectionStatus = MutableLiveData<ConnectionStatus>().apply { value = AVAILABLE }
 
-        val viewModel = createPostListMainViewModel(
-                localDraftUploadStarter = localDraftUploadStarter,
-                connectionStatus = connectionStatus
-        )
+        val viewModel = createPostListMainViewModel(localDraftUploadStarter)
 
         // When
         viewModel.start(site = site)
@@ -40,34 +31,8 @@ class PostListMainViewModelTest {
         verify(localDraftUploadStarter, times(1)).queueUpload(site = eq(site))
     }
 
-    @Test
-    fun `when the internet connection changes, it uploads all local drafts`() {
-        // Given
-        val site = SiteModel()
-        val localDraftUploadStarter = mock<LocalDraftUploadStarter>()
-        val connectionStatus = MutableLiveData<ConnectionStatus>().apply { value = AVAILABLE }
-
-        val viewModel = createPostListMainViewModel(
-                localDraftUploadStarter = localDraftUploadStarter,
-                connectionStatus = connectionStatus
-        )
-        viewModel.start(site = site)
-
-        // When
-        connectionStatus.postValue(UNAVAILABLE)
-        connectionStatus.postValue(AVAILABLE)
-
-        // Then
-        // The upload should be executed 3 times because we have 2 connections status changes plus the auto-upload
-        // during `viewModel.start()`.
-        verify(localDraftUploadStarter, times(3)).queueUpload(site = eq(site))
-    }
-
     private companion object {
-        fun createPostListMainViewModel(
-            localDraftUploadStarter: LocalDraftUploadStarter,
-            connectionStatus: LiveData<ConnectionStatus>
-        ): PostListMainViewModel {
+        fun createPostListMainViewModel(localDraftUploadStarter: LocalDraftUploadStarter): PostListMainViewModel {
             val prefs = mock<AppPrefsWrapper> {
                 on { postListViewLayoutType } doReturn STANDARD
             }
@@ -82,7 +47,8 @@ class PostListMainViewModelTest {
                     prefs = prefs,
                     mainDispatcher = mock(),
                     bgDispatcher = mock(),
-                    postListEventListenerFactory = mock()
+                    postListEventListenerFactory = mock(),
+                    localDraftUploadStarter = localDraftUploadStarter
             )
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterConcurrentTest.kt
@@ -20,6 +20,9 @@ import org.wordpress.android.util.NetworkUtilsWrapper
 
 /**
  * Tests for structured concurrency in [LocalDraftUploadStarter].
+ *
+ * This is intentionally a separate class from [LocalDraftUploadStarterTest] because this contains non-deterministic
+ * tests.
  */
 @RunWith(MockitoJUnitRunner::class)
 class LocalDraftUploadStarterConcurrentTest {

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterConcurrentTest.kt
@@ -1,0 +1,83 @@
+package org.wordpress.android.ui.uploads
+
+import android.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.util.NetworkUtilsWrapper
+
+/**
+ * Tests for structured concurrency in [LocalDraftUploadStarter].
+ */
+@RunWith(MockitoJUnitRunner::class)
+class LocalDraftUploadStarterConcurrentTest {
+    @get:Rule val rule = InstantTaskExecutorRule()
+
+    private val site = SiteModel()
+    private val posts = listOf(
+            PostModel(),
+            PostModel(),
+            PostModel(),
+            PostModel(),
+            PostModel()
+    )
+
+    private val postStore = mock<PostStore> {
+        on { getLocalDraftPosts(eq(site)) } doReturn posts
+    }
+
+    @Test
+    fun `it uploads local drafts concurrently`() {
+        // Given
+        val uploadServiceFacade = createMockedUploadServiceFacade()
+
+        val starter = createLocalDraftUploadStarter(uploadServiceFacade)
+
+        // When
+        runBlocking {
+            starter.queueUploadFromSite(site).join()
+        }
+
+        // Then
+        verify(uploadServiceFacade, times(posts.size)).uploadPost(
+                context = any(),
+                post = any(),
+                trackAnalytics = any(),
+                publish = any(),
+                isRetry = eq(true)
+        )
+    }
+
+    private fun createLocalDraftUploadStarter(uploadServiceFacade: UploadServiceFacade) = LocalDraftUploadStarter(
+            context = mock(),
+            postStore = postStore,
+            siteStore = mock(),
+            bgDispatcher = Dispatchers.Default,
+            ioDispatcher = Dispatchers.IO,
+            networkUtilsWrapper = createMockedNetworkUtilsWrapper(),
+            connectionStatus = mock(),
+            uploadServiceFacade = uploadServiceFacade
+    )
+
+    private companion object Fixtures {
+        fun createMockedNetworkUtilsWrapper() = mock<NetworkUtilsWrapper> {
+            on { isNetworkAvailable() } doReturn true
+        }
+
+        fun createMockedUploadServiceFacade() = mock<UploadServiceFacade> {
+            on { isPostUploadingOrQueued(any()) } doReturn false
+        }
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
@@ -126,7 +126,7 @@ class LocalDraftUploadStarterTest {
 
         // When
         runBlocking {
-            starter.queueUpload(site).join()
+            starter.queueUploadFromSite(site).join()
         }
 
         // Then
@@ -163,7 +163,7 @@ class LocalDraftUploadStarterTest {
 
         // When
         runBlocking {
-            starter.queueUpload(site).join()
+            starter.queueUploadFromSite(site).join()
         }
 
         // Then

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.uploads
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.ProcessLifecycleOwner
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
@@ -43,6 +44,9 @@ class LocalDraftUploadStarterTest {
             on { getLocalDraftPosts(eq(it)) } doReturn sitesAndPosts[it]
         }
     }
+    private val processLifecycleOwner = mock<ProcessLifecycleOwner> {
+        on { lifecycle } doReturn mock()
+    }
 
     @Test
     fun `when the internet connection is restored, it uploads all local drafts`() {
@@ -50,7 +54,7 @@ class LocalDraftUploadStarterTest {
         val networkUtilsWrapper = mock<NetworkUtilsWrapper> {
             on { isNetworkAvailable() } doReturn true
         }
-        val connectionStatus = MutableLiveData<ConnectionStatus>()
+        val connectionStatus = MutableLiveData<ConnectionStatus>().apply { value = UNAVAILABLE }
         val uploadServiceFacade = mock<UploadServiceFacade> {
             on { isPostUploadingOrQueued(any()) } doReturn false
         }
@@ -64,6 +68,7 @@ class LocalDraftUploadStarterTest {
                 connectionStatus = connectionStatus,
                 uploadServiceFacade = uploadServiceFacade
         )
+        starter.startAutoUploads(processLifecycleOwner)
 
         // When
         runBlocking {

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
@@ -191,6 +191,7 @@ class LocalDraftUploadStarterTest {
             postStore = postStore,
             siteStore = siteStore,
             bgDispatcher = Dispatchers.Default,
+            ioDispatcher = Dispatchers.IO,
             networkUtilsWrapper = createMockedNetworkUtilsWrapper(),
             connectionStatus = connectionStatus,
             uploadServiceFacade = uploadServiceFacade

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
@@ -1,0 +1,89 @@
+package org.wordpress.android.ui.uploads
+
+import android.arch.core.executor.testing.InstantTaskExecutorRule
+import android.arch.lifecycle.MutableLiveData
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.viewmodel.helpers.ConnectionStatus
+import org.wordpress.android.viewmodel.helpers.ConnectionStatus.AVAILABLE
+import org.wordpress.android.viewmodel.helpers.ConnectionStatus.UNAVAILABLE
+
+@RunWith(MockitoJUnitRunner::class)
+class LocalDraftUploadStarterTest {
+    @get:Rule val rule = InstantTaskExecutorRule()
+
+    private val sites = listOf(SiteModel(), SiteModel())
+    private val sitesAndPosts: Map<SiteModel, List<PostModel>> = mapOf(
+            sites[0] to listOf(PostModel(), PostModel()),
+            sites[1] to listOf(PostModel(), PostModel(), PostModel())
+    )
+    private val posts = sitesAndPosts.values.flatten()
+
+    private val siteStore = mock<SiteStore> {
+        on { sites } doReturn sites
+    }
+    private val postStore = mock<PostStore> {
+        sites.forEach {
+            on { getLocalDraftPosts(eq(it)) } doReturn sitesAndPosts[it]
+        }
+    }
+
+    @Test
+    fun `when the internet connection is restored, it uploads all local drafts`() {
+        // Given
+        val networkUtilsWrapper = mock<NetworkUtilsWrapper> {
+            on { isNetworkAvailable() } doReturn true
+        }
+        val connectionStatus = MutableLiveData<ConnectionStatus>()
+        val uploadServiceFacade = mock<UploadServiceFacade> {
+            on { isPostUploadingOrQueued(any()) } doReturn false
+        }
+
+        val starter = LocalDraftUploadStarter(
+                context = mock(),
+                postStore = postStore,
+                siteStore = siteStore,
+                bgDispatcher = Dispatchers.Default,
+                networkUtilsWrapper = networkUtilsWrapper,
+                connectionStatus = connectionStatus,
+                uploadServiceFacade = uploadServiceFacade
+        )
+
+        // When
+        runBlocking {
+            connectionStatus.postValue(AVAILABLE)
+
+            starter.waitForAllCoroutinesToFinish()
+        }
+
+        // Then
+        verify(uploadServiceFacade, times(posts.size)).uploadPost(
+                context = any(),
+                post = any(),
+                trackAnalytics = any(),
+                publish = any(),
+                isRetry = eq(true)
+        )
+    }
+
+    private suspend fun LocalDraftUploadStarter.waitForAllCoroutinesToFinish() {
+        val job = checkNotNull(coroutineContext[Job])
+        job.children.forEach { it.join() }
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
@@ -16,7 +16,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
-import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking

--- a/WordPress/src/test/java/org/wordpress/android/util/LiveDataUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/LiveDataUtilsTest.kt
@@ -66,4 +66,82 @@ class LiveDataUtilsTest : BaseUnitTest() {
         sourceB.value = null
         assertThat(combineMap.value).isEqualTo(mapOf(keyA to valueA))
     }
+
+    @Test
+    fun `when skipping 1 on a LiveData emitting nothing, nothing is emitted`() {
+        // Given
+        val source = MutableLiveData<String>()
+        check(source.value == null)
+
+        val skip = source.skip(1)
+
+        // When
+        var emitCount = 0
+        skip.observeForever {
+            emitCount += 1
+        }
+
+        // Then
+        assertThat(emitCount).isZero()
+        assertThat(skip.value).isNull()
+    }
+
+    @Test
+    fun `when skipping 1 on a LiveData emitting a single value, nothing is emitted`() {
+        // Given
+        val source = MutableLiveData<String>().apply { value = "Alpha" }
+        val skip = source.skip(1)
+
+        // When
+        var emitCount = 0
+        skip.observeForever {
+            emitCount += 1
+        }
+
+        // Then
+        assertThat(emitCount).isZero()
+        assertThat(skip.value).isNull()
+    }
+
+    @Test
+    fun `when skipping 1 on a LiveData emitting multiple values, the first value is not emitted`() {
+        // Given
+        val source = MutableLiveData<String>().apply { value = "Alpha" }
+        val skip = source.skip(1)
+
+        // When
+        var emitCount = 0
+        skip.observeForever {
+            emitCount += 1
+        }
+
+        source.postValue("Bravo")
+
+        // Then
+        assertThat(emitCount).isOne()
+        assertThat(skip.value).isEqualTo("Bravo")
+    }
+
+    @Test
+    fun `when skipping 3 on a LiveData emitting multiple values, the first three are not emitted`() {
+        // Given
+        val source = MutableLiveData<String>()
+        val skip = source.skip(3)
+
+        // When
+        var emitCount = 0
+        val emittedValues = mutableListOf<String>()
+        skip.observeForever { value ->
+            emitCount += 1
+
+            value?.let { emittedValues.add(it) }
+        }
+
+        listOf("Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel").forEach(source::postValue)
+
+        // Then
+        assertThat(emitCount).isEqualTo(5)
+        assertThat(emittedValues).isEqualTo(listOf("Delta", "Echo", "Foxtrot", "Golf", "Hotel"))
+        assertThat(skip.value).isEqualTo("Hotel")
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/util/LiveDataUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/LiveDataUtilsTest.kt
@@ -106,7 +106,10 @@ class LiveDataUtilsTest : BaseUnitTest() {
     @Test
     fun `when skipping 1 on a LiveData emitting multiple values, the first value is not emitted`() {
         // Given
-        val source = MutableLiveData<String>().apply { value = "Alpha" }
+        val source = MutableLiveData<String>().apply {
+            // Capture the scenario of the LiveData having a pre-existing value before an observer is added
+            value = "Alpha"
+        }
         val skip = source.skip(1)
 
         // When

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
@@ -27,7 +27,7 @@ class PostListViewModelTest {
         viewModel.swipeToRefresh()
 
         // Then
-        verify(localDraftUploadStarter, times(1)).queueUpload(site = eq(site))
+        verify(localDraftUploadStarter, times(1)).queueUploadFromSite(eq(site))
     }
 
     private companion object {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
@@ -28,7 +28,7 @@ class PostListViewModelTest {
         viewModel.swipeToRefresh()
 
         // Then
-        verify(localDraftUploadStarter, times(1)).uploadLocalDrafts(scope = eq(viewModel), site = eq(site))
+        verify(localDraftUploadStarter, times(1)).queueUpload(site = eq(site))
     }
 
     private companion object {
@@ -62,8 +62,7 @@ class PostListViewModelTest {
                     listItemUiStateHelper = mock(),
                     networkUtilsWrapper = mock(),
                     localDraftUploadStarter = localDraftUploadStarter,
-                    connectionStatus = mock(),
-                    bgDispatcher = Dispatchers.Default
+                    connectionStatus = mock()
             )
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
@@ -6,7 +6,6 @@ import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
-import kotlinx.coroutines.Dispatchers
 import org.junit.Test
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.list.PostListDescriptor.PostListDescriptorForXmlRpcSite


### PR DESCRIPTION
Closes #9852. 

This changes `LocalDraftUploadStarter` to queue uploads from anywhere. To accomplish this, I converted the class to a `@Singleton` so it can live in the background and watch for internet connection changes and app foreground events. 

I also added a few helpers:

- 77e5a86 `UploadServiceFacade` to make `LocalDraftUploadStarter` testable. 
- d3c1200 `LiveData.skip(times:)` to prevent triggering uploads twice on app start.

## Decisions

Some events like _App start_ trigger uploads of all local drafts of **all sites**. I could not find an easy way to capture the currently selected site from the `LocalDraftUploadStarter` class. But I believe this is what the user would expect anyway. 

For events triggered in the Post List, I opted to upload only the local drafts of the current site. I initially thought this would be good for UX perceived-performance when we include all Post statuses like local changes in `LocalDraftUploadStarter` soon. I was worried that the user would think nothing is happening while we are querying too many things. Now, I'm not so sure. Perhaps we can set it so the current site is prioritized in the queue instead. 🤔 

I also pondered making `LocalDraftUploadStarter` a `Service` but it looks like Services run on their own process which kind of makes it quite heavy and complicated as opposed to a singleton. 

## Events

The following shows the trigger changes and which events trigger what operation. 

| Event | Before | After | Uploads Which Site? | 
|--------|-------|----------|-----|
|   App started    |  ✖️    | ✔️ | all |
|   App placed in foreground    |  ✖️    | ✔️ | all |
|   Internet connection is restored while Post List is open    |  ✔️   | ✔️ | all (used to be the current only) |
|   Internet connection is restored while in other pages    |  ✖️    | ✔️ | all  |
|  The Post List is opened | ✔️ | ✔️ | current | 
|  Swipe to refresh on Post List | ✔️ | ✔️ | current | 

## Testing

1. Go offline 
2. Create a local draft
3. Trigger one of the events above. A snackbar should be shown that the local draft(s) were uploaded. 

Please also test local drafts from sites that are not currently selected. Depending on the event, they should be automatically uploaded too. 

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.


