### PR TITLE
Minified widget configuration

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -763,6 +763,14 @@
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE"/>
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".ui.stats.refresh.lists.widget.minified.StatsMinifiedWidgetConfigureActivity"
+            android:theme="@style/Calypso.NoActionBar">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE"/>
+            </intent-filter>
+        </activity>
         <receiver
             android:name=".util.analytics.receiver.InstallationReferrerReceiver"
             android:permission="android.permission.INSTALL_PACKAGES"

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -736,6 +736,16 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/stats_today_widget_info"/>
         </receiver>
+        <receiver android:name=".ui.stats.refresh.lists.widget.minified.StatsMinifiedWidget">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/stats_minified_widget_info"/>
+        </receiver>
+
         <service
             android:name=".ui.stats.refresh.lists.widget.WidgetService"
             android:permission="android.permission.BIND_REMOTEVIEWS" />

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -139,6 +139,7 @@ import org.wordpress.android.ui.stats.refresh.StatsActivity;
 import org.wordpress.android.ui.stats.refresh.StatsModule;
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.AllTimeWidgetListProvider;
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.StatsAllTimeWidget;
+import org.wordpress.android.ui.stats.refresh.lists.widget.minified.StatsMinifiedWidget;
 import org.wordpress.android.ui.stats.refresh.lists.widget.today.StatsTodayWidget;
 import org.wordpress.android.ui.stats.refresh.lists.widget.views.StatsViewsWidget;
 import org.wordpress.android.ui.stats.refresh.lists.widget.today.TodayWidgetListProvider;
@@ -466,6 +467,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(StatsAllTimeWidget object);
 
     void inject(StatsTodayWidget object);
+
+    void inject(StatsMinifiedWidget object);
 
     void inject(ViewsWidgetListProvider object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -16,8 +16,8 @@ import org.wordpress.android.ui.stats.refresh.StatsViewAllFragment;
 import org.wordpress.android.ui.stats.refresh.lists.StatsListFragment;
 import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailFragment;
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.management.InsightsManagementFragment;
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.ColorSelectionDialogFragment;
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.DataTypeSelectionDialogFragment;
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetColorSelectionDialogFragment;
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetDataTypeSelectionDialogFragment;
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment;
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetSiteSelectionDialogFragment;
 import org.wordpress.android.ui.stats.refresh.lists.widget.minified.StatsMinifiedWidgetConfigureFragment;
@@ -69,13 +69,13 @@ public abstract class ApplicationModule {
     abstract StatsWidgetSiteSelectionDialogFragment contributeSiteSelectionDialogFragment();
 
     @ContributesAndroidInjector
-    abstract ColorSelectionDialogFragment contributeViewModeSelectionDialogFragment();
+    abstract StatsWidgetColorSelectionDialogFragment contributeViewModeSelectionDialogFragment();
 
     @ContributesAndroidInjector
     abstract StatsMinifiedWidgetConfigureFragment contributeStatsMinifiedWidgetConfigureFragment();
 
     @ContributesAndroidInjector
-    abstract DataTypeSelectionDialogFragment contributeDataTypeSelectionDialogFragment();
+    abstract StatsWidgetDataTypeSelectionDialogFragment contributeDataTypeSelectionDialogFragment();
 
     @Provides
     public static WizardManager<SiteCreationStep> provideWizardManager(SiteCreationStepsProvider stepsProvider) {

--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -16,9 +16,11 @@ import org.wordpress.android.ui.stats.refresh.StatsViewAllFragment;
 import org.wordpress.android.ui.stats.refresh.lists.StatsListFragment;
 import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailFragment;
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.management.InsightsManagementFragment;
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetSiteSelectionDialogFragment;
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment;
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.ColorSelectionDialogFragment;
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.DataTypeSelectionDialogFragment;
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment;
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetSiteSelectionDialogFragment;
+import org.wordpress.android.ui.stats.refresh.lists.widget.minified.StatsMinifiedWidgetConfigureFragment;
 import org.wordpress.android.util.wizard.WizardManager;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatusLiveData;
@@ -68,6 +70,12 @@ public abstract class ApplicationModule {
 
     @ContributesAndroidInjector
     abstract ColorSelectionDialogFragment contributeViewModeSelectionDialogFragment();
+
+    @ContributesAndroidInjector
+    abstract StatsMinifiedWidgetConfigureFragment contributeStatsMinifiedWidgetConfigureFragment();
+
+    @ContributesAndroidInjector
+    abstract DataTypeSelectionDialogFragment contributeDataTypeSelectionDialogFragment();
 
     @Provides
     public static WizardManager<SiteCreationStep> provideWizardManager(SiteCreationStepsProvider stepsProvider) {

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -23,8 +23,10 @@ import org.wordpress.android.ui.stats.refresh.lists.detail.DetailListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.management.InsightsManagementViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel;
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsSiteSelectionViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel;
+import org.wordpress.android.ui.stats.refresh.lists.widget.minified.StatsMinifiedWidgetConfigureViewModel;
 import org.wordpress.android.viewmodel.ViewModelFactory;
 import org.wordpress.android.viewmodel.ViewModelKey;
 import org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModel;
@@ -147,6 +149,16 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(StatsSiteSelectionViewModel.class)
     abstract ViewModel statsSiteSelectionViewModel(StatsSiteSelectionViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(StatsDataTypeSelectionViewModel.class)
+    abstract ViewModel statsDataTypeSelectionViewModel(StatsDataTypeSelectionViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(StatsMinifiedWidgetConfigureViewModel.class)
+    abstract ViewModel statsMinifiedWidgetViewModel(StatsMinifiedWidgetConfigureViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -898,8 +898,8 @@ public class AppPrefs {
         return DeletablePrefKey.STATS_WIDGET_COLOR_MODE.name() + appWidgetId;
     }
 
-    public static void setStatsWidgetDatatTypeId(int colorModeId, int appWidgetId) {
-        prefs().edit().putInt(getDatatTypeIdWidgetKey(appWidgetId), colorModeId).apply();
+    public static void setStatsWidgetDatatTypeId(int dataTypeId, int appWidgetId) {
+        prefs().edit().putInt(getDatatTypeIdWidgetKey(appWidgetId), dataTypeId).apply();
     }
 
     public static int getStatsWidgetDatatTypeId(int appWidgetId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -123,7 +123,8 @@ public class AppPrefs {
 
         // Widget settings
         STATS_WIDGET_SELECTED_SITE_ID,
-        STATS_WIDGET_COLOR_MODE
+        STATS_WIDGET_COLOR_MODE,
+        STATS_WIDGET_DATA_TYPE
     }
 
     /**
@@ -895,5 +896,21 @@ public class AppPrefs {
 
     @NonNull private static String getColorModeIdWidgetKey(int appWidgetId) {
         return DeletablePrefKey.STATS_WIDGET_COLOR_MODE.name() + appWidgetId;
+    }
+
+    public static void setStatsWidgetDatatTypeId(int colorModeId, int appWidgetId) {
+        prefs().edit().putInt(getDatatTypeIdWidgetKey(appWidgetId), colorModeId).apply();
+    }
+
+    public static int getStatsWidgetDatatTypeId(int appWidgetId) {
+        return prefs().getInt(getDatatTypeIdWidgetKey(appWidgetId), -1);
+    }
+
+    public static void removeStatsWidgetDatatTypeId(int appWidgetId) {
+        prefs().edit().remove(getDatatTypeIdWidgetKey(appWidgetId)).apply();
+    }
+
+    @NonNull private static String getDatatTypeIdWidgetKey(int appWidgetId) {
+        return DeletablePrefKey.STATS_WIDGET_DATA_TYPE.name() + appWidgetId;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -5,6 +5,11 @@ import org.wordpress.android.ui.posts.PostListViewLayoutType
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.DARK
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.LIGHT
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel.DataType
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel.DataType.COMMENTS
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel.DataType.LIKES
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel.DataType.VIEWS
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel.DataType.VISITORS
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -63,8 +68,35 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun removeAppWidgetColorModeId(appWidgetId: Int) = AppPrefs.removeStatsWidgetColorModeId(appWidgetId)
 
+    fun getAppWidgetDataType(appWidgetId: Int): DataType? {
+        return when (AppPrefs.getStatsWidgetDatatTypeId(appWidgetId)) {
+            VIEWS_TYPE_ID -> VIEWS
+            VISITORS_TYPE_ID -> VISITORS
+            COMMENTS_TYPE_ID -> COMMENTS
+            LIKES_TYPE_ID -> LIKES
+            else -> null
+        }
+    }
+
+    fun setAppWidgetDataType(dataType: DataType, appWidgetId: Int) {
+        val dataTypeId = when (dataType) {
+            VIEWS -> VIEWS_TYPE_ID
+            VISITORS -> VISITORS_TYPE_ID
+            COMMENTS -> COMMENTS_TYPE_ID
+            LIKES -> LIKES_TYPE_ID
+        }
+        AppPrefs.setStatsWidgetDatatTypeId(dataTypeId, appWidgetId)
+    }
+
+    fun removeAppWidgetDataTypeModeId(appWidgetId: Int) = AppPrefs.removeStatsWidgetDatatTypeId(appWidgetId)
+
     companion object {
         private const val LIGHT_MODE_ID = 0
         private const val DARK_MODE_ID = 1
+
+        private const val VIEWS_TYPE_ID = 0
+        private const val VISITORS_TYPE_ID = 1
+        private const val COMMENTS_TYPE_ID = 2
+        private const val LIKES_TYPE_ID = 3
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/DataTypeSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/DataTypeSelectionDialogFragment.kt
@@ -1,0 +1,73 @@
+package org.wordpress.android.ui.stats.refresh.lists.widget.configuration
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.content.Context
+import android.os.Bundle
+import android.widget.RadioGroup
+import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProviders
+import dagger.android.support.AndroidSupportInjection
+import org.wordpress.android.R
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel.DataType
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel.DataType.COMMENTS
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel.DataType.LIKES
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel.DataType.VIEWS
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel.DataType.VISITORS
+import org.wordpress.android.util.image.ImageManager
+import javax.inject.Inject
+
+class DataTypeSelectionDialogFragment : AppCompatDialogFragment() {
+    @Inject lateinit var imageManager: ImageManager
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var viewModel: StatsDataTypeSelectionViewModel
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+                .get(StatsDataTypeSelectionViewModel::class.java)
+        val alertDialogBuilder = AlertDialog.Builder(activity)
+        val view = activity!!.layoutInflater.inflate(R.layout.stats_data_type_selector, null) as RadioGroup
+        view.setOnCheckedChangeListener { _, checkedId ->
+            checkedId.toDataType()?.let { viewModel.dataTypeClicked(it) }
+        }
+        alertDialogBuilder.setView(view)
+        viewModel.dataType.observe(this, Observer { updatedDataType ->
+            val currentDataType = view.checkedRadioButtonId.toDataType()
+            if (updatedDataType != currentDataType) {
+                updatedDataType?.let { view.check(updatedDataType.toViewId()) }
+            }
+        })
+        alertDialogBuilder.setTitle(R.string.stats_widget_select_type)
+
+        alertDialogBuilder.setPositiveButton(R.string.dialog_button_ok) { dialog, _ ->
+            dialog?.dismiss()
+        }
+        return alertDialogBuilder.create()
+    }
+
+    private fun DataType.toViewId(): Int {
+        return when (this) {
+            VIEWS -> R.id.stats_widget_views
+            VISITORS -> R.id.stats_widget_visitors
+            COMMENTS -> R.id.stats_widget_comments
+            LIKES -> R.id.stats_widget_likes
+        }
+    }
+
+    private fun Int.toDataType(): DataType? {
+        return when (this) {
+            R.id.stats_widget_views -> VIEWS
+            R.id.stats_widget_visitors -> VISITORS
+            R.id.stats_widget_comments -> COMMENTS
+            R.id.stats_widget_likes -> LIKES
+            else -> null
+        }
+    }
+
+    override fun onAttach(context: Context?) {
+        super.onAttach(context)
+        AndroidSupportInjection.inject(this)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsDataTypeSelectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsDataTypeSelectionViewModel.kt
@@ -1,0 +1,44 @@
+package org.wordpress.android.ui.stats.refresh.lists.widget.configuration
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.R
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+class StatsDataTypeSelectionViewModel
+@Inject constructor(
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+    private val appPrefsWrapper: AppPrefsWrapper
+) : ScopedViewModel(mainDispatcher) {
+    private val mutableDataType = MutableLiveData<DataType>()
+    val dataType: LiveData<DataType> = mutableDataType
+
+    private var appWidgetId: Int = -1
+
+    fun start(
+        appWidgetId: Int
+    ) {
+        this.appWidgetId = appWidgetId
+        val dataType = appPrefsWrapper.getAppWidgetDataType(appWidgetId)
+        if (dataType != null) {
+            mutableDataType.postValue(dataType)
+        }
+    }
+
+    fun dataTypeClicked(color: DataType) {
+        mutableDataType.postValue(color)
+    }
+
+    enum class DataType(@StringRes val title: Int) {
+        VIEWS(R.string.stats_views),
+        VISITORS(R.string.stats_visitors),
+        COMMENTS(R.string.stats_comments),
+        LIKES(R.string.stats_likes)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetColorSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetColorSelectionDialogFragment.kt
@@ -17,7 +17,7 @@ import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsCo
 import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
 
-class ColorSelectionDialogFragment : AppCompatDialogFragment() {
+class StatsWidgetColorSelectionDialogFragment : AppCompatDialogFragment() {
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: StatsColorSelectionViewModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
@@ -87,7 +87,7 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
             StatsWidgetSiteSelectionDialogFragment().show(fragmentManager, "stats_site_selection_fragment")
         }
         color_container.setOnClickListener {
-            ColorSelectionDialogFragment().show(fragmentManager, "stats_view_mode_selection_fragment")
+            StatsWidgetColorSelectionDialogFragment().show(fragmentManager, "stats_view_mode_selection_fragment")
         }
 
         add_widget_button.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetDataTypeSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetDataTypeSelectionDialogFragment.kt
@@ -19,7 +19,7 @@ import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDa
 import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
 
-class DataTypeSelectionDialogFragment : AppCompatDialogFragment() {
+class StatsWidgetDataTypeSelectionDialogFragment : AppCompatDialogFragment() {
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: StatsDataTypeSelectionViewModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidget.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidget.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.ui.stats.refresh.lists.widget.minified
+
+import org.wordpress.android.modules.AppComponent
+import org.wordpress.android.ui.stats.refresh.lists.widget.StatsWidget
+import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater
+import org.wordpress.android.ui.stats.refresh.lists.widget.today.TodayWidgetUpdater
+import javax.inject.Inject
+
+class StatsMinifiedWidget : StatsWidget() {
+    @Inject lateinit var todayWidgetUpdater: TodayWidgetUpdater
+    override val widgetUpdater: WidgetUpdater
+        get() = todayWidgetUpdater
+
+    override fun inject(appComponent: AppComponent) {
+        appComponent.inject(this)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureActivity.kt
@@ -1,0 +1,35 @@
+package org.wordpress.android.ui.stats.refresh.lists.widget.minified
+
+import android.content.Context
+import android.os.Bundle
+import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
+import kotlinx.android.synthetic.main.toolbar.*
+import org.wordpress.android.R
+import org.wordpress.android.util.LocaleManager
+
+class StatsMinifiedWidgetConfigureActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(R.layout.stats_minified_widget_configure_activity)
+
+        setSupportActionBar(toolbar)
+        supportActionBar?.let {
+            it.setHomeButtonEnabled(true)
+            it.setDisplayHomeAsUpEnabled(true)
+        }
+    }
+
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(LocaleManager.setLocale(newBase))
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            onBackPressed()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
@@ -67,6 +67,8 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
             return
         }
 
+        viewModel.start(appWidgetId, siteSelectionViewModel, colorSelectionViewModel, dataTypeSelectionViewModel)
+
         site_container.setOnClickListener {
             StatsWidgetSiteSelectionDialogFragment().show(fragmentManager, "stats_site_selection_fragment")
         }
@@ -104,8 +106,6 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
                 activity?.finish()
             }
         })
-
-        viewModel.start(appWidgetId, siteSelectionViewModel, colorSelectionViewModel, dataTypeSelectionViewModel)
     }
 
     enum class ViewType { WEEK_VIEWS, ALL_TIME_VIEWS, TODAY_VIEWS }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
@@ -1,0 +1,112 @@
+package org.wordpress.android.ui.stats.refresh.lists.widget.minified
+
+import android.app.Activity.RESULT_OK
+import android.appwidget.AppWidgetManager
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProviders
+import dagger.android.support.DaggerFragment
+import kotlinx.android.synthetic.main.stats_widget_configure_fragment.*
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.AllTimeWidgetUpdater
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.ColorSelectionDialogFragment
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.DataTypeSelectionDialogFragment
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsSiteSelectionViewModel
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetSiteSelectionDialogFragment
+import org.wordpress.android.ui.stats.refresh.lists.widget.today.TodayWidgetUpdater
+import org.wordpress.android.ui.stats.refresh.lists.widget.views.ViewsWidgetUpdater
+import org.wordpress.android.util.image.ImageManager
+import javax.inject.Inject
+
+class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject lateinit var viewsWidgetUpdater: ViewsWidgetUpdater
+    @Inject lateinit var allTimeWidgetUpdater: AllTimeWidgetUpdater
+    @Inject lateinit var todayWidgetUpdater: TodayWidgetUpdater
+    @Inject lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Inject lateinit var siteStore: SiteStore
+    @Inject lateinit var imageManager: ImageManager
+    private lateinit var viewModel: StatsMinifiedWidgetConfigureViewModel
+    private lateinit var siteSelectionViewModel: StatsSiteSelectionViewModel
+    private lateinit var colorSelectionViewModel: StatsColorSelectionViewModel
+    private lateinit var dataTypeSelectionViewModel: StatsDataTypeSelectionViewModel
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.stats_widget_configure_fragment, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+                .get(StatsMinifiedWidgetConfigureViewModel::class.java)
+        siteSelectionViewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+                .get(StatsSiteSelectionViewModel::class.java)
+        colorSelectionViewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+                .get(StatsColorSelectionViewModel::class.java)
+        dataTypeSelectionViewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+                .get(StatsDataTypeSelectionViewModel::class.java)
+        activity?.setResult(AppCompatActivity.RESULT_CANCELED)
+
+        val appWidgetId = activity?.intent?.extras?.getInt(
+                AppWidgetManager.EXTRA_APPWIDGET_ID,
+                AppWidgetManager.INVALID_APPWIDGET_ID
+        ) ?: AppWidgetManager.INVALID_APPWIDGET_ID
+
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            activity?.finish()
+            return
+        }
+
+        site_container.setOnClickListener {
+            StatsWidgetSiteSelectionDialogFragment().show(fragmentManager, "stats_site_selection_fragment")
+        }
+        color_container.setOnClickListener {
+            ColorSelectionDialogFragment().show(fragmentManager, "stats_view_mode_selection_fragment")
+        }
+        data_type_container.visibility = View.VISIBLE
+        data_type_container.setOnClickListener {
+            DataTypeSelectionDialogFragment().show(fragmentManager, "stats_data_type_selection_fragment")
+        }
+
+        add_widget_button.setOnClickListener {
+            viewModel.addWidget()
+        }
+
+        viewModel.settingsModel.observe(this, Observer { uiModel ->
+            uiModel?.let {
+                if (uiModel.siteTitle != null) {
+                    site_value.text = uiModel.siteTitle
+                }
+                color_value.setText(uiModel.color.title)
+                if (uiModel.dataType != null) {
+                    data_type_value.setText(uiModel.dataType.title)
+                }
+                add_widget_button.isEnabled = uiModel.buttonEnabled
+            }
+        })
+
+        viewModel.widgetAdded.observe(this, Observer { event ->
+            event?.getContentIfNotHandled()?.let {
+                // TODO Update minified widget
+                val resultValue = Intent()
+                resultValue.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+                activity?.setResult(RESULT_OK, resultValue)
+                activity?.finish()
+            }
+        })
+
+        viewModel.start(appWidgetId, siteSelectionViewModel, colorSelectionViewModel, dataTypeSelectionViewModel)
+    }
+
+    enum class ViewType { WEEK_VIEWS, ALL_TIME_VIEWS, TODAY_VIEWS }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
@@ -17,8 +17,8 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.AllTimeWidgetUpdater
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.ColorSelectionDialogFragment
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.DataTypeSelectionDialogFragment
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetColorSelectionDialogFragment
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetDataTypeSelectionDialogFragment
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsSiteSelectionViewModel
@@ -73,11 +73,11 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
             StatsWidgetSiteSelectionDialogFragment().show(fragmentManager, "stats_site_selection_fragment")
         }
         color_container.setOnClickListener {
-            ColorSelectionDialogFragment().show(fragmentManager, "stats_view_mode_selection_fragment")
+            StatsWidgetColorSelectionDialogFragment().show(fragmentManager, "stats_view_mode_selection_fragment")
         }
         data_type_container.visibility = View.VISIBLE
         data_type_container.setOnClickListener {
-            DataTypeSelectionDialogFragment().show(fragmentManager, "stats_data_type_selection_fragment")
+            StatsWidgetDataTypeSelectionDialogFragment().show(fragmentManager, "stats_data_type_selection_fragment")
         }
 
         add_widget_button.setOnClickListener {
@@ -107,6 +107,4 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
             }
         })
     }
-
-    enum class ViewType { WEEK_VIEWS, ALL_TIME_VIEWS, TODAY_VIEWS }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureViewModel.kt
@@ -22,16 +22,18 @@ class StatsMinifiedWidgetConfigureViewModel
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     private val appPrefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(mainDispatcher) {
-    val settingsModel: LiveData<WidgetSettingsModel> = merge(
-            siteSelectionViewModel.selectedSite,
-            colorSelectionViewModel.viewMode,
-            dataTypeSelectionViewModel.dataType
-    ) { selectedSite, viewMode, dataType ->
-        WidgetSettingsModel(
-                selectedSite?.title,
-                viewMode ?: LIGHT,
-                dataType
-        )
+    val settingsModel: LiveData<WidgetSettingsModel> by lazy {
+        merge(
+                siteSelectionViewModel.selectedSite,
+                colorSelectionViewModel.viewMode,
+                dataTypeSelectionViewModel.dataType
+        ) { selectedSite, viewMode, dataType ->
+            WidgetSettingsModel(
+                    selectedSite?.title,
+                    viewMode ?: LIGHT,
+                    dataType
+            )
+        }
     }
     private val mutableWidgetAdded = MutableLiveData<Event<WidgetAdded>>()
     val widgetAdded: LiveData<Event<WidgetAdded>> = mutableWidgetAdded

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureViewModel.kt
@@ -1,0 +1,78 @@
+package org.wordpress.android.ui.stats.refresh.lists.widget.minified
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.LIGHT
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel.DataType
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsSiteSelectionViewModel
+import org.wordpress.android.util.merge
+import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+class StatsMinifiedWidgetConfigureViewModel
+@Inject constructor(
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+    private val appPrefsWrapper: AppPrefsWrapper
+) : ScopedViewModel(mainDispatcher) {
+    val settingsModel: LiveData<WidgetSettingsModel> = merge(
+            siteSelectionViewModel.selectedSite,
+            colorSelectionViewModel.viewMode,
+            dataTypeSelectionViewModel.dataType
+    ) { selectedSite, viewMode, dataType ->
+        WidgetSettingsModel(
+                selectedSite?.title,
+                viewMode ?: LIGHT,
+                dataType
+        )
+    }
+    private val mutableWidgetAdded = MutableLiveData<Event<WidgetAdded>>()
+    val widgetAdded: LiveData<Event<WidgetAdded>> = mutableWidgetAdded
+
+    private var appWidgetId: Int = -1
+    private lateinit var siteSelectionViewModel: StatsSiteSelectionViewModel
+    private lateinit var colorSelectionViewModel: StatsColorSelectionViewModel
+    private lateinit var dataTypeSelectionViewModel: StatsDataTypeSelectionViewModel
+
+    fun start(
+        appWidgetId: Int,
+        siteSelectionViewModel: StatsSiteSelectionViewModel,
+        colorSelectionViewModel: StatsColorSelectionViewModel,
+        dataTypeSelectionViewModel: StatsDataTypeSelectionViewModel
+    ) {
+        this.appWidgetId = appWidgetId
+        this.siteSelectionViewModel = siteSelectionViewModel
+        this.colorSelectionViewModel = colorSelectionViewModel
+        this.dataTypeSelectionViewModel = dataTypeSelectionViewModel
+        colorSelectionViewModel.start(appWidgetId)
+        siteSelectionViewModel.start(appWidgetId)
+        dataTypeSelectionViewModel.start(appWidgetId)
+    }
+
+    fun addWidget() {
+        val selectedSite = siteSelectionViewModel.selectedSite.value
+        val dataType = dataTypeSelectionViewModel.dataType.value
+        if (appWidgetId != -1 && selectedSite != null && dataType != null) {
+            appPrefsWrapper.setAppWidgetSiteId(selectedSite.siteId, appWidgetId)
+            appPrefsWrapper.setAppWidgetColor(colorSelectionViewModel.viewMode.value ?: LIGHT, appWidgetId)
+            appPrefsWrapper.setAppWidgetDataType(dataType, appWidgetId)
+            mutableWidgetAdded.postValue(Event(WidgetAdded(appWidgetId)))
+        }
+    }
+
+    data class WidgetSettingsModel(
+        val siteTitle: String? = null,
+        val color: Color,
+        val dataType: DataType?,
+        val buttonEnabled: Boolean = siteTitle != null && dataType != null
+    )
+
+    data class WidgetAdded(val appWidgetId: Int)
+}

--- a/WordPress/src/main/res/layout/stats_color_selector.xml
+++ b/WordPress/src/main/res/layout/stats_color_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RadioGroup
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/colors"
+    android:id="@+id/data_types"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:descendantFocusability="beforeDescendants"

--- a/WordPress/src/main/res/layout/stats_data_type_selector.xml
+++ b/WordPress/src/main/res/layout/stats_data_type_selector.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RadioGroup
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/colors"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:descendantFocusability="beforeDescendants"
+    android:paddingEnd="@dimen/margin_extra_medium_large"
+    android:paddingStart="@dimen/margin_extra_medium_large"
+    android:paddingTop="@dimen/margin_extra_large"
+    android:scrollbars="vertical">
+
+    <androidx.appcompat.widget.AppCompatRadioButton
+        android:id="@+id/stats_widget_views"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/margin_extra_extra_large"
+        android:checked="true"
+        android:paddingStart="@dimen/stats_widget_color_selector_padding"
+        android:paddingEnd="@dimen/stats_widget_color_selector_padding"
+        android:text="@string/stats_views"/>
+
+    <androidx.appcompat.widget.AppCompatRadioButton
+        android:id="@+id/stats_widget_visitors"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/margin_extra_extra_large"
+        android:paddingStart="@dimen/stats_widget_color_selector_padding"
+        android:paddingEnd="@dimen/stats_widget_color_selector_padding"
+        android:text="@string/stats_visitors"/>
+
+    <androidx.appcompat.widget.AppCompatRadioButton
+        android:id="@+id/stats_widget_comments"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/margin_extra_extra_large"
+        android:paddingStart="@dimen/stats_widget_color_selector_padding"
+        android:paddingEnd="@dimen/stats_widget_color_selector_padding"
+        android:text="@string/stats_comments"/>
+
+    <androidx.appcompat.widget.AppCompatRadioButton
+        android:id="@+id/stats_widget_likes"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/margin_extra_extra_large"
+        android:paddingStart="@dimen/stats_widget_color_selector_padding"
+        android:paddingEnd="@dimen/stats_widget_color_selector_padding"
+        android:text="@string/stats_likes"/>
+</RadioGroup>

--- a/WordPress/src/main/res/layout/stats_data_type_selector.xml
+++ b/WordPress/src/main/res/layout/stats_data_type_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RadioGroup
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/colors"
+    android:id="@+id/data_types"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:descendantFocusability="beforeDescendants"

--- a/WordPress/src/main/res/layout/stats_minified_widget_configure_activity.xml
+++ b/WordPress/src/main/res/layout/stats_minified_widget_configure_activity.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/constraintLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/coordinatorLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <fragment
+            android:id="@+id/fragment_container"
+            android:name="org.wordpress.android.ui.stats.refresh.lists.widget.minified.StatsMinifiedWidgetConfigureFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_below="@id/toolbar"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/app_bar_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:animateLayoutChanges="true"
+            android:fitsSystemWindows="true">
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:layout_collapseMode="pin"
+                app:layout_scrollFlags="enterAlways"
+                app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+                app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+                app:title="@string/stats_insights_today_stats"/>
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/stats_widget_configure_fragment.xml
+++ b/WordPress/src/main/res/layout/stats_widget_configure_fragment.xml
@@ -66,6 +66,37 @@
             android:text="@string/stats_widget_color_light"/>
     </LinearLayout>
 
+    <LinearLayout
+        android:id="@+id/data_type_container"
+        android:visibility="gone"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/two_line_list_item_height"
+        android:background="?android:attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:orientation="vertical"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/color_container">
+
+        <TextView
+            android:id="@+id/data_type_title"
+            style="@style/StatsWidgetConfigureTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:layout_marginTop="@dimen/margin_extra_large"
+            android:text="@string/stats_widget_select_type"/>
+
+        <TextView
+            android:id="@+id/data_type_value"
+            style="@style/StatsWidgetConfigureValue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:layout_marginTop="@dimen/margin_small"
+            android:text="@string/stats_widget_type_caption"/>
+    </LinearLayout>
+
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/add_widget_button"
         style="@style/WordPress.Button.Primary"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -856,6 +856,7 @@
     <string name="stats_widget_select_your_site">Select your site</string>
     <string name="stats_widget_select_color">Color</string>
     <string name="stats_widget_select_type">Type</string>
+    <string name="stats_widget_type_caption">Select type</string>
     <string name="stats_widget_error_no_data">Couldn\'t load data</string>
     <string name="stats_widget_error_no_network">No network available</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -855,6 +855,7 @@
     <string name="stats_widget_color_dark">Dark</string>
     <string name="stats_widget_select_your_site">Select your site</string>
     <string name="stats_widget_select_color">Color</string>
+    <string name="stats_widget_select_type">Type</string>
     <string name="stats_widget_error_no_data">Couldn\'t load data</string>
     <string name="stats_widget_error_no_network">No network available</string>
 

--- a/WordPress/src/main/res/xml/stats_minified_widget_info.xml
+++ b/WordPress/src/main/res/xml/stats_minified_widget_info.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:configure="org.wordpress.android.ui.stats.refresh.lists.widget.minified.StatsMinifiedWidgetConfigureActivity"
+    android:initialKeyguardLayout="@layout/stats_widget_blocks_light"
+    android:initialLayout="@layout/stats_widget_blocks_light"
+    android:minHeight="110dp"
+    android:minResizeWidth="150dp"
+    android:minWidth="250dp"
+    android:previewImage="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp"
+    android:resizeMode="horizontal"
+    android:updatePeriodMillis="600000"
+    android:widgetCategory="home_screen">
+</appwidget-provider>


### PR DESCRIPTION
This PR adds a new dialog fragment to select a "Type" for the minified widget (views/visitors/comments/likes). This field is mandatory in the configuration. The Widget itself is not yet implemented.

To test:
* Add the new widget
* Check that there is a "Type" option on the configuration screen
* Check that you can select a "Type" 
* Selecting a "Type" and a "Site" enables the "Add" button

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
