### PR TITLE
Stop loading images in the content as featured images on post list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFeaturedImageTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFeaturedImageTracker.kt
@@ -6,8 +6,6 @@ import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload
-import org.wordpress.android.ui.reader.utils.ReaderImageScanner
-import org.wordpress.android.util.SiteUtils
 
 /**
  * This is a temporary class to make the PostListViewModel more manageable. Please feel free to refactor it any way
@@ -16,9 +14,9 @@ import org.wordpress.android.util.SiteUtils
 class PostListFeaturedImageTracker(private val dispatcher: Dispatcher, private val mediaStore: MediaStore) {
     private val featuredImageMap = HashMap<Long, String>()
 
-    fun getFeaturedImageUrl(site: SiteModel, featuredImageId: Long, postContent: String): String? {
+    fun getFeaturedImageUrl(site: SiteModel, featuredImageId: Long): String? {
         if (featuredImageId == 0L) {
-            return ReaderImageScanner(postContent, !SiteUtils.isPhotonCapable(site)).largestImage
+            return null
         }
         featuredImageMap[featuredImageId]?.let { return it }
         mediaStore.getSiteMediaWithId(site, featuredImageId)?.let { media ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.reader.utils.ReaderUtils
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.ui.utils.UiString
-import org.wordpress.android.util.ImageUtils
 import org.wordpress.android.util.image.ImageType
 import org.wordpress.android.viewmodel.posts.PostListItemAction
 import org.wordpress.android.viewmodel.posts.PostListItemAction.MoreItem
@@ -174,23 +173,12 @@ sealed class PostListItemViewHolder(
         if (imageUrl == null) {
             featuredImageView.visibility = View.GONE
             config.imageManager.cancelRequestAndClearImageView(featuredImageView)
-        } else if (imageUrl.startsWith("http")) {
+        } else {
             val photonUrl = ReaderUtils.getResizedImageUrl(
                     imageUrl, config.photonWidth, config.photonHeight, !config.isPhotonCapable
             )
             featuredImageView.visibility = View.VISIBLE
             config.imageManager.load(featuredImageView, ImageType.PHOTO, photonUrl, ScaleType.CENTER_CROP)
-        } else {
-            val bmp = ImageUtils.getWPImageSpanThumbnailFromFilePath(
-                    featuredImageView.context, imageUrl, config.photonWidth
-            )
-            if (bmp != null) {
-                featuredImageView.visibility = View.VISIBLE
-                config.imageManager.load(featuredImageView, bmp)
-            } else {
-                featuredImageView.visibility = View.GONE
-                config.imageManager.cancelRequestAndClearImageView(featuredImageView)
-            }
         }
         loadedFeaturedImgUrl = imageUrl
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -337,10 +337,7 @@ class PostListViewModel @Inject constructor(
                     unhandledConflicts = connector.doesPostHaveUnhandledConflict(post),
                     capabilitiesToPublish = connector.site.hasCapabilityPublishPosts,
                     statsSupported = isStatsSupported,
-                    featuredImageUrl = connector.getFeaturedImageUrl(
-                            post.featuredImageId,
-                            post.content
-                    ),
+                    featuredImageUrl = connector.getFeaturedImageUrl(post.featuredImageId),
                     formattedDate = PostUtils.getFormattedDate(post),
                     performingCriticalAction = connector.postActionHandler.isPerformingCriticalAction(LocalId(post.id)),
                     onAction = { postModel, buttonType, statEvent ->

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
@@ -14,9 +14,9 @@ class PostListViewModelConnector(
     val getUploadStatus: (PostModel) -> PostListItemUploadStatus,
     val doesPostHaveUnhandledConflict: (PostModel) -> Boolean,
     val postFetcher: PostFetcher,
-    private val getFeaturedImageUrl: (site: SiteModel, featuredImageId: Long, postContent: String) -> String?
+    private val getFeaturedImageUrl: (site: SiteModel, featuredImageId: Long) -> String?
 ) {
-    fun getFeaturedImageUrl(featuredImageId: Long, postContent: String): String? {
-        return getFeaturedImageUrl.invoke(site, featuredImageId, postContent)
+    fun getFeaturedImageUrl(featuredImageId: Long): String? {
+        return getFeaturedImageUrl.invoke(site, featuredImageId)
     }
 }


### PR DESCRIPTION
Fixes #9777 #9528

Show only actual featured images on the post list items. In other words don't try to find an image in the post content when a featured image is not set.

This PR also removes `else` branch which was loading images into a Bitmap. The code became unreachable after the change in https://github.com/wordpress-mobile/WordPress-Android/pull/10266/commits/181e7137e2ae75c8d4c64830db8ab04eb4d8907f. 

(This change should have a positive performance impact as the images were searched for and loaded into a bitmap on the UI thread)

To test:
1. My Site
2. Blog Posts
3. Create a post and add an image into it's content
4. Go back to My Site
5. Blog Posts
6. Notice the image is not displayed on the post list item
7. Open the post 
8. Post Settings
9. Add a featured image
10. Go back to Post List and notice the featured image is displayed

Update release notes:

- The changes are too minor
