### PR TITLE
[Analytica - GB] Update the tracker for unsupported blocks

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -32,6 +32,7 @@ import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.LiveData;
 
 import com.android.volley.toolbox.ImageLoader;
+import com.facebook.react.bridge.ReadableArray;
 
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -270,9 +271,9 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                 },
                 new OnEditorMountListener() {
                     @Override
-                    public void onEditorDidMount(boolean hasUnsupportedBlocks) {
+                    public void onEditorDidMount(ReadableArray unsupportedBlocks) {
                         mEditorDidMount = true;
-                        mEditorFragmentListener.onEditorFragmentContentReady(hasUnsupportedBlocks);
+                        mEditorFragmentListener.onEditorFragmentContentReady(unsupportedBlocks.size() > 0);
 
                         // Hide the progress bar when editor is ready
                         new Handler(Looper.getMainLooper()).post(new Runnable() {


### PR DESCRIPTION
This PR updates the interface implementation of the method that is used to keep track of unsupported blocks in the current post/page.

Prior to this PR, the JS side was sending a simple flag to signal the presence of unsupported blocks in the post. With the improved version of the JS side tracker, it will send the full list of unsupported block names. For now we're just checking if the list is empty or not, and then bump the same Analytics `has_unsupported_blocks` as before. 


**Do not merge** until https://github.com/wordpress-mobile/gutenberg-mobile/pull/1199 is merged in gb-mobile.

To test:

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
