### PR TITLE
Edit post model provider

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1408,7 +1408,7 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private void saveAsDraft() {
-        mEditPostSettingsFragment.updatePostStatus(PostStatus.DRAFT.toString());
+        mEditPostSettingsFragment.updatePostStatus(PostStatus.DRAFT);
         ToastUtils.showToast(EditPostActivity.this,
                 getString(R.string.editor_post_converted_back_to_draft), Duration.SHORT);
         UploadUtils.showSnackbar(findViewById(R.id.editor_activity), R.string.editor_uploading_post);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2670,9 +2670,9 @@ public class EditPostActivity extends AppCompatActivity implements
 
         boolean titleChanged = mPostProvider.updatePostTitleIfDifferent(title);
         boolean contentChanged = mPostProvider.updatePostContentIfDifferent(content);
-        boolean statusChanged = mPostSnapshotWhenEditorOpened != null && !mPostProvider.getPostModel().getStatus()
-                                                                                       .equals(mPostSnapshotWhenEditorOpened
-                                                                                               .getStatus());
+        String currentStatus = mPostProvider.getPostModel().getStatus();
+        boolean statusChanged = mPostSnapshotWhenEditorOpened != null && !currentStatus
+                .equals(mPostSnapshotWhenEditorOpened.getStatus());
 
         if (!mPostProvider.getPostModel().isLocalDraft() && (titleChanged || contentChanged || statusChanged)) {
             mPostProvider.setIsLocallyChanged(true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostModelProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostModelProvider.kt
@@ -1,0 +1,113 @@
+package org.wordpress.android.ui.posts
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.model.post.PostStatus.UNKNOWN
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class EditPostModelProvider
+@Inject constructor() {
+    var postModel: PostModel? = null
+        private set
+
+    private val _livePostModel = MutableLiveData<PostModel>()
+    val livePostModel: LiveData<PostModel> = _livePostModel
+
+    fun hasPost(): Boolean = postModel != null
+
+    fun set(postModel: PostModel) {
+        this.postModel = postModel
+        _livePostModel.postValue(postModel)
+    }
+
+    fun setStatus(postStatus: PostStatus) {
+        postModel?.let {
+            it.status = postStatus.toString()
+            _livePostModel.postValue(it)
+        }
+    }
+
+    fun getStatus(): PostStatus {
+        return postModel?.let { PostStatus.fromPost(postModel) } ?: UNKNOWN
+    }
+
+    fun setTitle(title: String?) {
+        if (title != null) {
+            postModel?.let {
+                it.title = title
+                _livePostModel.postValue(it)
+            }
+        }
+    }
+
+    fun setContent(content: String?) {
+        if (content != null) {
+            postModel?.let {
+                it.content = content
+                _livePostModel.postValue(it)
+            }
+        }
+    }
+
+    fun setIsLocallyChanged(isLocallyChanged: Boolean) {
+        postModel?.let {
+            it.setIsLocallyChanged(isLocallyChanged)
+            _livePostModel.postValue(it)
+        }
+    }
+
+    fun setDateLocallyChanged(mDateLocallyChanged: String) {
+        postModel?.let {
+            it.dateLocallyChanged = mDateLocallyChanged
+            _livePostModel.postValue(it)
+        }
+    }
+
+    fun setDateCreated(mDateCreated: String) {
+        postModel?.let {
+            it.dateCreated = mDateCreated
+            _livePostModel.postValue(it)
+        }
+    }
+
+    fun setFeaturedImageId(featuredImageId: Long) {
+        postModel?.let {
+            it.featuredImageId = featuredImageId
+            _livePostModel.postValue(it)
+        }
+    }
+
+    fun updatePublishDateIfShouldBePublishedImmediately(): Boolean {
+        postModel?.let {
+            if (PostUtils.updatePublishDateIfShouldBePublishedImmediately(it)) {
+                _livePostModel.postValue(it)
+                return true
+            }
+        }
+        return false
+    }
+
+    fun updatePostTitleIfDifferent(title: String): Boolean {
+        postModel?.let {
+            if (PostUtils.updatePostTitleIfDifferent(it, title)) {
+                _livePostModel.postValue(it)
+                return true
+            }
+        }
+        return false
+    }
+
+    fun updatePostContentIfDifferent(content: String): Boolean {
+        postModel?.let {
+            if (PostUtils.updatePostContentIfDifferent(it, content)) {
+                _livePostModel.postValue(it)
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostModelProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostModelProvider.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.posts
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.post.PostLocation
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.model.post.PostStatus.UNKNOWN
 import javax.inject.Inject
@@ -77,6 +78,62 @@ class EditPostModelProvider
     fun setFeaturedImageId(featuredImageId: Long) {
         postModel?.let {
             it.featuredImageId = featuredImageId
+            _livePostModel.postValue(it)
+        }
+    }
+
+    fun setPostFormat(postFormat: String) {
+        postModel?.let {
+            it.postFormat = postFormat
+            _livePostModel.postValue(it)
+        }
+    }
+
+    fun setExcerpt(excerpt: String) {
+        postModel?.let {
+            it.excerpt = excerpt
+            _livePostModel.postValue(it)
+        }
+    }
+
+    fun setSlug(slug: String) {
+        postModel?.let {
+            it.slug = slug
+            _livePostModel.postValue(it)
+        }
+    }
+
+    fun setPassword(password: String) {
+        postModel?.let {
+            it.password = password
+            _livePostModel.postValue(it)
+        }
+    }
+
+    fun setCategoryIdList(categoryIdList: List<Long>) {
+        postModel?.let {
+            it.categoryIdList = categoryIdList
+            _livePostModel.postValue(it)
+        }
+    }
+
+    fun setTagNameList(tagNameList: List<String>?) {
+        postModel?.let {
+            it.setTagNameList(tagNameList)
+            _livePostModel.postValue(it)
+        }
+    }
+
+    fun setLocation(postLocation: PostLocation) {
+        postModel?.let {
+            it.setLocation(postLocation.latitude, postLocation.longitude)
+            _livePostModel.postValue(it)
+        }
+    }
+
+    fun clearLocation() {
+        postModel?.let {
+            it.clearLocation()
             _livePostModel.postValue(it)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
@@ -13,8 +13,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
-import org.wordpress.android.fluxc.model.PostModel
-import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import javax.inject.Inject
@@ -51,7 +49,7 @@ class EditPostPublishSettingsFragment : Fragment() {
         })
         viewModel.onPublishedDateChanged.observe(this, Observer {
             it?.let { date ->
-                viewModel.updatePost(date, getPost())
+                viewModel.updatePost(date)
             }
         })
         viewModel.onPublishedLabelChanged.observe(this, Observer {
@@ -69,7 +67,7 @@ class EditPostPublishSettingsFragment : Fragment() {
                 )
             }
         })
-        viewModel.start(getPost())
+        viewModel.start()
         return rootView
     }
 
@@ -89,20 +87,6 @@ class EditPostPublishSettingsFragment : Fragment() {
 
         val fragment = PostTimePickerDialogFragment.newInstance()
         fragment.show(activity!!.supportFragmentManager, PostTimePickerDialogFragment.TAG)
-    }
-
-    private fun getPost(): PostModel? {
-        return getEditPostActivityHook()?.post
-    }
-
-    private fun getEditPostActivityHook(): EditPostActivityHook? {
-        val activity = activity ?: return null
-
-        return if (activity is EditPostActivityHook) {
-            activity
-        } else {
-            throw RuntimeException("$activity must implement EditPostActivityHook")
-        }
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
@@ -23,6 +23,7 @@ class EditPostPublishSettingsFragment : Fragment() {
     private lateinit var publishNotificationContainer: LinearLayout
     private lateinit var addToCalendarContainer: LinearLayout
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject lateinit var postModelProvider: EditPostModelProvider
     private lateinit var viewModel: EditPostPublishSettingsViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -47,11 +48,6 @@ class EditPostPublishSettingsFragment : Fragment() {
                 showPostTimeSelectionDialog()
             }
         })
-        viewModel.onPublishedDateChanged.observe(this, Observer {
-            it?.let { date ->
-                viewModel.updatePost(date)
-            }
-        })
         viewModel.onPublishedLabelChanged.observe(this, Observer {
             it?.let { label ->
                 dateAndTime.text = label
@@ -67,7 +63,9 @@ class EditPostPublishSettingsFragment : Fragment() {
                 )
             }
         })
-        viewModel.start()
+        postModelProvider.livePostModel.observe(this, Observer {
+            viewModel.onPostChanged(it)
+        })
         return rootView
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
@@ -1,18 +1,16 @@
 package org.wordpress.android.ui.posts
 
-import android.text.TextUtils
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.model.post.PostStatus.DRAFT
 import org.wordpress.android.fluxc.model.post.PostStatus.PUBLISHED
 import org.wordpress.android.fluxc.model.post.PostStatus.SCHEDULED
 import org.wordpress.android.util.DateTimeUtils
-import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.util.LocaleManagerWrapper
+import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Calendar
 import javax.inject.Inject
@@ -21,7 +19,8 @@ class EditPostPublishSettingsViewModel
 @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val postSettingsUtils: PostSettingsUtils,
-    private val localeManagerWrapper: LocaleManagerWrapper
+    private val localeManagerWrapper: LocaleManagerWrapper,
+    private val postModelProvider: EditPostModelProvider
 ) : ViewModel() {
     var canPublishImmediately: Boolean = false
 
@@ -47,21 +46,21 @@ class EditPostPublishSettingsViewModel
     private val _onToast = MutableLiveData<Event<String>>()
     val onToast: LiveData<Event<String>> = _onToast
 
-    fun start(postModel: PostModel?) {
-        val startCalendar = postModel?.let { getCurrentPublishDateAsCalendar(it) }
+    fun start() {
+        val startCalendar = postModelProvider.postModel?.let { getCurrentPublishDateAsCalendar() }
                 ?: localeManagerWrapper.getCurrentCalendar()
         year = startCalendar.get(Calendar.YEAR)
         month = startCalendar.get(Calendar.MONTH)
         day = startCalendar.get(Calendar.DAY_OF_MONTH)
         hour = startCalendar.get(Calendar.HOUR_OF_DAY)
         minute = startCalendar.get(Calendar.MINUTE)
-        onPostStatusChanged(postModel)
+        onPostStatusChanged()
     }
 
-    fun onPostStatusChanged(postModel: PostModel?) {
-        canPublishImmediately = postModel?.let { PostUtils.shouldPublishImmediatelyOptionBeAvailable(it) } ?: false
-        postModel?.let {
-            _onPublishedLabelChanged.postValue(postSettingsUtils.getPublishDateLabel(postModel))
+    fun onPostStatusChanged() {
+        canPublishImmediately = postModelProvider.postModel?.let { PostUtils.shouldPublishImmediatelyOptionBeAvailable(it) } ?: false
+        postModelProvider.postModel?.let {
+            _onPublishedLabelChanged.postValue(postSettingsUtils.getPublishDateLabel(it))
         }
     }
 
@@ -84,43 +83,41 @@ class EditPostPublishSettingsViewModel
         _onDatePicked.postValue(Event(Unit))
     }
 
-    private fun getCurrentPublishDateAsCalendar(postModel: PostModel): Calendar {
+    private fun getCurrentPublishDateAsCalendar(): Calendar {
         val calendar = localeManagerWrapper.getCurrentCalendar()
-        val dateCreated = postModel.dateCreated
+        val dateCreated = postModelProvider.postModel?.dateCreated
         // Set the currently selected time if available
-        if (!TextUtils.isEmpty(dateCreated)) {
+        if (!dateCreated.isNullOrEmpty()) {
             calendar.time = DateTimeUtils.dateFromIso8601(dateCreated)
         }
         return calendar
     }
 
-    fun updatePost(updatedDate: Calendar, post: PostModel?) {
-        post?.let {
-            post.dateCreated = DateTimeUtils.iso8601FromDate(updatedDate.time)
-            val initialPostStatus = PostStatus.fromPost(post)
-            val isPublishDateInTheFuture = PostUtils.isPublishDateInTheFuture(post)
-            var finalPostStatus = initialPostStatus
-            if (initialPostStatus == DRAFT && isPublishDateInTheFuture) {
-                // The previous logic was setting the status twice, once from draft to published and when the user
-                // picked the time, it set it from published to scheduled. This is now done in one step.
-                finalPostStatus = SCHEDULED
-            } else if (initialPostStatus == PUBLISHED && post.isLocalDraft()) {
-                // if user was changing dates for a local draft (not saved yet), only way to have it set to PUBLISH
-                // is by running into the if case above. So, if they're updating the date again by calling
-                // `updatePublishDate()`, get it back to DRAFT.
-                finalPostStatus = DRAFT
-            } else if (initialPostStatus == SCHEDULED && !isPublishDateInTheFuture) {
-                // if this is a SCHEDULED post and the user is trying to Back-date it now, let's update it to DRAFT.
-                // The other option was to make it published immediately but, let the user actively do that rather than
-                // having the app be smart about it - we don't want to accidentally publish a post.
-                finalPostStatus = DRAFT
-                // show toast only once, when time is shown
-                _onToast.postValue(Event(resourceProvider.getString(R.string.editor_post_converted_back_to_draft)))
-            }
-            post.status = finalPostStatus.toString()
-            _onPostStatusChanged.postValue(finalPostStatus)
-            val publishDateLabel = postSettingsUtils.getPublishDateLabel(post)
-            _onPublishedLabelChanged.postValue(publishDateLabel)
+    fun updatePost(updatedDate: Calendar) {
+        postModelProvider.setDateCreated(DateTimeUtils.iso8601FromDate(updatedDate.time))
+        val initialPostStatus = postModelProvider.getStatus()
+        val isPublishDateInTheFuture = PostUtils.isPublishDateInTheFuture(postModelProvider.postModel)
+        var finalPostStatus = initialPostStatus
+        if (initialPostStatus == DRAFT && isPublishDateInTheFuture) {
+            // The previous logic was setting the status twice, once from draft to published and when the user
+            // picked the time, it set it from published to scheduled. This is now done in one step.
+            finalPostStatus = SCHEDULED
+        } else if (initialPostStatus == PUBLISHED && postModelProvider.postModel?.isLocalDraft == true) {
+            // if user was changing dates for a local draft (not saved yet), only way to have it set to PUBLISH
+            // is by running into the if case above. So, if they're updating the date again by calling
+            // `updatePublishDate()`, get it back to DRAFT.
+            finalPostStatus = DRAFT
+        } else if (initialPostStatus == SCHEDULED && !isPublishDateInTheFuture) {
+            // if this is a SCHEDULED post and the user is trying to Back-date it now, let's update it to DRAFT.
+            // The other option was to make it published immediately but, let the user actively do that rather than
+            // having the app be smart about it - we don't want to accidentally publish a post.
+            finalPostStatus = DRAFT
+            // show toast only once, when time is shown
+            _onToast.postValue(Event(resourceProvider.getString(R.string.editor_post_converted_back_to_draft)))
         }
+        postModelProvider.setStatus(finalPostStatus)
+        _onPostStatusChanged.postValue(finalPostStatus)
+        val publishDateLabel = postModelProvider.postModel?.let { postSettingsUtils.getPublishDateLabel(it) }
+        _onPublishedLabelChanged.postValue(publishDateLabel)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
@@ -68,6 +68,7 @@ class EditPostPublishSettingsViewModel
         this.minute = selectedMinute
         val calendar = localeManagerWrapper.getCurrentCalendar()
         calendar.set(year!!, month!!, day!!, hour!!, minute!!)
+        calendar.timeZone = localeManagerWrapper.getTimeZone()
         updatePost(calendar)
     }
 
@@ -92,7 +93,7 @@ class EditPostPublishSettingsViewModel
     private fun updatePost(updatedDate: Calendar) {
         postModelProvider.setDateCreated(DateTimeUtils.iso8601FromDate(updatedDate.time))
         val initialPostStatus = postModelProvider.getStatus()
-        val isPublishDateInTheFuture = PostUtils.isPublishDateInTheFuture(postModelProvider.postModel)
+        val isPublishDateInTheFuture = updatedDate.after(localeManagerWrapper.getCurrentCalendar())
         var finalPostStatus = initialPostStatus
         if (initialPostStatus == DRAFT && isPublishDateInTheFuture) {
             // The previous logic was setting the status twice, once from draft to published and when the user

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -359,7 +359,7 @@ public class EditPostSettingsFragment extends Fragment {
         });
         mPublishedViewModel.getOnPostStatusChanged().observe(this, new Observer<PostStatus>() {
             @Override public void onChanged(PostStatus postStatus) {
-                updatePostStatus(postStatus.toString());
+                updatePostStatus(postStatus);
             }
         });
 
@@ -406,7 +406,6 @@ public class EditPostSettingsFragment extends Fragment {
         updateTagsTextView();
         updateStatusTextView();
         updatePublishDateTextView();
-        mPublishedViewModel.start();
         updateCategoriesTextView();
         initLocation();
         if (AppPrefs.isVisualEditorEnabled() || AppPrefs.isAztecEditorEnabled()) {
@@ -514,7 +513,7 @@ public class EditPostSettingsFragment extends Fragment {
         switch (fragment.getDialogType()) {
             case POST_STATUS:
                 int index = fragment.getCheckedIndex();
-                String status = getPostStatusAtIndex(index).toString();
+                PostStatus status = getPostStatusAtIndex(index);
                 updatePostStatus(status);
                 break;
             case POST_FORMAT:
@@ -609,17 +608,17 @@ public class EditPostSettingsFragment extends Fragment {
     }
 
     private void updateExcerpt(String excerpt) {
-        getPost().setExcerpt(excerpt);
+        mPostProvider.setExcerpt(excerpt);
         mExcerptTextView.setText(excerpt);
     }
 
     private void updateSlug(String slug) {
-        getPost().setSlug(slug);
+        mPostProvider.setSlug(slug);
         mSlugTextView.setText(slug);
     }
 
     private void updatePassword(String password) {
-        getPost().setPassword(password);
+        mPostProvider.setPassword(password);
         mPasswordTextView.setText(password);
     }
 
@@ -627,25 +626,24 @@ public class EditPostSettingsFragment extends Fragment {
         if (categoryList == null) {
             return;
         }
-        getPost().setCategoryIdList(categoryList);
+        mPostProvider.setCategoryIdList(categoryList);
         updateCategoriesTextView();
     }
 
-    public void updatePostStatus(String postStatus) {
-        getPost().setStatus(postStatus);
+    public void updatePostStatus(PostStatus postStatus) {
+        mPostProvider.setStatus(postStatus);
         updatePostStatusRelatedViews();
         updateSaveButton();
     }
 
     private void updatePostFormat(String postFormat) {
-        getPost().setPostFormat(postFormat);
+        mPostProvider.setPostFormat(postFormat);
         updatePostFormatTextView();
     }
 
     public void updatePostStatusRelatedViews() {
         updateStatusTextView();
         updatePublishDateTextView();
-        mPublishedViewModel.onPostStatusChanged();
     }
 
     private void updateStatusTextView() {
@@ -660,12 +658,11 @@ public class EditPostSettingsFragment extends Fragment {
     }
 
     private void updateTags(String selectedTags) {
-        PostModel postModel = getPost();
         if (!TextUtils.isEmpty(selectedTags)) {
             String tags = selectedTags.replace("\n", " ");
-            postModel.setTagNameList(Arrays.asList(TextUtils.split(tags, ",")));
+            mPostProvider.setTagNameList(Arrays.asList(TextUtils.split(tags, ",")));
         } else {
-            postModel.setTagNameList(null);
+            mPostProvider.setTagNameList(null);
         }
         updateTagsTextView();
     }
@@ -804,8 +801,7 @@ public class EditPostSettingsFragment extends Fragment {
     // Featured Image Helpers
 
     public void updateFeaturedImage(long featuredImageId) {
-        PostModel postModel = getPost();
-        postModel.setFeaturedImageId(featuredImageId);
+        mPostProvider.setFeaturedImageId(featuredImageId);
         updateFeaturedImageView();
     }
 
@@ -945,9 +941,8 @@ public class EditPostSettingsFragment extends Fragment {
     }
 
     private void setLocation(@Nullable Place place) {
-        PostModel postModel = getPost();
         if (place == null) {
-            postModel.clearLocation();
+            mPostProvider.clearLocation();
             mLocationTextView.setText("");
             mPostLocation = null;
             return;
@@ -957,7 +952,7 @@ public class EditPostSettingsFragment extends Fragment {
         }
         mPostLocation.setLatitude(place.getLatLng().latitude);
         mPostLocation.setLongitude(place.getLatLng().longitude);
-        postModel.setLocation(mPostLocation);
+        mPostProvider.setLocation(mPostLocation);
         mLocationTextView.setText(place.getAddress());
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -68,7 +68,6 @@ import org.wordpress.android.ui.prefs.SiteSettingsInterface.SiteSettingsListener
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
-import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.GeocoderUtils;
 import org.wordpress.android.util.SiteUtils;
@@ -81,7 +80,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Iterator;
 import java.util.List;
 
@@ -133,14 +131,13 @@ public class EditPostSettingsFragment extends Fragment {
     @Inject Dispatcher mDispatcher;
     @Inject ImageManager mImageManager;
     @Inject PostSettingsUtils mPostSettingsUtils;
+    @Inject EditPostModelProvider mPostProvider;
 
     @Inject ViewModelProvider.Factory mViewModelFactory;
     private EditPostPublishSettingsViewModel mPublishedViewModel;
 
 
     interface EditPostActivityHook {
-        PostModel getPost();
-
         SiteModel getSite();
     }
 
@@ -409,7 +406,7 @@ public class EditPostSettingsFragment extends Fragment {
         updateTagsTextView();
         updateStatusTextView();
         updatePublishDateTextView();
-        mPublishedViewModel.start(postModel);
+        mPublishedViewModel.start();
         updateCategoriesTextView();
         initLocation();
         if (AppPrefs.isVisualEditorEnabled() || AppPrefs.isAztecEditorEnabled()) {
@@ -581,11 +578,7 @@ public class EditPostSettingsFragment extends Fragment {
     // Helpers
 
     private PostModel getPost() {
-        if (getEditPostActivityHook() == null) {
-            // This can only happen during a callback while activity is re-created for some reason (config changes etc)
-            return null;
-        }
-        return getEditPostActivityHook().getPost();
+        return mPostProvider.getPostModel();
     }
 
     private SiteModel getSite() {
@@ -652,7 +645,7 @@ public class EditPostSettingsFragment extends Fragment {
     public void updatePostStatusRelatedViews() {
         updateStatusTextView();
         updatePublishDateTextView();
-        mPublishedViewModel.onPostStatusChanged(getPost());
+        mPublishedViewModel.onPostStatusChanged();
     }
 
     private void updateStatusTextView() {
@@ -854,19 +847,6 @@ public class EditPostSettingsFragment extends Fragment {
         if (isAdded()) {
             ActivityLauncher.showPhotoPickerForResult(getActivity(), MediaBrowserType.FEATURED_IMAGE_PICKER, getSite());
         }
-    }
-
-    // Publish Date Helpers
-
-    private Calendar getCurrentPublishDateAsCalendar() {
-        PostModel postModel = getPost();
-        Calendar calendar = Calendar.getInstance();
-        String dateCreated = postModel.getDateCreated();
-        // Set the currently selected time if available
-        if (!TextUtils.isEmpty(dateCreated)) {
-            calendar.setTime(DateTimeUtils.dateFromIso8601(dateCreated));
-        }
-        return calendar;
     }
 
     // FluxC events

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -316,10 +316,12 @@ public class PostUtils {
         return PostStatus.fromPost(postModel) == PostStatus.DRAFT;
     }
 
-    public static void updatePublishDateIfShouldBePublishedImmediately(PostModel postModel) {
+    public static boolean updatePublishDateIfShouldBePublishedImmediately(PostModel postModel) {
         if (shouldPublishImmediately(postModel)) {
             postModel.setDateCreated(DateTimeUtils.iso8601FromDate(new Date()));
+            return true;
         }
+        return false;
     }
 
     static boolean updatePostTitleIfDifferent(PostModel post, String newTitle) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
@@ -41,8 +41,9 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
         currentCalendar.set(2019, 6, 6, 10, 20, 0)
         currentCalendar.timeZone = TimeZone.getTimeZone("GMT")
         whenever(localeManagerWrapper.getCurrentCalendar()).thenAnswer {
-            val calendarInstance = Calendar.getInstance()
+            val calendarInstance = Calendar.getInstance(Locale.US)
             calendarInstance.time = currentCalendar.time
+            calendarInstance.timeZone = currentCalendar.timeZone
             calendarInstance
         }
         whenever(localeManagerWrapper.getTimeZone()).thenReturn(TimeZone.getTimeZone("GMT"))
@@ -66,7 +67,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
         assertThat(viewModel.year).isEqualTo(2019)
         assertThat(viewModel.month).isEqualTo(6)
         assertThat(viewModel.day).isEqualTo(6)
-        assertThat(viewModel.hour).isEqualTo(12)
+        assertThat(viewModel.hour).isEqualTo(10)
         assertThat(viewModel.minute).isEqualTo(20)
 
         assertThat(label).isEqualTo(expectedLabel)
@@ -84,7 +85,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
         assertThat(viewModel.year).isEqualTo(2019)
         assertThat(viewModel.month).isEqualTo(6)
         assertThat(viewModel.day).isEqualTo(6)
-        assertThat(viewModel.hour).isEqualTo(12)
+        assertThat(viewModel.hour).isEqualTo(10)
         assertThat(viewModel.minute).isEqualTo(20)
 
         assertThat(label).isNull()


### PR DESCRIPTION
This PR introduces an `EditPostModelProvider` which encapsulates the edited post in the EditPostActivity. It also wraps all the setters in order to expose a `LiveData` endpoint the other parts can listen to. Right now the update calls are very messy. This also allows us to not use the casted activity hook and get current post from there. 

This solves one of the issues of the `EditPostActivity` - by not mutating the original object we could listen to the changes and introduce UI updates that are not called manually. Right now this is a great risk of missing an UI update when updating the Post. 

Let me know if this is the right direction! 

To test:
* Test that the edit post activity, settings and the publish settings work as expected. 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
