### PR TITLE
Shorten numbers on small widgets

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
@@ -32,7 +32,8 @@ class OverviewMapper
         selectedItem: PeriodData?,
         previousItem: PeriodData?,
         selectedPosition: Int,
-        isLast: Boolean
+        isLast: Boolean,
+        startValue: Int = MILLION
     ): ValueItem {
         val value = selectedItem?.getValue(selectedPosition) ?: 0
         val previousValue = previousItem?.getValue(selectedPosition)
@@ -56,7 +57,7 @@ class OverviewMapper
             else -> State.NEGATIVE
         }
         return ValueItem(
-                value = value.toFormattedString(MILLION),
+                value = value.toFormattedString(startValue),
                 unit = units[selectedPosition],
                 isFirst = true,
                 change = change,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/StatsWidget.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/StatsWidget.kt
@@ -8,7 +8,7 @@ import android.os.Bundle
 import org.wordpress.android.WordPress
 import org.wordpress.android.modules.AppComponent
 
-const val SHOW_CHANGE_VALUE_KEY = "show_change_value_key"
+const val WIDE_VIEW_KEY = "show_change_value_key"
 const val SITE_ID_KEY = "site_id_key"
 
 abstract class StatsWidget : AppWidgetProvider() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetListProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetListProvider.kt
@@ -27,7 +27,7 @@ class AllTimeWidgetListProvider(val context: Context, intent: Intent) : RemoteVi
     }
 
     override fun onCreate() {
-        viewModel.start(siteId, colorMode.ordinal, appWidgetId)
+        viewModel.start(siteId, colorMode, appWidgetId)
     }
 
     override fun getLoadingView(): RemoteViews? = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetListViewModel.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.model.stats.InsightsAllTimeModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.AllTimeInsightsStore
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
+import org.wordpress.android.ui.stats.refresh.utils.ONE_THOUSAND
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
@@ -18,13 +19,13 @@ class AllTimeWidgetListViewModel
     private val resourceProvider: ResourceProvider
 ) {
     private var siteId: Long? = null
-    private var colorModeId: Int? = null
+    private var colorMode: Color = Color.LIGHT
     private var appWidgetId: Int? = null
     private val mutableData = mutableListOf<AllTimeItemUiModel>()
     val data: List<AllTimeItemUiModel> = mutableData
-    fun start(siteId: Long, colorModeId: Int, appWidgetId: Int) {
+    fun start(siteId: Long, colorMode: Color, appWidgetId: Int) {
         this.siteId = siteId
-        this.colorModeId = colorModeId
+        this.colorMode = colorMode
         this.appWidgetId = appWidgetId
     }
 
@@ -54,35 +55,34 @@ class AllTimeWidgetListViewModel
         domainModel: InsightsAllTimeModel,
         localSiteId: Long
     ): List<AllTimeItemUiModel> {
-        val layout = when (colorModeId) {
-            Color.DARK.ordinal -> R.layout.stats_views_widget_item_dark
-            Color.LIGHT.ordinal -> R.layout.stats_views_widget_item_light
-            else -> R.layout.stats_views_widget_item_light
+        val layout = when (colorMode) {
+            Color.DARK -> R.layout.stats_views_widget_item_dark
+            Color.LIGHT -> R.layout.stats_views_widget_item_light
         }
         return listOf(
                 AllTimeItemUiModel(
                         layout,
                         localSiteId,
                         resourceProvider.getString(R.string.stats_views),
-                        domainModel.views.toFormattedString()
+                        domainModel.views.toFormattedString(ONE_THOUSAND)
                 ),
                 AllTimeItemUiModel(
                         layout,
                         localSiteId,
                         resourceProvider.getString(R.string.stats_visitors),
-                        domainModel.visitors.toFormattedString()
+                        domainModel.visitors.toFormattedString(ONE_THOUSAND)
                 ),
                 AllTimeItemUiModel(
                         layout,
                         localSiteId,
                         resourceProvider.getString(R.string.posts),
-                        domainModel.posts.toFormattedString()
+                        domainModel.posts.toFormattedString(ONE_THOUSAND)
                 ),
                 AllTimeItemUiModel(
                         layout,
                         localSiteId,
                         resourceProvider.getString(R.string.stats_insights_best_ever),
-                        domainModel.viewsBestDayTotal.toFormattedString()
+                        domainModel.viewsBestDayTotal.toFormattedString(ONE_THOUSAND)
                 )
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetUpdater.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.ViewType.ALL_TIME_VIEWS
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color.LIGHT
 import org.wordpress.android.ui.stats.refresh.lists.widget.utils.WidgetUtils
+import org.wordpress.android.ui.stats.refresh.utils.MILLION
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -42,12 +43,12 @@ class AllTimeWidgetUpdater
         appWidgetManager: AppWidgetManager,
         appWidgetId: Int
     ) {
-        val showColumns = widgetUtils.isWidgetWiderThanLimit(appWidgetManager, appWidgetId)
+        val wideView = widgetUtils.isWidgetWiderThanLimit(appWidgetManager, appWidgetId)
         val colorMode = appPrefsWrapper.getAppWidgetColor(appWidgetId) ?: LIGHT
         val siteId = appPrefsWrapper.getAppWidgetSiteId(appWidgetId)
         val siteModel = siteStore.getSiteBySiteId(siteId)
         val networkAvailable = networkUtilsWrapper.isNetworkAvailable()
-        val views = RemoteViews(context.packageName, widgetUtils.getLayout(showColumns, colorMode))
+        val views = RemoteViews(context.packageName, widgetUtils.getLayout(wideView, colorMode))
         views.setTextViewText(R.id.widget_title, resourceProvider.getString(R.string.stats_insights_all_time_stats))
         widgetUtils.setSiteIcon(siteModel, context, views, appWidgetId)
         siteModel?.let {
@@ -57,7 +58,7 @@ class AllTimeWidgetUpdater
             )
         }
         if (networkAvailable && siteModel != null) {
-            if (showColumns) {
+            if (wideView) {
                 views.setOnClickPendingIntent(
                         R.id.widget_content,
                         widgetUtils.getPendingSelfIntent(context, siteModel.id, INSIGHTS)
@@ -73,7 +74,7 @@ class AllTimeWidgetUpdater
                         colorMode,
                         siteId,
                         ALL_TIME_VIEWS,
-                        showColumns
+                        wideView
                 )
             }
         } else {
@@ -115,16 +116,17 @@ class AllTimeWidgetUpdater
     ) {
         val allTimeInsights = allTimeStore.getAllTimeInsights(site)
         views.setTextViewText(R.id.first_block_title, resourceProvider.getString(R.string.stats_views))
-        views.setTextViewText(R.id.first_block_value, allTimeInsights?.views?.toFormattedString() ?: EMPTY_VALUE)
+        val viewsValue = allTimeInsights?.views?.toFormattedString(MILLION) ?: EMPTY_VALUE
+        views.setTextViewText(R.id.first_block_value, viewsValue)
         views.setTextViewText(R.id.second_block_title, resourceProvider.getString(R.string.stats_visitors))
-        views.setTextViewText(R.id.second_block_value, allTimeInsights?.visitors?.toFormattedString() ?: EMPTY_VALUE)
+        val visitorsValue = allTimeInsights?.visitors?.toFormattedString(MILLION) ?: EMPTY_VALUE
+        views.setTextViewText(R.id.second_block_value, visitorsValue)
         views.setTextViewText(R.id.third_block_title, resourceProvider.getString(R.string.posts))
-        views.setTextViewText(R.id.third_block_value, allTimeInsights?.posts?.toFormattedString() ?: EMPTY_VALUE)
+        val postsValue = allTimeInsights?.posts?.toFormattedString(MILLION) ?: EMPTY_VALUE
+        views.setTextViewText(R.id.third_block_value, postsValue)
         views.setTextViewText(R.id.fourth_block_title, resourceProvider.getString(R.string.stats_insights_best_ever))
-        views.setTextViewText(
-                R.id.fourth_block_value,
-                allTimeInsights?.viewsBestDayTotal?.toFormattedString() ?: EMPTY_VALUE
-        )
+        val bestDayValue = allTimeInsights?.viewsBestDayTotal?.toFormattedString(MILLION) ?: EMPTY_VALUE
+        views.setTextViewText(R.id.fourth_block_value, bestDayValue)
         appWidgetManager.updateAppWidget(appWidgetId, views)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetListViewModel.kt
@@ -23,7 +23,7 @@ class TodayWidgetListViewModel
     private var appWidgetId: Int? = null
     private val mutableData = mutableListOf<TodayItemUiModel>()
     val data: List<TodayItemUiModel> = mutableData
-    fun  start(siteId: Long, colorMode: Color, appWidgetId: Int) {
+    fun start(siteId: Long, colorMode: Color, appWidgetId: Int) {
         this.siteId = siteId
         this.colorMode = colorMode
         this.appWidgetId = appWidgetId

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetListViewModel.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.model.stats.VisitsModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.TodayInsightsStore
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
+import org.wordpress.android.ui.stats.refresh.utils.ONE_THOUSAND
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
@@ -22,7 +23,7 @@ class TodayWidgetListViewModel
     private var appWidgetId: Int? = null
     private val mutableData = mutableListOf<TodayItemUiModel>()
     val data: List<TodayItemUiModel> = mutableData
-    fun start(siteId: Long, colorMode: Color, appWidgetId: Int) {
+    fun  start(siteId: Long, colorMode: Color, appWidgetId: Int) {
         this.siteId = siteId
         this.colorMode = colorMode
         this.appWidgetId = appWidgetId
@@ -63,25 +64,25 @@ class TodayWidgetListViewModel
                         layout,
                         localSiteId,
                         resourceProvider.getString(R.string.stats_views),
-                        domainModel.views.toFormattedString()
+                        domainModel.views.toFormattedString(ONE_THOUSAND)
                 ),
                 TodayItemUiModel(
                         layout,
                         localSiteId,
                         resourceProvider.getString(R.string.stats_visitors),
-                        domainModel.visitors.toFormattedString()
+                        domainModel.visitors.toFormattedString(ONE_THOUSAND)
                 ),
                 TodayItemUiModel(
                         layout,
                         localSiteId,
                         resourceProvider.getString(R.string.posts),
-                        domainModel.posts.toFormattedString()
+                        domainModel.posts.toFormattedString(ONE_THOUSAND)
                 ),
                 TodayItemUiModel(
                         layout,
                         localSiteId,
                         resourceProvider.getString(R.string.stats_comments),
-                        domainModel.comments.toFormattedString()
+                        domainModel.comments.toFormattedString(ONE_THOUSAND)
                 )
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
@@ -13,9 +13,8 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.TodayInsightsStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.StatsTimeframe
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.ViewType.TODAY_VIEWS
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.ViewType
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.ViewType.TODAY_VIEWS
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
 import org.wordpress.android.ui.stats.refresh.lists.widget.utils.WidgetUtils
 import org.wordpress.android.ui.stats.refresh.utils.MILLION

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
@@ -13,10 +13,11 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.TodayInsightsStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.StatsTimeframe
+import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.ViewType
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
-import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater
 import org.wordpress.android.ui.stats.refresh.lists.widget.utils.WidgetUtils
+import org.wordpress.android.ui.stats.refresh.utils.MILLION
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -36,12 +37,12 @@ class TodayWidgetUpdater
         appWidgetManager: AppWidgetManager,
         appWidgetId: Int
     ) {
-        val showColumns = widgetUtils.isWidgetWiderThanLimit(appWidgetManager, appWidgetId)
+        val wideView = widgetUtils.isWidgetWiderThanLimit(appWidgetManager, appWidgetId)
         val colorMode = appPrefsWrapper.getAppWidgetColor(appWidgetId) ?: Color.LIGHT
         val siteId = appPrefsWrapper.getAppWidgetSiteId(appWidgetId)
         val siteModel = siteStore.getSiteBySiteId(siteId)
         val networkAvailable = networkUtilsWrapper.isNetworkAvailable()
-        val views = RemoteViews(context.packageName, widgetUtils.getLayout(showColumns, colorMode))
+        val views = RemoteViews(context.packageName, widgetUtils.getLayout(wideView, colorMode))
         views.setTextViewText(R.id.widget_title, resourceProvider.getString(R.string.stats_insights_today_stats))
         widgetUtils.setSiteIcon(siteModel, context, views, appWidgetId)
         siteModel?.let {
@@ -54,7 +55,7 @@ class TodayWidgetUpdater
             )
         }
         if (networkAvailable && siteModel != null) {
-            if (showColumns) {
+            if (wideView) {
                 views.setOnClickPendingIntent(
                         R.id.widget_content,
                         widgetUtils.getPendingSelfIntent(context, siteModel.id, StatsTimeframe.INSIGHTS)
@@ -68,7 +69,8 @@ class TodayWidgetUpdater
                         appWidgetId,
                         colorMode,
                         siteId,
-                        ViewType.TODAY_VIEWS
+                        ViewType.TODAY_VIEWS,
+                        wideView
                 )
             }
         } else {
@@ -108,13 +110,13 @@ class TodayWidgetUpdater
     ) {
         val todayInsights = todayInsightsStore.getTodayInsights(site)
         views.setTextViewText(R.id.first_block_title, resourceProvider.getString(R.string.stats_views))
-        views.setTextViewText(R.id.first_block_value, todayInsights?.views?.toFormattedString() ?: "-")
+        views.setTextViewText(R.id.first_block_value, todayInsights?.views?.toFormattedString(MILLION) ?: "-")
         views.setTextViewText(R.id.second_block_title, resourceProvider.getString(R.string.stats_visitors))
-        views.setTextViewText(R.id.second_block_value, todayInsights?.visitors?.toFormattedString() ?: "-")
+        views.setTextViewText(R.id.second_block_value, todayInsights?.visitors?.toFormattedString(MILLION) ?: "-")
         views.setTextViewText(R.id.third_block_title, resourceProvider.getString(R.string.posts))
-        views.setTextViewText(R.id.third_block_value, todayInsights?.posts?.toFormattedString() ?: "-")
+        views.setTextViewText(R.id.third_block_value, todayInsights?.posts?.toFormattedString(MILLION) ?: "-")
         views.setTextViewText(R.id.fourth_block_title, resourceProvider.getString(R.string.stats_comments))
-        views.setTextViewText(R.id.fourth_block_value, todayInsights?.comments?.toFormattedString() ?: "-")
+        views.setTextViewText(R.id.fourth_block_value, todayInsights?.comments?.toFormattedString(MILLION) ?: "-")
         appWidgetManager.updateAppWidget(appWidgetId, views)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
@@ -15,8 +15,8 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.stats.OldStatsActivity
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.StatsActivity
-import org.wordpress.android.ui.stats.refresh.lists.widget.SHOW_CHANGE_VALUE_KEY
 import org.wordpress.android.ui.stats.refresh.lists.widget.SITE_ID_KEY
+import org.wordpress.android.ui.stats.refresh.lists.widget.WIDE_VIEW_KEY
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetService
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.StatsAllTimeWidget
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.ViewType
@@ -108,7 +108,7 @@ class WidgetUtils
         colorMode: Color,
         siteId: Long,
         viewType: ViewType,
-        showChangeColumn: Boolean? = null
+        wideView: Boolean
     ) {
         views.setPendingIntentTemplate(R.id.widget_content, getPendingTemplate(context))
         views.setViewVisibility(R.id.widget_content, View.VISIBLE)
@@ -118,9 +118,7 @@ class WidgetUtils
         listIntent.putColorMode(colorMode)
         listIntent.putViewType(viewType)
         listIntent.putExtra(SITE_ID_KEY, siteId)
-        showChangeColumn?.let {
-            listIntent.putExtra(SHOW_CHANGE_VALUE_KEY, showChangeColumn)
-        }
+        listIntent.putExtra(WIDE_VIEW_KEY, wideView)
         listIntent.data = Uri.parse(
                 listIntent.toUri(Intent.URI_INTENT_SCHEME)
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetListProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetListProvider.kt
@@ -11,15 +11,15 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.ui.stats.OldStatsActivity
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.StatsActivity.Companion.INITIAL_SELECTED_PERIOD_KEY
-import org.wordpress.android.ui.stats.refresh.lists.widget.SHOW_CHANGE_VALUE_KEY
 import org.wordpress.android.ui.stats.refresh.lists.widget.SITE_ID_KEY
+import org.wordpress.android.ui.stats.refresh.lists.widget.WIDE_VIEW_KEY
 import org.wordpress.android.ui.stats.refresh.lists.widget.utils.getColorMode
 import javax.inject.Inject
 
 class ViewsWidgetListProvider(val context: Context, intent: Intent) : RemoteViewsFactory {
     @Inject lateinit var viewModel: ViewsWidgetListViewModel
     @Inject lateinit var viewsWidgetUpdater: ViewsWidgetUpdater
-    private val showChangeColumn: Boolean = intent.getBooleanExtra(SHOW_CHANGE_VALUE_KEY, true)
+    private val wideView: Boolean = intent.getBooleanExtra(WIDE_VIEW_KEY, true)
     private val colorMode = intent.getColorMode()
     private val siteId: Long = intent.getLongExtra(SITE_ID_KEY, 0L)
     private val appWidgetId = intent.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, -1)
@@ -29,7 +29,7 @@ class ViewsWidgetListProvider(val context: Context, intent: Intent) : RemoteView
     }
 
     override fun onCreate() {
-        viewModel.start(siteId, colorMode.ordinal, showChangeColumn, appWidgetId)
+        viewModel.start(siteId, colorMode, wideView, appWidgetId)
     }
 
     override fun getLoadingView(): RemoteViews? = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetListViewModel.kt
@@ -13,6 +13,8 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Value
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem.State.POSITIVE
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.OverviewMapper
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
+import org.wordpress.android.ui.stats.refresh.utils.MILLION
+import org.wordpress.android.ui.stats.refresh.utils.ONE_THOUSAND
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Date
@@ -29,15 +31,15 @@ class ViewsWidgetListViewModel
     private val statsDateFormatter: StatsDateFormatter
 ) {
     private var siteId: Long? = null
-    private var colorModeId: Int? = null
-    private var showChangeColumn: Boolean = true
+    private var colorMode: Color = Color.LIGHT
+    private var wideView: Boolean = true
     private var appWidgetId: Int? = null
     private val mutableData = mutableListOf<ListItemUiModel>()
     val data: List<ListItemUiModel> = mutableData
-    fun start(siteId: Long, colorModeId: Int, showChangeColumn: Boolean, appWidgetId: Int) {
+    fun start(siteId: Long, colorMode: Color, wideView: Boolean, appWidgetId: Int) {
         this.siteId = siteId
-        this.colorModeId = colorModeId
-        this.showChangeColumn = showChangeColumn
+        this.colorMode = colorMode
+        this.wideView = wideView
         this.appWidgetId = appWidgetId
     }
 
@@ -77,23 +79,23 @@ class ViewsWidgetListViewModel
         periods: List<PeriodData>,
         localSiteId: Int
     ): ListItemUiModel {
-        val layout = when (colorModeId) {
-            Color.DARK.ordinal -> R.layout.stats_views_widget_item_dark
-            Color.LIGHT.ordinal -> R.layout.stats_views_widget_item_light
-            else -> R.layout.stats_views_widget_item_light
+        val layout = when (colorMode) {
+            Color.DARK -> R.layout.stats_views_widget_item_dark
+            Color.LIGHT -> R.layout.stats_views_widget_item_light
         }
         val previousItem = periods.getOrNull(position + 1)
         val isCurrentDay = position == 0
-        val uiModel = overviewMapper.buildTitle(selectedItem, previousItem, 0, isCurrentDay)
+        val startValue = if (wideView) MILLION else ONE_THOUSAND
+        val uiModel = overviewMapper.buildTitle(selectedItem, previousItem, 0, isCurrentDay, startValue)
 
         val key = if (isCurrentDay) {
             resourceProvider.getString(R.string.stats_insights_today_stats)
         } else {
             statsDateFormatter.printDate(periods[position].period)
         }
-        val isPositiveChangeVisible = uiModel.state == POSITIVE && showChangeColumn && !uiModel.change.isNullOrEmpty()
-        val isNegativeChangeVisible = uiModel.state == NEGATIVE && showChangeColumn && !uiModel.change.isNullOrEmpty()
-        val isNeutralChangeVisible = uiModel.state == NEUTRAL && showChangeColumn && !uiModel.change.isNullOrEmpty()
+        val isPositiveChangeVisible = uiModel.state == POSITIVE && wideView && !uiModel.change.isNullOrEmpty()
+        val isNegativeChangeVisible = uiModel.state == NEGATIVE && wideView && !uiModel.change.isNullOrEmpty()
+        val isNeutralChangeVisible = uiModel.state == NEUTRAL && wideView && !uiModel.change.isNullOrEmpty()
         return ListItemUiModel(
                 layout,
                 key,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetUpdater.kt
@@ -11,10 +11,10 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.StatsTimeframe.DAY
 import org.wordpress.android.ui.stats.refresh.StatsActivity
+import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.ViewType.WEEK_VIEWS
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color.DARK
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color.LIGHT
-import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater
 import org.wordpress.android.ui.stats.refresh.lists.widget.utils.WidgetUtils
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -33,7 +33,7 @@ class ViewsWidgetUpdater
         appWidgetManager: AppWidgetManager,
         appWidgetId: Int
     ) {
-        val showChangeColumn = widgetUtils.isWidgetWiderThanLimit(appWidgetManager, appWidgetId)
+        val wideView = widgetUtils.isWidgetWiderThanLimit(appWidgetManager, appWidgetId)
         val colorMode = appPrefsWrapper.getAppWidgetColor(appWidgetId) ?: LIGHT
         val siteId = appPrefsWrapper.getAppWidgetSiteId(appWidgetId)
         val siteModel = siteStore.getSiteBySiteId(siteId)
@@ -61,7 +61,7 @@ class ViewsWidgetUpdater
                     colorMode,
                     siteId,
                     WEEK_VIEWS,
-                    showChangeColumn
+                    wideView
             )
         } else {
             widgetUtils.showError(appWidgetManager, views, appWidgetId, networkAvailable, resourceProvider, context)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
@@ -13,6 +13,7 @@ private val SUFFIXES = TreeMap(mapOf(
         1_000_000_000_000_000_000L to "E"
 ))
 
+const val ONE_THOUSAND = 1000
 const val TEN_THOUSAND = 10000
 const val HUNDRED_THOUSAND = 100000
 const val MILLION = 1000000

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCaseTest.kt
@@ -66,7 +66,7 @@ class OverviewUseCaseTest : BaseUnitTest() {
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         whenever(selectedDateProvider.getCurrentDate()).thenReturn(currentDate)
-        whenever(overviewMapper.buildTitle(any(), isNull(), any(), any())).thenReturn(title)
+        whenever(overviewMapper.buildTitle(any(), isNull(), any(), any(), any())).thenReturn(title)
         whenever(overviewMapper.buildChart(any(), any(), any(), any(), any(), any())).thenReturn(listOf(barChartItem))
         whenever(overviewMapper.buildColumns(any(), any(), any())).thenReturn(columns)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetListViewModelTest.kt
@@ -29,7 +29,7 @@ class AllTimeWidgetListViewModelTest {
     @Before
     fun setUp() {
         viewModel = AllTimeWidgetListViewModel(siteStore, allTimeStore, resourceProvider)
-        viewModel.start(siteId, color.ordinal, appWidgetId)
+        viewModel.start(siteId, color, appWidgetId)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetListViewModelTest.kt
@@ -76,6 +76,7 @@ class ViewsWidgetListViewModelTest {
                         eq(dates[0]),
                         isNull(),
                         any(),
+                        any(),
                         any()
                 )
         ).thenReturn(ValueItem(firstViews.toFormattedString(), 0, false, change, POSITIVE))
@@ -83,6 +84,7 @@ class ViewsWidgetListViewModelTest {
                 overviewMapper.buildTitle(
                         eq(dates[1]),
                         eq(dates[0]),
+                        any(),
                         any(),
                         any()
                 )
@@ -92,11 +94,12 @@ class ViewsWidgetListViewModelTest {
                         eq(dates[2]),
                         eq(dates[1]),
                         any(),
+                        any(),
                         any()
                 )
         ).thenReturn(ValueItem(todayViews.toFormattedString(), 0, true, change, NEUTRAL))
 
-        viewModel.start(siteId, color.ordinal, showChangeColumn, appWidgetId)
+        viewModel.start(siteId, color, showChangeColumn, appWidgetId)
 
         viewModel.onDataSetChanged { }
 
@@ -128,7 +131,7 @@ class ViewsWidgetListViewModelTest {
     fun `on missing site triggers error callback`() {
         whenever(siteStore.getSiteBySiteId(siteId)).thenReturn(null)
 
-        viewModel.start(siteId, color.ordinal, showChangeColumn, appWidgetId)
+        viewModel.start(siteId, color, showChangeColumn, appWidgetId)
 
         var errorCallbackTriggered = false
 


### PR DESCRIPTION
According to the specs, we need to shorten the numbers when the widget is small (in the list view). I'm shortening the numbers after 1000 on small widget widths and after 1 000 000 on bigger widths. This PR also includes some smaller refactorings.

This PR contains changes from https://github.com/wordpress-mobile/WordPress-Android/pull/10043 so it should be reviewed after it's merged.

To test:
* Check smaller and bigger widths on all the widgets and see that on the smallest size the get cropped.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
