### PR TITLE
Fix issue where two identical drafts were created

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 12.7
 -----
 * Show upload in progress notification when retrying
+* Fix issue where two identical drafts were created
 
 12.6
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -590,10 +590,19 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
                     sCurrentUploadingPostAnalyticsProperties = new HashMap<>();
                 }
                 sCurrentUploadingPostAnalyticsProperties.put(AnalyticsUtils.HAS_GUTENBERG_BLOCKS_KEY,
-                                                PostUtils.contentContainsGutenbergBlocks(event.post.getContent()));
+                        PostUtils.contentContainsGutenbergBlocks(event.post.getContent()));
                 AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_PUBLISHED_POST,
-                                                    mSiteStore.getSiteByLocalId(event.post.getLocalSiteId()),
-                                                    sCurrentUploadingPostAnalyticsProperties);
+                        mSiteStore.getSiteByLocalId(event.post.getLocalSiteId()),
+                        sCurrentUploadingPostAnalyticsProperties);
+            }
+            synchronized (sQueuedPostsList) {
+                for (PostModel post : sQueuedPostsList) {
+                    if (post.getId() == event.post.getId()) {
+                        // Check if a new version of the post we've just uploaded is in the queue and update its state
+                        post.setRemotePostId(event.post.getRemotePostId());
+                        post.setIsLocalDraft(false);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #9347 

Two identical drafts were being created under certain circumstances. 

I've noticed that before we add a post into the `sQueuedPostsList` [we check if it's already there ](https://github.com/wordpress-mobile/WordPress-Android/blob/d3da8ff56b85f889e5054d2b95e88529acf0e2d2/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java#L108) and when it is, we just update it. However, the issue is that if the post is being uploaded at the moment, it's no longer present in the `sQueuedPostsList`. 
When we finish the upload of the first instance of the post, the upload of the second instance starts. However, it's still marked as `localDraft` and it doesn't have valid `remotePostId`. This PR fixes the issue and updates these two fields when the upload of the first instance of the post finishes.

To test:
1. Go to My Site -> Blog Posts
2. Click on Create post button
3. Enter title + content
4. Click on toolbar overflow menu -> Save as draft
5. Press Up button (arrow) before the upload finishes
6. Notice the app doesn't create two drafts
-------------------------
1. Go to My Site -> Blog Posts
2. Click on Create post button
3. Enter "123" into title
4. Click on toolbar overflow menu -> Save as draft
5. Edit title to "1234"
6. Press Up button (arrow) before the upload finishes
7. Notice the app doesn't create two drafts and the most recent version "1234" gets uploaded

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
