### PR TITLE
Fix wrong Y axis values in Swedish

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -5,17 +5,14 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import com.github.mikephil.charting.charts.BarChart
-import com.github.mikephil.charting.components.AxisBase
 import com.github.mikephil.charting.components.Description
 import com.github.mikephil.charting.data.BarData
 import com.github.mikephil.charting.data.BarDataSet
 import com.github.mikephil.charting.data.BarEntry
 import com.github.mikephil.charting.data.Entry
-import com.github.mikephil.charting.formatter.LargeValueFormatter
 import com.github.mikephil.charting.highlight.Highlight
 import com.github.mikephil.charting.interfaces.datasets.IBarDataSet
 import com.github.mikephil.charting.listener.OnChartValueSelectedListener
-import com.github.mikephil.charting.utils.ViewPortHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
@@ -23,8 +20,8 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarChartItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarChartItem.Bar
+import org.wordpress.android.ui.stats.refresh.utils.LargeValueFormatter
 import org.wordpress.android.util.DisplayUtils
-import kotlin.math.round
 
 private const val MIN_COLUMN_COUNT = 5
 private const val MIN_VALUE = 5f
@@ -89,20 +86,7 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
                 R.color.neutral_50
         )
         axisLeft.apply {
-            valueFormatter = object : LargeValueFormatter() {
-                override fun getFormattedValue(value: Float, axis: AxisBase?): String {
-                    return super.getFormattedValue(round(value), axis)
-                }
-
-                override fun getFormattedValue(
-                    value: Float,
-                    entry: Entry?,
-                    dataSetIndex: Int,
-                    viewPortHandler: ViewPortHandler?
-                ): String {
-                    return super.getFormattedValue(round(value), entry, dataSetIndex, viewPortHandler)
-                }
-            }
+            valueFormatter = LargeValueFormatter()
             setDrawGridLines(true)
             setDrawTopYLabelEntry(true)
             setDrawZeroLine(false)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/LargeValueFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/LargeValueFormatter.kt
@@ -10,6 +10,10 @@ import java.text.DecimalFormatSymbols
 import java.util.Locale
 import kotlin.math.round
 
+/**
+ * This class is based on the {@link com.github.mikephil.charting.formatter.LargeValueFormatter} and fixes the issue
+ * with Locale other than US (in some languages is the DecimalFormat different).
+ */
 class LargeValueFormatter : IValueFormatter, IAxisValueFormatter {
     private var mSuffix = arrayOf("", "k", "m", "b", "t")
     private var mMaxLength = 5

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/LargeValueFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/LargeValueFormatter.kt
@@ -1,0 +1,46 @@
+package org.wordpress.android.ui.stats.refresh.utils
+
+import com.github.mikephil.charting.components.AxisBase
+import com.github.mikephil.charting.data.Entry
+import com.github.mikephil.charting.formatter.IAxisValueFormatter
+import com.github.mikephil.charting.formatter.IValueFormatter
+import com.github.mikephil.charting.utils.ViewPortHandler
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.util.Locale
+import kotlin.math.round
+
+class LargeValueFormatter : IValueFormatter, IAxisValueFormatter {
+    private var mSuffix = arrayOf("", "k", "m", "b", "t")
+    private var mMaxLength = 5
+    private val mFormat: DecimalFormat = DecimalFormat("###E00", DecimalFormatSymbols(Locale.US))
+
+    override fun getFormattedValue(
+        value: Float,
+        entry: Entry,
+        dataSetIndex: Int,
+        viewPortHandler: ViewPortHandler
+    ): String {
+        return makePretty(round(value).toDouble())
+    }
+
+    override fun getFormattedValue(value: Float, axis: AxisBase): String {
+        return makePretty(round(value).toDouble())
+    }
+
+    private fun makePretty(number: Double): String {
+        var r = mFormat.format(number)
+
+        val numericValue1 = Character.getNumericValue(r[r.length - 1])
+        val numericValue2 = Character.getNumericValue(r[r.length - 2])
+        val combined = Integer.valueOf(numericValue2.toString() + "" + numericValue1)
+
+        r = r.replace("E[0-9][0-9]".toRegex(), mSuffix[combined / 3])
+
+        while (r.length > mMaxLength || r.matches("[0-9]+\\.[a-z]".toRegex())) {
+            r = r.substring(0, r.length - 2) + r.substring(r.length - 1)
+        }
+
+        return r
+    }
+}


### PR DESCRIPTION
Fixes #9308 and #10071 
The value formatted by DecimalFormat is different in some languages (standard, US way is `520.0 520E00`, in Swedish it is `720.0 720×10^00`, we've seen cases of `520.0 520e00`). In the default `LargeValueFormatter` in the library we expect the first US format. In this PR I've created a new `LargeValueFormatter` in which I'm setting the default Locale to US so we always get the correct results. The `LargeValueFormatter` is mostly copy&paste of the same class in the MPAndroidChart library. 

To test:
* Change language to Swedish
* Go to Stats/DWMY
* Notice that the Y axis labels are now correct
* Check that nothing has changed in English

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
