### PR TITLE
Add instructions for imagemagick@6

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ it on [Google Play](https://play.google.com/store/apps/details?id=org.wordpress.
 ## Build Instructions ##
 
 1. Make sure you've installed [Android Studio](https://developer.android.com/studio/index.html).
+1. `brew install imagemagick@6` to install the correct ImageMagick formula.
+1. `export PKG_CONFIG_PATH="/usr/local/opt/imagemagick@6/lib/pkgconfig"`
 1. `git clone git@github.com:wordpress-mobile/WordPress-Android.git` in the folder of your preference.
 1. `cd WordPress-Android` to enter the working directory.
 1. `cp gradle.properties-example gradle.properties` to set up the sample app credentials file.


### PR DESCRIPTION
Whilst setting up my machine to do some work in this repo, I had need to run `bundle install`, and encountered an error.  After consulting @jkmassel it turns out I needed to install the ImageMagick@6 Homebrew formula.  This PR documents those setup instructions.  🙂 

To test:
Kind of hard to test, but I suppose one could run `brew remove imagemagick@6` to get into the state I was in that prompted this PR.

`bundle install` - Fails
`brew install imagemagick@6`
`export PKG_CONFIG_PATH="/usr/local/opt/imagemagick@6/lib/pkgconfig"`
`bundle install` - Succeeds!

~Update release notes:~

~- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.~
