### PR TITLE
Reintroduce 64 bit support

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -50,10 +50,6 @@ android {
 
         multiDexEnabled true
 
-        ndk {
-            abiFilters 'armeabi-v7a', 'x86'
-        }
-
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'org.wordpress.android.WordPressTestRunner'
 


### PR DESCRIPTION
During the Gutenberg integration, we added this `build.gradle` entry to build the app for 32 bit only due to a React Native limitation. React Native added support for 64 bit in [0.59](https://facebook.github.io/react-native/blog/2019/03/12/releasing-react-native-059) and since we have since updated React Native, we can remove the restriction.

This is particularly timely since all apps published on Google Play will [need to support 64 bit from August 1st](https://developer.android.com/distribute/best-practices/develop/64-bit).

To test:

- Build the app bundle and apk: `bundle exec fastlane build_beta`.
- Unzip the universal apk: `unzip build/wpandroid-12.9-rc-2-universal.apk -d build/wpandroid-12.9-rc-2-universal`.
- Run `ls build/wpandroid-12.9-rc-2-universal/lib` and see that the output contains 32 and 64 bit libraries (it should be `arm64-v8a armeabi-v7a x86 x86_64`).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
