### PR TITLE
Remove newPushedPost dispatch (should only exist on FluxC's side)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -50,7 +50,6 @@ import androidx.viewpager.widget.ViewPager;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.JavaScriptException;
 import org.wordpress.android.R;
@@ -4155,14 +4154,11 @@ public class EditPostActivity extends AppCompatActivity implements
                 AppLog.e(AppLog.T.POSTS, "UPDATE_POST failed: " + event.error.type + " - " + event.error.message);
             }
         } else if (event.causeOfChange instanceof CauseOfOnPostChanged.RemoteAutoSavePost) {
-            if (!event.isError()) {
-                mPost = mPostStore.getPostByLocalPostId(mPost.getId());
-            } else {
+            if (event.isError()) {
                 AppLog.e(T.POSTS, "REMOTE_AUTO_SAVE_POST failed: " + event.error.type + " - " + event.error.message);
-                updatePostLoadingAndDialogState(PostLoadingState.REMOTE_AUTO_SAVE_PREVIEW_ERROR, mPost);
             }
-            RemotePostPayload payload = new RemotePostPayload(mPost, mSite);
-            mDispatcher.dispatch(UploadActionBuilder.newPushedPostAction(payload));
+            mPost = mPostStore.getPostByLocalPostId(mPost.getId());
+            handleRemoteAutoSave(event.isError(), mPost);
         }
     }
 
@@ -4178,16 +4174,37 @@ public class EditPostActivity extends AppCompatActivity implements
                 || mPostLoadingState == PostLoadingState.REMOTE_AUTO_SAVING_FOR_PREVIEW;
     }
 
-    private void updatePostOnSuccessfulUpload(@NotNull OnPostUploaded event, PostModel post) {
-        if (!event.isError()) {
-            mPost = post;
-            mIsNewPost = false;
-            invalidateOptionsMenu();
-        }
+    private void updatePostOnSuccessfulUpload(PostModel post) {
+        mPost = post;
+        mIsNewPost = false;
+        invalidateOptionsMenu();
     }
 
     private boolean isRemoteAutoSaveError() {
         return mPostLoadingState == PostLoadingState.REMOTE_AUTO_SAVE_PREVIEW_ERROR;
+    }
+
+    private void handleRemoteAutoSave(boolean isError, PostModel post) {
+        // We are in the process of remote previewing a post from the editor
+        if (!isError && isUploadingPostForPreview()) {
+            // We were uploading post for preview and we got no error:
+            // update post status and preview it in the internal browser
+            updatePostOnSuccessfulUpload(post);
+            ActivityLauncher.previewPostOrPageForResult(
+                    EditPostActivity.this,
+                    mSite,
+                    post,
+                    mPostLoadingState == PostLoadingState.UPLOADING_FOR_PREVIEW
+                            ? RemotePreviewLogicHelper.RemotePreviewType.REMOTE_PREVIEW
+                            : RemotePreviewLogicHelper.RemotePreviewType.REMOTE_PREVIEW_WITH_REMOTE_AUTO_SAVE
+                                                       );
+            updatePostLoadingAndDialogState(PostLoadingState.PREVIEWING, mPost);
+        } else if (isError || isRemoteAutoSaveError()) {
+            // We got an error from the uploading or from the remote auto save of a post: show snackbar error
+            updatePostLoadingAndDialogState(PostLoadingState.NONE);
+            UploadUtils.showSnackbarError(findViewById(R.id.editor_activity),
+                    getString(R.string.remote_preview_operation_error));
+        }
     }
 
     @SuppressWarnings("unused")
@@ -4200,28 +4217,11 @@ public class EditPostActivity extends AppCompatActivity implements
                 View snackbarAttachView = findViewById(R.id.editor_activity);
                 UploadUtils.onPostUploadedSnackbarHandler(this, snackbarAttachView, event.isError(), post,
                         event.isError() ? event.error.message : null, getSite(), mDispatcher);
-                updatePostOnSuccessfulUpload(event, post);
-            } else {
-                // We are in the process of remote previewing a post from the editor
-                if (!event.isError() && isUploadingPostForPreview()) {
-                    // We were uploading post for preview and we got no error:
-                    // update post status and preview it in the internal browser
-                    updatePostOnSuccessfulUpload(event, post);
-                    ActivityLauncher.previewPostOrPageForResult(
-                            EditPostActivity.this,
-                            mSite,
-                            post,
-                            mPostLoadingState == PostLoadingState.UPLOADING_FOR_PREVIEW
-                                    ? RemotePreviewLogicHelper.RemotePreviewType.REMOTE_PREVIEW
-                                    : RemotePreviewLogicHelper.RemotePreviewType.REMOTE_PREVIEW_WITH_REMOTE_AUTO_SAVE
-                            );
-                    updatePostLoadingAndDialogState(PostLoadingState.PREVIEWING, mPost);
-                } else if (event.isError() || isRemoteAutoSaveError()) {
-                    // We got an error from the uploading or from the remote auto save of a post: show snackbar error
-                    updatePostLoadingAndDialogState(PostLoadingState.NONE);
-                    UploadUtils.showSnackbarError(findViewById(R.id.editor_activity),
-                            getString(R.string.remote_preview_operation_error));
+                if (!event.isError()) {
+                    updatePostOnSuccessfulUpload(post);
                 }
+            } else {
+                handleRemoteAutoSave(event.isError(), post);
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -638,7 +638,6 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN, priority = 9)
     public void onPostChanged(OnPostChanged event) {
-        AppLog.e(T.API, "causeOfChange: " + event.causeOfChange);
         if (event.causeOfChange instanceof CauseOfOnPostChanged.RemoteAutoSavePost) {
             int postLocalId = ((RemoteAutoSavePost) event.causeOfChange).getLocalPostId();
             PostModel post = mPostStore.getPostByLocalPostId(postLocalId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -20,6 +20,8 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
+import org.wordpress.android.fluxc.model.CauseOfOnPostChanged;
+import org.wordpress.android.fluxc.model.CauseOfOnPostChanged.RemoteAutoSavePost;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.PostModel;
@@ -28,6 +30,8 @@ import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.MediaStore.UploadMediaPayload;
+import org.wordpress.android.fluxc.store.PostStore;
+import org.wordpress.android.fluxc.store.PostStore.OnPostChanged;
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
 import org.wordpress.android.fluxc.store.SiteStore;
@@ -73,6 +77,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
 
     @Inject Dispatcher mDispatcher;
     @Inject SiteStore mSiteStore;
+    @Inject PostStore mPostStore;
     @Inject MediaStore mMediaStore;
     @Inject UiHelpers mUiHelpers;
 
@@ -628,6 +633,21 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
         }
 
         finishUpload();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN, priority = 9)
+    public void onPostChanged(OnPostChanged event) {
+        AppLog.e(T.API, "causeOfChange: " + event.causeOfChange);
+        if (event.causeOfChange instanceof CauseOfOnPostChanged.RemoteAutoSavePost) {
+            int postLocalId = ((RemoteAutoSavePost) event.causeOfChange).getLocalPostId();
+            PostModel post = mPostStore.getPostByLocalPostId(postLocalId);
+            SiteModel site = mSiteStore.getSiteByLocalId(post.getLocalSiteId());
+            sShouldRemoteAutoSavePosts.remove(postLocalId);
+            mPostUploadNotifier.incrementUploadedPostCountFromForegroundNotification(post);
+            mPostUploadNotifier.updateNotificationSuccessForPost(post, site, false);
+            finishUpload();
+        }
     }
 
     /**


### PR DESCRIPTION
I didn't realize `newPushedPostAction` was dispatched on the wpandroid side and we should not do this. I updated the code to handle remote auto saves for preview in the actual `onPostChanged` event without triggering `newPushedPostAction`.

This was used as a trick to trigger the `OnPostUploaded` event and use the same code path for upload (drafts) and remote-autove (published posts).

cc @malinajirka as we discussed implication of which event to fire on remote auto save response.