### PR TITLE
Fix './gradlew build' in libs/mocks

### DIFF
--- a/libs/mocks/WordPressMocks/build.gradle
+++ b/libs/mocks/WordPressMocks/build.gradle
@@ -8,6 +8,10 @@ android {
         versionCode 1
         versionName "1.0"
     }
+
+    lintOptions{
+        disable 'InvalidPackage'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
The `InvalidPackage` lint error is causing `./gradlew build` to fail due to WireMock including some libraries that are not designed for Android. We can safely ignore these errors as our WireMock setup works fine on Android.

To test:

- `cd libs/mocks && ./gradlew build`

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
