### PR TITLE
Replace "GENERIC_ERROR" with "Couldn't perform operation"

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -27,7 +27,8 @@ import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.utils.UiString;
 import org.wordpress.android.ui.utils.UiString.UiStringRes;
-import org.wordpress.android.ui.utils.UiString.UiStringText;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -81,9 +82,8 @@ public class UploadUtils {
             case INVALID_RESPONSE:
             case GENERIC_ERROR:
             default:
-                // In case of a generic or uncaught error, return the message from the API response or the error type
-                return TextUtils.isEmpty(error.message) ? new UiStringText(error.type.toString())
-                        : new UiStringText(error.message);
+                AppLog.w(T.MAIN, "Error message: " + error.message + " ,Error Type: " + error.type);
+                return new UiStringRes(R.string.error_generic_error);
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.fluxc.store.PostStore.PostErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.UploadStore.UploadError
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
 import org.wordpress.android.widgets.PostListButtonType
 
@@ -166,12 +165,12 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `error uploading post label shown when the post upload fails`() {
+    fun `generic error message shown when upload fails from unknown reason`() {
         val errorMsg = "testing error message"
         val state = createPostListItemUiState(
                 uploadStatus = createUploadStatus(uploadError = UploadError(PostError(GENERIC_ERROR, errorMsg)))
         )
-        assertThat(state.data.statuses).contains(UiStringText(errorMsg))
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.error_generic_error))
     }
 
     @Test


### PR DESCRIPTION
Fixes #10200

This PR replace "GENERIC_ERROR" label with a more user friendly "Couldn't perform operation" label.

To test:
1. Publish a post
2. Turn on airplane mode before the upload finishes
3. Notice the "Couldn't perform operation" label is shown

Update release notes:

- the change is too minor

|  
![Screenshot_1563447894](https://user-images.githubusercontent.com/2261188/61452682-a57c8f80-a95c-11e9-828f-02380d7a4938.png) |  ![Screenshot_1563447805](https://user-images.githubusercontent.com/2261188/61452684-a6adbc80-a95c-11e9-862e-8ad88da90755.png) |
|---|---|



