### PR TITLE
Align WPAndroid aztecVersion with GB mobile aztecVersion

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     ext {
-        aztecVersion = 'gb-stray-selection-fix-try1'
+        aztecVersion = 'v1.3.27'
     }
 
     repositories {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     ext {
-        aztecVersion = 'v1.3.26'
+        aztecVersion = 'gb-stray-selection-fix-try1'
     }
 
     repositories {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -2000,7 +2000,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     private static SpannableStringBuilder getCalypsoCompatibleStringBuilder(Context context, String postContent,
                                                                             AztecParser parser) {
         SpannableStringBuilder builder = new SpannableStringBuilder();
-        String cleanSource = Format.removeSourceEditorFormatting(postContent, true);
+        String cleanSource = Format.removeSourceEditorFormatting(postContent, true, false);
         builder.append(parser.parseHtmlForInspection(cleanSource, context));
         Format.preProcessSpannedText(builder, true);
         return builder;


### PR DESCRIPTION
In order to have a successful build in WPAndroid project, we need to align `aztecVersion` with `aztecVersion`  from `gutenberg-mobile` develop branch (https://github.com/wordpress-mobile/AztecEditor-Android/pull/817)

Once PR https://github.com/wordpress-mobile/AztecEditor-Android/pull/817 is merged, we can again point `aztecVersion` to the latest develop.