### PR TITLE
Stats accessibility improvements 1

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockDiffCallback.kt
@@ -101,7 +101,8 @@ class BlockDiffCallback(
                 TAB_CHANGED
             newItem is Columns && oldItem is Columns && oldItem.selectedColumn != newItem.selectedColumn ->
                 return SELECTED_COLUMN_CHANGED
-            newItem is Columns && oldItem is Columns && oldItem.values != newItem.values -> return COLUMNS_VALUE_CHANGED
+            newItem is Columns && oldItem is Columns && oldItem.columns != newItem.columns ->
+                return COLUMNS_VALUE_CHANGED
             newItem is BarChartItem && oldItem is BarChartItem && oldItem.selectedItem != newItem.selectedItem ->
                 return SELECTED_BAR_CHANGED
             else -> null

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsMapper.kt
@@ -27,8 +27,8 @@ class PostDayViewsMapper
         val value = selectedItem.count
         val previousValue = previousItem?.count
         val positive = value >= (previousValue ?: 0)
-        val change = buildChange(previousValue, value, positive)
-        val unformattedChange = buildChange(previousValue, value, positive) { this.toString() }
+        val change = buildChange(previousValue, value, positive, isFormattedNumber = true)
+        val unformattedChange = buildChange(previousValue, value, positive, isFormattedNumber = false)
 
         val state = when {
             isLast -> State.NEUTRAL
@@ -55,20 +55,28 @@ class PostDayViewsMapper
         previousValue: Int?,
         value: Int,
         positive: Boolean,
-        print: Int.() -> String = { this.toFormattedString() }
+        isFormattedNumber: Boolean
     ): String? {
         return previousValue?.let {
             val difference = value - previousValue
             val percentage = when (previousValue) {
                 value -> "0"
                 0 -> "∞"
-                else -> (difference * 100 / previousValue).print()
+                else -> mapIntToString((difference * 100 / previousValue), isFormattedNumber)
             }
+            val formattedDifference = mapIntToString(difference, isFormattedNumber)
             if (positive) {
-                resourceProvider.getString(R.string.stats_traffic_increase, difference.print(), percentage)
+                resourceProvider.getString(R.string.stats_traffic_increase, formattedDifference, percentage)
             } else {
-                resourceProvider.getString(R.string.stats_traffic_change, difference.print(), percentage)
+                resourceProvider.getString(R.string.stats_traffic_change, formattedDifference, percentage)
             }
+        }
+    }
+
+    private fun mapIntToString(value: Int, isFormattedNumber: Boolean): String {
+        return when (isFormattedNumber) {
+            true -> value.toFormattedString()
+            false -> value.toString()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsUseCase.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsPostProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
+import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -28,7 +29,8 @@ class PostDayViewsUseCase
     private val selectedDateProvider: SelectedDateProvider,
     private val statsSiteProvider: StatsSiteProvider,
     private val statsPostProvider: StatsPostProvider,
-    private val postDetailStore: PostDetailStore
+    private val postDetailStore: PostDetailStore,
+    private val resourceProvider: ResourceProvider
 ) : BaseStatsUseCase<PostDetailStatsModel, UiState>(
         PostDetailType.POST_OVERVIEW,
         mainDispatcher,
@@ -106,7 +108,14 @@ class PostDayViewsUseCase
     }
 
     override fun buildLoadingItem(): List<BlockListItem> {
-        return listOf(ValueItem(value = 0.toFormattedString(), unit = R.string.stats_views, isFirst = true))
+        return listOf(
+                ValueItem(
+                        value = 0.toFormattedString(),
+                        unit = R.string.stats_views,
+                        isFirst = true,
+                        contentDescription = resourceProvider.getString(R.string.stats_loading_card)
+                )
+        )
     }
 
     private fun onBarSelected(period: String?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -97,7 +97,8 @@ sealed class BlockListItem(val type: Type) {
         @StringRes val unit: Int,
         val isFirst: Boolean = false,
         val change: String? = null,
-        val state: State = POSITIVE
+        val state: State = POSITIVE,
+        val contentDescription: String
     ) : BlockListItem(VALUE_ITEM) {
         enum class State { POSITIVE, NEGATIVE, NEUTRAL }
     }
@@ -157,13 +158,14 @@ sealed class BlockListItem(val type: Type) {
     }
 
     data class Columns(
-        val headers: List<Int>,
-        val values: List<String>,
+        val columns: List<Column>,
         val selectedColumn: Int? = null,
         val onColumnSelected: ((position: Int) -> Unit)? = null
     ) : BlockListItem(COLUMNS) {
         override val itemId: Int
-            get() = headers.hashCode()
+            get() = columns.hashCode()
+
+        data class Column(val header: Int, val value: String, val contentDescription: String)
     }
 
     data class Link(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
@@ -3,13 +3,16 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel.PeriodData
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarChartItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarChartItem.Bar
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ChartLegend
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Columns
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Columns.Column
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem.State
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.MILLION
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
@@ -19,7 +22,8 @@ import javax.inject.Inject
 class OverviewMapper
 @Inject constructor(
     private val statsDateFormatter: StatsDateFormatter,
-    private val resourceProvider: ResourceProvider
+    private val resourceProvider: ResourceProvider,
+    private val contentDescriptionHelper: ContentDescriptionHelper
 ) {
     private val units = listOf(
             R.string.stats_views,
@@ -29,28 +33,18 @@ class OverviewMapper
     )
 
     fun buildTitle(
-        selectedItem: PeriodData?,
+        selectedItem: PeriodData,
         previousItem: PeriodData?,
         selectedPosition: Int,
         isLast: Boolean,
-        startValue: Int = MILLION
+        startValue: Int = MILLION,
+        statsGranularity: StatsGranularity = DAYS
     ): ValueItem {
-        val value = selectedItem?.getValue(selectedPosition) ?: 0
+        val value = selectedItem.getValue(selectedPosition) ?: 0
         val previousValue = previousItem?.getValue(selectedPosition)
         val positive = value >= (previousValue ?: 0)
-        val change = previousValue?.let {
-            val difference = value - previousValue
-            val percentage = when (previousValue) {
-                value -> "0"
-                0L -> "∞"
-                else -> (difference * 100 / previousValue).toFormattedString()
-            }
-            if (positive) {
-                resourceProvider.getString(R.string.stats_traffic_increase, difference.toFormattedString(), percentage)
-            } else {
-                resourceProvider.getString(R.string.stats_traffic_change, difference.toFormattedString(), percentage)
-            }
-        }
+        val change = buildChange(previousValue, value, positive)
+        val unformattedChange = buildChange(previousValue, value, positive) { this.toString() }
         val state = when {
             isLast -> State.NEUTRAL
             positive -> State.POSITIVE
@@ -61,8 +55,36 @@ class OverviewMapper
                 unit = units[selectedPosition],
                 isFirst = true,
                 change = change,
-                state = state
+                state = state,
+                contentDescription = resourceProvider.getString(
+                        R.string.stats_overview_content_description,
+                        value,
+                        resourceProvider.getString(units[selectedPosition]),
+                        statsDateFormatter.printGranularDate(selectedItem.period, statsGranularity),
+                        unformattedChange ?: ""
+                )
         )
+    }
+
+    private fun buildChange(
+        previousValue: Long?,
+        value: Long,
+        positive: Boolean,
+        print: Long.() -> String = { this.toFormattedString() }
+    ): String? {
+        return previousValue?.let {
+            val difference = value - previousValue
+            val percentage = when (previousValue) {
+                value -> "0"
+                0L -> "∞"
+                else -> (difference * 100 / previousValue).print()
+            }
+            if (positive) {
+                resourceProvider.getString(R.string.stats_traffic_increase, difference.print(), percentage)
+            } else {
+                resourceProvider.getString(R.string.stats_traffic_change, difference.print(), percentage)
+            }
+        }
     }
 
     private fun PeriodData.getValue(
@@ -82,13 +104,44 @@ class OverviewMapper
         onColumnSelected: (position: Int) -> Unit,
         selectedPosition: Int
     ): Columns {
+        val views = selectedItem?.views ?: 0
+        val visitors = selectedItem?.visitors ?: 0
+        val likes = selectedItem?.likes ?: 0
+        val comments = selectedItem?.comments ?: 0
         return Columns(
-                units,
                 listOf(
-                        selectedItem?.views?.toFormattedString() ?: "0",
-                        selectedItem?.visitors?.toFormattedString() ?: "0",
-                        selectedItem?.likes?.toFormattedString() ?: "0",
-                        selectedItem?.comments?.toFormattedString() ?: "0"
+                        Column(
+                                R.string.stats_views,
+                                views.toFormattedString(),
+                                contentDescriptionHelper.buildContentDescription(
+                                        R.string.stats_views,
+                                        views
+                                )
+                        ),
+                        Column(
+                                R.string.stats_visitors,
+                                visitors.toFormattedString(),
+                                contentDescriptionHelper.buildContentDescription(
+                                        R.string.stats_visitors,
+                                        visitors
+                                )
+                        ),
+                        Column(
+                                R.string.stats_likes,
+                                likes.toFormattedString(),
+                                contentDescriptionHelper.buildContentDescription(
+                                        R.string.stats_likes,
+                                        likes
+                                )
+                        ),
+                        Column(
+                                R.string.stats_comments,
+                                comments.toFormattedString(),
+                                contentDescriptionHelper.buildContentDescription(
+                                        R.string.stats_comments,
+                                        comments
+                                )
+                        )
                 ),
                 selectedPosition,
                 onColumnSelected
@@ -134,13 +187,15 @@ class OverviewMapper
         if (shouldShowVisitors) {
             result.add(ChartLegend(R.string.stats_visitors))
         }
-        result.add(BarChartItem(
-                chartItems,
-                overlappingEntries = overlappingItems,
-                selectedItem = selectedItemPeriod,
-                onBarSelected = onBarSelected,
-                onBarChartDrawn = onBarChartDrawn
-        ))
+        result.add(
+                BarChartItem(
+                        chartItems,
+                        overlappingEntries = overlappingItems,
+                        selectedItem = selectedItemPeriod,
+                        onBarSelected = onBarSelected,
+                        onBarChartDrawn = onBarChartDrawn
+                )
+        )
         return result
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
@@ -43,8 +43,8 @@ class OverviewMapper
         val value = selectedItem.getValue(selectedPosition) ?: 0
         val previousValue = previousItem?.getValue(selectedPosition)
         val positive = value >= (previousValue ?: 0)
-        val change = buildChange(previousValue, value, positive)
-        val unformattedChange = buildChange(previousValue, value, positive) { this.toString() }
+        val change = buildChange(previousValue, value, positive, isFormattedNumber = true)
+        val unformattedChange = buildChange(previousValue, value, positive, isFormattedNumber = false)
         val state = when {
             isLast -> State.NEUTRAL
             positive -> State.POSITIVE
@@ -70,20 +70,28 @@ class OverviewMapper
         previousValue: Long?,
         value: Long,
         positive: Boolean,
-        print: Long.() -> String = { this.toFormattedString() }
+        isFormattedNumber: Boolean
     ): String? {
         return previousValue?.let {
             val difference = value - previousValue
             val percentage = when (previousValue) {
                 value -> "0"
                 0L -> "∞"
-                else -> (difference * 100 / previousValue).print()
+                else -> mapLongToString((difference * 100 / previousValue), isFormattedNumber)
             }
+            val formattedDifference = mapLongToString(difference, isFormattedNumber)
             if (positive) {
-                resourceProvider.getString(R.string.stats_traffic_increase, difference.print(), percentage)
+                resourceProvider.getString(R.string.stats_traffic_increase, formattedDifference, percentage)
             } else {
-                resourceProvider.getString(R.string.stats_traffic_change, difference.print(), percentage)
+                resourceProvider.getString(R.string.stats_traffic_change, formattedDifference, percentage)
             }
+        }
+    }
+
+    private fun mapLongToString(value: Long, isFormattedNumber: Boolean): String {
+        return when (isFormattedNumber) {
+            true -> value.toFormattedString()
+            false -> value.toString()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.stats.refresh.utils.trackGranular
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -36,7 +37,8 @@ constructor(
     private val statsDateFormatter: StatsDateFormatter,
     private val overviewMapper: OverviewMapper,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
-    private val analyticsTracker: AnalyticsTrackerWrapper
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val resourceProvider: ResourceProvider
 ) : BaseStatsUseCase<VisitsAndViewsModel, UiState>(
         OVERVIEW,
         mainDispatcher,
@@ -50,7 +52,12 @@ constructor(
 
     override fun buildLoadingItem(): List<BlockListItem> =
             listOf(
-                    ValueItem(value = 0.toFormattedString(), unit = R.string.stats_views, isFirst = true)
+                    ValueItem(
+                            value = 0.toFormattedString(),
+                            unit = R.string.stats_views,
+                            isFirst = true,
+                            contentDescription = resourceProvider.getString(R.string.stats_loading_card)
+                    )
             )
 
     override suspend fun loadCachedData(): VisitsAndViewsModel? {
@@ -115,7 +122,8 @@ constructor(
                             selectedItem,
                             previousItem,
                             uiState.selectedPosition,
-                            isLast = selectedItem == domainModel.dates.last()
+                            isLast = selectedItem == domainModel.dates.last(),
+                            statsGranularity = statsGranularity
                     )
             )
             items.addAll(
@@ -166,7 +174,8 @@ constructor(
         private val statsDateFormatter: StatsDateFormatter,
         private val overviewMapper: OverviewMapper,
         private val visitsAndViewsStore: VisitsAndViewsStore,
-        private val analyticsTracker: AnalyticsTrackerWrapper
+        private val analyticsTracker: AnalyticsTrackerWrapper,
+        private val resourceProvider: ResourceProvider
     ) : GranularUseCaseFactory {
         override fun build(granularity: StatsGranularity, useCaseMode: UseCaseMode) =
                 OverviewUseCase(
@@ -177,7 +186,8 @@ constructor(
                         statsDateFormatter,
                         overviewMapper,
                         mainDispatcher,
-                        analyticsTracker
+                        analyticsTracker,
+                        resourceProvider
                 )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCase.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListI
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.NavigationAction
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.MILLION
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
@@ -37,7 +38,8 @@ class LatestPostSummaryUseCase
     private val statsSiteProvider: StatsSiteProvider,
     private val latestPostSummaryMapper: LatestPostSummaryMapper,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    private val popupMenuHandler: ItemPopupMenuHandler
+    private val popupMenuHandler: ItemPopupMenuHandler,
+    private val contentDescriptionHelper: ContentDescriptionHelper
 ) : StatelessUseCase<InsightsLatestPostModel>(LATEST_POST_SUMMARY, mainDispatcher) {
     override suspend fun loadCachedData(): InsightsLatestPostModel? {
         return latestPostStore.getLatestPostInsights(statsSiteProvider.siteModel)
@@ -75,25 +77,31 @@ class LatestPostSummaryUseCase
             items.add(
                     ValueItem(
                             domainModel.postViewsCount.toFormattedString(startValue = MILLION),
-                            R.string.stats_views
+                            R.string.stats_views,
+                            contentDescription = contentDescriptionHelper.buildContentDescription(
+                                    R.string.stats_views,
+                                    domainModel.postViewsCount.toLong()
+                            )
                     )
             )
             if (domainModel.dayViews.isNotEmpty()) {
                 items.add(latestPostSummaryMapper.buildBarChartItem(domainModel.dayViews))
             }
+            val postLikeCount = domainModel.postLikeCount.toFormattedString()
             items.add(
                     ListItemWithIcon(
                             R.drawable.ic_star_white_24dp,
                             textResource = R.string.stats_likes,
-                            value = domainModel.postLikeCount.toFormattedString(),
+                            value = postLikeCount,
                             showDivider = true
                     )
             )
+            val postCommentCount = domainModel.postCommentCount.toFormattedString()
             items.add(
                     ListItemWithIcon(
                             R.drawable.ic_comment_white_24dp,
                             textResource = R.string.stats_comments,
-                            value = domainModel.postCommentCount.toFormattedString(),
+                            value = postCommentCount,
                             showDivider = false
                     )
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/FourColumnsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/FourColumnsViewHolder.kt
@@ -40,6 +40,7 @@ class FourColumnsViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             else -> {
                 columnLayouts.forEachIndexed { index, layout ->
                     layout.setOnClickListener {
+                        it.announceForAccessibility(it.resources.getString(R.string.stats_graph_updated))
                         columns.onColumnSelected?.invoke(index)
                     }
                     layout.key().setText(columns.headers[index])

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/FourColumnsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/FourColumnsViewHolder.kt
@@ -21,7 +21,7 @@ class FourColumnsViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
     )
 
     fun bind(
-        columns: Columns,
+        item: Columns,
         payloads: List<Any>
     ) {
         val tabSelected = payloads.contains(SELECTED_COLUMN_CHANGED)
@@ -29,23 +29,25 @@ class FourColumnsViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         when {
             tabSelected -> {
                 columnLayouts.forEachIndexed { index, layout ->
-                    layout.setSelection(columns.selectedColumn == index)
+                    layout.setSelection(item.selectedColumn == index)
                 }
             }
             valuesChanged -> {
                 columnLayouts.forEachIndexed { index, layout ->
-                    layout.value().text = columns.values[index]
+                    layout.value().text = item.columns[index].value
                 }
             }
             else -> {
                 columnLayouts.forEachIndexed { index, layout ->
                     layout.setOnClickListener {
                         it.announceForAccessibility(it.resources.getString(R.string.stats_graph_updated))
-                        columns.onColumnSelected?.invoke(index)
+                        item.onColumnSelected?.invoke(index)
                     }
-                    layout.key().setText(columns.headers[index])
-                    layout.value().text = columns.values[index]
-                    layout.setSelection(columns.selectedColumn == null || columns.selectedColumn == index)
+                    val currentColumn = item.columns[index]
+                    layout.key().setText(currentColumn.header)
+                    layout.value().text = currentColumn.value
+                    layout.setSelection(item.selectedColumn == null || item.selectedColumn == index)
+                    layout.contentDescription = currentColumn.contentDescription
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/QuickScanItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/QuickScanItemViewHolder.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
 
 import android.view.ViewGroup
+import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.widget.TooltipCompat
 import org.wordpress.android.R
@@ -11,20 +12,32 @@ class QuickScanItemViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         parent,
         R.layout.stats_quick_scan_item
 ) {
+    private val startValueContainer = itemView.findViewById<LinearLayout>(R.id.start_value_container)
     private val startLabel = itemView.findViewById<TextView>(R.id.start_label)
     private val startValue = itemView.findViewById<TextView>(R.id.start_value)
+    private val endValueContainer = itemView.findViewById<LinearLayout>(R.id.end_value_container)
     private val endLabel = itemView.findViewById<TextView>(R.id.end_label)
     private val endValue = itemView.findViewById<TextView>(R.id.end_value)
 
     fun bind(item: QuickScanItem) {
-        bindColumn(item.startColumn, startLabel, startValue)
-        bindColumn(item.endColumn, endLabel, endValue)
+        bindColumn(item.startColumn, startLabel, startValue, startValueContainer)
+        bindColumn(item.endColumn, endLabel, endValue, endValueContainer)
     }
 
-    private fun bindColumn(column: Column, label: TextView, value: TextView) {
+    private fun bindColumn(
+        column: Column,
+        label: TextView,
+        value: TextView,
+        container: LinearLayout
+    ) {
         label.setText(column.label)
         value.text = column.value
-        TooltipCompat.setTooltipText(value, column.tooltip)
-        value.setOnClickListener { it.performLongClick() }
+        column.tooltip?.let {
+            TooltipCompat.setTooltipText(container, column.tooltip)
+            container.setOnClickListener {
+                container.announceForAccessibility(column.tooltip)
+                it.performLongClick()
+            }
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ValueViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ValueViewHolder.kt
@@ -36,5 +36,6 @@ class ValueViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         val topMargin = if (item.isFirst) container.resources.getDimensionPixelSize(R.dimen.margin_medium) else 0
         params.setMargins(0, topMargin, 0, 0)
         container.layoutParams = params
+        container.contentDescription = item.contentDescription
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
@@ -1,16 +1,15 @@
 package org.wordpress.android.ui.stats.refresh.utils
 
-import org.wordpress.android.R
+import org.wordpress.android.util.RtlUtils
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
 class ContentDescriptionHelper
-@Inject constructor(private val resourceProvider: ResourceProvider) {
+@Inject constructor(private val resourceProvider: ResourceProvider, private val rtlUtils: RtlUtils) {
     fun buildContentDescription(keyLabel: Int, key: Long): String {
-        return resourceProvider.getString(
-                R.string.stats_list_item_short_description,
-                resourceProvider.getString(keyLabel),
-                key
-        )
+        return when (rtlUtils.isRtl) {
+            true -> "$key :${resourceProvider.getString(keyLabel)}"
+            false -> "${resourceProvider.getString(keyLabel)}: $key"
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.ui.stats.refresh.utils
+
+import org.wordpress.android.R
+import org.wordpress.android.viewmodel.ResourceProvider
+import javax.inject.Inject
+
+class ContentDescriptionHelper
+@Inject constructor(private val resourceProvider: ResourceProvider) {
+    fun buildContentDescription(keyLabel: Int, key: Long): String {
+        return resourceProvider.getString(
+                R.string.stats_list_item_short_description,
+                resourceProvider.getString(keyLabel),
+                key
+        )
+    }
+}

--- a/WordPress/src/main/res/layout/stats_block_bar_chart_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_bar_chart_item.xml
@@ -4,6 +4,7 @@
               android:id="@+id/link_wrapper"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
+              android:contentDescription="@string/stats_bar_chart_content_description"
               android:layout_marginBottom="24dp"
               android:orientation="vertical"
               android:paddingEnd="@dimen/margin_extra_large"

--- a/WordPress/src/main/res/layout/stats_block_bar_chart_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_bar_chart_item.xml
@@ -13,14 +13,12 @@
     <com.github.mikephil.charting.charts.BarChart
         android:id="@+id/chart"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/stats_bar_chart_height"
-        android:importantForAccessibility="no"/>
+        android:layout_height="@dimen/stats_bar_chart_height"/>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="-10dp"
-        android:importantForAccessibility="no"
         android:layoutDirection="ltr"
         android:paddingEnd="15dp"
         android:paddingStart="33dp">

--- a/WordPress/src/main/res/layout/stats_block_bar_chart_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_bar_chart_item.xml
@@ -4,8 +4,8 @@
               android:id="@+id/link_wrapper"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
-              android:contentDescription="@string/stats_bar_chart_content_description"
               android:layout_marginBottom="24dp"
+              android:contentDescription="@string/stats_bar_chart_content_description"
               android:orientation="vertical"
               android:paddingEnd="@dimen/margin_extra_large"
               android:paddingStart="@dimen/margin_key">
@@ -13,31 +13,37 @@
     <com.github.mikephil.charting.charts.BarChart
         android:id="@+id/chart"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/stats_bar_chart_height"/>
+        android:layout_height="@dimen/stats_bar_chart_height"
+        android:importantForAccessibility="no"/>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="-10dp"
+        android:importantForAccessibility="no"
         android:layoutDirection="ltr"
         android:paddingEnd="15dp"
         android:paddingStart="33dp">
 
         <TextView
             android:id="@+id/label_start"
+            style="@style/StatsGraphLabel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="January 2019"
-            style="@style/StatsGraphLabel"/>
+            android:importantForAccessibility="no"
+            tools:text="January 2019"/>
+
         <View
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"/>
+
         <TextView
             android:id="@+id/label_end"
-            tools:text="December 2019"
+            style="@style/StatsGraphLabel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            style="@style/StatsGraphLabel"/>
+            android:importantForAccessibility="no"
+            tools:text="December 2019"/>
     </LinearLayout>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/stats_block_legend_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_legend_item.xml
@@ -2,7 +2,8 @@
 <TextView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/legend"
+    style="@style/StatsLegend"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    style="@style/StatsLegend"
+    android:focusable="false"
     android:text="@string/stats_visitors"/>

--- a/WordPress/src/main/res/layout/stats_block_legend_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_legend_item.xml
@@ -5,5 +5,6 @@
     style="@style/StatsLegend"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:importantForAccessibility="no"
     android:focusable="false"
     android:text="@string/stats_visitors"/>

--- a/WordPress/src/main/res/layout/stats_block_legend_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_legend_item.xml
@@ -6,5 +6,4 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:importantForAccessibility="no"
-    android:focusable="false"
     android:text="@string/stats_visitors"/>

--- a/WordPress/src/main/res/layout/stats_block_value_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_value_item.xml
@@ -4,6 +4,7 @@
     android:id="@+id/value_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:focusable="true"
     android:gravity="center_vertical"
     android:orientation="horizontal"
     android:paddingBottom="8dp"

--- a/WordPress/src/main/res/layout/stats_block_value_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_value_item.xml
@@ -4,7 +4,6 @@
     android:id="@+id/value_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:focusable="true"
     android:gravity="center_vertical"
     android:orientation="horizontal"
     android:paddingBottom="8dp"

--- a/WordPress/src/main/res/layout/stats_loading_view.xml
+++ b/WordPress/src/main/res/layout/stats_loading_view.xml
@@ -8,6 +8,7 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/stats_block_list"
+        android:contentDescription="@string/stats_loading_card"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
 </com.facebook.shimmer.ShimmerFrameLayout>

--- a/WordPress/src/main/res/layout/stats_quick_scan_item.xml
+++ b/WordPress/src/main/res/layout/stats_quick_scan_item.xml
@@ -1,41 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                                   xmlns:app="http://schemas.android.com/apk/res-auto"
-                                                   android:paddingTop="@dimen/margin_extra_large"
-                                                   android:paddingBottom="@dimen/margin_extra_large"
-                                                   android:layout_width="match_parent"
-                                                   android:layout_height="wrap_content">
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:importantForAccessibility="no"
+    android:paddingBottom="@dimen/margin_extra_large"
+    android:paddingTop="@dimen/margin_extra_large">
 
-
-    <TextView
-        android:id="@+id/start_label"
-        style="@style/StatsBlockQuickScanLabel"
+    <LinearLayout
+        android:id="@+id/start_value_container"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
-        android:text="@string/unknown"
-        app:layout_constraintBottom_toTopOf="@id/start_value"
-        app:layout_constraintEnd_toStartOf="@+id/horizontal_divider"
-        app:layout_constraintStart_toStartOf="parent"/>
-
-    <TextView
-        android:id="@+id/start_value"
-        style="@style/StatsBlockQuickScanValue"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
-        android:text="@string/unknown"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:focusable="true"
+        android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/horizontal_divider"
-        app:layout_constraintStart_toStartOf="parent"/>
+        app:layout_constraintStart_toStartOf="parent">
+
+        <TextView
+            android:id="@+id/start_label"
+            style="@style/StatsBlockQuickScanLabel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:labelFor="@id/end_value"
+            android:text="@string/unknown"/>
+
+        <TextView
+            android:id="@+id/start_value"
+            style="@style/StatsBlockQuickScanValue"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/unknown"/>
+    </LinearLayout>
 
     <View
         android:id="@+id/horizontal_divider"
         android:layout_width="1dp"
         android:layout_height="0dp"
         android:background="@color/grey_lighten_30"
+        android:focusable="false"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
@@ -43,28 +49,33 @@
         app:layout_constraintTop_toTopOf="parent"/>
 
 
-    <TextView
-        android:id="@+id/end_label"
-        style="@style/StatsBlockQuickScanLabel"
+    <LinearLayout
+        android:id="@+id/end_value_container"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
-        android:text="@string/unknown"
-        app:layout_constraintBottom_toTopOf="@id/end_value"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/horizontal_divider"/>
-
-    <TextView
-        android:id="@+id/end_value"
-        style="@style/StatsBlockQuickScanValue"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
-        android:text="@string/unknown"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:focusable="true"
+        android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/horizontal_divider"/>
+        app:layout_constraintStart_toEndOf="@id/horizontal_divider">
+
+        <TextView
+            android:id="@+id/end_label"
+            style="@style/StatsBlockQuickScanLabel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:labelFor="@id/end_value"
+            android:text="@string/unknown"/>
+
+        <TextView
+            android:id="@+id/end_value"
+            style="@style/StatsBlockQuickScanValue"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/unknown"/>
+
+    </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/stats_quick_scan_item.xml
+++ b/WordPress/src/main/res/layout/stats_quick_scan_item.xml
@@ -40,7 +40,6 @@
         android:layout_width="1dp"
         android:layout_height="0dp"
         android:background="@color/grey_lighten_30"
-        android:focusable="false"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"

--- a/WordPress/src/main/res/layout/stats_quick_scan_item.xml
+++ b/WordPress/src/main/res/layout/stats_quick_scan_item.xml
@@ -4,7 +4,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:importantForAccessibility="no"
     android:paddingBottom="@dimen/margin_extra_large"
     android:paddingTop="@dimen/margin_extra_large">
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -839,6 +839,11 @@
     <string name="stats_menu_move_down">Move down</string>
     <string name="stats_menu_remove">Remove from insights</string>
 
+    <!-- Stats accessibility strings -->
+    <string name="stats_loading_card">Loading selected card data</string>
+    <string name="stats_bar_chart_content_description">Graph of site views.</string>
+    <string name="stats_graph_updated">Graph updated.</string>
+
     <string name="stats_manage_your_stats">Manage Your Stats</string>
     <string name="stats_management_news_card_message">Choose what stats to see, and focus on the data you care most about. Tap %1$s at the bottom of Insights to customise your stats.</string>
     <string name="stats_management_try_it_now">Try it now</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -842,7 +842,9 @@
     <!-- Stats accessibility strings -->
     <string name="stats_loading_card">Loading selected card data</string>
     <string name="stats_bar_chart_content_description">Graph of site views.</string>
+    <string name="stats_overview_content_description">%1$s %2$s for period: %3$s, change from previous period - %4$s</string>
     <string name="stats_graph_updated">Graph updated.</string>
+    <string name="stats_list_item_short_description">%1$s: %2$s</string>
 
     <string name="stats_manage_your_stats">Manage Your Stats</string>
     <string name="stats_management_news_card_message">Choose what stats to see, and focus on the data you care most about. Tap %1$s at the bottom of Insights to customise your stats.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -844,7 +844,6 @@
     <string name="stats_bar_chart_content_description">Graph of site views.</string>
     <string name="stats_overview_content_description">%1$s %2$s for period: %3$s, change from previous period - %4$s</string>
     <string name="stats_graph_updated">Graph updated.</string>
-    <string name="stats_list_item_short_description">%1$s: %2$s</string>
 
     <string name="stats_manage_your_stats">Manage Your Stats</string>
     <string name="stats_management_news_card_message">Choose what stats to see, and focus on the data you care most about. Tap %1$s at the bottom of Insights to customise your stats.</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsMapperTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.detail
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
@@ -19,9 +20,21 @@ class PostDayViewsMapperTest : BaseUnitTest() {
     private lateinit var mapper: PostDayViewsMapper
     private val count = 20
     private val selectedItem = PostDetailStatsModel.Day("2010-10-10", count)
+    private val views = "Views"
+    private val date = "10. 10. 2010"
+    private val contentDescription = "Content description"
     @Before
     fun setUp() {
         mapper = PostDayViewsMapper(resourceProvider, statsDateFormatter)
+        whenever(resourceProvider.getString(R.string.stats_views)).thenReturn(views)
+        whenever(statsDateFormatter.printDate(any())).thenReturn(date)
+        whenever(resourceProvider.getString(
+                eq(R.string.stats_overview_content_description),
+                eq(count),
+                eq(views),
+                eq(date),
+                any()
+        )).thenReturn(contentDescription)
     }
 
     @Test
@@ -32,6 +45,7 @@ class PostDayViewsMapperTest : BaseUnitTest() {
         assertThat(title.unit).isEqualTo(R.string.stats_views)
         assertThat(title.change).isNull()
         assertThat(title.state).isEqualTo(State.POSITIVE)
+        assertThat(title.contentDescription).isEqualTo(contentDescription)
     }
 
     @Test
@@ -48,6 +62,7 @@ class PostDayViewsMapperTest : BaseUnitTest() {
         assertThat(title.unit).isEqualTo(R.string.stats_views)
         assertThat(title.change).isEqualTo(positiveLabel)
         assertThat(title.state).isEqualTo(State.POSITIVE)
+        assertThat(title.contentDescription).isEqualTo(contentDescription)
     }
 
     @Test
@@ -64,6 +79,7 @@ class PostDayViewsMapperTest : BaseUnitTest() {
         assertThat(title.unit).isEqualTo(R.string.stats_views)
         assertThat(title.change).isEqualTo(positiveLabel)
         assertThat(title.state).isEqualTo(State.POSITIVE)
+        assertThat(title.contentDescription).isEqualTo(contentDescription)
     }
 
     @Test
@@ -89,6 +105,13 @@ class PostDayViewsMapperTest : BaseUnitTest() {
         val negativeLabel = "-20 (-100%)"
         whenever(resourceProvider.getString(eq(R.string.stats_traffic_change), eq("-20"), eq("-100")))
                 .thenReturn(negativeLabel)
+        whenever(resourceProvider.getString(
+                eq(R.string.stats_overview_content_description),
+                eq(newCount),
+                eq(views),
+                eq(date),
+                any()
+        )).thenReturn(contentDescription)
 
         val title = mapper.buildTitle(newItem, selectedItem, false)
 
@@ -96,6 +119,7 @@ class PostDayViewsMapperTest : BaseUnitTest() {
         assertThat(title.unit).isEqualTo(R.string.stats_views)
         assertThat(title.change).isEqualTo(negativeLabel)
         assertThat(title.state).isEqualTo(State.NEGATIVE)
+        assertThat(title.contentDescription).isEqualTo(contentDescription)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsUseCaseTest.kt
@@ -10,6 +10,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Day
@@ -29,6 +30,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDa
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsPostProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.viewmodel.ResourceProvider
 
 class PostDayViewsUseCaseTest : BaseUnitTest() {
     @Mock lateinit var store: PostDetailStore
@@ -37,6 +39,7 @@ class PostDayViewsUseCaseTest : BaseUnitTest() {
     @Mock lateinit var mapper: PostDayViewsMapper
     @Mock lateinit var statsSiteProvider: StatsSiteProvider
     @Mock lateinit var statsPostProvider: StatsPostProvider
+    @Mock lateinit var resourceProvider: ResourceProvider
     @Mock lateinit var site: SiteModel
     @Mock lateinit var title: ValueItem
     @Mock lateinit var barChartItem: BarChartItem
@@ -53,11 +56,13 @@ class PostDayViewsUseCaseTest : BaseUnitTest() {
                 selectedDateProvider,
                 statsSiteProvider,
                 statsPostProvider,
-                store
+                store,
+                resourceProvider
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         whenever(statsPostProvider.postId).thenReturn(postId)
         whenever(mapper.buildTitle(any(), isNull(), any())).thenReturn(title)
+        whenever(resourceProvider.getString(R.string.stats_loading_card)).thenReturn("Loading")
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapperTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
@@ -9,31 +10,45 @@ import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel.PeriodData
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Columns.Column
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem.State.NEGATIVE
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem.State.NEUTRAL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem.State.POSITIVE
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.OverviewUseCase.UiState
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.viewmodel.ResourceProvider
 
 class OverviewMapperTest : BaseUnitTest() {
     @Mock lateinit var statsDateFormatter: StatsDateFormatter
     @Mock lateinit var resourceProvider: ResourceProvider
+    @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
     private lateinit var mapper: OverviewMapper
     private val views: Long = 10
     private val visitors: Long = 15
     private val likes: Long = 20
     private val comments: Long = 35
     private val selectedItem = PeriodData("2010-10-10", views, visitors, likes, 30, comments, 40)
+    private val likesTitle = "Likes"
+    private val printedDate = "10. 10. 2010"
     @Before
     fun setUp() {
-        mapper = OverviewMapper(statsDateFormatter, resourceProvider)
+        mapper = OverviewMapper(statsDateFormatter, resourceProvider, contentDescriptionHelper)
+        whenever(resourceProvider.getString(R.string.stats_likes)).thenReturn(likesTitle)
+        whenever(statsDateFormatter.printGranularDate(any<String>(), any())).thenReturn(printedDate)
     }
 
     @Test
     fun `builds title from item and position with empty previous item`() {
         val selectedPosition = 2
         val uiState = UiState(selectedPosition)
+        whenever(resourceProvider.getString(
+                eq(R.string.stats_overview_content_description),
+                eq(likes),
+                eq(likesTitle),
+                eq(printedDate),
+                eq("")
+        )).thenReturn("$likes")
 
         val title = mapper.buildTitle(
                 selectedItem,
@@ -57,6 +72,13 @@ class OverviewMapperTest : BaseUnitTest() {
         val positiveLabel = "+15 (300%)"
         whenever(resourceProvider.getString(eq(R.string.stats_traffic_increase), eq("15"), eq("300")))
                 .thenReturn(positiveLabel)
+        whenever(resourceProvider.getString(
+                eq(R.string.stats_overview_content_description),
+                eq(likes),
+                eq(likesTitle),
+                eq(printedDate),
+                eq(positiveLabel)
+        )).thenReturn(positiveLabel)
 
         val title = mapper.buildTitle(
                 selectedItem,
@@ -80,6 +102,13 @@ class OverviewMapperTest : BaseUnitTest() {
         val positiveLabel = "+20 (∞%)"
         whenever(resourceProvider.getString(eq(R.string.stats_traffic_increase), eq("20"), eq("∞")))
                 .thenReturn(positiveLabel)
+        whenever(resourceProvider.getString(
+                eq(R.string.stats_overview_content_description),
+                eq(likes),
+                eq(likesTitle),
+                eq(printedDate),
+                eq(positiveLabel)
+        )).thenReturn(positiveLabel)
 
         val title = mapper.buildTitle(
                 selectedItem,
@@ -103,6 +132,13 @@ class OverviewMapperTest : BaseUnitTest() {
         val negativeLabel = "-10 (-33%)"
         whenever(resourceProvider.getString(eq(R.string.stats_traffic_change), eq("-10"), eq("-33")))
                 .thenReturn(negativeLabel)
+        whenever(resourceProvider.getString(
+                eq(R.string.stats_overview_content_description),
+                eq(likes),
+                eq(likesTitle),
+                eq(printedDate),
+                eq(negativeLabel)
+        )).thenReturn(negativeLabel)
 
         val title = mapper.buildTitle(
                 selectedItem,
@@ -126,6 +162,13 @@ class OverviewMapperTest : BaseUnitTest() {
         val negativeLabel = "-20 (-100%)"
         whenever(resourceProvider.getString(eq(R.string.stats_traffic_change), eq("-20"), eq("-100")))
                 .thenReturn(negativeLabel)
+        whenever(resourceProvider.getString(
+                eq(R.string.stats_overview_content_description),
+                eq(newLikes),
+                eq(likesTitle),
+                eq(printedDate),
+                eq(negativeLabel)
+        )).thenReturn(negativeLabel)
 
         val title = mapper.buildTitle(
                 newItem,
@@ -149,6 +192,13 @@ class OverviewMapperTest : BaseUnitTest() {
         val positiveLabel = "+0 (0%)"
         whenever(resourceProvider.getString(eq(R.string.stats_traffic_increase), eq("0"), eq("0")))
                 .thenReturn(positiveLabel)
+        whenever(resourceProvider.getString(
+                eq(R.string.stats_overview_content_description),
+                eq(likes),
+                eq(likesTitle),
+                eq(printedDate),
+                eq(positiveLabel)
+        )).thenReturn(positiveLabel)
 
         val title = mapper.buildTitle(
                 selectedItem,
@@ -161,6 +211,7 @@ class OverviewMapperTest : BaseUnitTest() {
         assertThat(title.unit).isEqualTo(R.string.stats_likes)
         assertThat(title.change).isEqualTo(positiveLabel)
         assertThat(title.state).isEqualTo(POSITIVE)
+        assertThat(title.contentDescription).isEqualTo(positiveLabel)
     }
 
     @Test
@@ -172,6 +223,13 @@ class OverviewMapperTest : BaseUnitTest() {
         val negativeLabel = "-10 (-33%)"
         whenever(resourceProvider.getString(eq(R.string.stats_traffic_change), eq("-10"), eq("-33")))
                 .thenReturn(negativeLabel)
+        whenever(resourceProvider.getString(
+                eq(R.string.stats_overview_content_description),
+                eq(likes),
+                eq(likesTitle),
+                eq(printedDate),
+                eq(negativeLabel)
+        )).thenReturn(negativeLabel)
 
         val title = mapper.buildTitle(
                 selectedItem,
@@ -193,23 +251,44 @@ class OverviewMapperTest : BaseUnitTest() {
 
         val onColumnSelected: (Int) -> Unit = {}
 
+        val viewsContentDescription = "views description"
+        whenever(contentDescriptionHelper.buildContentDescription(
+                eq(R.string.stats_views),
+                eq(views)
+        )).thenReturn(viewsContentDescription)
+
+        val visitorsContentDescription = "visitors description"
+        whenever(contentDescriptionHelper.buildContentDescription(
+                eq(R.string.stats_visitors),
+                eq(visitors)
+        )).thenReturn(visitorsContentDescription)
+
+        val likesContentDescription = "likes description"
+        whenever(contentDescriptionHelper.buildContentDescription(
+                eq(R.string.stats_likes),
+                eq(likes)
+        )).thenReturn(likesContentDescription)
+
+        val commentsContentDescription = "comments description"
+        whenever(contentDescriptionHelper.buildContentDescription(
+                eq(R.string.stats_comments),
+                eq(comments)
+        )).thenReturn(commentsContentDescription)
+
         val result = mapper.buildColumns(selectedItem, onColumnSelected, uiState.selectedPosition)
 
-        assertThat(result.headers).containsExactly(
-                R.string.stats_views,
-                R.string.stats_visitors,
-                R.string.stats_likes,
-                R.string.stats_comments
-        )
-
-        assertThat(result.values).containsExactly(
-                views.toString(),
-                visitors.toString(),
-                likes.toString(),
-                comments.toString()
-        )
+        result.columns[0].assertColumn(R.string.stats_views, views, viewsContentDescription)
+        result.columns[1].assertColumn(R.string.stats_visitors, visitors, visitorsContentDescription)
+        result.columns[2].assertColumn(R.string.stats_likes, likes, likesContentDescription)
+        result.columns[3].assertColumn(R.string.stats_comments, comments, commentsContentDescription)
 
         assertThat(result.selectedColumn).isEqualTo(selectedPosition)
         assertThat(result.onColumnSelected).isEqualTo(onColumnSelected)
+    }
+
+    private fun Column.assertColumn(title: Int, value: Long, contentDescription: String) {
+        assertThat(this.header).isEqualTo(title)
+        assertThat(this.value).isEqualTo(value.toString())
+        assertThat(this.contentDescription).isEqualTo(contentDescription)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCaseTest.kt
@@ -10,6 +10,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.LimitMode.Top
@@ -31,6 +32,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDa
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Date
 
 class OverviewUseCaseTest : BaseUnitTest() {
@@ -39,6 +41,7 @@ class OverviewUseCaseTest : BaseUnitTest() {
     @Mock lateinit var statsDateFormatter: StatsDateFormatter
     @Mock lateinit var overviewMapper: OverviewMapper
     @Mock lateinit var statsSiteProvider: StatsSiteProvider
+    @Mock lateinit var resourceProvider: ResourceProvider
     @Mock lateinit var site: SiteModel
     @Mock lateinit var columns: Columns
     @Mock lateinit var title: ValueItem
@@ -62,13 +65,15 @@ class OverviewUseCaseTest : BaseUnitTest() {
                 statsDateFormatter,
                 overviewMapper,
                 Dispatchers.Unconfined,
-                analyticsTrackerWrapper
+                analyticsTrackerWrapper,
+                resourceProvider
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         whenever(selectedDateProvider.getCurrentDate()).thenReturn(currentDate)
-        whenever(overviewMapper.buildTitle(any(), isNull(), any(), any(), any())).thenReturn(title)
+        whenever(overviewMapper.buildTitle(any(), isNull(), any(), any(), any(), any())).thenReturn(title)
         whenever(overviewMapper.buildChart(any(), any(), any(), any(), any(), any())).thenReturn(listOf(barChartItem))
         whenever(overviewMapper.buildColumns(any(), any(), any())).thenReturn(columns)
+        whenever(resourceProvider.getString(R.string.stats_loading_card)).thenReturn("Loading")
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCaseTest.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListI
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Text
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -41,6 +42,7 @@ class LatestPostSummaryUseCaseTest : BaseUnitTest() {
     @Mock lateinit var site: SiteModel
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
     @Mock lateinit var popupMenuHandler: ItemPopupMenuHandler
+    @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
     private lateinit var useCase: LatestPostSummaryUseCase
     @Before
     fun setUp() = test {
@@ -50,10 +52,15 @@ class LatestPostSummaryUseCaseTest : BaseUnitTest() {
                 statsSiteProvider,
                 latestPostSummaryMapper,
                 tracker,
-                popupMenuHandler
+                popupMenuHandler,
+                contentDescriptionHelper
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         useCase.navigationTarget.observeForever {}
+        whenever(contentDescriptionHelper.buildContentDescription(
+                any(),
+                any()
+        )).thenReturn("likes: 10")
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetListViewModelTest.kt
@@ -77,27 +77,30 @@ class ViewsWidgetListViewModelTest {
                         isNull(),
                         any(),
                         any(),
+                        any(),
                         any()
                 )
-        ).thenReturn(ValueItem(firstViews.toFormattedString(), 0, false, change, POSITIVE))
+        ).thenReturn(ValueItem(firstViews.toFormattedString(), 0, false, change, POSITIVE, change))
         whenever(
                 overviewMapper.buildTitle(
                         eq(dates[1]),
                         eq(dates[0]),
                         any(),
                         any(),
+                        any(),
                         any()
                 )
-        ).thenReturn(ValueItem(todayViews.toFormattedString(), 0, true, change, NEGATIVE))
+        ).thenReturn(ValueItem(todayViews.toFormattedString(), 0, true, change, NEGATIVE, change))
         whenever(
                 overviewMapper.buildTitle(
                         eq(dates[2]),
                         eq(dates[1]),
                         any(),
                         any(),
+                        any(),
                         any()
                 )
-        ).thenReturn(ValueItem(todayViews.toFormattedString(), 0, true, change, NEUTRAL))
+        ).thenReturn(ValueItem(todayViews.toFormattedString(), 0, true, change, NEUTRAL, change))
 
         viewModel.start(siteId, color, showChangeColumn, appWidgetId)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelperTest.kt
@@ -1,0 +1,51 @@
+package org.wordpress.android.ui.stats.refresh.utils
+
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.R
+import org.wordpress.android.util.RtlUtils
+import org.wordpress.android.viewmodel.ResourceProvider
+
+@RunWith(MockitoJUnitRunner::class)
+class ContentDescriptionHelperTest {
+    @Mock lateinit var rtlUtils: RtlUtils
+    @Mock lateinit var resourceProvider: ResourceProvider
+    private lateinit var contentDescriptionHelper: ContentDescriptionHelper
+    @Before
+    fun setUp() {
+        contentDescriptionHelper = ContentDescriptionHelper(resourceProvider, rtlUtils)
+    }
+
+    @Test
+    fun `returns RTL text when isRtl true`() {
+        val keyResource = R.string.stats_views
+        val keyLabel = "Views"
+        val value: Long = 53
+
+        whenever(resourceProvider.getString(keyResource)).thenReturn(keyLabel)
+        whenever(rtlUtils.isRtl).thenReturn(true)
+
+        val contentDescription = contentDescriptionHelper.buildContentDescription(keyResource, value)
+
+        assertThat(contentDescription).isEqualTo("53 :Views")
+    }
+
+    @Test
+    fun `returns LTR text when isRtl is false`() {
+        val keyResource = R.string.stats_views
+        val keyLabel = "Views"
+        val value: Long = 53
+
+        whenever(resourceProvider.getString(keyResource)).thenReturn(keyLabel)
+        whenever(rtlUtils.isRtl).thenReturn(false)
+
+        val contentDescription = contentDescriptionHelper.buildContentDescription(keyResource, value)
+
+        assertThat(contentDescription).isEqualTo("Views: 53")
+    }
+}


### PR DESCRIPTION
This PR improves accessibility of the Overview card and of the Quick scan items.

* The Value and the Change in the Overview card should now have a natural content description.
* The Graph has a content description
* The clickable columns below the graph now have a better content description and an announcement when the user clicks them
* The Quick scan items are now read in order
* The graph and the legend are not marked as "not important for accessibility" 

I've created this PR from another one that grew too much so there is a chance I missed something related.

Overview card:
<img width="484" alt="Screenshot 2019-07-24 at 10 07 41" src="https://user-images.githubusercontent.com/1079756/61776239-e9f3a980-adfa-11e9-9615-17327e7add39.png">

Quick scan item:
<img width="485" alt="Screenshot 2019-07-24 at 09 48 47" src="https://user-images.githubusercontent.com/1079756/61774968-45706800-adf8-11e9-9d0b-19083f1fe87c.png">


To test:
* Test the two cards in the Talkback mode to hear if the content description works as expected
