### PR TITLE
WIP: Prevent LocalDraftUploadStarter from publishing a post

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 -----
 * Show upload in progress notification when retrying
 * Fix issue where two identical drafts were created
-
+* Fix issue where post with "Publish" status got automatically published
 12.6
 -----
 * Add Insights management introductory card

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.SiteStore
@@ -136,6 +137,7 @@ open class LocalDraftUploadStarter @Inject constructor(
         postsAndPages
                 .filterNot { uploadServiceFacade.isPostUploadingOrQueued(it) }
                 .filter { postUtilsWrapper.isPublishable(it) }
+                .filter { PostStatus.DRAFT.toString() == it.status || PostStatus.PENDING.toString() == it.status }
                 .forEach { localDraft ->
                     uploadServiceFacade.uploadPost(
                             context = context,


### PR DESCRIPTION
Fixes #10021 

Local drafts with "Publish" status got automatically uploaded to the server which resulted in them being published.

I prevented the app from automatically uploading local drafts which have different status then "Draft" or "Pending". Another solution would be to change their status back to "Draft" when the user leaves the editor. However, it might cause some side-effect. Eg. user picks a schedule date and when they leave the editor and come back they need to pick it again.

SideNote: We might want to consider creating a hotfix for this issue. Wdyt?

To test:
1. start a draft, enter title and text
2. post settings -> change status from Draft to Publish
3. Turn on airplane mode and exit the editor
4. The post is saved as local draft
5. Turn off airplane mode
6. Pull-to-refresh -> notice the post remains marked as "Local draft"

-----------------
1. start a draft, enter title and text
2. post settings -> change status from Draft to Publish
3. exit the editor
4. Notice the post is marked as "Local draft"

Update release notes:
- udpated
