### PR TITLE
Fixed VM context and empty field focus issue.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -432,7 +432,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
 
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
             if (targetFragment == null) {
-                throw IllegalStateException("CountryPickerDialogFragment is missing a targetFragment ")
+                throw IllegalStateException("StatePickerDialogFragment is missing a targetFragment ")
             }
 
             viewModel = ViewModelProviders.of(targetFragment!!, viewModelFactory)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -86,7 +86,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
 
         mainViewModel = ViewModelProviders.of(activity!!, viewModelFactory)
                 .get(DomainRegistrationMainViewModel::class.java)
-        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get(DomainRegistrationDetailsViewModel::class.java)
         setupObservers()
 
@@ -431,7 +431,11 @@ class DomainRegistrationDetailsFragment : Fragment() {
         }
 
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-            viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+            if (targetFragment == null) {
+                throw IllegalStateException("CountryPickerDialogFragment is missing a targetFragment ")
+            }
+            
+            viewModel = ViewModelProviders.of(targetFragment!!, viewModelFactory)
                     .get(DomainRegistrationDetailsViewModel::class.java)
             val builder = AlertDialog.Builder(requireContext())
             builder.setTitle(R.string.domain_registration_state_picker_dialog_title)
@@ -477,7 +481,11 @@ class DomainRegistrationDetailsFragment : Fragment() {
         }
 
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-            viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+            if (targetFragment == null) {
+                throw IllegalStateException("CountryPickerDialogFragment is missing a targetFragment ")
+            }
+
+            viewModel = ViewModelProviders.of(targetFragment!!, viewModelFactory)
                     .get(DomainRegistrationDetailsViewModel::class.java)
             val builder = AlertDialog.Builder(requireContext())
             builder.setTitle(R.string.domain_registration_country_picker_dialog_title)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -86,7 +86,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
 
         mainViewModel = ViewModelProviders.of(activity!!, viewModelFactory)
                 .get(DomainRegistrationMainViewModel::class.java)
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
                 .get(DomainRegistrationDetailsViewModel::class.java)
         setupObservers()
 
@@ -293,14 +293,22 @@ class DomainRegistrationDetailsFragment : Fragment() {
                 country_input, address_first_line_input, city_input, postal_code_input
         )
 
+        var fieldToFocusOn: TextInputEditText? = null
+
         requiredFields.forEach {
             if (TextUtils.isEmpty(it.text)) {
+                if (fieldToFocusOn == null) {
+                    fieldToFocusOn = it
+                }
                 showEmptyFieldError(it)
                 if (formIsCompleted) {
                     formIsCompleted = false
                 }
             }
         }
+
+        // focusing on first empty field
+        fieldToFocusOn?.requestFocus()
 
         return formIsCompleted
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -434,7 +434,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
             if (targetFragment == null) {
                 throw IllegalStateException("CountryPickerDialogFragment is missing a targetFragment ")
             }
-            
+
             viewModel = ViewModelProviders.of(targetFragment!!, viewModelFactory)
                     .get(DomainRegistrationDetailsViewModel::class.java)
             val builder = AlertDialog.Builder(requireContext())


### PR DESCRIPTION
Fixes #10242
Fixes #10241

Fixing provider of domain registration ViewModel and adding focusing for empty fields.

To test:
- Switch to a site with unredeemed domain credit.
- Tap on domain registration CTA, pick a domain name and proceed to domain contact details forms.
- Make sure country and state selectors are working (selected country or state is reflected in form).
- Clear "First Name" field, scroll to the bottom of the form and make sure soft keyboard is visible (tap on postal code field, for example).
- Press "Register Domain" button, and notice that form is focused on "First Name" field and error is displayed.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
