### PR TITLE
Issue/9920 editPostActivity.mOriginalPost investigation and fixes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -298,7 +298,6 @@ public class EditPostActivity extends AppCompatActivity implements
     private PostModel mPost;
     private PostModel mPostForUndo;
     private PostModel mPostSnapshotWhenEditorOpened;
-    private boolean mOriginalPostHadLocalChangesOnOpen;
 
     private Revision mRevision;
 
@@ -592,7 +591,6 @@ public class EditPostActivity extends AppCompatActivity implements
     private void initializePostObject() {
         if (mPost != null) {
             mPostSnapshotWhenEditorOpened = mPost.clone();
-            mOriginalPostHadLocalChangesOnOpen = mPostSnapshotWhenEditorOpened.isLocallyChanged();
             mPost = UploadService.updatePostWithCurrentlyCompletedUploads(mPost);
             if (mShowAztecEditor) {
                 try {
@@ -1230,7 +1228,7 @@ public class EditPostActivity extends AppCompatActivity implements
                         showDiscardChanges = true;
                     } else {
                         // we don't have history, so hide/show depending on the original post flag value
-                        showDiscardChanges = mOriginalPostHadLocalChangesOnOpen;
+                        showDiscardChanges = mPostSnapshotWhenEditorOpened.isLocallyChanged();
                     }
                 }
                 discardChanges.setVisible(showDiscardChanges);
@@ -1810,9 +1808,6 @@ public class EditPostActivity extends AppCompatActivity implements
 
     private synchronized void savePostToDb() {
         mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(mPost));
-
-        // update the original post object, so we'll know of new changes
-        mPostSnapshotWhenEditorOpened = mPost.clone();
 
         if (mShowAztecEditor) {
             // update the list of uploading ids

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -297,6 +297,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
     private PostModel mPost;
     private PostModel mPostForUndo;
+    // mPostSnapshotWhenEditorOpened should not be updated after the post editor session start
     private PostModel mPostSnapshotWhenEditorOpened;
 
     private Revision mRevision;
@@ -2062,7 +2063,11 @@ public class EditPostActivity extends AppCompatActivity implements
                 } else {
                     // the user has just tapped on "PUBLISH" on an empty post, make sure to set the status back to the
                     // original post's status as we could not proceed with the action
-                    mPost.setStatus(mPostSnapshotWhenEditorOpened.getStatus());
+                    if (mPostSnapshotWhenEditorOpened != null) {
+                        mPost.setStatus(mPostSnapshotWhenEditorOpened.getStatus());
+                    } else {
+                        mPost.setStatus(PostStatus.DRAFT.toString());
+                    }
                     EditPostActivity.this.runOnUiThread(new Runnable() {
                         @Override
                         public void run() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -298,7 +298,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private PostModel mPost;
     private PostModel mPostForUndo;
     // mPostSnapshotWhenEditorOpened should not be updated after the post editor session start
-    private PostModel mPostSnapshotWhenEditorOpened;
+    private @Nullable PostModel mPostSnapshotWhenEditorOpened;
 
     private Revision mRevision;
 
@@ -1229,7 +1229,8 @@ public class EditPostActivity extends AppCompatActivity implements
                         showDiscardChanges = true;
                     } else {
                         // we don't have history, so hide/show depending on the original post flag value
-                        showDiscardChanges = mPostSnapshotWhenEditorOpened.isLocallyChanged();
+                        showDiscardChanges = mPostSnapshotWhenEditorOpened != null
+                                             && mPostSnapshotWhenEditorOpened.isLocallyChanged();
                     }
                 }
                 discardChanges.setVisible(showDiscardChanges);
@@ -2171,7 +2172,8 @@ public class EditPostActivity extends AppCompatActivity implements
 
     private boolean isFirstTimePublish() {
         return (PostStatus.fromPost(mPost) == PostStatus.UNKNOWN || PostStatus.fromPost(mPost) == PostStatus.DRAFT)
-               && (mPost.isLocalDraft() || PostStatus.fromPost(mPostSnapshotWhenEditorOpened) == PostStatus.DRAFT
+               && (mPost.isLocalDraft() || mPostSnapshotWhenEditorOpened == null
+                   || PostStatus.fromPost(mPostSnapshotWhenEditorOpened) == PostStatus.DRAFT
                    || PostStatus.fromPost(mPostSnapshotWhenEditorOpened) == PostStatus.PENDING);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.posts;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
 
@@ -188,7 +189,7 @@ public class PostUtils {
     /**
      * Checks if two posts have differing data
      */
-    public static boolean postHasEdits(PostModel oldPost, PostModel newPost) {
+    public static boolean postHasEdits(@Nullable PostModel oldPost, PostModel newPost) {
         if (oldPost == null) {
             return newPost != null;
         }


### PR DESCRIPTION
Fixes #9920

Most of the investigation is there: https://github.com/wordpress-mobile/WordPress-Android/issues/9920#issuecomment-495214456

I wanted to simplify the [`shouldSavePost`](https://github.com/wordpress-mobile/WordPress-Android/blob/0a2d4f73140a47370d656c83b8ebb849b25b583b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L2158-L2169) method, it's only used in [`savePostAndOptionallyFinish`](https://github.com/wordpress-mobile/WordPress-Android/blob/1119c4f892f2eb8f4f36a3bf9d51d9db1c1ea296/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L2116) but it's hard to untangle the history of changes in there. It seems that it could be simplified to a call to `PostUtils.hasChanges()`, this might be worth its own ticket.

Note: this also fixes #9567 