### PR TITLE
Add realtime site address validation

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2308,7 +2308,6 @@
     <string name="login_log_in_for_deeplink">Log in to WordPress.com to access the post.</string>
     <string name="login_log_in_for_share_intent">Log in to WordPress.com to share the content.</string>
     <string name="login_invalid_site_url">Enter a valid URL e.g. example.com.</string>
-    <string name="login_empty_site_url">Please enter a site address</string>
     <string name="login_empty_username">Please enter a username</string>
     <string name="login_empty_password">Please enter a password</string>
     <string name="login_empty_2fa">Please enter a verification code</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2307,7 +2307,7 @@
     <string name="login_error_while_adding_site">Error while adding site. Error code: %s</string>
     <string name="login_log_in_for_deeplink">Log in to WordPress.com to access the post.</string>
     <string name="login_log_in_for_share_intent">Log in to WordPress.com to share the content.</string>
-    <string name="login_invalid_site_url">The site address you entered is invalid. Please re-enter it.</string>
+    <string name="login_invalid_site_url">Enter a valid URL e.g. example.com.</string>
     <string name="login_empty_site_url">Please enter a site address</string>
     <string name="login_empty_username">Please enter a username</string>
     <string name="login_empty_password">Please enter a password</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2296,7 +2296,7 @@
     <string name="login_continue">Continue</string>
     <string name="login_already_logged_in_wpcom">Already logged in to WordPress.com</string>
     <string name="login_username_at">\@%s</string>
-    <string name="enter_site_address">Enter the address of your WordPress site you\'d like to connect.</string>
+    <string name="enter_site_address">Enter the address of the WordPress site you\'d like to connect.</string>
     <string name="enter_site_address_share_intent">Enter the address of your WordPress site you\'d like to share the content to.</string>
     <string name="login_site_address">Site address</string>
     <string name="login_site_address_help">Need help finding your site address?</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2307,7 +2307,7 @@
     <string name="login_error_while_adding_site">Error while adding site. Error code: %s</string>
     <string name="login_log_in_for_deeplink">Log in to WordPress.com to access the post.</string>
     <string name="login_log_in_for_share_intent">Log in to WordPress.com to share the content.</string>
-    <string name="login_invalid_site_url">Enter a valid URL e.g. example.com.</string>
+    <string name="login_invalid_site_url">Please enter a complete website address, like example.com.</string>
     <string name="login_empty_username">Please enter a username</string>
     <string name="login_empty_password">Please enter a password</string>
     <string name="login_empty_2fa">Please enter a verification code</string>

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -68,6 +68,12 @@ dependencies {
     annotationProcessor 'com.google.dagger:dagger-android-processor:2.22.1'
 
     lintChecks 'org.wordpress:lint:1.0.1'
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:2.27.0'
+    testImplementation 'androidx.arch.core:core-testing:2.0.1'
+    testImplementation 'org.robolectric:robolectric:3.6.1'
+    testImplementation 'org.assertj:assertj-core:3.11.1'
 }
 
 // Add properties named "wp.xxx" to our BuildConfig

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -56,7 +56,7 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
 
     private String mRequestedSiteAddress;
 
-    private LoginSiteAddressValidator mLoginSiteAddressValidator = new LoginSiteAddressValidator();
+    private LoginSiteAddressValidator mLoginSiteAddressValidator;
 
     @Inject AccountStore mAccountStore;
     @Inject Dispatcher mDispatcher;
@@ -140,14 +140,21 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
         } else {
             mAnalyticsListener.trackUrlFormViewed();
         }
-    }
 
-    @Override public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
+        mLoginSiteAddressValidator = new LoginSiteAddressValidator();
 
         mLoginSiteAddressValidator.getIsValid().observe(this, new Observer<Boolean>() {
-            @Override public void onChanged(Boolean aBoolean) {
-                getPrimaryButton().setEnabled(aBoolean);
+            @Override public void onChanged(Boolean enabled) {
+                getPrimaryButton().setEnabled(enabled);
+            }
+        });
+        mLoginSiteAddressValidator.getErrorMessageResId().observe(this, new Observer<Integer>() {
+            @Override public void onChanged(Integer resId) {
+                if (resId != null) {
+                    showError(resId);
+                } else {
+                    mSiteAddressInput.setError(null);
+                }
             }
         });
     }
@@ -157,6 +164,11 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
         super.onSaveInstanceState(outState);
 
         outState.putString(KEY_REQUESTED_SITE_ADDRESS, mRequestedSiteAddress);
+    }
+
+    @Override public void onDestroyView() {
+        super.onDestroyView();
+        mLoginSiteAddressValidator.dispose();
     }
 
     protected void discover() {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -183,7 +183,9 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
 
     @Override
     public void onEditorCommit() {
-        discover();
+        if (getPrimaryButton().isEnabled()) {
+            discover();
+        }
     }
 
     @Override
@@ -355,7 +357,7 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
                 return;
             } else {
                 AppLog.e(T.API, "onDiscoveryResponse has error: " + event.error.name()
-                        + " - " + event.error.toString());
+                                + " - " + event.error.toString());
                 handleDiscoveryError(event.error, event.failedEndpoint);
                 return;
             }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressValidator.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressValidator.java
@@ -20,7 +20,7 @@ class LoginSiteAddressValidator {
     private MutableLiveData<Integer> mErrorMessageResId = new MutableLiveData<>();
 
     private String mCleanedSiteAddress = "";
-    private Debouncer mDebouncer = new Debouncer();
+    private final Debouncer mDebouncer;
 
     @NonNull LiveData<Boolean> getIsValid() {
         return mIsValid;
@@ -35,7 +35,12 @@ class LoginSiteAddressValidator {
     }
 
     LoginSiteAddressValidator() {
+        this(new Debouncer());
+    }
+
+    LoginSiteAddressValidator(@NonNull Debouncer debouncer) {
         mIsValid.setValue(false);
+        mDebouncer = debouncer;
     }
 
     void dispose() {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressValidator.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressValidator.java
@@ -1,0 +1,43 @@
+package org.wordpress.android.login;
+
+import android.util.Patterns;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Encapsulates the site address validation, cleaning, and error handling of {@link LoginSiteAddressFragment}.
+ */
+class LoginSiteAddressValidator {
+    private MutableLiveData<Boolean> mIsValid = new MutableLiveData<>();
+
+    @NonNull private String mCleanedSiteAddress = "";
+
+    LiveData<Boolean> getIsValid() {
+        return mIsValid;
+    }
+
+    @NotNull String getCleanedSiteAddress() {
+        return mCleanedSiteAddress;
+    }
+
+    LoginSiteAddressValidator() {
+        mIsValid.postValue(false);
+    }
+
+    public void setAddress(@NonNull String siteAddress) {
+        mCleanedSiteAddress = cleanSiteAddress(siteAddress);
+        mIsValid.postValue(siteAddressIsValid(mCleanedSiteAddress));
+    }
+
+    private static String cleanSiteAddress(@NonNull String siteAddress) {
+        return siteAddress.trim().replaceAll("[\r\n]", "");
+    }
+
+    private static boolean siteAddressIsValid(@NonNull String cleanedSiteAddress) {
+        return Patterns.WEB_URL.matcher(cleanedSiteAddress).matches();
+    }
+}

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressValidator.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressValidator.java
@@ -11,7 +11,7 @@ import org.wordpress.android.util.helpers.Debouncer;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Encapsulates the site address validation, cleaning, and error handling of {@link LoginSiteAddressFragment}.
+ * Encapsulates the site address validation, cleaning, and error reporting of {@link LoginSiteAddressFragment}.
  */
 class LoginSiteAddressValidator {
     private static final int SECONDS_DELAY_BEFORE_SHOWING_ERROR_MESSAGE = 2;
@@ -49,9 +49,10 @@ class LoginSiteAddressValidator {
         mIsValid.setValue(isValid);
         mErrorMessageResId.setValue(null);
 
+        // Call debounce regardless if there was an error so that the previous Runnable will be cancelled.
         mDebouncer.debounce(Void.class, new Runnable() {
             @Override public void run() {
-                if (!isValid) {
+                if (!isValid && !mCleanedSiteAddress.isEmpty()) {
                     mErrorMessageResId.postValue(R.string.login_invalid_site_url);
                 }
             }

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -39,7 +39,7 @@
     <string name="login_continue">Continue</string>
     <string name="login_already_logged_in_wpcom">Already logged in to WordPress.com</string>
     <string name="login_username_at">\@%s</string>
-    <string name="enter_site_address">Enter the address of your WordPress site you\'d like to connect.</string>
+    <string name="enter_site_address">Enter the address of the WordPress site you\'d like to connect.</string>
     <string name="enter_site_address_share_intent">Enter the address of your WordPress site you\'d like to share the content to.</string>
     <string name="login_site_address">Site address</string>
     <string name="login_site_address_help">Need help finding your site address?</string>

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -50,7 +50,6 @@
     <string name="login_error_while_adding_site">Error while adding site. Error code: %s</string>
     <string name="login_log_in_for_deeplink">Log in to WordPress.com to access the post.</string>
     <string name="login_log_in_for_share_intent">Log in to WordPress.com to share the content.</string>
-    <string name="login_empty_site_url">Please enter a site address</string>
     <string name="login_invalid_site_url">Enter a valid URL e.g. example.com.</string>
     <string name="login_empty_username">Please enter a username</string>
     <string name="login_empty_password">Please enter a password</string>

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -50,7 +50,7 @@
     <string name="login_error_while_adding_site">Error while adding site. Error code: %s</string>
     <string name="login_log_in_for_deeplink">Log in to WordPress.com to access the post.</string>
     <string name="login_log_in_for_share_intent">Log in to WordPress.com to share the content.</string>
-    <string name="login_invalid_site_url">Enter a valid URL e.g. example.com.</string>
+    <string name="login_invalid_site_url">Please enter a complete website address, like example.com.</string>
     <string name="login_empty_username">Please enter a username</string>
     <string name="login_empty_password">Please enter a password</string>
     <string name="login_empty_2fa">Please enter a verification code</string>

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -51,7 +51,7 @@
     <string name="login_log_in_for_deeplink">Log in to WordPress.com to access the post.</string>
     <string name="login_log_in_for_share_intent">Log in to WordPress.com to share the content.</string>
     <string name="login_empty_site_url">Please enter a site address</string>
-    <string name="login_invalid_site_url">The site address you entered is invalid. Please re-enter it.</string>
+    <string name="login_invalid_site_url">Enter a valid URL e.g. example.com.</string>
     <string name="login_empty_username">Please enter a username</string>
     <string name="login_empty_password">Please enter a password</string>
     <string name="login_empty_2fa">Please enter a verification code</string>

--- a/libs/login/WordPressLoginFlow/src/test/java/org/wordpress/android/login/LoginSiteAddressValidatorTest.java
+++ b/libs/login/WordPressLoginFlow/src/test/java/org/wordpress/android/login/LoginSiteAddressValidatorTest.java
@@ -1,0 +1,129 @@
+package org.wordpress.android.login;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.Observer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.robolectric.RobolectricTestRunner;
+import org.wordpress.android.util.helpers.Debouncer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+@RunWith(RobolectricTestRunner.class)
+public class LoginSiteAddressValidatorTest {
+    @Rule
+    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+
+    private Debouncer mDebouncer;
+    private LoginSiteAddressValidator mValidator;
+
+    @Before
+    public void setUp() {
+        mDebouncer = mock(Debouncer.class);
+        doAnswer(new Answer<Void>() {
+            @Override public Void answer(InvocationOnMock invocation) {
+                final Runnable runnable = invocation.getArgument(1);
+                runnable.run();
+                return null;
+            }
+        }).when(mDebouncer).debounce(any(), any(Runnable.class), anyLong(), any(TimeUnit.class));
+
+        mValidator = new LoginSiteAddressValidator(mDebouncer);
+    }
+
+    @After
+    public void tearDown() {
+        mValidator = null;
+        mDebouncer = null;
+    }
+
+    @Test
+    public void testAnErrorIsReturnedWhenGivenAnInvalidAddress() {
+        // Arrange
+        assertThat(mValidator.getErrorMessageResId().getValue()).isNull();
+
+        // Act
+        mValidator.setAddress("invalid");
+
+        // Assert
+        assertThat(mValidator.getErrorMessageResId().getValue()).isNotNull();
+        assertThat(mValidator.getCleanedSiteAddress()).isEqualTo("invalid");
+        assertThat(mValidator.getIsValid().getValue()).isFalse();
+    }
+
+    @Test
+    public void testNoErrorIsReturnedButIsInvalidWhenGivenAnEmptyAddress() {
+        // Act
+        mValidator.setAddress("");
+
+        // Assert
+        assertThat(mValidator.getErrorMessageResId().getValue()).isNull();
+        assertThat(mValidator.getIsValid().getValue()).isFalse();
+        assertThat(mValidator.getCleanedSiteAddress()).isEqualTo("");
+    }
+
+    @Test
+    public void testTheErrorIsImmediatelyClearedWhenANewAddressIsGiven() {
+        // Arrange
+        final ArrayList<Optional<Integer>> resIdValues = new ArrayList<>();
+        mValidator.getErrorMessageResId().observeForever(new Observer<Integer>() {
+            @Override public void onChanged(Integer resId) {
+                resIdValues.add(Optional.ofNullable(resId));
+            }
+        });
+
+        // Act
+        mValidator.setAddress("invalid");
+        mValidator.setAddress("another-invalid");
+
+        // Assert
+        assertThat(resIdValues).hasSize(4);
+        assertThat(resIdValues.get(0)).isEmpty();
+        assertThat(resIdValues.get(1)).isNotEmpty();
+        assertThat(resIdValues.get(2)).isEmpty();
+        assertThat(resIdValues.get(3)).isNotEmpty();
+    }
+
+    @Test
+    public void testItReturnsValidWhenGivenValidURLs() {
+        // Arrange
+        final List<String> validUrls = Arrays.asList(
+                "http://subdomain.example.com",
+                "http://example.ca",
+                "example.ca",
+                "subdomain.example.com",
+                "  space-with-subdomain.example.net",
+                "https://subdomain.example.com/folder",
+                "http://subdomain.example.com/folder/over/there ",
+                "7.7.7.7",
+                "http://7.7.13.45",
+                "http://47.147.43.45/folder   ");
+
+        // Act and Assert
+        assertThat(validUrls).allSatisfy(new Consumer<String>() {
+            @Override public void accept(String url) {
+                mValidator.setAddress(url);
+
+                assertThat(mValidator.getErrorMessageResId().getValue()).isNull();
+                assertThat(mValidator.getIsValid().getValue()).isTrue();
+            }
+        });
+    }
+}


### PR DESCRIPTION
Closes #9720.

This adds realtime validation for the site address in Login or Add Site. This is based on the iOS implementation described in https://github.com/wordpress-mobile/WordPress-iOS/issues/10294#issuecomment-486260221.

<img src="https://user-images.githubusercontent.com/198826/61565263-bfd66c00-aa35-11e9-97c7-92ce40cec9b6.gif" width="320">

- The error is only shown if the user has not typed anything after 2 seconds
- The _Next_ button is only enabled if the URL is valid

To implement this, I moved all the site address logic to a new class, `LoginSiteAddressValidator`. The class encapsulates the validation, cleaning, and error reporting using debounce. A corresponding unit test, `LoginSiteAddressValidatorTest`, has also been added.

### Known Issues

The `LoginSiteAddressFragment` doesn't retain any error message shown below the text field after configuration changes. I didn't attempt to fix this. I thought it would be a huge change. 

## Testing

### Adding a Site

1. Click on Sites → Switch Site.
2. Click on the + button at the top right.
3. Enter a site address.

### Logging in with a self-hosted site

1. On Login page, click on _Login_.
2. Click on _Log in by entering your site address_.
3. Enter a self-hosted site address.

On both scenarios, please test against the specs described above. Please also test that there are no regressions in logging in with a valid site. 

## Reviewing

Only 1 reviewer is needed but anyone can review.

### Editorial

We're hoping to get a review for the error message that is shown when the URL is invalid:

> Enter a valid URL eg. example.com.

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.

## Tasks 

- [x] Review
- [ ] Merge if approved
- [ ] Merge changes back to `WordPress-Login-Flow-Android`
- [ ] Apply copy changes to iOS