### PR TITLE
Unregister connection broadcast receiver when app in background

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.uploads
 import android.arch.lifecycle.Lifecycle.Event
 import android.arch.lifecycle.LifecycleObserver
 import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.Observer
 import android.arch.lifecycle.OnLifecycleEvent
 import android.arch.lifecycle.ProcessLifecycleOwner
 import android.content.Context
@@ -74,12 +75,11 @@ class LocalDraftUploadStarter @Inject constructor(
      * ```
      */
     fun activateAutoUploading(processLifecycleOwner: ProcessLifecycleOwner) {
-        // Since this class is meant to be a Singleton, it should be fine (I think) to use observeForever in here.
         // We're skipping the first emitted value because the processLifecycleObserver below will also trigger an
         // immediate upload.
-        connectionStatus.skip(1).observeForever {
+        connectionStatus.skip(1).observe(processLifecycleOwner, Observer {
             queueUploadFromAllSites()
-        }
+        })
 
         processLifecycleOwner.lifecycle.addObserver(processLifecycleObserver)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
@@ -9,11 +9,11 @@ import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ProcessLifecycleOwner
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argWhere
+import com.nhaarman.mockitokotlin2.clearInvocations
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
@@ -87,7 +87,7 @@ class LocalDraftUploadStarterTest {
         // we need to reset the uploadServiceFacade mock as when the app moves to ON_RESUME state (comes to foreground)
         // an automatic upload is initiated and we want to test whether changing connection while the app
         // is in the foreground initiates the upload.
-        reset(uploadServiceFacade)
+        clearInvocations(uploadServiceFacade)
         // When
         connectionStatus.postValue(AVAILABLE)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
@@ -13,6 +13,7 @@ import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
@@ -72,19 +73,51 @@ class LocalDraftUploadStarterTest {
     }
 
     @Test
-    fun `when the internet connection is restored, it uploads all local drafts`() {
+    fun `when the internet connection is restored and the app is in foreground, it uploads all local drafts`() {
         // Given
         val connectionStatus = createConnectionStatusLiveData(UNAVAILABLE)
         val uploadServiceFacade = createMockedUploadServiceFacade()
 
-        val starter = createLocalDraftUploadStarter(connectionStatus, uploadServiceFacade)
-        starter.activateAutoUploading(createMockedProcessLifecycleOwner())
+        // ON_RESUME -> app is in the foreground
+        val lifecycle = LifecycleRegistry(mock()).apply { handleLifecycleEvent(Event.ON_RESUME) }
 
+        val starter = createLocalDraftUploadStarter(connectionStatus, uploadServiceFacade)
+        starter.activateAutoUploading(createMockedProcessLifecycleOwner(lifecycle))
+
+        // we need to reset the uploadServiceFacade mock as when the app moves to ON_RESUME state (comes to foreground)
+        // an automatic upload is initiated and we want to test whether changing connection while the app
+        // is in the foreground initiates the upload.
+        reset(uploadServiceFacade)
         // When
         connectionStatus.postValue(AVAILABLE)
 
         // Then
         verify(uploadServiceFacade, times(posts.size + pages.size)).uploadPost(
+                context = any(),
+                post = any(),
+                trackAnalytics = any(),
+                publish = any(),
+                isRetry = eq(true)
+        )
+    }
+
+    @Test
+    fun `when the internet connection is restored and the app is in background it doesn't upload all local drafts`() {
+        // Given
+        val connectionStatus = createConnectionStatusLiveData(UNAVAILABLE)
+        val uploadServiceFacade = createMockedUploadServiceFacade()
+
+        // ON_CREATE -> app is in the background
+        val lifecycle = LifecycleRegistry(mock()).apply { handleLifecycleEvent(Event.ON_CREATE) }
+
+        val starter = createLocalDraftUploadStarter(connectionStatus, uploadServiceFacade)
+        starter.activateAutoUploading(createMockedProcessLifecycleOwner(lifecycle))
+
+        // When
+        connectionStatus.postValue(AVAILABLE)
+
+        // Then
+        verify(uploadServiceFacade, times(0)).uploadPost(
                 context = any(),
                 post = any(),
                 trackAnalytics = any(),


### PR DESCRIPTION
Note: https://github.com/wordpress-mobile/WordPress-Android/pull/9902 needs to be merged first + the target branch needs to be updated.

I haven't realized the downside of using `observeForever` until now -> When we use `observerForever` the app will register the BroadcastReceiver and it'll never unregister, unless the process is killed -> in other words it'll listen to connection changes even when it's in the background. Imagine all the apps would do the same thing -> When the device becomes online, the system will be flooded. More importantly, we are handling the same scenario in [WorkManager PR](https://github.com/wordpress-mobile/WordPress-Android/pull/9909), but we let the system decide when to start the upload.

We could theoretically simplify this code even more - remove `.skip(1)` and `processLifecycleObserver` if the ConnectionLiveData weren't using distinct(). 
```
fun activateAutoUploading(processLifecycleOwner: ProcessLifecycleOwner) {
        connectionStatus.observe(processLifecycleOwner, Observer {
            queueUploadFromAllSites()
        })
    }
```
As when the app comes to the foreground the LiveData become active and an event is emitted (the `distinct` consumes the event now).
It'd simplify this class, but at the same time we'd need to have support for both distinct and not-distinct ConnectionLiveData. We could use `@Named` Dagger's annotation but it's probably not worth it. I just wanted to mentioned it in case there is a better way how to do it.


To test:
1. Make sure the `queueUploadFromAllSites` is invoked when the connection status changes and the app is in the foreground.
2. Make sure the `queueUploadFromAllSites` is NOT invoked when the app is in the background.

Update release notes:

- The feature hasn't been released yet + the changes are too minor
