### PR TITLE
Improve stats architecture to reduce unnecessary refreshes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -170,7 +170,7 @@ class StatsFragment : DaggerFragment() {
         })
 
         viewModel.siteChanged.observe(this, Observer {
-            viewModel.refreshData()
+            viewModel.onSiteChanged()
         })
 
         viewModel.hideToolbar.observe(this, Observer { event ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import org.wordpress.android.R
+import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_INSIGHTS_ACCESSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_PERIOD_DAYS_ACCESSED
@@ -17,12 +17,14 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.ANNUAL_STATS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DAYS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.MONTHS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.WEEKS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.YEARS
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseParam.SITE
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.utils.NewsCardHandler
 import org.wordpress.android.ui.stats.refresh.utils.SelectedSectionManager
@@ -91,10 +93,6 @@ class StatsViewModel
     }
 
     fun onPullToRefresh() {
-        refreshData()
-    }
-
-    fun refreshData() {
         _showSnackbarMessage.value = null
         statsSiteProvider.clear()
         if (networkUtilsWrapper.isNetworkAvailable()) {
@@ -103,7 +101,13 @@ class StatsViewModel
             }
         } else {
             _isRefreshing.value = false
-            _showSnackbarMessage.value = SnackbarMessageHolder(R.string.no_network_title)
+            _showSnackbarMessage.value = SnackbarMessageHolder(string.no_network_title)
+        }
+    }
+
+    fun onSiteChanged() {
+        loadData {
+            listUseCases.values.forEach { it.onParamChanged(SITE) }
         }
     }
 
@@ -122,7 +126,7 @@ class StatsViewModel
             WEEKS -> analyticsTracker.trackGranular(STATS_PERIOD_WEEKS_ACCESSED, StatsGranularity.WEEKS)
             MONTHS -> analyticsTracker.trackGranular(STATS_PERIOD_MONTHS_ACCESSED, StatsGranularity.MONTHS)
             YEARS -> analyticsTracker.trackGranular(STATS_PERIOD_YEARS_ACCESSED, StatsGranularity.YEARS)
-            DETAIL -> {
+            ANNUAL_STATS, DETAIL -> {
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import org.wordpress.android.R.string
+import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_INSIGHTS_ACCESSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_PERIOD_DAYS_ACCESSED
@@ -101,7 +101,7 @@ class StatsViewModel
             }
         } else {
             _isRefreshing.value = false
-            _showSnackbarMessage.value = SnackbarMessageHolder(string.no_network_title)
+            _showSnackbarMessage.value = SnackbarMessageHolder(R.string.no_network_title)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostHeaderUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostHeaderUseCase.kt
@@ -22,7 +22,8 @@ class PostHeaderUseCase
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) : StatelessUseCase<String>(
         PostDetailType.POST_HEADER,
-        mainDispatcher
+        mainDispatcher,
+        listOf()
 ) {
     override suspend fun loadCachedData(): String? {
         return statsPostProvider.postTitle

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
@@ -102,10 +102,6 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
         }
     }
 
-    enum class UseCaseParam {
-        SITE, SELECTED_DATE
-    }
-
     protected suspend fun evaluateState(state: State<DOMAIN_MODEL>) {
         val useCaseState = when (state) {
             is Error -> ERROR
@@ -251,5 +247,10 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
     enum class UseCaseMode {
         BLOCK,
         VIEW_ALL
+    }
+
+    enum class UseCaseParam {
+        SITE,
+        SELECTED_DATE
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/GranularStatefulUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/GranularStatefulUseCase.kt
@@ -5,7 +5,9 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.StatsType
-import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatefulUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseParam.SELECTED_DATE
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseParam.SITE
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import java.util.Date
@@ -17,7 +19,7 @@ abstract class GranularStatefulUseCase<DOMAIN_MODEL, UI_STATE>(
     val selectedDateProvider: SelectedDateProvider,
     val statsGranularity: StatsGranularity,
     defaultUiState: UI_STATE
-) : StatefulUseCase<DOMAIN_MODEL, UI_STATE>(type, mainDispatcher, defaultUiState) {
+) : BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(type, mainDispatcher, defaultUiState, listOf(SITE, SELECTED_DATE)) {
     abstract suspend fun loadCachedData(selectedDate: Date, site: SiteModel): DOMAIN_MODEL?
 
     final override suspend fun loadCachedData(): DOMAIN_MODEL? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/GranularStatelessUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/GranularStatelessUseCase.kt
@@ -6,6 +6,8 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.StatsType
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatelessUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseParam.SELECTED_DATE
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseParam.SITE
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import java.util.Date
@@ -16,7 +18,7 @@ abstract class GranularStatelessUseCase<DOMAIN_MODEL>(
     val selectedDateProvider: SelectedDateProvider,
     val statsSiteProvider: StatsSiteProvider,
     val statsGranularity: StatsGranularity
-) : StatelessUseCase<DOMAIN_MODEL>(type, mainDispatcher) {
+) : StatelessUseCase<DOMAIN_MODEL>(type, mainDispatcher, listOf(SITE, SELECTED_DATE)) {
     abstract suspend fun loadCachedData(selectedDate: Date, site: SiteModel): DOMAIN_MODEL?
 
     final override suspend fun loadCachedData(): DOMAIN_MODEL? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
@@ -91,7 +91,7 @@ constructor(
         }
     }
 
-    override fun buildStatefulUiModel(domainModel: AuthorsModel, uiState: SelectedAuthor): List<BlockListItem> {
+    override fun buildUiModel(domainModel: AuthorsModel, uiState: SelectedAuthor): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
 
         if (useCaseMode == BLOCK) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCase.kt
@@ -88,7 +88,7 @@ constructor(
         }
     }
 
-    override fun buildStatefulUiModel(domainModel: ClicksModel, uiState: SelectedClicksGroup): List<BlockListItem> {
+    override fun buildUiModel(domainModel: ClicksModel, uiState: SelectedClicksGroup): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
 
         if (useCaseMode == BLOCK) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsType.OVERVIEW
 import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatefulUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularUseCaseFactory
@@ -37,7 +37,7 @@ constructor(
     private val overviewMapper: OverviewMapper,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     private val analyticsTracker: AnalyticsTrackerWrapper
-) : StatefulUseCase<VisitsAndViewsModel, UiState>(
+) : BaseStatsUseCase<VisitsAndViewsModel, UiState>(
         OVERVIEW,
         mainDispatcher,
         UiState()
@@ -88,7 +88,7 @@ constructor(
         }
     }
 
-    override fun buildStatefulUiModel(domainModel: VisitsAndViewsModel, uiState: UiState): List<BlockListItem> {
+    override fun buildUiModel(domainModel: VisitsAndViewsModel, uiState: UiState): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
         if (domainModel.dates.isNotEmpty()) {
             val periodFromProvider = selectedDateProvider.getSelectedDate(statsGranularity)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
@@ -89,7 +89,7 @@ constructor(
         }
     }
 
-    override fun buildStatefulUiModel(domainModel: ReferrersModel, uiState: SelectedGroup): List<BlockListItem> {
+    override fun buildUiModel(domainModel: ReferrersModel, uiState: SelectedGroup): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
 
         if (useCaseMode == BLOCK) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCase.kt
@@ -8,7 +8,7 @@ import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.COMMENTS
 import org.wordpress.android.fluxc.store.stats.insights.CommentsStore
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatefulUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
@@ -33,7 +33,7 @@ class CommentsUseCase
     private val commentsStore: CommentsStore,
     private val statsSiteProvider: StatsSiteProvider,
     private val popupMenuHandler: ItemPopupMenuHandler
-) : StatefulUseCase<CommentsModel, SelectedTabUiState>(COMMENTS, mainDispatcher, 0) {
+) : BaseStatsUseCase<CommentsModel, SelectedTabUiState>(COMMENTS, mainDispatcher, 0) {
     override suspend fun fetchRemoteData(forced: Boolean): State<CommentsModel> {
         val fetchMode = LimitMode.Top(BLOCK_ITEM_COUNT)
         val response = commentsStore.fetchComments(statsSiteProvider.siteModel, fetchMode, forced)
@@ -61,7 +61,7 @@ class CommentsUseCase
         return listOf(buildTitle(), Empty())
     }
 
-    override fun buildStatefulUiModel(model: CommentsModel, uiState: Int): List<BlockListItem> {
+    override fun buildUiModel(model: CommentsModel, uiState: Int): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
         items.add(buildTitle())
         if (model.authors.isNotEmpty() || model.posts.isNotEmpty()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowersUseCase.kt
@@ -18,7 +18,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.StatsUtilsWrapper
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewFollowersStats
-import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatefulUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
@@ -54,7 +54,7 @@ class FollowersUseCase(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val popupMenuHandler: ItemPopupMenuHandler,
     private val useCaseMode: UseCaseMode
-) : StatefulUseCase<Pair<FollowersModel, FollowersModel>, FollowersUiState>(
+) : BaseStatsUseCase<Pair<FollowersModel, FollowersModel>, FollowersUiState>(
         FOLLOWERS,
         mainDispatcher,
         FollowersUiState(isLoading = true)
@@ -124,7 +124,7 @@ class FollowersUseCase(
         return listOf(buildTitle(), Empty())
     }
 
-    override fun buildStatefulUiModel(
+    override fun buildUiModel(
         domainModel: Pair<FollowersModel, FollowersModel>,
         uiState: FollowersUiState
     ): List<BlockListItem> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ManagementControlUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ManagementControlUseCase.kt
@@ -20,7 +20,7 @@ class ManagementControlUseCase
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     private val newsCardHandler: NewsCardHandler,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
-) : StatelessUseCase<Boolean>(ManagementType.CONTROL, mainDispatcher) {
+) : StatelessUseCase<Boolean>(ManagementType.CONTROL, mainDispatcher, listOf()) {
     override suspend fun loadCachedData() = true
 
     override suspend fun fetchRemoteData(forced: Boolean): State<Boolean> = State.Data(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ManagementNewsCardUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ManagementNewsCardUseCase.kt
@@ -25,7 +25,7 @@ class ManagementNewsCardUseCase
     private val resourceProvider: ResourceProvider,
     private val newsCardHandler: NewsCardHandler,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
-) : StatelessUseCase<Boolean>(ManagementType.NEWS_CARD, mainDispatcher) {
+) : StatelessUseCase<Boolean>(ManagementType.NEWS_CARD, mainDispatcher, listOf()) {
     override suspend fun loadCachedData() = true
 
     override suspend fun fetchRemoteData(forced: Boolean): State<Boolean> = State.Data(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCase.kt
@@ -14,7 +14,7 @@ import org.wordpress.android.fluxc.store.stats.insights.TagsStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTag
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTagsAndCategoriesStats
-import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatefulUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
@@ -49,7 +49,7 @@ class TagsAndCategoriesUseCase
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val popupMenuHandler: ItemPopupMenuHandler,
     private val useCaseMode: UseCaseMode
-) : StatefulUseCase<TagsModel, TagsAndCategoriesUiState>(
+) : BaseStatsUseCase<TagsModel, TagsAndCategoriesUiState>(
         TAGS_AND_CATEGORIES,
         mainDispatcher,
         TagsAndCategoriesUiState(null)
@@ -78,7 +78,7 @@ class TagsAndCategoriesUseCase
         return listOf(buildTitle(), Empty())
     }
 
-    override fun buildStatefulUiModel(domainModel: TagsModel, uiState: TagsAndCategoriesUiState): List<BlockListItem> {
+    override fun buildUiModel(domainModel: TagsModel, uiState: TagsAndCategoriesUiState): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
 
         if (useCaseMode == BLOCK) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCaseTest.kt
@@ -108,7 +108,8 @@ class BaseStatsUseCaseTest : BaseUnitTest() {
     ) : BaseStatsUseCase<String, Int>(
             ALL_TIME_STATS,
             Dispatchers.Unconfined,
-            0
+            0,
+            listOf()
     ) {
         override fun buildLoadingItem(): List<BlockListItem> {
             return loadingItems


### PR DESCRIPTION
This PR improves the architecture of the stats. There are right now 2 use case params - Site and Selected date. Whenever they change, some of the use cases should be refreshed. Until now we were refreshing all the use cases whenever one of these params changed. After this is merged each use case can specify (in the constructor) which params should cause them to refresh. This is pretty useful also for the usecases that don't load any data - for example the Post detail title. I also believe it's logically more correct.

I've also removed the useless `StatefulUseCase` which was basically just copying the `BaseStatsUseCase`

To test:
* Check that the tabbed Stats, Stats detail and View more sites all work as expected
* Try switching dates in date selector
* Try switching dates in graph

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
