### PR TITLE
Feature/move existing actions to navbar and restyle toolbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -21,6 +21,7 @@ import android.widget.ProgressBar;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
+import androidx.appcompat.widget.TooltipCompat;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.lifecycle.ViewModelProviders;
@@ -140,6 +141,12 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
         mShareButton = findViewById(R.id.share_button);
         mExternalBrowserButton = findViewById(R.id.external_browser_button);
         mPreviewModeButton = findViewById(R.id.preview_type_selector_button);
+
+        TooltipCompat.setTooltipText(mNavigateBackButton, mNavigateBackButton.getContentDescription());
+        TooltipCompat.setTooltipText(mNavigateForwardButton, mNavigateForwardButton.getContentDescription());
+        TooltipCompat.setTooltipText(mShareButton, mShareButton.getContentDescription());
+        TooltipCompat.setTooltipText(mExternalBrowserButton, mExternalBrowserButton.getContentDescription());
+        TooltipCompat.setTooltipText(mPreviewModeButton, mPreviewModeButton.getContentDescription());
 
         mNavigateBackButton.setOnClickListener(new OnClickListener() {
             @Override public void onClick(View v) {

--- a/WordPress/src/main/res/layout/wpwebview_activity.xml
+++ b/WordPress/src/main/res/layout/wpwebview_activity.xml
@@ -7,9 +7,19 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <include
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
-        layout="@layout/toolbar"/>
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:layout_alignParentTop="true"
+        android:background="@color/white"
+        android:elevation="@dimen/appbar_elevation"
+        app:contentInsetEnd="@dimen/toolbar_content_offset_end"
+        app:contentInsetLeft="@dimen/toolbar_content_offset"
+        app:contentInsetRight="@dimen/toolbar_content_offset_end"
+        app:contentInsetStart="@dimen/toolbar_content_offset"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+        app:theme="@style/ThemeOverlay.AppCompat.Light"/>
 
     <include
         layout="@layout/progress_layout"

--- a/WordPress/src/main/res/menu/webview.xml
+++ b/WordPress/src/main/res/menu/webview.xml
@@ -1,20 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+      xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <item
-        android:id="@+id/menu_browser"
-        android:icon="@drawable/ic_globe_white_24dp"
-        android:title="@string/view_in_browser"
-        app:showAsAction="ifRoom" />
-    <item
-        android:id="@+id/menu_share"
-        android:icon="@drawable/ic_share_white_24dp"
-        android:title="@string/share_link"
-        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/menu_refresh"
         android:icon="@drawable/ic_refresh_white_24dp"
         android:title="@string/refresh"
-        app:showAsAction="never" />
+        app:iconTint="@color/grey_600"
+        app:showAsAction="always"/>
 </menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2427,7 +2427,7 @@
     <string name="reader_photo_view_desc">photo</string>
     <string name="stats_list_cell_chevron_expand_desc">expand</string>
     <string name="show_more_desc">show more</string>
-    <string name="open_external_link_desc">open external link</string>
+    <string name="open_external_link_desc">Open external link</string>
     <string name="notification_settings_switch_desc">Notifications</string>
     <string name="navigate_up_desc">navigate up</string>
     <string name="stats_list_cell_chevron_collapse_desc">collapse</string>
@@ -2461,10 +2461,10 @@
     <string name="quick_start_completed_tasks_header_chevron_expand_desc">expand</string>
     <string name="quick_start_completed_tasks_header_chevron_collapse_desc">collapse</string>
     <string name="suggestions_updated_content_description">Suggestions updated</string>
-    <string name="navigate_forward_desc">go forward</string>
-    <string name="navigate_back_desc">go back</string>
-    <string name="share_desc">share</string>
-    <string name="preview_type_desc">select preview type</string>
+    <string name="navigate_forward_desc">Go forward</string>
+    <string name="navigate_back_desc">Go back</string>
+    <string name="share_desc">Share</string>
+    <string name="preview_type_desc">Select preview type</string>
 
     <string name="content_description_more">More</string>
     <string name="quick_start_button_negative" tools:ignore="UnusedResources">Not now</string>


### PR DESCRIPTION
This PR moves existing share and external browser buttons into navbar and changes the style of the toolbar.

I also added tooltips for navbar menu items.

[![Image from Gyazo](https://i.gyazo.com/81ae8656353a8506e99c2daafba40b37.gif)](https://gyazo.com/81ae8656353a8506e99c2daafba40b37)

Back and forward buttons show "Go back" and "Go forward" tooltips.

All dimensions in the toolbar and title subtitle colors are standard.

[![Image from Gyazo](https://i.gyazo.com/b35367e660fd0b21bcb50ab2c14e5796.png)](https://gyazo.com/b35367e660fd0b21bcb50ab2c14e5796)



To test:
- Open site Preview.
- Notice that Share and External browser buttons work as expected (same is before).
- Notice white toolbar.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
