### PR TITLE
Add local changes label to page scheduled in offline

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
@@ -67,13 +67,14 @@ sealed class PageItem(open val type: Type) {
         override val id: Long,
         override val title: String,
         override val date: Date,
+        override val labels: List<Int> = emptyList(),
         override var imageUrl: String? = null,
         override var actionsEnabled: Boolean = true
     ) : Page(
             id = id,
             title = title,
             date = date,
-            labels = emptyList(),
+            labels = labels,
             indent = 0,
             imageUrl = imageUrl,
             actions = setOf(VIEW_PAGE, SET_PARENT, MOVE_TO_DRAFT, MOVE_TO_TRASH),

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -227,7 +227,12 @@ class PageListViewModel @Inject constructor(
     private fun prepareScheduledPages(pages: List<PageModel>, actionsEnabled: Boolean): List<PageItem> {
         return pages.asSequence().groupBy { it.date.toFormattedDateString() }
                 .map { (date, results) -> listOf(Divider(date)) +
-                        results.map { ScheduledPage(it.remoteId, it.title, it.date,
+                        results.map {
+                            val labels = mutableListOf<Int>()
+                            if (it.hasLocalChanges)
+                                labels.add(R.string.local_changes)
+
+                            ScheduledPage(it.remoteId, it.title, it.date, labels,
                                 getFeaturedImageUrl(it.featuredImageId), actionsEnabled) }
                 }
                 .fold(mutableListOf()) { acc: MutableList<PageItem>, list: List<PageItem> ->


### PR DESCRIPTION
Fixes #9949

This PR adds "local changes" label to scheduled pages which are changed locally.


To test:
1. My Site
2. Site Pages
3. Turn on Airplane mode
4. Click on "Create Page" FAB
5. Add title
6. Click on overflow menu - page settings
7. Change Publish date to a future date
8. Click on Schedule
9. Click on Scheduled tab and notice the item has "local changes" label

Update release notes:

- The changes are too minor


Before            |  After
:-------------------------:|:-------------------------:
![local-changes-scheduled-pages](https://user-images.githubusercontent.com/2261188/60659597-1056a280-9e56-11e9-9a6a-ade105402f4d.gif)  |  ![fixed-local-changes-scheduled-pages](https://user-images.githubusercontent.com/2261188/60659599-1482c000-9e56-11e9-945c-d6899db001bd.gif)






