### PR TITLE
Stats Views widget errors

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -77,6 +77,7 @@ import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.stats.StatsWidgetProvider;
 import org.wordpress.android.ui.stats.datasets.StatsDatabaseHelper;
 import org.wordpress.android.ui.stats.datasets.StatsTable;
+import org.wordpress.android.ui.stats.refresh.lists.widget.ViewsWidgetUpdater;
 import org.wordpress.android.ui.uploads.LocalDraftUploadStarter;
 import org.wordpress.android.ui.uploads.UploadService;
 import org.wordpress.android.util.AppLog;
@@ -147,6 +148,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
     @Inject MediaStore mMediaStore;
     @Inject ZendeskHelper mZendeskHelper;
     @Inject LocalDraftUploadStarter mLocalDraftUploadStarter;
+    @Inject ViewsWidgetUpdater mViewsWidgetUpdater;
 
     @Inject @Named("custom-ssl") RequestQueue mRequestQueue;
     public static RequestQueue sRequestQueue;
@@ -611,6 +613,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         // Reset Stats Data
         StatsDatabaseHelper.getDatabase(context).reset();
         StatsWidgetProvider.refreshAllWidgets(context, mSiteStore);
+        mViewsWidgetUpdater.updateAllWidgets(context);
 
         // Reset Notifications Data
         NotificationsTable.reset();

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
@@ -1,12 +1,12 @@
 package org.wordpress.android.ui.stats.refresh
 
-import android.arch.lifecycle.ViewModelProvider
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProviders
 import kotlinx.android.synthetic.main.toolbar.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/StatsViewsWidget.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/StatsViewsWidget.kt
@@ -1,30 +1,13 @@
 package org.wordpress.android.ui.stats.refresh.lists.widget
 
-import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
-import android.view.View
-import android.widget.ImageView.ScaleType.FIT_START
-import android.widget.RemoteViews
-import com.bumptech.glide.request.target.AppWidgetTarget
-import org.wordpress.android.R
 import org.wordpress.android.WordPress
-import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
-import org.wordpress.android.ui.stats.OldStatsActivity
-import org.wordpress.android.ui.stats.StatsTimeframe
-import org.wordpress.android.ui.stats.refresh.StatsActivity
-import org.wordpress.android.ui.stats.refresh.lists.widget.StatsViewsWidgetConfigureViewModel.Color
-import org.wordpress.android.util.NetworkUtilsWrapper
-import org.wordpress.android.util.image.ImageManager
-import org.wordpress.android.util.image.ImageType.ICON
-import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
-import kotlin.random.Random
 
 const val SHOW_CHANGE_VALUE_KEY = "show_change_value_key"
 const val COLOR_MODE_KEY = "color_mode_key"
@@ -34,14 +17,18 @@ private const val MIN_WIDTH = 250
 
 class StatsViewsWidget : AppWidgetProvider() {
     @Inject lateinit var appPrefsWrapper: AppPrefsWrapper
-    @Inject lateinit var siteStore: SiteStore
-    @Inject lateinit var imageManager: ImageManager
-    @Inject lateinit var networkUtilsWrapper: NetworkUtilsWrapper
-    @Inject lateinit var resourceProvider: ResourceProvider
+    @Inject lateinit var viewsWidgetUpdater: ViewsWidgetUpdater
 
     override fun onReceive(context: Context, intent: Intent?) {
         super.onReceive(context, intent)
         (context.applicationContext as WordPress).component().inject(this)
+        val appWidgetId = intent?.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, -1) ?: -1
+        if (appWidgetId > -1) {
+            viewsWidgetUpdater.updateAppWidget(
+                    context,
+                    appWidgetId = appWidgetId
+            )
+        }
     }
 
     override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
@@ -49,15 +36,10 @@ class StatsViewsWidget : AppWidgetProvider() {
         for (appWidgetId in appWidgetIds) {
             val minWidth = appWidgetManager.getAppWidgetOptions(appWidgetId)
                     .getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, 300)
-            updateAppWidget(
+            viewsWidgetUpdater.updateAppWidget(
                     context,
                     appWidgetManager,
                     appWidgetId,
-                    appPrefsWrapper,
-                    siteStore,
-                    imageManager,
-                    networkUtilsWrapper,
-                    resourceProvider,
                     minWidth > MIN_WIDTH
             )
         }
@@ -82,131 +64,13 @@ class StatsViewsWidget : AppWidgetProvider() {
 
             val minWidth = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH)
             (context.applicationContext as WordPress).component().inject(this)
-            updateAppWidget(
+            viewsWidgetUpdater.updateAppWidget(
                     context,
                     appWidgetManager,
                     appWidgetId,
-                    appPrefsWrapper,
-                    siteStore,
-                    imageManager,
-                    networkUtilsWrapper,
-                    resourceProvider,
                     minWidth > MIN_WIDTH
             )
         }
         super.onAppWidgetOptionsChanged(context, appWidgetManager, appWidgetId, newOptions)
-    }
-
-    companion object {
-        internal fun updateAppWidget(
-            context: Context,
-            appWidgetManager: AppWidgetManager,
-            appWidgetId: Int,
-            appPrefsWrapper: AppPrefsWrapper,
-            siteStore: SiteStore,
-            imageManager: ImageManager,
-            networkUtilsWrapper: NetworkUtilsWrapper,
-            resourceProvider: ResourceProvider,
-            showChangeColumn: Boolean = true
-        ) {
-            drawList(
-                    appWidgetId,
-                    context,
-                    appPrefsWrapper,
-                    siteStore,
-                    imageManager,
-                    networkUtilsWrapper,
-                    resourceProvider,
-                    appWidgetManager,
-                    showChangeColumn
-            )
-        }
-
-        private fun drawList(
-            appWidgetId: Int,
-            context: Context,
-            appPrefsWrapper: AppPrefsWrapper,
-            siteStore: SiteStore,
-            imageManager: ImageManager,
-            networkUtilsWrapper: NetworkUtilsWrapper,
-            resourceProvider: ResourceProvider,
-            appWidgetManager: AppWidgetManager,
-            showChangeColumn: Boolean
-        ) {
-            val colorModeId = appPrefsWrapper.getAppWidgetColorModeId(appWidgetId)
-            val siteId = appPrefsWrapper.getAppWidgetSiteId(appWidgetId)
-            val siteModel = siteStore.getSiteBySiteId(siteId)
-
-            val networkAvailable = networkUtilsWrapper.isNetworkAvailable()
-
-            val layout = when (colorModeId) {
-                Color.DARK.ordinal -> R.layout.stats_views_widget_dark
-                Color.LIGHT.ordinal -> R.layout.stats_views_widget_light
-                else -> R.layout.stats_views_widget_light
-            }
-            val views = RemoteViews(context.packageName, layout)
-            val siteIconUrl = siteModel?.iconUrl
-            val awt = AppWidgetTarget(context, R.id.widget_site_icon, views, appWidgetId)
-            imageManager.load(awt, context, ICON, siteIconUrl ?: "", FIT_START)
-            siteModel?.let {
-                views.setOnClickPendingIntent(R.id.widget_title, getPendingSelfIntent(context, siteModel.id))
-                views.setPendingIntentTemplate(R.id.widget_list, getPendingTemplate(context))
-            }
-            if (networkAvailable && siteModel != null) {
-                views.setViewVisibility(R.id.widget_list, View.VISIBLE)
-                views.setViewVisibility(R.id.widget_error, View.GONE)
-                val listIntent = Intent(context, WidgetService::class.java)
-                listIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-                listIntent.putExtra(SHOW_CHANGE_VALUE_KEY, showChangeColumn)
-                listIntent.putExtra(COLOR_MODE_KEY, colorModeId)
-                listIntent.putExtra(SITE_ID_KEY, siteId)
-                listIntent.data = Uri.parse(
-                        listIntent.toUri(Intent.URI_INTENT_SCHEME)
-                )
-                views.setRemoteAdapter(R.id.widget_list, listIntent)
-            } else {
-                views.setViewVisibility(R.id.widget_list, View.GONE)
-                views.setViewVisibility(R.id.widget_error, View.VISIBLE)
-                val errorMessage = if (!networkAvailable) {
-                    R.string.stats_widget_error_no_network
-                } else {
-                    R.string.stats_widget_error_no_data
-                }
-                views.setTextViewText(
-                        R.id.widget_error_message,
-                        resourceProvider.getString(errorMessage)
-                )
-                val intentSync = Intent(context, StatsViewsWidget::class.java)
-                intentSync.action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
-                val pendingSync = PendingIntent.getBroadcast(
-                        context,
-                        0,
-                        intentSync,
-                        PendingIntent.FLAG_UPDATE_CURRENT
-                )
-                views.setOnClickPendingIntent(R.id.widget_error, pendingSync)
-            }
-            appWidgetManager.updateAppWidget(appWidgetId, views)
-        }
-
-        private fun getPendingSelfIntent(context: Context, localSiteId: Int): PendingIntent {
-            val intent = Intent(context, StatsActivity::class.java)
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            intent.putExtra(WordPress.LOCAL_SITE_ID, localSiteId)
-            intent.putExtra(OldStatsActivity.ARG_DESIRED_TIMEFRAME, StatsTimeframe.DAY)
-            intent.putExtra(OldStatsActivity.ARG_LAUNCHED_FROM, OldStatsActivity.StatsLaunchedFrom.STATS_WIDGET)
-            return PendingIntent.getActivity(
-                    context,
-                    Random(localSiteId).nextInt(),
-                    intent,
-                    PendingIntent.FLAG_UPDATE_CURRENT
-            )
-        }
-
-        private fun getPendingTemplate(context: Context): PendingIntent {
-            val intent = Intent(context, StatsActivity::class.java)
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-            return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
-        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/StatsViewsWidget.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/StatsViewsWidget.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.view.View
 import android.widget.ImageView.ScaleType.FIT_START
 import android.widget.RemoteViews
 import com.bumptech.glide.request.target.AppWidgetTarget
@@ -18,8 +19,10 @@ import org.wordpress.android.ui.stats.OldStatsActivity
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.StatsActivity
 import org.wordpress.android.ui.stats.refresh.lists.widget.StatsViewsWidgetConfigureViewModel.Color
+import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.ICON
+import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 import kotlin.random.Random
 
@@ -33,6 +36,8 @@ class StatsViewsWidget : AppWidgetProvider() {
     @Inject lateinit var appPrefsWrapper: AppPrefsWrapper
     @Inject lateinit var siteStore: SiteStore
     @Inject lateinit var imageManager: ImageManager
+    @Inject lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+    @Inject lateinit var resourceProvider: ResourceProvider
 
     override fun onReceive(context: Context, intent: Intent?) {
         super.onReceive(context, intent)
@@ -51,6 +56,8 @@ class StatsViewsWidget : AppWidgetProvider() {
                     appPrefsWrapper,
                     siteStore,
                     imageManager,
+                    networkUtilsWrapper,
+                    resourceProvider,
                     minWidth > MIN_WIDTH
             )
         }
@@ -82,6 +89,8 @@ class StatsViewsWidget : AppWidgetProvider() {
                     appPrefsWrapper,
                     siteStore,
                     imageManager,
+                    networkUtilsWrapper,
+                    resourceProvider,
                     minWidth > MIN_WIDTH
             )
         }
@@ -96,9 +105,21 @@ class StatsViewsWidget : AppWidgetProvider() {
             appPrefsWrapper: AppPrefsWrapper,
             siteStore: SiteStore,
             imageManager: ImageManager,
+            networkUtilsWrapper: NetworkUtilsWrapper,
+            resourceProvider: ResourceProvider,
             showChangeColumn: Boolean = true
         ) {
-            drawList(appWidgetId, context, appPrefsWrapper, siteStore, imageManager, appWidgetManager, showChangeColumn)
+            drawList(
+                    appWidgetId,
+                    context,
+                    appPrefsWrapper,
+                    siteStore,
+                    imageManager,
+                    networkUtilsWrapper,
+                    resourceProvider,
+                    appWidgetManager,
+                    showChangeColumn
+            )
         }
 
         private fun drawList(
@@ -107,12 +128,16 @@ class StatsViewsWidget : AppWidgetProvider() {
             appPrefsWrapper: AppPrefsWrapper,
             siteStore: SiteStore,
             imageManager: ImageManager,
+            networkUtilsWrapper: NetworkUtilsWrapper,
+            resourceProvider: ResourceProvider,
             appWidgetManager: AppWidgetManager,
             showChangeColumn: Boolean
         ) {
             val colorModeId = appPrefsWrapper.getAppWidgetColorModeId(appWidgetId)
             val siteId = appPrefsWrapper.getAppWidgetSiteId(appWidgetId)
             val siteModel = siteStore.getSiteBySiteId(siteId)
+
+            val networkAvailable = networkUtilsWrapper.isNetworkAvailable()
 
             val layout = when (colorModeId) {
                 Color.DARK.ordinal -> R.layout.stats_views_widget_dark
@@ -127,15 +152,40 @@ class StatsViewsWidget : AppWidgetProvider() {
                 views.setOnClickPendingIntent(R.id.widget_title, getPendingSelfIntent(context, siteModel.id))
                 views.setPendingIntentTemplate(R.id.widget_list, getPendingTemplate(context))
             }
-            val listIntent = Intent(context, WidgetService::class.java)
-            listIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-            listIntent.putExtra(SHOW_CHANGE_VALUE_KEY, showChangeColumn)
-            listIntent.putExtra(COLOR_MODE_KEY, colorModeId)
-            listIntent.putExtra(SITE_ID_KEY, siteId)
-            listIntent.data = Uri.parse(
-                    listIntent.toUri(Intent.URI_INTENT_SCHEME)
-            )
-            views.setRemoteAdapter(R.id.widget_list, listIntent)
+            if (networkAvailable && siteModel != null) {
+                views.setViewVisibility(R.id.widget_list, View.VISIBLE)
+                views.setViewVisibility(R.id.widget_error, View.GONE)
+                val listIntent = Intent(context, WidgetService::class.java)
+                listIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+                listIntent.putExtra(SHOW_CHANGE_VALUE_KEY, showChangeColumn)
+                listIntent.putExtra(COLOR_MODE_KEY, colorModeId)
+                listIntent.putExtra(SITE_ID_KEY, siteId)
+                listIntent.data = Uri.parse(
+                        listIntent.toUri(Intent.URI_INTENT_SCHEME)
+                )
+                views.setRemoteAdapter(R.id.widget_list, listIntent)
+            } else {
+                views.setViewVisibility(R.id.widget_list, View.GONE)
+                views.setViewVisibility(R.id.widget_error, View.VISIBLE)
+                val errorMessage = if (!networkAvailable) {
+                    R.string.stats_widget_error_no_network
+                } else {
+                    R.string.stats_widget_error_no_data
+                }
+                views.setTextViewText(
+                        R.id.widget_error_message,
+                        resourceProvider.getString(errorMessage)
+                )
+                val intentSync = Intent(context, StatsViewsWidget::class.java)
+                intentSync.action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
+                val pendingSync = PendingIntent.getBroadcast(
+                        context,
+                        0,
+                        intentSync,
+                        PendingIntent.FLAG_UPDATE_CURRENT
+                )
+                views.setOnClickPendingIntent(R.id.widget_error, pendingSync)
+            }
             appWidgetManager.updateAppWidget(appWidgetId, views)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/StatsViewsWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/StatsViewsWidgetConfigureFragment.kt
@@ -14,20 +14,11 @@ import androidx.lifecycle.ViewModelProviders
 import dagger.android.support.DaggerFragment
 import kotlinx.android.synthetic.main.stats_views_widget_configure_fragment.*
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.store.SiteStore
-import org.wordpress.android.ui.prefs.AppPrefsWrapper
-import org.wordpress.android.util.NetworkUtilsWrapper
-import org.wordpress.android.util.image.ImageManager
-import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
 class StatsViewsWidgetConfigureFragment : DaggerFragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
-    @Inject lateinit var appPrefsWrapper: AppPrefsWrapper
-    @Inject lateinit var siteStore: SiteStore
-    @Inject lateinit var imageManager: ImageManager
-    @Inject lateinit var networkUtilsWrapper: NetworkUtilsWrapper
-    @Inject lateinit var resourceProvider: ResourceProvider
+    @Inject lateinit var viewsWidgetUpdater: ViewsWidgetUpdater
     private lateinit var viewModel: StatsViewsWidgetConfigureViewModel
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.stats_views_widget_configure_fragment, container, false)
@@ -72,16 +63,9 @@ class StatsViewsWidgetConfigureFragment : DaggerFragment() {
 
         viewModel.widgetAdded.observe(this, Observer { event ->
             event?.applyIfNotHandled {
-                val appWidgetManager = AppWidgetManager.getInstance(context)
-                StatsViewsWidget.updateAppWidget(
+                viewsWidgetUpdater.updateAppWidget(
                         context!!,
-                        appWidgetManager,
-                        appWidgetId,
-                        appPrefsWrapper,
-                        siteStore,
-                        imageManager,
-                        networkUtilsWrapper,
-                        resourceProvider
+                        appWidgetId = appWidgetId
                 )
                 val resultValue = Intent()
                 resultValue.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/StatsViewsWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/StatsViewsWidgetConfigureFragment.kt
@@ -16,7 +16,9 @@ import kotlinx.android.synthetic.main.stats_views_widget_configure_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.image.ImageManager
+import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
 class StatsViewsWidgetConfigureFragment : DaggerFragment() {
@@ -24,6 +26,8 @@ class StatsViewsWidgetConfigureFragment : DaggerFragment() {
     @Inject lateinit var appPrefsWrapper: AppPrefsWrapper
     @Inject lateinit var siteStore: SiteStore
     @Inject lateinit var imageManager: ImageManager
+    @Inject lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+    @Inject lateinit var resourceProvider: ResourceProvider
     private lateinit var viewModel: StatsViewsWidgetConfigureViewModel
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.stats_views_widget_configure_fragment, container, false)
@@ -75,7 +79,9 @@ class StatsViewsWidgetConfigureFragment : DaggerFragment() {
                         appWidgetId,
                         appPrefsWrapper,
                         siteStore,
-                        imageManager
+                        imageManager,
+                        networkUtilsWrapper,
+                        resourceProvider
                 )
                 val resultValue = Intent()
                 resultValue.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/ViewsWidgetListProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/ViewsWidgetListProvider.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.widget
 
+import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
 import android.view.View
@@ -15,22 +16,30 @@ import javax.inject.Inject
 
 class ViewsWidgetListProvider(val context: Context, intent: Intent) : RemoteViewsFactory {
     @Inject lateinit var viewModel: ViewsWidgetListViewModel
-    private var showChangeColumn: Boolean = intent.getBooleanExtra(SHOW_CHANGE_VALUE_KEY, true)
-    private var colorModeId: Int = intent.getIntExtra(COLOR_MODE_KEY, Color.LIGHT.ordinal)
-    private var siteId: Long = intent.getLongExtra(SITE_ID_KEY, 0L)
+    @Inject lateinit var viewsWidgetUpdater: ViewsWidgetUpdater
+    private val showChangeColumn: Boolean = intent.getBooleanExtra(SHOW_CHANGE_VALUE_KEY, true)
+    private val colorModeId: Int = intent.getIntExtra(COLOR_MODE_KEY, Color.LIGHT.ordinal)
+    private val siteId: Long = intent.getLongExtra(SITE_ID_KEY, 0L)
+    private val appWidgetId = intent.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, -1)
 
     init {
         (context.applicationContext as WordPress).component().inject(this)
     }
 
     override fun onCreate() {
-        viewModel.start(siteId, colorModeId, showChangeColumn)
+        viewModel.start(siteId, colorModeId, showChangeColumn, appWidgetId)
     }
 
     override fun getLoadingView(): RemoteViews? = null
 
     override fun onDataSetChanged() {
-        viewModel.onDataSetChanged()
+        viewModel.onDataSetChanged { appWidgetId, showChangeColumn ->
+            viewsWidgetUpdater.updateAppWidget(
+                    context,
+                    appWidgetId = appWidgetId,
+                    showChangeColumn = showChangeColumn
+            )
+        }
     }
 
     override fun hasStableIds(): Boolean = true

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/ViewsWidgetListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/ViewsWidgetListViewModel.kt
@@ -33,18 +33,20 @@ class ViewsWidgetListViewModel
     private var siteId: Long? = null
     private var colorModeId: Int? = null
     private var showChangeColumn: Boolean = true
+    private var appWidgetId: Int? = null
     private val mutableData = mutableListOf<ListItemUiModel>()
     val data: List<ListItemUiModel> = mutableData
-    fun start(siteId: Long, colorModeId: Int, showChangeColumn: Boolean) {
+    fun start(siteId: Long, colorModeId: Int, showChangeColumn: Boolean, appWidgetId: Int) {
         this.siteId = siteId
         this.colorModeId = colorModeId
         this.showChangeColumn = showChangeColumn
+        this.appWidgetId = appWidgetId
     }
 
-    fun onDataSetChanged() {
-        siteId?.let {
-            val site = siteStore.getSiteBySiteId(it)
-            site?.let {
+    fun onDataSetChanged(onError: (appWidgetId: Int, showChangeColumn: Boolean) -> Unit) {
+        siteId?.apply {
+            val site = siteStore.getSiteBySiteId(this)
+            if (site != null) {
                 val currentDate = Date()
                 runBlocking {
                     visitsAndViewsStore.fetchVisits(site, DAYS, Top(LIST_ITEM_COUNT + 1), currentDate)
@@ -62,6 +64,10 @@ class ViewsWidgetListViewModel
                 if (uiModels != data) {
                     mutableData.clear()
                     mutableData.addAll(uiModels)
+                }
+            } else {
+                appWidgetId?.let { nonNullAppWidgetId ->
+                    onError(nonNullAppWidgetId, showChangeColumn)
                 }
             }
         }
@@ -114,7 +120,5 @@ class ViewsWidgetListViewModel
         val period: String,
         val localSiteId: Int,
         val showDivider: Boolean = !isPositiveChangeVisible && !isNegativeChangeVisible && !isNeutralChangeVisible
-    ) {
-        enum class ChangeVisible { POSITIVE, NEGATIVE, NEUTRAL, NONE }
-    }
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/ViewsWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/ViewsWidgetUpdater.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.stats.refresh.lists.widget
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -62,6 +63,15 @@ class ViewsWidgetUpdater
             showError(views, appWidgetId, networkAvailable, resourceProvider, context)
         }
         appWidgetManager.updateAppWidget(appWidgetId, views)
+    }
+
+    fun updateAllWidgets(context: Context) {
+        val appWidgetManager = AppWidgetManager.getInstance(context)
+        val viewsWidget = ComponentName(context, StatsViewsWidget::class.java)
+        val allWidgetIds = appWidgetManager.getAppWidgetIds(viewsWidget)
+        for (appWidgetId in allWidgetIds) {
+            updateAppWidget(context, appWidgetManager, appWidgetId)
+        }
     }
 
     private fun showList(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/ViewsWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/ViewsWidgetUpdater.kt
@@ -1,0 +1,138 @@
+package org.wordpress.android.ui.stats.refresh.lists.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.view.View
+import android.widget.ImageView.ScaleType.FIT_START
+import android.widget.RemoteViews
+import com.bumptech.glide.request.target.AppWidgetTarget
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.stats.OldStatsActivity
+import org.wordpress.android.ui.stats.StatsTimeframe
+import org.wordpress.android.ui.stats.refresh.StatsActivity
+import org.wordpress.android.ui.stats.refresh.lists.widget.StatsViewsWidgetConfigureViewModel.Color.DARK
+import org.wordpress.android.ui.stats.refresh.lists.widget.StatsViewsWidgetConfigureViewModel.Color.LIGHT
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.image.ImageManager
+import org.wordpress.android.util.image.ImageType.ICON
+import org.wordpress.android.viewmodel.ResourceProvider
+import javax.inject.Inject
+import kotlin.random.Random
+
+class ViewsWidgetUpdater
+@Inject constructor(
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val siteStore: SiteStore,
+    private val imageManager: ImageManager,
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
+    private val resourceProvider: ResourceProvider
+) {
+    fun updateAppWidget(
+        context: Context,
+        appWidgetManager: AppWidgetManager = AppWidgetManager.getInstance(context),
+        appWidgetId: Int,
+        showChangeColumn: Boolean = true
+    ) {
+        val colorModeId = appPrefsWrapper.getAppWidgetColorModeId(appWidgetId)
+        val siteId = appPrefsWrapper.getAppWidgetSiteId(appWidgetId)
+        val siteModel = siteStore.getSiteBySiteId(siteId)
+        val networkAvailable = networkUtilsWrapper.isNetworkAvailable()
+        val layout = when (colorModeId) {
+            DARK.ordinal -> R.layout.stats_views_widget_dark
+            LIGHT.ordinal -> R.layout.stats_views_widget_light
+            else -> R.layout.stats_views_widget_light
+        }
+        val views = RemoteViews(context.packageName, layout)
+        val siteIconUrl = siteModel?.iconUrl
+        val awt = AppWidgetTarget(context, R.id.widget_site_icon, views, appWidgetId)
+        imageManager.load(awt, context, ICON, siteIconUrl ?: "", FIT_START)
+        siteModel?.let {
+            views.setOnClickPendingIntent(R.id.widget_title, getPendingSelfIntent(context, siteModel.id))
+            views.setPendingIntentTemplate(R.id.widget_list, getPendingTemplate(context))
+        }
+        if (networkAvailable && siteModel != null) {
+            showList(views, context, appWidgetId, showChangeColumn, colorModeId, siteId)
+        } else {
+            showError(views, appWidgetId, networkAvailable, resourceProvider, context)
+        }
+        appWidgetManager.updateAppWidget(appWidgetId, views)
+    }
+
+    private fun showList(
+        views: RemoteViews,
+        context: Context,
+        appWidgetId: Int,
+        showChangeColumn: Boolean,
+        colorModeId: Int,
+        siteId: Long
+    ) {
+        views.setViewVisibility(R.id.widget_list, View.VISIBLE)
+        views.setViewVisibility(R.id.widget_error, View.GONE)
+        val listIntent = Intent(context, WidgetService::class.java)
+        listIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+        listIntent.putExtra(SHOW_CHANGE_VALUE_KEY, showChangeColumn)
+        listIntent.putExtra(COLOR_MODE_KEY, colorModeId)
+        listIntent.putExtra(SITE_ID_KEY, siteId)
+        listIntent.data = Uri.parse(
+                listIntent.toUri(Intent.URI_INTENT_SCHEME)
+        )
+        views.setRemoteAdapter(R.id.widget_list, listIntent)
+    }
+
+    private fun showError(
+        views: RemoteViews,
+        appWidgetId: Int,
+        networkAvailable: Boolean,
+        resourceProvider: ResourceProvider,
+        context: Context
+    ) {
+        views.setViewVisibility(R.id.widget_list, View.GONE)
+        views.setViewVisibility(R.id.widget_error, View.VISIBLE)
+        val errorMessage = if (!networkAvailable) {
+            R.string.stats_widget_error_no_network
+        } else {
+            R.string.stats_widget_error_no_data
+        }
+        views.setTextViewText(
+                R.id.widget_error_message,
+                resourceProvider.getString(errorMessage)
+        )
+        val intentSync = Intent(context, StatsViewsWidget::class.java)
+        intentSync.action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
+
+        intentSync.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+        val pendingSync = PendingIntent.getBroadcast(
+                context,
+                Random(appWidgetId).nextInt(),
+                intentSync,
+                PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        views.setOnClickPendingIntent(R.id.widget_error, pendingSync)
+    }
+
+    private fun getPendingSelfIntent(context: Context, localSiteId: Int): PendingIntent {
+        val intent = Intent(context, StatsActivity::class.java)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        intent.putExtra(WordPress.LOCAL_SITE_ID, localSiteId)
+        intent.putExtra(OldStatsActivity.ARG_DESIRED_TIMEFRAME, StatsTimeframe.DAY)
+        intent.putExtra(OldStatsActivity.ARG_LAUNCHED_FROM, OldStatsActivity.StatsLaunchedFrom.STATS_WIDGET)
+        return PendingIntent.getActivity(
+                context,
+                Random(localSiteId).nextInt(),
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT
+        )
+    }
+
+    private fun getPendingTemplate(context: Context): PendingIntent {
+        val intent = Intent(context, StatsActivity::class.java)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+    }
+}

--- a/WordPress/src/main/res/layout/stats_views_widget_dark.xml
+++ b/WordPress/src/main/res/layout/stats_views_widget_dark.xml
@@ -19,7 +19,8 @@
             android:layout_width="@dimen/stats_widget_list_item_height"
             android:layout_height="@dimen/stats_widget_list_item_height"
             android:contentDescription="@string/my_site_icon_content_description"
-            android:src="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"/>
+            android:src="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
+            tools:src="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"/>
 
         <TextView
             android:id="@+id/widget_title"
@@ -35,15 +36,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:divider="@null"
-        android:dividerHeight="0dp"
-        android:visibility="gone"/>
+        android:dividerHeight="0dp"/>
 
     <LinearLayout
         android:id="@+id/widget_error"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="center"
-        android:background="?attr/selectableItemBackground"
+        android:layout_height="0dp"
+        android:layout_weight="1"
         android:clickable="true"
         android:focusable="true"
         android:gravity="center"
@@ -58,6 +57,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="2dp"
+            android:gravity="center_horizontal"
             android:text="@string/stats_widget_error_no_data"/>
 
         <TextView

--- a/WordPress/src/main/res/layout/stats_views_widget_dark.xml
+++ b/WordPress/src/main/res/layout/stats_views_widget_dark.xml
@@ -4,14 +4,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:background="@drawable/bg_rectangle_gray_800_radius_4dp">
+    android:background="@drawable/bg_rectangle_gray_800_radius_4dp"
+    android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="@dimen/stats_widget_list_item_height"
-        android:orientation="horizontal"
-        android:background="@drawable/bg_rectangle_gray_700_top_radius_4dp">
+        android:background="@drawable/bg_rectangle_gray_700_top_radius_4dp"
+        android:orientation="horizontal">
 
         <ImageView
             android:id="@+id/widget_site_icon"
@@ -35,5 +35,37 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:divider="@null"
-        android:dividerHeight="0dp"/>
+        android:dividerHeight="0dp"
+        android:visibility="gone"/>
+
+    <LinearLayout
+        android:id="@+id/widget_error"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:paddingEnd="@dimen/margin_extra_large"
+        android:paddingStart="@dimen/margin_extra_large"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/widget_error_message"
+            style="@style/StatsWidgetErrorMessage.Dark"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="2dp"
+            android:text="@string/stats_widget_error_no_data"/>
+
+        <TextView
+            android:id="@+id/widget_retry_button"
+            style="@style/StatsWidgetRetryButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:text="@string/retry"/>
+    </LinearLayout>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/stats_views_widget_light.xml
+++ b/WordPress/src/main/res/layout/stats_views_widget_light.xml
@@ -4,14 +4,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:background="@drawable/bg_rectangle_white_radius_4dp">
+    android:background="@drawable/bg_rectangle_white_radius_4dp"
+    android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="@dimen/stats_widget_list_item_height"
-        android:orientation="horizontal"
-        android:background="@drawable/bg_rectangle_gray_0_top_radius_4dp">
+        android:background="@drawable/bg_rectangle_gray_0_top_radius_4dp"
+        android:orientation="horizontal">
 
         <ImageView
             android:id="@+id/widget_site_icon"
@@ -37,4 +37,35 @@
         android:layout_height="wrap_content"
         android:divider="@null"
         android:dividerHeight="0dp"/>
+
+    <LinearLayout
+        android:id="@+id/widget_error"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:paddingEnd="@dimen/margin_extra_large"
+        android:paddingStart="@dimen/margin_extra_large"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/widget_error_message"
+            style="@style/StatsWidgetErrorMessage.Light"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="2dp"
+            android:gravity="center_horizontal"
+            android:text="@string/stats_widget_error_no_data"/>
+
+        <TextView
+            android:id="@+id/widget_retry_button"
+            style="@style/StatsWidgetRetryButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:text="@string/retry"/>
+    </LinearLayout>
 </LinearLayout>

--- a/WordPress/src/main/res/values/stats_styles.xml
+++ b/WordPress/src/main/res/values/stats_styles.xml
@@ -283,7 +283,6 @@
 
     <style name="StatsWidgetErrorMessage" parent="TextAppearance.AppCompat.Body1">
         <item name="android:textSize">@dimen/text_sz_large</item>
-        <item name="android:gravity">center_vertical</item>
     </style>
 
     <style name="StatsWidgetErrorMessage.Light">
@@ -296,7 +295,6 @@
 
     <style name="StatsWidgetRetryButton" parent="TextAppearance.AppCompat.Body1">
         <item name="android:textSize">@dimen/text_sz_medium</item>
-        <item name="android:gravity">center_vertical</item>
         <item name="android:textColor">@color/wp_blue_medium</item>
     </style>
 

--- a/WordPress/src/main/res/values/stats_styles.xml
+++ b/WordPress/src/main/res/values/stats_styles.xml
@@ -277,9 +277,27 @@
         <item name="android:textColor">@color/gray_900</item>
     </style>
 
-
     <style name="StatsWidgetTitle.Dark">
         <item name="android:textColor">@color/white</item>
+    </style>
+
+    <style name="StatsWidgetErrorMessage" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textSize">@dimen/text_sz_large</item>
+        <item name="android:gravity">center_vertical</item>
+    </style>
+
+    <style name="StatsWidgetErrorMessage.Light">
+        <item name="android:textColor">@color/gray_500</item>
+    </style>
+
+    <style name="StatsWidgetErrorMessage.Dark">
+        <item name="android:textColor">@color/gray_200</item>
+    </style>
+
+    <style name="StatsWidgetRetryButton" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textSize">@dimen/text_sz_medium</item>
+        <item name="android:gravity">center_vertical</item>
+        <item name="android:textColor">@color/wp_blue_medium</item>
     </style>
 
     <style name="StatsWidgetListItem">

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -851,6 +851,8 @@
     <string name="stats_widget_color_dark">Dark</string>
     <string name="stats_widget_select_your_site">Select your site</string>
     <string name="stats_widget_select_color">Color</string>
+    <string name="stats_widget_error_no_data">Couldn\'t load data</string>
+    <string name="stats_widget_error_no_network">No network available</string>
 
     <!-- Jetpack install -->
     <string name="jetpack">Jetpack</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/ViewsWidgetListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/ViewsWidgetListViewModelTest.kt
@@ -98,7 +98,7 @@ class ViewsWidgetListViewModelTest {
 
         viewModel.start(siteId, color.ordinal, showChangeColumn, appWidgetId)
 
-        viewModel.onDataSetChanged { _, _ ->  }
+        viewModel.onDataSetChanged { _, _ -> }
 
         viewModel.data.let { data ->
             assertThat(data).hasSize(dates.size)


### PR DESCRIPTION
This PR implements error states for the Views widget. We show an error message and a retry button when there is no connection or when we fail to load the site. This also happens when you log out in the app. 

To test:
* Turn off data
* Add a widget
* The Widget shows the "No connection" message and the retry button
* Turn on data
* Click "Retry"
* The widget is reloaded with the correct data

To test 2: 
* Add a widget
* Log out in the app
* The widget shows the "Couldn't load data" error and the "Retry" button

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
