### PR TITLE
Feature/beta hotfix tooling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: e1833343a11f01526c606c3f0215875aea77c2c7
-  ref: e1833343a11f01526c606c3f0215875aea77c2c7
+  revision: 9cefa93fed199849a9e53619e2576012412a4d67
+  tag: 0.6.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.5.0)
+    fastlane-plugin-wpmreleasetoolkit (0.6.0)
       diffy (~> 3.3)
       git (~> 1.3)
       jsonlint
@@ -13,7 +13,6 @@ GIT
       progress_bar (~> 1.3)
       rake (~> 12.3)
       rake-compiler (~> 1.0)
-      rmagick (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -132,7 +131,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.7.12)
+    oj (3.8.0)
     optimist (3.0.0)
     options (2.3.2)
     os (1.0.1)
@@ -150,7 +149,6 @@ GEM
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rmagick (3.2.0)
     rouge (2.0.7)
     rubyzip (1.2.3)
     sawyer (0.8.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,5 @@
-GIT
-  remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: d5ad0466ab9f72161cd55916577cf52ee386f9cf
-  tag: 0.5.0
+PATH
+  remote: ../release-toolkit
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.5.0)
       diffy (~> 3.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,7 @@
-PATH
-  remote: ../release-toolkit
+GIT
+  remote: https://github.com/wordpress-mobile/release-toolkit
+  revision: e1833343a11f01526c606c3f0215875aea77c2c7
+  ref: e1833343a11f01526c606c3f0215875aea77c2c7
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.5.0)
       diffy (~> 3.3)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -149,7 +149,7 @@ ENV["HAS_ALPHA_VERSION"]="true"
   #####################################################################################
   desc "Creates a new hotfix branch from the given tag"
   lane :new_hotfix_release do | options |
-    prev_ver = android_hotfix_prechecks(options)
+    prev_ver = android_hotfix_prechecks(version_name: options[:version_name], skip_confirm: options[:skip_confirm])
     android_bump_version_hotfix(previous_version_name: prev_ver, version_name: options[:version_name], version_code: options[:version_code])
     android_tag_build(tag_alpha: false)
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -149,9 +149,9 @@ ENV["HAS_ALPHA_VERSION"]="true"
   #####################################################################################
   desc "Creates a new hotfix branch from the given tag"
   lane :new_hotfix_release do | options |
-    #prev_ver = android_hotfix_prechecks(options)
-    #android_bump_version_hotfix(previous_version: prev_ver, version: options[:version])
-    #android_tag_build()
+    prev_ver = android_hotfix_prechecks(options)
+    android_bump_version_hotfix(previous_version_name: prev_ver, version_name: options[:version_name], version_code: options[:version_code])
+    android_tag_build(tag_alpha: false)
   end
   
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -111,6 +111,48 @@ ENV["HAS_ALPHA_VERSION"]="true"
       source_files: files, 
       release_version: options[:version])
   end 
+
+  #####################################################################################
+  # new_beta_release
+  # -----------------------------------------------------------------------------------
+  # This lane updates the release branch for a new beta release. It will update the
+  # current release branch by default. If you want to update a different branch
+  # (i.e. hotfix branch) pass the related version with the 'base_version' param
+  # (example: base_version:10.6.1 will work on the 10.6.1 branch)
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane new_beta_release [skip_confirm:<skip confirm>] [base_version:<version>]
+  #
+  # Example:
+  # bundle exec fastlane new_beta_release
+  # bundle exec fastlane new_beta_release skip_confirm:true
+  # bundle exec fastlane new_beta_release base_version:10.6.1
+  #####################################################################################
+  desc "Updates a release branch for a new beta release"
+  lane :new_beta_release do | options |
+    android_betabuild_prechecks(options)
+    android_bump_version_beta()
+    android_tag_build()
+  end
+
+  #####################################################################################
+  # new_hotfix_release
+  # -----------------------------------------------------------------------------------
+  # This lane updates the release branch for a new hotix release. 
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane new_hotfix_release [skip_confirm:<skip confirm>] [version:<version>]
+  #
+  # Example:
+  # bundle exec fastlane new_hotfix_release version:10.6.1
+  # bundle exec fastlane new_hotfix_release skip_confirm:true version:10.6.1
+  #####################################################################################
+  desc "Creates a new hotfix branch from the given tag"
+  lane :new_hotfix_release do | options |
+    #prev_ver = android_hotfix_prechecks(options)
+    #android_bump_version_hotfix(previous_version: prev_ver, version: options[:version])
+    #android_tag_build()
+  end
   
   #####################################################################################
   # finalize_release

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,8 +2,8 @@
 #
 # Ensure this file is checked in to source control!
 
-#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.5.0' 
-gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../../wordpress-mobile/release-toolkit'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref:'e1833343a11f01526c606c3f0215875aea77c2c7' 
+
 
 
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,7 +2,7 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref:'e1833343a11f01526c606c3f0215875aea77c2c7' 
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.6.0' 
 
 
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,7 +2,8 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.5.0' 
+#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.5.0' 
+gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../../wordpress-mobile/release-toolkit'
 
 
 


### PR DESCRIPTION
This PR adds two lanes to automate the versioning for new beta and hotfix releases.
There's a related PR in `release-toolkit`: https://github.com/wordpress-mobile/release-toolkit/pull/57.

## To test:
### 1. Beta 
The normal flow for this command is to call it without passing a version. It should read it from develop and update the related branch. 
Since the code will commit and push on the release branch, we'll override the release branch name to make it push to a different branch. 

1.1 Checkout a new `release/12.9` branch and push it with the `-u` option. (_Note 1_: You can actually call it with any number you want, the code only checks that it is a `release` branch. _Note 2_: You want to checkout a new branch, because the code will commit and push to the current one).
1.2 Run `bundle exec fastlane new_beta_release base_version:12.9` (You should use the same version you checked out above).
1.3 Verify that the code reads the correct versions from `gradle.properties`. It should read the one from `develop` and the one from `release/12.9`. They are probably the same as the branches are in sync now.
1.4 Verify that the alpha and beta names are correctly updated, the changes committed and pushed and the new version tagged. _Note_: The code should increment the current beta version number, currectly 12.8-rc-1 to 12.8-rc-2 and don't check the base version (12.8) against the release branch name (12.9). The check is intentionally disabled because this is an override feature and we may want a bit more freedom. 
1.5 Delete the new alpha and beta tags from your local repository and from GitHub.
1.6 Delete the `release/12.9` branch from your local repository  and from GitHub.

### 2. Hotfix
1. Add a `12.8` tag to your local repository (no need to push it).
2. Run `bundle exec fastlane new_hotfix_release version_name:12.8.1 version_code:800`. You can choose any 12.8.x version and any version code.
3. Verify that the code calculates the right base version.
4. Verify that the code checks out a new `release/12.8.1` branch from your `12.8` tag. 
5. Verify that the branch is pushed.
6. Verify that the version is correctly updated in `gradle.properties`.
7. Verify that the version is tagged.
8. Delete the new 12.8.1 tag from you local repository and from GitHub.
9. Delete the new `release/12.8.1` branch from your local repository and from GitHub.
10. Delete the `12.8` tag from your local repository.


Note: When approved, I'll update the reference to the release-toolbox before merging this to develop.
Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.