### PR TITLE
Draft: Move the editor preference option from App Settings screen to Site Settings screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -50,10 +50,6 @@ public class AppSettingsFragment extends PreferenceFragment
         implements OnPreferenceClickListener, Preference.OnPreferenceChangeListener {
     public static final int LANGUAGE_CHANGED = 1000;
 
-    private static final int IDX_LEGACY_EDITOR = 0;
-    private static final int IDX_VISUAL_EDITOR = 1;
-    private static final int IDX_AZTEC_EDITOR = 2;
-
     private DetailListPreference mLanguagePreference;
 
     // This Device settings
@@ -61,7 +57,6 @@ public class AppSettingsFragment extends PreferenceFragment
     private DetailListPreference mImageMaxSizePref;
     private DetailListPreference mImageQualityPref;
     private WPSwitchPreference mOptimizedVideo;
-    private WPSwitchPreference mGutenbergDefaultForNewPosts;
     private DetailListPreference mVideoWidthPref;
     private DetailListPreference mVideoEncorderBitratePref;
     private PreferenceScreen mPrivacySettings;
@@ -126,9 +121,6 @@ public class AppSettingsFragment extends PreferenceFragment
                 (WPSwitchPreference) WPPrefUtils
                         .getPrefAndSetChangeListener(this, R.string.pref_key_optimize_video, this);
 
-        mGutenbergDefaultForNewPosts =
-                (WPSwitchPreference) WPPrefUtils
-                        .getPrefAndSetChangeListener(this, R.string.pref_key_gutenberg_default_for_new_posts, this);
         mVideoWidthPref =
                 (DetailListPreference) WPPrefUtils
                         .getPrefAndSetChangeListener(this, R.string.pref_key_site_video_width, this);
@@ -159,7 +151,6 @@ public class AppSettingsFragment extends PreferenceFragment
                                      String.valueOf(AppPrefs.getVideoOptimizeQuality()),
                                      getLabelForVideoEncoderBitrateValue(AppPrefs.getVideoOptimizeQuality()));
 
-        mGutenbergDefaultForNewPosts.setChecked(AppPrefs.isGutenbergDefaultForNewPosts());
         mStripImageLocation.setChecked(AppPrefs.isStripImageLocation());
 
         if (!BuildConfig.OFFER_GUTENBERG) {
@@ -300,11 +291,6 @@ public class AppSettingsFragment extends PreferenceFragment
             setDetailListPreferenceValue(mVideoEncorderBitratePref,
                                          newValue.toString(),
                                          getLabelForVideoEncoderBitrateValue(AppPrefs.getVideoOptimizeQuality()));
-        } else if (preference == mGutenbergDefaultForNewPosts) {
-            AppPrefs.setGutenbergDefaultForNewPosts((Boolean) newValue);
-            // we need to refresh metadata as gutenberg_enabled is now part of the user data
-            AnalyticsUtils.refreshMetadata(mAccountStore, mSiteStore);
-            WPPrefUtils.setMobileEditorPreferenceToRemote(mDispatcher, mSiteStore);
         } else if (preference == mStripImageLocation) {
             AppPrefs.setStripImageLocation((Boolean) newValue);
         }
@@ -317,66 +303,6 @@ public class AppSettingsFragment extends PreferenceFragment
                 getActivity().finish();
         }
         return super.onOptionsItemSelected(item);
-    }
-
-    private void updateEditorSettings() {
-        if (!AppPrefs.isVisualEditorAvailable()) {
-            PreferenceScreen preferenceScreen =
-                    (PreferenceScreen) findPreference(getActivity().getString(R.string.pref_key_account_settings_root));
-            PreferenceCategory editor = (PreferenceCategory) findPreference(getActivity()
-                                                                                    .getString(
-                                                                                            R.string.pref_key_editor));
-            if (preferenceScreen != null && editor != null) {
-                preferenceScreen.removePreference(editor);
-            }
-        } else {
-            final DetailListPreference editorTypePreference =
-                    (DetailListPreference) findPreference(getActivity().getString(R.string.pref_key_editor_type));
-
-            editorTypePreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-                @Override
-                public boolean onPreferenceChange(final Preference preference, final Object value) {
-                    if (value != null) {
-                        int index = Integer.parseInt(value.toString());
-                        CharSequence[] entries = editorTypePreference.getEntries();
-                        editorTypePreference.setSummary(entries[index]);
-                        // we need to set value manually for DetailListPreference
-                        editorTypePreference.setValue(value.toString());
-
-                        switch (index) {
-                            case IDX_VISUAL_EDITOR:
-                                AppPrefs.setAztecEditorEnabled(false);
-                                AppPrefs.setVisualEditorEnabled(true);
-                                break;
-                            case IDX_AZTEC_EDITOR:
-                                AppPrefs.setAztecEditorEnabled(true);
-                                AppPrefs.setVisualEditorEnabled(false);
-                                break;
-                            default:
-                                AppPrefs.setAztecEditorEnabled(false);
-                                AppPrefs.setVisualEditorEnabled(false);
-                                break;
-                        }
-                        return true;
-                    } else {
-                        return false;
-                    }
-                }
-            });
-
-            final int editorTypeSetting;
-            if (AppPrefs.isAztecEditorEnabled()) {
-                editorTypeSetting = IDX_AZTEC_EDITOR;
-            } else if (AppPrefs.isVisualEditorEnabled()) {
-                editorTypeSetting = IDX_VISUAL_EDITOR;
-            } else {
-                editorTypeSetting = IDX_LEGACY_EDITOR;
-            }
-
-            CharSequence[] entries = editorTypePreference.getEntries();
-            editorTypePreference.setSummary(entries[editorTypeSetting]);
-            editorTypePreference.setValueIndex(editorTypeSetting);
-        }
     }
 
     private void changeLanguage(String languageCode) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -183,6 +183,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     private EditTextPreferenceWithValidation mPasswordPref;
 
     // Writing settings
+    private WPSwitchPreference mGutenbergDefaultForNewPosts;
     private DetailListPreference mCategoryPref;
     private DetailListPreference mFormatPref;
     private WPPreference mDateFormatPref;
@@ -732,6 +733,10 @@ public class SiteSettingsFragment extends PreferenceFragment
         } else if (preference == mTimezonePref) {
             setTimezonePref(newValue.toString());
             mSiteSettings.setTimezone(newValue.toString());
+        } else if (preference == mGutenbergDefaultForNewPosts) {
+            AppPrefs.setGutenbergDefaultForNewPosts((Boolean) newValue);
+            // we need to refresh metadata as gutenberg_enabled is now part of the user data
+            AnalyticsUtils.refreshMetadata(mAccountStore, mSiteStore);
         } else {
             return false;
         }
@@ -900,6 +905,10 @@ public class SiteSettingsFragment extends PreferenceFragment
         mLazyLoadImages = (WPSwitchPreference) getChangePref(R.string.pref_key_lazy_load_images);
         mSiteQuotaSpacePref = (EditTextPreference) getChangePref(R.string.pref_key_site_quota_space);
         sortLanguages();
+        mGutenbergDefaultForNewPosts =
+                (WPSwitchPreference) getChangePref(R.string.pref_key_gutenberg_default_for_new_posts);
+        // TODO: nigrate to site settings interface
+        mGutenbergDefaultForNewPosts.setChecked(AppPrefs.isGutenbergDefaultForNewPosts());
 
         boolean isAccessedViaWPComRest = SiteUtils.isAccessedViaWPComRest(mSite);
 
@@ -938,7 +947,8 @@ public class SiteSettingsFragment extends PreferenceFragment
                 mThreadingPref, mMultipleLinksPref, mModerationHoldPref, mBlacklistPref, mWeekStartPref,
                 mDateFormatPref, mTimeFormatPref, mTimezonePref, mPostsPerPagePref, mAmpPref,
                 mDeleteSitePref, mJpMonitorActivePref, mJpMonitorEmailNotesPref, mJpSsoPref,
-                mJpMonitorWpNotesPref, mJpBruteForcePref, mJpWhitelistPref, mJpMatchEmailPref, mJpUseTwoFactorPref
+                mJpMonitorWpNotesPref, mJpBruteForcePref, mJpWhitelistPref, mJpMatchEmailPref, mJpUseTwoFactorPref,
+                mGutenbergDefaultForNewPosts
         };
 
         for (Preference preference : editablePreference) {
@@ -1244,6 +1254,8 @@ public class SiteSettingsFragment extends PreferenceFragment
         mWeekStartPref.setSummary(mWeekStartPref.getEntry());
         mServeImagesFromOurServers.setChecked(mSiteSettings.isServeImagesFromOurServersEnabled());
         mLazyLoadImages.setChecked(mSiteSettings.isLazyLoadImagesEnabled());
+        // TODO: this needs to be migrated to site settings
+        mGutenbergDefaultForNewPosts.setChecked(AppPrefs.isGutenbergDefaultForNewPosts());
 
         if (mSiteSettings.getAmpSupported()) {
             mAmpPref.setChecked(mSiteSettings.getAmpEnabled());

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -22,8 +22,6 @@
     <string name="pref_key_language" translatable="false">wp_pref_language</string>
     <string name="pref_key_app_about" translatable="false">wp_pref_app_about</string>
     <string name="pref_key_oss_licenses" translatable="false">wp_pref_open_source_licenses</string>
-    <string name="pref_key_editor" translatable="false">wp_pref_editor</string>
-    <string name="pref_key_editor_type" translatable="false">pref_key_editor_type</string>
     <string name="pref_notification_blogs" translatable="false">wp_pref_notification_blogs</string>
     <string name="pref_notification_blogs_followed" translatable="false">pref_notification_blogs_followed</string>
     <string name="pref_notification_other_category" translatable="false">wp_pref_notification_other_category</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -784,7 +784,6 @@
     <string name="third_party_policy_learn_more_header">Third Party Policy</string>
     <string name="third_party_policy_learn_more_caption">We use other tracking tools, including some from third parties. Read about these and how to control them.</string>
     <string name="privacy_policy_read">Read privacy policy</string>
-    <string name="preference_editor">Editor</string>
     <string name="preference_strip_image_location">Remove location from media</string>
 
     <!-- stats -->

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -58,19 +58,6 @@
         android:title="@string/preference_open_device_settings"/>
 
     <PreferenceCategory
-        android:key="@string/pref_key_editor"
-        android:layout="@layout/wp_preference_category"
-        android:title="@string/preference_editor">
-
-        <org.wordpress.android.ui.prefs.WPSwitchPreference
-            android:id="@+id/pref_gutenberg_default_for_new_posts"
-            android:key="@string/pref_key_gutenberg_default_for_new_posts"
-            android:layout="@layout/wp_preference_layout"
-            android:title="@string/site_settings_gutenberg_default_for_new_posts"
-            android:summary="@string/site_settings_gutenberg_default_for_new_posts_summary"/>
-    </PreferenceCategory>
-
-    <PreferenceCategory
         android:key="@string/pref_key_optimize_media"
         android:layout="@layout/wp_preference_category"
         android:title="@string/media">

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -96,6 +96,13 @@
         android:key="@string/pref_key_site_writing"
         android:title="@string/site_settings_writing_header">
 
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_gutenberg_default_for_new_posts"
+            android:key="@string/pref_key_gutenberg_default_for_new_posts"
+            android:layout="@layout/wp_preference_layout"
+            android:title="@string/site_settings_gutenberg_default_for_new_posts"
+            android:summary="@string/site_settings_gutenberg_default_for_new_posts_summary"/>
+
         <org.wordpress.android.ui.prefs.DetailListPreference
             android:id="@+id/pref_default_category"
             android:key="@string/pref_key_site_category"


### PR DESCRIPTION
Move the "default editor for new posts" toggle from App Settings screen to Site Settings screen.

Just the UI is migrated. The setting is still saved locally and globally in app settings.

This is part of the work required for https://github.com/wordpress-mobile/gutenberg-mobile/issues/1233

To test:
- Open app settings and see there is no editor option.
- Go to site settings. The default editor preference is there.
- Change it.
- Re-open settings, it should show the correct value.
- Tap to create a new post, the right editor should be shown.

Note: Merged in a feature branch.