### PR TITLE
Fix - static keyword removed from PostStore.getNumLocalChanges()

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -101,6 +101,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment, WPMainA
     @Inject SiteStore mSiteStore;
     @Inject ImageManager mImageManager;
     @Inject AppPrefsWrapper mAppPrefsWrapper;
+    @Inject PostStore mPostStore;
 
     public static MeFragment newInstance() {
         return new MeFragment();
@@ -370,7 +371,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment, WPMainA
         // if there are local changes we need to let the user know they'll be lost if they logout, otherwise
         // we use a simpler (less scary!) confirmation
         String message;
-        if (PostStore.getNumLocalChanges() > 0) {
+        if (mPostStore.getNumLocalChanges() > 0) {
             message = getString(R.string.sign_out_wpcom_confirm_with_changes);
         } else {
             message = getString(R.string.sign_out_wpcom_confirm_with_no_changes);

--- a/build.gradle
+++ b/build.gradle
@@ -105,5 +105,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '7c051d2f349617ec76a1bc6a4788a2c49f15d1b2'
+    fluxCVersion = 'b3bbec15b0434c404b778764e26b9df4b18f5ab2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -105,5 +105,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '89b24713e6d8b239973883cdd601c9304d19a3ef'
+    fluxCVersion = '7c051d2f349617ec76a1bc6a4788a2c49f15d1b2'
 }


### PR DESCRIPTION
[This](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1270) PR in FluxC replaces all static methods in PostSqlUtils with instance methods. It also replaces `getNumLocalChanges()` static method with an instance method.


To test:
1. Quickly test post list, page list and Editor

Update release notes:

- There are no user facing changes
