### PR TITLE
Fix editor_opened missing events on Activity restart

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -528,10 +528,8 @@ public class EditPostActivity extends AppCompatActivity implements
         // ok now we are sure to have both a valid Post and showGutenberg flag, let's start the editing session tracker
         createPostEditorAnalyticsSessionTracker(mShowGutenbergEditor, mPost, mSite);
 
-        if (savedInstanceState == null) {
-            // Bump the stat the first time the editor is opened.
-            PostUtils.trackOpenEditorAnalytics(mPost, mSite);
-        }
+        // Bump editor opened event every time the activity is created, to match the EDITOR_CLOSED event onDestroy
+        PostUtils.trackOpenEditorAnalytics(mPost, mSite);
 
         if (mIsNewPost) {
             trackEditorCreatedPost(action, getIntent());

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -530,7 +530,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
         if (savedInstanceState == null) {
             // Bump the stat the first time the editor is opened.
-            PostUtils.trackOpenPostAnalytics(mPost, mSite);
+            PostUtils.trackOpenEditorAnalytics(mPost, mSite);
         }
 
         if (mIsNewPost) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -528,9 +528,6 @@ public class EditPostActivity extends AppCompatActivity implements
         // ok now we are sure to have both a valid Post and showGutenberg flag, let's start the editing session tracker
         createPostEditorAnalyticsSessionTracker(mShowGutenbergEditor, mPost, mSite);
 
-        // Bump editor opened event every time the activity is created, to match the EDITOR_CLOSED event onDestroy
-        PostUtils.trackOpenEditorAnalytics(mPost, mSite);
-
         if (mIsNewPost) {
             trackEditorCreatedPost(action, getIntent());
         } else {
@@ -713,6 +710,9 @@ public class EditPostActivity extends AppCompatActivity implements
         EventBus.getDefault().register(this);
 
         reattachUploadingMediaForAztec();
+
+        // Bump editor opened event every time the activity is resumed, to match the EDITOR_CLOSED event onPause
+        PostUtils.trackOpenEditorAnalytics(mPost, mSite);
     }
 
     private void reattachUploadingMediaForAztec() {
@@ -756,6 +756,8 @@ public class EditPostActivity extends AppCompatActivity implements
         super.onPause();
 
         EventBus.getDefault().unregister(this);
+
+        AnalyticsTracker.track(AnalyticsTracker.Stat.EDITOR_CLOSED);
     }
 
     @Override protected void onStop() {
@@ -773,7 +775,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 mPostEditorAnalyticsSession.end();
             }
         }
-        AnalyticsTracker.track(AnalyticsTracker.Stat.EDITOR_CLOSED);
+
         mDispatcher.unregister(this);
         if (mHandler != null) {
             mHandler.removeCallbacks(mSave);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -164,7 +164,7 @@ public class PostUtils {
         }
     }
 
-    public static void trackOpenPostAnalytics(PostModel post, SiteModel site) {
+    public static void trackOpenEditorAnalytics(PostModel post, SiteModel site) {
         Map<String, Object> properties = new HashMap<>();
         if (!post.isLocalDraft()) {
             properties.put("post_id", post.getRemotePostId());


### PR DESCRIPTION
This PR is part of a series of fixes about Analytics in Editor(s), tracked here: https://github.com/wordpress-mobile/WordPress-Android/issues/9895, and it does fixes the problem where the `editor_opened` event was undercounted compared to the `editor_closed` event.

The latter is always bumped `onDestroy` of the activity, so then the `editor_opened` should be always called onCreate. One can argue that the logic is OFF, but we've the concept of session that takes care of the same "editing session", so thus editor(open|close) events do only track the actual creation and disposal of the editor object in the app.
Btw, I'm not actually sure why we went down this road. cc @mzorz 

To test:
- Start the editor 
- The `editor_opened` event is bumped
- Rotate the device
- The `editor_closed` event is bumped
- The `editor_opened` event is bumped again on activity restart
- Close the editor
- The `editor_closed` event is correctly bumped

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
