### PR TITLE
Exclude language resources from App Bundle splitting to allow in-app switching

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -121,6 +121,14 @@ android {
         // MPAndroidChart uses androidX - remove this line when we migrate everything to androidX
         exclude 'META-INF/proguard/androidx-annotations.pro'
     }
+
+    bundle {
+        language {
+            // Don't split language resources for App Bundles.
+            // This is required to switch language in app.
+            enableSplit = false
+        }
+    }
 }
 
 // allows us to use cool things like @Parcelize annotations


### PR DESCRIPTION
In-app language switching is not working correctly since we have started using Android App Bundles. This is because the language files are not included for all languages.

This updates the configuration to include all languages in the app bundle. It will lead to a small increase in app download size (around 1.5MB).

To test:

- Build a new app bundle: `./tools/build-release-app-bundle.sh fix/android-app-bundle-languages`.
- Install it to your device: `./tools/install-app-bundle.sh build/wpandroid-12.6-rc-1.aab`
- Switch language: Me -> App Settings -> Interface Language.
- See that the language was changes successfully.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
