### PR TITLE
Add Slack notifications to CircleCI connected tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 orbs:
   android: wordpress-mobile/android@0.0.27
   bundle-install: toshimaru/bundle-install@0.1.1
+  slack: circleci/slack@2.5.0
 
 commands:
   copy-gradle-properties:
@@ -77,6 +78,9 @@ jobs:
           timeout: 10m
           results-history-name: CircleCI WordPress Connected Tests
       - android/save-gradle-cache
+      - slack/status:
+          fail_only: 'true'
+          failure_message: ':red_circle: WordPress Android end to end tests have failed!\nSee https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670'
   strings-check:
     docker:
       - image: circleci/ruby:2.3


### PR DESCRIPTION
This adds failure notifications to the A8C Slack when the end to end tests fail. They go to the `#android-notifications` channel. We can move them somewhere more prominent if they prove to be stable. Here is what it looks like:

![image](https://user-images.githubusercontent.com/1773641/60260483-9d877d80-98d1-11e9-98bb-b80d4537b00f.png) 

To test:

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
