### PR TITLE
Only run UI tests from org.wordpress.android.e2e on Firebase Test Lab

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ jobs:
           type: instrumentation
           apk-path: WordPress/build/outputs/apk/vanilla/debug/WordPress-vanilla-debug.apk
           test-apk-path: WordPress/build/outputs/apk/androidTest/vanilla/debug/WordPress-vanilla-debug-androidTest.apk
+          test-targets: package org.wordpress.android.e2e
           device: model=Nexus5X,version=26,locale=en,orientation=portrait
           project: api-project-108380595987
           timeout: 10m


### PR DESCRIPTION
For the past month or so we have been running connected tests every night on Firebase Test Lab (see https://github.com/wordpress-mobile/WordPress-Android/pull/9836). Unfortunately, these have proven to be quite flaky. This change is to only run the UI tests (in the `org.wordpress.android.e2e` package) in the nightly run. As well as eliminating the most flaky test (`WPScreenshotTest`), it speeds up the tests considerably which will be helpful if we decide to move the runs to each PR.

To test:

- Not much to test here other than see how it runs after this merges. I have tested the change locally. You can see a sample run [here](https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670/matrices/8975240249061002844).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
