### PR TITLE
[Editor] Make sure editor session starts (with `content_type=new`) matches post_created event

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -394,7 +394,8 @@ public class EditPostActivity extends AppCompatActivity implements
         mShortcutUtils.reportShortcutUsed(Shortcut.CREATE_NEW_POST);
     }
 
-    private void createPostEditorAnalyticsSessionTracker(boolean showGutenbergEditor, PostModel post, SiteModel site, boolean isNewPost) {
+    private void createPostEditorAnalyticsSessionTracker(boolean showGutenbergEditor, PostModel post, SiteModel site,
+                                                         boolean isNewPost) {
         if (mPostEditorAnalyticsSession == null) {
             mPostEditorAnalyticsSession = new PostEditorAnalyticsSession(
                     showGutenbergEditor ? Editor.GUTENBERG : Editor.CLASSIC,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -394,11 +394,11 @@ public class EditPostActivity extends AppCompatActivity implements
         mShortcutUtils.reportShortcutUsed(Shortcut.CREATE_NEW_POST);
     }
 
-    private void createPostEditorAnalyticsSessionTracker(boolean showGutenbergEditor, PostModel post, SiteModel site) {
+    private void createPostEditorAnalyticsSessionTracker(boolean showGutenbergEditor, PostModel post, SiteModel site, boolean isNewPost) {
         if (mPostEditorAnalyticsSession == null) {
             mPostEditorAnalyticsSession = new PostEditorAnalyticsSession(
                     showGutenbergEditor ? Editor.GUTENBERG : Editor.CLASSIC,
-                    post, site);
+                    post, site, isNewPost);
         }
     }
 
@@ -531,7 +531,7 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         // ok now we are sure to have both a valid Post and showGutenberg flag, let's start the editing session tracker
-        createPostEditorAnalyticsSessionTracker(mShowGutenbergEditor, mPost, mSite);
+        createPostEditorAnalyticsSessionTracker(mShowGutenbergEditor, mPost, mSite, mIsNewPost);
 
         // Bump post created analytics only once, first time the editor is opened
         if (mIsNewPost && savedInstanceState == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -1,7 +1,5 @@
 package org.wordpress.android.ui.posts;
 
-import android.text.TextUtils;
-
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.model.PostModel;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -47,7 +47,7 @@ public class PostEditorAnalyticsSession implements Serializable {
         PUBLISH
     }
 
-    PostEditorAnalyticsSession(Editor editor, PostModel post, SiteModel site) {
+    PostEditorAnalyticsSession(Editor editor, PostModel post, SiteModel site, boolean isNewPost) {
         // fill in which the current Editor is
         mCurrentEditor = editor;
 
@@ -69,7 +69,7 @@ public class PostEditorAnalyticsSession implements Serializable {
 
         // fill in mContentType
         String postContent = post.getContent();
-        if (TextUtils.isEmpty(post.getContent())) {
+        if (isNewPost) {
             mContentType = "new";
         } else if (PostUtils.contentContainsGutenbergBlocks(postContent)) {
             mContentType = "gutenberg";


### PR DESCRIPTION
This PR fixes #10061 by making sure to re-use the same logic to track a post as `new` in both `session_starts` and `post_created` events.

Note: The logic is pretty simple, there is a boolean flag passed to the activity, that is true on new posts only. Previously, the session_starts event was checking if the post content was empty or not, and it failed on draft posts with empty content.

To test:
- Start a new post from the app
- Set a breakpoint here https://github.com/wordpress-mobile/WordPress-Android/compare/issue/10061-fix-editor-session-starts-match-post_created?expand=1#diff-38b6aea9cfff5f3e0e4b7389b44de602R399 and make sure `isNewPost` is true
- Also set a breakpoint https://github.com/wordpress-mobile/WordPress-Android/compare/issue/10061-fix-editor-session-starts-match-post_created?expand=1#diff-38b6aea9cfff5f3e0e4b7389b44de602L537 and make sure `trackEditorCreatedPost` is reached


To test #2
- Open a draft post in the app
- Make sure `trackEditorCreatedPost` is not bumped
- Make sure `createPostEditorAnalyticsSessionTracker` is called with `isNewPost` = false

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
