### PR TITLE
Revert "Run connected tests on CI for every PR"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
           type: instrumentation
           apk-path: WordPress/build/outputs/apk/vanilla/debug/WordPress-vanilla-debug.apk
           test-apk-path: WordPress/build/outputs/apk/androidTest/vanilla/debug/WordPress-vanilla-debug-androidTest.apk
-          test-targets: notPackage org.wordpress.android.ui.screenshots
+          test-targets: package org.wordpress.android.e2e
           device: model=Nexus5X,version=26,locale=en,orientation=portrait
           project: api-project-108380595987
           timeout: 10m
@@ -97,4 +97,13 @@ workflows:
       - strings-check
       - test
       - lint
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
       - connected-tests


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-Android#10264

Reverting to allow us to investigate test flakiness. See the failure [here](https://circleci.com/gh/wordpress-mobile/WordPress-Android/17594).