### PR TITLE
[GB] - Revert synching editor preference to the backend

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -159,7 +159,6 @@ import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.WPHtml;
 import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.util.WPPermissionUtils;
-import org.wordpress.android.util.WPPrefUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.helpers.MediaFile;
@@ -2286,10 +2285,8 @@ public class EditPostActivity extends AppCompatActivity implements
                         setGutenbergEnabledIfNeeded();
                         String languageString = LocaleManager.getLanguage(EditPostActivity.this);
                         String wpcomLocaleSlug = languageString.replace("_", "-").toLowerCase(Locale.ENGLISH);
-                        WPPrefUtils.setMobileEditorPreferenceToRemote(mDispatcher, mSiteStore);
                         return GutenbergEditorFragment.newInstance("", "", mIsNewPost, wpcomLocaleSlug);
                     } else if (mShowAztecEditor) {
-                        WPPrefUtils.setMobileEditorPreferenceToRemote(mDispatcher, mSiteStore);
                         return AztecEditorFragment.newInstance("", "",
                                                                AppPrefs.isAztecEditorToolbarExpanded());
                     } else if (mShowNewEditor) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -304,7 +304,6 @@ public class AppSettingsFragment extends PreferenceFragment
             AppPrefs.setGutenbergDefaultForNewPosts((Boolean) newValue);
             // we need to refresh metadata as gutenberg_enabled is now part of the user data
             AnalyticsUtils.refreshMetadata(mAccountStore, mSiteStore);
-            WPPrefUtils.setMobileEditorPreferenceToRemote(mDispatcher, mSiteStore);
         } else if (preference == mStripImageLocation) {
             AppPrefs.setStripImageLocation((Boolean) newValue);
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPPrefUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPrefUtils.java
@@ -9,14 +9,6 @@ import android.widget.EditText;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
-import org.wordpress.android.fluxc.Dispatcher;
-import org.wordpress.android.fluxc.generated.SiteActionBuilder;
-import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.store.SiteStore;
-import org.wordpress.android.fluxc.store.SiteStore.DesignateMobileEditorPayload;
-import org.wordpress.android.ui.prefs.AppPrefs;
-
-import java.util.List;
 
 /**
  * Design guidelines for Calypso-styled Site Settings (and likely other screens)
@@ -167,27 +159,5 @@ public class WPPrefUtils {
     public static void setTextViewAttributes(TextView textView, int size, int colorRes) {
         textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, size);
         textView.setTextColor(textView.getResources().getColor(colorRes));
-    }
-
-    public static void setMobileEditorPreferenceToRemote(final Dispatcher dispatcher, final SiteStore siteStore) {
-        final List<SiteModel> sitesAccessedViaWPComRest = siteStore.getSitesAccessedViaWPComRest();
-        final boolean setDelay = sitesAccessedViaWPComRest.size() > 5;
-        final String editorSetting = AppPrefs.isGutenbergDefaultForNewPosts() ? "gutenberg" : "aztec";
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                for (SiteModel currentSite : sitesAccessedViaWPComRest) {
-                    dispatcher.dispatch(SiteActionBuilder.newDesignateMobileEditorAction(
-                            new DesignateMobileEditorPayload(currentSite, editorSetting)));
-                    if (setDelay) {
-                        try {
-                            Thread.sleep(200);
-                        } catch (InterruptedException e) {
-                            // no-op
-                        }
-                    }
-                }
-            }
-        }).start();
     }
 }


### PR DESCRIPTION
This PR reverts https://github.com/wordpress-mobile/WordPress-Android/issues/10192 and stop synching the editor preference to the wpcom backend.

Note: This PR just undoing the setting sync, but still leaving in the auto-defaulting to Gutenberg when a post with blocks is opened in the app. The app-wide preference, that is switched to true,  is only kept locally.


Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
