### PR TITLE
Disable periodic job - "Upload local drafts"

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -316,9 +316,14 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
 
         initWorkManager();
 
-        // Enqueue our periodic upload work request. The UploadWorkRequest will be called even if the app is closed.
-        // It will upload local draft or published posts with local changes to the server.
-        UploadWorkerKt.enqueuePeriodicUploadWorkRequestForAllSites();
+        // TODO Hotfix: WorkManager causes ANRs and we are not sure why yet. We are disabling it for now. We are also
+        //  canceling all the already scheduled WorkRequests.
+
+//        // Enqueue our periodic upload work request. The UploadWorkRequest will be called even if the app is closed.
+//        // It will upload local draft or published posts with local changes to the server.
+//        UploadWorkerKt.enqueuePeriodicUploadWorkRequestForAllSites();
+
+        UploadWorkerKt.cancelPeriodicUploadWorkRequestForAllSites();
     }
 
     protected void initWorkManager() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -29,7 +29,6 @@ import org.wordpress.android.ui.utils.UiString.UiStringText;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.UploadWorkerKt;
 import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.widgets.WPSnackbar;
 
@@ -118,8 +117,11 @@ public class UploadUtils {
 
         boolean savedLocally = data.getBooleanExtra(EditPostActivity.EXTRA_SAVED_AS_LOCAL_DRAFT, false);
         if (savedLocally && !NetworkUtils.isNetworkAvailable(activity)) {
-            // The network is not available, we can enqueue a request to upload local changes later
-            UploadWorkerKt.enqueueUploadWorkRequestForSite(site);
+            // TODO Hotfix: WorkManager causes ANRs and we are not sure why yet. We are disabling it for now.
+
+//            // The network is not available, we can enqueue a request to upload local changes later
+//            UploadWorkerKt.enqueueUploadWorkRequestForSite(site);
+
             // And tell the user about it
             ToastUtils.showToast(activity, R.string.error_publish_no_network,
                                  ToastUtils.Duration.SHORT);


### PR DESCRIPTION
Fixes #10094 

Disables scheduling of periodic jobs for uploading local drafts since they were causing ANRs on some devices. Also cancels all the already scheduled jobs.

We'll revert this PR when we figure out what causes the ANRs.

To test:
1. Install the current 12.6 and run `adb shell dumpsys jobscheduler` -> make sure the periodic task is scheduled
2. Install a version from this branch and run `adb shell dumpsys jobscheduler` -> make sure the periodic task is NOT scheduled

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
