### PR TITLE
Use a sample DSN that won't crash when used

### DIFF
--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -26,7 +26,7 @@ wp.zendesk.domain=https://www.google.com/
 wp.zendesk.oauth_client_id=wordpress
 wp.giphy.api_key=wordpress
 wp.reset_db_on_downgrade = false
-wp.sentry.dsn=wordpress
+wp.sentry.dsn=https://00000000000000000000000000000000@sentry.io/00000000
 
 # Needed to use the Google Maps component aka the PlacePicker (Post Settings -> Location)
 wp.res.com.google.android.geo.api.key = geo-api-key


### PR DESCRIPTION
This PR is a companion to https://github.com/woocommerce/woocommerce-android/pull/1146.

If you use something that doesn't look like a DSN to fire up Sentry, it'll throw an exception. Using a fake DSN resolves that.

**To Test:**

- Check out `develop`
- Delete your existing gradle.properties file and replace it with gradle.properties.example
- Build the branch, then run the code (the app should crash on launch)
- Check out this branch
- Build the branch (it should work now!!)
- To roll back, run bundle exec fastlane run configure_apply

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.