### PR TITLE
Fix #9825: hide the secondary update button on published posts and create a new confirmation dialog for post updates

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1165,7 +1165,8 @@ public class EditPostActivity extends AppCompatActivity implements
         MenuItem discardChanges = menu.findItem(R.id.menu_discard_changes);
 
         if (saveAsDraftMenuItem != null && mPost != null) {
-            if (PostStatus.fromPost(mPost) == PostStatus.PRIVATE) {
+            if (PostStatus.fromPost(mPost) == PostStatus.PRIVATE
+                || PostStatus.fromPost(mPost) == PostStatus.PUBLISHED) {
                 saveAsDraftMenuItem.setVisible(false);
             } else {
                 saveAsDraftMenuItem.setVisible(showMenuItems);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -241,6 +241,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private static final String TAG_DISCARDING_CHANGES_ERROR_DIALOG = "tag_discarding_changes_error_dialog";
     private static final String TAG_DISCARDING_CHANGES_NO_NETWORK_DIALOG = "tag_discarding_changes_no_network_dialog";
     private static final String TAG_PUBLISH_CONFIRMATION_DIALOG = "tag_publish_confirmation_dialog";
+    private static final String TAG_UPDATE_CONFIRMATION_DIALOG = "tag_update_confirmation_dialog";
     private static final String TAG_REMOVE_FAILED_UPLOADS_DIALOG = "tag_remove_failed_uploads_dialog";
     private static final String TAG_GB_INFORMATIVE_DIALOG = "tag_gb_informative_dialog";
 
@@ -856,7 +857,7 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private enum MainAction {
-        SUBMIT_FOR_REVIEW,
+        SUBMIT_POST_FOR_REVIEW,
         SCHEDULE_POST,
         PUBLISH_POST,
         UPDATE_POST,
@@ -865,7 +866,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
     private MainAction getMainAction() {
         if (!userCanPublishPosts()) {
-            return MainAction.SUBMIT_FOR_REVIEW;
+            return MainAction.SUBMIT_POST_FOR_REVIEW;
         }
 
         switch (PostStatus.fromPost(mPost)) {
@@ -898,7 +899,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
     private String getSaveButtonText() {
         switch (getMainAction()) {
-            case SUBMIT_FOR_REVIEW:
+            case SUBMIT_POST_FOR_REVIEW:
                 return getString(R.string.submit_for_review);
             case SCHEDULE_POST:
                 return getString(R.string.schedule_verb);
@@ -1505,8 +1506,9 @@ public class EditPostActivity extends AppCompatActivity implements
                 mHtmlModeMenuStateOn ? Editor.HTML : (isGutenberg ? Editor.GUTENBERG : Editor.CLASSIC));
     }
 
-    private void showUpdateConfirmationDialogAndPublishPost() {
-        showConfirmationDialogAndUploadPost(getString(R.string.dialog_confirm_update_title),
+    private void showUpdateConfirmationDialogAndUploadPost() {
+        showConfirmationDialogAndUploadPost(TAG_UPDATE_CONFIRMATION_DIALOG,
+                getString(R.string.dialog_confirm_update_title),
                 mPost.isPage() ? getString(R.string.dialog_confirm_update_message_page)
                         : getString(R.string.dialog_confirm_update_message_post),
                 getString(R.string.dialog_confirm_update_yes),
@@ -1514,19 +1516,20 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private void showPublishConfirmationDialogAndPublishPost() {
-        showConfirmationDialogAndUploadPost(getString(R.string.dialog_confirm_publish_title),
+        showConfirmationDialogAndUploadPost(TAG_PUBLISH_CONFIRMATION_DIALOG,
+                getString(R.string.dialog_confirm_publish_title),
                 mPost.isPage() ? getString(R.string.dialog_confirm_publish_message_page)
                         : getString(R.string.dialog_confirm_publish_message_post),
                 getString(R.string.dialog_confirm_publish_yes),
                 getString(R.string.keep_editing));
     }
 
-    private void showConfirmationDialogAndUploadPost(@NonNull String title, @NonNull String description,
-                                                     @NonNull String positiveButton, @NonNull String negativeButton) {
+    private void showConfirmationDialogAndUploadPost(@NonNull String identifier, @NonNull String title,
+                                                     @NonNull String description, @NonNull String positiveButton,
+                                                     @NonNull String negativeButton) {
         BasicFragmentDialog publishConfirmationDialog = new BasicFragmentDialog();
-        publishConfirmationDialog
-                .initialize(TAG_PUBLISH_CONFIRMATION_DIALOG, title, description, positiveButton, negativeButton, null);
-        publishConfirmationDialog.show(getSupportFragmentManager(), TAG_PUBLISH_CONFIRMATION_DIALOG);
+        publishConfirmationDialog.initialize(identifier, title, description, positiveButton, negativeButton, null);
+        publishConfirmationDialog.show(getSupportFragmentManager(), identifier);
     }
 
     private void showPublishConfirmationIfNeeded() {
@@ -1535,10 +1538,10 @@ public class EditPostActivity extends AppCompatActivity implements
                 showPublishConfirmationDialogAndPublishPost();
                 return;
             case UPDATE_POST:
-                showUpdateConfirmationDialogAndPublishPost();
+                showUpdateConfirmationDialogAndUploadPost();
                 return;
             // In other cases, we'll upload the post and don't change its status
-            case SUBMIT_FOR_REVIEW:
+            case SUBMIT_POST_FOR_REVIEW:
             case SCHEDULE_POST:
             case SAVE_DRAFT:
             default:
@@ -1766,6 +1769,7 @@ public class EditPostActivity extends AppCompatActivity implements
             case TAG_DISCARDING_CHANGES_ERROR_DIALOG:
             case TAG_DISCARDING_CHANGES_NO_NETWORK_DIALOG:
             case TAG_PUBLISH_CONFIRMATION_DIALOG:
+            case TAG_UPDATE_CONFIRMATION_DIALOG:
             case TAG_REMOVE_FAILED_UPLOADS_DIALOG:
                 break;
             default:
@@ -1787,6 +1791,9 @@ public class EditPostActivity extends AppCompatActivity implements
                 break;
             case TAG_DISCARDING_CHANGES_ERROR_DIALOG:
                 mZendeskHelper.createNewTicket(this, Origin.DISCARD_CHANGES, mSite);
+                break;
+            case TAG_UPDATE_CONFIRMATION_DIALOG:
+                uploadPost(false);
                 break;
             case TAG_PUBLISH_CONFIRMATION_DIALOG:
                 uploadPost(true);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -327,6 +327,10 @@
     <string name="dialog_confirm_publish_message_post">This post will be published immediately.</string>
     <string name="dialog_confirm_publish_message_page">This page will be published immediately.</string>
     <string name="dialog_confirm_publish_yes">Publish now</string>
+    <string name="dialog_confirm_update_title">Ready to Update?</string>
+    <string name="dialog_confirm_update_message_post">This published post will be updated immediately.</string>
+    <string name="dialog_confirm_update_message_page">This published page will be updated immediately.</string>
+    <string name="dialog_confirm_update_yes">Update now</string>
     <string name="dialog_confirm_delete_permanently_post">Are you sure you\'d like to permanently delete this post?</string>
 
     <!-- post version sync conflict dialog -->


### PR DESCRIPTION
Fix #9825: hide the secondary update button on published posts and create a new confirmation dialog for post updates.

To test:
- Edit a published post.
- Check there is no secondary push action in the overflow menu.
- Edit the post, tap the `Update` primary action, notice the dialog.

Note that the PR changes the logic a bit:
- I removed the `Update` primary option on remote drafts (it's now showing `Save`).

Update release notes:
- minor change, no change to the `RELEASE-NOTES.txt`.
