### PR TITLE
[GB-Mobile] Fix for Permissions Denied dialog loop

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -326,7 +326,13 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
-        checkAndRequestCameraAndStoragePermissions(requestCode);
+        if (PermissionUtils.checkCameraAndStoragePermissions(this.getActivity())) {
+            if (requestCode == CAPTURE_PHOTO_PERMISSION_REQUEST_CODE) {
+                mEditorFragmentListener.onCapturePhotoClicked();
+            } else if (requestCode == CAPTURE_VIDEO_PERMISSION_REQUEST_CODE) {
+                mEditorFragmentListener.onCaptureVideoClicked();
+            }
+        }
     }
 
     private void setEditorProgressBarVisibility(boolean shown) {


### PR DESCRIPTION
Fixes #10002 by making sure to not request permissions once again in the callback of permissions result. 

Test no.1
- Go to System settings -> Apps -> WP app -> Authorizations -> and disable permissions for the WP app
- Open the WP app and go to block editor
- Add a Image block and tap to add a picture
- Select Take a picture
- The system permissions dialog should show on the screen
- Select "Never ask again " and tap on Deny
- The app should not crash
- Tap again on the "Add image" label within the block,  and select Take a picture
- The app should show a dialog and gives instructions to open settings


Test no.2
- Enable Media and Storage permissions in system settings
- Start the app and go to block editor
- Add an image block and try to take a picture
- Everything should work as expected

Test no.3
- Disable permissions for the WP app (Media and Storage)
- Start the app and go to block editor
- Add an image block and take a picture
- When asked give the permissions to the WP app
- Everything should work as expected


Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
