### PR TITLE
Fix #9933: Retry button on local draft won't automatically publish the post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
@@ -14,7 +14,7 @@ sealed class PostListAction {
     class RetryUpload(
         val post: PostModel,
         val trackAnalytics: Boolean = PostUtils.isFirstTimePublish(post),
-        val publish: Boolean = false,
+        val makePublishable: Boolean = false,
         val retry: Boolean = true
     ) : PostListAction()
 
@@ -40,7 +40,7 @@ fun handlePostListAction(activity: FragmentActivity, action: PostListAction) {
                     activity,
                     action.post,
                     action.trackAnalytics,
-                    action.publish,
+                    action.makePublishable,
                     action.retry
             )
             activity.startService(intent)

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -750,6 +750,14 @@ public class UploadService extends Service {
             aztecRegisterFailedMediaForThisPost(post);
         }
 
+        // On retry, if the post is a local draft and the status is published, this means already
+        // tried to publish this post and something failed. "Retry" being generic term, we want to force
+        // the DRAFT status to make sure the user doesn't publish unexpectedly.
+        PostStatus status = PostStatus.fromPost(post);
+        if (post.isLocalDraft() && status == PostStatus.PUBLISHED) {
+            post.setStatus(PostStatus.DRAFT.toString());
+        }
+
         Set<MediaModel> failedMedia = mUploadStore.getFailedMediaForPost(post);
         ArrayList<MediaModel> mediaToRetry = new ArrayList<>(failedMedia);
         if (!failedMedia.isEmpty()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -52,7 +52,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 public class UploadService extends Service {
-    private static final String KEY_SHOULD_PUBLISH = "shouldPublish";
+    private static final String KEY_SHOULD_MAKE_PUBLISHABLE = "shouldPublish";
     private static final String KEY_SHOULD_RETRY = "shouldRetry";
     private static final String KEY_MEDIA_LIST = "mediaList";
     private static final String KEY_UPLOAD_MEDIA_FROM_EDITOR = "mediaFromEditor";
@@ -237,7 +237,7 @@ public class UploadService extends Service {
 
             // if the user tapped on the PUBLISH quick action, make this Post publishable and track
             // analytics before starting the upload process.
-            if (intent.getBooleanExtra(KEY_SHOULD_PUBLISH, false)) {
+            if (intent.getBooleanExtra(KEY_SHOULD_MAKE_PUBLISHABLE, false)) {
                 makePostPublishable(post);
                 PostUtils.trackSavePostAnalytics(post, mSiteStore.getSiteByLocalId(post.getLocalSiteId()));
             }
@@ -304,11 +304,11 @@ public class UploadService extends Service {
 
 
     public static Intent getUploadPostServiceIntent(Context context, @NonNull PostModel post, boolean trackAnalytics,
-                                                    boolean publish, boolean isRetry) {
+                                                    boolean makePublishable, boolean isRetry) {
         Intent intent = new Intent(context, UploadService.class);
         intent.putExtra(KEY_LOCAL_POST_ID, post.getId());
         intent.putExtra(KEY_SHOULD_TRACK_ANALYTICS, trackAnalytics);
-        intent.putExtra(KEY_SHOULD_PUBLISH, publish);
+        intent.putExtra(KEY_SHOULD_MAKE_PUBLISHABLE, makePublishable);
         intent.putExtra(KEY_SHOULD_RETRY, isRetry);
         return intent;
     }


### PR DESCRIPTION
Fix #9933: Retry button on local draft won't automatically publish the post.

we  have decide to go with this approach and so we closed: https://github.com/wordpress-mobile/WordPress-Android/pull/10029

Note: I renamed the field `publish` to `makePublishable` in `RetryUpload`. I was expecting that the post wouldn't be published if the field was `false`, but this is not what it does.