### PR TITLE
Show error when loading fails the first time

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/UiModelMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/UiModelMapper.kt
@@ -72,7 +72,7 @@ class UiModelMapper
         useCaseModels: List<UseCaseModel>,
         showError: (Int) -> Unit
     ): UiModel {
-            return mapStatsWithOverview(PostDetailType.POST_OVERVIEW, useCaseModels, showError)
+        return mapStatsWithOverview(PostDetailType.POST_OVERVIEW, useCaseModels, showError)
     }
 
     private fun mapStatsWithOverview(
@@ -84,8 +84,9 @@ class UiModelMapper
                 .fold(true) { acc, useCaseModel ->
                     acc && useCaseModel.state == ERROR
                 }
+        val overviewIsFailing = useCaseModels.any { it.type == overViewType && it.state == ERROR }
         val overviewHasData = useCaseModels.any { it.type == overViewType && it.data != null }
-        return if (!allFailing) {
+        return if (!allFailing && (overviewHasData || !overviewIsFailing)) {
             if (useCaseModels.isNotEmpty()) {
                 UiModel.Success(useCaseModels.mapNotNull { useCaseModel ->
                     if ((useCaseModel.type == overViewType) && useCaseModel.data != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
@@ -64,7 +64,7 @@ class SelectedDateProvider
     private fun updateSelectedDate(selectedDate: SelectedDate, statsSection: StatsSection) {
         val currentDate = mutableDates[statsSection]
         mutableDates[statsSection] = selectedDate
-        if (selectedDate.hasUpdatedDate(currentDate)) {
+        if (selectedDate != currentDate) {
             selectedDateChanged.postValue(Event(SectionChange(statsSection)))
         }
     }


### PR DESCRIPTION
Fixes #9336 
When you're loading stats for the first time and the loading fails, the app used to show an error in the Overview block and the rest of the blocks were Loading. This PR fixes this issue by showing a full-screen error when this use case happens. This is not very common because once we have data in the Overview block, we will always show it to the user with the blocks failing.

To test:
* Go to a fresh site (where there are no cached stats)
* Turn on Airplane mode
* Open DWMY stats
* See that there is a full-screen error with a `Retry` button
* Turn off Airplane mode
* Click on `Retry`
* The Stats are loaded

![show_error](https://user-images.githubusercontent.com/1079756/60034296-992d4b80-96aa-11e9-8bb6-7f89872ff821.gif)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
