### PR TITLE
Refactor and add additional tests to PagesViewModelTest

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -74,7 +74,7 @@ class PagesViewModelTest {
     }
 
     @Test
-    fun clearsResultAndLoadsDataOnStart() = test {
+    fun `when started with a non-empty PageStore, it clears the results and loads the data`() = test {
         // Arrange
         val pageModel = setUpPageStoreWithASinglePage()
 
@@ -88,7 +88,7 @@ class PagesViewModelTest {
     }
 
     @Test
-    fun onSiteWithoutPages() = test {
+    fun `when started with an empty PageStore, it shows an initial fetch UI`() = test {
         // Arrange
         setUpPageStoreWithEmptyPages()
 
@@ -101,7 +101,7 @@ class PagesViewModelTest {
     }
 
     @Test
-    fun onSearchReturnsResultsFromStore() = test {
+    fun `when searching, it returns the results from the Store`() = test {
         // Arrange
         setUpPageStoreWithEmptyPages()
         viewModel.start(site)
@@ -120,7 +120,7 @@ class PagesViewModelTest {
     }
 
     @Test
-    fun onEmptySearchResultEmitsEmptyItem() = runBlocking {
+    fun `when searching and the Store is empty, it returns an empty list`() = runBlocking {
         // Arrange
         setUpPageStoreWithEmptyPages()
         viewModel.start(site)
@@ -136,7 +136,7 @@ class PagesViewModelTest {
     }
 
     @Test
-    fun onEmptyQueryClearsSearch() = runBlocking {
+    fun `when searching with an empty query, it clears the search results`() = runBlocking {
         // Arrange
         setUpPageStoreWithEmptyPages()
         viewModel.start(site)
@@ -151,7 +151,7 @@ class PagesViewModelTest {
     }
 
     @Test
-    fun onStartUploadsAllLocalDrafts() = runBlocking {
+    fun `when started, it uploads all local drafts`() = runBlocking {
         // Arrange
         setUpPageStoreWithEmptyPages()
 
@@ -164,7 +164,7 @@ class PagesViewModelTest {
     }
 
     @Test
-    fun onPullToRefreshUploadsAllLocalDrafts() = runBlocking {
+    fun `when pulling to refresh, it uploads all local drafts`() = runBlocking {
         // Arrange
         setUpPageStoreWithEmptyPages()
         viewModel.start(site)


### PR DESCRIPTION
This is preemptive of what I'm planning to do in #9935. Which is, adding a`PostEvents.PostUploadStarted` handler to detect uploads and update `PagesViewModel.pageUpdateContinuations`. The auto-update of the list should automatically happen when that's done. At least, that's what I hypothesize. 😄 

## Changes

- b64e5d0 Refactored and renamed some methods to make them more reusable and single-purposed. 
- 15d3cc7 Made the tests more descriptive 
- 814d107 Added additional tests

## Testing

There are no front-end changes. Please review whether the new descriptions make sense. If there are tests that I can easily add, please let me know too.

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.

