### PR TITLE
Signup test: Using different mocks of rest/v1.1/me/ for login & signup

### DIFF
--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -37,6 +37,6 @@ wp.e2e.self_hosted_user.password=mocked_password
 wp.e2e.self_hosted_user.site_address=127.0.0.1:8080
 
 wp.e2e.signup_email=e2eflowsignuptestingmobile@example.com
-wp.e2e.signup_username=e2eflowtestingmobile
-wp.e2e.signup_display_name=Eeflowtestingmobile
+wp.e2e.signup_username=e2eflowsignuptestingmobile
+wp.e2e.signup_display_name=e2eflowsignuptestingmobile
 wp.e2e.signup_password=mocked_password

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/rest_v11_auth_send-signup-email.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/rest_v11_auth_send-signup-email.json
@@ -1,4 +1,6 @@
 {
+    "scenarioName": "auth",
+    "newScenarioState": "signed-up",
     "request": {
         "urlPath": "/rest/v1.1/auth/send-signup-email/",
         "method": "POST"

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/rest_v13_auth_send-login-email.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/rest_v13_auth_send-login-email.json
@@ -1,4 +1,6 @@
 {
+    "scenarioName": "auth",
+    "newScenarioState": "logged-in",
     "request": {
         "urlPath": "/rest/v1.3/auth/send-login-email/",
         "method": "POST"

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_signup.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_signup.json
@@ -1,5 +1,6 @@
 {
     "scenarioName": "auth",
+    "requiredScenarioState": "signed-up",
     "request": {
         "urlPath": "/rest/v1.1/me/",
         "method": "GET"
@@ -8,11 +9,11 @@
         "status": 200,
         "jsonBody": {
             "ID": 152748359,
-            "display_name": "e2eflowtestingmobile",
-            "username": "e2eflowtestingmobile",
-            "email": "e2eflowtestingmobile@example.com",
-            "primary_blog": 158396482,
-            "primary_blog_url": "http://e2eflowtestingmobile.wordpress.com",
+            "display_name": "e2eflowsignuptestingmobile",
+            "username": "e2eflowsignuptestingmobile",
+            "email": "e2eflowsignuptestingmobile@example.com",
+            "primary_blog": null,
+            "primary_blog_url": null,
             "primary_blog_is_jetpack": false,
             "language": "en",
             "locale_variant": "",
@@ -21,7 +22,7 @@
                 "global"
             ],
             "avatar_URL": "https://1.gravatar.com/avatar/7a4015c11be6a342f65e0e169092d402?s=96&d=identicon",
-            "profile_URL": "http://en.gravatar.com/e2eflowtestingmobile",
+            "profile_URL": "http://en.gravatar.com/e2eflowsignuptestingmobile",
             "verified": true,
             "email_verified": true,
             "date": "2019-02-14T09:49:17+00:00",


### PR DESCRIPTION
As discussed, this uses WireMock scenarios to give a different response to `rest/v1.1/me/` when logging in/signing up.

To test:

- `cp gradle.properties-example gradle.properties`
- Run the sign up test.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
