### PR TITLE
Extract configuration view models

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -22,6 +22,8 @@ import org.wordpress.android.ui.stats.refresh.lists.YearsListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.detail.DetailListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.management.InsightsManagementViewModel;
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel;
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsSiteSelectionViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel;
 import org.wordpress.android.viewmodel.ViewModelFactory;
 import org.wordpress.android.viewmodel.ViewModelKey;
@@ -140,6 +142,16 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(StatsWidgetConfigureViewModel.class)
     abstract ViewModel statsViewsWidgetViewModel(StatsWidgetConfigureViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(StatsSiteSelectionViewModel.class)
+    abstract ViewModel statsSiteSelectionViewModel(StatsSiteSelectionViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(StatsColorSelectionViewModel.class)
+    abstract ViewModel statsColorSelectionViewModel(StatsColorSelectionViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -2,9 +2,9 @@ package org.wordpress.android.ui.prefs
 
 import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.PostListViewLayoutType
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color.DARK
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color.LIGHT
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.DARK
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.LIGHT
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetListProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetListProvider.kt
@@ -11,7 +11,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.ui.stats.OldStatsActivity
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.lists.widget.SITE_ID_KEY
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.lists.widget.utils.getColorMode
 import javax.inject.Inject
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetListViewModel.kt
@@ -6,7 +6,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.stats.InsightsAllTimeModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.AllTimeInsightsStore
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.utils.ONE_THOUSAND
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.viewmodel.ResourceProvider

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetUpdater.kt
@@ -15,8 +15,8 @@ import org.wordpress.android.fluxc.store.stats.insights.AllTimeInsightsStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.StatsTimeframe.INSIGHTS
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.LIGHT
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.ViewType.ALL_TIME_VIEWS
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color.LIGHT
 import org.wordpress.android.ui.stats.refresh.lists.widget.utils.WidgetUtils
 import org.wordpress.android.ui.stats.refresh.utils.MILLION
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/ColorSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/ColorSelectionDialogFragment.kt
@@ -11,28 +11,27 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import dagger.android.support.AndroidSupportInjection
 import org.wordpress.android.R
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color.DARK
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color.LIGHT
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.DARK
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.LIGHT
 import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
 
 class ColorSelectionDialogFragment : AppCompatDialogFragment() {
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
-    private lateinit var viewModel: StatsWidgetConfigureViewModel
+    private lateinit var viewModel: StatsColorSelectionViewModel
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
-                .get(StatsWidgetConfigureViewModel::class.java)
+                .get(StatsColorSelectionViewModel::class.java)
         val alertDialogBuilder = AlertDialog.Builder(activity)
         val view = activity!!.layoutInflater.inflate(R.layout.stats_color_selector, null) as RadioGroup
         view.setOnCheckedChangeListener { _, checkedId ->
             checkedId.toColor()?.let { viewModel.colorClicked(it) }
         }
         alertDialogBuilder.setView(view)
-        viewModel.settingsModel.observe(this, Observer {
-            val updatedColor = it?.color
+        viewModel.viewMode.observe(this, Observer { updatedColor ->
             val currentColor = view.checkedRadioButtonId.toColor()
             if (updatedColor != currentColor) {
                 updatedColor?.let { view.check(updatedColor.toViewId()) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsColorSelectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsColorSelectionViewModel.kt
@@ -1,0 +1,41 @@
+package org.wordpress.android.ui.stats.refresh.lists.widget.configuration
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.R
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+class StatsColorSelectionViewModel
+@Inject constructor(
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+    private val appPrefsWrapper: AppPrefsWrapper
+) : ScopedViewModel(mainDispatcher) {
+    private val mutableViewMode = MutableLiveData<Color>()
+    val viewMode: LiveData<Color> = mutableViewMode
+
+    private var appWidgetId: Int = -1
+
+    fun start(
+        appWidgetId: Int
+    ) {
+        this.appWidgetId = appWidgetId
+        val colorMode = appPrefsWrapper.getAppWidgetColor(appWidgetId)
+        if (colorMode != null) {
+            mutableViewMode.postValue(colorMode)
+        }
+    }
+
+    fun colorClicked(color: Color) {
+        mutableViewMode.postValue(color)
+    }
+
+    enum class Color(@StringRes val title: Int) {
+        LIGHT(R.string.stats_widget_color_light), DARK(R.string.stats_widget_color_dark)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsSiteSelectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsSiteSelectionViewModel.kt
@@ -1,0 +1,72 @@
+package org.wordpress.android.ui.stats.refresh.lists.widget.configuration
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+class StatsSiteSelectionViewModel
+@Inject constructor(
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+    private val siteStore: SiteStore,
+    private val appPrefsWrapper: AppPrefsWrapper
+) : ScopedViewModel(mainDispatcher) {
+    private val mutableSelectedSite = MutableLiveData<SiteUiModel>()
+    val selectedSite: LiveData<SiteUiModel> = mutableSelectedSite
+
+    private val mutableSites = MutableLiveData<List<SiteUiModel>>()
+    val sites: LiveData<List<SiteUiModel>> = mutableSites
+    private val mutableHideSiteDialog = MutableLiveData<Event<Unit>>()
+    val hideSiteDialog: LiveData<Event<Unit>> = mutableHideSiteDialog
+
+    fun start(appWidgetId: Int) {
+        val siteId = appPrefsWrapper.getAppWidgetSiteId(appWidgetId)
+        if (siteId > -1) {
+            mutableSelectedSite.postValue(siteStore.getSiteBySiteId(siteId)?.let { toUiModel(it) })
+        }
+    }
+
+    fun loadSites() {
+        mutableSites.postValue(siteStore.sites.map { toUiModel(it) })
+    }
+
+    private fun toUiModel(site: SiteModel): SiteUiModel {
+        val blogName = SiteUtils.getSiteNameOrHomeURL(site)
+        val homeUrl = SiteUtils.getHomeURLOrHostName(site)
+        val title = when {
+            !blogName.isNullOrEmpty() -> blogName
+            !homeUrl.isNullOrEmpty() -> homeUrl
+            else -> null
+        }
+        val description = when {
+            !homeUrl.isNullOrEmpty() -> homeUrl
+            else -> null
+        }
+        return SiteUiModel(site.siteId, site.iconUrl, title, description, this::selectSite)
+    }
+
+    private fun selectSite(site: SiteUiModel) {
+        mutableHideSiteDialog.postValue(Event(Unit))
+        mutableSelectedSite.postValue(site)
+    }
+
+    data class SiteUiModel(
+        val siteId: Long,
+        val iconUrl: String?,
+        val title: String?,
+        val url: String?,
+        private val onClick: (site: SiteUiModel) -> Unit
+    ) {
+        fun click() {
+            onClick(this)
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
@@ -36,6 +36,8 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
     @Inject lateinit var siteStore: SiteStore
     @Inject lateinit var imageManager: ImageManager
     private lateinit var viewModel: StatsWidgetConfigureViewModel
+    private lateinit var siteSelectionViewModel: StatsSiteSelectionViewModel
+    private lateinit var colorSelectionViewModel: StatsColorSelectionViewModel
     private lateinit var viewType: ViewType
 
     override fun onInflate(context: Context?, attrs: AttributeSet?, savedInstanceState: Bundle?) {
@@ -63,6 +65,10 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
         super.onViewCreated(view, savedInstanceState)
         viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
                 .get(StatsWidgetConfigureViewModel::class.java)
+        siteSelectionViewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+                .get(StatsSiteSelectionViewModel::class.java)
+        colorSelectionViewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+                .get(StatsColorSelectionViewModel::class.java)
         activity?.setResult(AppCompatActivity.RESULT_CANCELED)
 
         val appWidgetId = activity?.intent?.extras?.getInt(
@@ -74,6 +80,8 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
             activity?.finish()
             return
         }
+
+        viewModel.start(appWidgetId, viewType, siteSelectionViewModel, colorSelectionViewModel)
 
         site_container.setOnClickListener {
             StatsWidgetSiteSelectionDialogFragment().show(fragmentManager, "stats_site_selection_fragment")
@@ -115,8 +123,6 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
                 activity?.finish()
             }
         })
-
-        viewModel.start(appWidgetId, viewType)
     }
 
     enum class ViewType { WEEK_VIEWS, ALL_TIME_VIEWS, TODAY_VIEWS }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureViewModel.kt
@@ -1,17 +1,13 @@
 package org.wordpress.android.ui.stats.refresh.lists.widget.configuration
 
-import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
-import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.LIGHT
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.ViewType
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color.LIGHT
-import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.merge
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -21,83 +17,48 @@ import javax.inject.Named
 class StatsWidgetConfigureViewModel
 @Inject constructor(
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
-    private val siteStore: SiteStore,
     private val appPrefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(mainDispatcher) {
-    private val mutableSelectedSite = MutableLiveData<SiteUiModel>()
-    private val mutableViewMode = MutableLiveData<Color>()
-    val settingsModel: LiveData<WidgetSettingsModel> = merge(
-            mutableSelectedSite,
-            mutableViewMode
-    ) { selectedSite, viewMode ->
-        WidgetSettingsModel(
-                selectedSite?.title,
-                viewMode ?: LIGHT
-        )
+    val settingsModel: LiveData<WidgetSettingsModel> by lazy {
+        merge(
+                siteSelectionViewModel.selectedSite,
+                colorSelectionViewModel.viewMode
+        ) { selectedSite, viewMode ->
+            WidgetSettingsModel(
+                    selectedSite?.title,
+                    viewMode ?: LIGHT
+            )
+        }
     }
     private val mutableWidgetAdded = MutableLiveData<Event<WidgetAdded>>()
     val widgetAdded: LiveData<Event<WidgetAdded>> = mutableWidgetAdded
 
-    private val mutableSites = MutableLiveData<List<SiteUiModel>>()
-    val sites: LiveData<List<SiteUiModel>> = mutableSites
-    private val mutableHideSiteDialog = MutableLiveData<Event<Unit>>()
-    val hideSiteDialog: LiveData<Event<Unit>> = mutableHideSiteDialog
-
     private var appWidgetId: Int = -1
     private lateinit var viewType: ViewType
+    private lateinit var siteSelectionViewModel: StatsSiteSelectionViewModel
+    private lateinit var colorSelectionViewModel: StatsColorSelectionViewModel
 
-    fun start(appWidgetId: Int, viewType: ViewType) {
+    fun start(
+        appWidgetId: Int,
+        viewType: ViewType,
+        siteSelectionViewModel: StatsSiteSelectionViewModel,
+        colorSelectionViewModel: StatsColorSelectionViewModel
+    ) {
         this.appWidgetId = appWidgetId
         this.viewType = viewType
-        val colorMode = appPrefsWrapper.getAppWidgetColor(appWidgetId)
-        if (colorMode != null) {
-            mutableViewMode.postValue(colorMode)
-        }
-        val siteId = appPrefsWrapper.getAppWidgetSiteId(appWidgetId)
-        if (siteId > -1) {
-            mutableSelectedSite.postValue(siteStore.getSiteBySiteId(siteId)?.let { toUiModel(it) })
-        }
-    }
-
-    fun colorClicked(color: Color) {
-        mutableViewMode.postValue(color)
+        this.siteSelectionViewModel = siteSelectionViewModel
+        this.colorSelectionViewModel = colorSelectionViewModel
+        colorSelectionViewModel.start(appWidgetId)
+        siteSelectionViewModel.start(appWidgetId)
     }
 
     fun addWidget() {
-        val selectedSite = mutableSelectedSite.value
+        val selectedSite = siteSelectionViewModel.selectedSite.value
         if (appWidgetId != -1 && selectedSite != null) {
             appPrefsWrapper.setAppWidgetSiteId(selectedSite.siteId, appWidgetId)
-            appPrefsWrapper.setAppWidgetColor(mutableViewMode.value ?: LIGHT, appWidgetId)
+            appPrefsWrapper.setAppWidgetColor(colorSelectionViewModel.viewMode.value ?: LIGHT, appWidgetId)
             mutableWidgetAdded.postValue(Event(WidgetAdded(appWidgetId, viewType)))
         }
-    }
-
-    fun loadSites() {
-        mutableSites.postValue(siteStore.sites.map { toUiModel(it) })
-    }
-
-    private fun toUiModel(site: SiteModel): SiteUiModel {
-        val blogName = SiteUtils.getSiteNameOrHomeURL(site)
-        val homeUrl = SiteUtils.getHomeURLOrHostName(site)
-        val title = when {
-            !blogName.isNullOrEmpty() -> blogName
-            !homeUrl.isNullOrEmpty() -> homeUrl
-            else -> null
-        }
-        val description = when {
-            !homeUrl.isNullOrEmpty() -> homeUrl
-            else -> null
-        }
-        return SiteUiModel(site.siteId, site.iconUrl, title, description, this::selectSite)
-    }
-
-    private fun selectSite(site: SiteUiModel) {
-        mutableHideSiteDialog.postValue(Event(Unit))
-        mutableSelectedSite.postValue(site)
-    }
-
-    enum class Color(@StringRes val title: Int) {
-        LIGHT(R.string.stats_widget_color_light), DARK(R.string.stats_widget_color_dark)
     }
 
     data class WidgetSettingsModel(
@@ -107,16 +68,4 @@ class StatsWidgetConfigureViewModel
     )
 
     data class WidgetAdded(val appWidgetId: Int, val viewType: ViewType)
-
-    data class SiteUiModel(
-        val siteId: Long,
-        val iconUrl: String?,
-        val title: String?,
-        val url: String?,
-        private val onClick: (site: SiteUiModel) -> Unit
-    ) {
-        fun click() {
-            onClick(this)
-        }
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetSiteAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetSiteAdapter.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.stats.refresh.lists.widget.configuration
 
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView.Adapter
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.SiteUiModel
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsSiteSelectionViewModel.SiteUiModel
 import org.wordpress.android.util.image.ImageManager
 
 class StatsWidgetSiteAdapter(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetSiteSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetSiteSelectionDialogFragment.kt
@@ -20,7 +20,7 @@ import javax.inject.Inject
 class StatsWidgetSiteSelectionDialogFragment : AppCompatDialogFragment() {
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
-    private lateinit var viewModel: StatsWidgetConfigureViewModel
+    private lateinit var viewModel: StatsSiteSelectionViewModel
     private fun buildView(): View? {
         val rootView = activity!!.layoutInflater.inflate(R.layout.stats_widget_site_selector, null)
         val recyclerView = rootView.findViewById<RecyclerView>(R.id.recycler_view)
@@ -37,7 +37,7 @@ class StatsWidgetSiteSelectionDialogFragment : AppCompatDialogFragment() {
         alertDialogBuilder.setCancelable(true)
 
         viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
-                .get(StatsWidgetConfigureViewModel::class.java)
+                .get(StatsSiteSelectionViewModel::class.java)
         viewModel.sites.observe(this, Observer {
             (dialog.recycler_view.adapter as? StatsWidgetSiteAdapter)?.update(it ?: listOf())
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetSiteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetSiteViewHolder.kt
@@ -5,7 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import kotlinx.android.synthetic.main.stats_widget_site_selector_item.view.*
 import org.wordpress.android.R
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.SiteUiModel
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsSiteSelectionViewModel.SiteUiModel
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.BLAVATAR
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetListProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetListProvider.kt
@@ -11,7 +11,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.ui.stats.OldStatsActivity
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.lists.widget.SITE_ID_KEY
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.lists.widget.utils.getColorMode
 import javax.inject.Inject
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetListViewModel.kt
@@ -6,7 +6,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.stats.VisitsModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.TodayInsightsStore
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.utils.ONE_THOUSAND
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.viewmodel.ResourceProvider

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.ViewType.TODAY_VIEWS
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.lists.widget.utils.WidgetUtils
 import org.wordpress.android.ui.stats.refresh.utils.MILLION
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/StatsIntentUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/StatsIntentUtils.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.stats.refresh.lists.widget.utils
 
 import android.content.Intent
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.ViewType
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 
 private const val COLOR_MODE_KEY = "color_mode_key"
 private const val VIEW_TYPE_KEY = "view_type_key"

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
@@ -20,9 +20,9 @@ import org.wordpress.android.ui.stats.refresh.lists.widget.WIDE_VIEW_KEY
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetService
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.StatsAllTimeWidget
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.ViewType
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color.DARK
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color.LIGHT
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.DARK
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.LIGHT
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.ICON
 import org.wordpress.android.viewmodel.ResourceProvider

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetListViewModel.kt
@@ -14,7 +14,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Value
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem.State.POSITIVE
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.OVERVIEW_ITEMS_TO_LOAD
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.OverviewMapper
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.utils.MILLION
 import org.wordpress.android.ui.stats.refresh.utils.ONE_THOUSAND
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetUpdater.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.StatsTimeframe.DAY
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.ViewType.WEEK_VIEWS
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color.LIGHT
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.LIGHT
 import org.wordpress.android.ui.stats.refresh.lists.widget.utils.WidgetUtils
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.viewmodel.ResourceProvider

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetListViewModelTest.kt
@@ -13,7 +13,7 @@ import org.wordpress.android.fluxc.model.stats.InsightsAllTimeModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.AllTimeInsightsStore
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.AllTimeWidgetListViewModel.AllTimeItemUiModel
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.viewmodel.ResourceProvider
 
 @RunWith(MockitoJUnitRunner::class)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsColorSelectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsColorSelectionViewModelTest.kt
@@ -1,0 +1,37 @@
+package org.wordpress.android.ui.stats.refresh.lists.widget.configuration
+
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.DARK
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.LIGHT
+
+class StatsColorSelectionViewModelTest : BaseUnitTest() {
+    @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
+    private lateinit var viewModel: StatsColorSelectionViewModel
+    @Before
+    fun setUp() {
+        viewModel = StatsColorSelectionViewModel(Dispatchers.Unconfined, appPrefsWrapper)
+    }
+
+    @Test
+    fun `updated model on view mode click`() {
+        var viewMode: Color? = null
+        viewModel.viewMode.observeForever {
+            viewMode = it
+        }
+
+        viewModel.colorClicked(DARK)
+
+        Assertions.assertThat(viewMode).isEqualTo(DARK)
+
+        viewModel.colorClicked(LIGHT)
+
+        Assertions.assertThat(viewMode).isEqualTo(LIGHT)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsSiteSelectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsSiteSelectionViewModelTest.kt
@@ -1,0 +1,70 @@
+package org.wordpress.android.ui.stats.refresh.lists.widget.configuration
+
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsSiteSelectionViewModel.SiteUiModel
+
+class StatsSiteSelectionViewModelTest : BaseUnitTest() {
+    @Mock private lateinit var siteStore: SiteStore
+    @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Mock private lateinit var site: SiteModel
+    private lateinit var viewModel: StatsSiteSelectionViewModel
+    private val siteId = 15L
+    private val siteName = "WordPress"
+    private val siteUrl = "wordpress.com"
+    private val iconUrl = "icon.jpg"
+    @Before
+    fun setUp() {
+        viewModel = StatsSiteSelectionViewModel(Dispatchers.Unconfined, siteStore, appPrefsWrapper)
+        whenever(site.siteId).thenReturn(siteId)
+        whenever(site.name).thenReturn(siteName)
+        whenever(site.url).thenReturn(siteUrl)
+        whenever(site.iconUrl).thenReturn(iconUrl)
+    }
+    @Test
+    fun `loads sites`() {
+        var sites: List<SiteUiModel>? = null
+        viewModel.sites.observeForever { sites = it }
+
+        whenever(siteStore.sites).thenReturn(listOf(site))
+
+        viewModel.loadSites()
+
+        Assertions.assertThat(sites).isNotNull
+        Assertions.assertThat(sites).hasSize(1)
+        val loadedSite = sites!![0]
+        Assertions.assertThat(loadedSite.iconUrl).isEqualTo(iconUrl)
+        Assertions.assertThat(loadedSite.siteId).isEqualTo(siteId)
+        Assertions.assertThat(loadedSite.title).isEqualTo(siteName)
+        Assertions.assertThat(loadedSite.url).isEqualTo(siteUrl)
+    }
+
+    @Test
+    fun `hides dialog and selects site on site click`() {
+        var sites: List<SiteUiModel>? = null
+        viewModel.sites.observeForever { sites = it }
+
+        whenever(siteStore.sites).thenReturn(listOf(site))
+
+        viewModel.loadSites()
+
+        Assertions.assertThat(sites).isNotNull
+        Assertions.assertThat(sites).hasSize(1)
+        val loadedSite = sites!![0]
+
+        var hideSiteDialog: Unit? = null
+        viewModel.hideSiteDialog.observeForever { hideSiteDialog = it?.getContentIfNotHandled() }
+
+        loadedSite.click()
+
+        Assertions.assertThat(hideSiteDialog).isNotNull
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetListViewModelTest.kt
@@ -12,7 +12,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.VisitsModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.TodayInsightsStore
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.lists.widget.today.TodayWidgetListViewModel.TodayItemUiModel
 import org.wordpress.android.viewmodel.ResourceProvider
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetListViewModelTest.kt
@@ -23,7 +23,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Value
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem.State.NEUTRAL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem.State.POSITIVE
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.OverviewMapper
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.viewmodel.ResourceProvider


### PR DESCRIPTION
In order to implement the minified widgets I need to extract common functionality from the configuration view model for site and color mode selection. That's done in this PR. 

https://github.com/wordpress-mobile/WordPress-Android/pull/10045 needs to be merged before this PR is reviewed.

To test:
* There is nothing to test

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
