### PR TITLE
Fix/update fastlane

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org" do
-  gem 'fastlane', "2.126"
+  gem 'fastlane', "2.127.2"
   gem 'nokogiri'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.4)
     emoji_regex (1.0.1)
-    excon (0.64.0)
+    excon (0.65.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
@@ -44,7 +44,7 @@ GEM
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.5)
-    fastlane (2.126.0)
+    fastlane (2.127.2)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -64,7 +64,7 @@ GEM
       highline (>= 1.7.2, < 2.0.0)
       json (< 3.0.0)
       jwt (~> 2.1.0)
-      mini_magick (~> 4.5.1)
+      mini_magick (>= 4.9.4, < 5.0.0)
       multi_xml (~> 0.5)
       multipart-post (~> 2.0.0)
       plist (>= 3.1.0, < 4.0.0)
@@ -120,7 +120,7 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)
-    mini_magick (4.5.1)
+    mini_magick (4.9.5)
     mini_portile2 (2.4.0)
     multi_json (1.13.1)
     multi_xml (0.6.0)
@@ -149,6 +149,7 @@ GEM
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
+    rmagick (3.2.0)
     rouge (2.0.7)
     rubyzip (1.2.3)
     sawyer (0.8.2)
@@ -192,7 +193,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane (= 2.126)!
+  fastlane (= 2.127.2)!
   fastlane-plugin-wpmreleasetoolkit!
   nokogiri!
   rmagick (~> 3.2.0)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -209,19 +209,19 @@ ENV["HAS_ALPHA_VERSION"]="true"
   end
 
   #####################################################################################
-  # build_test_releases
+  # build_pre_releases
   # -----------------------------------------------------------------------------------
   # This lane builds the app it for both internal and external distribution 
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_test_releases [skip_confirm:<skip confirm>]
+  # bundle exec fastlane build_pre_releases [skip_confirm:<skip confirm>]
   #
   # Example:
-  # bundle exec fastlane build_test_releases 
-  # bundle exec fastlane build_test_releases skip_confirm:true 
+  # bundle exec fastlane build_pre_releases 
+  # bundle exec fastlane build_pre_releases skip_confirm:true 
   #####################################################################################
   desc "Builds and updates for distribution"
-  lane :build_test_releases do | options |
+  lane :build_pre_releases do | options |
     android_build_prechecks(skip_confirm: options[:skip_confirm], 
       alpha: true,
       beta: true,


### PR DESCRIPTION
This PR updates Fastlane to get rid of the `mini_magick` security alert.
It also renames the `build_test_releases` lane to `build_pre_releases` to make it consistent with the name we gave it on the other projects. 

To test:
1. Run `bundle install`.
2. Run one of the release lanes (`build_pre_releases`) and verify that it works. 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
