### PR TITLE
Update minified widget title

### DIFF
--- a/WordPress/src/main/res/layout/stats_minified_widget_configure_activity.xml
+++ b/WordPress/src/main/res/layout/stats_minified_widget_configure_activity.xml
@@ -34,7 +34,7 @@
                 app:layout_scrollFlags="enterAlways"
                 app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
                 app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-                app:title="@string/stats_insights_today_stats"/>
+                app:title="@string/stats_widget_minified_name"/>
 
         </com.google.android.material.appbar.AppBarLayout>
 


### PR DESCRIPTION
Title of the minified widget configuration screen should be "At a glance" instead of "Today"

To test:
* Add the minified widget
* The configuration screen opens
* The title is "At a glance" 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
