### PR TITLE
Issue/only show dotblog domain suggestion for blogger plan sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -54,7 +54,7 @@ class DomainRegistrationActivity : AppCompatActivity() {
                 var fragment = supportFragmentManager.findFragmentByTag(DomainSuggestionsFragment.TAG)
                 if (fragment == null) {
                     fragment = DomainSuggestionsFragment.newInstance()
-                    showFragment(fragment, DomainSuggestionsFragment.TAG, slideIn = false)
+                    showFragment(fragment, DomainSuggestionsFragment.TAG, slideIn = false, isRootFragment = true)
                 }
             }
         })
@@ -89,7 +89,12 @@ class DomainRegistrationActivity : AppCompatActivity() {
         })
     }
 
-    private fun showFragment(fragment: Fragment, tag: String, slideIn: Boolean = true) {
+    private fun showFragment(
+        fragment: Fragment,
+        tag: String,
+        slideIn: Boolean = true,
+        isRootFragment: Boolean = false
+    ) {
         val transaction = supportFragmentManager.beginTransaction()
 
         if (slideIn) {
@@ -98,10 +103,12 @@ class DomainRegistrationActivity : AppCompatActivity() {
                     R.anim.activity_slide_in_from_left, R.anim.activity_slide_out_to_right
             )
         }
+        
+        if (!isRootFragment) {
+            transaction.addToBackStack(null)
+        }
 
-        transaction.addToBackStack(null)
-                .replace(R.id.fragment_container, fragment, tag)
-                .commit()
+        transaction.replace(R.id.fragment_container, fragment, tag).commit()
     }
 
     private fun shouldShowCongratsScreen(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -103,7 +103,6 @@ class DomainRegistrationActivity : AppCompatActivity() {
                     R.anim.activity_slide_in_from_left, R.anim.activity_slide_out_to_right
             )
         }
-        
         if (!isRootFragment) {
             transaction.addToBackStack(null)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansConstants.java
@@ -11,6 +11,9 @@ public class PlansConstants {
     public static final long PREMIUM_PLAN_ID = 1003L;
     public static final long BUSINESS_PLAN_ID = 1008L;
 
+    public static final long BLOGGER_PLAN_ONE_YEAR_ID = 1010L;
+    public static final long BLOGGER_PLAN_TWO_YEARS_ID = 1030L;
+
     public static final long JETPACK_FREE_PLAN_ID = 2002L;
     public static final long JETPACK_PREMIUM_PLAN_ID = 2000L;
     public static final long JETPACK_BUSINESS_PLAN_ID = 2001L;

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -100,6 +100,11 @@ public class SiteUtils {
         return site.getPlanId() == PlansConstants.FREE_PLAN_ID;
     }
 
+    public static boolean onBloggerPlan(@NonNull SiteModel site) {
+        return site.getPlanId() == PlansConstants.BLOGGER_PLAN_ONE_YEAR_ID
+               || site.getPlanId() == PlansConstants.BLOGGER_PLAN_TWO_YEARS_ID;
+    }
+
     public static boolean hasCustomDomain(@NonNull SiteModel site) {
         return !site.getUrl().contains(".wordpress.com");
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModel.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
 import org.wordpress.android.models.networkresource.ListState
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.helpers.Debouncer
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -97,8 +98,12 @@ class DomainSuggestionsViewModel @Inject constructor(
     private fun fetchSuggestions() {
         suggestions = ListState.Loading(suggestions)
 
-        val suggestDomainsPayload =
-                SuggestDomainsPayload(searchQuery, false, false, true, SUGGESTIONS_REQUEST_COUNT, false)
+        val suggestDomainsPayload = if (SiteUtils.onBloggerPlan(site)) {
+            SuggestDomainsPayload(searchQuery, SUGGESTIONS_REQUEST_COUNT, listOf("blog"))
+        } else {
+            SuggestDomainsPayload(searchQuery, false, false, true, SUGGESTIONS_REQUEST_COUNT, false)
+        }
+
         dispatcher.dispatch(SiteActionBuilder.newSuggestDomainsAction(suggestDomainsPayload))
 
         // Reset the selected suggestion, if list is updated

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModel.kt
@@ -99,7 +99,7 @@ class DomainSuggestionsViewModel @Inject constructor(
         suggestions = ListState.Loading(suggestions)
 
         val suggestDomainsPayload = if (SiteUtils.onBloggerPlan(site)) {
-            SuggestDomainsPayload(searchQuery, SUGGESTIONS_REQUEST_COUNT, listOf("blog"))
+            SuggestDomainsPayload(searchQuery, SUGGESTIONS_REQUEST_COUNT, "blog")
         } else {
             SuggestDomainsPayload(searchQuery, false, false, true, SUGGESTIONS_REQUEST_COUNT, false)
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModel.kt
@@ -66,6 +66,7 @@ class DomainSuggestionsViewModel @Inject constructor(
     companion object {
         private const val SEARCH_QUERY_DELAY_MS = 250L
         private const val SUGGESTIONS_REQUEST_COUNT = 20
+        private const val BLOG_DOMAIN_TLDS = "blog"
     }
 
     // Bind Dispatcher to Lifecycle
@@ -99,7 +100,7 @@ class DomainSuggestionsViewModel @Inject constructor(
         suggestions = ListState.Loading(suggestions)
 
         val suggestDomainsPayload = if (SiteUtils.onBloggerPlan(site)) {
-            SuggestDomainsPayload(searchQuery, SUGGESTIONS_REQUEST_COUNT, "blog")
+            SuggestDomainsPayload(searchQuery, SUGGESTIONS_REQUEST_COUNT, BLOG_DOMAIN_TLDS)
         } else {
             SuggestDomainsPayload(searchQuery, false, false, true, SUGGESTIONS_REQUEST_COUNT, false)
         }

--- a/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
@@ -4,6 +4,8 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.plans.PlansConstants.BLOGGER_PLAN_ONE_YEAR_ID
+import org.wordpress.android.ui.plans.PlansConstants.BLOGGER_PLAN_TWO_YEARS_ID
 import org.wordpress.android.ui.plans.PlansConstants.FREE_PLAN_ID
 import org.wordpress.android.ui.plans.PlansConstants.PREMIUM_PLAN_ID
 
@@ -17,6 +19,20 @@ class SiteUtilsTest {
 
         site.planId = PREMIUM_PLAN_ID
         assertFalse(SiteUtils.onFreePlan(site))
+    }
+
+    @Test
+    fun `onBloggerPlan returns true when site is on blogger plan`() {
+        val site = SiteModel()
+        site.planId = BLOGGER_PLAN_ONE_YEAR_ID
+
+        assertTrue(SiteUtils.onBloggerPlan(site))
+
+        site.planId = BLOGGER_PLAN_TWO_YEARS_ID
+        assertTrue(SiteUtils.onBloggerPlan(site))
+
+        site.planId = FREE_PLAN_ID
+        assertFalse(SiteUtils.onBloggerPlan(site))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
@@ -1,13 +1,23 @@
 package org.wordpress.android.viewmodel.domains
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentCaptor
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.SiteAction
+import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
+import org.wordpress.android.ui.plans.PlansConstants
 import org.wordpress.android.util.helpers.Debouncer
 
 class DomainSuggestionsViewModelTest : BaseUnitTest() {
@@ -21,11 +31,16 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     fun setUp() {
         site = SiteModel().also { it.name = "Test Site" }
         viewModel = DomainSuggestionsViewModel(dispatcher, debouncer)
-        viewModel.start(site)
+
+        whenever(debouncer.debounce(any(), any(), any(), any())).thenAnswer { invocation ->
+            val delayedRunnable = invocation.arguments[1] as Runnable
+            delayedRunnable.run()
+        }
     }
 
     @Test
     fun `intro is visible at start`() {
+        viewModel.start(site)
         assertNotNull(viewModel.isIntroVisible.value)
         viewModel.isIntroVisible.value?.let { isIntroVisible ->
             assert(isIntroVisible)
@@ -34,6 +49,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `intro is hidden when search query is not empty`() {
+        viewModel.start(site)
         viewModel.updateSearchQuery("Hello World")
 
         assertNotNull(viewModel.isIntroVisible.value)
@@ -44,6 +60,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `intro is visible when search query is empty`() {
+        viewModel.start(site)
         viewModel.updateSearchQuery("Hello World")
         viewModel.updateSearchQuery("")
 
@@ -51,5 +68,53 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
         viewModel.isIntroVisible.value?.let { isIntroVisible ->
             assert(isIntroVisible)
         }
+    }
+
+    @Test
+    fun `site on blogger plan is requesting only dot blog domain suggestions`() {
+        site.planId = PlansConstants.BLOGGER_PLAN_ONE_YEAR_ID
+        viewModel.start(site)
+        viewModel.updateSearchQuery("test")
+
+        val captor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher, times(2)).dispatch(captor.capture())
+
+        val lastAction = captor.value
+
+        assertThat(lastAction.type).isEqualTo(SiteAction.SUGGEST_DOMAINS)
+        assertThat(lastAction.payload).isNotNull
+        assertThat(lastAction.payload).isInstanceOf(SuggestDomainsPayload::class.java)
+
+        val payload = lastAction.payload as SuggestDomainsPayload
+        assertThat(payload.tlds).isNotNull
+        assertThat(payload.tlds!!.size).isEqualTo(1)
+        assertThat(payload.tlds!![0]).isEqualTo("blog")
+        assertThat(payload.onlyWordpressCom).isNull()
+        assertThat(payload.includeWordpressCom).isNull()
+        assertThat(payload.includeDotBlogSubdomain).isNull()
+        assertThat(payload.includeVendorDot).isFalse()
+    }
+
+    @Test
+    fun `site on non blogger plan is requesting all possible domain suggestions`() {
+        site.planId = PlansConstants.PREMIUM_PLAN_ID
+        viewModel.start(site)
+        viewModel.updateSearchQuery("test")
+
+        val captor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher, times(2)).dispatch(captor.capture())
+
+        val lastAction = captor.value
+
+        assertThat(lastAction.type).isEqualTo(SiteAction.SUGGEST_DOMAINS)
+        assertThat(lastAction.payload).isNotNull
+        assertThat(lastAction.payload).isInstanceOf(SuggestDomainsPayload::class.java)
+
+        val payload = lastAction.payload as SuggestDomainsPayload
+        assertThat(payload.onlyWordpressCom).isFalse()
+        assertThat(payload.includeWordpressCom).isFalse()
+        assertThat(payload.includeDotBlogSubdomain).isTrue()
+        assertThat(payload.includeVendorDot).isFalse()
+        assertThat(payload.tlds).isNull()
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
@@ -86,9 +86,8 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
         assertThat(lastAction.payload).isInstanceOf(SuggestDomainsPayload::class.java)
 
         val payload = lastAction.payload as SuggestDomainsPayload
-        assertThat(payload.tlds).isNotNull
-        assertThat(payload.tlds!!.size).isEqualTo(1)
-        assertThat(payload.tlds!![0]).isEqualTo("blog")
+        assertThat(payload.tlds).isNotNull()
+        assertThat(payload.tlds).isEqualTo("blog")
         assertThat(payload.onlyWordpressCom).isNull()
         assertThat(payload.includeWordpressCom).isNull()
         assertThat(payload.includeDotBlogSubdomain).isNull()
@@ -107,7 +106,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
         val lastAction = captor.value
 
         assertThat(lastAction.type).isEqualTo(SiteAction.SUGGEST_DOMAINS)
-        assertThat(lastAction.payload).isNotNull
+        assertThat(lastAction.payload).isNotNull()
         assertThat(lastAction.payload).isInstanceOf(SuggestDomainsPayload::class.java)
 
         val payload = lastAction.payload as SuggestDomainsPayload

--- a/build.gradle
+++ b/build.gradle
@@ -105,5 +105,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '175489109026f10c36bb614c0e7407fb2c9ab6c0'
+    fluxCVersion = 'a34f6bd836a7ce77acd13ecaf2b078af710ccc87'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -105,5 +105,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'a94ec77a561a54f80ef135c5e52280877583bace'
+    fluxCVersion = '662a962acbb466a2c0b040b30633d4fd3fe10dd5'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -105,5 +105,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '662a962acbb466a2c0b040b30633d4fd3fe10dd5'
+    fluxCVersion = '175489109026f10c36bb614c0e7407fb2c9ab6c0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -105,5 +105,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '2c38f70f8a45ec12f12ebac1de1c646ea9e49b7f'
+    fluxCVersion = 'a94ec77a561a54f80ef135c5e52280877583bace'
 }


### PR DESCRIPTION
Should be merged after[ Flux-C counterpart](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1304) is merged and commit hash is updated.

This PR limits domain suggestions for customers on blogger plans to .blog TLDs.

[iOS issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/12063)

To test:
- Install Wasabi build.
- Select a site on 1 or 2 years Blogger plans with unredeemed domain credit.
- From the MySite fragment tap on domain registration CTA and navigate to domain suggestion screen.
- Confirm that only .blog domain names are suggested.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
