### PR TITLE
AutoUpload only publishable local drafts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtilsWrapper.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.ui.posts
+
+import dagger.Reusable
+import org.wordpress.android.fluxc.model.PostModel
+import javax.inject.Inject
+
+/**
+ * Injectable wrapper around PostUtils.
+ *
+ * PostUtils interface is consisted of static methods, which make the client code difficult to test/mock. Main purpose
+ * of this wrapper is to make testing easier.
+ *
+ */
+@Reusable
+class PostUtilsWrapper @Inject constructor() {
+    fun isPublishable(post: PostModel) = PostUtils.isPublishable(post)
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterConcurrentTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.ui.posts.PostUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 
 /**
@@ -75,6 +76,7 @@ class LocalDraftUploadStarterConcurrentTest {
             bgDispatcher = Dispatchers.Default,
             ioDispatcher = Dispatchers.IO,
             networkUtilsWrapper = createMockedNetworkUtilsWrapper(),
+            postUtilsWrapper = createMockedPostUtilsWrapper(),
             connectionStatus = mock(),
             uploadServiceFacade = uploadServiceFacade
     )
@@ -86,6 +88,10 @@ class LocalDraftUploadStarterConcurrentTest {
 
         fun createMockedUploadServiceFacade() = mock<UploadServiceFacade> {
             on { isPostUploadingOrQueued(any()) } doReturn false
+        }
+
+        fun createMockedPostUtilsWrapper() = mock<PostUtilsWrapper> {
+            on { isPublishable(any()) } doReturn true
         }
     }
 }


### PR DESCRIPTION
Fixes #9955 

LocalDraftUploadStarted doesn't automatically upload local drafts which are not publishable.

To test:
1. Turn on Airplane mode
2. My Site -> Blog Posts
3. Create a Post
4. Enter a title
5. Press back
6. Open the post
7. Remove the title
8. Press back
9. Turn off airplane mode + you can also pull to refresh
10. Notice the failed upload notification isn't shown
11. Turn on airplane mode
12. Create a local draft
13. Turn off airplane mode
14. Make sure the second local draft gets uploaded - in other words make sure the "unpublishable" draft doesn't block all uploads

Update release notes:

- The feature hasn't been released yet + the changes are too minor
