### PR TITLE
Post scheduling tests

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 12.9
 -----
+* Add Publish screen to Edit post settings - with notification for scheduled posts and option to add event to calendar
  
 12.8
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
@@ -108,17 +108,6 @@ class EditPostPublishSettingsViewModel
         }
     }
 
-    private fun getCurrentPublishDateAsCalendar(postModel: PostModel): Calendar {
-        val calendar = localeManagerWrapper.getCurrentCalendar()
-        val dateCreated = postModel.dateCreated
-        // Set the currently selected time if available
-        if (!TextUtils.isEmpty(dateCreated)) {
-            calendar.time = DateTimeUtils.dateFromIso8601(dateCreated)
-            calendar.timeZone = localeManagerWrapper.getTimeZone()
-        }
-        return calendar
-    }
-
     fun updatePost(updatedDate: Calendar, post: PostModel?) {
         post?.let {
             post.dateCreated = DateTimeUtils.iso8601FromDate(updatedDate.time)
@@ -184,6 +173,28 @@ class EditPostPublishSettingsViewModel
         updateUiModel(post)
     }
 
+    fun onAddToCalendar(post: PostModel) {
+        val startTime = DateTimeUtils.dateFromIso8601(post.dateCreated).time
+        val site = siteStore.getSiteByLocalId(post.localSiteId)
+        val title = resourceProvider.getString(
+                R.string.calendar_scheduled_post_title,
+                post.title,
+                site.name ?: site.url
+        )
+        _onAddToCalendar.value = Event(CalendarEvent(title, startTime))
+    }
+
+    private fun getCurrentPublishDateAsCalendar(postModel: PostModel): Calendar {
+        val calendar = localeManagerWrapper.getCurrentCalendar()
+        val dateCreated = postModel.dateCreated
+        // Set the currently selected time if available
+        if (!TextUtils.isEmpty(dateCreated)) {
+            calendar.time = DateTimeUtils.dateFromIso8601(dateCreated)
+            calendar.timeZone = localeManagerWrapper.getTimeZone()
+        }
+        return calendar
+    }
+
     private fun updateNotifications(
         post: PostModel,
         schedulingReminderPeriod: SchedulingReminderModel.Period = OFF
@@ -224,17 +235,6 @@ class EditPostPublishSettingsViewModel
             TEN_MINUTES -> R.string.post_notification_ten_minutes_before
             WHEN_PUBLISHED -> R.string.post_notification_when_published
         }
-    }
-
-    fun onAddToCalendar(post: PostModel) {
-        val startTime = DateTimeUtils.dateFromIso8601(post.dateCreated).time
-        val site = siteStore.getSiteByLocalId(post.localSiteId)
-        val title = resourceProvider.getString(
-                R.string.calendar_scheduled_post_title,
-                post.title,
-                site.name ?: site.url
-        )
-        _onAddToCalendar.value = Event(CalendarEvent(title, startTime))
     }
 
     data class PublishUiModel(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishNotificationReceiver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishNotificationReceiver.kt
@@ -7,57 +7,25 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
-import org.wordpress.android.fluxc.model.post.PostStatus
-import org.wordpress.android.fluxc.model.post.PostStatus.SCHEDULED
-import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore
-import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.OFF
-import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.ONE_HOUR
-import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.TEN_MINUTES
-import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.WHEN_PUBLISHED
-import org.wordpress.android.fluxc.store.PostStore
-import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
 class PublishNotificationReceiver : BroadcastReceiver() {
-    @Inject lateinit var postSchedulingNotificationStore: PostSchedulingNotificationStore
-    @Inject lateinit var postStore: PostStore
-    @Inject lateinit var resourceProvider: ResourceProvider
+    @Inject lateinit var publishNotificationReceiverViewModel: PublishNotificationReceiverViewModel
     override fun onReceive(context: Context, intent: Intent) {
         (context.applicationContext as WordPress).component().inject(this)
         val notificationId = intent.getIntExtra(NOTIFICATION_ID, 0)
-        postSchedulingNotificationStore.getSchedulingReminder(notificationId)?.let { notification ->
-            postStore.getPostByLocalPostId(notification.postId)?.let { post ->
-                val postStatus = PostStatus.fromPost(post)
-                if (postStatus == SCHEDULED) {
-                    val (titleRes, messageRes) = when (notification.scheduledTime) {
-                        ONE_HOUR -> Pair(
-                                R.string.notification_scheduled_post_one_hour_reminder,
-                                R.string.notification_post_will_be_published_in_one_hour
-                        )
-                        TEN_MINUTES -> Pair(
-                                R.string.notification_scheduled_post_ten_minute_reminder,
-                                R.string.notification_post_will_be_published_in_ten_minutes
-                        )
-                        WHEN_PUBLISHED -> Pair(
-                                R.string.notification_scheduled_post,
-                                R.string.notification_post_has_been_published
-                        )
-                        OFF -> return
-                    }
-                    val title = resourceProvider.getString(titleRes)
-                    val message = resourceProvider.getString(messageRes, post.title)
-                    val notificationCompat = NotificationCompat.Builder(
-                            context,
-                            context.getString(R.string.notification_channel_reminder_id)
-                    )
-                            .setContentTitle(title)
-                            .setContentText(message)
-                            .setAutoCancel(true)
-                            .setSmallIcon(R.drawable.ic_my_sites_white_24dp)
-                            .build()
-                    NotificationManagerCompat.from(context).notify(notificationId, notificationCompat)
-                }
-            }
+        val uiModel = publishNotificationReceiverViewModel.loadNotification(notificationId)
+        if (uiModel != null) {
+            val notificationCompat = NotificationCompat.Builder(
+                    context,
+                    context.getString(R.string.notification_channel_reminder_id)
+            )
+                    .setContentTitle(uiModel.title)
+                    .setContentText(uiModel.message)
+                    .setAutoCancel(true)
+                    .setSmallIcon(R.drawable.ic_my_sites_white_24dp)
+                    .build()
+            NotificationManagerCompat.from(context).notify(notificationId, notificationCompat)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishNotificationReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishNotificationReceiverViewModel.kt
@@ -1,0 +1,51 @@
+package org.wordpress.android.ui.posts
+
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.model.post.PostStatus.SCHEDULED
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.OFF
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.ONE_HOUR
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.TEN_MINUTES
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.WHEN_PUBLISHED
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.viewmodel.ResourceProvider
+import javax.inject.Inject
+
+class PublishNotificationReceiverViewModel
+@Inject constructor(
+    private val postSchedulingNotificationStore: PostSchedulingNotificationStore,
+    private val postStore: PostStore,
+    private val resourceProvider: ResourceProvider
+) {
+    fun loadNotification(notificationId: Int): NotificationUiModel? {
+        postSchedulingNotificationStore.getSchedulingReminder(notificationId)?.let { notification ->
+            postStore.getPostByLocalPostId(notification.postId)?.let { post ->
+                val postStatus = PostStatus.fromPost(post)
+                if (postStatus == SCHEDULED) {
+                    val (titleRes, messageRes) = when (notification.scheduledTime) {
+                        ONE_HOUR -> Pair(
+                                R.string.notification_scheduled_post_one_hour_reminder,
+                                R.string.notification_post_will_be_published_in_one_hour
+                        )
+                        TEN_MINUTES -> Pair(
+                                R.string.notification_scheduled_post_ten_minute_reminder,
+                                R.string.notification_post_will_be_published_in_ten_minutes
+                        )
+                        WHEN_PUBLISHED -> Pair(
+                                R.string.notification_scheduled_post,
+                                R.string.notification_post_has_been_published
+                        )
+                        OFF -> return null
+                    }
+                    val title = resourceProvider.getString(titleRes)
+                    val message = resourceProvider.getString(messageRes, post.title)
+                    return NotificationUiModel(title, message)
+                }
+            }
+        }
+        return null
+    }
+
+    data class NotificationUiModel(val title: String, val message: String)
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
@@ -9,11 +9,14 @@ import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.OFF
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.ONE_HOUR
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel.CalendarEvent
 import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel.PublishUiModel
 import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -329,5 +332,51 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
             assertThat(this.notificationVisible).isTrue()
             assertThat(this.notificationLabel).isEqualTo(R.string.post_notification_off)
         }
+    }
+
+    @Test
+    fun `onAddToCalendar adds a calendar event`() {
+        val post = PostModel()
+        val postId = 1
+        post.id = postId
+        post.dateCreated = "2019-05-05T14:33:20+0000"
+        val postTitle = "Post title"
+        post.title = postTitle
+        val localSiteId = 2
+        post.localSiteId = localSiteId
+
+        val site = SiteModel()
+        val siteTitle = "Site title"
+        site.name = siteTitle
+        whenever(siteStore.getSiteByLocalId(localSiteId)).thenReturn(site)
+
+        var calendarEvent: CalendarEvent? = null
+        viewModel.onAddToCalendar.observeForever {
+            calendarEvent = it?.getContentIfNotHandled()
+        }
+
+        val eventTitle = "Event title"
+        whenever(resourceProvider.getString(
+                R.string.calendar_scheduled_post_title,
+                postTitle,
+                siteTitle
+        )).thenReturn(eventTitle)
+
+        viewModel.onAddToCalendar(post)
+
+        assertThat(calendarEvent!!.startTime).isEqualTo(213)
+        assertThat(calendarEvent!!.title).isEqualTo(eventTitle)
+    }
+
+    @Test
+    fun `onNotificationCreated updates notification`() {
+        var schedulingReminderPeriod: SchedulingReminderModel.Period? = null
+        viewModel.onNotificationTime.observeForever {
+            schedulingReminderPeriod = it
+        }
+
+        viewModel.onNotificationCreated(ONE_HOUR)
+
+        assertThat(schedulingReminderPeriod).isEqualTo(ONE_HOUR)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
@@ -344,6 +344,8 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
         post.title = postTitle
         val localSiteId = 2
         post.localSiteId = localSiteId
+        val postLink = "link.com"
+        post.link = postLink
 
         val site = SiteModel()
         val siteTitle = "Site title"
@@ -356,16 +358,23 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
         }
 
         val eventTitle = "Event title"
+        val eventDescription = "Event description"
         whenever(resourceProvider.getString(
                 R.string.calendar_scheduled_post_title,
-                postTitle,
-                siteTitle
+                postTitle
         )).thenReturn(eventTitle)
+        whenever(resourceProvider.getString(
+                R.string.calendar_scheduled_post_description,
+                postTitle,
+                siteTitle,
+                postLink
+        )).thenReturn(eventDescription)
 
         viewModel.onAddToCalendar(post)
 
-        assertThat(calendarEvent!!.startTime).isEqualTo(213)
+        assertThat(calendarEvent!!.startTime).isEqualTo(1557066800000L)
         assertThat(calendarEvent!!.title).isEqualTo(eventTitle)
+        assertThat(calendarEvent!!.description).isEqualTo(eventDescription)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PublishNotificationReceiverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PublishNotificationReceiverViewModelTest.kt
@@ -1,0 +1,108 @@
+package org.wordpress.android.ui.posts
+
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.OFF
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.ONE_HOUR
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.util.DateTimeUtils
+import org.wordpress.android.viewmodel.ResourceProvider
+import java.util.Calendar
+
+@RunWith(MockitoJUnitRunner::class)
+class PublishNotificationReceiverViewModelTest {
+    @Mock lateinit var postSchedulingNotificationStore: PostSchedulingNotificationStore
+    @Mock lateinit var postStore: PostStore
+    @Mock lateinit var resourceProvider: ResourceProvider
+    private lateinit var viewModel: PublishNotificationReceiverViewModel
+    private val notificationId = 3
+    private val postId = 5
+
+    @Before
+    fun setUp() {
+        viewModel = PublishNotificationReceiverViewModel(postSchedulingNotificationStore, postStore, resourceProvider)
+    }
+
+    @Test
+    fun `loadNotification returns correct data for ONE_HOUR when post is scheduled`() {
+        whenever(postSchedulingNotificationStore.getSchedulingReminder(notificationId)).thenReturn(
+                SchedulingReminderModel(notificationId, postId, ONE_HOUR)
+        )
+        val post = PostModel()
+        post.status = PostStatus.PUBLISHED.toString()
+        val postTitle = "Post title"
+        post.title = postTitle
+        val now = Calendar.getInstance()
+        now.add(Calendar.DAY_OF_MONTH, 10)
+        post.dateCreated = DateTimeUtils.iso8601FromDate(now.time)
+        whenever(postStore.getPostByLocalPostId(postId)).thenReturn(post)
+
+        val expectedTitle = "Notification title"
+        val expectedMessage = "Notification message"
+        whenever(resourceProvider.getString(R.string.notification_scheduled_post_one_hour_reminder)).thenReturn(
+                expectedTitle
+        )
+        whenever(
+                resourceProvider.getString(
+                        R.string.notification_post_will_be_published_in_one_hour,
+                        postTitle
+                )
+        ).thenReturn(
+                expectedMessage
+        )
+
+        val uiModel = viewModel.loadNotification(notificationId)
+
+        assertThat(uiModel).isNotNull()
+        assertThat(uiModel!!.title).isEqualTo(expectedTitle)
+        assertThat(uiModel.message).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `loadNotification returns null for OFF type`() {
+        whenever(postSchedulingNotificationStore.getSchedulingReminder(notificationId)).thenReturn(
+                SchedulingReminderModel(notificationId, postId, OFF)
+        )
+        val post = PostModel()
+        post.status = PostStatus.PUBLISHED.toString()
+        val postTitle = "Post title"
+        post.title = postTitle
+        val now = Calendar.getInstance()
+        now.add(Calendar.DAY_OF_MONTH, 10)
+        post.dateCreated = DateTimeUtils.iso8601FromDate(now.time)
+        whenever(postStore.getPostByLocalPostId(postId)).thenReturn(post)
+
+        val uiModel = viewModel.loadNotification(notificationId)
+
+        assertThat(uiModel).isNull()
+    }
+
+    @Test
+    fun `loadNotification returns null when post is already published`() {
+        whenever(postSchedulingNotificationStore.getSchedulingReminder(notificationId)).thenReturn(
+                SchedulingReminderModel(notificationId, postId, ONE_HOUR)
+        )
+        val post = PostModel()
+        post.status = PostStatus.PUBLISHED.toString()
+        val postTitle = "Post title"
+        post.title = postTitle
+        val now = Calendar.getInstance()
+        now.add(Calendar.DAY_OF_MONTH, -10)
+        post.dateCreated = DateTimeUtils.iso8601FromDate(now.time)
+        whenever(postStore.getPostByLocalPostId(postId)).thenReturn(post)
+
+        val uiModel = viewModel.loadNotification(notificationId)
+
+        assertThat(uiModel).isNull()
+    }
+}


### PR DESCRIPTION
This PR adds missing tests for the ViewModels for the Post Scheduling improvements

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
