### PR TITLE
Update login library subtree

### DIFF
--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -51,7 +51,7 @@ dependencies {
             exclude group: "org.wordpress", module: "utils"
         }
     } else {
-        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:8cdbf03cf3d595ef904bab3c1dc207e39242c882") {
+        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:9f07b031646dd3e6021d4b8e0a35647c9109ff27") {
             exclude group: "com.android.support"
             exclude group: "org.wordpress", module: "utils"
         }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupEmailFragment.java
@@ -325,6 +325,10 @@ public class SignupEmailFragment extends LoginBaseFormFragment<LoginListener> im
         super.onActivityResult(requestCode, resultCode, data);
 
         if (requestCode == EMAIL_CREDENTIALS_REQUEST_CODE) {
+            if (mEmailInput == null) {
+                // Activity result received before the fragments onCreateView(), disregard result.
+                return;
+            }
             if (resultCode == RESULT_OK) {
                 Credential credential = data.getParcelableExtra(Credential.EXTRA_KEY);
                 mEmailInput.getEditText().setText(credential.getId());


### PR DESCRIPTION
`subtree pull`s the latest change from the login library. Also a single commit updating the standalone FluxC hash for the login library - this is the hash used when building the library on its own, for example from CircleCI in the login lib repo.

Here's a draft PR in the login lib repo with the result of `subtree push` from this branch, which also includes the AndroidX changes: https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/20.

Once this current PR is merged into WPAndroid `develop`, I'll `subtree push` again from WPAndroid `develop` this time and open a fresh PR in the login lib.

#### To test:

Not much to do for this PR, but give https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/20 a look and verify the changes make sense.

#### Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

(Not applicable)