### PR TITLE
Publish notification dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -85,6 +85,7 @@ import org.wordpress.android.ui.posts.EditPostSettingsFragment;
 import org.wordpress.android.ui.posts.HistoryListFragment;
 import org.wordpress.android.ui.posts.PostDatePickerDialogFragment;
 import org.wordpress.android.ui.posts.PostListFragment;
+import org.wordpress.android.ui.posts.PostNotificationTimeDialogFragment;
 import org.wordpress.android.ui.posts.PostPreviewActivity;
 import org.wordpress.android.ui.posts.PostPreviewFragment;
 import org.wordpress.android.ui.posts.PostSettingsTagsActivity;
@@ -495,6 +496,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(PostDatePickerDialogFragment object);
 
     void inject(PostTimePickerDialogFragment object);
+
+    void inject(PostNotificationTimeDialogFragment object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
@@ -66,14 +66,17 @@ class EditPostPublishSettingsFragment : Fragment() {
                 publishNotificationContainer.isEnabled = uiModel.notificationEnabled
                 if (uiModel.notificationEnabled) {
                     publishNotificationContainer.setOnClickListener {
-                        showNotificationTimeSelectionDialog(uiModel.notificationTime)
+                        viewModel.onShowDialog(getPost())
                     }
                 } else {
                     publishNotificationContainer.setOnClickListener(null)
                 }
-                publishNotification.setText(uiModel.notificationTime.toLabel())
+                publishNotification.setText(uiModel.notificationLabel)
                 publishNotificationContainer.visibility = if (uiModel.notificationVisible) View.VISIBLE else View.GONE
             }
+        })
+        viewModel.onShowNotificationDialog.observe(this, Observer {
+            showNotificationTimeSelectionDialog(it)
         })
         viewModel.onToast.observe(this, Observer {
             it?.applyIfNotHandled {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
@@ -20,9 +20,6 @@ import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import javax.inject.Inject
 
 class EditPostPublishSettingsFragment : Fragment() {
-    private lateinit var dateAndTime: TextView
-    private lateinit var publishNotification: TextView
-    private lateinit var publishNotificationContainer: LinearLayout
     private lateinit var addToCalendarContainer: LinearLayout
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: EditPostPublishSettingsViewModel
@@ -36,10 +33,11 @@ class EditPostPublishSettingsFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val rootView = inflater.inflate(R.layout.edit_post_published_settings_fragment, container, false) as ViewGroup
-        dateAndTime = rootView.findViewById(R.id.publish_time_and_date)
+        val dateAndTime = rootView.findViewById<TextView>(R.id.publish_time_and_date)
         val dateAndTimeContainer = rootView.findViewById<LinearLayout>(R.id.publish_time_and_date_container)
-        publishNotification = rootView.findViewById(R.id.publish_notification)
-        publishNotificationContainer = rootView.findViewById(R.id.publish_notification_container)
+        val publishNotification = rootView.findViewById<TextView>(R.id.publish_notification)
+        val publishNotificationTitle = rootView.findViewById<TextView>(R.id.publish_notification_title)
+        val publishNotificationContainer = rootView.findViewById<LinearLayout>(R.id.publish_notification_container)
         addToCalendarContainer = rootView.findViewById(R.id.post_add_to_calendar_container)
 
         dateAndTimeContainer.setOnClickListener { showPostDateSelectionDialog() }
@@ -54,9 +52,24 @@ class EditPostPublishSettingsFragment : Fragment() {
                 viewModel.updatePost(date, getPost())
             }
         })
-        viewModel.onPublishedLabelChanged.observe(this, Observer {
-            it?.let { label ->
-                dateAndTime.text = label
+        viewModel.onNotificationTime.observe(this, Observer {
+            it?.let { notificationTime ->
+                viewModel.updateUiModel(notificationTime, getPost())
+            }
+        })
+        viewModel.onUiModel.observe(this, Observer {
+            it?.let { uiModel ->
+                dateAndTime.text = uiModel.publishDateLabel
+                publishNotificationTitle.isEnabled = uiModel.notificationEnabled
+                publishNotification.isEnabled = uiModel.notificationEnabled
+                publishNotificationContainer.isEnabled = uiModel.notificationEnabled
+                if (uiModel.notificationEnabled) {
+                    publishNotificationContainer.setOnClickListener { showNotificationTimeSelectionDialog() }
+                } else {
+                    publishNotificationContainer.setOnClickListener(null)
+                }
+                publishNotification.setText(it.notificationLabel)
+                publishNotificationContainer.visibility = if (uiModel.notificationVisible) View.VISIBLE else View.GONE
             }
         })
         viewModel.onToast.observe(this, Observer {
@@ -89,6 +102,15 @@ class EditPostPublishSettingsFragment : Fragment() {
 
         val fragment = PostTimePickerDialogFragment.newInstance()
         fragment.show(activity!!.supportFragmentManager, PostTimePickerDialogFragment.TAG)
+    }
+
+    private fun showNotificationTimeSelectionDialog() {
+        if (!isAdded) {
+            return
+        }
+
+        val fragment = PostNotificationTimeDialogFragment.newInstance()
+        fragment.show(activity!!.supportFragmentManager, PostNotificationTimeDialogFragment.TAG)
     }
 
     private fun getPost(): PostModel? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
@@ -76,7 +76,9 @@ class EditPostPublishSettingsFragment : Fragment() {
             }
         })
         viewModel.onShowNotificationDialog.observe(this, Observer {
-            showNotificationTimeSelectionDialog(it)
+            it?.getContentIfNotHandled()?.let { notificationTime ->
+                showNotificationTimeSelectionDialog(notificationTime)
+            }
         })
         viewModel.onToast.observe(this, Observer {
             it?.applyIfNotHandled {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
+import org.wordpress.android.ui.posts.PostNotificationTimeDialogFragment.NotificationTime
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import javax.inject.Inject
@@ -64,11 +65,13 @@ class EditPostPublishSettingsFragment : Fragment() {
                 publishNotification.isEnabled = uiModel.notificationEnabled
                 publishNotificationContainer.isEnabled = uiModel.notificationEnabled
                 if (uiModel.notificationEnabled) {
-                    publishNotificationContainer.setOnClickListener { showNotificationTimeSelectionDialog() }
+                    publishNotificationContainer.setOnClickListener {
+                        showNotificationTimeSelectionDialog(uiModel.notificationTime)
+                    }
                 } else {
                     publishNotificationContainer.setOnClickListener(null)
                 }
-                publishNotification.setText(it.notificationLabel)
+                publishNotification.setText(uiModel.notificationTime.toLabel())
                 publishNotificationContainer.visibility = if (uiModel.notificationVisible) View.VISIBLE else View.GONE
             }
         })
@@ -104,12 +107,12 @@ class EditPostPublishSettingsFragment : Fragment() {
         fragment.show(activity!!.supportFragmentManager, PostTimePickerDialogFragment.TAG)
     }
 
-    private fun showNotificationTimeSelectionDialog() {
+    private fun showNotificationTimeSelectionDialog(notificationTime: NotificationTime?) {
         if (!isAdded) {
             return
         }
 
-        val fragment = PostNotificationTimeDialogFragment.newInstance()
+        val fragment = PostNotificationTimeDialogFragment.newInstance(notificationTime)
         fragment.show(activity!!.supportFragmentManager, PostNotificationTimeDialogFragment.TAG)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.model.post.PostStatus.DRAFT
 import org.wordpress.android.fluxc.model.post.PostStatus.PUBLISHED
 import org.wordpress.android.fluxc.model.post.PostStatus.SCHEDULED
 import org.wordpress.android.ui.posts.PostNotificationTimeDialogFragment.NotificationTime
+import org.wordpress.android.ui.posts.PostNotificationTimeDialogFragment.NotificationTime.OFF
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.viewmodel.Event
@@ -126,7 +127,7 @@ class EditPostPublishSettingsViewModel
         }
     }
 
-    fun updateUiModel(notificationTime: NotificationTime? = onNotificationTime.value, post: PostModel?) {
+    fun updateUiModel(updatedNotificationTime: NotificationTime? = onNotificationTime.value, post: PostModel?) {
         if (post != null) {
             val publishDateLabel = postSettingsUtils.getPublishDateLabel(post)
             val futureTime = localeManagerWrapper.getCurrentCalendar().timeInMillis + 6000
@@ -135,14 +136,14 @@ class EditPostPublishSettingsViewModel
                     ?: localeManagerWrapper.getCurrentCalendar().time).time
             val enableNotification = dateCreated > futureTime
             val showNotification = dateCreated > now
-            val label = if (notificationTime != null && enableNotification && showNotification) {
-                notificationTime.toLabel()
+            val notificationTime = if (updatedNotificationTime != null && enableNotification && showNotification) {
+                updatedNotificationTime
             } else {
-                R.string.post_notification_off
+                OFF
             }
             _onUiModel.value = PublishUiModel(
                     publishDateLabel,
-                    notificationLabel = label,
+                    notificationTime = notificationTime,
                     notificationEnabled = enableNotification,
                     notificationVisible = showNotification
             )
@@ -157,7 +158,7 @@ class EditPostPublishSettingsViewModel
 
     data class PublishUiModel(
         val publishDateLabel: String,
-        val notificationLabel: Int = R.string.post_notification_off,
+        val notificationTime: NotificationTime = OFF,
         val notificationEnabled: Boolean = false,
         val notificationVisible: Boolean = true
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.model.post.PostStatus.DRAFT
 import org.wordpress.android.fluxc.model.post.PostStatus.PUBLISHED
 import org.wordpress.android.fluxc.model.post.PostStatus.SCHEDULED
 import org.wordpress.android.ui.posts.PostNotificationTimeDialogFragment.NotificationTime
+import org.wordpress.android.ui.posts.PostNotificationTimeDialogFragment.NotificationTime.OFF
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.viewmodel.Event
@@ -56,11 +57,7 @@ class EditPostPublishSettingsViewModel
         val startCalendar = postModel?.let { getCurrentPublishDateAsCalendar(it) }
                 ?: localeManagerWrapper.getCurrentCalendar()
         updateUiModel(post = postModel)
-        year = startCalendar.get(Calendar.YEAR)
-        month = startCalendar.get(Calendar.MONTH)
-        day = startCalendar.get(Calendar.DAY_OF_MONTH)
-        hour = startCalendar.get(Calendar.HOUR_OF_DAY)
-        minute = startCalendar.get(Calendar.MINUTE)
+        updateDateAndTimeFromCalendar(startCalendar)
         onPostStatusChanged(postModel)
     }
 
@@ -70,7 +67,9 @@ class EditPostPublishSettingsViewModel
     }
 
     fun publishNow() {
-        _onPublishedDateChanged.postValue(localeManagerWrapper.getCurrentCalendar())
+        val currentCalendar = localeManagerWrapper.getCurrentCalendar()
+        updateDateAndTimeFromCalendar(currentCalendar)
+        _onPublishedDateChanged.postValue(currentCalendar)
     }
 
     fun onTimeSelected(selectedHour: Int, selectedMinute: Int) {
@@ -91,10 +90,18 @@ class EditPostPublishSettingsViewModel
     fun onShowDialog(postModel: PostModel?) {
         if (areNotificationsEnabled(postModel)) {
             // This will be replaced by loading notification time from the DB
-            _onShowNotificationDialog.postValue(Event(onNotificationTime.value))
+            _onShowNotificationDialog.postValue(Event(onNotificationTime.value ?: OFF))
         } else {
             _onToast.postValue(Event(resourceProvider.getString(R.string.post_notification_error)))
         }
+    }
+
+    private fun updateDateAndTimeFromCalendar(startCalendar: Calendar) {
+        year = startCalendar.get(Calendar.YEAR)
+        month = startCalendar.get(Calendar.MONTH)
+        day = startCalendar.get(Calendar.DAY_OF_MONTH)
+        hour = startCalendar.get(Calendar.HOUR_OF_DAY)
+        minute = startCalendar.get(Calendar.MINUTE)
     }
 
     private fun getCurrentPublishDateAsCalendar(postModel: PostModel): Calendar {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
@@ -47,8 +47,8 @@ class EditPostPublishSettingsViewModel
     val onUiModel: LiveData<PublishUiModel> = _onUiModel
     private val _onToast = MutableLiveData<Event<String>>()
     val onToast: LiveData<Event<String>> = _onToast
-    private val _onShowNotificationDialog = MutableLiveData<NotificationTime>()
-    val onShowNotificationDialog: LiveData<NotificationTime> = _onShowNotificationDialog
+    private val _onShowNotificationDialog = MutableLiveData<Event<NotificationTime?>>()
+    val onShowNotificationDialog: LiveData<Event<NotificationTime?>> = _onShowNotificationDialog
     private val _onNotificationTime = MutableLiveData<NotificationTime>()
     val onNotificationTime: LiveData<NotificationTime> = _onNotificationTime
 
@@ -91,7 +91,7 @@ class EditPostPublishSettingsViewModel
     fun onShowDialog(postModel: PostModel?) {
         if (areNotificationsEnabled(postModel)) {
             // This will be replaced by loading notification time from the DB
-            _onShowNotificationDialog.postValue(onNotificationTime.value)
+            _onShowNotificationDialog.postValue(Event(onNotificationTime.value))
         } else {
             _onToast.postValue(Event(resourceProvider.getString(R.string.post_notification_error)))
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -61,6 +61,7 @@ import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaBrowserType;
+import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel.PublishUiModel;
 import org.wordpress.android.ui.posts.PostSettingsListDialogFragment.DialogType;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
@@ -355,9 +356,9 @@ public class EditPostSettingsFragment extends Fragment {
             mFormatContainer.setVisibility(View.GONE);
         }
 
-        mPublishedViewModel.getOnPublishedLabelChanged().observe(this, new Observer<String>() {
-            @Override public void onChanged(String label) {
-                updatePublishDateTextView(label);
+        mPublishedViewModel.getOnUiModel().observe(this, new Observer<PublishUiModel>() {
+            @Override public void onChanged(PublishUiModel uiModel) {
+                updatePublishDateTextView(uiModel.getPublishDateLabel());
             }
         });
         mPublishedViewModel.getOnPostStatusChanged().observe(this, new Observer<PostStatus>() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationTimeDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationTimeDialogFragment.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.os.Bundle
 import android.widget.RadioGroup
 import androidx.fragment.app.DialogFragment
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import org.wordpress.android.R
@@ -27,12 +26,8 @@ class PostNotificationTimeDialogFragment : DialogFragment() {
         val alertDialogBuilder = AlertDialog.Builder(activity)
         val view = activity!!.layoutInflater.inflate(R.layout.post_notification_type_selector, null) as RadioGroup
         alertDialogBuilder.setView(view)
-        viewModel.onNotificationTime.observe(this, Observer { updatedNotificationTime ->
-            val currentDataType = view.checkedRadioButtonId.toNotificationTime()
-            if (updatedNotificationTime != currentDataType) {
-                updatedNotificationTime?.let { view.check(updatedNotificationTime.toViewId()) }
-            }
-        })
+        val notificationTime = arguments?.getString(ARG_NOTIFICATION_TIME)?.let { NotificationTime.valueOf(it) } ?: OFF
+        view.check(notificationTime.toViewId())
         alertDialogBuilder.setTitle(R.string.post_settings_notification)
 
         alertDialogBuilder.setPositiveButton(R.string.dialog_button_ok) { dialog, _ ->
@@ -81,9 +76,16 @@ class PostNotificationTimeDialogFragment : DialogFragment() {
 
     companion object {
         const val TAG = "post_notification_time_dialog_fragment"
+        const val ARG_NOTIFICATION_TIME = "notification_time"
 
-        fun newInstance(): PostNotificationTimeDialogFragment {
-            return PostNotificationTimeDialogFragment()
+        fun newInstance(notificationTime: NotificationTime?): PostNotificationTimeDialogFragment {
+            val fragment = PostNotificationTimeDialogFragment()
+            notificationTime?.let {
+                val args = Bundle()
+                args.putString(ARG_NOTIFICATION_TIME, notificationTime.name)
+                fragment.arguments = args
+            }
+            return fragment
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationTimeDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationTimeDialogFragment.kt
@@ -33,7 +33,7 @@ class PostNotificationTimeDialogFragment : DialogFragment() {
                 updatedNotificationTime?.let { view.check(updatedNotificationTime.toViewId()) }
             }
         })
-        alertDialogBuilder.setTitle(R.string.stats_widget_select_type)
+        alertDialogBuilder.setTitle(R.string.post_settings_notification)
 
         alertDialogBuilder.setPositiveButton(R.string.dialog_button_ok) { dialog, _ ->
             viewModel.createNotification(view.checkedRadioButtonId.toNotificationTime())

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationTimeDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationTimeDialogFragment.kt
@@ -1,0 +1,89 @@
+package org.wordpress.android.ui.posts
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.content.Context
+import android.os.Bundle
+import android.widget.RadioGroup
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProviders
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.ui.posts.PostNotificationTimeDialogFragment.NotificationTime.OFF
+import org.wordpress.android.ui.posts.PostNotificationTimeDialogFragment.NotificationTime.ONE_HOUR_BEFORE
+import org.wordpress.android.ui.posts.PostNotificationTimeDialogFragment.NotificationTime.TEN_MINUTES_BEFORE
+import org.wordpress.android.ui.posts.PostNotificationTimeDialogFragment.NotificationTime.WHEN_PUBLISHED
+import javax.inject.Inject
+
+class PostNotificationTimeDialogFragment : DialogFragment() {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var viewModel: EditPostPublishSettingsViewModel
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+                .get(EditPostPublishSettingsViewModel::class.java)
+        val alertDialogBuilder = AlertDialog.Builder(activity)
+        val view = activity!!.layoutInflater.inflate(R.layout.post_notification_type_selector, null) as RadioGroup
+        alertDialogBuilder.setView(view)
+        viewModel.onNotificationTime.observe(this, Observer { updatedNotificationTime ->
+            val currentDataType = view.checkedRadioButtonId.toNotificationTime()
+            if (updatedNotificationTime != currentDataType) {
+                updatedNotificationTime?.let { view.check(updatedNotificationTime.toViewId()) }
+            }
+        })
+        alertDialogBuilder.setTitle(R.string.stats_widget_select_type)
+
+        alertDialogBuilder.setPositiveButton(R.string.dialog_button_ok) { dialog, _ ->
+            viewModel.createNotification(view.checkedRadioButtonId.toNotificationTime())
+            dialog?.dismiss()
+        }
+        return alertDialogBuilder.create()
+    }
+
+    private fun Int.toNotificationTime(): NotificationTime {
+        return when (this) {
+            R.id.off -> OFF
+            R.id.one_hour_before -> ONE_HOUR_BEFORE
+            R.id.ten_minutes_before -> TEN_MINUTES_BEFORE
+            R.id.when_published -> WHEN_PUBLISHED
+            else -> OFF
+        }
+    }
+
+    enum class NotificationTime {
+        OFF, ONE_HOUR_BEFORE, TEN_MINUTES_BEFORE, WHEN_PUBLISHED;
+
+        fun toViewId(): Int {
+            return when (this) {
+                OFF -> R.id.off
+                ONE_HOUR_BEFORE -> R.id.one_hour_before
+                TEN_MINUTES_BEFORE -> R.id.ten_minutes_before
+                WHEN_PUBLISHED -> R.id.when_published
+            }
+        }
+
+        fun toLabel(): Int {
+            return when (this) {
+                OFF -> R.string.post_notification_off
+                ONE_HOUR_BEFORE -> R.string.post_notification_one_hour_before
+                TEN_MINUTES_BEFORE -> R.string.post_notification_ten_minutes_before
+                WHEN_PUBLISHED -> R.string.post_notification_when_published
+            }
+        }
+    }
+
+    override fun onAttach(context: Context?) {
+        super.onAttach(context)
+        (activity!!.applicationContext as WordPress).component().inject(this)
+    }
+
+    companion object {
+        const val TAG = "post_notification_time_dialog_fragment"
+
+        fun newInstance(): PostNotificationTimeDialogFragment {
+            return PostNotificationTimeDialogFragment()
+        }
+    }
+}

--- a/WordPress/src/main/res/layout/edit_post_published_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_published_settings_fragment.xml
@@ -23,6 +23,7 @@
         style="@style/PostSettingsContainer">
 
         <TextView
+            android:id="@+id/publish_notification_title"
             style="@style/PostSettingsTitle"
             android:enabled="false"
             android:text="@string/post_settings_notification"/>
@@ -31,7 +32,7 @@
             android:id="@+id/publish_notification"
             style="@style/PostSettingsSubtitle"
             android:enabled="false"
-            android:hint="@string/off"/>
+            android:hint="@string/post_notification_off"/>
     </LinearLayout>
 
     <LinearLayout

--- a/WordPress/src/main/res/layout/post_notification_type_selector.xml
+++ b/WordPress/src/main/res/layout/post_notification_type_selector.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RadioGroup
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/data_types"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:descendantFocusability="beforeDescendants"
+    android:paddingEnd="@dimen/margin_extra_medium_large"
+    android:paddingStart="@dimen/margin_extra_medium_large"
+    android:paddingTop="@dimen/margin_extra_large"
+    android:scrollbars="vertical">
+
+    <androidx.appcompat.widget.AppCompatRadioButton
+        android:id="@+id/off"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/margin_extra_extra_large"
+        android:checked="true"
+        android:paddingEnd="@dimen/stats_widget_color_selector_padding"
+        android:paddingStart="@dimen/stats_widget_color_selector_padding"
+        android:text="@string/post_notification_off"/>
+
+    <androidx.appcompat.widget.AppCompatRadioButton
+        android:id="@+id/one_hour_before"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/margin_extra_extra_large"
+        android:paddingEnd="@dimen/stats_widget_color_selector_padding"
+        android:paddingStart="@dimen/stats_widget_color_selector_padding"
+        android:text="@string/post_notification_one_hour_before"/>
+
+    <androidx.appcompat.widget.AppCompatRadioButton
+        android:id="@+id/ten_minutes_before"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/margin_extra_extra_large"
+        android:paddingEnd="@dimen/stats_widget_color_selector_padding"
+        android:paddingStart="@dimen/stats_widget_color_selector_padding"
+        android:text="@string/post_notification_ten_minutes_before"/>
+
+    <androidx.appcompat.widget.AppCompatRadioButton
+        android:id="@+id/when_published"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/margin_extra_extra_large"
+        android:paddingEnd="@dimen/stats_widget_color_selector_padding"
+        android:paddingStart="@dimen/stats_widget_color_selector_padding"
+        android:text="@string/post_notification_when_published"/>
+</RadioGroup>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1315,6 +1315,11 @@
     <string name="post_settings_notification">Notification</string>
     <string name="post_settings_add_to_calendar">Add to calendar</string>
 
+    <string name="post_notification_off">Off</string>
+    <string name="post_notification_one_hour_before">1 hour before</string>
+    <string name="post_notification_ten_minutes_before">10 minutes before</string>
+    <string name="post_notification_when_published">When published</string>
+
     <!-- post date selection -->
     <string name="publish_date">Publish</string>
     <string name="immediately">Immediately</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1319,6 +1319,7 @@
     <string name="post_notification_one_hour_before">1 hour before</string>
     <string name="post_notification_ten_minutes_before">10 minutes before</string>
     <string name="post_notification_when_published">When published</string>
+    <string name="post_notification_error">Notification can\'t be created when the publish date is in the past.</string>
 
     <!-- post date selection -->
     <string name="publish_date">Publish</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel.PublishUiModel
+import org.wordpress.android.ui.posts.PostNotificationTimeDialogFragment.NotificationTime
 import org.wordpress.android.ui.posts.PostNotificationTimeDialogFragment.NotificationTime.ONE_HOUR_BEFORE
 import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -155,7 +156,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
         assertThat(updatedStatus).isEqualTo(PostStatus.SCHEDULED)
         uiModel?.apply {
             assertThat(this.publishDateLabel).isEqualTo("Updated date")
-            assertThat(this.notificationLabel).isEqualTo(R.string.post_notification_off)
+            assertThat(this.notificationTime).isEqualTo(NotificationTime.OFF)
             assertThat(this.notificationEnabled).isTrue()
             assertThat(this.notificationVisible).isTrue()
         }
@@ -185,7 +186,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
         assertThat(updatedStatus).isEqualTo(PostStatus.DRAFT)
         uiModel?.apply {
             assertThat(this.publishDateLabel).isEqualTo("Updated date")
-            assertThat(this.notificationLabel).isEqualTo(R.string.post_notification_off)
+            assertThat(this.notificationTime).isEqualTo(NotificationTime.OFF)
             assertThat(this.notificationEnabled).isFalse()
             assertThat(this.notificationVisible).isTrue()
         }
@@ -226,7 +227,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
         assertThat(updatedStatus).isEqualTo(PostStatus.DRAFT)
         uiModel?.apply {
             assertThat(this.publishDateLabel).isEqualTo("Updated date")
-            assertThat(this.notificationLabel).isEqualTo(R.string.post_notification_off)
+            assertThat(this.notificationTime).isEqualTo(NotificationTime.OFF)
             assertThat(this.notificationEnabled).isFalse()
             assertThat(this.notificationVisible).isTrue()
         }
@@ -252,7 +253,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
 
         uiModel?.apply {
             assertThat(this.publishDateLabel).isEqualTo("Updated date")
-            assertThat(this.notificationLabel).isEqualTo(R.string.post_notification_off)
+            assertThat(this.notificationTime).isEqualTo(NotificationTime.OFF)
             assertThat(this.notificationEnabled).isFalse()
             assertThat(this.notificationVisible).isFalse()
         }
@@ -279,7 +280,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
             assertThat(this.publishDateLabel).isEqualTo("Updated date")
             assertThat(this.notificationEnabled).isFalse()
             assertThat(this.notificationVisible).isTrue()
-            assertThat(this.notificationLabel).isEqualTo(R.string.post_notification_off)
+            assertThat(this.notificationTime).isEqualTo(NotificationTime.OFF)
         }
     }
 
@@ -303,7 +304,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
             assertThat(this.publishDateLabel).isEqualTo("Updated date")
             assertThat(this.notificationEnabled).isFalse()
             assertThat(this.notificationVisible).isTrue()
-            assertThat(this.notificationLabel).isEqualTo(R.string.post_notification_off)
+            assertThat(this.notificationTime).isEqualTo(NotificationTime.OFF)
         }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
@@ -11,7 +11,6 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel.PublishUiModel
-import org.wordpress.android.ui.posts.PostNotificationTimeDialogFragment.NotificationTime
 import org.wordpress.android.ui.posts.PostNotificationTimeDialogFragment.NotificationTime.ONE_HOUR_BEFORE
 import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -156,7 +155,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
         assertThat(updatedStatus).isEqualTo(PostStatus.SCHEDULED)
         uiModel?.apply {
             assertThat(this.publishDateLabel).isEqualTo("Updated date")
-            assertThat(this.notificationTime).isEqualTo(NotificationTime.OFF)
+            assertThat(this.notificationLabel).isEqualTo(R.string.post_notification_off)
             assertThat(this.notificationEnabled).isTrue()
             assertThat(this.notificationVisible).isTrue()
         }
@@ -186,7 +185,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
         assertThat(updatedStatus).isEqualTo(PostStatus.DRAFT)
         uiModel?.apply {
             assertThat(this.publishDateLabel).isEqualTo("Updated date")
-            assertThat(this.notificationTime).isEqualTo(NotificationTime.OFF)
+            assertThat(this.notificationLabel).isEqualTo(R.string.post_notification_off)
             assertThat(this.notificationEnabled).isFalse()
             assertThat(this.notificationVisible).isTrue()
         }
@@ -227,7 +226,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
         assertThat(updatedStatus).isEqualTo(PostStatus.DRAFT)
         uiModel?.apply {
             assertThat(this.publishDateLabel).isEqualTo("Updated date")
-            assertThat(this.notificationTime).isEqualTo(NotificationTime.OFF)
+            assertThat(this.notificationLabel).isEqualTo(R.string.post_notification_off)
             assertThat(this.notificationEnabled).isFalse()
             assertThat(this.notificationVisible).isTrue()
         }
@@ -253,7 +252,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
 
         uiModel?.apply {
             assertThat(this.publishDateLabel).isEqualTo("Updated date")
-            assertThat(this.notificationTime).isEqualTo(NotificationTime.OFF)
+            assertThat(this.notificationLabel).isEqualTo(R.string.post_notification_off)
             assertThat(this.notificationEnabled).isFalse()
             assertThat(this.notificationVisible).isFalse()
         }
@@ -280,7 +279,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
             assertThat(this.publishDateLabel).isEqualTo("Updated date")
             assertThat(this.notificationEnabled).isFalse()
             assertThat(this.notificationVisible).isTrue()
-            assertThat(this.notificationTime).isEqualTo(NotificationTime.OFF)
+            assertThat(this.notificationLabel).isEqualTo(R.string.post_notification_off)
         }
     }
 
@@ -304,7 +303,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
             assertThat(this.publishDateLabel).isEqualTo("Updated date")
             assertThat(this.notificationEnabled).isFalse()
             assertThat(this.notificationVisible).isTrue()
-            assertThat(this.notificationTime).isEqualTo(NotificationTime.OFF)
+            assertThat(this.notificationLabel).isEqualTo(R.string.post_notification_off)
         }
     }
 }


### PR DESCRIPTION
This PR introduces logic for enabling/disabling/hiding of the "Notification" field in the publish settings. Once the field is enabled, there is a dialog that allows the user to select the notification time (`OFF`, `ONE_HOUR_BEFORE`, `TEN_MINUTES_BEFORE`, `WHEN_PUBLISHED`) which will be used to schedule notifications in future PRs. 

To test:
* Go to Publish settings
* Set the date into the past
* Notice that the "Notification" field is hidden
* Set the date to "Immediately/now"
* Notice that the "Notification" field is disabled
* Set the date to future
* Notice that the "Notification" field is enabled
* Click on the "Notification" field
* Select an item from the dialog
* Click on "OK"
* Notice that the selected item is now visible in the "Notification" field

![Screenshot_1563293061](https://user-images.githubusercontent.com/1079756/61310230-2e2bec00-a7f4-11e9-8d11-3cf92cda512c.png)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
