### PR TITLE
Fix issue when media in post were sometimes uploaded with local path

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -402,6 +402,21 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
     }
 
     private boolean isSameMediaFileQueuedForThisPost(MediaModel media1, MediaModel media2) {
+        /*
+            This method used to be called "compareBySiteAndFilePath" and compared just siteId and filePath. It made
+            sense since a media file is tied to a site and can be referenced from multiple posts on that site. This
+            approach tried to prevent wasting users' data.
+
+            The issue was that when a same image was added to content of two posts only a single MediaModel was
+            enqueued. However, MediaModel references only a single post (`localPostId`). When the upload finished
+            only the first post got updated with the url. The second post got uploaded to the server with a path to
+            local image. We decided to check whether the image belongs to the same post so we can be sure the local
+            path gets replaced with the url.
+
+            More info can be found here - https://github.com/wordpress-mobile/WordPress-Android/pull/10204.
+
+            Issue with a proper fix - https://github.com/wordpress-mobile/WordPress-Android/issues/10210
+         */
         return (media1.getLocalSiteId() == media2.getLocalSiteId() && media1.getLocalPostId() == media2.getLocalPostId()
                 && StringUtils.equals(media1.getFilePath(), media2.getFilePath()));
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -384,7 +384,7 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
                               + " and site id " + mediaModel.getLocalSiteId() + ". Comparing with " + queuedMedia
                                       .getFilePath()
                               + ", " + queuedMedia.getLocalSiteId());
-            if (compareBySiteAndFilePath(queuedMedia, mediaModel)) {
+            if (isSameMediaFileQueuedForThisPost(queuedMedia, mediaModel)) {
                 return true;
             }
         }
@@ -394,15 +394,15 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
                               + " and site id " + mediaModel.getLocalSiteId() + ". Comparing with " + queuedMedia
                                       .getFilePath()
                               + ", " + queuedMedia.getLocalSiteId());
-            if (compareBySiteAndFilePath(queuedMedia, mediaModel)) {
+            if (isSameMediaFileQueuedForThisPost(queuedMedia, mediaModel)) {
                 return true;
             }
         }
         return false;
     }
 
-    private boolean compareBySiteAndFilePath(MediaModel media1, MediaModel media2) {
-        return (media1.getLocalSiteId() == media2.getLocalSiteId()
+    private boolean isSameMediaFileQueuedForThisPost(MediaModel media1, MediaModel media2) {
+        return (media1.getLocalSiteId() == media2.getLocalSiteId() && media1.getLocalPostId() == media2.getLocalPostId()
                 && StringUtils.equals(media1.getFilePath(), media2.getFilePath()));
     }
 


### PR DESCRIPTION
Fixes #10203 

Fixes issue where posts were sometimes uploaded with local media.

Clarification why this issue is happening
1. User adds imageA to postA-> UploadService is started -> the iamge is added to the UploadQueue
2. User adds imageA to a postB -> UploadService is started -> the image is **not** added into the queue as it's already there
3. The upload of imageA finishes -> the content of postA gets updated (local path is replaced with url), but the content of postB is never updated as the image wasn't tied to/referencing it. PostB doesn't have any pending MediaUploads so it's pushed to the server.

To test:
1. Turn on airplane mode
2. Create a draft and add an image into the content
3. Click on Back
4. Create another draft and add **the same** image into the content
5. Click on back
6. Turn off the airplane mode
7. Wait until the uploads completes
8. Open the first post
9. Switch to HTML mode
10. Verify the media item cotnains url to the remote file
11. Repeat steps 8-10 for the second post


Update release notes:
- Too minor change - the chance a real user would add a same media to two posts and uploaded them at the same time are quite low

