### PR TITLE
Connected Tests: Fix deprecation warnings after Android X upgrade

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
@@ -12,7 +12,7 @@ import org.hamcrest.Matchers;
 import org.wordpress.android.R;
 import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
 
-import static androidx.test.InstrumentationRegistry.getTargetContext;
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -76,7 +76,7 @@ public class LoginFlow {
         // Follow the magic link to continue login
         // Intent is invoked directly rather than through a browser as WireMock is unavailable once in the background
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("wordpress://magic-login?token=valid_token"))
-                .setPackage(getTargetContext().getPackageName());
+                .setPackage(getApplicationContext().getPackageName());
         magicLinkActivityTestRule.launchActivity(intent);
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
@@ -9,7 +9,7 @@ import androidx.test.rule.ActivityTestRule;
 import org.wordpress.android.R;
 import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
 
-import static androidx.test.InstrumentationRegistry.getTargetContext;
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.matcher.ViewMatchers.withHint;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -36,7 +36,7 @@ public class SignupFlow {
         Intent intent = new Intent(
                 Intent.ACTION_VIEW,
                 Uri.parse("wordpress://magic-login?token=valid_token&new_user=1")
-        ).setPackage(getTargetContext().getPackageName());
+        ).setPackage(getApplicationContext().getPackageName());
 
         magicLinkActivityTestRule.launchActivity(intent);
     }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
@@ -5,7 +5,7 @@ import androidx.test.espresso.action.ViewActions;
 
 import org.wordpress.android.R;
 
-import static androidx.test.InstrumentationRegistry.getInstrumentation;
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.Espresso.pressBack;
@@ -76,7 +76,7 @@ public class EditorPage {
     }
 
     public void openSettings() {
-        openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+        openActionBarOverflowOrOptionsMenu(getApplicationContext());
         clickOn(onView(withText("Post settings")));
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.support;
 
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
@@ -31,8 +32,7 @@ public class BaseTest {
 
     @Before
     public void setup() {
-        mAppContext =
-                (WordPress) InstrumentationRegistry.getInstrumentation().getTargetContext().getApplicationContext();
+        mAppContext = ApplicationProvider.getApplicationContext();
         mMockedAppComponent = DaggerAppComponentTest.builder()
                                                     .application(mAppContext)
                                                     .build();
@@ -41,7 +41,8 @@ public class BaseTest {
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(
             options().port(WIREMOCK_PORT)
-                     .fileSource(new AssetFileSource(InstrumentationRegistry.getContext().getAssets()))
+                     .fileSource(new AssetFileSource(
+                             InstrumentationRegistry.getInstrumentation().getContext().getAssets()))
                      .extensions(new ResponseTemplateTransformer(true))
                      .notifier(new AndroidNotifier()));
     @Rule

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/PlaceholderComparison.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/PlaceholderComparison.java
@@ -9,7 +9,7 @@ import android.graphics.drawable.Drawable;
 import android.util.Size;
 import android.widget.ImageView;
 
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
@@ -27,7 +27,7 @@ public class PlaceholderComparison {
     private ImageType mImageType;
 
     public PlaceholderComparison(ImageType imageType) {
-        mContext = InstrumentationRegistry.getTargetContext();
+        mContext = ApplicationProvider.getApplicationContext();
         mImageType = imageType;
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -6,7 +6,6 @@ import android.view.ViewGroup;
 import android.view.ViewParent;
 
 import androidx.recyclerview.widget.RecyclerView;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.espresso.AmbiguousViewMatcherException;
 import androidx.test.espresso.Espresso;
 import androidx.test.espresso.ViewInteraction;
@@ -25,7 +24,6 @@ import org.wordpress.android.util.image.ImageType;
 import java.util.Collection;
 import java.util.function.Supplier;
 
-import static androidx.test.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
@@ -40,6 +38,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.runner.lifecycle.Stage.RESUMED;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
@@ -509,7 +508,7 @@ public class WPSupportUtils {
 
     private static Activity mCurrentActivity;
     public static Activity getCurrentActivity() {
-        InstrumentationRegistry.getInstrumentation().runOnMainSync(new Runnable() {
+        getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
                 Collection resumedActivities = ActivityLifecycleMonitorRegistry

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPLocaleTestRule.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPLocaleTestRule.java
@@ -1,6 +1,8 @@
 package org.wordpress.android.ui.screenshots;
 
-import androidx.test.InstrumentationRegistry;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -45,7 +47,7 @@ public class WPLocaleTestRule implements TestRule {
     }
 
     private static void changeLocale(String localeCode) {
-        LocaleManager.setNewLocale(InstrumentationRegistry.getTargetContext(), localeCode);
+        LocaleManager.setNewLocale(ApplicationProvider.getApplicationContext(), localeCode);
         WordPress.updateContextLocale();
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/UploadWorkerTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/UploadWorkerTest.kt
@@ -1,8 +1,9 @@
 package org.wordpress.android.util
 
+import android.content.Context
 import android.util.Log
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.work.Configuration
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
@@ -32,7 +33,7 @@ class UploadWorkerTest {
 
     @Before
     fun setUp() {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val context = ApplicationProvider.getApplicationContext<Context>()
         val config = Configuration.Builder()
                 .setMinimumLoggingLevel(Log.DEBUG)
                 // Use a SynchronousExecutor here to make it easier to write tests


### PR DESCRIPTION
The recent Android X changes introduced a few deprecation warnings in our connected tests related to `InstrumentationRegistry`. this is a simple update to fix that.

To test:

- Connected tests still pass: either through Android Studio or with `./gradlew WordPress:connectedVanillaDebugAndroidTest`.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
