### PR TITLE
Run connected tests on CI for every PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
           type: instrumentation
           apk-path: WordPress/build/outputs/apk/vanilla/debug/WordPress-vanilla-debug.apk
           test-apk-path: WordPress/build/outputs/apk/androidTest/vanilla/debug/WordPress-vanilla-debug-androidTest.apk
-          test-targets: package org.wordpress.android.e2e
+          test-targets: notPackage org.wordpress.android.ui.screenshots
           device: model=Nexus5X,version=26,locale=en,orientation=portrait
           project: api-project-108380595987
           timeout: 10m
@@ -97,13 +97,4 @@ workflows:
       - strings-check
       - test
       - lint
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
       - connected-tests


### PR DESCRIPTION
This updates our CircleCI config to run all connected tests (apart from screenshots) on every PR. They have been running every night reliably for some time now.

To test:

- CI is green and includes the connected tests 😄 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
