### PR TITLE
Update network_security_config to enable React Native bundler

### DIFF
--- a/WordPress/src/debug/AndroidManifest.xml
+++ b/WordPress/src/debug/AndroidManifest.xml
@@ -7,7 +7,9 @@
     <application
         tools:replace="android:name,android:supportsRtl"
         android:name=".WordPressDebug"
-        android:supportsRtl="true">
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:supportsRtl="true"
+        tools:ignore="UnusedAttribute">
     </application>
 
     <!--

--- a/WordPress/src/debug/res/xml/network_security_config.xml
+++ b/WordPress/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <!-- Trust user added certificate authorities while debuggable only -->
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+
+    <!-- Enable use of React Native bundler in debug builds -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="false">10.0.2.2</domain>
+        <domain includeSubdomains="false">10.0.3.2</domain>
+    </domain-config>
+</network-security-config>

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -54,11 +54,9 @@
         android:icon="@mipmap/app_icon"
         android:label="@string/app_name"
         android:largeHeap="true"
-        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/WordPress"
         tools:replace="allowBackup, icon,android:supportsRtl"
-        android:supportsRtl="true"
-        tools:ignore="UnusedAttribute">
+        android:supportsRtl="true">
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"

--- a/WordPress/src/main/res/xml/network_security_config.xml
+++ b/WordPress/src/main/res/xml/network_security_config.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-    <debug-overrides>
-        <trust-anchors>
-            <!-- Trust user added certificate authorities while debuggable only -->
-            <certificates src="user" />
-        </trust-anchors>
-    </debug-overrides>
-</network-security-config>


### PR DESCRIPTION
## Description

### React Native bundler

This PR is for the purpose of enabling the connection to the React Native bundler when _only on debug builds_ of the app. This was accomplished by permitting cleartext traffic to `localhost`, `10.0.2.2`, and `10.0.3.2`. This is confined to debug builds by including this xml file in the `debug/` directory. Before the changes in this PR, attempting to use the gutenberg editor with a debug build of WPAndroid that built gutenberg from source would result in a red screen with a "Could not connect to development server" error.

### MITM proxying

The only configuration we had in `main/res/xml/network_security_config.xml` [was for the purpose of enabling MITM proxying on debuggable builds](https://github.com/wordpress-mobile/WordPress-Android/pull/4944). In particular, it is worth noting that the change was within a `<debug-overrides>` tag [which means it is only applied to debuggable builds](https://developer.android.com/training/articles/security-config#debug-overrides). Because we obviously want this change to apply to debug builds, I needed to also include this logic in the `debug/` copy of `network_security_config.xml`. 

Furthermore, because it seemed like this logic is only needed in debug builds, I went further and removed the `main/` copy of `network_security_config.xml`. The effect of this change is that any non-debug build type that _is_ debuggable will now _not_ permit MITM proxying. In summary, the following table shows when a MITM proxy would work before and after the changes in this PR:

---- | Before| Now
--- | ---- | ----
Debug && debuggable=true | X | X
! Debug && debuggable=false | |
! Debug && debuggable=true | X |

⚠️ Please let me know if you can think of any reason we want to be able to use MITM proxies on non-Debug build types that are debuggable. In that case, I should revert the changes I made inside `main/`.

## Testing

#### React Native bundler - Debug

1. Update `gradle.properties` so gutenberg is built from source (`wp.BUILD_GUTENBERG_FROM_SOURCE=true`)
1. Create a debug build of WPAndroid
2. Start metro bunder (`yarn start` from within `libs/gutenberg-mobile/`)
3. Connect device to computer via usb
4. execute `adb reverse tcp:8081 tcp:8081` from the command line
5. Open the gutenberg editor from within the WPAndroid app (may need to update "App Settings" to "Use Block Editor")
6. Observe that there is no red screen, the metro bundler responds, and the gutenberg editor is loaded.

#### React Native bundler - Release


Since the app doesn't try to use the metro bundler on release builds, it's a bit difficult to manually verify that the changes to allow cleartext were not leaking into release without going fairly low-level. In other words, sorry these steps require code—it's the best I came up with ‾\_(ツ)_/‾)

1. Add the following code somewhere in the app that is easy to trigger (I added it to `MyProfilActivity::onResume`, but `LoginActivity` seems like a good candidate too):
```
    protected void onResume() {

      [...]

      new MyAsyncTask().execute();
    }

    private static class MyAsyncTask extends AsyncTask<Void, Void, Void> {
        @Override protected Void doInBackground(Void... voids) {
            Log.e("TEST", "sending test request");
            try {
                URL url = new URL("http://10.0.2.2"); // ip that allows cleartext on debug builds
                HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
                urlConnection.setRequestMethod("GET");
                urlConnection.connect();
            } catch (Exception e) {
                e.printStackTrace();
           }
            return null;
        }
    }
```
2. Create a release build of WPAndroid
3. Trigger the above code
4. Observe that there is an error in the logs because Cleartext http traffic is not permitted:
```
E/TEST: sending test request
W/System.err: java.io.IOException: Cleartext HTTP traffic to 10.0.2.2 not permitted
```

Executing this same test code on a debug build results in no error being logged.

#### MITM Proxy

Since I am moving the trust-anchor element, we should also verify that there are no regressions with our MITM proxying. I did that by following the test steps from [the original PR](https://github.com/wordpress-mobile/WordPress-Android/pull/4944):

1. Set up an API 24+ device to proxy through something like Charles
2. Enable SSL proxying and install the custom certificate for the HTTP debugger on the device (you can confirm this is working by visiting HTTPS sites in the device's Chrome browser - traffic should be appearing, decrypted, in the debugger)
3. Build a debug version of the app on the device and log in to WP.com - notice the traffic is appearing and decrypted
4. Build a release version of the app on the device and log in to WP.com - notice the traffic is not decrypted (login should either fail or the device should fall back to mobile data)

### Update release notes
There are no user facing changes, so `RELEASE-NOTES.txt` were *not* updated.

