### PR TITLE
Fix highlighted text in quick start snackbar on api <= 23

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -83,7 +83,6 @@ class QuickStartUtils {
             formattedMessage = formattedMessage.replaceFirst(spanTagEnd, "")
             formattedMessage = formattedMessage.replaceFirst("  ", " ")
 
-
             val mutableSpannedMessage = SpannableStringBuilder(formattedMessage)
             // nothing to highlight
             if (startOfHighlight != -1 && endOfHighlight != -1) {

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -9,7 +9,6 @@ import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.support.v4.content.ContextCompat
 import android.support.v4.graphics.drawable.DrawableCompat
-import android.text.Html
 import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.style.ForegroundColorSpan
@@ -65,26 +64,30 @@ class QuickStartUtils {
         fun stylizeQuickStartPrompt(context: Context, messageId: Int, iconId: Int = -1): Spannable {
             val spanTagOpen = context.resources.getString(R.string.quick_start_span_start)
             val spanTagEnd = context.resources.getString(R.string.quick_start_span_end)
-            val formattedMessage = context.resources.getString(messageId, spanTagOpen, spanTagEnd)
+            var formattedMessage = context.resources.getString(messageId, spanTagOpen, spanTagEnd)
 
-            val spannedMessage = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
-                Html.fromHtml(formattedMessage, Html.FROM_HTML_MODE_LEGACY)
-            } else {
-                Html.fromHtml(formattedMessage)
-            }
+            val startOfHighlight = formattedMessage.indexOf(spanTagOpen)
 
-            val highlightColor = ContextCompat.getColor(context, R.color.accent_300)
+            // remove the <span> tag
+            formattedMessage = formattedMessage.replaceFirst(spanTagOpen, "")
+            /**
+             * Some string resources contain whitespaces before and after the placeholder tags.
+             * For example: `Tap %1$s Customize %2$s to start` becomes `Tap <span> Customize </span> to start`.
+             * However, when we remove "<span>" the string ends up having two whitespaces.
+             */
+            formattedMessage = formattedMessage.replaceFirst("  ", " ")
 
-            val mutableSpannedMessage = SpannableStringBuilder(spannedMessage)
-            val foregroundColorSpan = mutableSpannedMessage
-                    .getSpans(0, spannedMessage.length, ForegroundColorSpan::class.java).firstOrNull()
+            val endOfHighlight = formattedMessage.indexOf(spanTagEnd)
 
+            // remove the </span> tag
+            formattedMessage = formattedMessage.replaceFirst(spanTagEnd, "")
+            formattedMessage = formattedMessage.replaceFirst("  ", " ")
+
+
+            val mutableSpannedMessage = SpannableStringBuilder(formattedMessage)
             // nothing to highlight
-            if (foregroundColorSpan != null) {
-                val startOfHighlight = mutableSpannedMessage.getSpanStart(foregroundColorSpan)
-                val endOfHighlight = mutableSpannedMessage.getSpanEnd(foregroundColorSpan)
-
-                mutableSpannedMessage.removeSpan(foregroundColorSpan)
+            if (startOfHighlight != -1 && endOfHighlight != -1) {
+                val highlightColor = ContextCompat.getColor(context, R.color.accent_300)
                 mutableSpannedMessage.setSpan(
                         ForegroundColorSpan(highlightColor),
                         startOfHighlight, endOfHighlight, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2546,7 +2546,7 @@
     <string name="quick_start_sites_type_grow">Grow Your Audience</string>
     <string name="quick_start_sites_type_subtitle">%1$d of %2$d complete</string>
     <string name="quick_start_span_end" translatable="false">&lt;/span&gt;</string>
-    <string name="quick_start_span_start" translatable="false">&lt;span style="color:#0"&gt;</string>
+    <string name="quick_start_span_start" translatable="false">&lt;span&gt;</string>
     <string name="quick_start_focus_point_description">tap here</string>
 
     <!-- Pages -->


### PR DESCRIPTION
Fixes #9897 

The text in QuickStart SnackBar isn't highlighted on API <= 23. The deprecated version of `Html.fromHtml` doesn't create a span and therefore ` if (foregroundColorSpan != null)` is always false on API <= 23.

![Untitled](https://user-images.githubusercontent.com/2261188/58098922-d3528b80-7bda-11e9-895c-4b343923dcae.jpg)



To test: - use device with API <= 23
1. Create a site and walk through all tasks in QuickStart

Update release notes:

- The changes are too minor