### PR TITLE
Update work library for AndroidX and update deprecated classes

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -158,8 +158,8 @@ dependencies {
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.percentlayout:percentlayout:1.0.0'
     implementation 'androidx.preference:preference:1.0.0'
-    implementation "android.arch.work:work-runtime:$arch_work_version"
-    implementation "android.arch.work:work-runtime-ktx:$arch_work_version"
+    implementation "androidx.work:work-runtime:$androidx_work_version"
+    implementation "androidx.work:work-runtime-ktx:$androidx_work_version"
 
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
@@ -231,7 +231,7 @@ dependencies {
     androidTestImplementation 'tools.fastlane:screengrab:1.2.0',  {
         exclude group: 'com.android.support.test.uiautomator', module: 'uiautomator-v18'
     }
-    androidTestImplementation "android.arch.work:work-testing:$arch_work_version"
+    androidTestImplementation "androidx.work:work-testing:$androidx_work_version"
 
     kaptAndroidTest "com.google.dagger:dagger-compiler:$daggerVersion"
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -228,6 +228,7 @@ dependencies {
 
     androidTestImplementation 'androidx.test:runner:1.1.0'
     androidTestImplementation 'androidx.test:rules:1.1.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
     androidTestImplementation 'tools.fastlane:screengrab:1.2.0',  {
         exclude group: 'com.android.support.test.uiautomator', module: 'uiautomator-v18'
     }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -1,7 +1,8 @@
 package org.wordpress.android.e2e;
 
 import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
 
 import org.junit.After;
 import org.junit.Before;

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/DemoModeEnabler.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/DemoModeEnabler.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.support
 
 import android.os.ParcelFileDescriptor
 import android.os.ParcelFileDescriptor.AutoCloseInputStream
-import androidx.test.InstrumentationRegistry
+import androidx.test.platform.app.InstrumentationRegistry
 import java.io.BufferedReader
 import java.io.InputStreamReader
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -3,7 +3,7 @@ package org.wordpress.android.ui.screenshots;
 import androidx.test.espresso.Espresso;
 import androidx.test.filters.LargeTest;
 import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.ClassRule;
 import org.junit.Rule;

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/UploadWorkerTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/UploadWorkerTest.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.util
 
 import android.util.Log
-import androidx.test.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import androidx.work.Configuration
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
@@ -32,7 +32,7 @@ class UploadWorkerTest {
 
     @Before
     fun setUp() {
-        val context = InstrumentationRegistry.getTargetContext()
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
         val config = Configuration.Builder()
                 .setMinimumLoggingLevel(Log.DEBUG)
                 // Use a SynchronousExecutor here to make it easier to write tests

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.11'
     ext.kotlin_coroutines_version = '1.1.0'
-    ext.arch_components_version = '1.1.1'
-    ext.arch_work_version = "1.0.1"
+    ext.androidx_work_version = "2.0.1"
 
     repositories {
         google()


### PR DESCRIPTION
1. Update work library for AndroidX
2. Update deprecated `AndroidJunit4` and `InstrumentationRegistry` imports to use these from `androidx.test.ext`.

To test:
- Make sure it builds and run the `UploadWorkerTest`

```sh
./gradlew :WordPress:cAT -Pandroid.testInstrumentationRunnerArguments.class=org.wordpress.android.util.UploadWorkerTest
```

### Update release notes:

No need to update `RELEASE-NOTES.txt` for that.
