### PR TITLE
Improve error messaging when changing account settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -286,7 +286,13 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
             showChangePasswordProgressDialog(false);
 
             if (event.isError()) {
-                ToastUtils.showToast(getActivity(), event.error.message, ToastUtils.Duration.LONG);
+                // We usually rely on event.error.type and provide our own localized message.
+                // This case is exceptional because:
+                // 1. The server-side error type is generic, but patching this server-side is quite involved
+                // 2. We know the error string return from the server has decent localization
+                String errorMessage = !TextUtils.isEmpty(event.error.message) ? event.error.message
+                        : getString(R.string.error_post_account_settings);
+                ToastUtils.showToast(getActivity(), errorMessage, ToastUtils.Duration.LONG);
                 AppLog.e(T.SETTINGS, event.error.message);
             } else {
                 ToastUtils.showToast(getActivity(), R.string.change_password_confirmation, ToastUtils.Duration.LONG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.text.InputType;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -299,8 +300,13 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
                                 ToastUtils.Duration.LONG);
                         break;
                     case SETTINGS_POST_ERROR:
-                        ToastUtils.showToast(getActivity(), R.string.error_post_account_settings,
-                                ToastUtils.Duration.LONG);
+                        // We usually rely on event.error.type and provide our own localized message.
+                        // This case is exceptional because:
+                        // 1. The server-side error type is generic, but patching this server-side is quite involved
+                        // 2. We know the error string return from the server has decent localization
+                        String errorMessage = !TextUtils.isEmpty(event.error.message) ? event.error.message
+                                : getString(R.string.error_post_account_settings);
+                        ToastUtils.showToast(getActivity(), errorMessage, ToastUtils.Duration.LONG);
                         // we optimistically show the email change snackbar, if that request fails, we should
                         // remove the snackbar
                         checkIfEmailChangeIsPending();


### PR DESCRIPTION
Fixes #9384, improving the error message shown when changing the account e-mail fails.

Supersedes #9496, which is stalled.

The ideal solution for this would have been a server-side patch to return more detailed error types (which become `event.error.type` via FluxC), so we could use those to present our own localized error strings. However this turned out to be more involved than was probably worthwhile, considering these error strings happen to have decent localization server-side (see https://github.com/wordpress-mobile/WordPress-Android/issues/9384#issuecomment-487052372).

### To test:

1. Visit the Account Settings screen (login to WP.com account > Me > Account Settings)
2. Attempt to change your e-mail address to e.g. one that's already taken
3. Notice the error toast is helpful
4. Change device language (nothing too rare)
5. Repeat steps 1-2
6. Verify that error toast is localized

Also repeat the same for changing password (you can use a password like `123456` to pass device validation but trip server validation) - this was already using server-side messages, but I updated it to handle the case of an empty message.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`. (Pretty minor change, didn't add anything.)
