### PR TITLE
Gutenberg/Android X: Apply Java 1.8 compileOptions even when building from binaries

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -63,12 +63,10 @@ android {
     }
 
     // Gutenberg's dependency - react-native-video is using
-    // Java API 1.8 so we need this when building from source
-    if (rootProject.ext.buildGutenbergFromSource) {
-        compileOptions {
-            sourceCompatibility JavaVersion.VERSION_1_8
-            targetCompatibility JavaVersion.VERSION_1_8
-        }
+    // Java API 1.8
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     flavorDimensions "buildType"


### PR DESCRIPTION
I added this conditional in https://github.com/wordpress-mobile/WordPress-Android/pull/9882 in order to fix tests after `react-native-video` was introduced. It does not seem to be needed anymore and removing it should unblock the Android X migration (https://github.com/wordpress-mobile/WordPress-Android/pull/10020).

It will fix the build on https://github.com/wordpress-mobile/WordPress-Android/pull/10020 with `wp.BUILD_GUTENBERG_FROM_SOURCE=false`.

To test:

With `wp.BUILD_GUTENBERG_FROM_SOURCE=false`:

- `./gradlew WordPress:assembleVanillaDebug`
- `./gradlew WordPress:assembleVanillaDebugAndroidTest`

With `wp.BUILD_GUTENBERG_FROM_SOURCE=true`:

- `./gradlew WordPress:assembleVanillaDebug`
- `./gradlew WordPress:assembleVanillaDebugAndroidTest`

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
