### PR TITLE
Handle 2FA error for OAuth client during login

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Using another account like bar@email.com will cause the `Client cannot use "pass
 
 For security reasons, some account-related actions aren't supported for development 
 builds when using a WordPress.com account with 2-factor authentication enabled.
-There is also currently an [issue](https://github.com/wordpress-mobile/WordPress-Android/issues/8754) where a restart of the app is required to complete login in this case. 
 
 Read more about [OAuth2][6] and the [WordPress.com REST endpoint][7].
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -301,8 +301,12 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
         } else {
             if (event.isError()) {
                 switch (event.error.type) {
-                    case SETTINGS_FETCH_ERROR:
+                    case SETTINGS_FETCH_GENERIC_ERROR:
                         ToastUtils.showToast(getActivity(), R.string.error_fetch_account_settings,
+                                ToastUtils.Duration.LONG);
+                        break;
+                    case SETTINGS_FETCH_REAUTHORIZATION_REQUIRED_ERROR:
+                        ToastUtils.showToast(getActivity(), R.string.error_disabled_apis,
                                 ToastUtils.Duration.LONG);
                         break;
                     case SETTINGS_POST_ERROR:

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -213,9 +213,13 @@ public class AppSettingsFragment extends PreferenceFragment
 
         if (event.isError()) {
             switch (event.error.type) {
-                case SETTINGS_FETCH_ERROR:
+                case SETTINGS_FETCH_GENERIC_ERROR:
                     ToastUtils
                             .showToast(getActivity(), R.string.error_fetch_account_settings, ToastUtils.Duration.LONG);
+                    break;
+                case SETTINGS_FETCH_REAUTHORIZATION_REQUIRED_ERROR:
+                    ToastUtils.showToast(getActivity(), R.string.error_disabled_apis,
+                            ToastUtils.Duration.LONG);
                     break;
                 case SETTINGS_POST_ERROR:
                     ToastUtils.showToast(getActivity(), R.string.error_post_account_settings, ToastUtils.Duration.LONG);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1480,6 +1480,7 @@
     <string name="error_refresh_unauthorized_posts">You don\'t have permission to view or edit posts</string>
     <string name="error_fetch_my_profile">Couldn\'t retrieve your profile</string>
     <string name="error_fetch_account_settings">Couldn\'t retrieve your account settings</string>
+    <string name="error_disabled_apis">Could not fetch settings: Some APIs are disabled for this account + client ID combination.</string>
     <string name="error_post_my_profile_no_connection">No connection, couldn\'t save your profile</string>
     <string name="error_post_account_settings">Couldn\'t save your account settings</string>
     <string name="error_generic">An error occurred</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1480,7 +1480,7 @@
     <string name="error_refresh_unauthorized_posts">You don\'t have permission to view or edit posts</string>
     <string name="error_fetch_my_profile">Couldn\'t retrieve your profile</string>
     <string name="error_fetch_account_settings">Couldn\'t retrieve your account settings</string>
-    <string name="error_disabled_apis">Could not fetch settings: Some APIs are disabled for this account + client ID combination.</string>
+    <string name="error_disabled_apis">Could not fetch settings: Some APIs are unavailable for this OAuth app ID + account combination.</string>
     <string name="error_post_my_profile_no_connection">No connection, couldn\'t save your profile</string>
     <string name="error_post_account_settings">Couldn\'t save your account settings</string>
     <string name="error_generic">An error occurred</string>

--- a/build.gradle
+++ b/build.gradle
@@ -105,5 +105,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '3a44520084671ff0018086933626075b5e323d98'
+    fluxCVersion = 'a978c7b736e08f0bc7959b1ef6b87d5975abb423'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -105,5 +105,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'a978c7b736e08f0bc7959b1ef6b87d5975abb423'
+    fluxCVersion = '9f07b031646dd3e6021d4b8e0a35647c9109ff27'
 }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
@@ -34,6 +34,7 @@ import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.AccountStore.AccountErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
@@ -41,6 +42,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.ToastUtils.Duration;
 
 import javax.inject.Inject;
 
@@ -291,9 +293,15 @@ public abstract class LoginBaseFormFragment<LoginListenerType> extends Fragment 
 
         if (event.isError()) {
             AppLog.e(AppLog.T.API, "onAccountChanged has error: " + event.error.type + " - " + event.error.message);
-            ToastUtils.showToast(getContext(), R.string.error_fetch_my_profile);
-            onLoginFinished(false);
-            return;
+            if (event.error.type == AccountErrorType.SETTINGS_FETCH_REAUTHORIZATION_REQUIRED_ERROR) {
+                // This probably means we're logging in to 2FA-enabled account with a non-production WP.com client id.
+                // A few WordPress.com APIs like /me/settings/ won't work for this account.
+                ToastUtils.showToast(getContext(), R.string.error_disabled_apis, Duration.LONG);
+            } else {
+                ToastUtils.showToast(getContext(), R.string.error_fetch_my_profile, Duration.LONG);
+                onLoginFinished(false);
+                return;
+            }
         }
 
         if (event.causeOfChange == AccountAction.FETCH_ACCOUNT) {

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -82,6 +82,7 @@
     <string name="cannot_add_duplicate_site">This site already exists in the app, you can\'t add it.</string>
     <string name="duplicate_site_detected">A duplicate site has been detected.</string>
     <string name="error_fetch_my_profile">Couldn\'t retrieve your profile</string>
+    <string name="error_disabled_apis">Could not fetch settings: Some APIs are disabled for this account + client ID combination.</string>
     <string name="login_to_to_connect_jetpack">Log in to the WordPress.com account you used to connect Jetpack.</string>
     <string name="auth_required">Log in again to continue.</string>
     <string name="checking_email">Checking email</string>

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -82,7 +82,7 @@
     <string name="cannot_add_duplicate_site">This site already exists in the app, you can\'t add it.</string>
     <string name="duplicate_site_detected">A duplicate site has been detected.</string>
     <string name="error_fetch_my_profile">Couldn\'t retrieve your profile</string>
-    <string name="error_disabled_apis">Could not fetch settings: Some APIs are disabled for this account + client ID combination.</string>
+    <string name="error_disabled_apis">Could not fetch settings: Some APIs are unavailable for this OAuth app ID + account combination.</string>
     <string name="login_to_to_connect_jetpack">Log in to the WordPress.com account you used to connect Jetpack.</string>
     <string name="auth_required">Log in again to continue.</string>
     <string name="checking_email">Checking email</string>


### PR DESCRIPTION
Fixes #8754. **Relies on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1283, which should be reviewed and merged first.**

When logging into a 2FA-enabled account with personal (non-production) OAuth clients, login will no longer halt. Instead, you'll get a warning about disabled APIs and the flow will proceed:

![2fa-warning-android](https://user-images.githubusercontent.com/9613966/59440323-c46b8d00-8dc4-11e9-839d-cd4dc687d9e5.png)

See https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1283 for some background on the error and what it means.

### To test:

1. Generate an OAuth client id and secret for an account that has 2fa enabled ([instructions](https://github.com/wordpress-mobile/WordPress-Android/#oauth2-authentication)).
2. Update `wp.OAUTH.APP.ID` and `wp.OAUTH.APP.SECRET` in `gradle.properties` to those values.
3. Run a clean build of the app, and log into the account the credentials belong to.
4. After entering the 2FA code, confirm that you see the error in the screenshot above, and that login completes without incident.
5. Confirm that the app otherwise behaves normally after login.
6. Visit `Me > Account Settings` and `Me > App Settings`, and confirm you get the same toast warning.

### Update release notes:
- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

(This change only affects developers using personal OAuth credentials, no user-facing changes for WPAndroid.)