### PR TITLE
Add better error message for Facebook connection

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/PublicizeService.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/PublicizeService.java
@@ -3,6 +3,8 @@ package org.wordpress.android.models;
 import org.wordpress.android.util.StringUtils;
 
 public class PublicizeService {
+    public static final String FACEBOOK_SERVICE_ID = "facebook";
+
     private String mId;
     private String mLabel;
     private String mDescription;

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
@@ -19,6 +19,7 @@ import org.wordpress.android.models.PublicizeService;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
 import org.wordpress.android.ui.publicize.PublicizeEvents.ActionCompleted;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.JSONUtils;
 
 import java.util.HashMap;
@@ -214,6 +215,9 @@ public class PublicizeActions {
             final boolean hasExternalAccounts = totalExternalAccounts > 0;
             if (PublicizeTable.onlyExternalConnections(serviceId)) {
                 if (!hasExternalAccounts && serviceId.equals(PublicizeService.FACEBOOK_SERVICE_ID)) {
+                    AppLog.i(T.SHARING,
+                            "The Facebook account cannot be linked because either there was no Page selected or the "
+                            + "Page is set as not published.");
                     throw new PublicizeConnectionValidationException(R.string.sharing_facebook_account_must_have_pages);
                 } else {
                     return hasExternalAccounts;

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
@@ -124,7 +124,15 @@ public class PublicizeActions {
         RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
             public void onResponse(JSONObject jsonObject) {
-                if (shouldShowChooserDialog(siteId, serviceId, jsonObject)) {
+                final boolean showChooserDialog;
+                try {
+                    showChooserDialog = shouldShowChooserDialog(siteId, serviceId, jsonObject);
+                } catch (PublicizeConnectionValidationException e) {
+                    EventBus.getDefault().post(new ActionCompleted(false, ConnectAction.CONNECT, serviceId, e.mReason));
+                    return;
+                }
+
+                if (showChooserDialog) {
                     // show dialog showing multiple options
                     EventBus.getDefault()
                             .post(new PublicizeEvents.ActionRequestChooseAccount(siteId, serviceId, jsonObject));

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
@@ -18,7 +18,6 @@ import org.wordpress.android.models.PublicizeConnection;
 import org.wordpress.android.models.PublicizeService;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
 import org.wordpress.android.ui.publicize.PublicizeEvents.ActionCompleted;
-import org.wordpress.android.ui.publicize.PublicizeEvents.ActionCompleted.Reason;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.JSONUtils;
 
@@ -39,10 +38,10 @@ public class PublicizeActions {
     }
 
     private static class PublicizeConnectionValidationException extends Exception {
-        @NonNull private final Reason mReason;
+        private final int mReasonResId;
 
-        PublicizeConnectionValidationException(@NonNull Reason reason) {
-            mReason = reason;
+        PublicizeConnectionValidationException(int reasonResId) {
+            mReasonResId = reasonResId;
         }
     }
 
@@ -128,7 +127,9 @@ public class PublicizeActions {
                 try {
                     showChooserDialog = shouldShowChooserDialog(siteId, serviceId, jsonObject);
                 } catch (PublicizeConnectionValidationException e) {
-                    EventBus.getDefault().post(new ActionCompleted(false, ConnectAction.CONNECT, serviceId, e.mReason));
+                    final ActionCompleted event =
+                            new ActionCompleted(false, ConnectAction.CONNECT, serviceId, e.mReasonResId);
+                    EventBus.getDefault().post(event);
                     return;
                 }
 
@@ -213,9 +214,7 @@ public class PublicizeActions {
             final boolean hasExternalAccounts = totalExternalAccounts > 0;
             if (PublicizeTable.onlyExternalConnections(serviceId)) {
                 if (!hasExternalAccounts && serviceId.equals(PublicizeService.FACEBOOK_SERVICE_ID)) {
-                    final Reason reason = new Reason(R.string.sharing_facebook_account_must_have_pages,
-                            R.string.sharing_facebook_account_must_have_pages_explanation_url);
-                    throw new PublicizeConnectionValidationException(reason);
+                    throw new PublicizeConnectionValidationException(R.string.sharing_facebook_account_must_have_pages);
                 } else {
                     return hasExternalAccounts;
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
@@ -11,12 +11,14 @@ import org.greenrobot.eventbus.EventBus;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.PublicizeTable;
 import org.wordpress.android.models.PublicizeConnection;
 import org.wordpress.android.models.PublicizeService;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
 import org.wordpress.android.ui.publicize.PublicizeEvents.ActionCompleted;
+import org.wordpress.android.ui.publicize.PublicizeEvents.ActionCompleted.Reason;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.JSONUtils;
 
@@ -34,6 +36,14 @@ public class PublicizeActions {
         void onRequestDisconnect(PublicizeConnection connection);
 
         void onRequestReconnect(PublicizeService service, PublicizeConnection connection);
+    }
+
+    private static class PublicizeConnectionValidationException extends Exception {
+        @NonNull private final Reason mReason;
+
+        PublicizeConnectionValidationException(@NonNull Reason reason) {
+            mReason = reason;
+        }
     }
 
     /*
@@ -169,10 +179,11 @@ public class PublicizeActions {
         WordPress.getRestClientUtilsV1_1().post(path, params, null, listener, errorListener);
     }
 
-    private static boolean shouldShowChooserDialog(long siteId, String serviceId, JSONObject jsonObject) {
+    private static boolean shouldShowChooserDialog(long siteId, String serviceId, JSONObject jsonObject)
+            throws PublicizeConnectionValidationException {
         JSONArray jsonConnectionList = jsonObject.optJSONArray("connections");
 
-        if (jsonConnectionList == null || jsonConnectionList.length() <= 1) {
+        if (jsonConnectionList == null || jsonConnectionList.length() <= 0) {
             return false;
         }
 
@@ -191,10 +202,17 @@ public class PublicizeActions {
                 }
             }
 
+            final boolean hasExternalAccounts = totalExternalAccounts > 0;
             if (PublicizeTable.onlyExternalConnections(serviceId)) {
-                return totalExternalAccounts > 0;
+                if (!hasExternalAccounts && serviceId.equals(PublicizeService.FACEBOOK_SERVICE_ID)) {
+                    final Reason reason = new Reason(R.string.sharing_facebook_account_must_have_pages,
+                            R.string.sharing_facebook_account_must_have_pages_explanation_url);
+                    throw new PublicizeConnectionValidationException(reason);
+                } else {
+                    return hasExternalAccounts;
+                }
             } else {
-                return totalAccounts > 0 || totalExternalAccounts > 0;
+                return totalAccounts > 0 || hasExternalAccounts;
             }
         } catch (JSONException e) {
             return false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeEvents.java
@@ -1,12 +1,9 @@
 package org.wordpress.android.ui.publicize;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.json.JSONObject;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
-
-import java.net.URL;
 
 /**
  * Publicize-related EventBus event classes

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeEvents.java
@@ -25,18 +25,18 @@ public class PublicizeEvents {
         /**
          * The reason for why {@link #mSucceeded} is false.
          */
-        @Nullable private final Reason mReason;
+        @Nullable private final Integer mReasonResId;
         private String mService;
 
         public ActionCompleted(boolean succeeded, ConnectAction action, String service) {
             this(succeeded, action, service, null);
         }
 
-        ActionCompleted(boolean succeeded, ConnectAction action, String service, @Nullable Reason reason) {
+        ActionCompleted(boolean succeeded, ConnectAction action, String service, @Nullable Integer reasonResId) {
             mSucceeded = succeeded;
             mAction = action;
             mService = service;
-            mReason = reason;
+            mReasonResId = reasonResId;
         }
 
         public ConnectAction getAction() {
@@ -51,29 +51,8 @@ public class PublicizeEvents {
             return mService;
         }
 
-        @Nullable public Reason getReason() {
-            return mReason;
-        }
-
-        public static class Reason {
-            private final int mMessageResId;
-            /**
-             * A resource Id containing a URL which points to a page, explaining more about {@link #mMessageResId}.
-             */
-            private final int mExplanationURLResId;
-
-            Reason(int messageResId, int explanationURLResId) {
-                mMessageResId = messageResId;
-                mExplanationURLResId = explanationURLResId;
-            }
-
-            public int getMessageResId() {
-                return mMessageResId;
-            }
-
-            public int getExplanationURLResId() {
-                return mExplanationURLResId;
-            }
+        @Nullable public Integer getReasonResId() {
+            return mReasonResId;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeEvents.java
@@ -58,21 +58,21 @@ public class PublicizeEvents {
         public static class Reason {
             private final int mMessageResId;
             /**
-             * A URL that the user can be forward to in order to explain more about the {@link #mMessageResId}.
+             * A resource Id containing a URL which points to a page, explaining more about {@link #mMessageResId}.
              */
-            @NonNull private final URL mExplanationURL;
+            private final int mExplanationURLResId;
 
-            Reason(int messageResId, @NonNull URL explanationURL) {
+            Reason(int messageResId, int explanationURLResId) {
                 mMessageResId = messageResId;
-                mExplanationURL = explanationURL;
+                mExplanationURLResId = explanationURLResId;
             }
 
             public int getMessageResId() {
                 return mMessageResId;
             }
 
-            @NonNull public URL getExplanationURL() {
-                return mExplanationURL;
+            public int getExplanationURLResId() {
+                return mExplanationURLResId;
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeEvents.java
@@ -1,7 +1,12 @@
 package org.wordpress.android.ui.publicize;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.json.JSONObject;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
+
+import java.net.URL;
 
 /**
  * Publicize-related EventBus event classes
@@ -17,12 +22,21 @@ public class PublicizeEvents {
     public static class ActionCompleted {
         private final boolean mSucceeded;
         private final ConnectAction mAction;
+        /**
+         * The reason for why {@link #mSucceeded} is false.
+         */
+        @Nullable private final Reason mReason;
         private String mService;
 
         public ActionCompleted(boolean succeeded, ConnectAction action, String service) {
+            this(succeeded, action, service, null);
+        }
+
+        ActionCompleted(boolean succeeded, ConnectAction action, String service, @Nullable Reason reason) {
             mSucceeded = succeeded;
             mAction = action;
             mService = service;
+            mReason = reason;
         }
 
         public ConnectAction getAction() {
@@ -35,6 +49,31 @@ public class PublicizeEvents {
 
         public String getService() {
             return mService;
+        }
+
+        @Nullable public Reason getReason() {
+            return mReason;
+        }
+
+        public static class Reason {
+            private final int mMessageResId;
+            /**
+             * A URL that the user can be forward to in order to explain more about the {@link #mMessageResId}.
+             */
+            @NonNull private final URL mExplanationURL;
+
+            Reason(int messageResId, @NonNull URL explanationURL) {
+                mMessageResId = messageResId;
+                mExplanationURL = explanationURL;
+            }
+
+            public int getMessageResId() {
+                return mMessageResId;
+            }
+
+            @NonNull public URL getExplanationURL() {
+                return mExplanationURL;
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -378,7 +378,8 @@ public class PublicizeListActivity extends AppCompatActivity
     }
 
     private void showAlertForFailureReason(int reasonResId) {
-        final AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        final AlertDialog.Builder builder =
+                new AlertDialog.Builder(new ContextThemeWrapper(this, R.style.Calypso_Dialog));
         builder.setMessage(reasonResId);
         builder.setPositiveButton(R.string.ok, (dialog, which) -> dialog.dismiss());
         builder.show();

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -7,7 +7,6 @@ import android.os.Bundle;
 import android.view.ContextThemeWrapper;
 import android.view.MenuItem;
 
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
@@ -28,7 +27,6 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.PublicizeConnection;
 import org.wordpress.android.models.PublicizeService;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
-import org.wordpress.android.ui.publicize.PublicizeEvents.ActionCompleted;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter;
 import org.wordpress.android.ui.publicize.services.PublicizeUpdateService;
 import org.wordpress.android.util.LocaleManager;
@@ -324,8 +322,8 @@ public class PublicizeListActivity extends AppCompatActivity
                 AnalyticsUtils.trackWithSiteDetails(Stat.PUBLICIZE_SERVICE_DISCONNECTED, mSite, analyticsProperties);
             }
         } else {
-            if (event.getReason() != null) {
-                showAlertForFailureReason(event.getReason());
+            if (event.getReasonResId() != null) {
+                showAlertForFailureReason(event.getReasonResId());
             } else {
                 ToastUtils.showToast(this, R.string.error_generic);
             }
@@ -379,10 +377,9 @@ public class PublicizeListActivity extends AppCompatActivity
                             .commit();
     }
 
-    private void showAlertForFailureReason(@NonNull ActionCompleted.Reason reason) {
+    private void showAlertForFailureReason(int reasonResId) {
         final AlertDialog.Builder builder = new AlertDialog.Builder(this);
-        builder.setMessage(reason.getMessageResId());
-        builder.setNeutralButton(R.string.learn_more, (dialog, which) -> dialog.dismiss());
+        builder.setMessage(reasonResId);
         builder.setPositiveButton(R.string.ok, (dialog, which) -> dialog.dismiss());
         builder.show();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.view.ContextThemeWrapper;
 import android.view.MenuItem;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
@@ -27,6 +28,7 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.PublicizeConnection;
 import org.wordpress.android.models.PublicizeService;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
+import org.wordpress.android.ui.publicize.PublicizeEvents.ActionCompleted;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter;
 import org.wordpress.android.ui.publicize.services.PublicizeUpdateService;
 import org.wordpress.android.util.LocaleManager;
@@ -322,7 +324,11 @@ public class PublicizeListActivity extends AppCompatActivity
                 AnalyticsUtils.trackWithSiteDetails(Stat.PUBLICIZE_SERVICE_DISCONNECTED, mSite, analyticsProperties);
             }
         } else {
-            ToastUtils.showToast(this, R.string.error_generic);
+            if (event.getReason() != null) {
+                showAlertForFailureReason(event.getReason());
+            } else {
+                ToastUtils.showToast(this, R.string.error_generic);
+            }
         }
     }
 
@@ -371,5 +377,13 @@ public class PublicizeListActivity extends AppCompatActivity
                             .addToBackStack(null)
                             .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
                             .commit();
+    }
+
+    private void showAlertForFailureReason(@NonNull ActionCompleted.Reason reason) {
+        final AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setMessage(reason.getMessageResId());
+        builder.setNeutralButton(R.string.learn_more, (dialog, which) -> dialog.dismiss());
+        builder.setPositiveButton(R.string.ok, (dialog, which) -> dialog.dismiss());
+        builder.show();
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1905,7 +1905,6 @@
     <string name="sharing_label_message">Change the text of the sharing buttons\' label. This text won\'t appear until you add at least one sharing button.</string>
     <string name="sharing_twitter_message">This will be included in tweets when people share using the Twitter button</string>
     <string name="sharing_facebook_account_must_have_pages">The Facebook connection could not be made because this account does not have access to any pages. Facebook supports sharing connections to Facebook Pages, but not to Facebook Profiles.</string>
-    <string name="sharing_facebook_account_must_have_pages_explanation_url" translatable="false">https://en.support.wordpress.com/publicize/#facebook-pages</string>
 
     <!--Theme Browser-->
     <string name="current_theme">Current Theme</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1903,6 +1903,8 @@
     <string name="connecting_account">Connecting account</string>
     <string name="sharing_label_message">Change the text of the sharing buttons\' label. This text won\'t appear until you add at least one sharing button.</string>
     <string name="sharing_twitter_message">This will be included in tweets when people share using the Twitter button</string>
+    <string name="sharing_facebook_account_must_have_pages">The Facebook connection could not be made because this account does not have access to any pages. Facebook supports sharing connections to Facebook Pages, but not to Facebook Profiles.</string>
+    <string name="sharing_facebook_account_must_have_pages_explanation_url" translatable="false">https://en.support.wordpress.com/publicize/#facebook-pages</string>
 
     <!--Theme Browser-->
     <string name="current_theme">Current Theme</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -110,6 +110,7 @@
     <string name="write_post">Write Post</string>
     <string name="dismiss">dismiss</string>
     <string name="exit">exit</string>
+    <string name="ok">OK</string>
 
     <string name="button_not_now">Not now</string>
 


### PR DESCRIPTION
Fixes #8715. 

This adds handling for when connecting a Facebook account with no selected Pages. The error message is propagated from `PublicizeActions` to `PublicizeListActivity`. The error message string was taken from the iOS app:

<img src="https://user-images.githubusercontent.com/198826/61500287-d45c2b00-a987-11e9-8625-d983adb72906.png" width="240">

Here is what this PR changes:

| Before | After |
|--------|-------|
| <img src="https://user-images.githubusercontent.com/198826/61500486-8e539700-a988-11e9-9264-aa4c69049296.png" width="320">   |    <img src="https://user-images.githubusercontent.com/198826/61500488-93184b00-a988-11e9-9ca1-324a165e1e54.png" width="320">   |

I chose to handle Facebook for now. Twitter and Tumblr seem to work fine without any other requirements other than an active account. It looks like iOS adds special handling [only for Facebook](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/ViewRelated/Blog/SharingAccountViewController.swift#L111-L122) too. 

LinkedIn connections currently do not work and the issue is reported in #10252. 

Big thanks to @malinajirka for pointing me in the right direction with his description in #8715. 

## Testing

1. Go to Sharing → Facebook
2. Click on _Connect_. 
3. Try to connect a Facebook account with and without a Page.

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.
