### PR TITLE
[Analytics] Add post_type prop to editor events

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1680,7 +1680,7 @@ public class EditPostActivity extends AppCompatActivity implements
             // Quick press
             normalizedSourceName = "quick-press";
         }
-        properties.put("post_type", mPost.isPage() ? "page" : "post");
+        PostUtils.addPostTypeToAnalyticsProperties(mPost, properties);
         properties.put("created_post_source", normalizedSourceName);
         AnalyticsUtils.trackWithSiteDetails(
                 AnalyticsTracker.Stat.EDITOR_CREATED_POST,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1680,6 +1680,7 @@ public class EditPostActivity extends AppCompatActivity implements
             // Quick press
             normalizedSourceName = "quick-press";
         }
+        properties.put("post_type", mPost.isPage() ? "page" : "post");
         properties.put("created_post_source", normalizedSourceName);
         AnalyticsUtils.trackWithSiteDetails(
                 AnalyticsTracker.Stat.EDITOR_CREATED_POST,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -49,6 +49,14 @@ public class PostUtils {
     private static final String GB_IMG_BLOCK_HEADER_PLACEHOLDER = "<!-- wp:image {\"id\":%s} -->";
     private static final String GB_IMG_BLOCK_CLASS_PLACEHOLDER = "class=\"wp-image-%s\"";
 
+    public static Map<String, Object> addPostTypeToAnalyticsProperties(PostModel post, Map<String, Object> properties) {
+        if (properties == null) {
+            properties = new HashMap<>();
+        }
+        properties.put("post_type", post.isPage() ? "page" : "post");
+        return properties;
+    }
+
     /*
      * collapses shortcodes in the passed post content, stripping anything between the
      * shortcode name and the closing brace
@@ -125,7 +133,7 @@ public class PostUtils {
     public static void trackSavePostAnalytics(PostModel post, SiteModel site) {
         PostStatus status = PostStatus.fromPost(post);
         Map<String, Object> properties = new HashMap<>();
-        properties.put("post_type", post.isPage() ? "page" : "post");
+        PostUtils.addPostTypeToAnalyticsProperties(post, properties);
         switch (status) {
             case PUBLISHED:
                 if (!post.isLocalDraft()) {
@@ -169,7 +177,7 @@ public class PostUtils {
 
     public static void trackOpenEditorAnalytics(PostModel post, SiteModel site) {
         Map<String, Object> properties = new HashMap<>();
-        properties.put("post_type", post.isPage() ? "page" : "post");
+        PostUtils.addPostTypeToAnalyticsProperties(post, properties);
         if (!post.isLocalDraft()) {
             properties.put("post_id", post.getRemotePostId());
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -125,6 +125,7 @@ public class PostUtils {
     public static void trackSavePostAnalytics(PostModel post, SiteModel site) {
         PostStatus status = PostStatus.fromPost(post);
         Map<String, Object> properties = new HashMap<>();
+        properties.put("post_type", post.isPage() ? "page" : "post");
         switch (status) {
             case PUBLISHED:
                 if (!post.isLocalDraft()) {
@@ -168,6 +169,7 @@ public class PostUtils {
 
     public static void trackOpenEditorAnalytics(PostModel post, SiteModel site) {
         Map<String, Object> properties = new HashMap<>();
+        properties.put("post_type", post.isPage() ? "page" : "post");
         if (!post.isLocalDraft()) {
             properties.put("post_id", post.getRemotePostId());
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -589,7 +589,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
                 } else {
                     sCurrentUploadingPostAnalyticsProperties = new HashMap<>();
                 }
-                sCurrentUploadingPostAnalyticsProperties.put("post_type", event.post.isPage() ? "page" : "post");
+                PostUtils.addPostTypeToAnalyticsProperties(event.post, sCurrentUploadingPostAnalyticsProperties);
                 sCurrentUploadingPostAnalyticsProperties.put(AnalyticsUtils.HAS_GUTENBERG_BLOCKS_KEY,
                         PostUtils.contentContainsGutenbergBlocks(event.post.getContent()));
                 AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_PUBLISHED_POST,

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -589,6 +589,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
                 } else {
                     sCurrentUploadingPostAnalyticsProperties = new HashMap<>();
                 }
+                sCurrentUploadingPostAnalyticsProperties.put("post_type", event.post.isPage() ? "page" : "post");
                 sCurrentUploadingPostAnalyticsProperties.put(AnalyticsUtils.HAS_GUTENBERG_BLOCKS_KEY,
                         PostUtils.contentContainsGutenbergBlocks(event.post.getContent()));
                 AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_PUBLISHED_POST,


### PR DESCRIPTION
We found out in https://github.com/wordpress-mobile/WordPress-Android/issues/10098#issuecomment-505477451 that some/most of the editor analytics events don't include the post_type prop to them, making hard to distinguish between page and post.

This PR does add `post_type` to most of those events. 

To test:
- Start a new post
- Publish it
- Check in Logcat that `editor_post_published` has the post_type prop in it.

Repeat the step above by saving a draft, and check the prop bumped in Analytics.

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
