### PR TITLE
Merge login lib changes and implement new interface methods

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -826,4 +826,12 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     public AndroidInjector<Fragment> supportFragmentInjector() {
         return mFragmentInjector;
     }
+
+    @Override public void showHelpFindingConnectedEmail() {
+        // Not used in WordPress app
+    }
+
+    @Override public void gotConnectedSiteInfo(String siteAddress, boolean hasJetpack) {
+        // Not used in WordPress app
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -236,4 +236,18 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     public void trackWpComBackgroundServiceUpdate(Map<String, ?> properties) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_WPCOM_BACKGROUND_SERVICE_UPDATE, properties);
     }
+
+    @Override public void trackConnectedSiteInfoRequested(String url) {
+        // Not used in WordPress app
+    }
+
+    @Override
+    public void trackConnectedSiteInfoFailed(String url, String errorContext, String errorType,
+                                             String errorDescription) {
+        // Not used in WordPress app
+    }
+
+    @Override public void trackConnectedSiteInfoSucceeded(Map<String, ?> properties) {
+        // Not used in WordPress app
+    }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2270,6 +2270,7 @@
     <string name="enter_your_password_instead">Enter your password instead</string>
     <string name="alternatively">Alternatively:</string>
     <string name="enter_email_wordpress_com">Log in to WordPress.com using an email address to manage all your WordPress sites.</string>
+    <string name="enter_email_for_site">Log in with WordPress.com to connect to %1$s</string>
     <string name="next">Next</string>
     <string name="open_mail">Open mail</string>
     <string name="enter_site_address_instead">Log in by entering your site address.</string>
@@ -2320,6 +2321,8 @@
     <string name="login_error_generic_start">Google login could not be started.</string>
     <string name="login_error_suffix">\nMaybe try a different account?</string>
     <string name="enter_wpcom_or_jetpack_site">Please enter a WordPress.com or Jetpack-connected self-hosted WordPress site</string>
+    <string name="enter_wordpress_site">The website at this address is not a WordPress site. For us to connect to it, the site must have WordPress installed.</string>
+    <string name="login_need_help_finding_connected_email">Need help finding the email you connected with?</string>
     <!-- Screen titles -->
     <string name="email_address_login_title">Email address login</string>
     <string name="site_address_login_title">Site address login</string>

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -51,4 +51,7 @@ public interface LoginAnalyticsListener {
     void trackUrlHelpScreenViewed();
     void trackUsernamePasswordFormViewed();
     void trackWpComBackgroundServiceUpdate(Map<String, ?> properties);
+    void trackConnectedSiteInfoRequested(String url);
+    void trackConnectedSiteInfoFailed(String url, String errorContext, String errorType, String errorDescription);
+    void trackConnectedSiteInfoSucceeded(Map<String, ?> properties);
 }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -26,6 +26,7 @@ public interface LoginListener {
     void helpEmailScreen(String email);
     void helpSocialEmailScreen(String email);
     void addGoogleLoginFragment();
+    void showHelpFindingConnectedEmail();
 
     // Login Request Magic Link callbacks
     void showMagicLinkSentScreen(String email);
@@ -47,6 +48,7 @@ public interface LoginListener {
     // Login Site Address input callbacks
     void alreadyLoggedInWpcom(ArrayList<Integer> oldSitesIds);
     void gotWpcomSiteInfo(String siteAddress, String siteName, String siteIconUrl);
+    void gotConnectedSiteInfo(String siteAddress, boolean hasJetpack);
     void gotXmlRpcEndpoint(String inputSiteAddress, String endpointAddress);
     void handleSslCertificateError(MemorizingTrustManager memorizingTrustManager, SelfSignedSSLCallback callback);
     void helpSiteAddress(String url);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMode.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMode.java
@@ -9,7 +9,8 @@ public enum LoginMode {
     JETPACK_STATS,
     WPCOM_LOGIN_DEEPLINK,
     WPCOM_REAUTHENTICATE,
-    SHARE_INTENT;
+    SHARE_INTENT,
+    WOO_LOGIN_MODE;
 
     private static final String ARG_LOGIN_MODE = "ARG_LOGIN_MODE";
 

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_password_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_password_screen.xml
@@ -18,6 +18,8 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_extra_large"
         android:layout_marginBottom="@dimen/margin_extra_large"
+        android:textAlignment="viewStart"
+        android:gravity="start"
         tools:text="@string/enter_site_address" />
 
     <LinearLayout

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_screen.xml
@@ -19,6 +19,8 @@
         android:layout_marginBottom="@dimen/margin_extra_large"
         android:layout_marginTop="@dimen/margin_extra_large"
         android:layout_width="match_parent"
+        android:textAlignment="viewStart"
+        android:gravity="start"
         tools:text="@string/enter_email_wordpress_com"
         style="@style/LoginTheme.TextLabel" >
     </TextView>

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_form_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_form_screen.xml
@@ -52,6 +52,7 @@
             android:paddingEnd="@dimen/margin_medium_large"
             android:layout_marginRight="@dimen/margin_extra_large"
             android:layout_marginEnd="@dimen/margin_extra_large"
+            android:textAlignment="viewStart"
             android:gravity="start|center_vertical"
             tools:text="Secondary action"/>
 

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_site_address_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_site_address_screen.xml
@@ -17,6 +17,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_extra_large"
+        android:textAlignment="viewStart"
+        android:gravity="start"
         android:layout_marginBottom="@dimen/margin_extra_large"
         tools:text="@string/enter_site_address" />
 

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="login_promo_text_notifications">Your notifications travel with you — see comments and likes as they happen.</string>
     <string name="login_promo_text_jetpack">Manage your Jetpack-powered site on the go — you\'ve got WordPress in your pocket.</string>
     <string name="enter_email_wordpress_com">Log in to WordPress.com using an email address to manage all your WordPress sites.</string>
+    <string name="enter_email_for_site">Log in with WordPress.com to connect to %1$s</string>
     <string name="next">Next</string>
     <string name="open_mail">Open mail</string>
     <string name="alternatively">Alternatively:</string>
@@ -100,7 +101,7 @@
         site XMLRPC endpoint. The app needs that in order to communicate with your site. Contact your host to solve
         this problem.</string>
     <string name="enter_wpcom_or_jetpack_site">Please enter a WordPress.com or Jetpack-connected self-hosted WordPress site</string>
-
+    <string name="enter_wordpress_site">The website at this address is not a WordPress site. For us to connect to it, the site must have WordPress installed.</string>
     <string name="error_generic_network">A network error occurred. Please check your connection and try again.</string>
 
     <string name="notification_login_title_success">Logged in!</string>
@@ -139,4 +140,6 @@
     <!-- Placeholder for notification channel to be used by login service notification.
      This resource must be overwritten in the host project with a real notification channel id it has configured. -->
     <string name="login_notification_channel_id">placeholder</string>
+
+    <string name="login_need_help_finding_connected_email">Need help finding the email you connected with?</string>
 </resources>

--- a/libs/login/gradle.properties-example
+++ b/libs/login/gradle.properties-example
@@ -4,6 +4,7 @@
 wp.debug.wpcom_login_email =
 wp.debug.wpcom_login_username =
 wp.debug.wpcom_login_password =
+wp.debug.wpcom_website_url =
 
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
This PR merges the `woocommerce-android` changes to the login library from [this PR](https://github.com/woocommerce/woocommerce-android/pull/1150). There were several new interface methods added existing classes:

**LoginAnalyticsListener**
- `trackConnectedSiteInfoRequested`
- `trackConnectedSiteInfoFailed`
- `trackConnectedSiteInfoSucceeded`

**LoginListener**
- `showHelpFindingConnectedEmail`
- `gotConnectedSiteInfo`

I've implemented these new interface methods in `LoginActivity` and `LoginAnalyticsTracker` but there is no logic needed since none of them are currently being used in WPAndroid. Those are the only two changes to WPAndroid directly. 

Full documentation around the changes to login library are documented in [this PR](https://github.com/woocommerce/woocommerce-android/pull/1150), but the **WPAndroid app should see no difference in the login experience**.

### Recommended Test Scenarios
- Verify login flow is unchanged from the current login flow of WPAndroid
- Verify the text in each of the login views is also unchanged
- Login with email
- Login by site url
- Login w/ Magic Link
- Login w/ Google

To test:

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
