### PR TITLE
Gutenberg mobile release v1.7.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,9 @@
 -----
 * Show upload in progress notification when retrying
 * Fix issue where two identical drafts were created
+* Block Editor: Fixed keyboard flickering issue after pressing Enter repeatedly on the Post Title.
+* Block Editor: New blocks are available: video/quote/more
+* Block Editor: performance improvements
 
 12.6
 -----


### PR DESCRIPTION
This PR updates the gutenberg-mobile reference to point to the latest release, v1.7.0.

The reference is currently pointing to the release/1.7.0 branch on https://github.com/wordpress-mobile/gutenberg-mobile. Relevant PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1116.

To test:
The block editor should work as normal.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
