### PR TITLE
Update highlight color in quick start's Snackbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -73,7 +73,7 @@ class QuickStartUtils {
                 Html.fromHtml(formattedMessage)
             }
 
-            val highlightColor = ContextCompat.getColor(context, R.color.accent_300)
+            val highlightColor = ContextCompat.getColor(context, android.R.color.white)
 
             val mutableSpannedMessage = SpannableStringBuilder(spannedMessage)
             val foregroundColorSpan = mutableSpannedMessage

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -5,6 +5,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.res.Resources
+import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.support.v4.content.ContextCompat
@@ -14,6 +15,7 @@ import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.style.ForegroundColorSpan
 import android.text.style.ImageSpan
+import android.text.style.StyleSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -87,6 +89,10 @@ class QuickStartUtils {
                 mutableSpannedMessage.removeSpan(foregroundColorSpan)
                 mutableSpannedMessage.setSpan(
                         ForegroundColorSpan(highlightColor),
+                        startOfHighlight, endOfHighlight, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+                mutableSpannedMessage.setSpan(
+                        StyleSpan(Typeface.BOLD),
                         startOfHighlight, endOfHighlight, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
                 )
 


### PR DESCRIPTION
Fixes #9853 

Changes color and adds "bold" style to the highlighted item in the QuickStart's Snackbar.

![quick-start-snackbar](https://user-images.githubusercontent.com/2261188/58092572-bc0ca180-7bcc-11e9-94de-279105088a96.jpg)

To test:
1. Create a site
2.  Quick Start dialog is shown when you get redirected from the Site Creation flow to My Site fragment
3. Click on "Accept"
4. Click on "Customize your site"
5. Click on "Upload a site icon"
6. Notice the highlighted text in the Snackbar is white

Update release notes:

- Minor change

cc @SylvesterWilmott 
