### PR TITLE
Automatically upload local drafts and locally changed posts and pages

### DIFF
--- a/WordPress/src/debug/java/org/wordpress/android/WordPressDebug.java
+++ b/WordPress/src/debug/java/org/wordpress/android/WordPressDebug.java
@@ -29,7 +29,7 @@ public class WordPressDebug extends WordPress {
     protected void initWorkManager() {
         Configuration config = (new Configuration.Builder())
                 .setMinimumLoggingLevel(Log.DEBUG)
-                .setWorkerFactory(new UploadWorker.Factory(mLocalDraftUploadStarter, mSiteStore))
+                .setWorkerFactory(new UploadWorker.Factory(mUploadStarter, mSiteStore))
                 .build();
         WorkManager.initialize(this, config);
     }

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -78,7 +78,7 @@ import org.wordpress.android.ui.stats.StatsWidgetProvider;
 import org.wordpress.android.ui.stats.datasets.StatsDatabaseHelper;
 import org.wordpress.android.ui.stats.datasets.StatsTable;
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater.StatsWidgetUpdaters;
-import org.wordpress.android.ui.uploads.LocalDraftUploadStarter;
+import org.wordpress.android.ui.uploads.UploadStarter;
 import org.wordpress.android.ui.uploads.UploadService;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.AppLogListener;
@@ -147,7 +147,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
     @Inject SiteStore mSiteStore;
     @Inject MediaStore mMediaStore;
     @Inject ZendeskHelper mZendeskHelper;
-    @Inject LocalDraftUploadStarter mLocalDraftUploadStarter;
+    @Inject UploadStarter mUploadStarter;
     @Inject StatsWidgetUpdaters mStatsWidgetUpdaters;
 
     @Inject @Named("custom-ssl") RequestQueue mRequestQueue;
@@ -285,7 +285,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
 
         // Make the UploadStarter observe the app process so it can auto-start uploads
-        mLocalDraftUploadStarter.activateAutoUploading((ProcessLifecycleOwner) ProcessLifecycleOwner.get());
+        mUploadStarter.activateAutoUploading((ProcessLifecycleOwner) ProcessLifecycleOwner.get());
 
         initAnalytics(SystemClock.elapsedRealtime() - startDate);
 
@@ -325,7 +325,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
     }
 
     protected void initWorkManager() {
-        UploadWorker.Factory factory = new UploadWorker.Factory(mLocalDraftUploadStarter, mSiteStore);
+        UploadWorker.Factory factory = new UploadWorker.Factory(mUploadStarter, mSiteStore);
         androidx.work.Configuration config =
                 (new androidx.work.Configuration.Builder()).setWorkerFactory(factory).build();
         WorkManager.initialize(this, config);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -39,7 +39,7 @@ import org.wordpress.android.ui.posts.PostListViewLayoutType.STANDARD
 import org.wordpress.android.ui.posts.PostListViewLayoutTypeMenuUiState.CompactViewLayoutTypeMenuUiState
 import org.wordpress.android.ui.posts.PostListViewLayoutTypeMenuUiState.StandardViewLayoutTypeMenuUiState
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
-import org.wordpress.android.ui.uploads.LocalDraftUploadStarter
+import org.wordpress.android.ui.uploads.UploadStarter
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.ToastUtils.Duration
@@ -72,7 +72,7 @@ class PostListMainViewModel @Inject constructor(
     private val postListEventListenerFactory: PostListEventListener.Factory,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
-    private val localDraftUploadStarter: LocalDraftUploadStarter
+    private val uploadStarter: UploadStarter
 ) : ViewModel(), LifecycleOwner, CoroutineScope {
     private val lifecycleRegistry = LifecycleRegistry(this)
     override fun getLifecycle(): Lifecycle = lifecycleRegistry
@@ -231,7 +231,7 @@ class PostListMainViewModel @Inject constructor(
         )
         lifecycleRegistry.markState(Lifecycle.State.STARTED)
 
-        localDraftUploadStarter.queueUploadFromSite(site)
+        uploadStarter.queueUploadFromSite(site)
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -31,7 +31,7 @@ import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 /**
- * Automatically uploads local drafts.
+ * Automatically uploads posts and pages with local changes.
  *
  * Auto-uploads happen when the app is placed in the foreground or when the internet connection is restored. In
  * addition to this, call sites can also request an immediate execution by calling [upload].
@@ -131,8 +131,8 @@ open class UploadStarter @Inject constructor(
      * This is meant to be used by [checkConnectionAndUpload] only.
      */
     private suspend fun upload(site: SiteModel) = coroutineScope {
-        val posts = async { postStore.getLocalDraftPosts(site) }
-        val pages = async { pageStore.getLocalDraftPages(site) }
+        val posts = async { postStore.getLocallyChangedPosts(site) }
+        val pages = async { pageStore.getLocallyChangedPages(site) }
 
         val postsAndPages = posts.await() + pages.await()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -39,7 +39,7 @@ import kotlin.coroutines.CoroutineContext
  * The method [activateAutoUploading] must be called once, preferably during app creation, for the auto-uploads to work.
  */
 @Singleton
-open class LocalDraftUploadStarter @Inject constructor(
+open class UploadStarter @Inject constructor(
     /**
      * The Application context
      */
@@ -76,7 +76,7 @@ open class LocalDraftUploadStarter @Inject constructor(
      * This must be called during [org.wordpress.android.WordPress]' creation like so:
      *
      * ```
-     * mLocalDraftUploadStarter.activateAutoUploading(ProcessLifecycleOwner.get())
+     * mUploadStarter.activateAutoUploading(ProcessLifecycleOwner.get())
      * ```
      */
     fun activateAutoUploading(processLifecycleOwner: ProcessLifecycleOwner) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -35,7 +35,7 @@ import org.wordpress.android.ui.pages.PageItem.Action.SET_PARENT
 import org.wordpress.android.ui.pages.PageItem.Action.VIEW_PAGE
 import org.wordpress.android.ui.pages.PageItem.Page
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
-import org.wordpress.android.ui.uploads.LocalDraftUploadStarter
+import org.wordpress.android.ui.uploads.UploadStarter
 import org.wordpress.android.ui.uploads.PostEvents
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.EventBusWrapper
@@ -76,7 +76,7 @@ class PagesViewModel
     private val dispatcher: Dispatcher,
     private val actionPerfomer: ActionPerformer,
     private val networkUtils: NetworkUtilsWrapper,
-    private val localDraftUploadStarter: LocalDraftUploadStarter,
+    private val uploadStarter: UploadStarter,
     private val eventBusWrapper: EventBusWrapper,
     @Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val defaultDispatcher: CoroutineDispatcher
@@ -155,7 +155,7 @@ class PagesViewModel
 
             loadPagesAsync()
 
-            localDraftUploadStarter.queueUploadFromSite(site)
+            uploadStarter.queueUploadFromSite(site)
         }
     }
 
@@ -421,7 +421,7 @@ class PagesViewModel
     }
 
     fun onPullToRefresh() {
-        localDraftUploadStarter.queueUploadFromSite(site)
+        uploadStarter.queueUploadFromSite(site)
 
         launch {
             reloadPages(FETCHING)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -34,7 +34,7 @@ import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
 import org.wordpress.android.ui.posts.PostListType.SEARCH
 import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.ui.posts.trackPostListAction
-import org.wordpress.android.ui.uploads.LocalDraftUploadStarter
+import org.wordpress.android.ui.uploads.UploadStarter
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.SiteUtils
@@ -62,7 +62,7 @@ class PostListViewModel @Inject constructor(
     private val accountStore: AccountStore,
     private val listItemUiStateHelper: PostListItemUiStateHelper,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
-    private val localDraftUploadStarter: LocalDraftUploadStarter,
+    private val uploadStarter: UploadStarter,
     @Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     connectionStatus: LiveData<ConnectionStatus>
@@ -285,7 +285,7 @@ class PostListViewModel @Inject constructor(
     // Public Methods
 
     fun swipeToRefresh() {
-        localDraftUploadStarter.queueUploadFromSite(connector.site)
+        uploadStarter.queueUploadFromSite(connector.site)
         fetchFirstPage()
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
@@ -16,11 +16,11 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.PostListViewLayoutType.COMPACT
 import org.wordpress.android.ui.posts.PostListViewLayoutType.STANDARD
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
-import org.wordpress.android.ui.uploads.LocalDraftUploadStarter
+import org.wordpress.android.ui.uploads.UploadStarter
 
 class PostListMainViewModelTest : BaseUnitTest() {
     lateinit var site: SiteModel
-    @Mock lateinit var localDraftUploadStarter: LocalDraftUploadStarter
+    @Mock lateinit var uploadStarter: UploadStarter
     private lateinit var viewModel: PostListMainViewModel
 
     @UseExperimental(ExperimentalCoroutinesApi::class)
@@ -43,7 +43,7 @@ class PostListMainViewModelTest : BaseUnitTest() {
                 mainDispatcher = Dispatchers.Unconfined,
                 bgDispatcher = Dispatchers.Unconfined,
                 postListEventListenerFactory = mock(),
-                localDraftUploadStarter = localDraftUploadStarter
+                uploadStarter = uploadStarter
         )
     }
 
@@ -51,7 +51,7 @@ class PostListMainViewModelTest : BaseUnitTest() {
     fun `when started, it uploads all local drafts`() {
         viewModel.start(site)
 
-        verify(localDraftUploadStarter, times(1)).queueUploadFromSite(eq(site))
+        verify(uploadStarter, times(1)).queueUploadFromSite(eq(site))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
@@ -21,13 +21,13 @@ import org.wordpress.android.ui.posts.PostUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 
 /**
- * Tests for structured concurrency in [LocalDraftUploadStarter].
+ * Tests for structured concurrency in [UploadStarter].
  *
- * This is intentionally a separate class from [LocalDraftUploadStarterTest] because this contains non-deterministic
+ * This is intentionally a separate class from [UploadStarterTest] because this contains non-deterministic
  * tests.
  */
 @RunWith(MockitoJUnitRunner::class)
-class LocalDraftUploadStarterConcurrentTest {
+class UploadStarterConcurrentTest {
     @get:Rule val rule = InstantTaskExecutorRule()
 
     private val site = SiteModel()
@@ -51,7 +51,7 @@ class LocalDraftUploadStarterConcurrentTest {
         // Given
         val uploadServiceFacade = createMockedUploadServiceFacade()
 
-        val starter = createLocalDraftUploadStarter(uploadServiceFacade)
+        val starter = createUploadStarter(uploadServiceFacade)
 
         // When
         runBlocking {
@@ -68,7 +68,7 @@ class LocalDraftUploadStarterConcurrentTest {
         )
     }
 
-    private fun createLocalDraftUploadStarter(uploadServiceFacade: UploadServiceFacade) = LocalDraftUploadStarter(
+    private fun createUploadStarter(uploadServiceFacade: UploadServiceFacade) = UploadStarter(
             context = mock(),
             postStore = postStore,
             pageStore = pageStore,

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
@@ -40,10 +40,10 @@ class UploadStarterConcurrentTest {
     )
 
     private val postStore = mock<PostStore> {
-        on { getLocalDraftPosts(eq(site)) } doReturn posts
+        on { getLocallyChangedPosts(eq(site)) } doReturn posts
     }
     private val pageStore = mock<PageStore> {
-        onBlocking { getLocalDraftPages(any()) } doReturn emptyList()
+        onBlocking { getLocallyChangedPages(any()) } doReturn emptyList()
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -66,12 +66,12 @@ class UploadStarterTest {
     }
     private val postStore = mock<PostStore> {
         sites.forEach {
-            on { getLocalDraftPosts(eq(it)) } doReturn sitesAndPosts.getValue(it)
+            on { getLocallyChangedPosts(eq(it)) } doReturn sitesAndPosts.getValue(it)
         }
     }
     private val pageStore = mock<PageStore> {
         sites.forEach {
-            onBlocking { getLocalDraftPages(eq(it)) } doReturn sitesAndPages.getValue(it)
+            onBlocking { getLocallyChangedPages(eq(it)) } doReturn sitesAndPages.getValue(it)
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -39,7 +39,7 @@ import java.util.UUID
 import kotlin.random.Random
 
 @RunWith(MockitoJUnitRunner::class)
-class LocalDraftUploadStarterTest {
+class UploadStarterTest {
     @get:Rule val rule = InstantTaskExecutorRule()
 
     private val sites = listOf(SiteModel(), SiteModel())
@@ -84,7 +84,7 @@ class LocalDraftUploadStarterTest {
         // ON_RESUME -> app is in the foreground
         val lifecycle = LifecycleRegistry(mock()).apply { handleLifecycleEvent(Event.ON_RESUME) }
 
-        val starter = createLocalDraftUploadStarter(connectionStatus, uploadServiceFacade)
+        val starter = createUploadStarter(connectionStatus, uploadServiceFacade)
         starter.activateAutoUploading(createMockedProcessLifecycleOwner(lifecycle))
 
         // we need to reset the uploadServiceFacade mock as when the app moves to ON_RESUME state (comes to foreground)
@@ -113,7 +113,7 @@ class LocalDraftUploadStarterTest {
         // ON_CREATE -> app is in the background
         val lifecycle = LifecycleRegistry(mock()).apply { handleLifecycleEvent(Event.ON_CREATE) }
 
-        val starter = createLocalDraftUploadStarter(connectionStatus, uploadServiceFacade)
+        val starter = createUploadStarter(connectionStatus, uploadServiceFacade)
         starter.activateAutoUploading(createMockedProcessLifecycleOwner(lifecycle))
 
         // When
@@ -137,7 +137,7 @@ class LocalDraftUploadStarterTest {
 
         val lifecycle = LifecycleRegistry(mock()).apply { handleLifecycleEvent(Event.ON_CREATE) }
 
-        val starter = createLocalDraftUploadStarter(connectionStatus, uploadServiceFacade)
+        val starter = createUploadStarter(connectionStatus, uploadServiceFacade)
         starter.activateAutoUploading(createMockedProcessLifecycleOwner(lifecycle))
 
         // When
@@ -161,7 +161,7 @@ class LocalDraftUploadStarterTest {
         val connectionStatus = createConnectionStatusLiveData(null)
         val uploadServiceFacade = createMockedUploadServiceFacade()
 
-        val starter = createLocalDraftUploadStarter(connectionStatus, uploadServiceFacade)
+        val starter = createUploadStarter(connectionStatus, uploadServiceFacade)
 
         // When
         starter.queueUploadFromSite(site)
@@ -191,7 +191,7 @@ class LocalDraftUploadStarterTest {
             }
         }
 
-        val starter = createLocalDraftUploadStarter(connectionStatus, uploadServiceFacade, postUtilsWrapper)
+        val starter = createUploadStarter(connectionStatus, uploadServiceFacade, postUtilsWrapper)
 
         // When
         starter.queueUploadFromSite(site)
@@ -237,7 +237,7 @@ class LocalDraftUploadStarterTest {
             }
         }
 
-        val starter = createLocalDraftUploadStarter(connectionStatus, uploadServiceFacade)
+        val starter = createUploadStarter(connectionStatus, uploadServiceFacade)
 
         // When
         starter.queueUploadFromSite(site)
@@ -267,7 +267,7 @@ class LocalDraftUploadStarterTest {
 
         // This UploadStore.getNumberOfPostUploadErrorsOrCancellations mocked method will always return that
         // any post was cancelled 1000 times. The auto upload should not be started.
-        val starter = createLocalDraftUploadStarter(connectionStatus, uploadServiceFacade,
+        val starter = createUploadStarter(connectionStatus, uploadServiceFacade,
                 uploadStore = createMockedUploadStore(1000))
 
         // When
@@ -285,12 +285,12 @@ class LocalDraftUploadStarterTest {
     }
 
     @UseExperimental(ExperimentalCoroutinesApi::class)
-    private fun createLocalDraftUploadStarter(
+    private fun createUploadStarter(
         connectionStatus: LiveData<ConnectionStatus>,
         uploadServiceFacade: UploadServiceFacade,
         postUtilsWrapper: PostUtilsWrapper = createMockedPostUtilsWrapper(),
         uploadStore: UploadStore = createMockedUploadStore(0)
-    ) = LocalDraftUploadStarter(
+    ) = UploadStarter(
             context = mock(),
             postStore = postStore,
             pageStore = pageStore,

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -28,7 +28,7 @@ import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded
 import org.wordpress.android.test
-import org.wordpress.android.ui.uploads.LocalDraftUploadStarter
+import org.wordpress.android.ui.uploads.UploadStarter
 import org.wordpress.android.ui.uploads.PostEvents
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState
@@ -50,7 +50,7 @@ class PagesViewModelTest {
     @Mock lateinit var dispatcher: Dispatcher
     @Mock lateinit var actionPerformer: ActionPerformer
     @Mock lateinit var networkUtils: NetworkUtilsWrapper
-    @Mock lateinit var localDraftUploadStarter: LocalDraftUploadStarter
+    @Mock lateinit var uploadStarter: UploadStarter
     private lateinit var viewModel: PagesViewModel
     private lateinit var listStates: MutableList<PageListState>
     private lateinit var pages: MutableList<List<PageModel>>
@@ -64,7 +64,7 @@ class PagesViewModelTest {
                 dispatcher = dispatcher,
                 actionPerfomer = actionPerformer,
                 networkUtils = networkUtils,
-                localDraftUploadStarter = localDraftUploadStarter,
+                uploadStarter = uploadStarter,
                 uiDispatcher = Dispatchers.Unconfined,
                 defaultDispatcher = Dispatchers.Unconfined,
                 eventBusWrapper = mock()
@@ -164,8 +164,8 @@ class PagesViewModelTest {
         viewModel.start(site)
 
         // Assert
-        verify(localDraftUploadStarter, times(1)).queueUploadFromSite(eq(site))
-        verifyNoMoreInteractions(localDraftUploadStarter)
+        verify(uploadStarter, times(1)).queueUploadFromSite(eq(site))
+        verifyNoMoreInteractions(uploadStarter)
     }
 
     @Test
@@ -179,8 +179,8 @@ class PagesViewModelTest {
 
         // Assert
         // We get 2 calls because the `viewModel.start()` also requests an upload
-        verify(localDraftUploadStarter, times(2)).queueUploadFromSite(eq(site))
-        verifyNoMoreInteractions(localDraftUploadStarter)
+        verify(uploadStarter, times(2)).queueUploadFromSite(eq(site))
+        verifyNoMoreInteractions(uploadStarter)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
@@ -20,11 +20,11 @@ import org.wordpress.android.fluxc.store.ListStore
 import org.wordpress.android.ui.posts.PostListType
 import org.wordpress.android.ui.posts.PostListType.DRAFTS
 import org.wordpress.android.ui.posts.PostListType.SEARCH
-import org.wordpress.android.ui.uploads.LocalDraftUploadStarter
+import org.wordpress.android.ui.uploads.UploadStarter
 
 class PostListViewModelTest : BaseUnitTest() {
     @Mock private lateinit var site: SiteModel
-    @Mock private lateinit var localDraftUploadStarter: LocalDraftUploadStarter
+    @Mock private lateinit var uploadStarter: UploadStarter
 
     private lateinit var viewModel: PostListViewModel
 
@@ -69,7 +69,7 @@ class PostListViewModelTest : BaseUnitTest() {
                 accountStore = mock(),
                 listItemUiStateHelper = mock(),
                 networkUtilsWrapper = mock(),
-                localDraftUploadStarter = localDraftUploadStarter,
+                uploadStarter = uploadStarter,
                 connectionStatus = mock(),
                 uiDispatcher = TEST_DISPATCHER,
                 bgDispatcher = TEST_DISPATCHER
@@ -84,7 +84,7 @@ class PostListViewModelTest : BaseUnitTest() {
         viewModel.swipeToRefresh()
 
         // Then
-        verify(localDraftUploadStarter, times(1)).queueUploadFromSite(eq(site))
+        verify(uploadStarter, times(1)).queueUploadFromSite(eq(site))
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -105,5 +105,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '2c38f70f8a45ec12f12ebac1de1c646ea9e49b7f'
+    fluxCVersion = '60d040f9746c6a853d1b37f7ee54621832b63531'
 }


### PR DESCRIPTION
Closes #10174. 

- [x] ⚠️ This requires https://github.com/wordpress-mobile/WordPress-Android/pull/10172 to be reviewed and merged first. 
- [ ] ⚠️ The companion FluxC PR, https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1303, should also be reviewed first. 

## Summary

When the `LocalDraftUploadStarter` was created in https://github.com/wordpress-mobile/WordPress-Android/pull/9774, it was only uploading local draft posts, and later on, pages. The reasons for this were:

- I wanted to test out the implementation first and see how it works.
- I wasn't sure whether we should support this for other statuses. There were still some discussions going on. 

Today, it looks like we can now safely do this. This change makes it so that all **local drafts** and all posts and pages that are **locally changed** will be automatically uploaded. Based on some testing, this is what iOS does today. 

## Testing

1. Go offline.
2. Create or edit posts and pages to end up with different statuses:
    - Local draft
    - Existing draft with changes
    - Existing uploaded post/page with changes
3. Go online.

Confirm that all are automatically uploaded. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.

## Other Tasks

- [ ] If https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1303 is approved and merged, the `fluxCVersion` should be updated to the `develop` version.