### PR TITLE
Fix Android Test build errors caused by Gutenberg change

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -61,9 +61,11 @@ android {
         buildConfigField "boolean", "NEW_SITE_CREATION_ENABLED", "true"
         buildConfigField "boolean", "OFFER_GUTENBERG", "true"
         buildConfigField "boolean", "DOMAIN_REGISTRATION_ENABLED", "false"
+    }
 
-        // Gutenberg's dependency - react-native-video is using
-        // Java API 1.8
+    // Gutenberg's dependency - react-native-video is using
+    // Java API 1.8 so we need this when building from source
+    if (rootProject.ext.buildGutenbergFromSource) {
         compileOptions {
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
The changes from https://github.com/wordpress-mobile/WordPress-Android/pull/9644 are causing build errors for our connected tests. You can see the failure on CircleCI [here](https://circleci.com/gh/wordpress-mobile/WordPress-Android/13205).

The problem is that [the new `compileOptions` entry 
](https://github.com/wordpress-mobile/WordPress-Android/pull/9644/files#r276201252) isn't playing nicely with the Android tests. I'm not sure why this is. Since the setting is only needed when building from source, I have added a conditional check around it.

**Note:** `assembleVanillaDebugAndroidTest` will still fail when building Gutenberg from source. I tried moving the Gradle config to `WordPressEditor` but that didn't work.

To test:

With `wp.BUILD_GUTENBERG_FROM_SOURCE=false`:

- `./gradlew WordPress:assembleVanillaDebug`
- `./gradlew WordPress:assembleVanillaDebugAndroidTest`

With `wp.BUILD_GUTENBERG_FROM_SOURCE=true`:

- `./gradlew WordPress:assembleVanillaDebug`

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
