### PR TITLE
Add commands to validate strings in Editor for translation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,9 @@ jobs:
       - run:
           name: Validate login strings
           command: bundle exec fastlane validate_login_strings pr_url:$CIRCLE_PULL_REQUEST
+      - run:
+          name: Validate aztec strings
+          command: bundle exec fastlane validate_aztec_strings pr_url:$CIRCLE_PULL_REQUEST
 
 workflows:
   wordpress_android:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -175,7 +175,8 @@ desc "Run release preflight checks"
 ######################################################################## 
   main_strings_path = "./WordPress/src/main/res/values/strings.xml"
   libraries_strings_path = [
-    {library: "Login Library", strings_path: "./libs/login/WordPressLoginFlow/src/main/res/values/strings.xml", exclusions: ["default_web_client_id"]}
+    {library: "Login Library", strings_path: "./libs/login/WordPressLoginFlow/src/main/res/values/strings.xml", exclusions: ["default_web_client_id"]},
+    {library: "Aztec Library", strings_path: "./libs/editor/WordPressEditor/src/main/res/values/strings.xml"}
   ]
 
   desc "Merge libraries strings files into the main app one"
@@ -197,6 +198,18 @@ desc "Run release preflight checks"
 
     an_validate_lib_strings(app_strings_path: main_strings_path, libs_strings_path: libraries_strings_path, diff_url: diff_url) 
   end 
+
+  lane :validate_aztec_strings do | options |
+    pr_number = options[:pr_number]
+    pr_number = options[:pr_url].split('/').last unless options[:pr_url].nil?
+
+    diff_url = nil
+    if (pr_number.nil? == false)
+      diff_url = "https://patch-diff.githubusercontent.com/raw/wordpress-mobile/WordPress-Android/pull/#{pr_number}.diff"
+    end
+
+    an_validate_lib_strings(app_strings_path: main_strings_path, libs_strings_path: libraries_strings_path, diff_url: diff_url)
+  end
 
 ########################################################################
 # Helper Lanes


### PR DESCRIPTION
Aims at fixing #10132 

WIP - this adds commands to validate strings for the Editor, the same way we do for the login library.

@loremattei in doing this I stopped as soon as I realized Aztec has strings itself on another repo which are not imported the same way as the Login library - or the Login library they're brought into the WordPress project using [`implementation project:`](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/build.gradle#L257-L258)), the difference being the Login library is "already there", while Aztec is in turn brought with the `api` gradle directive not importing the project directly, so apparently the file wouldn't be immediately available.

Not sure how to continue from there, but leaving this draft PR open if it helps in any way 🤷‍♂ 

