### PR TITLE
Update FluxC reference

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,5 +105,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'f49752fbd271e8c745b58fd28de20c2106a29ce9'
+    fluxCVersion = '5f057c5fbb8d585c22761a7874327e2889a3f6dd'
 }


### PR DESCRIPTION
This PR updates the reference to FluxC in order to incorporate this fix: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1292.


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
