### PR TITLE
Revert: Start uploadService as foreground service (656e7268)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.uploads
 
 import android.content.Context
-import androidx.core.content.ContextCompat
 import org.wordpress.android.fluxc.model.PostModel
 import javax.inject.Inject
 
@@ -14,7 +13,7 @@ import javax.inject.Inject
 class UploadServiceFacade @Inject constructor() {
     fun uploadPost(context: Context, post: PostModel, trackAnalytics: Boolean, publish: Boolean, isRetry: Boolean) {
         val intent = UploadService.getUploadPostServiceIntent(context, post, trackAnalytics, publish, isRetry)
-        ContextCompat.startForegroundService(context, intent)
+        context.startService(intent)
     }
 
     fun isPostUploadingOrQueued(post: PostModel) = UploadService.isPostUploadingOrQueued(post)


### PR DESCRIPTION
Fixes #10096 

Revert changes made in https://github.com/wordpress-mobile/WordPress-Android/pull/10003 as if the service doesn't call "startForeground", the application crashes. I'm not sure under which circumstances it doesn't call "startForeground", but we can create a regular fix in 12.8. 

We'll be receiving quite a lot of non-fatal errors in Sentry for now, but that's definitely better than a crash.

To test:
- Since it just reverts the PR I believe there is no need to test anything.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

cc @loremattei 
