### PR TITLE
Use local post ID in HistoryList to fix TransactionTooLargeException

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -31,13 +31,13 @@ class HistoryListFragment : Fragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
 
     companion object {
-        private const val KEY_POST = "key_post"
+        private const val KEY_POST_LOCAL_ID = "key_post_local_id"
         private const val KEY_SITE = "key_site"
 
         fun newInstance(@NonNull post: PostModel, @NonNull site: SiteModel): HistoryListFragment {
             val fragment = HistoryListFragment()
             val bundle = Bundle()
-            bundle.putSerializable(KEY_POST, post)
+            bundle.putInt(KEY_POST_LOCAL_ID, post.id)
             bundle.putSerializable(KEY_SITE, site)
             fragment.arguments = bundle
             return fragment
@@ -80,18 +80,16 @@ class HistoryListFragment : Fragment() {
         (nonNullActivity.application as WordPress).component()?.inject(this)
 
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(HistoryViewModel::class.java)
-        viewModel.create(arguments?.get(KEY_POST) as PostModel, arguments?.get(KEY_SITE) as SiteModel)
+        viewModel.create(
+                localPostId = arguments?.getInt(KEY_POST_LOCAL_ID) ?: 0,
+                site = arguments?.get(KEY_SITE) as SiteModel
+        )
         updatePostOrPageEmptyView()
         setObservers()
     }
 
     private fun updatePostOrPageEmptyView() {
         actionable_empty_view.title.text = getString(R.string.history_empty_title)
-        actionable_empty_view.subtitle.text = if ((arguments?.get(KEY_POST) as PostModel).isPage) {
-            getString(R.string.history_empty_subtitle_page)
-        } else {
-            getString(R.string.history_empty_subtitle_post)
-        }
         actionable_empty_view.button.visibility = View.GONE
         actionable_empty_view.subtitle.visibility = View.VISIBLE
     }
@@ -149,6 +147,14 @@ class HistoryListFragment : Fragment() {
         viewModel.showDialog.observe(this, Observer {
             if (it is Revision && activity is HistoryItemClickInterface) {
                 (activity as HistoryItemClickInterface).onHistoryItemClicked(it, viewModel.revisionsList)
+            }
+        })
+
+        viewModel.post.observe(this, Observer { post ->
+            actionable_empty_view.subtitle.text = if (post?.isPage == true) {
+                getString(R.string.history_empty_subtitle_page)
+            } else {
+                getString(R.string.history_empty_subtitle_post)
             }
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -93,9 +93,7 @@ class HistoryViewModel @Inject constructor(
             return@launch
         }
 
-        val post: PostModel = withContext(bgDispatcher) {
-            postStore.getPostByLocalPostId(localPostId)
-        } ?: return@launch
+        val post: PostModel? = withContext(bgDispatcher) { postStore.getPostByLocalPostId(localPostId) }
 
         revisionsList = ArrayList()
         _revisions.value = emptyList()
@@ -159,12 +157,17 @@ class HistoryViewModel @Inject constructor(
     }
 
     private fun fetchRevisions() {
-        val post = this.post.value ?: return
+        val post = this.post.value
 
-        _listStatus.value = HistoryListStatus.FETCHING
-        val payload = FetchRevisionsPayload(post, site)
-        launch {
-            dispatcher.dispatch(PostActionBuilder.newFetchRevisionsAction(payload))
+        if (post != null) {
+            _listStatus.value = HistoryListStatus.FETCHING
+            val payload = FetchRevisionsPayload(post, site)
+            launch {
+                dispatcher.dispatch(PostActionBuilder.newFetchRevisionsAction(payload))
+            }
+        } else {
+            _listStatus.value = HistoryListStatus.DONE
+            createRevisionsList(emptyList())
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
@@ -21,6 +22,8 @@ import org.wordpress.android.fluxc.model.revisions.RevisionModel
 import org.wordpress.android.fluxc.store.PostStore.FetchRevisionsPayload
 import org.wordpress.android.fluxc.store.PostStore.OnRevisionsFetched
 import org.wordpress.android.models.Person
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.modules.DEFAULT_SCOPE
 import org.wordpress.android.modules.UI_SCOPE
 import org.wordpress.android.ui.history.HistoryListItem
 import org.wordpress.android.ui.history.HistoryListItem.Revision
@@ -30,6 +33,7 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
+import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus.AVAILABLE
@@ -41,8 +45,9 @@ class HistoryViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val networkUtils: NetworkUtilsWrapper,
     @param:Named(UI_SCOPE) private val uiScope: CoroutineScope,
+    @Named(BG_THREAD) defaultDispatcher: CoroutineDispatcher,
     connectionStatus: LiveData<ConnectionStatus>
-) : ViewModel(), LifecycleOwner {
+) : ScopedViewModel(defaultDispatcher),  LifecycleOwner {
     enum class HistoryListStatus {
         DONE,
         ERROR,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -117,7 +117,10 @@ class HistoryViewModel @Inject constructor(
 
         revisionAuthorsId = ArrayList(revisionAuthorsId.distinct())
         _revisions.value = getHistoryListItemsFromRevisionModels(revisions)
-        fetchRevisionAuthorDetails(revisionAuthorsId)
+
+        if (revisionAuthorsId.isNotEmpty()) {
+            fetchRevisionAuthorDetails(revisionAuthorsId)
+        }
     }
 
     private fun fetchRevisionAuthorDetails(authorsId: List<String>) {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/history/HistoryViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/history/HistoryViewModelTest.kt
@@ -1,0 +1,87 @@
+package org.wordpress.android.viewmodel.history
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.argWhere
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.PostAction
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.fluxc.store.PostStore.FetchRevisionsPayload
+import org.wordpress.android.viewmodel.history.HistoryViewModel.HistoryListStatus
+
+@RunWith(MockitoJUnitRunner::class)
+class HistoryViewModelTest {
+    @get:Rule val rule = InstantTaskExecutorRule()
+
+    private val defaultPost = PostModel().apply {
+        id = 1_569
+    }
+    private val postStore = mock<PostStore> {
+        on { getPostByLocalPostId(eq(defaultPost.id)) } doReturn defaultPost
+    }
+    private val dispatcher = mock<Dispatcher>()
+
+    @Test
+    fun `when started, it will load the post and fetch the revisions`() {
+        // Arrange
+        val viewModel = createHistoryVieWModel()
+
+        assertThat(viewModel.post.value).isNull()
+
+        // Act
+        viewModel.create(localPostId = defaultPost.id, site = SiteModel())
+
+        // Assert
+        assertThat(viewModel.post.value).isEqualTo(defaultPost)
+
+        verify(postStore, times(1)).getPostByLocalPostId(eq(defaultPost.id))
+        verify(dispatcher, times(1)).dispatch(argWhere {
+            it.type == PostAction.FETCH_REVISIONS &&
+                    it.payload is FetchRevisionsPayload &&
+                    (it.payload as FetchRevisionsPayload).post === defaultPost
+        })
+
+        assertThat(viewModel.listStatus.value).isEqualTo(HistoryListStatus.FETCHING)
+    }
+
+    @Test
+    fun `when the post cannot be loaded, it will show an empty list`() {
+        // Arrange
+        val viewModel = createHistoryVieWModel()
+        val invalidPostLocalId = 9_014_134
+
+        // Act
+        viewModel.create(localPostId = invalidPostLocalId, site = SiteModel())
+
+        // Assert
+        verify(postStore, times(1)).getPostByLocalPostId(eq(invalidPostLocalId))
+
+        assertThat(viewModel.post.value).isNull()
+        assertThat(viewModel.revisions.value).isEmpty()
+        assertThat(viewModel.listStatus.value).isEqualTo(HistoryListStatus.DONE)
+    }
+
+    @UseExperimental(ExperimentalCoroutinesApi::class)
+    private fun createHistoryVieWModel() = HistoryViewModel(
+            dispatcher = dispatcher,
+            resourceProvider = mock(),
+            networkUtils = mock(),
+            postStore = postStore,
+            uiDispatcher = Dispatchers.Unconfined,
+            bgDispatcher = Dispatchers.Unconfined,
+            connectionStatus = mock()
+    )
+}


### PR DESCRIPTION
Fixes #9685 and #5456.

## Findings

When I edit a post with 300K words and put the app to the background, the app will consistently crash.

Using [toolargetool](https://github.com/guardian/toolargetool), I found that the `EditPostActivity`'s `Bundle` grows as the `PostModel` contents grows. At 2000 words:

```
2019-07-16 12:52:01.792 32319-32319/org.wordpress.android D/TooLargeTool: EditPostActivity.onSaveInstanceState wrote: Bundle161877096 contains 16 keys and measures 38.3 KB when serialized as a Parcel
    * stateKeyDroppedMediaUri = 0.1 KB
    * android:viewHierarchyState = 1.0 KB
    * stateKeyRevision = 0.0 KB
    * android:support:fragments = 33.7 KB
	...
```

At 5000 words:

```
2019-07-16 12:52:54.698 32319-32319/org.wordpress.android D/TooLargeTool: EditPostActivity.onSaveInstanceState wrote: Bundle106500119 contains 16 keys and measures 58.7 KB when serialized as a Parcel
    * stateKeyDroppedMediaUri = 0.1 KB
    * android:viewHierarchyState = 1.0 KB
    * stateKeyRevision = 0.0 KB
    * android:support:fragments = 54.1 KB
	...
```

I honed in on the `android:support:fragments` which grows similarly. Digging deeper, I found that `HistoryListFragment` bundles a `key_post` object which is a `PostModel`. At 2000 words:

```
2019-07-16 12:52:02.058 32319-32319/org.wordpress.android D/TooLargeTool: HistoryListFragment.onSaveInstanceState wrote: Bundle27877272 contains 3 keys and measures 2.8 KB when serialized as a Parcel
    * SITE = 1.9 KB
    * android:user_visible_hint = 0.1 KB
    * android:view_state = 0.9 KB
    * fragment arguments = Bundle57837811 contains 2 keys and measures 16.6 KB when serialized as a Parcel
    * key_post = 14.7 KB
    * key_site = 1.9 KB
```

And at 5000 words:

```
2019-07-16 12:52:54.838 32319-32319/org.wordpress.android D/TooLargeTool: HistoryListFragment.onSaveInstanceState wrote: Bundle148956272 contains 3 keys and measures 2.8 KB when serialized as a Parcel
    * SITE = 1.9 KB
    * android:user_visible_hint = 0.1 KB
    * android:view_state = 0.9 KB
    * fragment arguments = Bundle231264648 contains 2 keys and measures 36.9 KB when serialized as a Parcel
    * key_post = 35.1 KB
    * key_site = 1.9 KB
```

If the post contents is even bigger, we would hit the `Bundle` size limit. 

## Solution

This PR changes the `HistoryListFragment` so it will only accept a local post ID and it handles the loading of the `PostModel` itself in the background. When the state is saved, only the local post ID will be saved. The `EditPostActivity` `android:support:fragments` object no longer grows and stays at about `19.1KB`.

Editing the post with 300K words no longer crashes. It takes 5 seconds to load like always but that is currently not the focus of this fix. I tested this with a post that has a lot of images and embedded Youtube videos and I have not observed any crashes.

### Other Changes

Since the `HistoryListFragment` now only has the local post id, I added a simple routine for the unlikely scenario where the `PostModel` cannot be loaded. The history page will show an empty view.

## Testing

### History List

Please do a regression test for the revision history like:

- Loading the list while online or offline
- Viewing a revision
- Restoring a revision
- Reloading the list when the device is back online
- Swiping to refresh

All the existing features should still work without problems.

### TransactionTooLargeException 

Please also test if you will still receive a `TransactionTooLargeException` crash after this change. There are reproduction steps in the linked issues like:

- https://github.com/wordpress-mobile/WordPress-Android/issues/9685#issuecomment-499279610
- https://github.com/wordpress-mobile/WordPress-Android/issues/9685#issuecomment-493581306

I found that the most consistent way I will receive the crash is:

1. Create a post with a very big content in the Web.
2. On the device, enable Developer → Don't keep activities.
3. Edit the post.
4. Put the app in the background.

The crash happens after this.

## Reviewing

Only 1 reviewer is needed but anyone can review.

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.
