### PR TITLE
Use correct colors and shorten value in country map

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockDiffCallback.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM_WITH_ICON
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LOADING_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.MAP
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.MAP_LEGEND
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.QUICK_SCAN_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.REFERRED_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TABS
@@ -67,6 +68,7 @@ class BlockDiffCallback(
                 DIVIDER,
                 LOADING_ITEM,
                 MAP,
+                MAP_LEGEND,
                 CHART_LEGEND,
                 REFERRED_ITEM,
                 QUICK_SCAN_ITEM,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListI
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.LoadingItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.MapItem
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.MapLegend
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.QuickScanItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ReferredItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TabsItem
@@ -48,6 +49,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM_WITH_ICON
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LOADING_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.MAP
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.MAP_LEGEND
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.QUICK_SCAN_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.REFERRED_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TABS
@@ -75,6 +77,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.LinkVie
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ListItemViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ListItemWithIconViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.LoadingItemViewHolder
+import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.MapLegendViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.MapViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.QuickScanItemViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ReferredItemViewHolder
@@ -119,6 +122,7 @@ class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockListItemVi
             DIVIDER -> DividerViewHolder(parent)
             LOADING_ITEM -> LoadingItemViewHolder(parent)
             MAP -> MapViewHolder(parent)
+            MAP_LEGEND -> MapLegendViewHolder(parent)
             VALUE_ITEM -> ValueViewHolder(parent)
             ACTIVITY_ITEM -> ActivityViewHolder(parent)
             REFERRED_ITEM -> ReferredItemViewHolder(parent)
@@ -157,6 +161,7 @@ class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockListItemVi
                     payloads.contains(EXPAND_CHANGED)
             )
             is MapViewHolder -> holder.bind(item as MapItem)
+            is MapLegendViewHolder -> holder.bind(item as MapLegend)
             is EmptyViewHolder -> holder.bind(item as Empty)
             is ActivityViewHolder -> holder.bind(item as ActivityItem)
             is LoadingItemViewHolder -> holder.bind(item as LoadingItem)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM_WITH_ICON
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LOADING_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.MAP
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.MAP_LEGEND
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.QUICK_SCAN_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.REFERRED_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TABS
@@ -56,6 +57,7 @@ sealed class BlockListItem(val type: Type) {
         TABS,
         HEADER,
         MAP,
+        MAP_LEGEND,
         EXPANDABLE_ITEM,
         DIVIDER,
         LOADING_ITEM,
@@ -219,6 +221,8 @@ sealed class BlockListItem(val type: Type) {
     data class Empty(@StringRes val textResource: Int? = null, val text: String? = null) : BlockListItem(EMPTY)
 
     data class MapItem(val mapData: String, @StringRes val label: Int) : BlockListItem(MAP)
+
+    data class MapLegend(val startLegend: String, val endLegend: String) : BlockListItem(MAP_LEGEND)
 
     object Divider : BlockListItem(DIVIDER)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCase.kt
@@ -98,23 +98,23 @@ constructor(
             items.add(Empty(R.string.stats_no_data_for_period))
         } else {
             val stringBuilder = StringBuilder()
-            var minCountry: Int? = null
-            var maxCountry: Int? = null
+            var minViews: Int? = null
+            var maxViews: Int? = null
             for (country in domainModel.countries) {
-                if (country.views < minCountry ?: Int.MAX_VALUE) {
-                    minCountry = country.views
+                if (country.views < minViews ?: Int.MAX_VALUE) {
+                    minViews = country.views
                 }
-                if (country.views > maxCountry ?: 0) {
-                    maxCountry = country.views
+                if (country.views > maxViews ?: 0) {
+                    maxViews = country.views
                 }
                 stringBuilder.append("['").append(country.countryCode).append("',").append(country.views).append("],")
             }
-            val startLabel = if (minCountry == maxCountry) {
+            val startLabel = if (minViews == maxViews) {
                 0
             } else {
-                minCountry ?: 0
+                minViews ?: 0
             }.toFormattedString()
-            val endLabel = (maxCountry ?: 0).toFormattedString()
+            val endLabel = (maxViews ?: 0).toFormattedString()
             items.add(MapItem(stringBuilder.toString(), R.string.stats_country_views_label))
             items.add(MapLegend(startLabel, endLabel))
             items.add(Header(R.string.stats_country_label, R.string.stats_country_views_label))

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCase.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Heade
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.MapItem
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.MapLegend
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.NavigationAction.Companion.create
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularStatelessUseCase
@@ -97,10 +98,25 @@ constructor(
             items.add(Empty(R.string.stats_no_data_for_period))
         } else {
             val stringBuilder = StringBuilder()
+            var minCountry: Int? = null
+            var maxCountry: Int? = null
             for (country in domainModel.countries) {
+                if (country.views < minCountry ?: Int.MAX_VALUE) {
+                    minCountry = country.views
+                }
+                if (country.views > maxCountry ?: 0) {
+                    maxCountry = country.views
+                }
                 stringBuilder.append("['").append(country.countryCode).append("',").append(country.views).append("],")
             }
+            val startLabel = if (minCountry == maxCountry) {
+                0
+            } else {
+                minCountry ?: 0
+            }.toFormattedString()
+            val endLabel = (maxCountry ?: 0).toFormattedString()
             items.add(MapItem(stringBuilder.toString(), R.string.stats_country_views_label))
+            items.add(MapLegend(startLabel, endLabel))
             items.add(Header(R.string.stats_country_label, R.string.stats_country_views_label))
             domainModel.countries.forEachIndexed { index, group ->
                 items.add(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MapLegendViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MapLegendViewHolder.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
 
-import android.annotation.SuppressLint
 import android.view.ViewGroup
 import android.widget.TextView
 import org.wordpress.android.R
@@ -12,7 +11,6 @@ class MapLegendViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
 ) {
     private val startLegend: TextView = itemView.findViewById(R.id.start_legend)
     private val endLegend: TextView = itemView.findViewById(R.id.end_legend)
-    @SuppressLint("SetJavaScriptEnabled")
     fun bind(item: MapLegend) {
         startLegend.text = item.startLegend
         endLegend.text = item.endLegend

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MapLegendViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MapLegendViewHolder.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
+
+import android.annotation.SuppressLint
+import android.view.ViewGroup
+import android.widget.TextView
+import org.wordpress.android.R
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.MapLegend
+
+class MapLegendViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
+        parent,
+        R.layout.stats_block_map_legend_item
+) {
+    private val startLegend: TextView = itemView.findViewById(R.id.start_legend)
+    private val endLegend: TextView = itemView.findViewById(R.id.end_legend)
+    @SuppressLint("SetJavaScriptEnabled")
+    fun bind(item: MapLegend) {
+        startLegend.text = item.startLegend
+        endLegend.text = item.endLegend
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MapViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MapViewHolder.kt
@@ -34,7 +34,12 @@ class MapViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             // https://developers.google.com/chart/interactive/docs/release_notes#release-candidate-details
             val colorLow = Integer.toHexString(ContextCompat.getColor(itemView.context, R.color.accent_50) and 0xffffff)
             val colorHigh = Integer.toHexString(ContextCompat.getColor(itemView.context, R.color.accent) and 0xffffff)
-            val emptyColor = Integer.toHexString(ContextCompat.getColor(itemView.context, R.color.neutral_50) and 0xffffff)
+            val emptyColor = Integer.toHexString(
+                    ContextCompat.getColor(
+                            itemView.context,
+                            R.color.neutral_50
+                    ) and 0xffffff
+            )
             val htmlPage = ("<html>" +
                     "<head>" +
                     "<script type=\"text/javascript\" src=\"https://www.gstatic.com/charts/loader.js\"></script>" +

--- a/WordPress/src/main/res/drawable/bg_rectangle_gradient_accent_50_accent.xml
+++ b/WordPress/src/main/res/drawable/bg_rectangle_gradient_accent_50_accent.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="rectangle">
+
+    <gradient
+        android:angle="0"
+        android:endColor="@color/accent"
+        android:startColor="@color/accent_50"
+        android:type="linear"/>
+
+    <corners
+        android:radius="0dp"/>
+
+</shape>

--- a/WordPress/src/main/res/layout/stats_block_map_legend_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_map_legend_item.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/StatsBlockLine"
+    android:layout_width="match_parent"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:layout_height="48dp">
+
+    <TextView
+        android:id="@+id/start_legend"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:textColor="@color/neutral_700"
+        android:textSize="@dimen/text_sz_small"
+        tools:text="154"/>
+
+    <View
+        android:id="@+id/legend_gradient"
+        android:layout_width="60dp"
+        android:layout_height="8dp"
+        android:layout_marginStart="8dp"
+        android:background="@drawable/bg_rectangle_gradient_accent_50_accent"/>
+
+    <TextView
+        android:id="@+id/end_legend"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="8dp"
+        android:gravity="center"
+        android:textColor="@color/neutral_700"
+        android:textSize="@dimen/text_sz_small"
+        tools:text="15,213"/>
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/stats_block_map_legend_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_map_legend_item.xml
@@ -4,35 +4,32 @@
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/StatsBlockLine"
     android:layout_width="match_parent"
-    android:orientation="horizontal"
     android:gravity="center_vertical"
-    android:layout_height="48dp">
+    android:orientation="horizontal">
 
     <TextView
         android:id="@+id/start_legend"
+        style="@style/StatsMapLegend"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center"
-        android:textColor="@color/neutral_700"
-        android:textSize="@dimen/text_sz_small"
         tools:text="154"/>
 
     <View
         android:id="@+id/legend_gradient"
-        android:layout_width="60dp"
-        android:layout_height="8dp"
-        android:layout_marginStart="8dp"
+        android:layout_width="@dimen/stats_map_legend_width"
+        android:layout_height="@dimen/margin_medium"
+        android:layout_marginStart="@dimen/margin_medium"
         android:background="@drawable/bg_rectangle_gradient_accent_50_accent"/>
 
     <TextView
         android:id="@+id/end_legend"
+        style="@style/StatsMapLegend"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="8dp"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/margin_medium"
         android:gravity="center"
-        android:textColor="@color/neutral_700"
-        android:textSize="@dimen/text_sz_small"
         tools:text="15,213"/>
 
 </LinearLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -211,6 +211,7 @@
     <dimen name="stats_label_min_text_size">6sp</dimen>
     <dimen name="stats_activity_box_size">12dp</dimen>
     <dimen name="stats_activity_box_end_margin">4dp</dimen>
+    <dimen name="stats_map_legend_width">60dp</dimen>
 
     <!-- stats widget-->
     <dimen name="stats_widget_icon_size">18dp</dimen>

--- a/WordPress/src/main/res/values/stats_styles.xml
+++ b/WordPress/src/main/res/values/stats_styles.xml
@@ -248,6 +248,11 @@
         <item name="android:textSize">@dimen/text_sz_medium</item>
     </style>
 
+    <style name="StatsMapLegend" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">@color/neutral_700</item>
+        <item name="android:textSize">@dimen/text_sz_small</item>
+    </style>
+
     <style name="StatsWidgetConfigureTitle" parent="TextAppearance.AppCompat.Body2">
         <item name="android:textColor">@color/grey_900</item>
         <item name="android:textSize">@dimen/text_sz_large</item>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCaseTest.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Heade
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.MapItem
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.MapLegend
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.HEADER
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LINK
@@ -96,13 +97,16 @@ class CountryViewsUseCaseTest : BaseUnitTest() {
 
         assertThat(result.state).isEqualTo(UseCaseState.SUCCESS)
         result.data!!.apply {
-            assertThat(this).hasSize(4)
+            assertThat(this).hasSize(5)
             assertTitle(this[0])
             val mapItem = (this[1] as MapItem)
             assertThat(mapItem.mapData).isEqualTo("['CZ',500],")
             assertThat(mapItem.label).isEqualTo(R.string.stats_country_views_label)
-            assertLabel(this[2])
-            assertItem(this[3], country.fullName, country.views, country.flagIconUrl)
+            val mapLegendItem = (this[2] as MapLegend)
+            assertThat(mapLegendItem.startLegend).isEqualTo("0")
+            assertThat(mapLegendItem.endLegend).isEqualTo("500")
+            assertLabel(this[3])
+            assertItem(this[4], country.fullName, country.views, country.flagIconUrl)
         }
     }
 
@@ -129,8 +133,8 @@ class CountryViewsUseCaseTest : BaseUnitTest() {
 
         assertThat(result.state).isEqualTo(UseCaseState.SUCCESS)
         result.data!!.apply {
-            assertThat(this).hasSize(5)
-            assertLink(this[4])
+            assertThat(this).hasSize(6)
+            assertLink(this[5])
         }
     }
 


### PR DESCRIPTION
We were not using the correct value for countries without values. This PR sets the color to `neutral_50`. We were also not using the correct colors and text sizes for the legend so I'm extracting the legend into its own list item so I can easily control it. Setting it in Javascript has its limits.

Is it correct @SylvesterWilmott to use `neutral_50` for the empty country and `neutral_700` for the legend text color?

![Screenshot_1561996769](https://user-images.githubusercontent.com/1079756/60450751-d35a9800-9c2a-11e9-9478-4e4de0c546a7.png)

To test:
* Go to Stats/DWMY
* Scroll to the Countries block
* Check that the colors are updated
* Check that the behaviour is still correct

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
