### PR TITLE
Issue/10189 Clears old data from previous visits to wizard steps

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScre
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_INFO
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.VERTICALS
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.CreateSiteState
@@ -131,6 +132,7 @@ class SiteCreationMainVM @Inject constructor(
             }
             DOMAINS -> siteCreationState.domain?.let {
                 siteCreationState = siteCreationState.copy(domain = null) }
+            SITE_PREVIEW -> {} // intentionally left empty
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -55,7 +55,7 @@ class SiteCreationMainVM @Inject constructor(
     val navigationTargetObservable: SingleEventObservable<NavigationTarget> by lazy {
         SingleEventObservable(
                 Transformations.map(wizardManager.navigatorLiveData) {
-                    clearOldState(it)
+                    clearOldSiteCreationState(it)
                     WizardNavigationTarget(it, siteCreationState)
                 }
         )
@@ -119,12 +119,18 @@ class SiteCreationMainVM @Inject constructor(
         }
     }
 
-    private fun clearOldState(wizardStep: SiteCreationStep) {
+    private fun clearOldSiteCreationState(wizardStep: SiteCreationStep) {
         when (wizardStep) {
-            SEGMENTS -> siteCreationState = siteCreationState.copy(segmentId = null)
-            VERTICALS -> siteCreationState = siteCreationState.copy(verticalId = null)
-            SITE_INFO -> siteCreationState = siteCreationState.copy(siteTitle = null, siteTagLine = null)
-            DOMAINS -> siteCreationState = siteCreationState.copy(domain = null)
+            SEGMENTS -> siteCreationState.segmentId?.let {
+                siteCreationState = siteCreationState.copy(segmentId = null) }
+            VERTICALS -> siteCreationState.verticalId?.let {
+                siteCreationState = siteCreationState.copy(verticalId = null) }
+            SITE_INFO -> {
+                siteCreationState.siteTitle?.let { siteCreationState = siteCreationState.copy(siteTitle = null) }
+                siteCreationState.siteTagLine?.let { siteCreationState = siteCreationState.copy(siteTagLine = null) }
+            }
+            DOMAINS -> siteCreationState.domain?.let {
+                siteCreationState = siteCreationState.copy(domain = null) }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -12,6 +12,10 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleEmpty
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_INFO
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.VERTICALS
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.CreateSiteState
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -51,6 +55,7 @@ class SiteCreationMainVM @Inject constructor(
     val navigationTargetObservable: SingleEventObservable<NavigationTarget> by lazy {
         SingleEventObservable(
                 Transformations.map(wizardManager.navigatorLiveData) {
+                    clearOldState(it)
                     WizardNavigationTarget(it, siteCreationState)
                 }
         )
@@ -111,6 +116,15 @@ class SiteCreationMainVM @Inject constructor(
         } else {
             wizardManager.onBackPressed()
             _onBackPressedObservable.call()
+        }
+    }
+
+    private fun clearOldState(wizardStep: SiteCreationStep) {
+        when (wizardStep) {
+            SEGMENTS -> siteCreationState = siteCreationState.copy(segmentId = null)
+            VERTICALS -> siteCreationState = siteCreationState.copy(verticalId = null)
+            SITE_INFO -> siteCreationState = siteCreationState.copy(siteTitle = null, siteTagLine = null)
+            DOMAINS -> siteCreationState = siteCreationState.copy(domain = null)
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -223,7 +223,7 @@ class SiteCreationMainVMTest {
     fun siteCreationStateRestored() {
         /* we need to model a real use case of data only existing for steps the user has visited (Segment only in
         this case). Otherwise, subsequent steps' state will be cleared and make the test fail. (issue #10189)*/
-        val expectedState = SiteCreationState(1L)
+        val expectedState = SiteCreationState(SEGMENT_ID)
         whenever(savedInstanceState.getParcelable<SiteCreationState>(KEY_SITE_CREATION_STATE))
                 .thenReturn(expectedState)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -221,7 +221,9 @@ class SiteCreationMainVMTest {
 
     @Test
     fun siteCreationStateRestored() {
-        val expectedState = SiteCreationState()
+        /* we need to model a real use case of data only existing for steps the user has visited (Segment only in
+        this case). Otherwise, subsequent steps' state will be cleared and make the test fail. (issue #10189)*/
+        val expectedState = SiteCreationState(1L)
         whenever(savedInstanceState.getParcelable<SiteCreationState>(KEY_SITE_CREATION_STATE))
                 .thenReturn(expectedState)
 
@@ -229,9 +231,9 @@ class SiteCreationMainVMTest {
         val newViewModel = SiteCreationMainVM(tracker, wizardManager)
         newViewModel.start(savedInstanceState)
 
-        /* we need simulate navigation to the next step as wizardManager.showNextStep() isn't invoked
-        when the VM is restored from a savedInstanceState. */
-        wizardManagerNavigatorLiveData.value = siteCreationStep
+        /* we need to simulate navigation to the next step (Vertical selection, see comment above) as
+        wizardManager.showNextStep() isn't invoked when the VM is restored from a savedInstanceState. */
+        wizardManagerNavigatorLiveData.value = SiteCreationStep.VERTICALS
 
         newViewModel.navigationTargetObservable.observeForever(navigationTargetObserver)
         assertThat(currentWizardState(newViewModel)).isSameAs(expectedState)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -255,6 +255,19 @@ class SiteCreationMainVMTest {
         verify(wizardManager).setCurrentStepIndex(index)
     }
 
+    @Test
+    fun oldSiteCreationDataClearedWhenReturningToPreviousStep() {
+        // See issue #10189 - unintended data retained if user goes backwards in wizard
+        whenever(wizardManager.showNextStep()).then {
+            wizardManagerNavigatorLiveData.value = SiteCreationStep.SITE_INFO
+            Unit
+        }
+        viewModel.onVerticalsScreenFinished(VERTICAL_ID)
+        assertThat(currentWizardState(viewModel).verticalId).isEqualTo(VERTICAL_ID)
+        wizardManagerNavigatorLiveData.value = SiteCreationStep.VERTICALS
+        assertThat(currentWizardState(viewModel).verticalId).isEqualTo(null)
+    }
+
     private fun currentWizardState(vm: SiteCreationMainVM) =
             vm.navigationTargetObservable.lastEvent!!.wizardState
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -258,10 +258,6 @@ class SiteCreationMainVMTest {
     @Test
     fun oldSiteCreationDataClearedWhenReturningToPreviousStep() {
         // See issue #10189 - unintended data retained if user goes backwards in wizard
-        whenever(wizardManager.showNextStep()).then {
-            wizardManagerNavigatorLiveData.value = SiteCreationStep.SITE_INFO
-            Unit
-        }
         viewModel.onVerticalsScreenFinished(VERTICAL_ID)
         assertThat(currentWizardState(viewModel).verticalId).isEqualTo(VERTICAL_ID)
         wizardManagerNavigatorLiveData.value = SiteCreationStep.VERTICALS

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -107,6 +107,10 @@ class SiteCreationMainVMTest {
 
     @Test
     fun siteCreationStateUpdatedWithSelectedSegment() {
+        whenever(wizardManager.showNextStep()).then {
+            wizardManagerNavigatorLiveData.value = SiteCreationStep.VERTICALS
+            Unit
+        }
         viewModel.onSegmentSelected(SEGMENT_ID)
         assertThat(currentWizardState(viewModel).segmentId).isEqualTo(SEGMENT_ID)
     }


### PR DESCRIPTION
Fixes #10189

### To test:
Steps to reproduce the behavior

1. My Site
2. Switch Site
3. Click on plus sign icon in the top right corner
4. Select "Create WordPress.com site"
5. Choose a site type
6. Enter some custom vertical type, click next
7. Enter site title and tagline, click next
8. On the choose a domain screen, hit the back arrow
9. On the title/tagline screen, hit the back arrow
10. On the vertical screen, hit the back arrow
11. Choose a site type
12. Press skip for site vertical
13. Press skip for title/tagline
14. Search a domain, select, and press create (before you search you can verify you do not see the previously entered title)
15. Verify that the previously entered verticalId, title, and tagline are gone because you skipped on your second pass through the wizard.

*Note if you can not create sites in test build like me, you may need to verify through the debugger (and through the lack of old title searches appearing like they were before the fix)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
