### PR TITLE
Updated post search prompt

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2575,7 +2575,7 @@
     <string name="post_list_drafts">Drafts</string>
     <string name="post_list_scheduled">Scheduled</string>
     <string name="post_list_trashed">Trashed</string>
-    <string name="post_list_search_prompt">Search posts</string>
+    <string name="post_list_search_prompt">Search published posts</string>
     <string name="post_list_search_nothing_found">No posts matching your search</string>
 
 


### PR DESCRIPTION
Fixes #10164

This PR just updates a single string resource.

To test:
- Open post search and make sure the empty view says "Search published posts"

[![Image from Gyazo](https://i.gyazo.com/fc5106cf9a8613aef0e3f62d683a9d6c.png)](https://gyazo.com/fc5106cf9a8613aef0e3f62d683a9d6c)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
