### PR TITLE
Fix SAVE action in the editor on local drafts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1502,7 +1502,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // the user tapped on it accidentally
         PostStatus status = PostStatus.fromPost(mPost);
         if (userCanPublishPosts() && (status == PostStatus.DRAFT || status == PostStatus.UNKNOWN)
-            && mPost.isLocalDraft()) {
+            && mPost.isLocalDraft() && isNewPost()) {
             showPublishConfirmationDialog();
         } else {
             // otherwise, if they're updating a Post, just go ahead and save it to the server

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1312,7 +1312,7 @@ public class EditPostActivity extends AppCompatActivity implements
             if (shouldShowAsyncPromoDialog()) {
                 showAsyncPromoDialog(mPost.isPage(), PostStatus.fromPost(mPost) == PostStatus.SCHEDULED);
             } else {
-                showPublishConfirmationOrUpdateIfNotLocalDraft();
+                showPublishConfirmationForNewLocalDraftOrUpdate();
             }
         } else {
             // Disable other action bar buttons while a media upload is in progress
@@ -1497,8 +1497,8 @@ public class EditPostActivity extends AppCompatActivity implements
         publishConfirmationDialog.show(getSupportFragmentManager(), TAG_PUBLISH_CONFIRMATION_DIALOG);
     }
 
-    private void showPublishConfirmationOrUpdateIfNotLocalDraft() {
-        // if post is a draft, first make sure to confirm the PUBLISH action, in case
+    private void showPublishConfirmationForNewLocalDraftOrUpdate() {
+        // if post is a new draft, first make sure to confirm the PUBLISH action, in case
         // the user tapped on it accidentally
         PostStatus status = PostStatus.fromPost(mPost);
         if (userCanPublishPosts() && (status == PostStatus.DRAFT || status == PostStatus.UNKNOWN)


### PR DESCRIPTION
Fixes #9966

Updates the logic when the PublishConfirmationDialog is shown so it corresponds with the following line https://github.com/wordpress-mobile/WordPress-Android/blob/9e3f6b03a5a4e57e2728cd120ec8ac022016034e/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L874


I've copied a few test scenarios from https://github.com/wordpress-mobile/WordPress-Android/pull/9661
To test:
TEST A
1. turn airplane mode ON
2. start a draft, give it a title, some content
3. exit the editor and observe it's saved as Local Drafts
4. open it again
5. edit the title or content
6. tap on SAVE (navigation bar)
7. Notice the "Ready to publish? Keep editing / Publish immediately" dialog is NOT shown
-----------------
TEST B
1. start a draft post, enter some title and body
2. tap on the overflow menu icon and tap `Settings` 
3. set the status to `Pending review`
4. tap back twice (once to go back to editing, another one to exit the editor)
5. observe the Post gets saved and reflects on the Posts list as `Pending review`
6. open it again
7. open the menu and tap on `Publish Now`
8. accept the confirmation dialog
9. observe the Post gets published.
-----------------
TEST C
1. start a draft post, enter some title and body
2. tap PUBLISH on the action bar
3. accept the confirmation dialog
4. observe the Post gets published.
-----------------
TEST D
1. start a draft post, enter some title and body
2. exit the editor so it gets saved as a Draft
3. open it again
4. tap on the overflow menu icon and tap `Publish Now`
5. accept the confirmation dialog
6. observe the Post gets published.
-----------------
TEST E
1. tap on an existing, scheduled Post in the Post list to open it
2. open the overflow menu and tap `Publish Now`
3. accept the confirmation dialog
4. observe the post actually gets published (post list updated, post is published on the web, etc.)
-----------------
TEST F
1. tap on an existing, scheduled Post in the Post list to open it
2. tap on SCHEDULE (main action button on the navigation bar)
3. it should just update the Post on the server (as nothing changed, it'll remain scheduled as it already was)
-----------------
TEST G
1. start a new draft
2. enter something in title and body
3. tap on the menu icon and tap on Settings
4. change the post status from Draft to Published
5. go back to editing
6. now open the overflow menu again
7. tap `Save as draft`
8. observe a snackbar is shown "Your post is uploading", toast is shown "Post converted back to draft" and it effectively gets uploaded as a Draft.~

-----------------
TEST H - I've filled an issue for this scenario https://github.com/wordpress-mobile/WordPress-Android/issues/10021 as it doesn't work. But I believe it's not related to this PR.
1. start a draft, enter title and text
2. post settings -> change status from `Draft` to  `Publish`
3. exit the editor
4. observe it's been saved as a Local Draft (that's fine)
5. ok so, open it again
6. tap on PUBLISH
7. observe the Post gets uploaded and published

Update release notes:

- The changes are too minor
