### PR TITLE
Automatically update Page List if an upload is completed in the background

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -115,9 +115,8 @@ class PagesFragment : Fragment() {
                 return
             }
 
-            val wasPageUpdated = data.getBooleanExtra(EditPostActivity.EXTRA_HAS_CHANGES, false)
             if (pageId != -1L) {
-                onPageEditFinished(pageId, wasPageUpdated)
+                viewModel.onPageEditFinished()
             }
         } else if (requestCode == RequestCodes.PAGE_PARENT && resultCode == Activity.RESULT_OK && data != null) {
             val parentId = data.getLongExtra(EXTRA_PAGE_PARENT_ID_KEY, -1)
@@ -135,10 +134,6 @@ class PagesFragment : Fragment() {
 
     fun onSpecificPageRequested(remotePageId: Long) {
         viewModel.onSpecificPageRequested(remotePageId)
-    }
-
-    private fun onPageEditFinished(pageId: Long, wasPageUpdated: Boolean) {
-        viewModel.onPageEditFinished(pageId, wasPageUpdated)
     }
 
     private fun onPageParentSet(pageId: Long, parentId: Long) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostEvents.java
@@ -6,7 +6,7 @@ public class PostEvents {
     public static class PostUploadStarted {
         public final PostModel post;
 
-        PostUploadStarted(PostModel post) {
+        public PostUploadStarted(PostModel post) {
             this.post = post;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/EventBusAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/EventBusAdapter.kt
@@ -1,10 +1,10 @@
 package org.wordpress.android.util
 
-import org.greenrobot.eventbus.EventBus
+import de.greenrobot.event.EventBus
 import javax.inject.Inject
 
 /**
- * Provides an interface for [org.greenrobot.eventbus.EventBus] which can be mocked and used in unit tests.
+ * Provides an interface for [de.greenrobot.eventbus.EventBus] which can be mocked and used in unit tests.
  */
 class EventBusAdapter @Inject constructor() {
     fun register(subscriber: Any) {

--- a/WordPress/src/main/java/org/wordpress/android/util/EventBusAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/EventBusAdapter.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.util
+
+import org.greenrobot.eventbus.EventBus
+import javax.inject.Inject
+
+/**
+ * Provides an interface for [org.greenrobot.eventbus.EventBus] which can be mocked and used in unit tests.
+ */
+class EventBusAdapter @Inject constructor() {
+    fun register(subscriber: Any) {
+        EventBus.getDefault().register(subscriber)
+    }
+
+    fun unregister(subscriber: Any) {
+        EventBus.getDefault().unregister(subscriber)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/EventBusWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/EventBusWrapper.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 /**
  * Provides an interface for [de.greenrobot.eventbus.EventBus] which can be mocked and used in unit tests.
  */
-class EventBusAdapter @Inject constructor() {
+class EventBusWrapper @Inject constructor() {
     fun register(subscriber: Any) {
         EventBus.getDefault().register(subscriber)
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/EventBusWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/EventBusWrapper.kt
@@ -1,11 +1,13 @@
 package org.wordpress.android.util
 
+import dagger.Reusable
 import de.greenrobot.event.EventBus
 import javax.inject.Inject
 
 /**
  * Provides an interface for [de.greenrobot.eventbus.EventBus] which can be mocked and used in unit tests.
  */
+@Reusable
 class EventBusWrapper @Inject constructor() {
     fun register(subscriber: Any) {
         EventBus.getDefault().register(subscriber)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -39,7 +39,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.uploads.LocalDraftUploadStarter
 import org.wordpress.android.ui.uploads.PostEvents
 import org.wordpress.android.util.AppLog
-import org.wordpress.android.util.EventBusAdapter
+import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtils
 import org.wordpress.android.util.coroutines.suspendCoroutineWithTimeout
@@ -78,7 +78,7 @@ class PagesViewModel
     private val actionPerfomer: ActionPerformer,
     private val networkUtils: NetworkUtilsWrapper,
     private val localDraftUploadStarter: LocalDraftUploadStarter,
-    private val eventBusAdapter: EventBusAdapter,
+    private val eventBusWrapper: EventBusWrapper,
     @Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val defaultDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(uiDispatcher) {
@@ -152,7 +152,7 @@ class PagesViewModel
         if (_site == null) {
             _site = site
 
-            eventBusAdapter.register(this)
+            eventBusWrapper.register(this)
 
             loadPagesAsync()
 
@@ -166,7 +166,7 @@ class PagesViewModel
 
     override fun onCleared() {
         dispatcher.unregister(this)
-        eventBusAdapter.unregister(this)
+        eventBusWrapper.unregister(this)
 
         actionPerfomer.onCleanup()
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -205,16 +205,9 @@ class PagesViewModel
         pageMap = pageStore.getPagesFromDb(site).associateBy { it.remoteId }
     }
 
-    fun onPageEditFinished(remotePageId: Long, wasPageUpdated: Boolean) {
+    fun onPageEditFinished() {
         launch {
             refreshPages() // show local changes immediately
-
-            if (wasPageUpdated) {
-                performIfNetworkAvailableAsync {
-                    waitForPageUpdate(remotePageId)
-                    reloadPages()
-                }
-            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -180,18 +180,18 @@ class PagesViewModel
 
     private suspend fun reloadPages(state: PageListState = REFRESHING) {
         if (performIfNetworkAvailableAsync {
-            _listState.setOnUi(state)
+                    _listState.setOnUi(state)
 
-            val result = pageStore.requestPagesFromServer(site)
-            if (result.isError) {
-                _listState.setOnUi(ERROR)
-                showSnackbar(SnackbarMessageHolder(string.error_refresh_pages))
-                AppLog.e(AppLog.T.PAGES, "An error occurred while fetching the Pages")
-            } else {
-                _listState.setOnUi(DONE)
-            }
-            refreshPages()
-        }) else {
+                    val result = pageStore.requestPagesFromServer(site)
+                    if (result.isError) {
+                        _listState.setOnUi(ERROR)
+                        showSnackbar(SnackbarMessageHolder(string.error_refresh_pages))
+                        AppLog.e(AppLog.T.PAGES, "An error occurred while fetching the Pages")
+                    } else {
+                        _listState.setOnUi(DONE)
+                    }
+                    refreshPages()
+                }) else {
             _listState.setOnUi(DONE)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.viewmodel.pages
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import android.support.annotation.StringRes
-import de.greenrobot.event.EventBus
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -40,6 +39,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.uploads.LocalDraftUploadStarter
 import org.wordpress.android.ui.uploads.PostEvents
 import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.EventBusAdapter
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtils
 import org.wordpress.android.util.coroutines.suspendCoroutineWithTimeout
@@ -78,6 +78,7 @@ class PagesViewModel
     private val actionPerfomer: ActionPerformer,
     private val networkUtils: NetworkUtilsWrapper,
     private val localDraftUploadStarter: LocalDraftUploadStarter,
+    private val eventBusAdapter: EventBusAdapter,
     @Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val defaultDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(uiDispatcher) {
@@ -151,7 +152,7 @@ class PagesViewModel
         if (_site == null) {
             _site = site
 
-            EventBus.getDefault().register(this)
+            eventBusAdapter.register(this)
 
             loadPagesAsync()
 
@@ -165,7 +166,7 @@ class PagesViewModel
 
     override fun onCleared() {
         dispatcher.unregister(this)
-        EventBus.getDefault().unregister(this)
+        eventBusAdapter.unregister(this)
 
         actionPerfomer.onCleanup()
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -39,7 +39,6 @@ import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.DRAFTS
 import java.util.Date
 import java.util.SortedMap
-import kotlin.random.Random
 
 @RunWith(MockitoJUnitRunner::class)
 class PagesViewModelTest {
@@ -68,7 +67,7 @@ class PagesViewModelTest {
                 localDraftUploadStarter = localDraftUploadStarter,
                 uiDispatcher = Dispatchers.Unconfined,
                 defaultDispatcher = Dispatchers.Unconfined,
-                eventBusAdapter = mock()
+                eventBusWrapper = mock()
         )
         listStates = mutableListOf()
         pages = mutableListOf()

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -207,7 +207,6 @@ class PagesViewModelTest {
         setUpPageStoreWithEmptyPages()
         viewModel.start(site)
 
-
         viewModel.onEventBackgroundThread(PostEvents.PostUploadStarted(page))
         assertThat(viewModel.arePageActionsEnabled).isFalse()
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -237,8 +237,8 @@ class PagesViewModelTest {
 
     private companion object Fixtures {
         fun createPostModel() = PostModel().apply {
-            id = Random(100).nextInt()
-            remotePostId = Random(200).nextLong()
+            id = 1_001
+            remotePostId = 2_034
             setIsPage(true)
         }
     }


### PR DESCRIPTION
Closes #9935. 

## Findings

`PagesViewModel` automatically updates the list only if it has received an `onPageEditFinished` event. If the upload happens in the background, like those started by `LocalDraftUploadStarter`, it does not "see" it and just ignores the `OnPostUploaded` event. 

## Solution

I experimented with reusing `PostListEventListener` but the changes started getting too intrusive. I opted to make `PagesViewModel` start watching uploads on `PostUploadStarted` events instead of `onPageEditFinished`. 

The automated tests that cover this were done previously in #9936 and this PR only updates them. 

<img src="https://user-images.githubusercontent.com/198826/58433426-81938080-8074-11e9-8c78-6e0623732bc8.gif" width="320">

## Testing

1. Go offline
2. Open Pages
3. Create a draft 
4. Go online 
5. The draft should no longer show up as _Local Draft_ once the upload completes.

Please also do a regression test for when leaving the Editor while online. 

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.



