### PR TITLE
Stats Widget - Add Color selection dialog fragment to configuration activity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -15,6 +15,7 @@ import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailFragment;
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.management.InsightsManagementFragment;
 import org.wordpress.android.ui.stats.refresh.lists.widget.SiteSelectionDialogFragment;
 import org.wordpress.android.ui.stats.refresh.lists.widget.StatsViewsWidgetConfigureFragment;
+import org.wordpress.android.ui.stats.refresh.lists.widget.ColorSelectionDialogFragment;
 import org.wordpress.android.util.wizard.WizardManager;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatusLiveData;
@@ -55,6 +56,9 @@ public abstract class ApplicationModule {
 
     @ContributesAndroidInjector
     abstract SiteSelectionDialogFragment contributeSiteSelectionDialogFragment();
+
+    @ContributesAndroidInjector
+    abstract ColorSelectionDialogFragment contributeViewModeSelectionDialogFragment();
 
     @Provides
     public static WizardManager<SiteCreationStep> provideWizardManager(NewSiteCreationStepsProvider stepsProvider) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/ColorSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/ColorSelectionDialogFragment.kt
@@ -1,0 +1,68 @@
+package org.wordpress.android.ui.stats.refresh.lists.widget
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.arch.lifecycle.Observer
+import android.arch.lifecycle.ViewModelProvider
+import android.arch.lifecycle.ViewModelProviders
+import android.content.Context
+import android.os.Bundle
+import android.support.v7.app.AppCompatDialogFragment
+import android.widget.RadioGroup
+import dagger.android.support.AndroidSupportInjection
+import org.wordpress.android.R
+import org.wordpress.android.R.layout
+import org.wordpress.android.ui.stats.refresh.lists.widget.ViewsWidgetViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.ViewsWidgetViewModel.Color.DARK
+import org.wordpress.android.ui.stats.refresh.lists.widget.ViewsWidgetViewModel.Color.LIGHT
+import org.wordpress.android.util.image.ImageManager
+import javax.inject.Inject
+
+class ColorSelectionDialogFragment : AppCompatDialogFragment() {
+    @Inject lateinit var imageManager: ImageManager
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var viewModel: ViewsWidgetViewModel
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        viewModel = ViewModelProviders.of(activity!!, viewModelFactory).get(ViewsWidgetViewModel::class.java)
+        val alertDialogBuilder = AlertDialog.Builder(activity)
+        val view = activity!!.layoutInflater.inflate(layout.stats_color_selector, null) as RadioGroup
+        view.setOnCheckedChangeListener { _, checkedId ->
+            checkedId.toColor()?.let { viewModel.colorClicked(it) }
+        }
+        alertDialogBuilder.setView(view)
+        viewModel.settingsModel.observe(this, Observer {
+            val updatedColor = it?.color
+            val currentColor = view.checkedRadioButtonId.toColor()
+            if (updatedColor != currentColor) {
+                updatedColor?.let { view.check(updatedColor.toViewId()) }
+            }
+        })
+        alertDialogBuilder.setTitle(R.string.stats_widget_select_colour)
+
+        alertDialogBuilder.setPositiveButton(R.string.dialog_button_ok) { dialog, _ ->
+            dialog?.dismiss()
+        }
+        return alertDialogBuilder.create()
+    }
+
+    private fun Color.toViewId(): Int {
+        return when (this) {
+            LIGHT -> R.id.stats_widget_light_color
+            DARK -> R.id.stats_widget_dark_color
+        }
+    }
+
+    private fun Int.toColor(): Color? {
+        return when (this) {
+            R.id.stats_widget_light_color -> LIGHT
+            R.id.stats_widget_dark_color -> DARK
+            else -> null
+        }
+    }
+
+    override fun onAttach(context: Context?) {
+        super.onAttach(context)
+        AndroidSupportInjection.inject(this)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/ColorSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/ColorSelectionDialogFragment.kt
@@ -38,7 +38,7 @@ class ColorSelectionDialogFragment : AppCompatDialogFragment() {
                 updatedColor?.let { view.check(updatedColor.toViewId()) }
             }
         })
-        alertDialogBuilder.setTitle(R.string.stats_widget_select_colour)
+        alertDialogBuilder.setTitle(R.string.stats_widget_select_color)
 
         alertDialogBuilder.setPositiveButton(R.string.dialog_button_ok) { dialog, _ ->
             dialog?.dismiss()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/SiteSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/SiteSelectionDialogFragment.kt
@@ -14,12 +14,10 @@ import android.view.View
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.stats_site_selector.*
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
 
 class SiteSelectionDialogFragment : AppCompatDialogFragment() {
-    @Inject lateinit var siteStore: SiteStore
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: ViewsWidgetViewModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/StatsViewsWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/StatsViewsWidgetConfigureFragment.kt
@@ -54,9 +54,7 @@ class StatsViewsWidgetConfigureFragment : DaggerFragment() {
                 if (uiModel.siteTitle != null) {
                     site_value.text = uiModel.siteTitle
                 }
-                if (uiModel.color != null) {
-                    color_value.setText(uiModel.color.title)
-                }
+                color_value.setText(uiModel.color.title)
                 add_widget_button.isEnabled = uiModel.buttonEnabled
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/StatsViewsWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/StatsViewsWidgetConfigureFragment.kt
@@ -42,7 +42,7 @@ class StatsViewsWidgetConfigureFragment : DaggerFragment() {
             SiteSelectionDialogFragment().show(fragmentManager, "stats_site_selection_fragment")
         }
         color_container.setOnClickListener {
-            viewModel.colorClicked()
+            ColorSelectionDialogFragment().show(fragmentManager, "stats_view_mode_selection_fragment")
         }
 
         add_widget_button.setOnClickListener {
@@ -54,8 +54,8 @@ class StatsViewsWidgetConfigureFragment : DaggerFragment() {
                 if (uiModel.siteTitle != null) {
                     site_value.text = uiModel.siteTitle
                 }
-                if (uiModel.viewMode != null) {
-                    color_value.setText(uiModel.viewMode.title)
+                if (uiModel.color != null) {
+                    color_value.setText(uiModel.color.title)
                 }
                 add_widget_button.isEnabled = uiModel.buttonEnabled
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/ViewsWidgetViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/ViewsWidgetViewModel.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.stats.refresh.lists.widget.ViewsWidgetViewModel.Color.LIGHT
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.merge
 import org.wordpress.android.viewmodel.Event
@@ -23,14 +24,14 @@ class ViewsWidgetViewModel
     private val appPrefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(mainDispatcher) {
     private val mutableSelectedSite = MutableLiveData<SiteUiModel>()
-    private val mutableViewMode = MutableLiveData<ViewMode>()
+    private val mutableViewMode = MutableLiveData<Color>()
     val settingsModel: LiveData<WidgetSettingsModel> = merge(
             mutableSelectedSite,
             mutableViewMode
     ) { selectedSite, viewMode ->
         WidgetSettingsModel(
                 selectedSite?.title,
-                viewMode
+                viewMode ?: LIGHT
         )
     }
     private val mutableWidgetAdded = MutableLiveData<Event<WidgetAdded>>()
@@ -47,7 +48,7 @@ class ViewsWidgetViewModel
         this.appWidgetId = appWidgetId
         val colorModeId = appPrefsWrapper.getAppWidgetColorModeId(appWidgetId)
         if (colorModeId >= 0) {
-            mutableViewMode.postValue(ViewMode.values()[colorModeId])
+            mutableViewMode.postValue(Color.values()[colorModeId])
         }
         val siteId = appPrefsWrapper.getAppWidgetSiteId(appWidgetId)
         if (siteId > -1) {
@@ -55,8 +56,8 @@ class ViewsWidgetViewModel
         }
     }
 
-    fun colorClicked() {
-        TODO("not implemented")
+    fun colorClicked(color: Color) {
+        mutableViewMode.postValue(color)
     }
 
     fun addWidget() {
@@ -97,14 +98,14 @@ class ViewsWidgetViewModel
         }
     }
 
-    enum class ViewMode(@StringRes val title: Int) {
+    enum class Color(@StringRes val title: Int) {
         LIGHT(R.string.stats_widget_color_light), DARK(R.string.stats_widget_color_dark)
     }
 
     data class WidgetSettingsModel(
         val siteTitle: String? = null,
-        val viewMode: ViewMode? = null,
-        val buttonEnabled: Boolean = siteTitle != null && viewMode != null
+        val color: Color,
+        val buttonEnabled: Boolean = siteTitle != null
     )
 
     data class WidgetAdded(val appWidgetId: Int)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/ViewsWidgetViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/ViewsWidgetViewModel.kt
@@ -62,10 +62,9 @@ class ViewsWidgetViewModel
 
     fun addWidget() {
         val selectedSite = mutableSelectedSite.value
-        val selectedViewMode = mutableViewMode.value
-        if (appWidgetId != -1 && selectedSite != null && selectedViewMode != null) {
+        if (appWidgetId != -1 && selectedSite != null) {
             appPrefsWrapper.setAppWidgetSiteId(selectedSite.siteId, appWidgetId)
-            appPrefsWrapper.setAppWidgetColorModeId(selectedViewMode.ordinal, appWidgetId)
+            appPrefsWrapper.setAppWidgetColorModeId((mutableViewMode.value ?: LIGHT).ordinal, appWidgetId)
             mutableWidgetAdded.postValue(Event(WidgetAdded(appWidgetId)))
         }
     }

--- a/WordPress/src/main/res/layout/stats_color_selector.xml
+++ b/WordPress/src/main/res/layout/stats_color_selector.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RadioGroup
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/colors"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:descendantFocusability="beforeDescendants"
+    android:paddingEnd="@dimen/margin_extra_medium_large"
+    android:paddingStart="@dimen/margin_extra_medium_large"
+    android:paddingTop="16dp"
+    android:scrollbars="vertical">
+
+    <android.support.v7.widget.AppCompatRadioButton
+        android:id="@+id/stats_widget_light_color"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:checked="true"
+        android:paddingStart="28dp"
+        android:paddingEnd="28dp"
+        android:text="@string/stats_widget_color_light"/>
+
+    <android.support.v7.widget.AppCompatRadioButton
+        android:id="@+id/stats_widget_dark_color"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:paddingStart="28dp"
+        android:paddingEnd="28dp"
+        android:text="@string/stats_widget_color_dark"/>
+</RadioGroup>

--- a/WordPress/src/main/res/layout/stats_color_selector.xml
+++ b/WordPress/src/main/res/layout/stats_color_selector.xml
@@ -7,23 +7,23 @@
     android:descendantFocusability="beforeDescendants"
     android:paddingEnd="@dimen/margin_extra_medium_large"
     android:paddingStart="@dimen/margin_extra_medium_large"
-    android:paddingTop="16dp"
+    android:paddingTop="@dimen/margin_extra_large"
     android:scrollbars="vertical">
 
     <android.support.v7.widget.AppCompatRadioButton
         android:id="@+id/stats_widget_light_color"
         android:layout_width="match_parent"
-        android:layout_height="48dp"
+        android:layout_height="@dimen/margin_extra_extra_large"
         android:checked="true"
-        android:paddingStart="28dp"
-        android:paddingEnd="28dp"
+        android:paddingStart="@dimen/stats_widget_color_selector_padding"
+        android:paddingEnd="@dimen/stats_widget_color_selector_padding"
         android:text="@string/stats_widget_color_light"/>
 
     <android.support.v7.widget.AppCompatRadioButton
         android:id="@+id/stats_widget_dark_color"
         android:layout_width="match_parent"
-        android:layout_height="48dp"
-        android:paddingStart="28dp"
-        android:paddingEnd="28dp"
+        android:layout_height="@dimen/margin_extra_extra_large"
+        android:paddingStart="@dimen/stats_widget_color_selector_padding"
+        android:paddingEnd="@dimen/stats_widget_color_selector_padding"
         android:text="@string/stats_widget_color_dark"/>
 </RadioGroup>

--- a/WordPress/src/main/res/layout/stats_views_widget_configure_activity.xml
+++ b/WordPress/src/main/res/layout/stats_views_widget_configure_activity.xml
@@ -34,7 +34,7 @@
                 app:layout_scrollFlags="enterAlways"
                 app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
                 app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-                app:title="@string/stats"/>
+                app:title="@string/stats_widget_views_title"/>
 
         </android.support.design.widget.AppBarLayout>
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -227,6 +227,7 @@
     <dimen name="stats_widget_dialog_icon_top_bottom_margin">20dp</dimen>
     <dimen name="stats_widget_dialog_title_left_margin">80dp</dimen>
     <dimen name="stats_widget_dialog_list_height">288dp</dimen>
+    <dimen name="stats_widget_color_selector_padding">28dp</dimen>
 
     <!-- my site -->
     <dimen name="my_site_list_row_icon_margin_right">28dp</dimen>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -836,6 +836,7 @@
     <!-- Stats refreshed widgets -->
 
     <string name="stats_widget_add">Add widget</string>
+    <string name="stats_widget_views_title">Views This Week</string>
     <string name="stats_widget_site">Site</string>
     <string name="stats_widget_site_caption">Select your site</string>
     <string name="stats_widget_color">Color</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -843,7 +843,7 @@
     <string name="stats_widget_color_light">Light</string>
     <string name="stats_widget_color_dark">Dark</string>
     <string name="stats_widget_select_your_site">Select your site</string>
-    <string name="stats_widget_select_colour">Colour</string>
+    <string name="stats_widget_select_color">Color</string>
 
     <!-- Jetpack install -->
     <string name="jetpack">Jetpack</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -842,6 +842,7 @@
     <string name="stats_widget_color_light">Light</string>
     <string name="stats_widget_color_dark">Dark</string>
     <string name="stats_widget_select_your_site">Select your site</string>
+    <string name="stats_widget_select_colour">Colour</string>
 
     <!-- Jetpack install -->
     <string name="jetpack">Jetpack</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/ViewsWidgetViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/ViewsWidgetViewModelTest.kt
@@ -11,7 +11,9 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.widget.ViewsWidgetViewModel.SiteUiModel
-import org.wordpress.android.ui.stats.refresh.lists.widget.ViewsWidgetViewModel.ViewMode
+import org.wordpress.android.ui.stats.refresh.lists.widget.ViewsWidgetViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.ViewsWidgetViewModel.Color.DARK
+import org.wordpress.android.ui.stats.refresh.lists.widget.ViewsWidgetViewModel.Color.LIGHT
 import org.wordpress.android.ui.stats.refresh.lists.widget.ViewsWidgetViewModel.WidgetSettingsModel
 
 class ViewsWidgetViewModelTest : BaseUnitTest() {
@@ -35,7 +37,7 @@ class ViewsWidgetViewModelTest : BaseUnitTest() {
     @Test
     fun `loads site and view mode from app prefs on start`() {
         val appWidgetId = 10
-        whenever(appPrefsWrapper.getAppWidgetColorModeId(appWidgetId)).thenReturn(ViewMode.DARK.ordinal)
+        whenever(appPrefsWrapper.getAppWidgetColorModeId(appWidgetId)).thenReturn(Color.DARK.ordinal)
         whenever(appPrefsWrapper.getAppWidgetSiteId(appWidgetId)).thenReturn(siteId)
         whenever(siteStore.getSiteBySiteId(siteId)).thenReturn(site)
 
@@ -49,33 +51,13 @@ class ViewsWidgetViewModelTest : BaseUnitTest() {
         assertThat(settingsModel).isNotNull
         assertThat(settingsModel!!.buttonEnabled).isTrue()
         assertThat(settingsModel!!.siteTitle).isEqualTo(siteName)
-        assertThat(settingsModel!!.viewMode).isEqualTo(ViewMode.DARK)
-    }
-
-    @Test
-    fun `button is disabled when view mode not set`() {
-        val appWidgetId = 10
-        whenever(appPrefsWrapper.getAppWidgetColorModeId(appWidgetId)).thenReturn(-1)
-        whenever(appPrefsWrapper.getAppWidgetSiteId(appWidgetId)).thenReturn(siteId)
-        whenever(siteStore.getSiteBySiteId(siteId)).thenReturn(site)
-
-        var settingsModel: WidgetSettingsModel? = null
-        viewModel.settingsModel.observeForever {
-            settingsModel = it
-        }
-
-        viewModel.start(appWidgetId)
-
-        assertThat(settingsModel).isNotNull
-        assertThat(settingsModel!!.buttonEnabled).isFalse()
-        assertThat(settingsModel!!.siteTitle).isEqualTo(siteName)
-        assertThat(settingsModel!!.viewMode).isNull()
+        assertThat(settingsModel!!.color).isEqualTo(Color.DARK)
     }
 
     @Test
     fun `button is disabled when site not set`() {
         val appWidgetId = 10
-        whenever(appPrefsWrapper.getAppWidgetColorModeId(appWidgetId)).thenReturn(ViewMode.DARK.ordinal)
+        whenever(appPrefsWrapper.getAppWidgetColorModeId(appWidgetId)).thenReturn(Color.DARK.ordinal)
         whenever(appPrefsWrapper.getAppWidgetSiteId(appWidgetId)).thenReturn(-1)
 
         var settingsModel: WidgetSettingsModel? = null
@@ -88,7 +70,7 @@ class ViewsWidgetViewModelTest : BaseUnitTest() {
         assertThat(settingsModel).isNotNull
         assertThat(settingsModel!!.buttonEnabled).isFalse()
         assertThat(settingsModel!!.siteTitle).isNull()
-        assertThat(settingsModel!!.viewMode).isEqualTo(ViewMode.DARK)
+        assertThat(settingsModel!!.color).isEqualTo(Color.DARK)
     }
 
     @Test
@@ -133,5 +115,21 @@ class ViewsWidgetViewModelTest : BaseUnitTest() {
 
         assertThat(settingsModel!!.siteTitle).isEqualTo(siteName)
         assertThat(hideSite).isNotNull
+    }
+
+    @Test
+    fun `updated model on view mode click`() {
+        var settingsModel: WidgetSettingsModel? = null
+        viewModel.settingsModel.observeForever {
+            settingsModel = it
+        }
+
+        viewModel.colorClicked(DARK)
+
+        assertThat(settingsModel!!.color).isEqualTo(DARK)
+
+        viewModel.colorClicked(LIGHT)
+
+        assertThat(settingsModel!!.color).isEqualTo(LIGHT)
     }
 }


### PR DESCRIPTION
This PR adds a dialog to select a color mode for the widget.

To test:
* Add the new stats widget
* Click on Color item on the new configuration screen
* A dialog with Light/Dark color mode opens
* Select either of the options
* Click on OK
* The value is saved in the Color item
* Repeat
