### PR TITLE
Feature/allow preview mode switch for site preview and posts view only

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -471,14 +471,15 @@ public class ActivityLauncher {
             String siteUrl = site.getUrl();
             if (site.isWPCom()) {
                 // Show wp.com sites authenticated
-                WPWebViewActivity.openUrlByUsingGlobalWPCOMCredentials(context, siteUrl);
+                WPWebViewActivity.openUrlByUsingGlobalWPCOMCredentials(context, siteUrl, true);
             } else if (!TextUtils.isEmpty(site.getUsername()) && !TextUtils.isEmpty(site.getPassword())) {
                 // Show self-hosted sites as authenticated since we should have the username & password
-                WPWebViewActivity.openUrlByUsingBlogCredentials(context, site, null, siteUrl, new String[]{}, false);
+                WPWebViewActivity
+                        .openUrlByUsingBlogCredentials(context, site, null, siteUrl, new String[]{}, false, true);
             } else {
                 // Show non-wp.com sites without a password unauthenticated. These would be Jetpack sites that are
                 // connected through REST API.
-                WPWebViewActivity.openURL(context, siteUrl);
+                WPWebViewActivity.openURL(context, siteUrl, true);
             }
         }
     }
@@ -582,10 +583,10 @@ public class ActivityLauncher {
         String shareableUrl = post.getLink();
         String shareSubject = post.getTitle();
         if (site.isWPCom()) {
-            WPWebViewActivity.openPostUrlByUsingGlobalWPCOMCredentials(context, url, shareableUrl, shareSubject);
+            WPWebViewActivity.openPostUrlByUsingGlobalWPCOMCredentials(context, url, shareableUrl, shareSubject, true);
         } else if (site.isJetpackConnected()) {
             WPWebViewActivity
-                    .openJetpackBlogPostPreview(context, url, shareableUrl, shareSubject, site.getFrameNonce());
+                    .openJetpackBlogPostPreview(context, url, shareableUrl, shareSubject, site.getFrameNonce(), true);
         } else {
             // Add the original post URL to the list of allowed URLs.
             // This is necessary because links are disabled in the webview, but WP removes "?preview=true"
@@ -593,7 +594,7 @@ public class ActivityLauncher {
             // permalink structure settings.
             // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/4873
             WPWebViewActivity
-                    .openUrlByUsingBlogCredentials(context, site, post, url, new String[]{post.getLink()}, true);
+                    .openUrlByUsingBlogCredentials(context, site, post, url, new String[]{post.getLink()}, true, true);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionWebViewActivity.java
@@ -81,6 +81,7 @@ public class JetpackConnectionWebViewActivity extends WPWebViewActivity
         mSource = (JetpackConnectionSource) getIntent().getSerializableExtra(TRACKING_SOURCE_KEY);
         // We need to get the site before calling super since it'll create the web client
         super.onCreate(savedInstanceState);
+        toggleNavbarVisibility(false);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -287,20 +287,27 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
         openWPCOMURL(context, url, null, null, false);
     }
 
-    public static void openUrlByUsingGlobalWPCOMCredentials(Context context, String url,
+    public static void openUrlByUsingGlobalWPCOMCredentials(Context context,
+                                                            String url,
                                                             boolean allowPreviewModeSelection) {
         openWPCOMURL(context, url, null, null, allowPreviewModeSelection);
     }
 
-    public static void openPostUrlByUsingGlobalWPCOMCredentials(Context context, String url, String shareableUrl,
+    public static void openPostUrlByUsingGlobalWPCOMCredentials(Context context,
+                                                                String url,
+                                                                String shareableUrl,
                                                                 String shareSubject,
                                                                 boolean allowPreviewModeSelection) {
         openWPCOMURL(context, url, shareableUrl, shareSubject, allowPreviewModeSelection);
     }
 
     // frameNonce is used to show drafts, without it "no page found" error would be thrown
-    public static void openJetpackBlogPostPreview(Context context, String url, String shareableUrl, String shareSubject,
-                                                  String frameNonce, boolean allowPreviewModeSelection) {
+    public static void openJetpackBlogPostPreview(Context context,
+                                                  String url,
+                                                  String shareableUrl,
+                                                  String shareSubject,
+                                                  String frameNonce,
+                                                  boolean allowPreviewModeSelection) {
         if (!TextUtils.isEmpty(frameNonce)) {
             url += "&frame-nonce=" + UrlUtils.urlEncode(frameNonce);
         }
@@ -318,8 +325,12 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
     }
 
     // Note: The webview has links disabled (excepted for urls in the whitelist: listOfAllowedURLs)
-    public static void openUrlByUsingBlogCredentials(Context context, SiteModel site, PostModel post, String url,
-                                                     String[] listOfAllowedURLs, boolean disableLinks,
+    public static void openUrlByUsingBlogCredentials(Context context,
+                                                     SiteModel site,
+                                                     PostModel post,
+                                                     String url,
+                                                     String[] listOfAllowedURLs,
+                                                     boolean disableLinks,
                                                      boolean allowPreviewModeSelection) {
         if (context == null) {
             AppLog.e(AppLog.T.UTILS, "Context is null");

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
@@ -43,6 +43,7 @@ public class ThemeWebActivity extends WPWebViewActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setActionBarTitleToThemeName();
+        toggleNavbarVisibility(false);
     }
 
     public static String getSiteLoginUrl(SiteModel site) {

--- a/WordPress/src/main/res/layout/wpwebview_activity.xml
+++ b/WordPress/src/main/res/layout/wpwebview_activity.xml
@@ -28,57 +28,62 @@
             android:id="@+id/webView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_above="@+id/divider"
+            android:layout_above="@+id/navbar_container"
             android:layout_alignParentTop="true"/>
 
-        <View
-            android:id="@+id/divider"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/list_divider_height"
-            android:layout_above="@+id/navbar"
-            android:background="@color/neutral_100"/>
-
         <LinearLayout
-            android:id="@+id/navbar"
+            android:id="@+id/navbar_container"
             android:layout_width="match_parent"
-            android:layout_height="@dimen/web_preview_navbar_height"
+            android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
-            android:background="@color/white"
-            android:orientation="horizontal"
-            android:weightSum="100">
+            android:orientation="vertical">
 
-            <ImageButton
-                android:id="@+id/back_button"
-                style="@style/WebPreviewNavbarButton"
-                android:contentDescription="@string/navigate_back_desc"
-                android:src="@drawable/ic_arrow_left_white_24dp"/>
+            <View
+                android:id="@+id/divider"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/list_divider_height"
+                android:background="@color/neutral_100"/>
 
-            <ImageButton
-                android:id="@+id/forward_button"
-                style="@style/WebPreviewNavbarButton"
-                android:contentDescription="@string/navigate_forward_desc"
-                android:src="@drawable/ic_arrow_right_white_24dp"/>
+            <LinearLayout
+                android:id="@+id/navbar"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/web_preview_navbar_height"
+                android:background="@color/white"
+                android:orientation="horizontal"
+                android:weightSum="100">
 
-            <ImageButton
-                android:id="@+id/share_button"
-                style="@style/WebPreviewNavbarButton"
-                android:contentDescription="@string/share_desc"
-                android:src="@drawable/ic_share_white_24dp"/>
+                <ImageButton
+                    android:id="@+id/back_button"
+                    style="@style/WebPreviewNavbarButton"
+                    android:contentDescription="@string/navigate_back_desc"
+                    android:src="@drawable/ic_arrow_left_white_24dp"/>
 
-            <ImageButton
-                android:id="@+id/external_browser_button"
-                style="@style/WebPreviewNavbarButton"
-                android:contentDescription="@string/open_external_link_desc"
-                android:src="@drawable/ic_globe_white_24dp"/>
+                <ImageButton
+                    android:id="@+id/forward_button"
+                    style="@style/WebPreviewNavbarButton"
+                    android:contentDescription="@string/navigate_forward_desc"
+                    android:src="@drawable/ic_arrow_right_white_24dp"/>
 
-            <ImageButton
-                android:id="@+id/preview_type_selector_button"
-                style="@style/WebPreviewNavbarButton"
-                android:contentDescription="@string/preview_type_desc"
-                android:src="@drawable/ic_devices_white_24dp"/>
+                <ImageButton
+                    android:id="@+id/share_button"
+                    style="@style/WebPreviewNavbarButton"
+                    android:contentDescription="@string/share_desc"
+                    android:src="@drawable/ic_share_white_24dp"/>
 
+                <ImageButton
+                    android:id="@+id/external_browser_button"
+                    style="@style/WebPreviewNavbarButton"
+                    android:contentDescription="@string/open_external_link_desc"
+                    android:src="@drawable/ic_globe_white_24dp"/>
+
+                <ImageButton
+                    android:id="@+id/preview_type_selector_button"
+                    style="@style/WebPreviewNavbarButton"
+                    android:contentDescription="@string/preview_type_desc"
+                    android:src="@drawable/ic_devices_white_24dp"/>
+
+            </LinearLayout>
         </LinearLayout>
-
     </RelativeLayout>
 
     <org.wordpress.android.ui.ActionableEmptyView
@@ -92,7 +97,7 @@
         app:aevImage="@drawable/img_illustration_cloud_off_152dp"
         app:aevSubtitle="@string/error_network_connection"
         app:aevTitle="@string/error_browser_no_network"
-        tools:visibility="visible">
+        tools:visibility="gone">
     </org.wordpress.android.ui.ActionableEmptyView>
 
     <ProgressBar


### PR DESCRIPTION
This PR limits the preview mode swithc to Site Preview and Post View cases.

For the rest of the cases navbar will either be invisible (existing use cases like Theme Preview and Jetpack connect) or show only 4 items, like this:

Having a bunch of overloads for methods like `openUrlByUsingGlobalWPCOMCredentials` is not the most elegant solution, and I'm open to suggestions :)

[![Image from Gyazo](https://i.gyazo.com/7ae809d5dd3d273e0601684a42935434.png)](https://gyazo.com/7ae809d5dd3d273e0601684a42935434)

To test 1:
- While being logged out from wordpress.com add a self-hosted site without Jetpack. Navigate to stats and proceed to Jetpack connection flow.
- Observe the webpage that prompts you to login with wordpress.com credentials.
- Notice that there is no bottom navbar.

To test 2:
- Navigate to Themes screen, and tap on any non-active theme to navigate to Theme Preview.
- Notice that there is no bottom navbar.

To test 3:
- Navigate to Reader, and tap on the "Visit" link at the Post Card.
- Notice that there is navbar, but preview mode switch is not visible.

To test 4:
- Navigate to Post list, and tap on the "View" link of any remote post.
- Notice that there is navbar, and the preview mode switch is visible.

To test 5:
- Navigate to MySite fragment, and open site preview by tapping on the site title or using "View site" button.
- Notice that there is navbar, and the preview mode switch is visible.

Any other places where we open WPWebViewActivity?

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
