### PR TITLE
Update dagger version to v2.22.1

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ReleaseNotesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ReleaseNotesActivity.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -21,7 +22,6 @@ import org.wordpress.android.ui.WebViewActivity;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.HelpActivity.Origin;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 /**

--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,6 @@ buildScan {
 }
 
 ext {
-    daggerVersion = '2.11'
-    fluxCVersion = 'ed6d69693da290807e017f34cdedfa76bf0648e9'
+    daggerVersion = '2.22.1'
+    fluxCVersion = 'f80be620a514cd4ca36479e260d02b3ae8a6d6da'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -105,5 +105,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'f80be620a514cd4ca36479e260d02b3ae8a6d6da'
+    fluxCVersion = '89b24713e6d8b239973883cdd601c9304d19a3ef'
 }

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -61,11 +61,11 @@ dependencies {
     annotationProcessor 'com.github.bumptech.glide:compiler:4.6.1'
 
     // Dagger
-    implementation 'com.google.dagger:dagger:2.11'
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.11'
+    implementation 'com.google.dagger:dagger:2.22.1'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.22.1'
     compileOnly 'org.glassfish:javax.annotation:10.0-b28'
-    implementation 'com.google.dagger:dagger-android-support:2.11'
-    annotationProcessor 'com.google.dagger:dagger-android-processor:2.11'
+    implementation 'com.google.dagger:dagger-android-support:2.22.1'
+    annotationProcessor 'com.google.dagger:dagger-android-processor:2.22.1'
 
     lintChecks 'org.wordpress:lint:1.0.1'
 }


### PR DESCRIPTION
Fixes #9889

Updates Dagger to v2.22.1 as preparation for AndroidX migration.

Merge instructions:
1. Review and merge [`issue/fluxc-dagger-upgrade`](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1266) in FluxC's repo
2. Update FluxC's hash 
3. Review and merge this PR

To test:
1. Build and run the app
2. Walk through the basic flows at least - login, reader, notifications, create a post

Update release notes:

- There are no user facing changes
