### PR TITLE
Sign app for release in tools/install-app-bundle.sh

### DIFF
--- a/libs/mocks/build.gradle
+++ b/libs/mocks/build.gradle
@@ -21,7 +21,3 @@ allprojects {
         
     }
 }
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
-}

--- a/tools/gradle-functions.sh
+++ b/tools/gradle-functions.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# This script defines some shared functions that are used by the app bundles scipts.
+
+function get_gradle_property {
+  GRADLE_PROPERTIES=$1
+  PROP_KEY=$2
+  PROP_VALUE=`cat "$GRADLE_PROPERTIES" | grep "$PROP_KEY" | cut -d'=' -f2`
+  echo $PROP_VALUE
+}
+
+function gradle_version_name {
+  BUILDFILE=$1
+  grep -E 'versionName' $BUILDFILE | sed s/versionName// | grep -Eo "[a-zA-Z0-9.-]+"
+}
+
+function gradle_version_code {
+  BUILDFILE=$1
+  grep -E 'versionCode' $BUILDFILE | sed s/versionCode// | grep -Eo "[a-zA-Z0-9.-]+"
+}

--- a/tools/install-app-bundle.sh
+++ b/tools/install-app-bundle.sh
@@ -8,11 +8,18 @@ command -v bundletool > /dev/null || { echo "bundletool is required to build the
 # Exit if any command fails
 set -eu
 
+# Load the Gradle helper functions
+source "./tools/gradle-functions.sh"
+
 APP_BUNDLE="$1"
 TMP_DIR=$(mktemp -d)
 
 echo "Generating APKs..."
 bundletool build-apks --bundle="$APP_BUNDLE" \
-                      --output="$TMP_DIR/output.apks"
+                      --output="$TMP_DIR/output.apks" \
+                      --ks="$(get_gradle_property gradle.properties storeFile)" \
+                      --ks-pass="pass:$(get_gradle_property gradle.properties storePassword)" \
+                      --ks-key-alias="$(get_gradle_property gradle.properties keyAlias)" \
+                      --key-pass="pass:$(get_gradle_property gradle.properties keyPassword)"
 echo "Installing..."
 bundletool install-apks --apks="$TMP_DIR/output.apks"


### PR DESCRIPTION
This matches the logic from https://github.com/woocommerce/woocommerce-android/pull/1028 by signing the app when it is installed with `./tools/install-app-bundle.sh`.

To test:

- Build the app bundle: `./tools/build-release-app-bundle.sh update-app-bundle-scripts`.
- Install it: `./tools/install-app-bundle.sh build/wpandroid-12.4-rc-3.aab`.
- Check that the app works (including Google login).

You can skip the first step if you already have an app bundle to test.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
