### PR TITLE
Remove unnecessary launch rule

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -1,8 +1,7 @@
 package org.wordpress.android.e2e;
 
-import androidx.test.rule.ActivityTestRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
+import androidx.test.rule.ActivityTestRule;
 
 import org.junit.After;
 import org.junit.Before;

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
@@ -2,7 +2,6 @@ package org.wordpress.android.support;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.rule.ActivityTestRule;
 
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -18,7 +17,6 @@ import org.wordpress.android.mocks.AndroidNotifier;
 import org.wordpress.android.mocks.AssetFileSource;
 import org.wordpress.android.modules.AppComponentTest;
 import org.wordpress.android.modules.DaggerAppComponentTest;
-import org.wordpress.android.ui.WPLaunchActivity;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_SITE_ADDRESS;

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
@@ -45,8 +45,6 @@ public class BaseTest {
                              InstrumentationRegistry.getInstrumentation().getContext().getAssets()))
                      .extensions(new ResponseTemplateTransformer(true))
                      .notifier(new AndroidNotifier()));
-    @Rule
-    public ActivityTestRule<WPLaunchActivity> mActivityTestRule = new ActivityTestRule<>(WPLaunchActivity.class);
 
     private void logout() {
         boolean isSelfHosted = new MePage().go().isSelfHosted();


### PR DESCRIPTION
I think this can reduce the flakiness we we're seeing with the tests. We had an activity test rule in `BaseTest` which would cause the tests to try and load up that activity which might not be available and as a result lead to the timeout in launching that intent. 

To test: We'll have to merge and observe how it behaves but I've manually triggered a number of runs without failures so crossing my fingers that's not just my good luck

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
