### PR TITLE
[Analytics] Fix for editor_post_published event that is bumped multiple times on save

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2276,12 +2276,6 @@ public class EditPostActivity extends AppCompatActivity implements
                || (originalStatus == PostStatus.SCHEDULED && publishPost)
                || (originalStatus == PostStatus.PUBLISHED && mPost.isLocalDraft())
                || (originalStatus == PostStatus.PUBLISHED && mPost.getRemotePostId() == 0);
-
-        /*
-        return (PostStatus.fromPost(mPost) == PostStatus.UNKNOWN || PostStatus.fromPost(mPost) == PostStatus.DRAFT)
-               && (mPost.isLocalDraft() || mPostSnapshotWhenEditorOpened == null
-                   || PostStatus.fromPost(mPostSnapshotWhenEditorOpened) == PostStatus.DRAFT
-                   || PostStatus.fromPost(mPostSnapshotWhenEditorOpened) == PostStatus.PENDING); */
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1844,7 +1844,7 @@ public class EditPostActivity extends AppCompatActivity implements
                         .incrementInteractions(APP_REVIEWS_EVENT_INCREMENTED_BY_PUBLISHING_POST_OR_PAGE);
                 break;
             case TAG_FAILED_MEDIA_UPLOADS_DIALOG:
-                savePostOnlineAndFinishAsync(isFirstTimePublish(), true);
+                savePostOnlineAndFinishAsync(isFirstTimePublish(false), true);
                 break;
             case ASYNC_PROMO_PUBLISH_DIALOG_TAG:
                 uploadPost(true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2111,7 +2111,7 @@ public class EditPostActivity extends AppCompatActivity implements
         new Thread(new Runnable() {
             @Override
             public void run() {
-                boolean isFirstTimePublish = isFirstTimePublish();
+                boolean isFirstTimePublish = isFirstTimePublish(publishPost);
                 if (publishPost) {
                     // now set status to PUBLISHED - only do this AFTER we have run the isFirstTimePublish() check,
                     // otherwise we'd have an incorrect value
@@ -2202,7 +2202,7 @@ public class EditPostActivity extends AppCompatActivity implements
             @Override
             public void run() {
                 // check if the opened post had some unsaved local changes
-                boolean isFirstTimePublish = isFirstTimePublish();
+                boolean isFirstTimePublish = isFirstTimePublish(false);
 
                 boolean postUpdateSuccessful = updatePostObject();
                 if (!postUpdateSuccessful) {
@@ -2270,11 +2270,18 @@ public class EditPostActivity extends AppCompatActivity implements
         return !PostUtils.isPublishable(mPost) && isNewPost();
     }
 
-    private boolean isFirstTimePublish() {
+    private boolean isFirstTimePublish(final boolean publishPost) {
+        final PostStatus originalStatus = PostStatus.fromPost(mPost);
+        return ((originalStatus == PostStatus.DRAFT || originalStatus == PostStatus.UNKNOWN) && publishPost)
+               || (originalStatus == PostStatus.SCHEDULED && publishPost)
+               || (originalStatus == PostStatus.PUBLISHED && mPost.isLocalDraft())
+               || (originalStatus == PostStatus.PUBLISHED && mPost.getRemotePostId() == 0);
+
+        /*
         return (PostStatus.fromPost(mPost) == PostStatus.UNKNOWN || PostStatus.fromPost(mPost) == PostStatus.DRAFT)
                && (mPost.isLocalDraft() || mPostSnapshotWhenEditorOpened == null
                    || PostStatus.fromPost(mPostSnapshotWhenEditorOpened) == PostStatus.DRAFT
-                   || PostStatus.fromPost(mPostSnapshotWhenEditorOpened) == PostStatus.PENDING);
+                   || PostStatus.fromPost(mPostSnapshotWhenEditorOpened) == PostStatus.PENDING); */
     }
 
     /**


### PR DESCRIPTION
Fixes #10098 by making sure to bump `editor_post_published` the first time the post is Published on the remote site, and not each time a draft post is saved or updated.

Test 1:
- Start writing a Draft
- Tap on the Save menu
- Re-open and publish it
(there should be only one `editor_post_published` in Logcat)

Test 2:
- Start writing a Draft
- Tap on the back arrow
- Re-open and publish it
(there should be only one `editor_post_published` in Logcat)

Test 3:
- Start writing a Draft
- Tap on the back arrow
- Re-open and just update it
(there should be NO `editor_post_published` in Logcat)


Note: This PR is not intended to fix all the issue with the `editor_post_published` event, but rather to stop the double counting of it, and make analytics go back to "normal" values pre version 12.2

Note 2: There are for sure other flows in the app that publish the post, but doesn't trigger `editor_post_published` event,  ie: moving a post from Private to Published, but those are a vast minority of the normal flows. Also tapping on the notification Retry actions cannot bump the stats fine, but this is another problem.

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
