### PR TITLE
Add support for retrying media upload when updating post from editor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -242,7 +242,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private static final String TAG_DISCARDING_CHANGES_NO_NETWORK_DIALOG = "tag_discarding_changes_no_network_dialog";
     private static final String TAG_PUBLISH_CONFIRMATION_DIALOG = "tag_publish_confirmation_dialog";
     private static final String TAG_UPDATE_CONFIRMATION_DIALOG = "tag_update_confirmation_dialog";
-    private static final String TAG_REMOVE_FAILED_UPLOADS_DIALOG = "tag_remove_failed_uploads_dialog";
+    private static final String TAG_FAILED_MEDIA_UPLOADS_DIALOG = "tag_remove_failed_uploads_dialog";
     private static final String TAG_GB_INFORMATIVE_DIALOG = "tag_gb_informative_dialog";
 
     private static final int PAGE_CONTENT = 0;
@@ -1803,13 +1803,16 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override
     public void onNegativeClicked(@NonNull String instanceTag) {
         switch (instanceTag) {
+            case TAG_FAILED_MEDIA_UPLOADS_DIALOG:
+                // Clear failed uploads
+                mEditorFragment.removeAllFailedMediaUploads();
+                break;
             case ASYNC_PROMO_PUBLISH_DIALOG_TAG:
             case ASYNC_PROMO_SCHEDULE_DIALOG_TAG:
             case TAG_DISCARDING_CHANGES_ERROR_DIALOG:
             case TAG_DISCARDING_CHANGES_NO_NETWORK_DIALOG:
             case TAG_PUBLISH_CONFIRMATION_DIALOG:
             case TAG_UPDATE_CONFIRMATION_DIALOG:
-            case TAG_REMOVE_FAILED_UPLOADS_DIALOG:
                 break;
             default:
                 AppLog.e(T.EDITOR, "Dialog instanceTag is not recognized");
@@ -1839,9 +1842,8 @@ public class EditPostActivity extends AppCompatActivity implements
                 AppRatingDialog.INSTANCE
                         .incrementInteractions(APP_REVIEWS_EVENT_INCREMENTED_BY_PUBLISHING_POST_OR_PAGE);
                 break;
-            case TAG_REMOVE_FAILED_UPLOADS_DIALOG:
-                // Clear failed uploads
-                mEditorFragment.removeAllFailedMediaUploads();
+            case TAG_FAILED_MEDIA_UPLOADS_DIALOG:
+                savePostOnlineAndFinishAsync(isFirstTimePublish(), true);
                 break;
             case ASYNC_PROMO_PUBLISH_DIALOG_TAG:
                 uploadPost(true);
@@ -2184,13 +2186,13 @@ public class EditPostActivity extends AppCompatActivity implements
     private void showRemoveFailedUploadsDialog() {
         BasicFragmentDialog removeFailedUploadsDialog = new BasicFragmentDialog();
         removeFailedUploadsDialog.initialize(
-                TAG_REMOVE_FAILED_UPLOADS_DIALOG,
+                TAG_FAILED_MEDIA_UPLOADS_DIALOG,
                 "",
                 getString(R.string.editor_toast_failed_uploads),
+                getString(R.string.editor_retry_failed_uploads),
                 getString(R.string.editor_remove_failed_uploads),
-                getString(android.R.string.cancel),
                 null);
-        removeFailedUploadsDialog.show(getSupportFragmentManager(), TAG_REMOVE_FAILED_UPLOADS_DIALOG);
+        removeFailedUploadsDialog.show(getSupportFragmentManager(), TAG_FAILED_MEDIA_UPLOADS_DIALOG);
     }
 
     private void savePostAndOptionallyFinish(final boolean doFinish) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -793,10 +793,10 @@ public class UploadService extends Service {
 
     private ArrayList<MediaModel> getAllFailedMediaForPost(PostModel postModel) {
         Set<MediaModel> failedMedia = mUploadStore.getFailedMediaForPost(postModel);
-        return removeRecentlyDeletedMediaFromCollection(failedMedia);
+        return filterOutRecentlyDeletedMedia(failedMedia);
     }
 
-    private ArrayList<MediaModel> removeRecentlyDeletedMediaFromCollection(Set<MediaModel> failedMedia) {
+    private ArrayList<MediaModel> filterOutRecentlyDeletedMedia(Set<MediaModel> failedMedia) {
         ArrayList<MediaModel> mediaToRetry = new ArrayList<>(failedMedia);
         ListIterator<MediaModel> iterator = mediaToRetry.listIterator();
         while (iterator.hasNext()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -47,7 +47,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -755,7 +754,7 @@ public class UploadService extends Service {
             aztecRegisterFailedMediaForThisPost(post);
         }
 
-        ArrayList<MediaModel> mediaToRetry = getAllFailedMediaForPost(post);
+        List<MediaModel> mediaToRetry = getAllFailedMediaForPost(post);
 
         if (!mediaToRetry.isEmpty()) {
             // reset these media items to QUEUED
@@ -791,18 +790,17 @@ public class UploadService extends Service {
         }
     }
 
-    private ArrayList<MediaModel> getAllFailedMediaForPost(PostModel postModel) {
+    private List<MediaModel> getAllFailedMediaForPost(PostModel postModel) {
         Set<MediaModel> failedMedia = mUploadStore.getFailedMediaForPost(postModel);
         return filterOutRecentlyDeletedMedia(failedMedia);
     }
 
-    private ArrayList<MediaModel> filterOutRecentlyDeletedMedia(Set<MediaModel> failedMedia) {
-        ArrayList<MediaModel> mediaToRetry = new ArrayList<>(failedMedia);
-        ListIterator<MediaModel> iterator = mediaToRetry.listIterator();
-        while (iterator.hasNext()) {
-            String mediaIdToCompare = String.valueOf(iterator.next().getId());
-            if (mUserDeletedMediaItemIds.contains(mediaIdToCompare)) {
-                iterator.remove();
+    private List<MediaModel> filterOutRecentlyDeletedMedia(Set<MediaModel> failedMedia) {
+        List<MediaModel> mediaToRetry = new ArrayList<>();
+        for (MediaModel mediaModel : failedMedia) {
+            String mediaIdToCompare = String.valueOf(mediaModel.getId());
+            if (!mUserDeletedMediaItemIds.contains(mediaIdToCompare)) {
+                mediaToRetry.add(mediaModel);
             }
         }
         return mediaToRetry;

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2176,8 +2176,9 @@
     <string name="editor_toast_invalid_path">Invalid file path</string>
     <string name="editor_toast_uploading_please_wait">You are currently uploading media. Please wait until this completes.</string>
     <string name="editor_toast_failed_uploads">Some media uploads have failed. You can\'t save or publish
-        your post in this state. Would you like to remove all failed media?</string>
+        your post in this state.</string>
     <string name="editor_remove_failed_uploads">Remove failed uploads</string>
+    <string name="editor_retry_failed_uploads">Retry uploading</string>
     <string name="error_all_media_upload_canceled">All media uploads have been cancelled due to an unknown error. Please retry uploading</string>
 
     <string name="photo_picker_title">Choose photo</string>


### PR DESCRIPTION
Fixes #10113 

Note "Copy Review"
- Since the purpose of the dialog have changed we'll probably need to update the texts. I just removed "Would you like to remove all failed media?" this part, but other suggestions are more than welcome.

Before             |  After
:-------------------------:|:-------------------------:
<img width="281" alt="Screenshot 2019-06-27 at 16 19 57" src="https://user-images.githubusercontent.com/2261188/60273941-7a6fc480-98f7-11e9-9bc6-4bf7f4a11efe.png"> | <img width="281" alt="Screenshot 2019-06-27 at 16 20 03" src="https://user-images.githubusercontent.com/2261188/60273940-7a6fc480-98f7-11e9-96f4-4081dbe8ee29.png"> 



Add support for retrying media upload when the user tries to publish/save/update a post from the editor.

To test:
1. Open a draft
2. Turn on airplane mode
3. Add media
4. Wait until the upload fails
5. Turn off the airplane mode
6. Click on Publish
7. Publish confirmation dialog is shown
8. Confirm the publish action
9. Can't publish a post with failed media dialog is shown -> click on "retry upload"

Perform steps 1-8 and try to click on "remove all media" in the last step and then publish the post. 
Perform steps 1-8 and try to click on "remove all media" in the last step, add a new media and publish the post.


Before             |  After
:-------------------------:|:-------------------------:
![retry-upload](https://user-images.githubusercontent.com/2261188/60273823-3977b000-98f7-11e9-978a-81f56e9930c6.gif) | ![fixed-retry-upload](https://user-images.githubusercontent.com/2261188/60273824-3977b000-98f7-11e9-961f-c7f91f488cc3.gif)  


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

cc @osullivanchris The current copy(text) of the action buttons is too long so the system will automatically show one action per line. Is that an issue? I mean it could have happened even before - on a small device or with other locales, but I thought it's worth mentioning.
