### PR TITLE
Fix flakiness when entering image in publish test

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
@@ -64,7 +64,7 @@ public class EditorPage {
         }
 
         // Click on a random image
-        onView(withIndex(withId(R.id.media_grid_item_image), 0)).perform(click());
+        clickOn(onView(withIndex(withId(R.id.media_grid_item_image), 0)));
 
         // Click the confirm button
         clickOn(confirmButton);


### PR DESCRIPTION
Fixes flakiness that happens sometimes when entering image https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670/matrices/4727315096010686186/executions/bs.f1e3e3cd6f059a45/testcases/1

I'm thinking the cause is not waiting for the grid image before trying to click

To test: I've ran it a couple times and not gotten any flakiness, let's merge and see

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
