### PR TITLE
GB - Bump unsupported blocks list to Tracks

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3802,13 +3802,13 @@ public class EditPostActivity extends AppCompatActivity implements
                 ((GutenbergEditorFragment) mEditorFragment).resetUploadingMediaToFailed(mediaIds);
             }
         } else if (mShowAztecEditor && mEditorFragment instanceof AztecEditorFragment) {
-            mPostEditorAnalyticsSession.start(false);
+            mPostEditorAnalyticsSession.start(null);
         }
     }
 
     @Override
-    public void onEditorFragmentContentReady(boolean hasUnsupportedContent) {
-        mPostEditorAnalyticsSession.start(hasUnsupportedContent);
+    public void onEditorFragmentContentReady(ArrayList<Object> unsupportedBlocksList) {
+        mPostEditorAnalyticsSession.start(unsupportedBlocksList);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -80,11 +80,10 @@ public class PostEditorAnalyticsSession implements Serializable {
 
     public void start(ArrayList<Object> unsupportedBlocksList) {
         if (!mStarted) {
-            mHasUnsupportedBlocks = unsupportedBlocksList != null && unsupportedBlocksList.size() > 0;
             Map<String, Object> properties = getCommonProperties();
-            if (unsupportedBlocksList != null && unsupportedBlocksList.size() > 0) {
-                properties.put(KEY_UNSUPPORTED_BLOCKS, unsupportedBlocksList);
-            }
+            mHasUnsupportedBlocks = unsupportedBlocksList != null && unsupportedBlocksList.size() > 0;
+            properties.put(KEY_UNSUPPORTED_BLOCKS,
+                    unsupportedBlocksList != null ? unsupportedBlocksList : new ArrayList<>());
             AnalyticsTracker.track(Stat.EDITOR_SESSION_START, properties);
             mStarted = true;
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -80,8 +80,8 @@ public class PostEditorAnalyticsSession implements Serializable {
 
     public void start(ArrayList<Object> unsupportedBlocksList) {
         if (!mStarted) {
-            Map<String, Object> properties = getCommonProperties();
             mHasUnsupportedBlocks = unsupportedBlocksList != null && unsupportedBlocksList.size() > 0;
+            Map<String, Object> properties = getCommonProperties();
             properties.put(KEY_UNSUPPORTED_BLOCKS,
                     unsupportedBlocksList != null ? unsupportedBlocksList : new ArrayList<>());
             AnalyticsTracker.track(Stat.EDITOR_SESSION_START, properties);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -19,6 +19,7 @@ public class PostEditorAnalyticsSession implements Serializable {
     private static final String KEY_CONTENT_TYPE = "content_type";
     private static final String KEY_EDITOR = "editor";
     private static final String KEY_HAS_UNSUPPORTED_BLOCKS = "has_unsupported_blocks";
+    private static final String KEY_UNSUPPORTED_BLOCKS = "unsupported_blocks";
     private static final String KEY_POST_TYPE = "post_type";
     private static final String KEY_OUTCOME = "outcome";
     private static final String KEY_SESSION_ID = "session_id";
@@ -31,6 +32,7 @@ public class PostEditorAnalyticsSession implements Serializable {
     private Editor mCurrentEditor;
     private boolean mHasUnsupportedBlocks = false;
     private Outcome mOutcome = null;
+    private ArrayList<Object> mUnsupportedBlocks = null;
 
     enum Editor {
         GUTENBERG,
@@ -80,6 +82,7 @@ public class PostEditorAnalyticsSession implements Serializable {
     public void start(ArrayList<Object> unsupportedBlocksList) {
         if (!mStarted) {
             mHasUnsupportedBlocks = unsupportedBlocksList != null && unsupportedBlocksList.size() > 0;
+            mUnsupportedBlocks = unsupportedBlocksList;
             Map<String, Object> properties = getCommonProperties();
             AnalyticsTracker.track(Stat.EDITOR_SESSION_START, properties);
             mStarted = true;
@@ -128,6 +131,9 @@ public class PostEditorAnalyticsSession implements Serializable {
         properties.put(KEY_BLOG_TYPE, mBlogType);
         properties.put(KEY_SESSION_ID, mSessionId);
         properties.put(KEY_HAS_UNSUPPORTED_BLOCKS, mHasUnsupportedBlocks ? "1" : "0");
+        if (mUnsupportedBlocks != null && mUnsupportedBlocks.size() > 0) {
+            properties.put(KEY_UNSUPPORTED_BLOCKS, mUnsupportedBlocks);
+        }
         return properties;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -32,7 +32,6 @@ public class PostEditorAnalyticsSession implements Serializable {
     private Editor mCurrentEditor;
     private boolean mHasUnsupportedBlocks = false;
     private Outcome mOutcome = null;
-    private ArrayList<Object> mUnsupportedBlocks = null;
 
     enum Editor {
         GUTENBERG,
@@ -82,10 +81,9 @@ public class PostEditorAnalyticsSession implements Serializable {
     public void start(ArrayList<Object> unsupportedBlocksList) {
         if (!mStarted) {
             mHasUnsupportedBlocks = unsupportedBlocksList != null && unsupportedBlocksList.size() > 0;
-            mUnsupportedBlocks = unsupportedBlocksList;
             Map<String, Object> properties = getCommonProperties();
-            if (mUnsupportedBlocks != null && mUnsupportedBlocks.size() > 0) {
-                properties.put(KEY_UNSUPPORTED_BLOCKS, mUnsupportedBlocks);
+            if (unsupportedBlocksList != null && unsupportedBlocksList.size() > 0) {
+                properties.put(KEY_UNSUPPORTED_BLOCKS, unsupportedBlocksList);
             }
             AnalyticsTracker.track(Stat.EDITOR_SESSION_START, properties);
             mStarted = true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -84,6 +84,9 @@ public class PostEditorAnalyticsSession implements Serializable {
             mHasUnsupportedBlocks = unsupportedBlocksList != null && unsupportedBlocksList.size() > 0;
             mUnsupportedBlocks = unsupportedBlocksList;
             Map<String, Object> properties = getCommonProperties();
+            if (mUnsupportedBlocks != null && mUnsupportedBlocks.size() > 0) {
+                properties.put(KEY_UNSUPPORTED_BLOCKS, mUnsupportedBlocks);
+            }
             AnalyticsTracker.track(Stat.EDITOR_SESSION_START, properties);
             mStarted = true;
         } else {
@@ -131,9 +134,6 @@ public class PostEditorAnalyticsSession implements Serializable {
         properties.put(KEY_BLOG_TYPE, mBlogType);
         properties.put(KEY_SESSION_ID, mSessionId);
         properties.put(KEY_HAS_UNSUPPORTED_BLOCKS, mHasUnsupportedBlocks ? "1" : "0");
-        if (mUnsupportedBlocks != null && mUnsupportedBlocks.size() > 0) {
-            properties.put(KEY_UNSUPPORTED_BLOCKS, mUnsupportedBlocks);
-        }
         return properties;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -8,6 +8,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -76,9 +77,9 @@ public class PostEditorAnalyticsSession implements Serializable {
         }
     }
 
-    public void start(boolean hasUnsupportedBlocks) {
+    public void start(ArrayList<Object> unsupportedBlocksList) {
         if (!mStarted) {
-            mHasUnsupportedBlocks = hasUnsupportedBlocks;
+            mHasUnsupportedBlocks = unsupportedBlocksList != null && unsupportedBlocksList.size() > 0;
             Map<String, Object> properties = getCommonProperties();
             AnalyticsTracker.track(Stat.EDITOR_SESSION_START, properties);
             mStarted = true;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -181,7 +181,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
      */
     public interface EditorFragmentListener {
         void onEditorFragmentInitialized();
-        void onEditorFragmentContentReady(boolean hasUnsupportedContent);
+        void onEditorFragmentContentReady(ArrayList<Object> unsupportedBlocks);
         void onSettingsClicked();
         void onAddMediaClicked();
         void onAddMediaImageClicked();

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -272,7 +272,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                     @Override
                     public void onEditorDidMount(ArrayList<Object> unsupportedBlocks) {
                         mEditorDidMount = true;
-                        mEditorFragmentListener.onEditorFragmentContentReady(unsupportedBlocks.size() > 0);
+                        mEditorFragmentListener.onEditorFragmentContentReady(unsupportedBlocks);
 
                         // Hide the progress bar when editor is ready
                         new Handler(Looper.getMainLooper()).post(new Runnable() {


### PR DESCRIPTION
This is the Android side of https://github.com/wordpress-mobile/gutenberg-mobile/issues/1174

A new property `unsupported_blocks` is added to the `EDITOR_SESSION_*` events, and it does hold the list of unsupported blocks found in the post.

Note that the new property is just a simple list of String, and can contain more than one instance of the same element, when the same unsupported block type is found more than once in the opened post.
Is it ok @koke ? Or do we need to count the instances of each block and send a map instead?

![Screenshot 2019-07-17 at 11 13 28](https://user-images.githubusercontent.com/518232/61363264-fe2c2980-a883-11e9-8c1b-3aa4b35f6f55.png)

To test:

- Start the app and open a GB post that does contain unsupported blocks
- Wait a bit and go to Tracks live view
- Check the event `wpandroid_editor_session_end` or similar "session" event
- Look at properties and check that `unsupported_blocks` does contain the list of the unsupported blocks found in the post


Note: This PR does target `12.9`

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
