### PR TITLE
Improve post scheduled in offline message

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -123,7 +123,11 @@ public class UploadUtils {
             // The network is not available, we can enqueue a request to upload local changes later
             UploadWorkerKt.enqueueUploadWorkRequestForSite(site);
             // And tell the user about it
-            showSnackbar(snackbarAttachView, R.string.error_publish_no_network);
+            if (PostStatus.SCHEDULED.toString().equals(post.getStatus())) {
+                showSnackbar(snackbarAttachView, R.string.error_schedule_no_network);
+            } else {
+                showSnackbar(snackbarAttachView, R.string.error_publish_no_network);
+            }
             return;
         }
 
@@ -236,8 +240,13 @@ public class UploadUtils {
 
     public static void publishPost(Activity activity, final PostModel post, SiteModel site, Dispatcher dispatcher) {
         if (!NetworkUtils.isNetworkAvailable(activity)) {
-            ToastUtils.showToast(activity, R.string.error_publish_no_network,
-                                 ToastUtils.Duration.SHORT);
+            if (PostStatus.SCHEDULED.toString().equals(post.getStatus())) {
+                ToastUtils.showToast(activity, R.string.error_schedule_no_network,
+                        ToastUtils.Duration.SHORT);
+            } else {
+                ToastUtils.showToast(activity, R.string.error_publish_no_network,
+                        ToastUtils.Duration.SHORT);
+            }
             return;
         }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1518,6 +1518,7 @@
     <string name="error_publish_empty_page">Can\'t publish an empty page</string>
     <string name="error_save_empty_draft">Can\'t save an empty draft</string>
     <string name="error_publish_no_network">Device is offline. Post saved locally.</string>
+    <string name="error_schedule_no_network">Post will be scheduled next time your device is online.</string>
     <string name="error_upload_post_param">There was an error uploading this post: %s.</string>
     <string name="error_upload_page_param">There was an error uploading this page: %s.</string>
     <string name="error_upload_post_media_param">There was an error uploading the media in this post: %s.</string>


### PR DESCRIPTION
Fixes #10154 

Improves Snackbar message copy when a post is scheduled in offline.

To test:
1. My Site
2. Post List
3. Turn on Airplane mode
4. Create a new draft
5. Add title
6. Overflow menu - Post Settings
7. Set the publish date to future
8. Click on Schedule
9. Observe the following `Post will be scheduled next time your device is online` Snackbar message is shown

Update release notes:

- The changes are too minor.

Before            |  After
:-------------------------:|:-------------------------:
![schedule-post-message](https://user-images.githubusercontent.com/2261188/60662250-21a2ad80-9e5c-11e9-873c-5924b2ca47f7.gif) | ![fixed-schedule-post-message](https://user-images.githubusercontent.com/2261188/60662265-2d8e6f80-9e5c-11e9-92a0-1f6d3d766ccf.gif)


