### PR TITLE
Issue/10087 domain suggestions on clear

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -57,6 +57,7 @@ class SiteCreationDomainsViewModel @Inject constructor(
         get() = bgDispatcher + job
     private var isStarted = false
     private var segmentId by Delegates.notNull<Long>()
+    private var siteTitle: String? = null
 
     private val _uiState: MutableLiveData<DomainsUiState> = MutableLiveData()
     val uiState: LiveData<DomainsUiState> = _uiState
@@ -92,6 +93,7 @@ class SiteCreationDomainsViewModel @Inject constructor(
             return
         }
         this.segmentId = segmentId
+        this.siteTitle = siteTitle
         isStarted = true
         tracker.trackDomainsAccessed()
         // isNullOrBlank not smart-casting for some reason..
@@ -119,7 +121,12 @@ class SiteCreationDomainsViewModel @Inject constructor(
     }
 
     fun updateQuery(query: String) {
-        updateQueryInternal(UserQuery(query))
+        val siteTitle: String? = this.siteTitle
+        if (query.isBlank() && !siteTitle.isNullOrBlank()) {
+            updateQueryInternal(TitleQuery(siteTitle))
+        } else {
+            updateQueryInternal(UserQuery(query))
+        }
     }
 
     private fun updateQueryInternal(query: DomainSuggestionsQuery?) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -202,7 +202,7 @@ class SiteCreationDomainsViewModelTest {
     fun verifyClearQueryWithNonEmptyTitleUiStateAfterResponseWithMultipleResults() = testWithSuccessResponse {
         viewModel.start(MULTI_RESULT_DOMAIN_FETCH_QUERY.first, SEGMENT_ID)
         viewModel.updateQuery(MULTI_RESULT_DOMAIN_FETCH_QUERY.first)
-        viewModel.updateQuery("");
+        viewModel.updateQuery("")
         val captor = ArgumentCaptor.forClass(DomainsUiState::class.java)
         verify(uiStateObserver, times(6)).onChanged(captor.capture())
         verifyVisibleItemsContentUiState(captor.lastValue, false, 20)
@@ -216,7 +216,7 @@ class SiteCreationDomainsViewModelTest {
     fun verifyClearQueryWithEmptyTitleInitialState() = testWithSuccessResponse {
         viewModel.start(null, SEGMENT_ID)
         viewModel.updateQuery(MULTI_RESULT_DOMAIN_FETCH_QUERY.first)
-        viewModel.updateQuery("");
+        viewModel.updateQuery("")
         val captor = ArgumentCaptor.forClass(DomainsUiState::class.java)
         verify(uiStateObserver, times(4)).onChanged(captor.capture())
         verifyInitialContentUiState(captor.lastValue)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.sitecreation.domains
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.firstValue
+import com.nhaarman.mockitokotlin2.lastValue
 import com.nhaarman.mockitokotlin2.secondValue
 import com.nhaarman.mockitokotlin2.thirdValue
 import com.nhaarman.mockitokotlin2.times
@@ -191,6 +192,34 @@ class SiteCreationDomainsViewModelTest {
                 captor.thirdValue.contentState.items[0],
                 instanceOf(DomainsFetchSuggestionsErrorUiState::class.java)
         )
+    }
+
+    /**
+     * Verifies the UI state after the user enters an empty query (presses clear button) with a non-empty site title
+     * which results in multiple domain suggestions.
+     */
+    @Test
+    fun verifyClearQueryWithNonEmptyTitleUiStateAfterResponseWithMultipleResults() = testWithSuccessResponse {
+        viewModel.start(MULTI_RESULT_DOMAIN_FETCH_QUERY.first, SEGMENT_ID)
+        viewModel.updateQuery(MULTI_RESULT_DOMAIN_FETCH_QUERY.first)
+        viewModel.updateQuery("");
+        val captor = ArgumentCaptor.forClass(DomainsUiState::class.java)
+        verify(uiStateObserver, times(6)).onChanged(captor.capture())
+        verifyVisibleItemsContentUiState(captor.lastValue, false, 20)
+    }
+
+    /**
+     * Verifies the UI state after the user enters an empty query (presses clear button) with an empty site title
+     * which results in initial UI state
+     */
+    @Test
+    fun verifyClearQueryWithEmptyTitleInitialState() = testWithSuccessResponse {
+        viewModel.start(null, SEGMENT_ID)
+        viewModel.updateQuery(MULTI_RESULT_DOMAIN_FETCH_QUERY.first)
+        viewModel.updateQuery("");
+        val captor = ArgumentCaptor.forClass(DomainsUiState::class.java)
+        verify(uiStateObserver, times(4)).onChanged(captor.capture())
+        verifyInitialContentUiState(captor.lastValue)
     }
 
     /**


### PR DESCRIPTION
Fixes #10087

This PR adds default suggestions to the site creation domain search after clear. I also included two new tests that test clear behavior when a title is or is not set. 

Before Fix:
![issue-10087-before-fix](https://user-images.githubusercontent.com/1103838/60867619-2a8ada80-a1e0-11e9-8f36-460eb3c73069.gif)


To test:

1. My Site
2. Switch Site
3. Click on plus sign icon in the top right corner
4. Select "Create WordPress.com site"
5. Choose a site type
6. Skip
7. Enter site title
8. Click on Next
9. Notice the list of default suggestions is shown
10. Type a query and clear it
11. Notice the list of default suggestions is not shown

After Fix:
![wordpress-10087-fixed](https://user-images.githubusercontent.com/1103838/60867644-38d8f680-a1e0-11e9-9bfc-f73f210d0db8.gif)



Update release notes:
- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
