### PR TITLE
Logout issue with stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/WidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/WidgetUpdater.kt
@@ -1,8 +1,11 @@
 package org.wordpress.android.ui.stats.refresh.lists.widget
 
 import android.appwidget.AppWidgetManager
+import android.content.ComponentName
 import android.content.Context
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.AllTimeWidgetUpdater
+import org.wordpress.android.ui.stats.refresh.lists.widget.minified.MinifiedWidgetUpdater
+import org.wordpress.android.ui.stats.refresh.lists.widget.today.TodayWidgetUpdater
 import org.wordpress.android.ui.stats.refresh.lists.widget.views.ViewsWidgetUpdater
 import javax.inject.Inject
 
@@ -13,15 +16,31 @@ interface WidgetUpdater {
         appWidgetManager: AppWidgetManager? = null
     )
 
-    fun updateAllWidgets(context: Context)
+    fun componentName(context: Context): ComponentName
+
     fun delete(appWidgetId: Int)
 
     class StatsWidgetUpdaters
-    @Inject constructor(viewsWidgetUpdater: ViewsWidgetUpdater, allTimeWidgetUpdater: AllTimeWidgetUpdater) {
-        private val widgetUpdaters = listOf(viewsWidgetUpdater, allTimeWidgetUpdater)
+    @Inject constructor(
+        viewsWidgetUpdater: ViewsWidgetUpdater,
+        allTimeWidgetUpdater: AllTimeWidgetUpdater,
+        todayWidgetUpdater: TodayWidgetUpdater,
+        minifiedWidgetUpdater: MinifiedWidgetUpdater
+    ) {
+        private val widgetUpdaters = listOf(
+                viewsWidgetUpdater,
+                allTimeWidgetUpdater,
+                todayWidgetUpdater,
+                minifiedWidgetUpdater
+        )
+
         fun update(context: Context) {
             widgetUpdaters.forEach {
-                it.updateAllWidgets(context)
+                val appWidgetManager = AppWidgetManager.getInstance(context)
+                val allWidgetIds = appWidgetManager.getAppWidgetIds(it.componentName(context))
+                for (appWidgetId in allWidgetIds) {
+                    it.updateAppWidget(context, appWidgetId, appWidgetManager)
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetUpdater.kt
@@ -47,14 +47,14 @@ class AllTimeWidgetUpdater
         val hasToken = accountStore.hasAccessToken()
         val views = RemoteViews(context.packageName, widgetUtils.getLayout(colorMode))
         views.setTextViewText(R.id.widget_title, resourceProvider.getString(R.string.stats_insights_all_time_stats))
-        widgetUtils.setSiteIcon(siteModel, context, views, appWidgetId)
-        siteModel?.let {
-            views.setOnClickPendingIntent(
-                    R.id.widget_title_container,
-                    widgetUtils.getPendingSelfIntent(context, siteModel.id, INSIGHTS)
-            )
-        }
         if (networkAvailable && siteModel != null && hasToken) {
+            widgetUtils.setSiteIcon(siteModel, context, views, appWidgetId)
+            siteModel.let {
+                views.setOnClickPendingIntent(
+                        R.id.widget_title_container,
+                        widgetUtils.getPendingSelfIntent(context, siteModel.id, INSIGHTS)
+                )
+            }
             widgetUtils.showList(
                     widgetManager,
                     views,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetUpdater.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.widget.RemoteViews
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.StatsTimeframe.INSIGHTS
@@ -23,6 +24,7 @@ class AllTimeWidgetUpdater
 @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val siteStore: SiteStore,
+    private val accountStore: AccountStore,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val resourceProvider: ResourceProvider,
     private val widgetUtils: WidgetUtils,
@@ -42,6 +44,7 @@ class AllTimeWidgetUpdater
         val siteId = appPrefsWrapper.getAppWidgetSiteId(appWidgetId)
         val siteModel = siteStore.getSiteBySiteId(siteId)
         val networkAvailable = networkUtilsWrapper.isNetworkAvailable()
+        val hasToken = accountStore.hasAccessToken()
         val views = RemoteViews(context.packageName, widgetUtils.getLayout(colorMode))
         views.setTextViewText(R.id.widget_title, resourceProvider.getString(R.string.stats_insights_all_time_stats))
         widgetUtils.setSiteIcon(siteModel, context, views, appWidgetId)
@@ -51,7 +54,7 @@ class AllTimeWidgetUpdater
                     widgetUtils.getPendingSelfIntent(context, siteModel.id, INSIGHTS)
             )
         }
-        if (networkAvailable && siteModel != null) {
+        if (networkAvailable && siteModel != null && hasToken) {
             widgetUtils.showList(
                     widgetManager,
                     views,
@@ -63,18 +66,20 @@ class AllTimeWidgetUpdater
                     isWideView
             )
         } else {
-            widgetUtils.showError(widgetManager, views, appWidgetId, networkAvailable, resourceProvider, context)
+            widgetUtils.showError(
+                    widgetManager,
+                    views,
+                    appWidgetId,
+                    networkAvailable,
+                    hasToken,
+                    resourceProvider,
+                    context,
+                    StatsAllTimeWidget::class.java
+            )
         }
     }
 
-    override fun updateAllWidgets(context: Context) {
-        val appWidgetManager = AppWidgetManager.getInstance(context)
-        val viewsWidget = ComponentName(context, StatsAllTimeWidget::class.java)
-        val allWidgetIds = appWidgetManager.getAppWidgetIds(viewsWidget)
-        for (appWidgetId in allWidgetIds) {
-            updateAppWidget(context, appWidgetId)
-        }
-    }
+    override fun componentName(context: Context) = ComponentName(context, StatsAllTimeWidget::class.java)
 
     override fun delete(appWidgetId: Int) {
         analyticsTrackerWrapper.trackWithWidgetType(AnalyticsTracker.Stat.STATS_WIDGET_REMOVED, ALL_TIME_VIEWS)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/MinifiedWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/MinifiedWidgetUpdater.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.stats.refresh.lists.widget.minified
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
+import android.view.View
 import android.widget.RemoteViews
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -64,22 +65,22 @@ class MinifiedWidgetUpdater
         widgetUtils.setSiteIcon(siteModel, context, views, appWidgetId)
         val hasAccessToken = accountStore.hasAccessToken()
         if (networkAvailable && hasAccessToken && siteModel != null && dataType != null) {
+            views.setViewVisibility(R.id.widget_content, View.VISIBLE)
+            views.setViewVisibility(R.id.widget_site_icon, View.VISIBLE)
+            views.setViewVisibility(R.id.widget_retry_button, View.GONE)
             views.setOnClickPendingIntent(
                     R.id.widget_container,
                     widgetUtils.getPendingSelfIntent(context, siteModel.id, INSIGHTS)
             )
             showValue(widgetManager, appWidgetId, views, siteModel, dataType, isWideView)
         } else {
-            widgetUtils.showError(
-                    widgetManager,
-                    views,
-                    appWidgetId,
-                    networkAvailable,
-                    hasAccessToken,
-                    resourceProvider,
-                    context,
-                    StatsMinifiedWidget::class.java
-            )
+            views.setViewVisibility(R.id.widget_content, View.GONE)
+            views.setViewVisibility(R.id.widget_site_icon, View.GONE)
+            views.setViewVisibility(R.id.widget_retry_button, View.VISIBLE)
+
+            val pendingSync = widgetUtils.getRetryIntent(context, StatsMinifiedWidget::class.java, appWidgetId)
+            views.setOnClickPendingIntent(R.id.widget_container, pendingSync)
+            widgetManager.updateAppWidget(appWidgetId, views)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
@@ -1,10 +1,9 @@
 package org.wordpress.android.ui.stats.refresh.lists.widget.today
 
-import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
-import android.content.Intent
+import android.view.View
 import android.widget.RemoteViews
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
@@ -1,8 +1,10 @@
 package org.wordpress.android.ui.stats.refresh.lists.widget.today
 
+import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
+import android.content.Intent
 import android.widget.RemoteViews
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -46,15 +48,15 @@ class TodayWidgetUpdater
         val networkAvailable = networkUtilsWrapper.isNetworkAvailable()
         val views = RemoteViews(context.packageName, widgetUtils.getLayout(colorMode))
         views.setTextViewText(R.id.widget_title, resourceProvider.getString(R.string.stats_insights_today_stats))
-        widgetUtils.setSiteIcon(siteModel, context, views, appWidgetId)
-        siteModel?.let {
-            views.setOnClickPendingIntent(
-                    R.id.widget_title_container,
-                    widgetUtils.getPendingSelfIntent(context, siteModel.id, StatsTimeframe.INSIGHTS)
-            )
-        }
         val hasAccessToken = accountStore.hasAccessToken()
         if (networkAvailable && hasAccessToken && siteModel != null) {
+            widgetUtils.setSiteIcon(siteModel, context, views, appWidgetId)
+            siteModel.let {
+                views.setOnClickPendingIntent(
+                        R.id.widget_title_container,
+                        widgetUtils.getPendingSelfIntent(context, siteModel.id, StatsTimeframe.INSIGHTS)
+                )
+            }
             widgetUtils.showList(
                     widgetManager,
                     views,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.stats.refresh.lists.widget.today
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
-import android.view.View
 import android.widget.RemoteViews
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.ui.stats.refresh.StatsActivity
 import org.wordpress.android.ui.stats.refresh.lists.widget.IS_WIDE_VIEW_KEY
 import org.wordpress.android.ui.stats.refresh.lists.widget.SITE_ID_KEY
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetService
-import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.StatsAllTimeWidget
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.DARK
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.LIGHT
@@ -71,13 +70,17 @@ class WidgetUtils
         views: RemoteViews,
         appWidgetId: Int,
         networkAvailable: Boolean,
+        hasAccessToken: Boolean,
         resourceProvider: ResourceProvider,
-        context: Context
+        context: Context,
+        widgetType: Class<*>
     ) {
         views.setViewVisibility(R.id.widget_content, View.GONE)
         views.setViewVisibility(R.id.widget_error, View.VISIBLE)
         val errorMessage = if (!networkAvailable) {
             R.string.stats_widget_error_no_network
+        } else if (!hasAccessToken) {
+            R.string.stats_widget_error_no_access_token
         } else {
             R.string.stats_widget_error_no_data
         }
@@ -85,7 +88,7 @@ class WidgetUtils
                 R.id.widget_error_message,
                 resourceProvider.getString(errorMessage)
         )
-        val intentSync = Intent(context, StatsAllTimeWidget::class.java)
+        val intentSync = Intent(context, widgetType)
         intentSync.action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
 
         intentSync.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
@@ -75,6 +75,15 @@ class WidgetUtils
         context: Context,
         widgetType: Class<*>
     ) {
+        views.setOnClickPendingIntent(
+                R.id.widget_title_container,
+                PendingIntent.getActivity(
+                        context,
+                        0,
+                        Intent(),
+                        PendingIntent.FLAG_UPDATE_CURRENT
+                )
+        )
         views.setViewVisibility(R.id.widget_content, View.GONE)
         views.setViewVisibility(R.id.widget_error, View.VISIBLE)
         val errorMessage = if (!networkAvailable) {
@@ -88,18 +97,26 @@ class WidgetUtils
                 R.id.widget_error_message,
                 resourceProvider.getString(errorMessage)
         )
+        val pendingSync = getRetryIntent(context, widgetType, appWidgetId)
+        views.setOnClickPendingIntent(R.id.widget_error, pendingSync)
+        appWidgetManager.updateAppWidget(appWidgetId, views)
+    }
+
+    fun getRetryIntent(
+        context: Context,
+        widgetType: Class<*>,
+        appWidgetId: Int
+    ): PendingIntent? {
         val intentSync = Intent(context, widgetType)
         intentSync.action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
 
         intentSync.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-        val pendingSync = PendingIntent.getBroadcast(
+        return PendingIntent.getBroadcast(
                 context,
                 Random(appWidgetId).nextInt(),
                 intentSync,
                 PendingIntent.FLAG_UPDATE_CURRENT
         )
-        views.setOnClickPendingIntent(R.id.widget_error, pendingSync)
-        appWidgetManager.updateAppWidget(appWidgetId, views)
     }
 
     fun showList(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
@@ -59,6 +59,7 @@ class WidgetUtils
         views: RemoteViews,
         appWidgetId: Int
     ) {
+        views.setViewVisibility(R.id.widget_site_icon, View.VISIBLE)
         GlobalScope.launch(Dispatchers.Main) {
             val awt = AppWidgetTarget(context, R.id.widget_site_icon, views, appWidgetId)
             imageManager.load(awt, context, ICON, siteModel?.iconUrl ?: "", FIT_START)
@@ -75,6 +76,7 @@ class WidgetUtils
         context: Context,
         widgetType: Class<*>
     ) {
+        views.setViewVisibility(R.id.widget_site_icon, View.GONE)
         views.setOnClickPendingIntent(
                 R.id.widget_title_container,
                 PendingIntent.getActivity(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetUpdater.kt
@@ -45,14 +45,14 @@ class ViewsWidgetUpdater
         val views = RemoteViews(context.packageName, layout)
         views.setTextViewText(R.id.widget_title, resourceProvider.getString(R.string.stats_views))
         widgetUtils.setSiteIcon(siteModel, context, views, appWidgetId)
-        siteModel?.let {
-            views.setOnClickPendingIntent(
-                    R.id.widget_title_container,
-                    widgetUtils.getPendingSelfIntent(context, siteModel.id, DAY)
-            )
-        }
         val hasAccessToken = accountStore.hasAccessToken()
         if (networkAvailable && hasAccessToken && siteModel != null) {
+            siteModel.let {
+                views.setOnClickPendingIntent(
+                        R.id.widget_title_container,
+                        widgetUtils.getPendingSelfIntent(context, siteModel.id, DAY)
+                )
+            }
             widgetUtils.showList(
                     widgetManager,
                     views,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetUpdater.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.widget.RemoteViews
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.StatsTimeframe.DAY
@@ -23,6 +24,7 @@ class ViewsWidgetUpdater
 @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val siteStore: SiteStore,
+    private val accountStore: AccountStore,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val resourceProvider: ResourceProvider,
     private val widgetUtils: WidgetUtils,
@@ -49,7 +51,8 @@ class ViewsWidgetUpdater
                     widgetUtils.getPendingSelfIntent(context, siteModel.id, DAY)
             )
         }
-        if (networkAvailable && siteModel != null) {
+        val hasAccessToken = accountStore.hasAccessToken()
+        if (networkAvailable && hasAccessToken && siteModel != null) {
             widgetUtils.showList(
                     widgetManager,
                     views,
@@ -61,18 +64,20 @@ class ViewsWidgetUpdater
                     isWideView
             )
         } else {
-            widgetUtils.showError(widgetManager, views, appWidgetId, networkAvailable, resourceProvider, context)
+            widgetUtils.showError(
+                    widgetManager,
+                    views,
+                    appWidgetId,
+                    networkAvailable,
+                    hasAccessToken,
+                    resourceProvider,
+                    context,
+                    StatsViewsWidget::class.java
+            )
         }
     }
 
-    override fun updateAllWidgets(context: Context) {
-        val appWidgetManager = AppWidgetManager.getInstance(context)
-        val viewsWidget = ComponentName(context, StatsViewsWidget::class.java)
-        val allWidgetIds = appWidgetManager.getAppWidgetIds(viewsWidget)
-        for (appWidgetId in allWidgetIds) {
-            updateAppWidget(context, appWidgetId)
-        }
-    }
+    override fun componentName(context: Context) = ComponentName(context, StatsViewsWidget::class.java)
 
     override fun delete(appWidgetId: Int) {
         analyticsTrackerWrapper.trackWithWidgetType(AnalyticsTracker.Stat.STATS_WIDGET_REMOVED, WEEK_VIEWS)

--- a/WordPress/src/main/res/layout/stats_widget_minified_dark.xml
+++ b/WordPress/src/main/res/layout/stats_widget_minified_dark.xml
@@ -41,4 +41,13 @@
             tools:text="15,908"/>
 
     </LinearLayout>
+
+    <TextView
+        android:id="@+id/widget_retry_button"
+        style="@style/StatsWidgetRetryButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:visibility="gone"
+        android:text="@string/retry"/>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/stats_widget_minified_light.xml
+++ b/WordPress/src/main/res/layout/stats_widget_minified_light.xml
@@ -41,4 +41,13 @@
             tools:text="15,908"/>
 
     </LinearLayout>
+
+    <TextView
+        android:id="@+id/widget_retry_button"
+        style="@style/StatsWidgetRetryButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:visibility="gone"
+        android:text="@string/retry"/>
 </LinearLayout>

--- a/WordPress/src/main/res/values/stats_styles.xml
+++ b/WordPress/src/main/res/values/stats_styles.xml
@@ -261,7 +261,6 @@
     <style name="StatsWidgetSiteIcon">
         <item name="android:paddingBottom">10dp</item>
         <item name="android:layout_marginStart">@dimen/margin_large</item>
-        <item name="android:layout_marginEnd">@dimen/margin_large</item>
         <item name="android:paddingTop">10dp</item>
     </style>
 
@@ -289,6 +288,7 @@
     <style name="StatsWidgetTitle" parent="TextAppearance.AppCompat.Body2">
         <item name="android:textSize">@dimen/text_sz_medium</item>
         <item name="android:gravity">center_vertical</item>
+        <item name="android:layout_marginStart">@dimen/margin_large</item>
     </style>
 
     <style name="StatsWidgetTitle.Light">

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -862,6 +862,7 @@
     <string name="stats_widget_select_type">Type</string>
     <string name="stats_widget_error_no_data">Couldn\'t load data</string>
     <string name="stats_widget_error_no_network">No network available</string>
+    <string name="stats_widget_error_no_access_token">To view your stats, log in to the WordPress.com account</string>
 
     <!-- Jetpack install -->
     <string name="jetpack">Jetpack</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -862,7 +862,7 @@
     <string name="stats_widget_select_type">Type</string>
     <string name="stats_widget_error_no_data">Couldn\'t load data</string>
     <string name="stats_widget_error_no_network">No network available</string>
-    <string name="stats_widget_error_no_access_token">To view your stats, log in to the WordPress.com account</string>
+    <string name="stats_widget_error_no_access_token">To view your stats, log in to the WordPress.com account.</string>
 
     <!-- Jetpack install -->
     <string name="jetpack">Jetpack</string>


### PR DESCRIPTION
Fixes #10145 and #9775

There were 3 issues fixed in this PR. 
- One is that during logout I was updating `Views` widget and `AllTime` widget. The other ones just kept their data. 
- I've also added a check to all the widget updaters to show an error when the user is not logged in while updating the data. 
- Retry was updating the widget always with the `AllTime` type. This is now fixed and Retry should work as expected.

One thing might still happen and that's the issue when you log in with a different account and click on a widget. I don't think we're purging the database properly for the Stats. I think this is super minor and related more to the stats than to the widgets so I'd rather address it in a PR on develop.

To test:
* Log in to the App
* Add all kinds of widgets with various sites
* Log out
* The widgets now show an error
* Log back in
* Click on Retry
* The data is reloaded in the widgets

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
