### PR TITLE
Fix #10021: auto upload local drafts with the Draft status only

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,9 @@
 12.8
 -----
 
+12.7.1
+------
+* Fix issue where local draft with "Publish" status got automatically published
 
 12.7
 -----
@@ -12,12 +15,10 @@
 * Fixed issue where text appeared behind list of themes on the theme screen
 * Domain Registration functionality for Business plan customers on a site without a custom domain during plugin installation
 
-* Fix issue where post with "Publish" status got automatically published
 12.6
 -----
 * Add Insights management introductory card
 * Local draft pages will be automatically uploaded to the server as soon as an internet connection is available.
-
 * Block Editor: A new block is available: video block.
 * Block Editor: Added UI to display a warning when a block has invalid content.
 * Block Editor: Fixed issue with link settings where “Open in New Tab” was always OFF on open.

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 * Fixed issue where text appeared behind list of themes on the theme screen
 * Domain Registration functionality for Business plan customers on a site without a custom domain during plugin installation
 
+* Fix issue where post with "Publish" status got automatically published
 12.6
 -----
 * Add Insights management introductory card

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -137,7 +137,7 @@ open class LocalDraftUploadStarter @Inject constructor(
         postsAndPages
                 .filterNot { uploadServiceFacade.isPostUploadingOrQueued(it) }
                 .filter { postUtilsWrapper.isPublishable(it) }
-                .filter { PostStatus.DRAFT.toString() == it.status || PostStatus.PENDING.toString() == it.status }
+                .filter { PostStatus.DRAFT.toString() == it.status }
                 .forEach { localDraft ->
                     uploadServiceFacade.uploadPost(
                             context = context,

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarter.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.SiteStore
@@ -136,6 +137,7 @@ open class LocalDraftUploadStarter @Inject constructor(
         postsAndPages
                 .filterNot { uploadServiceFacade.isPostUploadingOrQueued(it) }
                 .filter { postUtilsWrapper.isPublishable(it) }
+                .filter { PostStatus.DRAFT.toString() == it.status || PostStatus.PENDING.toString() == it.status }
                 .forEach { localDraft ->
                     uploadServiceFacade.uploadPost(
                             context = context,

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterConcurrentTest.kt
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.ui.posts.PostUtilsWrapper
@@ -31,16 +32,16 @@ class LocalDraftUploadStarterConcurrentTest {
     @get:Rule val rule = InstantTaskExecutorRule()
 
     private val site = SiteModel()
-    private val posts = listOf(
-            PostModel(),
-            PostModel(),
-            PostModel(),
-            PostModel(),
-            PostModel()
+    private val draftPosts = listOf(
+            createDraftPostModel(),
+            createDraftPostModel(),
+            createDraftPostModel(),
+            createDraftPostModel(),
+            createDraftPostModel()
     )
 
     private val postStore = mock<PostStore> {
-        on { getLocalDraftPosts(eq(site)) } doReturn posts
+        on { getLocalDraftPosts(eq(site)) } doReturn draftPosts
     }
     private val pageStore = mock<PageStore> {
         onBlocking { getLocalDraftPages(any()) } doReturn emptyList()
@@ -59,7 +60,7 @@ class LocalDraftUploadStarterConcurrentTest {
         }
 
         // Then
-        verify(uploadServiceFacade, times(posts.size)).uploadPost(
+        verify(uploadServiceFacade, times(draftPosts.size)).uploadPost(
                 context = any(),
                 post = any(),
                 trackAnalytics = any(),
@@ -92,6 +93,10 @@ class LocalDraftUploadStarterConcurrentTest {
 
         fun createMockedPostUtilsWrapper() = mock<PostUtilsWrapper> {
             on { isPublishable(any()) } doReturn true
+        }
+
+        fun createDraftPostModel() = PostModel().apply {
+            status = PostStatus.DRAFT.toString()
         }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
@@ -25,6 +25,7 @@ import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.SiteStore
@@ -41,35 +42,35 @@ class LocalDraftUploadStarterTest {
     @get:Rule val rule = InstantTaskExecutorRule()
 
     private val sites = listOf(SiteModel(), SiteModel())
-    private val sitesAndPosts: Map<SiteModel, List<PostModel>> = mapOf(
-            sites[0] to listOf(createPostModel(), createPostModel()),
+    private val sitesAndDraftPosts: Map<SiteModel, List<PostModel>> = mapOf(
+            sites[0] to listOf(createDraftPostModel(), createDraftPostModel()),
             sites[1] to listOf(
-                    createPostModel(),
-                    createPostModel(),
-                    createPostModel(),
-                    createPostModel(),
-                    createPostModel()
+                    createDraftPostModel(),
+                    createDraftPostModel(),
+                    createDraftPostModel(),
+                    createDraftPostModel(),
+                    createDraftPostModel()
             )
     )
-    private val posts = sitesAndPosts.values.flatten()
+    private val draftPosts = sitesAndDraftPosts.values.flatten()
 
-    private val sitesAndPages: Map<SiteModel, List<PostModel>> = mapOf(
-            sites[0] to listOf(createPostModel(), createPostModel()),
-            sites[1] to listOf(createPostModel(), createPostModel(), createPostModel(), createPostModel())
+    private val sitesAndDraftPages: Map<SiteModel, List<PostModel>> = mapOf(
+            sites[0] to listOf(createDraftPostModel(), createDraftPostModel()),
+            sites[1] to listOf(createDraftPostModel(), createDraftPostModel(), createDraftPostModel(), createDraftPostModel())
     )
-    private val pages = sitesAndPages.values.flatten()
+    private val draftPages = sitesAndDraftPages.values.flatten()
 
     private val siteStore = mock<SiteStore> {
         on { sites } doReturn sites
     }
     private val postStore = mock<PostStore> {
         sites.forEach {
-            on { getLocalDraftPosts(eq(it)) } doReturn sitesAndPosts.getValue(it)
+            on { getLocalDraftPosts(eq(it)) } doReturn sitesAndDraftPosts.getValue(it)
         }
     }
     private val pageStore = mock<PageStore> {
         sites.forEach {
-            onBlocking { getLocalDraftPages(eq(it)) } doReturn sitesAndPages.getValue(it)
+            onBlocking { getLocalDraftPages(eq(it)) } doReturn sitesAndDraftPages.getValue(it)
         }
     }
 
@@ -93,7 +94,7 @@ class LocalDraftUploadStarterTest {
         connectionStatus.postValue(AVAILABLE)
 
         // Then
-        verify(uploadServiceFacade, times(posts.size + pages.size)).uploadPost(
+        verify(uploadServiceFacade, times(draftPosts.size + draftPages.size)).uploadPost(
                 context = any(),
                 post = any(),
                 trackAnalytics = any(),
@@ -142,7 +143,7 @@ class LocalDraftUploadStarterTest {
         lifecycle.handleLifecycleEvent(Event.ON_START)
 
         // Then
-        verify(uploadServiceFacade, times(posts.size + pages.size)).uploadPost(
+        verify(uploadServiceFacade, times(draftPosts.size + draftPages.size)).uploadPost(
                 context = any(),
                 post = any(),
                 trackAnalytics = any(),
@@ -165,7 +166,7 @@ class LocalDraftUploadStarterTest {
         starter.queueUploadFromSite(site)
 
         // Then
-        val expectedUploadPostExecutions = sitesAndPosts.getValue(site).size + sitesAndPages.getValue(site).size
+        val expectedUploadPostExecutions = sitesAndDraftPosts.getValue(site).size + sitesAndDraftPages.getValue(site).size
         verify(uploadServiceFacade, times(expectedUploadPostExecutions)).uploadPost(
                 context = any(),
                 post = any(),
@@ -185,7 +186,7 @@ class LocalDraftUploadStarterTest {
         val postUtilsWrapper = mock<PostUtilsWrapper> {
             on { isPublishable(any()) } doAnswer {
                 // return isPublishable = false on the first post of the site
-                it.getArgument<PostModel>(0) != sitesAndPosts[site]?.get(0)!!
+                it.getArgument<PostModel>(0) != sitesAndDraftPosts[site]?.get(0)!!
             }
         }
 
@@ -196,7 +197,7 @@ class LocalDraftUploadStarterTest {
 
         // Then
         // subtract - 1 as we've returned isPublishable = false for the first post of the site
-        val expectedUploadPostExecutions = sitesAndPosts.getValue(site).size + sitesAndPages.getValue(site).size - 1
+        val expectedUploadPostExecutions = sitesAndDraftPosts.getValue(site).size + sitesAndDraftPages.getValue(site).size - 1
         verify(uploadServiceFacade, times(expectedUploadPostExecutions)).uploadPost(
                 context = any(),
                 post = any(),
@@ -210,14 +211,14 @@ class LocalDraftUploadStarterTest {
     fun `when uploading, it ignores local drafts that are already queued`() {
         // Given
         val site: SiteModel = sites[1]
-        val (expectedQueuedPosts, expectedUploadedPosts) = sitesAndPosts.getValue(site).let { posts ->
+        val (expectedQueuedPosts, expectedUploadedPosts) = sitesAndDraftPosts.getValue(site).let { posts ->
             // Split into halves of already queued and what should be uploaded
             return@let Pair(
                     posts.subList(0, posts.size / 2),
                     posts.subList(posts.size / 2, posts.size)
             )
         }
-        val (expectedQueuedPages, expectedUploadedPages) = sitesAndPages.getValue(site).let { pages ->
+        val (expectedQueuedPages, expectedUploadedPages) = sitesAndDraftPages.getValue(site).let { pages ->
             // Split into halves of already queued and what should be uploaded
             return@let Pair(
                     pages.subList(0, pages.size / 2),
@@ -250,7 +251,7 @@ class LocalDraftUploadStarterTest {
         )
         verify(
                 uploadServiceFacade,
-                times(sitesAndPosts.getValue(site).size + sitesAndPages.getValue(site).size)
+                times(sitesAndDraftPosts.getValue(site).size + sitesAndDraftPages.getValue(site).size)
         ).isPostUploadingOrQueued(any())
         verifyNoMoreInteractions(uploadServiceFacade)
     }
@@ -296,9 +297,10 @@ class LocalDraftUploadStarterTest {
             on { this.lifecycle } doReturn lifecycle
         }
 
-        fun createPostModel() = PostModel().apply {
+        fun createDraftPostModel() = PostModel().apply {
             id = Random.nextInt()
             title = UUID.randomUUID().toString()
+            status = PostStatus.DRAFT.toString()
         }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/LocalDraftUploadStarterTest.kt
@@ -56,7 +56,12 @@ class LocalDraftUploadStarterTest {
 
     private val sitesAndDraftPages: Map<SiteModel, List<PostModel>> = mapOf(
             sites[0] to listOf(createDraftPostModel(), createDraftPostModel()),
-            sites[1] to listOf(createDraftPostModel(), createDraftPostModel(), createDraftPostModel(), createDraftPostModel())
+            sites[1] to listOf(
+                    createDraftPostModel(),
+                    createDraftPostModel(),
+                    createDraftPostModel(),
+                    createDraftPostModel()
+            )
     )
     private val draftPages = sitesAndDraftPages.values.flatten()
 
@@ -166,7 +171,8 @@ class LocalDraftUploadStarterTest {
         starter.queueUploadFromSite(site)
 
         // Then
-        val expectedUploadPostExecutions = sitesAndDraftPosts.getValue(site).size + sitesAndDraftPages.getValue(site).size
+        val expectedUploadPostExecutions = sitesAndDraftPosts.getValue(site).size +
+                sitesAndDraftPages.getValue(site).size
         verify(uploadServiceFacade, times(expectedUploadPostExecutions)).uploadPost(
                 context = any(),
                 post = any(),
@@ -197,7 +203,8 @@ class LocalDraftUploadStarterTest {
 
         // Then
         // subtract - 1 as we've returned isPublishable = false for the first post of the site
-        val expectedUploadPostExecutions = sitesAndDraftPosts.getValue(site).size + sitesAndDraftPages.getValue(site).size - 1
+        val expectedUploadPostExecutions = sitesAndDraftPosts.getValue(site).size +
+                sitesAndDraftPages.getValue(site).size - 1
         verify(uploadServiceFacade, times(expectedUploadPostExecutions)).uploadPost(
                 context = any(),
                 post = any(),


### PR DESCRIPTION
Fix #10021: auto upload local drafts with the Draft status only

ht @malinajirka who did the original fix https://github.com/wordpress-mobile/WordPress-Android/pull/10029

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.


Note: targeted branch is `hotfix/12.7.1` cc @loremattei 