### PR TITLE
Issue/10031 Add comments to Tracks events which are part of critical path

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -847,6 +847,8 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
             }
             AnalyticsUtils.refreshMetadata(mAccountStore, mSiteStore);
             mApplicationOpenedDate = new Date();
+            // This stat is part of a funnel that provides critical information.  Before
+            // making ANY modification to this stat please refer to: p4qSXL-35X-p2
             AnalyticsTracker.track(Stat.APPLICATION_OPENED);
             if (NetworkUtils.isNetworkAvailable(mContext)) {
                 // Refresh account informations and Notifications

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -381,6 +381,8 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
 
     @Override
     public void doStartSignup() {
+        // This stat is part of a funnel that provides critical information.  Before
+        // making ANY modification to this stat please refer to: p4qSXL-35X-p2
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_BUTTON_TAPPED);
         mSignupSheet = new SignupBottomSheetDialog(this, this);
         mSignupSheet.show();

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
@@ -97,6 +97,10 @@ class SiteCreationTracker @Inject constructor(val tracker: AnalyticsTrackerWrapp
         tracker.track(AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_PREVIEW_OK_BUTTON_TAPPED)
     }
 
+    /**
+     * This stat is part of a funnel that provides critical information.  Before
+     * making ANY modification to this stat please refer to: p4qSXL-35X-p2
+     */
     fun trackSiteCreated() {
         tracker.track(AnalyticsTracker.Stat.SITE_CREATED)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceManager.kt
@@ -82,6 +82,8 @@ class SiteCreationServiceManager @Inject constructor(
             }
             SUCCESS -> {
                 updateServiceState(SUCCESS, newSiteRemoteId)
+                // This stat is part of a funnel that provides critical information.  Before
+                // making ANY modification to this stat please refer to: p4qSXL-35X-p2
                 tracker.trackSiteCreated()
             }
             FAILURE -> {

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -502,6 +502,8 @@ public class AnalyticsUtils {
      */
     public static void trackAnalyticsAccountCreated(String username, String email) {
         AnalyticsUtils.refreshMetadataNewUser(username, email);
+        // This stat is part of a funnel that provides critical information.  Before
+        // making ANY modification to this stat please refer to: p4qSXL-35X-p2
         AnalyticsTracker.track(Stat.CREATED_ACCOUNT);
     }
 

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -20,6 +20,8 @@ public final class AnalyticsTracker {
     public static final String NOTIFICATIONS_SELECTED_FILTER = "selected_filter";
 
     public enum Stat {
+        // This stat is part of a funnel that provides critical information.  Before
+        // making ANY modification to this stat please refer to: p4qSXL-35X-p2
         APPLICATION_OPENED,
         APPLICATION_CLOSED,
         APPLICATION_INSTALLED,
@@ -273,6 +275,8 @@ public final class AnalyticsTracker {
         CREATE_ACCOUNT_EMAIL_EXISTS,
         CREATE_ACCOUNT_USERNAME_EXISTS,
         CREATE_ACCOUNT_FAILED,
+        // This stat is part of a funnel that provides critical information.  Before
+        // making ANY modification to this stat please refer to: p4qSXL-35X-p2
         CREATED_ACCOUNT,
         CREATED_SITE,
         ACCOUNT_LOGOUT,
@@ -340,6 +344,8 @@ public final class AnalyticsTracker {
         PAGES_TAB_PRESSED,
         PAGES_OPTIONS_PRESSED,
         PAGES_SEARCH_ACCESSED,
+        // This stat is part of a funnel that provides critical information.  Before
+        // making ANY modification to this stat please refer to: p4qSXL-35X-p2
         SIGNUP_BUTTON_TAPPED,
         SIGNUP_EMAIL_BUTTON_TAPPED,
         SIGNUP_EMAIL_EPILOGUE_GRAVATAR_CROPPED,
@@ -392,6 +398,8 @@ public final class AnalyticsTracker {
         ENHANCED_SITE_CREATION_EXITED,
         ENHANCED_SITE_CREATION_ERROR_SHOWN,
         ENHANCED_SITE_CREATION_BACKGROUND_SERVICE_UPDATED,
+        // This stat is part of a funnel that provides critical information.  Before
+        // making ANY modification to this stat please refer to: p4qSXL-35X-p2
         SITE_CREATED,
         MEDIA_LIBRARY_ADDED_PHOTO,
         MEDIA_LIBRARY_ADDED_VIDEO,

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -278,7 +278,6 @@ public final class AnalyticsTracker {
         // This stat is part of a funnel that provides critical information.  Before
         // making ANY modification to this stat please refer to: p4qSXL-35X-p2
         CREATED_ACCOUNT,
-        CREATED_SITE,
         ACCOUNT_LOGOUT,
         SHARED_ITEM,
         SHARED_ITEM_READER,

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -935,8 +935,6 @@ public class AnalyticsTrackerNosara extends Tracker {
                 // This stat is part of a funnel that provides critical information.  Before
                 // making ANY modification to this stat please refer to: p4qSXL-35X-p2
                 return "account_created";
-            case CREATED_SITE:
-                return "site_created";
             case SHARED_ITEM:
                 return "item_shared";
             case SHARED_ITEM_READER:

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -568,6 +568,8 @@ public class AnalyticsTrackerNosara extends Tracker {
 
         switch (stat) {
             case APPLICATION_OPENED:
+                // This stat is part of a funnel that provides critical information.  Before
+                // making ANY modification to this stat please refer to: p4qSXL-35X-p2
                 return "application_opened";
             case APPLICATION_CLOSED:
                 return "application_closed";
@@ -930,6 +932,8 @@ public class AnalyticsTrackerNosara extends Tracker {
             case CREATE_ACCOUNT_FAILED:
                 return "account_create_failed";
             case CREATED_ACCOUNT:
+                // This stat is part of a funnel that provides critical information.  Before
+                // making ANY modification to this stat please refer to: p4qSXL-35X-p2
                 return "account_created";
             case CREATED_SITE:
                 return "site_created";
@@ -1146,6 +1150,8 @@ public class AnalyticsTrackerNosara extends Tracker {
             case PAGES_SEARCH_ACCESSED:
                 return "site_pages_search_accessed";
             case SIGNUP_BUTTON_TAPPED:
+                // This stat is part of a funnel that provides critical information.  Before
+                // making ANY modification to this stat please refer to: p4qSXL-35X-p2
                 return "signup_button_tapped";
             case SIGNUP_EMAIL_BUTTON_TAPPED:
                 return "signup_email_button_tapped";
@@ -1250,6 +1256,8 @@ public class AnalyticsTrackerNosara extends Tracker {
             case ENHANCED_SITE_CREATION_BACKGROUND_SERVICE_UPDATED:
                 return "enhanced_site_creation_background_service_updated";
             case SITE_CREATED:
+                // This stat is part of a funnel that provides critical information.  Before
+                // making ANY modification to this stat please refer to: p4qSXL-35X-p2
                 return "site_created";
             case PERSON_REMOVED:
                 return "people_management_person_removed";


### PR DESCRIPTION
Fixes #10031 

- Adds comments to events which are part of a critical funnel.
- Also removes `CREATED_SITE` enum value which has duplicate `SITE_CREATED`.

To test:
- Make sure I haven't forgotten to add a comment to one of the places.
- Make sure "CREATED_SITE" enum value was not being used

Update release notes:

- There are no user facing changes
