### PR TITLE
CircleCI: Update Orb to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 orbs:
-  android: wordpress-mobile/android@0.0.22
+  android: wordpress-mobile/android@0.0.27
   bundle-install: toshimaru/bundle-install@0.1.1
 
 commands:


### PR DESCRIPTION
This updates the Orb to the latest to include the latest improvements. In particular, https://github.com/wordpress-mobile/circleci-orbs/pull/18 ensures that there is no chance of leaking credentials from Firebase Test Lab runs.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
