### PR TITLE
Use the stylesheet field as identifier for the customizer url

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
@@ -6,6 +6,8 @@ import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
 
+import androidx.annotation.NonNull;
+
 import org.wordpress.android.R;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.ThemeModel;
@@ -43,7 +45,8 @@ public class ThemeWebActivity extends WPWebViewActivity {
         return WPWebViewActivity.getSiteLoginUrl(site);
     }
 
-    public static void openTheme(Activity activity, SiteModel site, ThemeModel theme, ThemeWebActivityType type) {
+    public static void openTheme(Activity activity, @NonNull SiteModel site, @NonNull ThemeModel theme,
+                                 @NonNull ThemeWebActivityType type) {
         String url = getUrl(site, theme, type, !theme.isFree());
         if (TextUtils.isEmpty(url)) {
             ToastUtils.showToast(activity, R.string.could_not_load_theme);
@@ -83,7 +86,16 @@ public class ThemeWebActivity extends WPWebViewActivity {
         activity.startActivityForResult(intent, ThemeBrowserActivity.ACTIVATE_THEME);
     }
 
-    public static String getUrl(SiteModel site, ThemeModel theme, ThemeWebActivityType type, boolean isPremium) {
+    public static String getIdentifierForCustomizer(@NonNull SiteModel site, @NonNull ThemeModel theme) {
+        if (site.isJetpackConnected()) {
+            return theme.getThemeId();
+        } else {
+            return theme.getStylesheet();
+        }
+    }
+
+    public static String getUrl(@NonNull SiteModel site, @NonNull ThemeModel theme, @NonNull ThemeWebActivityType type,
+                                boolean isPremium) {
         if (theme.isWpComTheme()) {
             switch (type) {
                 case PREVIEW:
@@ -105,7 +117,7 @@ public class ThemeWebActivity extends WPWebViewActivity {
         } else {
             switch (type) {
                 case PREVIEW:
-                    return site.getAdminUrl() + "customize.php?theme=" + theme.getThemeId();
+                    return site.getAdminUrl() + "customize.php?theme=" + getIdentifierForCustomizer(site, theme);
                 case DEMO:
                     return site.getAdminUrl() + "themes.php?theme=" + theme.getThemeId();
                 case DETAILS:


### PR DESCRIPTION
Fixes #10030 

I got the logic [from Calypso](https://github.com/Automattic/wp-calypso/blob/59bdfeeb97eda4266ad39410cb0a074d2c88dbc8/client/state/themes/selectors.js#L444-L452). Some rationale on the [original PR
](https://github.com/Automattic/wp-calypso/pull/11228)

To test: 
- open the customizer for a Site using Pachyderm: https://bia.is/s/FW1D/pachyderm-theme.webm
- make sure the customizer open in the app browser.

Update release notes:

- Minor change, I haven't added an item to `RELEASE-NOTES.txt`.
