### PR TITLE
Update login library with latest changes from WCAndroid

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -831,7 +831,10 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         // Not used in WordPress app
     }
 
-    @Override public void gotConnectedSiteInfo(String siteAddress, boolean hasJetpack) {
+    @Override public void gotConnectedSiteInfo(
+            @NonNull String siteAddress,
+            @Nullable String redirectUrl,
+            boolean hasJetpack) {
         // Not used in WordPress app
     }
 }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -48,7 +48,7 @@ public interface LoginListener {
     // Login Site Address input callbacks
     void alreadyLoggedInWpcom(ArrayList<Integer> oldSitesIds);
     void gotWpcomSiteInfo(String siteAddress, String siteName, String siteIconUrl);
-    void gotConnectedSiteInfo(String siteAddress, boolean hasJetpack);
+    void gotConnectedSiteInfo(@NonNull String siteAddress, @Nullable String redirectUrl, boolean hasJetpack);
     void gotXmlRpcEndpoint(String inputSiteAddress, String endpointAddress);
     void handleSslCertificateError(MemorizingTrustManager memorizingTrustManager, SelfSignedSSLCallback callback);
     void helpSiteAddress(String url);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -425,7 +425,10 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
                 } else if (event.info.hasJetpack && event.info.isJetpackActive && event.info.isJetpackConnected) {
                     hasJetpack = true;
                 }
-                mLoginListener.gotConnectedSiteInfo(event.info.url, hasJetpack);
+                mLoginListener.gotConnectedSiteInfo(
+                        event.info.url,
+                        event.info.urlAfterRedirects,
+                        hasJetpack);
             }
         }
     }


### PR DESCRIPTION
This PR merges in the changes required for redirect support as described in this PR: https://github.com/woocommerce/woocommerce-android/pull/1224 - please see that PR for additional information. 

WordPress Android does not use this functionality, but did require a tweak to an unused method to have it conform to the changes in the `LoginListener`. 

**Note:** this PR is in draft and will not be ready for merge until the [login library PR](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/23) is merged and this branch updated with the login library's `develop` branch.