### PR TITLE
Bump post created analytics only once

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -528,9 +528,12 @@ public class EditPostActivity extends AppCompatActivity implements
         // ok now we are sure to have both a valid Post and showGutenberg flag, let's start the editing session tracker
         createPostEditorAnalyticsSessionTracker(mShowGutenbergEditor, mPost, mSite);
 
-        if (mIsNewPost) {
+        // Bump post created analytics only once, first time the editor is opened
+        if (mIsNewPost && savedInstanceState == null) {
             trackEditorCreatedPost(action, getIntent());
-        } else {
+        }
+
+        if (!mIsNewPost) {
             // if we are opening a Post for which an error notification exists, we need to remove it from the dashboard
             // to prevent the user from tapping RETRY on a Post that is being currently edited
             UploadService.cancelFinalNotification(this, mPost);


### PR DESCRIPTION
Make sure to bump `post_created` analytics only once, the first time the editor is opened on a new post.

This PR is part of a series of fixes about Analytics in Editor(s), tracked here: #9895.

To test:

- Start the editor on a new post
- Make sure `trackEditorCreatedPost` in EditPostActivity is called only once
-- Try to rotate the device
-- Try do add a picture
-- Open settings

Will update event description and spreadsheet once merged.

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
