### PR TITLE
Fix failing CI test

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
@@ -64,7 +64,8 @@ public class EditorPage {
         }
 
         // Click on a random image
-        clickOn(onView(withIndex(withId(R.id.media_grid_item_image), 0)));
+        waitForElementToBeDisplayed(onView(withText("WordPress media")));
+        onView(withIndex(withId(R.id.media_grid_item_image), 0)).perform(click());
 
         // Click the confirm button
         clickOn(confirmButton);


### PR DESCRIPTION
Fixes publish test wailing on CI. Wait on the header instead

To test: Ensure the tests pass on CI. 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
