### PR TITLE
Remove feature flag and custom domain check from plugins row visibility check

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 * Block Editor: New blocks are available: video/quote/more
 * Block Editor: performance improvements
 * Fixed issue where text appeared behind list of themes on the theme screen
-* Domain Registration functionality for Business plan customers on a site without a custom domain who wish to install plugin(s)
+* Domain Registration functionality for Business plan customers on a site without a custom domain during plugin installation
 
 12.6
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 * Block Editor: New blocks are available: video/quote/more
 * Block Editor: performance improvements
 * Fixed issue where text appeared behind list of themes on the theme screen
-* Domain Registration functionality for Business plan customers on a site without custom domain who wish to install plugin(s)
+* Domain Registration functionality for Business plan customers on a site without a custom domain who wish to install plugin(s)
 
 12.6
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * Block Editor: New blocks are available: video/quote/more
 * Block Editor: performance improvements
 * Fixed issue where text appeared behind list of themes on the theme screen
+* Domain Registration functionality for Business plan customers on a site without custom domain who wish to install plugin(s)
 
 12.6
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -574,7 +574,7 @@ public class PluginDetailActivity extends AppCompatActivity implements OnDomainR
     }
 
     private boolean isCustomDomainRequired() {
-        return mSite.getUrl().contains(".wordpress.com") && BuildConfig.DOMAIN_REGISTRATION_ENABLED;
+        return mSite.getUrl().contains(".wordpress.com");
     }
 
     private void refreshViews() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
@@ -5,7 +5,6 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.plugin.ImmutablePluginModel;
 import org.wordpress.android.util.AppLog;
@@ -27,16 +26,10 @@ public class PluginUtils {
             return SiteUtils.checkMinimalJetpackVersion(site, "5.6");
         }
 
-        boolean isCustomDomain = !site.getUrl().contains(".wordpress.com");
-        boolean isCustomDomainRegistrationAvailable = BuildConfig.DOMAIN_REGISTRATION_ENABLED;
-
         // If the site has business plan we can do an Automated Transfer
         return site.isWPCom()
                && SiteUtils.hasNonJetpackBusinessPlan(site)
                && site.getHasCapabilityManageOptions() // Automated Transfer require admin capabilities
-               // Automated Transfers require custom domains, so if the user has a `xyz.wordpress.com` site
-               // custom domain registrations feature needs to be enabled in order to access plugin feature
-               && (isCustomDomain || isCustomDomainRegistrationAvailable)
                && !site.isPrivate(); // Private sites are not eligible for Automated Transfer
     }
 


### PR DESCRIPTION
Anyone can review this PR.

This PR removes custom domain check and feature flag check when deciding the visibility of Plugins row on MySite fragment.

It also removes the feature flag check when a user tries to install a plugin.

Domain registration functionality is already merged into develop.

I left the feature flag in build.gradle as it is still used with domain registration CTA.

To test 1:

1. Using a vanilla build, select a site on business plan without a custom domain.
2. Notice that Plugins row is visible in MySite fragment.
3. Navigate to Plugins browser, and to details of any plugin.
4. Tap Install.
5. Notice that prompt to register custom domain is visible.

To test 2:

1. Using a vanilla build, select a site on not on a business plan.
2. Notice that Plugins row is not visible in MySite fragment.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
