### PR TITLE
Fix a typo in a string

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2093,7 +2093,7 @@
     <string name="plugin_external_link_icon_content_description">External link</string>
     <string name="plugin_chevron_icon_content_description">Toggle text</string>
 
-    <string name="plugin_fetching_error_after_at">It takes longer then usual to refresh plugin details. Please check again later.</string>
+    <string name="plugin_fetching_error_after_at">It takes longer than usual to refresh plugin details. Please check again later.</string>
 
     <!--My profile-->
     <string name="my_profile">My Profile</string>


### PR DESCRIPTION
This PR fixes a typo in a string that was highlighted by one of the translators. 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
