### PR TITLE
Use latest gb-mobile, compat with AndroidX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ allprojects {
 
     configurations.all {
         resolutionStrategy {
-            force 'org.webkit:android-jsc:r224109'
+            force 'org.webkit:android-jsc:r241213'
         }
     }
 


### PR DESCRIPTION
Updates the Gutenberg mobile ref to point to the latest work, including the effort to migrate to AndroidX.
This PR starts as a Draft PR because we don't want to merge the latest of gb-mobile just yet.

Gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1112

To test:
* Build and run WPAndroid and check that the block editor is working as normal.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
