### PR TITLE
Fix for editor analytics session_end undercounted

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -716,6 +716,8 @@ public class EditPostActivity extends AppCompatActivity implements
 
         // Bump editor opened event every time the activity is resumed, to match the EDITOR_CLOSED event onPause
         PostUtils.trackOpenEditorAnalytics(mPost, mSite);
+
+        mIsConfigChange = false;
     }
 
     private void reattachUploadingMediaForAztec() {


### PR DESCRIPTION
This PR tries to fix the major cases where the analytics `session_end` is undercounted due to `mIsConfigChange` being set to true in `onSaveInstaceState`, but never set it back to `false` when the editor is back on the screen. Think when you select a picture from the media library, etc.

This PR makes sure to set `mIsConfigChange` to false during `onResume`, so the session is not undercounted when the editor is closed.

**Testing Steps 1**
- Start the editor
- Add a picture from the WP media library, or take a new picture
- Don't write in the editor
- Publish the post. 
- onDestroy is called for EditPostActivity and session stats are bumped

Unfortunately there are some cases where we cannot completely monitor the lifecycle of the activity with that simple `mIsConfigChange` variable. 
IE: Start the editor write something and then tap the home screen. Close the app by swiping it up. In this case the activity is never restored, and mIsConfigChange = true (analytics cannot be bumped then).  In addition to this, `onDestroy` is not even called, so the call that bumps analytics is not reached actually.

Below is another path that leads to sessions_end not being bumped.

**Testing Steps 2**
- Start editing a post
- Put the app in the background
- Long press on the icon and launch stats or notifications
- onDestroy is called for EditPostActivity, `session_end== false` and analytics are bumped


I'm not sure it's worth the effort to introduce some more logic to catch all the cases. If we really want to do that maybe we can think to add a timer to track session end when it's not clear if we need to bump it or not, and remove it `onResume`. 
cc @mzorz thought?

(This is part of a series of fixes about Analytics in Editor(s), tracked here: #9895.)


Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.