### PR TITLE
Update upload media errors for published/scheduled/etc..

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -4,6 +4,7 @@ import androidx.annotation.ColorRes
 import org.apache.commons.text.StringEscapeUtils
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
+import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_BUTTON_PRESSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_ITEM_SELECTED
@@ -11,9 +12,13 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.model.post.PostStatus.DRAFT
 import org.wordpress.android.fluxc.model.post.PostStatus.PENDING
 import org.wordpress.android.fluxc.model.post.PostStatus.PRIVATE
+import org.wordpress.android.fluxc.model.post.PostStatus.PUBLISHED
 import org.wordpress.android.fluxc.model.post.PostStatus.SCHEDULED
+import org.wordpress.android.fluxc.model.post.PostStatus.TRASHED
+import org.wordpress.android.fluxc.model.post.PostStatus.UNKNOWN
 import org.wordpress.android.fluxc.store.UploadStore.UploadError
 import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
@@ -171,7 +176,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         val labels: MutableList<UiString> = ArrayList()
         when {
             uploadUiState is PostUploadUiState.UploadFailed -> {
-                getErrorLabel(uploadUiState.error)?.let { labels.add(it) }
+                getErrorLabel(uploadUiState.error, postStatus)?.let { labels.add(it) }
             }
             uploadUiState is UploadingPost -> if (uploadUiState.isDraft) {
                 labels.add(UiStringRes(R.string.post_uploading_draft))
@@ -201,9 +206,14 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         return labels
     }
 
-    private fun getErrorLabel(uploadError: UploadError): UiString? {
+    private fun getErrorLabel(uploadError: UploadError, postStatus: PostStatus): UiString? {
         return when {
-            uploadError.mediaError != null -> UiStringRes(R.string.error_media_recover_post)
+            uploadError.mediaError != null -> when (postStatus) {
+                PRIVATE, PUBLISHED -> UiStringRes(string.error_media_recover_post_not_published)
+                SCHEDULED -> UiStringRes(string.error_media_recover_post_not_scheduled)
+                PENDING -> UiStringRes(string.error_media_recover_post_not_submitted)
+                DRAFT, TRASHED, UNKNOWN -> UiStringRes(string.error_media_recover_post)
+            }
             uploadError.postError != null -> UploadUtils.getErrorMessageResIdFromPostError(
                     false,
                     uploadError.postError

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1533,7 +1533,10 @@
     <string name="error_media_load">Unable to load media</string>
     <string name="error_media_save">Unable to save media</string>
     <string name="error_media_canceled">Uploading media were canceled</string>
-    <string name="error_media_recover_post">Unable to upload this post\'s media</string>
+    <string name="error_media_recover_post">Could not upload media</string>
+    <string name="error_media_recover_post_not_published">Could not upload media. Post not published.</string>
+    <string name="error_media_recover_post_not_scheduled">Could not upload media. Post not scheduled.</string>
+    <string name="error_media_recover_post_not_submitted">Could not upload media. Post not submitted.</string>
     <string name="error_post_does_not_exist">This post no longer exists</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
     <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -180,8 +180,7 @@ class PostListItemUiStateHelperTest {
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_PRIVATE),
                 uploadStatus = createUploadStatus(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
         )
-        assertThat(state.data.statuses).contains(UiStringRes(R.string.error_media_recover_post_not_published))
-        assertThat(state.data.statuses).hasSize(1)
+        assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post_not_published))
     }
 
     @Test
@@ -190,8 +189,7 @@ class PostListItemUiStateHelperTest {
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_PENDING),
                 uploadStatus = createUploadStatus(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
         )
-        assertThat(state.data.statuses).contains(UiStringRes(R.string.error_media_recover_post_not_submitted))
-        assertThat(state.data.statuses).hasSize(1)
+        assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post_not_submitted))
     }
 
     @Test
@@ -200,8 +198,7 @@ class PostListItemUiStateHelperTest {
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_SCHEDULED),
                 uploadStatus = createUploadStatus(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
         )
-        assertThat(state.data.statuses).contains(UiStringRes(R.string.error_media_recover_post_not_scheduled))
-        assertThat(state.data.statuses).hasSize(1)
+        assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post_not_scheduled))
     }
 
     @Test
@@ -210,8 +207,7 @@ class PostListItemUiStateHelperTest {
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_DRAFT),
                 uploadStatus = createUploadStatus(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
         )
-        assertThat(state.data.statuses).contains(UiStringRes(R.string.error_media_recover_post))
-        assertThat(state.data.statuses).hasSize(1)
+        assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.widgets.PostListButtonType
 private const val FORMATTER_DATE = "January 1st, 1:35pm"
 
 private val POST_STATE_PUBLISH = PostStatus.PUBLISHED.toString()
+private val POST_STATE_SCHEDULED = PostStatus.SCHEDULED.toString()
 private val POST_STATE_PRIVATE = PostStatus.PRIVATE.toString()
 private val POST_STATE_PENDING = PostStatus.PENDING.toString()
 private val POST_STATE_DRAFT = PostStatus.DRAFT.toString()
@@ -177,6 +178,36 @@ class PostListItemUiStateHelperTest {
     fun `given a mix of info and error statuses, only the error status is shown`() {
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_PRIVATE),
+                uploadStatus = createUploadStatus(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
+        )
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.error_media_recover_post_not_published))
+        assertThat(state.data.statuses).hasSize(1)
+    }
+
+    @Test
+    fun `media upload error shown with specific message for pending post`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(isLocallyChanged = true, status = POST_STATE_PENDING),
+                uploadStatus = createUploadStatus(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
+        )
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.error_media_recover_post_not_submitted))
+        assertThat(state.data.statuses).hasSize(1)
+    }
+
+    @Test
+    fun `media upload error shown with specific message for scheduled post`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(isLocallyChanged = true, status = POST_STATE_SCHEDULED),
+                uploadStatus = createUploadStatus(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
+        )
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.error_media_recover_post_not_scheduled))
+        assertThat(state.data.statuses).hasSize(1)
+    }
+
+    @Test
+    fun `base media upload error shown for draft`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(isLocallyChanged = true, status = POST_STATE_DRAFT),
                 uploadStatus = createUploadStatus(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
         )
         assertThat(state.data.statuses).contains(UiStringRes(R.string.error_media_recover_post))


### PR DESCRIPTION
Fixes #9933  by changing the error message after media upload failure.

Test 1:
- Create a new post.
- Add a media and make the upload fail (airplane mode for example).
- Go back (draft), check the message is "Could not upload media"

Test 2:
- Create a new post.
- Add a media and make the upload fail (airplane mode for example).
- Tap publish, check the message is "Could not upload media. Post not published."

Do the same test for private, scheduled and pending posts and notice different error message.

Note: I first wanted to compose the error message using the base "Could not upload media" and concatenate the specific error, but it's often source of issues in translations and should be solved by translation memory.


Before | After
-|-
![ff395b985733](https://user-images.githubusercontent.com/40213/58335719-7fe27680-7e42-11e9-9b20-ff395b985733.png)|![Screenshot_1562597183](https://user-images.githubusercontent.com/40213/60819483-f7285b80-a19f-11e9-8188-e6979cb96472.png)


