### PR TITLE
Check login status in widget configuration

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsColorSelectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsColorSelectionViewModel.kt
@@ -5,8 +5,10 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -14,10 +16,17 @@ import javax.inject.Named
 class StatsColorSelectionViewModel
 @Inject constructor(
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+    private val accountStore: AccountStore,
     private val appPrefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(mainDispatcher) {
     private val mutableViewMode = MutableLiveData<Color>()
     val viewMode: LiveData<Color> = mutableViewMode
+
+    private val mutableNotification = MutableLiveData<Event<Int>>()
+    val notification: LiveData<Event<Int>> = mutableNotification
+
+    private val mutableDialogOpened = MutableLiveData<Event<Unit>>()
+    val dialogOpened: LiveData<Event<Unit>> = mutableDialogOpened
 
     private var appWidgetId: Int = -1
 
@@ -31,8 +40,16 @@ class StatsColorSelectionViewModel
         }
     }
 
-    fun colorClicked(color: Color) {
+    fun selectColor(color: Color) {
         mutableViewMode.postValue(color)
+    }
+
+    fun openColorDialog() {
+        if (accountStore.hasAccessToken()) {
+            mutableDialogOpened.postValue(Event(Unit))
+        } else {
+            mutableNotification.postValue(Event(R.string.stats_widget_log_in_message))
+        }
     }
 
     enum class Color(@StringRes val title: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsDataTypeSelectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsDataTypeSelectionViewModel.kt
@@ -5,8 +5,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
+import org.wordpress.android.R.string
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -14,10 +17,17 @@ import javax.inject.Named
 class StatsDataTypeSelectionViewModel
 @Inject constructor(
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+    private val accountStore: AccountStore,
     private val appPrefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(mainDispatcher) {
     private val mutableDataType = MutableLiveData<DataType>()
     val dataType: LiveData<DataType> = mutableDataType
+
+    private val mutableNotification = MutableLiveData<Event<Int>>()
+    val notification: LiveData<Event<Int>> = mutableNotification
+
+    private val mutableDialogOpened = MutableLiveData<Event<Unit>>()
+    val dialogOpened: LiveData<Event<Unit>> = mutableDialogOpened
 
     private var appWidgetId: Int = -1
 
@@ -31,8 +41,16 @@ class StatsDataTypeSelectionViewModel
         }
     }
 
-    fun dataTypeClicked(color: DataType) {
-        mutableDataType.postValue(color)
+    fun selectDataType(dataType: DataType) {
+        mutableDataType.postValue(dataType)
+    }
+
+    fun openDataTypeDialog() {
+        if (accountStore.hasAccessToken()) {
+            mutableDialogOpened.postValue(Event(Unit))
+        } else {
+            mutableNotification.postValue(Event(string.stats_widget_log_in_message))
+        }
     }
 
     enum class DataType(@StringRes val title: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsSiteSelectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsSiteSelectionViewModel.kt
@@ -3,7 +3,9 @@ package org.wordpress.android.ui.stats.refresh.lists.widget.configuration
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
@@ -17,6 +19,7 @@ class StatsSiteSelectionViewModel
 @Inject constructor(
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     private val siteStore: SiteStore,
+    private val accountStore: AccountStore,
     private val appPrefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(mainDispatcher) {
     private val mutableSelectedSite = MutableLiveData<SiteUiModel>()
@@ -26,6 +29,12 @@ class StatsSiteSelectionViewModel
     val sites: LiveData<List<SiteUiModel>> = mutableSites
     private val mutableHideSiteDialog = MutableLiveData<Event<Unit>>()
     val hideSiteDialog: LiveData<Event<Unit>> = mutableHideSiteDialog
+
+    private val mutableNotification = MutableLiveData<Event<Int>>()
+    val notification: LiveData<Event<Int>> = mutableNotification
+
+    private val mutableDialogOpened = MutableLiveData<Event<Unit>>()
+    val dialogOpened: LiveData<Event<Unit>> = mutableDialogOpened
 
     fun start(appWidgetId: Int) {
         val siteId = appPrefsWrapper.getAppWidgetSiteId(appWidgetId)
@@ -56,6 +65,14 @@ class StatsSiteSelectionViewModel
     private fun selectSite(site: SiteUiModel) {
         mutableHideSiteDialog.postValue(Event(Unit))
         mutableSelectedSite.postValue(site)
+    }
+
+    fun openSiteDialog() {
+        if (accountStore.hasAccessToken()) {
+            mutableDialogOpened.postValue(Event(Unit))
+        } else {
+            mutableNotification.postValue(Event(R.string.stats_widget_log_in_message))
+        }
     }
 
     data class SiteUiModel(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetColorSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetColorSelectionDialogFragment.kt
@@ -28,7 +28,7 @@ class StatsWidgetColorSelectionDialogFragment : AppCompatDialogFragment() {
         val alertDialogBuilder = AlertDialog.Builder(activity)
         val view = activity!!.layoutInflater.inflate(R.layout.stats_color_selector, null) as RadioGroup
         view.setOnCheckedChangeListener { _, checkedId ->
-            checkedId.toColor()?.let { viewModel.colorClicked(it) }
+            checkedId.toColor()?.let { viewModel.selectColor(it) }
         }
         alertDialogBuilder.setView(view)
         viewModel.viewMode.observe(this, Observer { updatedColor ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
@@ -24,7 +24,9 @@ import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWi
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.ViewType.WEEK_VIEWS
 import org.wordpress.android.ui.stats.refresh.lists.widget.today.TodayWidgetUpdater
 import org.wordpress.android.ui.stats.refresh.lists.widget.views.ViewsWidgetUpdater
+import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.image.ImageManager
+import org.wordpress.android.util.merge
 import javax.inject.Inject
 
 class StatsWidgetConfigureFragment : DaggerFragment() {
@@ -84,15 +86,35 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
         viewModel.start(appWidgetId, viewType, siteSelectionViewModel, colorSelectionViewModel)
 
         site_container.setOnClickListener {
-            StatsWidgetSiteSelectionDialogFragment().show(fragmentManager, "stats_site_selection_fragment")
+            siteSelectionViewModel.openSiteDialog()
         }
         color_container.setOnClickListener {
-            StatsWidgetColorSelectionDialogFragment().show(fragmentManager, "stats_view_mode_selection_fragment")
+            colorSelectionViewModel.openColorDialog()
         }
 
         add_widget_button.setOnClickListener {
             viewModel.addWidget()
         }
+
+        siteSelectionViewModel.dialogOpened.observe(this, Observer { event ->
+            event?.applyIfNotHandled {
+                StatsWidgetSiteSelectionDialogFragment().show(fragmentManager, "stats_site_selection_fragment")
+            }
+        })
+
+        colorSelectionViewModel.dialogOpened.observe(this, Observer { event ->
+            event?.applyIfNotHandled {
+                StatsWidgetColorSelectionDialogFragment().show(fragmentManager, "stats_view_mode_selection_fragment")
+            }
+        })
+
+        merge(siteSelectionViewModel.notification, colorSelectionViewModel.notification).observe(
+                this,
+                Observer { event ->
+                    event?.applyIfNotHandled {
+                        ToastUtils.showToast(activity, this)
+                    }
+                })
 
         viewModel.settingsModel.observe(this, Observer { uiModel ->
             uiModel?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetDataTypeSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetDataTypeSelectionDialogFragment.kt
@@ -30,7 +30,7 @@ class StatsWidgetDataTypeSelectionDialogFragment : AppCompatDialogFragment() {
         val alertDialogBuilder = AlertDialog.Builder(activity)
         val view = activity!!.layoutInflater.inflate(R.layout.stats_data_type_selector, null) as RadioGroup
         view.setOnCheckedChangeListener { _, checkedId ->
-            checkedId.toDataType()?.let { viewModel.dataTypeClicked(it) }
+            checkedId.toDataType()?.let { viewModel.selectDataType(it) }
         }
         alertDialogBuilder.setView(view)
         viewModel.dataType.observe(this, Observer { updatedDataType ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
@@ -9,14 +9,17 @@ import android.view.View
 import android.widget.ImageView.ScaleType.FIT_START
 import android.widget.RemoteViews
 import com.bumptech.glide.request.target.AppWidgetTarget
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.stats.OldStatsActivity
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.StatsActivity
-import org.wordpress.android.ui.stats.refresh.lists.widget.SITE_ID_KEY
 import org.wordpress.android.ui.stats.refresh.lists.widget.IS_WIDE_VIEW_KEY
+import org.wordpress.android.ui.stats.refresh.lists.widget.SITE_ID_KEY
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetService
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.StatsAllTimeWidget
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
@@ -57,8 +60,10 @@ class WidgetUtils
         views: RemoteViews,
         appWidgetId: Int
     ) {
-        val awt = AppWidgetTarget(context, R.id.widget_site_icon, views, appWidgetId)
-        imageManager.load(awt, context, ICON, siteModel?.iconUrl ?: "", FIT_START)
+        GlobalScope.launch(Dispatchers.Main) {
+            val awt = AppWidgetTarget(context, R.id.widget_site_icon, views, appWidgetId)
+            imageManager.load(awt, context, ICON, siteModel?.iconUrl ?: "", FIT_START)
+        }
     }
 
     fun showError(

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1087,6 +1087,8 @@
     <string name="stats_insights_add_insights_header">Add Insights</string>
     <string name="stats_insights_management_drag_and_drop_hint">Items shown above will show in your Insights tab. Drag and drop to customize.</string>
 
+    <string name="stats_widget_log_in_message">Please log in to the WordPress app to add a widget.</string>
+
     <!-- Stats post detail -->
     <string name="stats_detail_months_and_years">Months and Years</string>
     <string name="stats_months_and_years_period_label">Period</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsColorSelectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsColorSelectionViewModelTest.kt
@@ -1,22 +1,28 @@
 package org.wordpress.android.ui.stats.refresh.lists.widget.configuration
 
+import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.DARK
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.LIGHT
+import org.wordpress.android.viewmodel.Event
 
 class StatsColorSelectionViewModelTest : BaseUnitTest() {
     @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Mock private lateinit var accountStore: AccountStore
     private lateinit var viewModel: StatsColorSelectionViewModel
     @Before
     fun setUp() {
-        viewModel = StatsColorSelectionViewModel(Dispatchers.Unconfined, appPrefsWrapper)
+        viewModel = StatsColorSelectionViewModel(Dispatchers.Unconfined, accountStore, appPrefsWrapper)
     }
 
     @Test
@@ -26,12 +32,39 @@ class StatsColorSelectionViewModelTest : BaseUnitTest() {
             viewMode = it
         }
 
-        viewModel.colorClicked(DARK)
+        viewModel.selectColor(DARK)
 
         Assertions.assertThat(viewMode).isEqualTo(DARK)
 
-        viewModel.colorClicked(LIGHT)
+        viewModel.selectColor(LIGHT)
 
         Assertions.assertThat(viewMode).isEqualTo(LIGHT)
+    }
+
+    @Test
+    fun `opens dialog when access token present`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        var event: Event<Unit>? = null
+        viewModel.dialogOpened.observeForever {
+            event = it
+        }
+
+        viewModel.openColorDialog()
+
+        assertThat(event).isNotNull
+    }
+
+    @Test
+    fun `shows notification when access token not present`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        var notification: Event<Int>? = null
+        viewModel.notification.observeForever {
+            notification = it
+        }
+
+        viewModel.openColorDialog()
+
+        assertThat(notification).isNotNull
+        assertThat(notification?.getContentIfNotHandled()).isEqualTo(R.string.stats_widget_log_in_message)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsDataTypeSelectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsDataTypeSelectionViewModelTest.kt
@@ -1,0 +1,50 @@
+package org.wordpress.android.ui.stats.refresh.lists.widget.configuration
+
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.viewmodel.Event
+
+class StatsDataTypeSelectionViewModelTest : BaseUnitTest() {
+    @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Mock private lateinit var accountStore: AccountStore
+    private lateinit var viewModel: StatsDataTypeSelectionViewModel
+    @Before
+    fun setUp() {
+        viewModel = StatsDataTypeSelectionViewModel(Dispatchers.Unconfined, accountStore, appPrefsWrapper)
+    }
+
+    @Test
+    fun `opens dialog when access token present`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        var event: Event<Unit>? = null
+        viewModel.dialogOpened.observeForever {
+            event = it
+        }
+
+        viewModel.openDataTypeDialog()
+
+        Assertions.assertThat(event).isNotNull
+    }
+
+    @Test
+    fun `shows notification when access token not present`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        var notification: Event<Int>? = null
+        viewModel.notification.observeForever {
+            notification = it
+        }
+
+        viewModel.openDataTypeDialog()
+
+        Assertions.assertThat(notification).isNotNull
+        Assertions.assertThat(notification?.getContentIfNotHandled()).isEqualTo(R.string.stats_widget_log_in_message)
+    }
+}


### PR DESCRIPTION
This PR adds a check when clicking on any item in widget configuration and shows a toast when the user is not logged in to the app. You cannot add a widget if you're not logged in.

To test:
* Clear data in the app
* Add a widget
* Try to click on Site/Color/Data type
* A toast is shown with an error that tells you to log in to the WP app

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
