### PR TITLE
Stats accessibility improvements 2

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 13.0
 -----
+* Improve accessibility in the Stats
  
 12.9
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
@@ -74,7 +74,13 @@ class PostAverageViewsPerDayUseCase(
                 )
         )
         val shownYears = domainModel.yearsAverage.sortedByDescending { it.year }.takeLast(itemsToLoad)
-        val yearList = postDetailMapper.mapYears(shownYears, uiState, this::onUiState)
+        val yearList = postDetailMapper.mapYears(
+                shownYears,
+                uiState,
+                R.string.stats_months_and_years_period_label,
+                R.string.stats_months_and_years_views_label,
+                this::onUiState
+        )
 
         items.addAll(yearList)
         if (useCaseMode == BLOCK && domainModel.yearsAverage.size > itemsToLoad) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
@@ -67,18 +67,18 @@ class PostAverageViewsPerDayUseCase(
         if (useCaseMode == BLOCK) {
             items.add(Title(R.string.stats_detail_average_views_per_day))
         }
+        val header = Header(
+                R.string.stats_months_and_years_period_label,
+                R.string.stats_months_and_years_views_label
+        )
         items.add(
-                Header(
-                        R.string.stats_months_and_years_period_label,
-                        R.string.stats_months_and_years_views_label
-                )
+                header
         )
         val shownYears = domainModel.yearsAverage.sortedByDescending { it.year }.takeLast(itemsToLoad)
         val yearList = postDetailMapper.mapYears(
                 shownYears,
                 uiState,
-                R.string.stats_months_and_years_period_label,
-                R.string.stats_months_and_years_views_label,
+                header,
                 this::onUiState
         )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDetailMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDetailMapper.kt
@@ -49,17 +49,16 @@ class PostDetailMapper
                 if (isExpanded) {
                     yearList.addAll(year.months.sortedByDescending { it.month }.map { month ->
                         val text = DateFormatSymbols(localeManagerWrapper.getLocale()).shortMonths[month.month - 1]
-                        val value = month.count.toFormattedString(locale = localeManagerWrapper.getLocale())
                         ListItemWithIcon(
                                 text = text,
-                                value = value,
+                                value = month.count.toFormattedString(locale = localeManagerWrapper.getLocale()),
                                 textStyle = LIGHT,
                                 showDivider = false,
                                 contentDescription = contentDescriptionHelper.buildContentDescription(
                                         keyLabel,
                                         text,
                                         valueLabel,
-                                        value
+                                        month.count
                                 )
                         )
                     })
@@ -82,17 +81,16 @@ class PostDetailMapper
         keyLabel: Int,
         valueLabel: Int
     ): ListItemWithIcon {
-        val value = year.value.toFormattedString(locale = localeManagerWrapper.getLocale())
         val text = year.year.toString()
         return ListItemWithIcon(
                 text = text,
-                value = value,
+                value = year.value.toFormattedString(locale = localeManagerWrapper.getLocale()),
                 showDivider = isNextNotExpanded && index < size - 1,
                 contentDescription = contentDescriptionHelper.buildContentDescription(
                         keyLabel,
                         text,
                         valueLabel,
-                        value
+                        year.value
                 )
         )
     }
@@ -131,8 +129,8 @@ class PostDetailMapper
                 if (isExpanded) {
                     weekList.addAll(week.days
                             .map { day ->
-                                val value = day.average.toFormattedString(locale = localeManagerWrapper.getLocale())
                                 val text = statsDateFormatter.printDayWithoutYear(day.date)
+                                val value = day.average.toFormattedString(locale = localeManagerWrapper.getLocale())
                                 ListItemWithIcon(
                                         text = text,
                                         value = value,
@@ -142,7 +140,7 @@ class PostDetailMapper
                                                 keyLabel,
                                                 text,
                                                 valueLabel,
-                                                value
+                                                day.average
                                         )
                                 )
                             })
@@ -187,7 +185,7 @@ class PostDetailMapper
                         keyLabel,
                         label,
                         valueLabel,
-                        value
+                        week.weekAverage
                 )
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDetailMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDetailMapper.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Divider
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ExpandableItem
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon.TextStyle.LIGHT
 import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
@@ -25,8 +26,7 @@ class PostDetailMapper
     fun mapYears(
         shownYears: List<Year>,
         expandedYearUiState: ExpandedYearUiState,
-        keyLabel: Int,
-        valueLabel: Int,
+        header: Header,
         onUiState: (ExpandedYearUiState) -> Unit
     ): List<BlockListItem> {
         val yearList = mutableListOf<BlockListItem>()
@@ -40,7 +40,7 @@ class PostDetailMapper
                 }
                 yearList.add(
                         ExpandableItem(
-                                mapYear(year, index, shownYears.size, isNextNotExpanded, keyLabel, valueLabel),
+                                mapYear(year, index, shownYears.size, isNextNotExpanded, header),
                                 isExpanded = isExpanded
                         ) { changedExpandedState ->
                             val expandedYear = if (changedExpandedState) year.year else null
@@ -55,9 +55,8 @@ class PostDetailMapper
                                 textStyle = LIGHT,
                                 showDivider = false,
                                 contentDescription = contentDescriptionHelper.buildContentDescription(
-                                        keyLabel,
+                                        header,
                                         text,
-                                        valueLabel,
                                         month.count
                                 )
                         )
@@ -66,7 +65,7 @@ class PostDetailMapper
                 }
             } else {
                 yearList.add(
-                        mapYear(year, index, shownYears.size, isNextNotExpanded, keyLabel, valueLabel)
+                        mapYear(year, index, shownYears.size, isNextNotExpanded, header)
                 )
             }
         }
@@ -78,8 +77,7 @@ class PostDetailMapper
         index: Int,
         size: Int,
         isNextNotExpanded: Boolean,
-        keyLabel: Int,
-        valueLabel: Int
+        header: Header
     ): ListItemWithIcon {
         val text = year.year.toString()
         return ListItemWithIcon(
@@ -87,9 +85,8 @@ class PostDetailMapper
                 value = year.value.toFormattedString(locale = localeManagerWrapper.getLocale()),
                 showDivider = isNextNotExpanded && index < size - 1,
                 contentDescription = contentDescriptionHelper.buildContentDescription(
-                        keyLabel,
+                        header,
                         text,
-                        valueLabel,
                         year.value
                 )
         )
@@ -99,8 +96,7 @@ class PostDetailMapper
         weeks: List<PostDetailStatsModel.Week>,
         visibleCount: Int,
         uiState: ExpandedWeekUiState,
-        keyLabel: Int,
-        valueLabel: Int,
+        header: Header,
         onUiState: (ExpandedWeekUiState) -> Unit
     ): List<BlockListItem> {
         val weekList = mutableListOf<BlockListItem>()
@@ -120,7 +116,7 @@ class PostDetailMapper
                 }
                 weekList.add(
                         ExpandableItem(
-                                mapWeek(week, index, visibleWeeks.size, isNextNotExpanded, keyLabel, valueLabel),
+                                mapWeek(week, index, visibleWeeks.size, isNextNotExpanded, header),
                                 isExpanded = isExpanded
                         ) { changedExpandedState ->
                             val expandedFirstDay = if (changedExpandedState) week.firstDay else null
@@ -137,9 +133,8 @@ class PostDetailMapper
                                         textStyle = LIGHT,
                                         showDivider = false,
                                         contentDescription = contentDescriptionHelper.buildContentDescription(
-                                                keyLabel,
+                                                header,
                                                 text,
-                                                valueLabel,
                                                 day.average
                                         )
                                 )
@@ -147,7 +142,7 @@ class PostDetailMapper
                     weekList.add(Divider)
                 }
             } else {
-                weekList.add(mapWeek(week, index, visibleWeeks.size, isNextNotExpanded, keyLabel, valueLabel))
+                weekList.add(mapWeek(week, index, visibleWeeks.size, isNextNotExpanded, header))
             }
         }
         return weekList
@@ -167,8 +162,7 @@ class PostDetailMapper
         index: Int,
         size: Int,
         isNextNotExpanded: Boolean,
-        keyLabel: Int,
-        valueLabel: Int
+        header: Header
     ): ListItemWithIcon {
         val lastDay = week.lastDay
         val label = if (lastDay != null) {
@@ -176,15 +170,13 @@ class PostDetailMapper
         } else {
             statsDateFormatter.printGranularDate(week.firstDay, DAYS)
         }
-        val value = week.weekAverage.toFormattedString(locale = localeManagerWrapper.getLocale())
         return ListItemWithIcon(
                 text = label,
-                value = value,
+                value = week.weekAverage.toFormattedString(locale = localeManagerWrapper.getLocale()),
                 showDivider = isNextNotExpanded && index < size - 1,
                 contentDescription = contentDescriptionHelper.buildContentDescription(
-                        keyLabel,
+                        header,
                         label,
-                        valueLabel,
                         week.weekAverage
                 )
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCase.kt
@@ -74,7 +74,13 @@ class PostMonthsAndYearsUseCase(
                 )
         )
         val shownYears = domainModel.yearsTotal.sortedByDescending { it.year }.takeLast(itemsToLoad)
-        val yearList = postDetailMapper.mapYears(shownYears, uiState, this::onUiState)
+        val yearList = postDetailMapper.mapYears(
+                shownYears,
+                uiState,
+                R.string.stats_months_and_years_period_label,
+                R.string.stats_months_and_years_views_label,
+                this::onUiState
+        )
 
         items.addAll(yearList)
         if (useCaseMode == BLOCK && domainModel.yearsTotal.size > itemsToLoad) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCase.kt
@@ -67,18 +67,18 @@ class PostMonthsAndYearsUseCase(
         if (useCaseMode == BLOCK) {
             items.add(Title(R.string.stats_detail_months_and_years))
         }
+        val header = Header(
+                R.string.stats_months_and_years_period_label,
+                R.string.stats_months_and_years_views_label
+        )
         items.add(
-                Header(
-                        R.string.stats_months_and_years_period_label,
-                        R.string.stats_months_and_years_views_label
-                )
+                header
         )
         val shownYears = domainModel.yearsTotal.sortedByDescending { it.year }.takeLast(itemsToLoad)
         val yearList = postDetailMapper.mapYears(
                 shownYears,
                 uiState,
-                R.string.stats_months_and_years_period_label,
-                R.string.stats_months_and_years_views_label,
+                header,
                 this::onUiState
         )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCase.kt
@@ -73,7 +73,14 @@ class PostRecentWeeksUseCase(
                         R.string.stats_months_and_years_views_label
                 )
         )
-        val yearList = postDetailMapper.mapWeeks(domainModel.weekViews, itemsToLoad, uiState, this::onUiState)
+        val yearList = postDetailMapper.mapWeeks(
+                domainModel.weekViews,
+                itemsToLoad,
+                uiState,
+                R.string.stats_months_and_years_period_label,
+                R.string.stats_months_and_years_views_label,
+                this::onUiState
+        )
 
         items.addAll(yearList)
         if (useCaseMode == BLOCK && domainModel.weekViews.size > itemsToLoad) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCase.kt
@@ -67,18 +67,18 @@ class PostRecentWeeksUseCase(
         if (useCaseMode == BLOCK) {
             items.add(Title(R.string.stats_detail_recent_weeks))
         }
+        val header = Header(
+                R.string.stats_months_and_years_period_label,
+                R.string.stats_months_and_years_views_label
+        )
         items.add(
-                Header(
-                        R.string.stats_months_and_years_period_label,
-                        R.string.stats_months_and_years_views_label
-                )
+                header
         )
         val yearList = postDetailMapper.mapWeeks(
                 domainModel.weekViews,
                 itemsToLoad,
                 uiState,
-                R.string.stats_months_and_years_period_label,
-                R.string.stats_months_and_years_views_label,
+                header,
                 this::onUiState
         )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -106,7 +106,8 @@ sealed class BlockListItem(val type: Type) {
     data class ListItem(
         val text: String,
         val value: String,
-        val showDivider: Boolean = true
+        val showDivider: Boolean = true,
+        val contentDescription: String
     ) : BlockListItem(LIST_ITEM) {
         override val itemId: Int
             get() = text.hashCode()
@@ -123,7 +124,8 @@ sealed class BlockListItem(val type: Type) {
         val barWidth: Int? = null,
         val showDivider: Boolean = true,
         val textStyle: TextStyle = TextStyle.NORMAL,
-        val navigationAction: NavigationAction? = null
+        val navigationAction: NavigationAction? = null,
+        val contentDescription: String
     ) : BlockListItem(LIST_ITEM_WITH_ICON) {
         override val itemId: Int
             get() = (icon ?: 0) + (iconUrl?.hashCode() ?: 0) + (textResource ?: 0) + (text?.hashCode() ?: 0)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
@@ -107,19 +107,18 @@ constructor(
             items.add(Header(R.string.stats_author_label, R.string.stats_author_views_label))
             val maxViews = domainModel.authors.maxBy { it.views }?.views ?: 0
             domainModel.authors.forEachIndexed { index, author ->
-                val value = author.views.toFormattedString()
                 val headerItem = ListItemWithIcon(
                         iconUrl = author.avatarUrl,
                         iconStyle = AVATAR,
                         text = author.name,
                         barWidth = getBarWidth(author.views, maxViews),
-                        value = value,
+                        value = author.views.toFormattedString(),
                         showDivider = index < domainModel.authors.size - 1,
                         contentDescription = contentDescriptionHelper.buildContentDescription(
                                 R.string.stats_author_label,
                                 author.name,
                                 R.string.stats_author_views_label,
-                                value
+                                author.views
                         )
                 )
                 if (author.posts.isEmpty()) {
@@ -131,10 +130,9 @@ constructor(
                     })
                     if (isExpanded) {
                         items.addAll(author.posts.map { post ->
-                            val postViews = post.views.toFormattedString()
                             ListItemWithIcon(
                                     text = post.title,
-                                    value = postViews,
+                                    value = post.views.toFormattedString(),
                                     iconStyle = if (author.avatarUrl != null) EMPTY_SPACE else NORMAL,
                                     textStyle = LIGHT,
                                     showDivider = false,
@@ -146,7 +144,7 @@ constructor(
                                             R.string.stats_post_label,
                                             post.title,
                                             R.string.stats_post_views_label,
-                                            postViews
+                                            post.views
                                     )
                             )
                         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
@@ -104,7 +104,8 @@ constructor(
         if (domainModel.authors.isEmpty()) {
             items.add(Empty(R.string.stats_no_data_for_period))
         } else {
-            items.add(Header(R.string.stats_author_label, R.string.stats_author_views_label))
+            val header = Header(R.string.stats_author_label, R.string.stats_author_views_label)
+            items.add(header)
             val maxViews = domainModel.authors.maxBy { it.views }?.views ?: 0
             domainModel.authors.forEachIndexed { index, author ->
                 val headerItem = ListItemWithIcon(
@@ -115,9 +116,8 @@ constructor(
                         value = author.views.toFormattedString(),
                         showDivider = index < domainModel.authors.size - 1,
                         contentDescription = contentDescriptionHelper.buildContentDescription(
-                                R.string.stats_author_label,
+                                header,
                                 author.name,
-                                R.string.stats_author_views_label,
                                 author.views
                         )
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCase.kt
@@ -101,17 +101,16 @@ constructor(
         } else {
             items.add(Header(R.string.stats_clicks_link_label, R.string.stats_clicks_label))
             domainModel.groups.forEachIndexed { index, group ->
-                val value = group.views?.toFormattedString()
                 val groupName = group.name
                 val contentDescription = contentDescriptionHelper.buildContentDescription(
-                            R.string.stats_clicks_link_label,
-                            groupName ?: "",
-                            R.string.stats_clicks_label,
-                            value ?: ""
-                    )
+                        R.string.stats_clicks_link_label,
+                        groupName ?: "",
+                        R.string.stats_clicks_label,
+                        group.views ?: 0
+                )
                 val headerItem = ListItemWithIcon(
                         text = groupName,
-                        value = value,
+                        value = group.views?.toFormattedString(),
                         showDivider = index < domainModel.groups.size - 1,
                         navigationAction = group.url?.let { create(it, this::onItemClick) },
                         contentDescription = contentDescription
@@ -125,18 +124,17 @@ constructor(
                     })
                     if (isExpanded) {
                         items.addAll(group.clicks.map { click ->
-                            val clickValue = click.views.toFormattedString()
                             ListItemWithIcon(
                                     text = click.name,
                                     textStyle = LIGHT,
-                                    value = clickValue,
+                                    value = click.views.toFormattedString(),
                                     showDivider = false,
                                     navigationAction = click.url?.let { create(it, this::onItemClick) },
                                     contentDescription = contentDescriptionHelper.buildContentDescription(
                                             R.string.stats_clicks_link_label,
                                             click.name,
                                             R.string.stats_clicks_label,
-                                            clickValue
+                                            click.views
                                     )
                             )
                         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCase.kt
@@ -99,13 +99,13 @@ constructor(
         if (domainModel.groups.isEmpty()) {
             items.add(Empty(R.string.stats_no_data_for_period))
         } else {
-            items.add(Header(R.string.stats_clicks_link_label, R.string.stats_clicks_label))
+            val header = Header(R.string.stats_clicks_link_label, R.string.stats_clicks_label)
+            items.add(header)
             domainModel.groups.forEachIndexed { index, group ->
                 val groupName = group.name
                 val contentDescription = contentDescriptionHelper.buildContentDescription(
-                        R.string.stats_clicks_link_label,
+                        header,
                         groupName ?: "",
-                        R.string.stats_clicks_label,
                         group.views ?: 0
                 )
                 val headerItem = ListItemWithIcon(
@@ -131,9 +131,8 @@ constructor(
                                     showDivider = false,
                                     navigationAction = click.url?.let { create(it, this::onItemClick) },
                                     contentDescription = contentDescriptionHelper.buildContentDescription(
-                                            R.string.stats_clicks_link_label,
+                                            header,
                                             click.name,
-                                            R.string.stats_clicks_label,
                                             click.views
                                     )
                             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCase.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularStatelessUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.ui.stats.refresh.utils.trackGranular
@@ -44,6 +45,7 @@ constructor(
     statsSiteProvider: StatsSiteProvider,
     selectedDateProvider: SelectedDateProvider,
     private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val contentDescriptionHelper: ContentDescriptionHelper,
     private val useCaseMode: UseCaseMode
 ) : GranularStatelessUseCase<CountryViewsModel>(
         COUNTRIES,
@@ -119,12 +121,19 @@ constructor(
             items.add(MapLegend(startLabel, endLabel))
             items.add(Header(R.string.stats_country_label, R.string.stats_country_views_label))
             domainModel.countries.forEachIndexed { index, group ->
+                val value = group.views.toFormattedString()
                 items.add(
                         ListItemWithIcon(
                                 iconUrl = group.flagIconUrl,
                                 text = group.fullName,
-                                value = group.views.toFormattedString(),
-                                showDivider = index < domainModel.countries.size - 1
+                                value = value,
+                                showDivider = index < domainModel.countries.size - 1,
+                                contentDescription = contentDescriptionHelper.buildContentDescription(
+                                        R.string.stats_country_label,
+                                        group.fullName,
+                                        R.string.stats_country_views_label,
+                                        value
+                                )
                         )
                 )
             }
@@ -157,7 +166,8 @@ constructor(
         private val store: CountryViewsStore,
         private val statsSiteProvider: StatsSiteProvider,
         private val selectedDateProvider: SelectedDateProvider,
-        private val analyticsTracker: AnalyticsTrackerWrapper
+        private val analyticsTracker: AnalyticsTrackerWrapper,
+        private val contentDescriptionHelper: ContentDescriptionHelper
     ) : GranularUseCaseFactory {
         override fun build(granularity: StatsGranularity, useCaseMode: UseCaseMode) =
                 CountryViewsUseCase(
@@ -167,6 +177,7 @@ constructor(
                         statsSiteProvider,
                         selectedDateProvider,
                         analyticsTracker,
+                        contentDescriptionHelper,
                         useCaseMode
                 )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCase.kt
@@ -121,18 +121,17 @@ constructor(
             items.add(MapLegend(startLabel, endLabel))
             items.add(Header(R.string.stats_country_label, R.string.stats_country_views_label))
             domainModel.countries.forEachIndexed { index, group ->
-                val value = group.views.toFormattedString()
                 items.add(
                         ListItemWithIcon(
                                 iconUrl = group.flagIconUrl,
                                 text = group.fullName,
-                                value = value,
+                                value = group.views.toFormattedString(),
                                 showDivider = index < domainModel.countries.size - 1,
                                 contentDescription = contentDescriptionHelper.buildContentDescription(
                                         R.string.stats_country_label,
                                         group.fullName,
                                         R.string.stats_country_views_label,
-                                        value
+                                        group.views
                                 )
                         )
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCase.kt
@@ -119,7 +119,8 @@ constructor(
             val endLabel = (maxViews ?: 0).toFormattedString()
             items.add(MapItem(stringBuilder.toString(), R.string.stats_country_views_label))
             items.add(MapLegend(startLabel, endLabel))
-            items.add(Header(R.string.stats_country_label, R.string.stats_country_views_label))
+            val header = Header(R.string.stats_country_label, R.string.stats_country_views_label)
+            items.add(header)
             domainModel.countries.forEachIndexed { index, group ->
                 items.add(
                         ListItemWithIcon(
@@ -128,9 +129,8 @@ constructor(
                                 value = group.views.toFormattedString(),
                                 showDivider = index < domainModel.countries.size - 1,
                                 contentDescription = contentDescriptionHelper.buildContentDescription(
-                                        R.string.stats_country_label,
+                                        header,
                                         group.fullName,
-                                        R.string.stats_country_views_label,
                                         group.views
                                 )
                         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCase.kt
@@ -111,11 +111,10 @@ constructor(
                     POST -> R.drawable.ic_posts_white_24dp
                     HOMEPAGE, PAGE -> R.drawable.ic_pages_white_24dp
                 }
-                val value = viewsModel.views.toFormattedString()
                 ListItemWithIcon(
                         icon = icon,
                         text = viewsModel.title,
-                        value = value,
+                        value = viewsModel.views.toFormattedString(),
                         showDivider = index < domainModel.views.size - 1,
                         barWidth = getBarWidth(viewsModel.views, maxViews),
                         navigationAction = create(
@@ -126,7 +125,7 @@ constructor(
                                 R.string.stats_posts_and_pages_title_label,
                                 viewsModel.title,
                                 R.string.stats_posts_and_pages_views_label,
-                                value
+                                viewsModel.views
                         )
                 )
             })

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCase.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularStatelessUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.getBarWidth
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
@@ -49,6 +50,7 @@ constructor(
     statsSiteProvider: StatsSiteProvider,
     selectedDateProvider: SelectedDateProvider,
     private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val contentDescriptionHelper: ContentDescriptionHelper,
     private val useCaseMode: UseCaseMode
 ) : GranularStatelessUseCase<PostAndPageViewsModel>(
         POSTS_AND_PAGES,
@@ -109,15 +111,22 @@ constructor(
                     POST -> R.drawable.ic_posts_white_24dp
                     HOMEPAGE, PAGE -> R.drawable.ic_pages_white_24dp
                 }
+                val value = viewsModel.views.toFormattedString()
                 ListItemWithIcon(
                         icon = icon,
                         text = viewsModel.title,
-                        value = viewsModel.views.toFormattedString(),
+                        value = value,
                         showDivider = index < domainModel.views.size - 1,
                         barWidth = getBarWidth(viewsModel.views, maxViews),
                         navigationAction = create(
                                 LinkClickParams(viewsModel.id, viewsModel.url, viewsModel.title, viewsModel.type),
                                 this::onLinkClicked
+                        ),
+                        contentDescription = contentDescriptionHelper.buildContentDescription(
+                                R.string.stats_posts_and_pages_title_label,
+                                viewsModel.title,
+                                R.string.stats_posts_and_pages_views_label,
+                                value
                         )
                 )
             })
@@ -172,6 +181,7 @@ constructor(
         private val postsAndPageViewsStore: PostAndPageViewsStore,
         private val selectedDateProvider: SelectedDateProvider,
         private val statsSiteProvider: StatsSiteProvider,
+        private val contentDescriptionHelper: ContentDescriptionHelper,
         private val analyticsTracker: AnalyticsTrackerWrapper
     ) : GranularUseCaseFactory {
         override fun build(granularity: StatsGranularity, useCaseMode: UseCaseMode) =
@@ -182,6 +192,7 @@ constructor(
                         statsSiteProvider,
                         selectedDateProvider,
                         analyticsTracker,
+                        contentDescriptionHelper,
                         useCaseMode
                 )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCase.kt
@@ -104,7 +104,8 @@ constructor(
         if (domainModel.views.isEmpty()) {
             items.add(Empty(R.string.stats_no_data_for_period))
         } else {
-            items.add(Header(R.string.stats_posts_and_pages_title_label, R.string.stats_posts_and_pages_views_label))
+            val header = Header(R.string.stats_posts_and_pages_title_label, R.string.stats_posts_and_pages_views_label)
+            items.add(header)
             val maxViews = domainModel.views.maxBy { it.views }?.views ?: 0
             items.addAll(domainModel.views.mapIndexed { index, viewsModel ->
                 val icon = when (viewsModel.type) {
@@ -122,9 +123,8 @@ constructor(
                                 this::onLinkClicked
                         ),
                         contentDescription = contentDescriptionHelper.buildContentDescription(
-                                R.string.stats_posts_and_pages_title_label,
+                                header,
                                 viewsModel.title,
-                                R.string.stats_posts_and_pages_views_label,
                                 viewsModel.views
                         )
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
@@ -111,7 +111,7 @@ constructor(
                             R.string.stats_referrer_label,
                             text ?: "",
                             R.string.stats_referrer_views_label,
-                            value
+                            group.total ?: 0
                     )
                 if (group.referrers.isEmpty()) {
                     val headerItem = ListItemWithIcon(
@@ -145,21 +145,20 @@ constructor(
                             } else {
                                 NORMAL
                             }
-                            val referrerValue = referrer.views.toFormattedString()
                             ListItemWithIcon(
                                     icon = referrerIcon,
                                     iconUrl = if (referrerIcon == null) referrer.icon else null,
                                     iconStyle = iconStyle,
                                     textStyle = LIGHT,
                                     text = referrer.name,
-                                    value = referrerValue,
+                                    value = referrer.views.toFormattedString(),
                                     showDivider = false,
                                     navigationAction = referrer.url?.let { create(it, this::onItemClick) },
                                     contentDescription = contentDescriptionHelper.buildContentDescription(
                                             R.string.stats_referrer_label,
                                             referrer.name,
                                             R.string.stats_referrer_views_label,
-                                            referrerValue
+                                            referrer.views
                                     )
                             )
                         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
@@ -105,20 +105,18 @@ constructor(
             items.add(header)
             domainModel.groups.forEachIndexed { index, group ->
                 val icon = buildIcon(group.icon)
-                val text = group.name
-                val value = (group.total ?: 0).toFormattedString()
                 val contentDescription =
                     contentDescriptionHelper.buildContentDescription(
                             header,
-                            text ?: "",
+                            group.name ?: "",
                             group.total ?: 0
                     )
                 if (group.referrers.isEmpty()) {
                     val headerItem = ListItemWithIcon(
                             icon = icon,
                             iconUrl = if (icon == null) group.icon else null,
-                            text = text,
-                            value = value,
+                            text = group.name,
+                            value = group.total?.toFormattedString(),
                             showDivider = index < domainModel.groups.size - 1,
                             navigationAction = group.url?.let { create(it, this::onItemClick) },
                             contentDescription = contentDescription
@@ -128,8 +126,8 @@ constructor(
                     val headerItem = ListItemWithIcon(
                             icon = icon,
                             iconUrl = if (icon == null) group.icon else null,
-                            text = text,
-                            value = value,
+                            text = group.name,
+                            value = group.total?.toFormattedString(),
                             showDivider = index < domainModel.groups.size - 1,
                             contentDescription = contentDescription
                     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
@@ -101,16 +101,16 @@ constructor(
         if (domainModel.groups.isEmpty()) {
             items.add(Empty(R.string.stats_no_data_for_period))
         } else {
-            items.add(Header(R.string.stats_referrer_label, R.string.stats_referrer_views_label))
+            val header = Header(R.string.stats_referrer_label, R.string.stats_referrer_views_label)
+            items.add(header)
             domainModel.groups.forEachIndexed { index, group ->
                 val icon = buildIcon(group.icon)
                 val text = group.name
                 val value = (group.total ?: 0).toFormattedString()
                 val contentDescription =
                     contentDescriptionHelper.buildContentDescription(
-                            R.string.stats_referrer_label,
+                            header,
                             text ?: "",
-                            R.string.stats_referrer_views_label,
                             group.total ?: 0
                     )
                 if (group.referrers.isEmpty()) {
@@ -155,9 +155,8 @@ constructor(
                                     showDivider = false,
                                     navigationAction = referrer.url?.let { create(it, this::onItemClick) },
                                     contentDescription = contentDescriptionHelper.buildContentDescription(
-                                            R.string.stats_referrer_label,
+                                            header,
                                             referrer.name,
-                                            R.string.stats_referrer_views_label,
                                             referrer.views
                                     )
                             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCase.kt
@@ -100,32 +100,30 @@ constructor(
             items.add(Header(R.string.stats_search_terms_label, R.string.stats_search_terms_views_label))
             val hasEncryptedCount = domainModel.unknownSearchCount > 0
             val mappedSearchTerms = domainModel.searchTerms.mapIndexed { index, searchTerm ->
-                val value = searchTerm.views.toFormattedString()
                 ListItemWithIcon(
                         text = searchTerm.text,
-                        value = value,
+                        value = searchTerm.views.toFormattedString(),
                         showDivider = index < domainModel.searchTerms.size - 1,
                         contentDescription = contentDescriptionHelper.buildContentDescription(
                                 R.string.stats_search_terms_label,
                                 searchTerm.text,
                                 R.string.stats_search_terms_views_label,
-                                value
+                                searchTerm.views
                         )
                 )
             }
             if (hasEncryptedCount) {
                 items.addAll(mappedSearchTerms.take(mappedSearchTerms.size - 1))
-                val value = domainModel.unknownSearchCount.toFormattedString()
                 items.add(
                         ListItemWithIcon(
                                 textResource = R.string.stats_search_terms_unknown_search_terms,
-                                value = value,
+                                value = domainModel.unknownSearchCount.toFormattedString(),
                                 showDivider = false,
                                 contentDescription = contentDescriptionHelper.buildContentDescription(
                                         R.string.stats_search_terms_label,
                                         R.string.stats_search_terms_unknown_search_terms,
                                         R.string.stats_search_terms_views_label,
-                                        value
+                                        domainModel.unknownSearchCount
                                 )
                         )
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCase.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularStatelessUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.ui.stats.refresh.utils.trackGranular
@@ -42,6 +43,7 @@ constructor(
     statsSiteProvider: StatsSiteProvider,
     selectedDateProvider: SelectedDateProvider,
     private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val contentDescriptionHelper: ContentDescriptionHelper,
     private val useCaseMode: UseCaseMode
 ) : GranularStatelessUseCase<SearchTermsModel>(
         SEARCH_TERMS,
@@ -98,19 +100,33 @@ constructor(
             items.add(Header(R.string.stats_search_terms_label, R.string.stats_search_terms_views_label))
             val hasEncryptedCount = domainModel.unknownSearchCount > 0
             val mappedSearchTerms = domainModel.searchTerms.mapIndexed { index, searchTerm ->
+                val value = searchTerm.views.toFormattedString()
                 ListItemWithIcon(
                         text = searchTerm.text,
-                        value = searchTerm.views.toFormattedString(),
-                        showDivider = index < domainModel.searchTerms.size - 1
+                        value = value,
+                        showDivider = index < domainModel.searchTerms.size - 1,
+                        contentDescription = contentDescriptionHelper.buildContentDescription(
+                                R.string.stats_search_terms_label,
+                                searchTerm.text,
+                                R.string.stats_search_terms_views_label,
+                                value
+                        )
                 )
             }
             if (hasEncryptedCount) {
                 items.addAll(mappedSearchTerms.take(mappedSearchTerms.size - 1))
+                val value = domainModel.unknownSearchCount.toFormattedString()
                 items.add(
                         ListItemWithIcon(
                                 textResource = R.string.stats_search_terms_unknown_search_terms,
-                                value = domainModel.unknownSearchCount.toFormattedString(),
-                                showDivider = false
+                                value = value,
+                                showDivider = false,
+                                contentDescription = contentDescriptionHelper.buildContentDescription(
+                                        R.string.stats_search_terms_label,
+                                        R.string.stats_search_terms_unknown_search_terms,
+                                        R.string.stats_search_terms_views_label,
+                                        value
+                                )
                         )
                 )
             } else {
@@ -145,7 +161,8 @@ constructor(
         private val store: SearchTermsStore,
         private val selectedDateProvider: SelectedDateProvider,
         private val statsSiteProvider: StatsSiteProvider,
-        private val analyticsTracker: AnalyticsTrackerWrapper
+        private val analyticsTracker: AnalyticsTrackerWrapper,
+        private val contentDescriptionHelper: ContentDescriptionHelper
     ) : GranularUseCaseFactory {
         override fun build(granularity: StatsGranularity, useCaseMode: UseCaseMode) =
                 SearchTermsUseCase(
@@ -155,6 +172,7 @@ constructor(
                         statsSiteProvider,
                         selectedDateProvider,
                         analyticsTracker,
+                        contentDescriptionHelper,
                         useCaseMode
                 )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCase.kt
@@ -97,7 +97,8 @@ constructor(
         if (domainModel.searchTerms.isEmpty()) {
             items.add(Empty(R.string.stats_no_data_for_period))
         } else {
-            items.add(Header(R.string.stats_search_terms_label, R.string.stats_search_terms_views_label))
+            val header = Header(R.string.stats_search_terms_label, R.string.stats_search_terms_views_label)
+            items.add(header)
             val hasEncryptedCount = domainModel.unknownSearchCount > 0
             val mappedSearchTerms = domainModel.searchTerms.mapIndexed { index, searchTerm ->
                 ListItemWithIcon(
@@ -105,9 +106,8 @@ constructor(
                         value = searchTerm.views.toFormattedString(),
                         showDivider = index < domainModel.searchTerms.size - 1,
                         contentDescription = contentDescriptionHelper.buildContentDescription(
-                                R.string.stats_search_terms_label,
+                                header,
                                 searchTerm.text,
-                                R.string.stats_search_terms_views_label,
                                 searchTerm.views
                         )
                 )
@@ -120,9 +120,8 @@ constructor(
                                 value = domainModel.unknownSearchCount.toFormattedString(),
                                 showDivider = false,
                                 contentDescription = contentDescriptionHelper.buildContentDescription(
-                                        R.string.stats_search_terms_label,
+                                        header,
                                         R.string.stats_search_terms_unknown_search_terms,
-                                        R.string.stats_search_terms_views_label,
                                         domainModel.unknownSearchCount
                                 )
                         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCase.kt
@@ -96,17 +96,16 @@ constructor(
         } else {
             items.add(Header(R.string.stats_videos_title_label, R.string.stats_videos_views_label))
             items.addAll(domainModel.plays.mapIndexed { index, videoPlays ->
-                val value = videoPlays.plays.toFormattedString()
                 ListItemWithIcon(
                         text = videoPlays.title,
-                        value = value,
+                        value = videoPlays.plays.toFormattedString(),
                         showDivider = index < domainModel.plays.size - 1,
                         navigationAction = videoPlays.url?.let { NavigationAction.create(it, this::onItemClick) },
                         contentDescription = contentDescriptionHelper.buildContentDescription(
                                 R.string.stats_videos_title_label,
                                 videoPlays.title,
                                 R.string.stats_videos_views_label,
-                                value
+                                videoPlays.plays
                         )
                 )
             })

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCase.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularStatelessUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.ui.stats.refresh.utils.trackGranular
@@ -43,6 +44,7 @@ constructor(
     statsSiteProvider: StatsSiteProvider,
     selectedDateProvider: SelectedDateProvider,
     private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val contentDescriptionHelper: ContentDescriptionHelper,
     private val useCaseMode: UseCaseMode
 ) : GranularStatelessUseCase<VideoPlaysModel>(
         VIDEOS,
@@ -94,11 +96,18 @@ constructor(
         } else {
             items.add(Header(R.string.stats_videos_title_label, R.string.stats_videos_views_label))
             items.addAll(domainModel.plays.mapIndexed { index, videoPlays ->
+                val value = videoPlays.plays.toFormattedString()
                 ListItemWithIcon(
                         text = videoPlays.title,
-                        value = videoPlays.plays.toFormattedString(),
+                        value = value,
                         showDivider = index < domainModel.plays.size - 1,
-                        navigationAction = videoPlays.url?.let { NavigationAction.create(it, this::onItemClick) }
+                        navigationAction = videoPlays.url?.let { NavigationAction.create(it, this::onItemClick) },
+                        contentDescription = contentDescriptionHelper.buildContentDescription(
+                                R.string.stats_videos_title_label,
+                                videoPlays.title,
+                                R.string.stats_videos_views_label,
+                                value
+                        )
                 )
             })
 
@@ -135,7 +144,8 @@ constructor(
         private val store: VideoPlaysStore,
         private val selectedDateProvider: SelectedDateProvider,
         private val statsSiteProvider: StatsSiteProvider,
-        private val analyticsTracker: AnalyticsTrackerWrapper
+        private val analyticsTracker: AnalyticsTrackerWrapper,
+        private val contentDescriptionHelper: ContentDescriptionHelper
     ) : GranularUseCaseFactory {
         override fun build(granularity: StatsGranularity, useCaseMode: UseCaseMode) =
                 VideoPlaysUseCase(
@@ -145,6 +155,7 @@ constructor(
                         statsSiteProvider,
                         selectedDateProvider,
                         analyticsTracker,
+                        contentDescriptionHelper,
                         useCaseMode
                 )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCase.kt
@@ -94,7 +94,8 @@ constructor(
         if (domainModel.plays.isEmpty()) {
             items.add(Empty(R.string.stats_no_data_for_period))
         } else {
-            items.add(Header(R.string.stats_videos_title_label, R.string.stats_videos_views_label))
+            val header = Header(R.string.stats_videos_title_label, R.string.stats_videos_views_label)
+            items.add(header)
             items.addAll(domainModel.plays.mapIndexed { index, videoPlays ->
                 ListItemWithIcon(
                         text = videoPlays.title,
@@ -102,9 +103,8 @@ constructor(
                         showDivider = index < domainModel.plays.size - 1,
                         navigationAction = videoPlays.url?.let { NavigationAction.create(it, this::onItemClick) },
                         contentDescription = contentDescriptionHelper.buildContentDescription(
-                                R.string.stats_videos_title_label,
+                                header,
                                 videoPlays.title,
-                                R.string.stats_videos_views_label,
                                 videoPlays.plays
                         )
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AnnualStatsMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AnnualStatsMapper.kt
@@ -6,11 +6,12 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.QuickScanItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.QuickScanItem.Column
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import javax.inject.Inject
 
 class AnnualStatsMapper
-@Inject constructor() {
+@Inject constructor(private val contentDescriptionHelper: ContentDescriptionHelper) {
     fun mapYearInBlock(selectedYear: YearInsights): List<BlockListItem> {
         return listOf(
                 QuickScanItem(
@@ -58,33 +59,45 @@ class AnnualStatsMapper
 
     fun mapYearInViewAll(selectedYear: YearInsights): List<BlockListItem> {
         return listOf(
-                ListItemWithIcon(
+                mapItem(
                         textResource = R.string.stats_insights_posts,
                         value = selectedYear.totalPosts.toFormattedString()
                 ),
-                ListItemWithIcon(
+                mapItem(
                         textResource = R.string.stats_insights_total_comments,
                         value = selectedYear.totalComments.toFormattedString()
                 ),
-                ListItemWithIcon(
+                mapItem(
                         textResource = R.string.stats_insights_average_comments,
-                        value = selectedYear.avgComments?.toFormattedString() ?: "0"
+                        value = selectedYear.avgComments?.toFormattedString()
                 ),
-                ListItemWithIcon(
+                mapItem(
                         textResource = R.string.stats_insights_total_likes,
                         value = selectedYear.totalLikes.toFormattedString()
                 ),
-                ListItemWithIcon(
+                mapItem(
                         textResource = R.string.stats_insights_average_likes,
-                        value = selectedYear.avgLikes?.toFormattedString() ?: "0"
+                        value = selectedYear.avgLikes?.toFormattedString()
                 ),
-                ListItemWithIcon(
+                mapItem(
                         textResource = R.string.stats_insights_total_words,
                         value = selectedYear.totalWords.toFormattedString()
                 ),
-                ListItemWithIcon(
+                mapItem(
                         textResource = R.string.stats_insights_average_words,
-                        value = selectedYear.avgWords?.toFormattedString() ?: "0"
+                        value = selectedYear.avgWords?.toFormattedString()
+                )
+        )
+    }
+
+    private fun mapItem(textResource: Int, value: String?): ListItemWithIcon {
+        val nonNullValue = value ?: "0"
+        return ListItemWithIcon(
+                textResource = textResource,
+                value = nonNullValue,
+                contentDescription = contentDescriptionHelper.buildContentDescription(
+                        textResource,
+                        nonNullValue
                 )
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCase.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListI
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon.IconStyle.AVATAR
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TabsItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
@@ -32,7 +33,8 @@ class CommentsUseCase
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     private val commentsStore: CommentsStore,
     private val statsSiteProvider: StatsSiteProvider,
-    private val popupMenuHandler: ItemPopupMenuHandler
+    private val popupMenuHandler: ItemPopupMenuHandler,
+    private val contentDescriptionHelper: ContentDescriptionHelper
 ) : BaseStatsUseCase<CommentsModel, SelectedTabUiState>(COMMENTS, mainDispatcher, 0) {
     override suspend fun fetchRemoteData(forced: Boolean): State<CommentsModel> {
         val fetchMode = LimitMode.Top(BLOCK_ITEM_COUNT)
@@ -90,12 +92,19 @@ class CommentsUseCase
         if (authors.isNotEmpty()) {
             mutableItems.add(Header(R.string.stats_comments_author_label, R.string.stats_comments_label))
             mutableItems.addAll(authors.mapIndexed { index, author ->
+                val value = author.comments.toFormattedString()
                 ListItemWithIcon(
                         iconUrl = author.gravatar,
                         iconStyle = AVATAR,
                         text = author.name,
-                        value = author.comments.toFormattedString(),
-                        showDivider = index < authors.size - 1
+                        value = value,
+                        showDivider = index < authors.size - 1,
+                        contentDescription = contentDescriptionHelper.buildContentDescription(
+                                R.string.stats_comments_author_label,
+                                author.name,
+                                R.string.stats_comments_label,
+                                value
+                        )
                 )
             })
         } else {
@@ -109,10 +118,17 @@ class CommentsUseCase
         if (posts.isNotEmpty()) {
             mutableItems.add(Header(R.string.stats_comments_title_label, R.string.stats_comments_label))
             mutableItems.addAll(posts.mapIndexed { index, post ->
+                val value = post.comments.toFormattedString()
                 ListItem(
                         post.name,
-                        post.comments.toFormattedString(),
-                        index < posts.size - 1
+                        value,
+                        index < posts.size - 1,
+                        contentDescription = contentDescriptionHelper.buildContentDescription(
+                                R.string.stats_comments_title_label,
+                                post.name,
+                                R.string.stats_comments_label,
+                                value
+                        )
                 )
             })
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCase.kt
@@ -92,18 +92,17 @@ class CommentsUseCase
         if (authors.isNotEmpty()) {
             mutableItems.add(Header(R.string.stats_comments_author_label, R.string.stats_comments_label))
             mutableItems.addAll(authors.mapIndexed { index, author ->
-                val value = author.comments.toFormattedString()
                 ListItemWithIcon(
                         iconUrl = author.gravatar,
                         iconStyle = AVATAR,
                         text = author.name,
-                        value = value,
+                        value = author.comments.toFormattedString(),
                         showDivider = index < authors.size - 1,
                         contentDescription = contentDescriptionHelper.buildContentDescription(
                                 R.string.stats_comments_author_label,
                                 author.name,
                                 R.string.stats_comments_label,
-                                value
+                                author.comments
                         )
                 )
             })
@@ -118,16 +117,15 @@ class CommentsUseCase
         if (posts.isNotEmpty()) {
             mutableItems.add(Header(R.string.stats_comments_title_label, R.string.stats_comments_label))
             mutableItems.addAll(posts.mapIndexed { index, post ->
-                val value = post.comments.toFormattedString()
                 ListItem(
                         post.name,
-                        value,
+                        post.comments.toFormattedString(),
                         index < posts.size - 1,
                         contentDescription = contentDescriptionHelper.buildContentDescription(
                                 R.string.stats_comments_title_label,
                                 post.name,
                                 R.string.stats_comments_label,
-                                value
+                                post.comments
                         )
                 )
             })

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCase.kt
@@ -90,7 +90,8 @@ class CommentsUseCase
     private fun buildAuthorsTab(authors: List<CommentsModel.Author>): List<BlockListItem> {
         val mutableItems = mutableListOf<BlockListItem>()
         if (authors.isNotEmpty()) {
-            mutableItems.add(Header(R.string.stats_comments_author_label, R.string.stats_comments_label))
+            val header = Header(R.string.stats_comments_author_label, R.string.stats_comments_label)
+            mutableItems.add(header)
             mutableItems.addAll(authors.mapIndexed { index, author ->
                 ListItemWithIcon(
                         iconUrl = author.gravatar,
@@ -99,9 +100,8 @@ class CommentsUseCase
                         value = author.comments.toFormattedString(),
                         showDivider = index < authors.size - 1,
                         contentDescription = contentDescriptionHelper.buildContentDescription(
-                                R.string.stats_comments_author_label,
+                                header,
                                 author.name,
-                                R.string.stats_comments_label,
                                 author.comments
                         )
                 )
@@ -115,16 +115,16 @@ class CommentsUseCase
     private fun buildPostsTab(posts: List<CommentsModel.Post>): List<BlockListItem> {
         val mutableItems = mutableListOf<BlockListItem>()
         if (posts.isNotEmpty()) {
-            mutableItems.add(Header(R.string.stats_comments_title_label, R.string.stats_comments_label))
+            val header = Header(R.string.stats_comments_title_label, R.string.stats_comments_label)
+            mutableItems.add(header)
             mutableItems.addAll(posts.mapIndexed { index, post ->
                 ListItem(
                         post.name,
                         post.comments.toFormattedString(),
                         index < posts.size - 1,
                         contentDescription = contentDescriptionHelper.buildContentDescription(
-                                R.string.stats_comments_title_label,
+                                header,
                                 post.name,
-                                R.string.stats_comments_label,
                                 post.comments
                         )
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTotalsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTotalsUseCase.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.F
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.FollowerTotalsUseCase.FollowerType.EMAIL
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.FollowerTotalsUseCase.FollowerType.SOCIAL
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.FollowerTotalsUseCase.FollowerType.WP_COM
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import javax.inject.Inject
@@ -31,7 +32,8 @@ class FollowerTotalsUseCase
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val followersStore: FollowersStore,
     private val publicizeStore: PublicizeStore,
-    private val statsSiteProvider: StatsSiteProvider
+    private val statsSiteProvider: StatsSiteProvider,
+    private val contentDescriptionHelper: ContentDescriptionHelper
 ) : StatelessUseCase<Map<FollowerType, Int>>(FOLLOWER_TOTALS, mainDispatcher) {
     override fun buildLoadingItem(): List<BlockListItem> = listOf(Title(R.string.stats_view_follower_totals))
 
@@ -137,12 +139,20 @@ class FollowerTotalsUseCase
 
         if (domainModel.isNotEmpty()) {
             domainModel.entries.forEach {
-                items.add(ListItemWithIcon(
-                        icon = getIcon(it.key),
-                        textResource = getTitle(it.key),
-                        value = it.value.toFormattedString(),
-                        showDivider = domainModel.entries.indexOf(it) < domainModel.size - 1
-                ))
+                val textResource = getTitle(it.key)
+                val value = it.value.toFormattedString()
+                items.add(
+                        ListItemWithIcon(
+                                icon = getIcon(it.key),
+                                textResource = textResource,
+                                value = value,
+                                showDivider = domainModel.entries.indexOf(it) < domainModel.size - 1,
+                                contentDescription = contentDescriptionHelper.buildContentDescription(
+                                        textResource,
+                                        value
+                                )
+                        )
+                )
             }
         } else {
             items.add(Empty())

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTotalsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTotalsUseCase.kt
@@ -139,17 +139,16 @@ class FollowerTotalsUseCase
 
         if (domainModel.isNotEmpty()) {
             domainModel.entries.forEach {
-                val textResource = getTitle(it.key)
-                val value = it.value.toFormattedString()
+                val title = getTitle(it.key)
                 items.add(
                         ListItemWithIcon(
                                 icon = getIcon(it.key),
-                                textResource = textResource,
-                                value = value,
+                                textResource = title,
+                                value = it.value.toFormattedString(),
                                 showDivider = domainModel.entries.indexOf(it) < domainModel.size - 1,
                                 contentDescription = contentDescriptionHelper.buildContentDescription(
-                                        textResource,
-                                        value
+                                        title,
+                                        it.value
                                 )
                         )
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowersUseCase.kt
@@ -197,8 +197,9 @@ class FollowersUseCase(
                             )
                     )
             )
-            mutableItems.add(Header(R.string.stats_follower_label, R.string.stats_follower_since_label))
-            model.followers.toUserItems(R.string.stats_follower_label, R.string.stats_follower_since_label)
+            val header = Header(R.string.stats_follower_label, R.string.stats_follower_since_label)
+            mutableItems.add(header)
+            model.followers.toUserItems(header)
                     .let { mutableItems.addAll(it) }
         } else {
             mutableItems.add(Empty())
@@ -206,7 +207,7 @@ class FollowersUseCase(
         return mutableItems
     }
 
-    private fun List<FollowerModel>.toUserItems(keyLabel: Int, valueLabel: Int): List<ListItemWithIcon> {
+    private fun List<FollowerModel>.toUserItems(header: Header): List<ListItemWithIcon> {
         return this.mapIndexed { index, follower ->
             val value = statsUtilsWrapper.getSinceLabelLowerCase(follower.dateSubscribed)
             ListItemWithIcon(
@@ -216,9 +217,8 @@ class FollowersUseCase(
                     value = value,
                     showDivider = index < this.size - 1,
                     contentDescription = contentDescriptionHelper.buildContentDescription(
-                            keyLabel,
+                            header,
                             follower.label,
-                            valueLabel,
                             value
                     )
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCase.kt
@@ -87,28 +87,27 @@ class LatestPostSummaryUseCase
             if (domainModel.dayViews.isNotEmpty()) {
                 items.add(latestPostSummaryMapper.buildBarChartItem(domainModel.dayViews))
             }
-            val postLikeCount = domainModel.postLikeCount.toFormattedString()
             items.add(
                     ListItemWithIcon(
                             R.drawable.ic_star_white_24dp,
                             textResource = R.string.stats_likes,
-                            value = postLikeCount,
+                            value = domainModel.postLikeCount.toFormattedString(),
                             showDivider = true,
                             contentDescription = contentDescriptionHelper.buildContentDescription(
                                     R.string.stats_likes,
-                                    postLikeCount
+                                    domainModel.postLikeCount.toLong()
                             )
                     )
             )
-            val postCommentCount = domainModel.postCommentCount.toFormattedString()
             items.add(
                     ListItemWithIcon(
                             R.drawable.ic_comment_white_24dp,
                             textResource = R.string.stats_comments,
-                            value = postCommentCount,
+                            value = domainModel.postCommentCount.toFormattedString(),
                             showDivider = false,
                             contentDescription = contentDescriptionHelper.buildContentDescription(
-                                    R.string.stats_comments, postCommentCount
+                                    R.string.stats_comments,
+                                    domainModel.postCommentCount.toLong()
                             )
                     )
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCase.kt
@@ -80,34 +80,36 @@ class LatestPostSummaryUseCase
                             R.string.stats_views,
                             contentDescription = contentDescriptionHelper.buildContentDescription(
                                     R.string.stats_views,
-                                    domainModel.postViewsCount.toLong()
+                                    domainModel.postViewsCount
                             )
                     )
             )
             if (domainModel.dayViews.isNotEmpty()) {
                 items.add(latestPostSummaryMapper.buildBarChartItem(domainModel.dayViews))
             }
+            val postLikeCount = domainModel.postLikeCount.toFormattedString()
             items.add(
                     ListItemWithIcon(
                             R.drawable.ic_star_white_24dp,
                             textResource = R.string.stats_likes,
-                            value = domainModel.postLikeCount.toFormattedString(),
+                            value = postLikeCount,
                             showDivider = true,
                             contentDescription = contentDescriptionHelper.buildContentDescription(
                                     R.string.stats_likes,
-                                    domainModel.postLikeCount.toLong()
+                                    domainModel.postLikeCount
                             )
                     )
             )
+            val postCommentCount = domainModel.postCommentCount.toFormattedString()
             items.add(
                     ListItemWithIcon(
                             R.drawable.ic_comment_white_24dp,
                             textResource = R.string.stats_comments,
-                            value = domainModel.postCommentCount.toFormattedString(),
+                            value = postCommentCount,
                             showDivider = false,
                             contentDescription = contentDescriptionHelper.buildContentDescription(
                                     R.string.stats_comments,
-                                    domainModel.postCommentCount.toLong()
+                                    domainModel.postCommentCount
                             )
                     )
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCase.kt
@@ -93,7 +93,11 @@ class LatestPostSummaryUseCase
                             R.drawable.ic_star_white_24dp,
                             textResource = R.string.stats_likes,
                             value = postLikeCount,
-                            showDivider = true
+                            showDivider = true,
+                            contentDescription = contentDescriptionHelper.buildContentDescription(
+                                    R.string.stats_likes,
+                                    postLikeCount
+                            )
                     )
             )
             val postCommentCount = domainModel.postCommentCount.toFormattedString()
@@ -102,7 +106,10 @@ class LatestPostSummaryUseCase
                             R.drawable.ic_comment_white_24dp,
                             textResource = R.string.stats_comments,
                             value = postCommentCount,
-                            showDivider = false
+                            showDivider = false,
+                            contentDescription = contentDescriptionHelper.buildContentDescription(
+                                    R.string.stats_comments, postCommentCount
+                            )
                     )
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCase.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases
 import android.view.View
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
-import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.PublicizeModel
@@ -84,12 +83,18 @@ class PublicizeUseCase
         if (domainModel.services.isEmpty()) {
             items.add(Empty())
         } else {
-            items.add(Header(string.stats_publicize_service_label, string.stats_publicize_followers_label))
-            items.addAll(domainModel.services.let { mapper.map(it) })
+            items.add(Header(R.string.stats_publicize_service_label, R.string.stats_publicize_followers_label))
+            items.addAll(domainModel.services.let {
+                mapper.map(
+                        it,
+                        R.string.stats_publicize_service_label,
+                        R.string.stats_publicize_followers_label
+                )
+            })
             if (useCaseMode == BLOCK && domainModel.hasMore) {
                 items.add(
                         Link(
-                                text = string.stats_insights_view_more,
+                                text = R.string.stats_insights_view_more,
                                 navigateAction = NavigationAction.create(this::onLinkClick)
                         )
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCase.kt
@@ -83,13 +83,10 @@ class PublicizeUseCase
         if (domainModel.services.isEmpty()) {
             items.add(Empty())
         } else {
-            items.add(Header(R.string.stats_publicize_service_label, R.string.stats_publicize_followers_label))
+            val header = Header(R.string.stats_publicize_service_label, R.string.stats_publicize_followers_label)
+            items.add(header)
             items.addAll(domainModel.services.let {
-                mapper.map(
-                        it,
-                        R.string.stats_publicize_service_label,
-                        R.string.stats_publicize_followers_label
-                )
+                mapper.map(it, header)
             })
             if (useCaseMode == BLOCK && domainModel.hasMore) {
                 items.add(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCase.kt
@@ -139,15 +139,14 @@ class TagsAndCategoriesUseCase
 
     private fun mapTag(tag: TagModel, index: Int, listSize: Int, maxViews: Long): ListItemWithIcon {
         val item = tag.items.first()
-        val value = tag.views.toFormattedString()
         return ListItemWithIcon(
                 icon = getIcon(item.type),
                 text = item.name,
-                value = value,
+                value = tag.views.toFormattedString(),
                 barWidth = getBarWidth(tag.views, maxViews),
                 showDivider = index < listSize - 1,
                 navigationAction = NavigationAction.create(item.link, this::onTagClick),
-                contentDescription = buildContentDescription(item.name, value)
+                contentDescription = buildContentDescription(item.name, tag.views)
         )
     }
 
@@ -158,14 +157,13 @@ class TagsAndCategoriesUseCase
                 else -> resourceProvider.getString(R.string.stats_category_folded_name, acc, item.name)
             }
         }
-        val value = tag.views.toFormattedString()
         return ListItemWithIcon(
                 icon = R.drawable.ic_folder_multiple_white_24dp,
                 text = text,
-                value = value,
+                value = tag.views.toFormattedString(),
                 barWidth = getBarWidth(tag.views, maxViews),
                 showDivider = index < listSize - 1,
-                contentDescription = buildContentDescription(text, value)
+                contentDescription = buildContentDescription(text, tag.views)
         )
     }
 
@@ -197,12 +195,12 @@ class TagsAndCategoriesUseCase
         popupMenuHandler.onMenuClick(view, type)
     }
 
-    private fun buildContentDescription(key: String, value: String): String {
+    private fun buildContentDescription(key: String, value: Long): String {
         return contentDescriptionHelper.buildContentDescription(
                 R.string.stats_tags_and_categories_title_label,
                 key,
                 R.string.stats_tags_and_categories_views_label,
-                value
+                value.toInt()
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCase.kt
@@ -147,7 +147,11 @@ class TagsAndCategoriesUseCase
                 barWidth = getBarWidth(tag.views, maxViews),
                 showDivider = index < listSize - 1,
                 navigationAction = NavigationAction.create(item.link, this::onTagClick),
-                contentDescription = buildContentDescription(header, item.name, tag.views)
+                contentDescription = contentDescriptionHelper.buildContentDescription(
+                        header,
+                        item.name,
+                        tag.views
+                )
         )
     }
 
@@ -170,7 +174,11 @@ class TagsAndCategoriesUseCase
                 value = tag.views.toFormattedString(),
                 barWidth = getBarWidth(tag.views, maxViews),
                 showDivider = index < listSize - 1,
-                contentDescription = buildContentDescription(header, text, tag.views)
+                contentDescription = contentDescriptionHelper.buildContentDescription(
+                        header,
+                        text,
+                        tag.views
+                )
         )
     }
 
@@ -181,7 +189,10 @@ class TagsAndCategoriesUseCase
                 text = item.name,
                 showDivider = false,
                 navigationAction = NavigationAction.create(item.link, this::onTagClick),
-                contentDescription = buildContentDescription(header, item.name)
+                contentDescription = contentDescriptionHelper.buildContentDescription(
+                        header.startLabel,
+                        item.name
+                )
         )
     }
 
@@ -200,21 +211,6 @@ class TagsAndCategoriesUseCase
 
     private fun onMenuClick(view: View) {
         popupMenuHandler.onMenuClick(view, type)
-    }
-
-    private fun buildContentDescription(header: Header, key: String, value: Long): String {
-        return contentDescriptionHelper.buildContentDescription(
-                header,
-                key,
-                value.toInt()
-        )
-    }
-
-    private fun buildContentDescription(header: Header, key: String): String {
-        return contentDescriptionHelper.buildContentDescription(
-                header.startLabel,
-                key
-        )
     }
 
     data class TagsAndCategoriesUiState(val expandedTag: TagModel? = null)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ExpandableItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ExpandableItemViewHolder.kt
@@ -30,6 +30,7 @@ class ExpandableItemViewHolder(parent: ViewGroup, val imageManager: ImageManager
         val header = expandableItem.header
         iconContainer.setIconOrAvatar(header, imageManager)
         text.setTextOrHide(header.textResource, header.text)
+        text.contentDescription = header.contentDescription
         expandButton.visibility = View.VISIBLE
         value.setTextOrHide(header.valueResource, header.value)
         divider.setVisible(header.showDivider && !expandableItem.isExpanded)
@@ -48,6 +49,12 @@ class ExpandableItemViewHolder(parent: ViewGroup, val imageManager: ImageManager
         }
         itemView.isClickable = true
         itemView.setOnClickListener {
+            val announcement = if (expandableItem.isExpanded) {
+                itemView.resources.getString(R.string.stats_item_collapsed)
+            } else {
+                itemView.resources.getString(R.string.stats_item_expanded)
+            }
+            itemView.announceForAccessibility(announcement)
             expandableItem.onExpandClicked(!expandableItem.isExpanded)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ExpandableItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ExpandableItemViewHolder.kt
@@ -32,6 +32,11 @@ class ExpandableItemViewHolder(parent: ViewGroup, val imageManager: ImageManager
         text.setTextOrHide(header.textResource, header.text)
         text.contentDescription = header.contentDescription
         expandButton.visibility = View.VISIBLE
+        val expandButtonDescription = when (expandableItem.isExpanded) {
+            true -> R.string.stats_collapse_content_description
+            false -> R.string.stats_expand_content_description
+        }
+        expandButton.contentDescription = itemView.resources.getString(expandButtonDescription)
         value.setTextOrHide(header.valueResource, header.value)
         divider.setVisible(header.showDivider && !expandableItem.isExpanded)
         if (header.barWidth != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ListItemViewHolder.kt
@@ -25,5 +25,6 @@ class ListItemViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         } else {
             View.GONE
         }
+        itemView.contentDescription = item.contentDescription
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ListItemWithIconViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ListItemWithIconViewHolder.kt
@@ -54,5 +54,6 @@ class ListItemWithIconViewHolder(parent: ViewGroup, val imageManager: ImageManag
             bar.visibility = View.GONE
             topMargin.visibility = View.GONE
         }
+        itemView.contentDescription = item.contentDescription
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ListItemWithIconViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ListItemWithIconViewHolder.kt
@@ -40,15 +40,14 @@ class ListItemWithIconViewHolder(parent: ViewGroup, val imageManager: ImageManag
         }
         val clickAction = item.navigationAction
         if (clickAction != null) {
-            itemView.isClickable = true
             val outValue = TypedValue()
             itemView.context.theme.resolveAttribute(android.R.attr.selectableItemBackground, outValue, true)
             itemView.setBackgroundResource(outValue.resourceId)
             itemView.setOnClickListener { clickAction.click() }
         } else {
-            itemView.isClickable = false
-            itemView.background = null
             itemView.setOnClickListener(null)
+            itemView.background = null
+            itemView.isClickable = false
         }
         if (item.barWidth != null) {
             bar.visibility = View.VISIBLE

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ListItemWithIconViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ListItemWithIconViewHolder.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
 
+import android.util.TypedValue
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
@@ -40,6 +41,9 @@ class ListItemWithIconViewHolder(parent: ViewGroup, val imageManager: ImageManag
         val clickAction = item.navigationAction
         if (clickAction != null) {
             itemView.isClickable = true
+            val outValue = TypedValue()
+            itemView.context.theme.resolveAttribute(android.R.attr.selectableItemBackground, outValue, true)
+            itemView.setBackgroundResource(outValue.resourceId)
             itemView.setOnClickListener { clickAction.click() }
         } else {
             itemView.isClickable = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
@@ -6,6 +6,16 @@ import javax.inject.Inject
 
 class ContentDescriptionHelper
 @Inject constructor(private val resourceProvider: ResourceProvider) {
+    fun buildContentDescription(keyLabel: Int, key: String, valueLabel: Int, value: Int): String {
+        return resourceProvider.getString(
+                R.string.stats_list_item_description,
+                resourceProvider.getString(keyLabel),
+                key,
+                resourceProvider.getString(valueLabel),
+                value
+        )
+    }
+
     fun buildContentDescription(keyLabel: Int, key: String, valueLabel: Int, value: String): String {
         return resourceProvider.getString(
                 R.string.stats_list_item_description,
@@ -16,7 +26,7 @@ class ContentDescriptionHelper
         )
     }
 
-    fun buildContentDescription(keyLabel: Int, key: Int, valueLabel: Int, value: String): String {
+    fun buildContentDescription(keyLabel: Int, key: Int, valueLabel: Int, value: Int): String {
         return resourceProvider.getString(
                 R.string.stats_list_item_description,
                 resourceProvider.getString(keyLabel),

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
@@ -6,6 +6,34 @@ import javax.inject.Inject
 
 class ContentDescriptionHelper
 @Inject constructor(private val resourceProvider: ResourceProvider) {
+    fun buildContentDescription(keyLabel: Int, key: String, valueLabel: Int, value: String): String {
+        return resourceProvider.getString(
+                R.string.stats_list_item_description,
+                resourceProvider.getString(keyLabel),
+                key,
+                resourceProvider.getString(valueLabel),
+                value
+        )
+    }
+
+    fun buildContentDescription(keyLabel: Int, key: Int, valueLabel: Int, value: String): String {
+        return resourceProvider.getString(
+                R.string.stats_list_item_description,
+                resourceProvider.getString(keyLabel),
+                resourceProvider.getString(key),
+                resourceProvider.getString(valueLabel),
+                value
+        )
+    }
+
+    fun buildContentDescription(keyLabel: Int, key: String): String {
+        return resourceProvider.getString(
+                R.string.stats_list_item_short_description,
+                resourceProvider.getString(keyLabel),
+                key
+        )
+    }
+
     fun buildContentDescription(keyLabel: Int, key: Long): String {
         return resourceProvider.getString(
                 R.string.stats_list_item_short_description,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 
 class ContentDescriptionHelper
 @Inject constructor(private val resourceProvider: ResourceProvider) {
-    fun buildContentDescription(header: Header, key: String, value: Int): String {
+    fun buildContentDescription(header: Header, key: String, value: Any): String {
         return buildContentDescription(header.startLabel, key, header.endLabel, value)
     }
 
@@ -27,25 +27,8 @@ class ContentDescriptionHelper
         )
     }
 
-    fun buildContentDescription(
-        @StringRes keyLabel: Int,
-        @StringRes key: Int,
-        @StringRes valueLabel: Int,
-        value: Int
-    ): String {
-        return buildContentDescription(keyLabel, resourceProvider.getString(key), valueLabel, value)
-    }
-
-    fun buildContentDescription(header: Header, @StringRes key: Int, value: Int): String {
+    fun buildContentDescription(header: Header, @StringRes key: Int, value: Any): String {
         return buildContentDescription(header, resourceProvider.getString(key), value)
-    }
-
-    fun buildContentDescription(@StringRes keyLabel: Int, key: String): String {
-        return resourceProvider.getString(
-                R.string.stats_list_item_short_description,
-                resourceProvider.getString(keyLabel),
-                key
-        )
     }
 
     fun buildContentDescription(@StringRes keyLabel: Int, key: Any): String {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
@@ -1,9 +1,9 @@
 package org.wordpress.android.ui.stats.refresh.utils
 
-import org.wordpress.android.util.RtlUtils
 import androidx.annotation.StringRes
 import org.wordpress.android.R
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
+import org.wordpress.android.util.RtlUtils
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
@@ -32,7 +32,7 @@ class ContentDescriptionHelper
         return buildContentDescription(header, resourceProvider.getString(key), value)
     }
 
-    fun buildContentDescription(keyLabel: Int, key: Long): String {
+    fun buildContentDescription(keyLabel: Int, key: Any): String {
         return when (rtlUtils.isRtl) {
             true -> "$key :${resourceProvider.getString(keyLabel)}"
             false -> "${resourceProvider.getString(keyLabel)}: $key"

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
@@ -1,12 +1,23 @@
 package org.wordpress.android.ui.stats.refresh.utils
 
+import androidx.annotation.StringRes
 import org.wordpress.android.R
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
 class ContentDescriptionHelper
 @Inject constructor(private val resourceProvider: ResourceProvider) {
-    fun buildContentDescription(keyLabel: Int, key: String, valueLabel: Int, value: Int): String {
+    fun buildContentDescription(header: Header, key: String, value: Int): String {
+        return buildContentDescription(header.startLabel, key, header.endLabel, value)
+    }
+
+    fun buildContentDescription(
+        @StringRes keyLabel: Int,
+        key: String,
+        @StringRes valueLabel: Int,
+        value: Any
+    ): String {
         return resourceProvider.getString(
                 R.string.stats_list_item_description,
                 resourceProvider.getString(keyLabel),
@@ -16,27 +27,20 @@ class ContentDescriptionHelper
         )
     }
 
-    fun buildContentDescription(keyLabel: Int, key: String, valueLabel: Int, value: String): String {
-        return resourceProvider.getString(
-                R.string.stats_list_item_description,
-                resourceProvider.getString(keyLabel),
-                key,
-                resourceProvider.getString(valueLabel),
-                value
-        )
+    fun buildContentDescription(
+        @StringRes keyLabel: Int,
+        @StringRes key: Int,
+        @StringRes valueLabel: Int,
+        value: Int
+    ): String {
+        return buildContentDescription(keyLabel, resourceProvider.getString(key), valueLabel, value)
     }
 
-    fun buildContentDescription(keyLabel: Int, key: Int, valueLabel: Int, value: Int): String {
-        return resourceProvider.getString(
-                R.string.stats_list_item_description,
-                resourceProvider.getString(keyLabel),
-                resourceProvider.getString(key),
-                resourceProvider.getString(valueLabel),
-                value
-        )
+    fun buildContentDescription(header: Header, @StringRes key: Int, value: Int): String {
+        return buildContentDescription(header, resourceProvider.getString(key), value)
     }
 
-    fun buildContentDescription(keyLabel: Int, key: String): String {
+    fun buildContentDescription(@StringRes keyLabel: Int, key: String): String {
         return resourceProvider.getString(
                 R.string.stats_list_item_short_description,
                 resourceProvider.getString(keyLabel),
@@ -44,7 +48,7 @@ class ContentDescriptionHelper
         )
     }
 
-    fun buildContentDescription(keyLabel: Int, key: Long): String {
+    fun buildContentDescription(@StringRes keyLabel: Int, key: Any): String {
         return resourceProvider.getString(
                 R.string.stats_list_item_short_description,
                 resourceProvider.getString(keyLabel),

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ServiceMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ServiceMapper.kt
@@ -33,18 +33,17 @@ class ServiceMapper
         return services.mapIndexed { index, service ->
             val mappedService = getService(service.name)
             val text = if (mappedService?.nameResource == null) service.name else null
-            val value = service.followers.toFormattedString()
             val contentDescription = contentDescriptionHelper.buildContentDescription(
                     keyLabel,
                     text ?: "",
                     valueLabel,
-                    value
+                    service.followers
             )
             ListItemWithIcon(
                     iconUrl = mappedService?.iconUrl?.let { it + dimension },
                     text = text,
                     textResource = mappedService?.nameResource,
-                    value = value,
+                    value = service.followers.toFormattedString(),
                     showDivider = index < services.size - 1,
                     contentDescription = contentDescription
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ServiceMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ServiceMapper.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.stats.refresh.utils
 
 import androidx.annotation.StringRes
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.stats.PublicizeModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.utils.ServiceMapper.Service.FACEBOOK
 import org.wordpress.android.ui.stats.refresh.utils.ServiceMapper.Service.GOOGLE_PLUS
@@ -21,17 +20,33 @@ private const val LINKED_IN_ICON = "https://secure.gravatar.com/blavatar/f54db46
 private const val PATH_ICON = "https://secure.gravatar.com/blavatar/3a03c8ce5bf1271fb3760bb6e79b02c1?s="
 
 class ServiceMapper
-@Inject constructor(private val resourceProvider: ResourceProvider) {
-    fun map(services: List<PublicizeModel.Service>): List<ListItemWithIcon> {
+@Inject constructor(
+    private val resourceProvider: ResourceProvider,
+    private val contentDescriptionHelper: ContentDescriptionHelper
+) {
+    fun map(
+        services: List<org.wordpress.android.fluxc.model.stats.PublicizeModel.Service>,
+        keyLabel: Int,
+        valueLabel: Int
+    ): List<ListItemWithIcon> {
         val dimension = resourceProvider.getDimensionPixelSize(R.dimen.avatar_sz_small)
         return services.mapIndexed { index, service ->
             val mappedService = getService(service.name)
+            val text = if (mappedService?.nameResource == null) service.name else null
+            val value = service.followers.toFormattedString()
+            val contentDescription = contentDescriptionHelper.buildContentDescription(
+                    keyLabel,
+                    text ?: "",
+                    valueLabel,
+                    value
+            )
             ListItemWithIcon(
                     iconUrl = mappedService?.iconUrl?.let { it + dimension },
-                    text = if (mappedService?.nameResource == null) service.name else null,
+                    text = text,
                     textResource = mappedService?.nameResource,
-                    value = service.followers.toFormattedString(),
-                    showDivider = index < services.size - 1
+                    value = value,
+                    showDivider = index < services.size - 1,
+                    contentDescription = contentDescription
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ServiceMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ServiceMapper.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.stats.refresh.utils
 
 import androidx.annotation.StringRes
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.stats.PublicizeModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.utils.ServiceMapper.Service.FACEBOOK
@@ -26,7 +27,7 @@ class ServiceMapper
     private val contentDescriptionHelper: ContentDescriptionHelper
 ) {
     fun map(
-        services: List<org.wordpress.android.fluxc.model.stats.PublicizeModel.Service>,
+        services: List<PublicizeModel.Service>,
         header: Header
     ): List<ListItemWithIcon> {
         val dimension = resourceProvider.getDimensionPixelSize(R.dimen.avatar_sz_small)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ServiceMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ServiceMapper.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.stats.refresh.utils
 
 import androidx.annotation.StringRes
 import org.wordpress.android.R
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.utils.ServiceMapper.Service.FACEBOOK
 import org.wordpress.android.ui.stats.refresh.utils.ServiceMapper.Service.GOOGLE_PLUS
@@ -26,17 +27,15 @@ class ServiceMapper
 ) {
     fun map(
         services: List<org.wordpress.android.fluxc.model.stats.PublicizeModel.Service>,
-        keyLabel: Int,
-        valueLabel: Int
+        header: Header
     ): List<ListItemWithIcon> {
         val dimension = resourceProvider.getDimensionPixelSize(R.dimen.avatar_sz_small)
         return services.mapIndexed { index, service ->
             val mappedService = getService(service.name)
             val text = if (mappedService?.nameResource == null) service.name else null
             val contentDescription = contentDescriptionHelper.buildContentDescription(
-                    keyLabel,
+                    header,
                     text ?: "",
-                    valueLabel,
                     service.followers
             )
             ListItemWithIcon(

--- a/WordPress/src/main/res/layout/stats_block_activity_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_activity_item.xml
@@ -5,7 +5,8 @@
     android:id="@+id/link_wrapper"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:animateLayoutChanges="true">
+    android:animateLayoutChanges="true"
+    android:contentDescription="@string/stats_posting_activity_graph">
 
     <include
         android:id="@+id/first_activity"
@@ -35,8 +36,7 @@
         app:layout_constraintEnd_toStartOf="@+id/third_activity"
         app:layout_constraintStart_toEndOf="@+id/first_activity"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_goneMarginEnd="@dimen/margin_extra_large"
-        />
+        app:layout_goneMarginEnd="@dimen/margin_extra_large"/>
 
     <include
         android:id="@+id/third_activity"
@@ -50,8 +50,7 @@
         app:layout_constraintBottom_toTopOf="@+id/fewer_posts_label"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/second_activity"
-        app:layout_constraintTop_toTopOf="parent"
-        />
+        app:layout_constraintTop_toTopOf="parent"/>
 
     <TextView
         android:id="@+id/fewer_posts_label"

--- a/WordPress/src/main/res/layout/stats_block_header_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_header_item.xml
@@ -2,11 +2,12 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:tools="http://schemas.android.com/tools"
               style="@style/StatsBlockLine"
-              android:paddingStart="@dimen/margin_extra_large"
-              android:paddingEnd="@dimen/margin_extra_large"
               android:layout_width="match_parent"
               android:layout_height="@dimen/stats_header_height"
-              android:orientation="horizontal">
+              android:importantForAccessibility="no"
+              android:orientation="horizontal"
+              android:paddingEnd="@dimen/margin_extra_large"
+              android:paddingStart="@dimen/margin_extra_large">
 
     <TextView
         android:id="@+id/start_label"
@@ -16,10 +17,11 @@
         android:layout_gravity="center_vertical"
         android:text="@string/unknown"
         tools:text="First item"/>
+
     <View
         android:layout_width="0dp"
-        android:layout_weight="1"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:layout_weight="1"/>
 
     <TextView
         android:id="@+id/end_label"

--- a/WordPress/src/main/res/layout/stats_block_header_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_header_item.xml
@@ -15,13 +15,15 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
+        android:importantForAccessibility="no"
         android:text="@string/unknown"
         tools:text="First item"/>
 
     <View
         android:layout_width="0dp"
         android:layout_height="match_parent"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        android:importantForAccessibility="no"/>
 
     <TextView
         android:id="@+id/end_label"
@@ -29,6 +31,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
+        android:importantForAccessibility="no"
         android:text="@string/unknown"
         tools:text="Second item"/>
 

--- a/WordPress/src/main/res/layout/stats_block_list_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_list_item.xml
@@ -66,6 +66,7 @@
             android:layout_width="@dimen/stats_block_icon_size"
             android:layout_height="@dimen/stats_block_icon_size"
             android:contentDescription="@null"
+            android:importantForAccessibility="no"
             android:scaleType="fitCenter"
             android:src="@drawable/ic_share_white_24dp"/>
 
@@ -74,6 +75,7 @@
             android:layout_width="@dimen/avatar_sz_small"
             android:layout_height="@dimen/avatar_sz_small"
             android:contentDescription="@null"
+            android:importantForAccessibility="no"
             android:src="@drawable/bg_rectangle_neutral_100_globe_32dp"
             android:visibility="gone"/>
     </LinearLayout>
@@ -83,6 +85,7 @@
         style="@style/StatsBlockValue"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:importantForAccessibility="no"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/expand_button"
         app:layout_constraintHorizontal_chainStyle="packed"
@@ -97,7 +100,7 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:layout_marginStart="@dimen/margin_medium"
-        android:contentDescription="@string/icon"
+        android:contentDescription="@string/stats_expand_content_description"
         android:src="@drawable/ic_chevron_down_white_16dp"
         android:tint="@color/neutral_500"
         android:visibility="gone"
@@ -132,8 +135,8 @@
         android:id="@+id/divider"
         android:layout_width="0dp"
         android:layout_height="1dp"
-        android:importantForAccessibility="no"
         android:background="@color/neutral_0"
+        android:importantForAccessibility="no"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@+id/text"/>

--- a/WordPress/src/main/res/layout/stats_block_list_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_list_item.xml
@@ -12,6 +12,7 @@
         android:layout_width="0dp"
         android:layout_height="@dimen/margin_medium_large"
         android:background="@color/transparent"
+        android:importantForAccessibility="no"
         android:visibility="gone"
         app:layout_constraintBottom_toTopOf="@+id/text"
         app:layout_constraintEnd_toStartOf="@+id/value"
@@ -52,6 +53,7 @@
         android:layout_marginBottom="8dp"
         android:layout_marginStart="@dimen/margin_extra_large"
         android:layout_marginTop="@dimen/margin_medium"
+        android:importantForAccessibility="no"
         android:orientation="vertical"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -63,7 +65,7 @@
             android:id="@+id/icon"
             android:layout_width="@dimen/stats_block_icon_size"
             android:layout_height="@dimen/stats_block_icon_size"
-            android:contentDescription="@string/icon"
+            android:contentDescription="@null"
             android:scaleType="fitCenter"
             android:src="@drawable/ic_share_white_24dp"/>
 
@@ -71,7 +73,7 @@
             android:id="@+id/avatar"
             android:layout_width="@dimen/avatar_sz_small"
             android:layout_height="@dimen/avatar_sz_small"
-            android:contentDescription="@string/reader_avatar_desc"
+            android:contentDescription="@null"
             android:src="@drawable/bg_rectangle_neutral_100_globe_32dp"
             android:visibility="gone"/>
     </LinearLayout>
@@ -113,6 +115,7 @@
         android:layout_height="5dp"
         android:layout_marginBottom="@dimen/margin_large"
         android:layout_marginTop="@dimen/margin_key"
+        android:importantForAccessibility="no"
         android:progressDrawable="@drawable/stats_bar_background"
         android:text="@string/unknown"
         android:visibility="gone"
@@ -129,6 +132,7 @@
         android:id="@+id/divider"
         android:layout_width="0dp"
         android:layout_height="1dp"
+        android:importantForAccessibility="no"
         android:background="@color/neutral_0"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WordPress/src/main/res/layout/stats_block_map_legend_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_map_legend_item.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/StatsBlockLine"
     android:layout_width="match_parent"
+    android:importantForAccessibility="no"
     android:gravity="center_vertical"
     android:orientation="horizontal">
 

--- a/WordPress/src/main/res/layout/stats_block_single_activity.xml
+++ b/WordPress/src/main/res/layout/stats_block_single_activity.xml
@@ -2,17 +2,19 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
-    android:gravity="center_horizontal"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:gravity="center_horizontal"
+    android:importantForAccessibility="no"
+    android:orientation="vertical">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/activity"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
-        android:layout_marginTop="8dp"/>
+        android:layout_marginTop="8dp"
+        android:importantForAccessibility="no"/>
 
     <TextView
         android:id="@+id/label"
@@ -20,5 +22,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
+        android:importantForAccessibility="no"
         tools:text="Jan"/>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/stats_block_web_view_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_web_view_item.xml
@@ -4,6 +4,7 @@
     style="@style/StatsBlockLine"
     android:layout_width="match_parent"
     android:layout_height="200dp"
+    android:importantForAccessibility="no"
     android:paddingEnd="16dp"
     android:paddingStart="16dp">
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -844,6 +844,7 @@
     <string name="stats_bar_chart_content_description">Graph of site views.</string>
     <string name="stats_overview_content_description">%1$s %2$s for period: %3$s, change from previous period - %4$s</string>
     <string name="stats_graph_updated">Graph updated.</string>
+    <string name="stats_list_item_description">%1$s: %2$s, %3$s: %4$s</string>
     <string name="stats_list_item_short_description">%1$s: %2$s</string>
 
     <string name="stats_manage_your_stats">Manage Your Stats</string>
@@ -1127,6 +1128,8 @@
     <string name="stats_authors">Authors</string>
     <string name="stats_author_label">Author</string>
     <string name="stats_author_views_label">Views</string>
+    <string name="stats_post_label">Post</string>
+    <string name="stats_post_views_label">Views</string>
 
     <string name="stats_select_previous_period_description">Select previous period</string>
     <string name="stats_select_next_period_description">Select next period</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -844,6 +844,10 @@
     <string name="stats_bar_chart_content_description">Graph of site views.</string>
     <string name="stats_overview_content_description">%1$s %2$s for period: %3$s, change from previous period - %4$s</string>
     <string name="stats_graph_updated">Graph updated.</string>
+    <string name="stats_expand_content_description">Expand</string>
+    <string name="stats_item_expanded">Item expanded</string>
+    <string name="stats_item_collapsed">Item collapsed</string>
+    <string name="stats_posting_activity_graph">Graph of posting activity.</string>
     <string name="stats_list_item_description">%1$s: %2$s, %3$s: %4$s</string>
     <string name="stats_list_item_short_description">%1$s: %2$s</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -845,6 +845,7 @@
     <string name="stats_overview_content_description">%1$s %2$s for period: %3$s, change from previous period - %4$s</string>
     <string name="stats_graph_updated">Graph updated.</string>
     <string name="stats_expand_content_description">Expand</string>
+    <string name="stats_collapse_content_description">Collapse</string>
     <string name="stats_item_expanded">Item expanded</string>
     <string name="stats_item_collapsed">Item collapsed</string>
     <string name="stats_posting_activity_graph">Graph of posting activity.</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCaseTest.kt
@@ -81,15 +81,40 @@ class PostAverageViewsPerDayUseCaseTest : BaseUnitTest() {
         )
         val nonExpandedUiState = ExpandedYearUiState()
         val expandedUiState = ExpandedYearUiState(expandedYear = 2019)
-        whenever(postDetailMapper.mapYears(eq(data), eq(nonExpandedUiState), expandCaptor.capture())).thenReturn(
-                listOf(ExpandableItem(ListItemWithIcon(text = "2010", value = "150"), false) {
-                    expandCaptor.lastValue.invoke(expandedUiState)
-                })
+        whenever(
+                postDetailMapper.mapYears(
+                        eq(data),
+                        eq(nonExpandedUiState),
+                        eq(R.string.stats_months_and_years_period_label),
+                        eq(R.string.stats_months_and_years_views_label),
+                        expandCaptor.capture()
+                )
+        ).thenReturn(
+                listOf(
+                        ExpandableItem(
+                                ListItemWithIcon(text = "2010", value = "150", contentDescription = "2010: 150"),
+                                false
+                        ) {
+                            expandCaptor.lastValue.invoke(expandedUiState)
+                        })
         )
-        whenever(postDetailMapper.mapYears(eq(data), eq(expandedUiState), expandCaptor.capture())).thenReturn(
-                listOf(ExpandableItem(ListItemWithIcon(text = "2010", value = "150"), false) {
-                    expandCaptor.lastValue.invoke(expandedUiState)
-                }, ListItemWithIcon(text = "Jan", value = "100"))
+        whenever(
+                postDetailMapper.mapYears(
+                        eq(data),
+                        eq(expandedUiState),
+                        eq(R.string.stats_months_and_years_period_label),
+                        eq(R.string.stats_months_and_years_views_label),
+                        expandCaptor.capture()
+                )
+        ).thenReturn(
+                listOf(
+                        ExpandableItem(
+                                ListItemWithIcon(text = "2010", value = "150", contentDescription = "2010: 150"),
+                                false
+                        ) {
+                            expandCaptor.lastValue.invoke(expandedUiState)
+                        }, ListItemWithIcon(text = "Jan", value = "100", contentDescription = "Jan: 100")
+                )
         )
 
         val result = loadData(true, forced)
@@ -140,12 +165,18 @@ class PostAverageViewsPerDayUseCaseTest : BaseUnitTest() {
                 postDetailMapper.mapYears(
                         eq(data.takeLast(6)),
                         eq(nonExpandedUiState),
+                        eq(R.string.stats_months_and_years_period_label),
+                        eq(R.string.stats_months_and_years_views_label),
                         expandCaptor.capture()
                 )
         ).thenReturn(
-                listOf(ExpandableItem(ListItemWithIcon(text = "2010", value = "150"), false) {
-                    expandCaptor.lastValue.invoke(expandedUiState)
-                })
+                listOf(
+                        ExpandableItem(
+                                ListItemWithIcon(text = "2010", value = "150", contentDescription = "2010: 150"),
+                                false
+                        ) {
+                            expandCaptor.lastValue.invoke(expandedUiState)
+                        })
         )
 
         val result = loadData(true, forced)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCaseTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.stats.refresh.lists.detail
 
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
@@ -85,8 +86,7 @@ class PostAverageViewsPerDayUseCaseTest : BaseUnitTest() {
                 postDetailMapper.mapYears(
                         eq(data),
                         eq(nonExpandedUiState),
-                        eq(R.string.stats_months_and_years_period_label),
-                        eq(R.string.stats_months_and_years_views_label),
+                        any(),
                         expandCaptor.capture()
                 )
         ).thenReturn(
@@ -102,8 +102,7 @@ class PostAverageViewsPerDayUseCaseTest : BaseUnitTest() {
                 postDetailMapper.mapYears(
                         eq(data),
                         eq(expandedUiState),
-                        eq(R.string.stats_months_and_years_period_label),
-                        eq(R.string.stats_months_and_years_views_label),
+                        any(),
                         expandCaptor.capture()
                 )
         ).thenReturn(
@@ -165,8 +164,7 @@ class PostAverageViewsPerDayUseCaseTest : BaseUnitTest() {
                 postDetailMapper.mapYears(
                         eq(data.takeLast(6)),
                         eq(nonExpandedUiState),
-                        eq(R.string.stats_months_and_years_period_label),
-                        eq(R.string.stats_months_and_years_views_label),
+                        any(),
                         expandCaptor.capture()
                 )
         ).thenReturn(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDetailMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDetailMapperTest.kt
@@ -1,11 +1,14 @@
 package org.wordpress.android.ui.stats.refresh.lists.detail
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Day
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Month
@@ -16,6 +19,7 @@ import org.wordpress.android.ui.stats.refresh.lists.detail.PostDetailMapper.Expa
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Divider
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ExpandableItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.util.LocaleManagerWrapper
 import java.util.Calendar
@@ -24,11 +28,19 @@ import java.util.Locale
 class PostDetailMapperTest : BaseUnitTest() {
     @Mock lateinit var localeManagerWrapper: LocaleManagerWrapper
     @Mock lateinit var statsDateFormatter: StatsDateFormatter
+    @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
     private lateinit var postDetailMapper: PostDetailMapper
+    private val contentDescription = "period, views"
     @Before
     fun setUp() {
-        postDetailMapper = PostDetailMapper(localeManagerWrapper, statsDateFormatter)
+        postDetailMapper = PostDetailMapper(localeManagerWrapper, statsDateFormatter, contentDescriptionHelper)
         whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
+        whenever(contentDescriptionHelper.buildContentDescription(
+                eq(R.string.stats_months_and_years_period_label),
+                any<String>(),
+                eq(R.string.stats_months_and_years_views_label),
+                any()
+        )).thenReturn(contentDescription)
     }
 
     @Test
@@ -37,7 +49,12 @@ class PostDetailMapperTest : BaseUnitTest() {
         val year2019 = PostDetailStatsModel.Year(2019, listOf(Month(1, 50)), 100)
         val years = listOf(year2018, year2019)
         var expandedYear: Int? = null
-        val result = postDetailMapper.mapYears(years, ExpandedYearUiState()) {
+        val result = postDetailMapper.mapYears(
+                years,
+                ExpandedYearUiState(),
+                R.string.stats_months_and_years_period_label,
+                R.string.stats_months_and_years_views_label
+        ) {
             expandedYear = it.expandedYear
         }
         assertThat(result).hasSize(2)
@@ -46,12 +63,14 @@ class PostDetailMapperTest : BaseUnitTest() {
             assertThat(this.header.text).isEqualTo("2018")
             assertThat(this.header.value).isEqualTo("50")
             assertThat(this.header.showDivider).isTrue()
+            assertThat(this.header.contentDescription).isEqualTo(contentDescription)
         }
         (result[1] as ExpandableItem).apply {
             assertThat(this.isExpanded).isFalse()
             assertThat(this.header.text).isEqualTo("2019")
             assertThat(this.header.value).isEqualTo("100")
             assertThat(this.header.showDivider).isFalse()
+            assertThat(this.header.contentDescription).isEqualTo(contentDescription)
 
             this.onExpandClicked.invoke(true)
 
@@ -64,7 +83,12 @@ class PostDetailMapperTest : BaseUnitTest() {
         val january = Month(1, 50)
         val february = Month(2, 40)
         val years = listOf(PostDetailStatsModel.Year(2019, listOf(january, february), 100))
-        val result = postDetailMapper.mapYears(years, ExpandedYearUiState(expandedYear = 2019)) { }
+        val result = postDetailMapper.mapYears(
+                years,
+                ExpandedYearUiState(expandedYear = 2019),
+                R.string.stats_months_and_years_period_label,
+                R.string.stats_months_and_years_views_label
+        ) { }
         assertThat(result).hasSize(5)
         assertThat(result[0] is Divider).isTrue()
         (result[1] as ExpandableItem).apply {
@@ -72,16 +96,19 @@ class PostDetailMapperTest : BaseUnitTest() {
             assertThat(this.header.text).isEqualTo("2019")
             assertThat(this.header.value).isEqualTo("100")
             assertThat(this.header.showDivider).isFalse()
+            assertThat(this.header.contentDescription).isEqualTo(contentDescription)
         }
         (result[2] as ListItemWithIcon).apply {
             assertThat(this.text).isEqualTo("Feb")
             assertThat(this.value).isEqualTo("40")
             assertThat(this.showDivider).isFalse()
+            assertThat(this.contentDescription).isEqualTo(contentDescription)
         }
         (result[3] as ListItemWithIcon).apply {
             assertThat(this.text).isEqualTo("Jan")
             assertThat(this.value).isEqualTo("50")
             assertThat(this.showDivider).isFalse()
+            assertThat(this.contentDescription).isEqualTo(contentDescription)
         }
         assertThat(result[4] is Divider).isTrue()
     }
@@ -109,7 +136,13 @@ class PostDetailMapperTest : BaseUnitTest() {
         val secondWeekLabel = "Jan 9 - Jan 16, 2019"
         whenever(statsDateFormatter.printWeek(secondWeekFirstDay, secondWeekLastDay)).thenReturn(secondWeekLabel)
 
-        val result = postDetailMapper.mapWeeks(weeks, 1, ExpandedWeekUiState()) {}
+        val result = postDetailMapper.mapWeeks(
+                weeks,
+                1,
+                ExpandedWeekUiState(),
+                R.string.stats_months_and_years_period_label,
+                R.string.stats_months_and_years_views_label
+        ) {}
 
         assertThat(result).hasSize(1)
         (result[0] as ExpandableItem).apply {
@@ -117,6 +150,7 @@ class PostDetailMapperTest : BaseUnitTest() {
             assertThat(this.header.text).isEqualTo(secondWeekLabel)
             assertThat(this.header.value).isEqualTo("350")
             assertThat(this.header.showDivider).isFalse()
+            assertThat(this.header.contentDescription).isEqualTo(contentDescription)
         }
     }
 
@@ -138,7 +172,13 @@ class PostDetailMapperTest : BaseUnitTest() {
         val weekLabel = "Jan 9 - Jan 16, 2019"
         whenever(statsDateFormatter.printWeek(firstDay, lastDay)).thenReturn(weekLabel)
 
-        val result = postDetailMapper.mapWeeks(weeks, 1, ExpandedWeekUiState(firstDay)) {}
+        val result = postDetailMapper.mapWeeks(
+                weeks,
+                1,
+                ExpandedWeekUiState(firstDay),
+                R.string.stats_months_and_years_period_label,
+                R.string.stats_months_and_years_views_label
+        ) {}
 
         assertThat(result).hasSize(5)
         assertThat(result[0] is Divider).isTrue()
@@ -147,16 +187,19 @@ class PostDetailMapperTest : BaseUnitTest() {
             assertThat(this.header.text).isEqualTo(weekLabel)
             assertThat(this.header.value).isEqualTo("350")
             assertThat(this.header.showDivider).isFalse()
+            assertThat(this.header.contentDescription).isEqualTo(contentDescription)
         }
         (result[2] as ListItemWithIcon).apply {
             assertThat(this.text).isEqualTo("Jan 16")
             assertThat(this.value).isEqualTo("400")
             assertThat(this.showDivider).isFalse()
+            assertThat(this.contentDescription).isEqualTo(contentDescription)
         }
         (result[3] as ListItemWithIcon).apply {
             assertThat(this.text).isEqualTo("Jan 9")
             assertThat(this.value).isEqualTo("300")
             assertThat(this.showDivider).isFalse()
+            assertThat(this.contentDescription).isEqualTo(contentDescription)
         }
         assertThat(result[4] is Divider).isTrue()
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDetailMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDetailMapperTest.kt
@@ -39,7 +39,7 @@ class PostDetailMapperTest : BaseUnitTest() {
                 eq(R.string.stats_months_and_years_period_label),
                 any<String>(),
                 eq(R.string.stats_months_and_years_views_label),
-                any()
+                any<Int>()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDetailMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDetailMapperTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.detail
 
 import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -18,6 +17,7 @@ import org.wordpress.android.ui.stats.refresh.lists.detail.PostDetailMapper.Expa
 import org.wordpress.android.ui.stats.refresh.lists.detail.PostDetailMapper.ExpandedYearUiState
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Divider
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ExpandableItem
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
@@ -36,10 +36,9 @@ class PostDetailMapperTest : BaseUnitTest() {
         postDetailMapper = PostDetailMapper(localeManagerWrapper, statsDateFormatter, contentDescriptionHelper)
         whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
         whenever(contentDescriptionHelper.buildContentDescription(
-                eq(R.string.stats_months_and_years_period_label),
+                any(),
                 any<String>(),
-                eq(R.string.stats_months_and_years_views_label),
-                any<Int>()
+                any()
         )).thenReturn(contentDescription)
     }
 
@@ -52,8 +51,7 @@ class PostDetailMapperTest : BaseUnitTest() {
         val result = postDetailMapper.mapYears(
                 years,
                 ExpandedYearUiState(),
-                R.string.stats_months_and_years_period_label,
-                R.string.stats_months_and_years_views_label
+                Header(R.string.stats_months_and_years_period_label, R.string.stats_months_and_years_views_label)
         ) {
             expandedYear = it.expandedYear
         }
@@ -86,8 +84,7 @@ class PostDetailMapperTest : BaseUnitTest() {
         val result = postDetailMapper.mapYears(
                 years,
                 ExpandedYearUiState(expandedYear = 2019),
-                R.string.stats_months_and_years_period_label,
-                R.string.stats_months_and_years_views_label
+                Header(R.string.stats_months_and_years_period_label, R.string.stats_months_and_years_views_label)
         ) { }
         assertThat(result).hasSize(5)
         assertThat(result[0] is Divider).isTrue()
@@ -140,8 +137,7 @@ class PostDetailMapperTest : BaseUnitTest() {
                 weeks,
                 1,
                 ExpandedWeekUiState(),
-                R.string.stats_months_and_years_period_label,
-                R.string.stats_months_and_years_views_label
+                Header(R.string.stats_months_and_years_period_label, R.string.stats_months_and_years_views_label)
         ) {}
 
         assertThat(result).hasSize(1)
@@ -176,8 +172,7 @@ class PostDetailMapperTest : BaseUnitTest() {
                 weeks,
                 1,
                 ExpandedWeekUiState(firstDay),
-                R.string.stats_months_and_years_period_label,
-                R.string.stats_months_and_years_views_label
+                Header(R.string.stats_months_and_years_period_label, R.string.stats_months_and_years_views_label)
         ) {}
 
         assertThat(result).hasSize(5)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCaseTest.kt
@@ -81,15 +81,40 @@ class PostMonthsAndYearsUseCaseTest : BaseUnitTest() {
         )
         val nonExpandedUiState = ExpandedYearUiState()
         val expandedUiState = ExpandedYearUiState(expandedYear = 2019)
-        whenever(postDetailMapper.mapYears(eq(data), eq(nonExpandedUiState), expandCaptor.capture())).thenReturn(
-                listOf(ExpandableItem(ListItemWithIcon(text = "2010", value = "150"), false) {
-                    expandCaptor.lastValue.invoke(expandedUiState)
-                })
+        whenever(
+                postDetailMapper.mapYears(
+                        eq(data),
+                        eq(nonExpandedUiState),
+                        eq(R.string.stats_months_and_years_period_label),
+                        eq(R.string.stats_months_and_years_views_label),
+                        expandCaptor.capture()
+                )
+        ).thenReturn(
+                listOf(
+                        ExpandableItem(
+                                ListItemWithIcon(text = "2010", value = "150", contentDescription = "2010: 150"),
+                                false
+                        ) {
+                            expandCaptor.lastValue.invoke(expandedUiState)
+                        })
         )
-        whenever(postDetailMapper.mapYears(eq(data), eq(expandedUiState), expandCaptor.capture())).thenReturn(
-                listOf(ExpandableItem(ListItemWithIcon(text = "2010", value = "150"), false) {
-                    expandCaptor.lastValue.invoke(expandedUiState)
-                }, ListItemWithIcon(text = "Jan", value = "100"))
+        whenever(
+                postDetailMapper.mapYears(
+                        eq(data),
+                        eq(expandedUiState),
+                        eq(R.string.stats_months_and_years_period_label),
+                        eq(R.string.stats_months_and_years_views_label),
+                        expandCaptor.capture()
+                )
+        ).thenReturn(
+                listOf(
+                        ExpandableItem(
+                                ListItemWithIcon(text = "2010", value = "150", contentDescription = "2010: 150"),
+                                false
+                        ) {
+                            expandCaptor.lastValue.invoke(expandedUiState)
+                        }, ListItemWithIcon(text = "Jan", value = "100", contentDescription = "2010: 150")
+                )
         )
 
         val result = loadData(true, forced)
@@ -140,12 +165,18 @@ class PostMonthsAndYearsUseCaseTest : BaseUnitTest() {
                 postDetailMapper.mapYears(
                         eq(data.takeLast(6)),
                         eq(nonExpandedUiState),
+                        eq(R.string.stats_months_and_years_period_label),
+                        eq(R.string.stats_months_and_years_views_label),
                         expandCaptor.capture()
                 )
         ).thenReturn(
-                listOf(ExpandableItem(ListItemWithIcon(text = "2010", value = "150"), false) {
-                    expandCaptor.lastValue.invoke(expandedUiState)
-                })
+                listOf(
+                        ExpandableItem(
+                                ListItemWithIcon(text = "2010", value = "150", contentDescription = "2010: 150"),
+                                false
+                        ) {
+                            expandCaptor.lastValue.invoke(expandedUiState)
+                        })
         )
 
         val result = loadData(true, forced)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCaseTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.stats.refresh.lists.detail
 
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
@@ -85,8 +86,7 @@ class PostMonthsAndYearsUseCaseTest : BaseUnitTest() {
                 postDetailMapper.mapYears(
                         eq(data),
                         eq(nonExpandedUiState),
-                        eq(R.string.stats_months_and_years_period_label),
-                        eq(R.string.stats_months_and_years_views_label),
+                        any(),
                         expandCaptor.capture()
                 )
         ).thenReturn(
@@ -102,8 +102,7 @@ class PostMonthsAndYearsUseCaseTest : BaseUnitTest() {
                 postDetailMapper.mapYears(
                         eq(data),
                         eq(expandedUiState),
-                        eq(R.string.stats_months_and_years_period_label),
-                        eq(R.string.stats_months_and_years_views_label),
+                        any(),
                         expandCaptor.capture()
                 )
         ).thenReturn(
@@ -165,8 +164,7 @@ class PostMonthsAndYearsUseCaseTest : BaseUnitTest() {
                 postDetailMapper.mapYears(
                         eq(data.takeLast(6)),
                         eq(nonExpandedUiState),
-                        eq(R.string.stats_months_and_years_period_label),
-                        eq(R.string.stats_months_and_years_views_label),
+                        any(),
                         expandCaptor.capture()
                 )
         ).thenReturn(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCaseTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.stats.refresh.lists.detail
 
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
@@ -86,19 +87,48 @@ class PostRecentWeeksUseCaseTest : BaseUnitTest() {
         val lastDayCalendar = Calendar.getInstance()
         lastDayCalendar.set(2019, 3, 24)
         val expandedUiState = ExpandedWeekUiState(expandedWeekFirstDay = lastDayCalendar.time)
-        whenever(postDetailMapper.mapWeeks(eq(data), eq(6), eq(nonExpandedUiState), expandCaptor.capture())).thenReturn(
-                listOf(ExpandableItem(ListItemWithIcon(text = "Mar 18 - Mar 24, 2019", value = "150"), false) {
-                    expandCaptor.lastValue.invoke(expandedUiState)
-                })
-        )
-        whenever(postDetailMapper.mapWeeks(eq(data), eq(6), eq(expandedUiState), expandCaptor.capture())).thenReturn(
+        whenever(
+                postDetailMapper.mapWeeks(
+                        eq(data),
+                        eq(6),
+                        eq(nonExpandedUiState),
+                        any(),
+                        any(),
+                        expandCaptor.capture()
+                )
+        ).thenReturn(
                 listOf(
                         ExpandableItem(
-                                ListItemWithIcon(text = "Mar 18 - Mar 24, 2019", value = "150"),
+                                ListItemWithIcon(
+                                        text = "Mar 18 - Mar 24, 2019",
+                                        value = "150",
+                                        contentDescription = "Mar: 150"
+                                ), false
+                        ) {
+                            expandCaptor.lastValue.invoke(expandedUiState)
+                        })
+        )
+        whenever(
+                postDetailMapper.mapWeeks(
+                        eq(data),
+                        eq(6),
+                        eq(expandedUiState),
+                        any(),
+                        any(),
+                        expandCaptor.capture()
+                )
+        ).thenReturn(
+                listOf(
+                        ExpandableItem(
+                                ListItemWithIcon(
+                                        text = "Mar 18 - Mar 24, 2019",
+                                        value = "150",
+                                        contentDescription = "Mar: 150"
+                                ),
                                 false
                         ) { expandCaptor.lastValue.invoke(expandedUiState) },
-                        ListItemWithIcon(text = "Mar 18", value = "50"),
-                        ListItemWithIcon(text = "Mar 24", value = "100")
+                        ListItemWithIcon(text = "Mar 18", value = "50", contentDescription = "Mar: 50"),
+                        ListItemWithIcon(text = "Mar 24", value = "100", contentDescription = "Mar: 100")
                 )
         )
 
@@ -149,12 +179,21 @@ class PostRecentWeeksUseCaseTest : BaseUnitTest() {
                         eq(data),
                         eq(6),
                         eq(nonExpandedUiState),
+                        any(),
+                        any(),
                         expandCaptor.capture()
                 )
         ).thenReturn(
-                listOf(ExpandableItem(ListItemWithIcon(text = "Mar 18 - Mar 24, 2019", value = "150"), false) {
-                    expandCaptor.lastValue.invoke(expandedUiState)
-                })
+                listOf(
+                        ExpandableItem(
+                                ListItemWithIcon(
+                                        text = "Mar 18 - Mar 24, 2019",
+                                        value = "150",
+                                        contentDescription = "Mar: 150"
+                                ), false
+                        ) {
+                            expandCaptor.lastValue.invoke(expandedUiState)
+                        })
         )
 
         val result = loadData(true, forced)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCaseTest.kt
@@ -93,7 +93,6 @@ class PostRecentWeeksUseCaseTest : BaseUnitTest() {
                         eq(6),
                         eq(nonExpandedUiState),
                         any(),
-                        any(),
                         expandCaptor.capture()
                 )
         ).thenReturn(
@@ -113,7 +112,6 @@ class PostRecentWeeksUseCaseTest : BaseUnitTest() {
                         eq(data),
                         eq(6),
                         eq(expandedUiState),
-                        any(),
                         any(),
                         expandCaptor.capture()
                 )
@@ -179,7 +177,6 @@ class PostRecentWeeksUseCaseTest : BaseUnitTest() {
                         eq(data),
                         eq(6),
                         eq(nonExpandedUiState),
-                        any(),
                         any(),
                         expandCaptor.capture()
                 )

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCaseTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
@@ -37,6 +38,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -52,12 +54,14 @@ class AuthorsUseCaseTest : BaseUnitTest() {
     @Mock lateinit var site: SiteModel
     @Mock lateinit var selectedDateProvider: SelectedDateProvider
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
+    @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
     private lateinit var useCase: AuthorsUseCase
     private val firstAuthorViews = 20
     private val secondAuthorViews = 40
     private val authorWithoutPosts = Author("group1", firstAuthorViews, "group1.jpg", listOf())
     private val post = Post("Post1", "Post title", 20, "post.com")
     private val authorWithPosts = Author("group2", secondAuthorViews, "group2.jpg", listOf(post))
+    private val contentDescription = "title, views"
     @Before
     fun setUp() {
         useCase = AuthorsUseCase(
@@ -67,6 +71,7 @@ class AuthorsUseCaseTest : BaseUnitTest() {
                 statsSiteProvider,
                 selectedDateProvider,
                 tracker,
+                contentDescriptionHelper,
                 BLOCK
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
@@ -77,6 +82,12 @@ class AuthorsUseCaseTest : BaseUnitTest() {
                         listOf(selectedDate)
                 )
         )
+        whenever(contentDescriptionHelper.buildContentDescription(
+                any(),
+                any<String>(),
+                any(),
+                any()
+        )).thenReturn(contentDescription)
     }
 
     @Test
@@ -257,6 +268,7 @@ class AuthorsUseCaseTest : BaseUnitTest() {
             assertThat(item.barWidth).isNull()
         }
         assertThat(item.iconUrl).isEqualTo(icon)
+        assertThat(item.contentDescription).isEqualTo(contentDescription)
     }
 
     private fun assertExpandableItem(
@@ -271,6 +283,7 @@ class AuthorsUseCaseTest : BaseUnitTest() {
         assertThat(item.header.value).isEqualTo(views.toFormattedString())
         assertThat(item.header.iconUrl).isEqualTo(icon)
         assertThat(item.header.barWidth).isEqualTo(bar)
+        assertThat(item.header.contentDescription).isEqualTo(contentDescription)
         return item
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCaseTest.kt
@@ -86,7 +86,7 @@ class AuthorsUseCaseTest : BaseUnitTest() {
                 any(),
                 any<String>(),
                 any(),
-                any()
+                any<Int>()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCaseTest.kt
@@ -85,6 +85,11 @@ class AuthorsUseCaseTest : BaseUnitTest() {
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
                 any<String>(),
+                any()
+        )).thenReturn(contentDescription)
+        whenever(contentDescriptionHelper.buildContentDescription(
+                any(),
+                any<String>(),
                 any(),
                 any<Int>()
         )).thenReturn(contentDescription)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCaseTest.kt
@@ -87,7 +87,7 @@ class ClicksUseCaseTest : BaseUnitTest() {
                 any(),
                 any<String>(),
                 any(),
-                any()
+                any<Int>()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCaseTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
@@ -37,6 +38,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -53,12 +55,14 @@ class ClicksUseCaseTest : BaseUnitTest() {
     @Mock lateinit var site: SiteModel
     @Mock lateinit var selectedDateProvider: SelectedDateProvider
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
+    @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
     private lateinit var useCase: ClicksUseCase
     private val firstGroupViews = 50
     private val secondGroupViews = 30
     private val singleClick = Group("group1", "Group 1", "group1.jpg", "group1.com", firstGroupViews, listOf())
     private val click = Click("Click 1", 20, "click.jpg", "click.com")
     private val group = Group("group2", "Group 2", "group2.jpg", "group2.com", secondGroupViews, listOf(click))
+    private val contentDescription = "title, views"
     @Before
     fun setUp() {
         useCase = ClicksUseCase(
@@ -68,6 +72,7 @@ class ClicksUseCaseTest : BaseUnitTest() {
                 statsSiteProvider,
                 selectedDateProvider,
                 tracker,
+                contentDescriptionHelper,
                 BLOCK
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
@@ -78,6 +83,12 @@ class ClicksUseCaseTest : BaseUnitTest() {
                 )
         )
         whenever((selectedDateProvider.getSelectedDate(statsGranularity))).thenReturn(selectedDate)
+        whenever(contentDescriptionHelper.buildContentDescription(
+                any(),
+                any<String>(),
+                any(),
+                any()
+        )).thenReturn(contentDescription)
     }
 
     @Test
@@ -233,6 +244,7 @@ class ClicksUseCaseTest : BaseUnitTest() {
             assertThat(item.value).isNull()
         }
         assertThat(item.iconUrl).isNull()
+        assertThat(item.contentDescription).isEqualTo(contentDescription)
     }
 
     private fun assertExpandableItem(
@@ -244,6 +256,7 @@ class ClicksUseCaseTest : BaseUnitTest() {
         assertThat((item as ExpandableItem).header.text).isEqualTo(label)
         assertThat(item.header.value).isEqualTo(views.toFormattedString())
         assertThat(item.header.iconUrl).isNull()
+        assertThat(item.header.contentDescription).isEqualTo(contentDescription)
         return item
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCaseTest.kt
@@ -86,8 +86,7 @@ class ClicksUseCaseTest : BaseUnitTest() {
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
                 any<String>(),
-                any(),
-                any<Int>()
+                any()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCaseTest.kt
@@ -80,7 +80,7 @@ class CountryViewsUseCaseTest : BaseUnitTest() {
                 any(),
                 any<String>(),
                 any(),
-                any()
+                any<Int>()
         )).thenReturn("title, views")
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCaseTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
@@ -35,6 +36,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import java.util.Date
@@ -51,6 +53,7 @@ class CountryViewsUseCaseTest : BaseUnitTest() {
     @Mock lateinit var site: SiteModel
     @Mock lateinit var selectedDateProvider: SelectedDateProvider
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
+    @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
     private lateinit var useCase: CountryViewsUseCase
     private val country = Country("CZ", "Czech Republic", 500, "flag.jpg", "flatFlag.jpg")
     @Before
@@ -62,6 +65,7 @@ class CountryViewsUseCaseTest : BaseUnitTest() {
                 statsSiteProvider,
                 selectedDateProvider,
                 tracker,
+                contentDescriptionHelper,
                 BLOCK
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
@@ -72,6 +76,12 @@ class CountryViewsUseCaseTest : BaseUnitTest() {
                         listOf(selectedDate)
                 )
         )
+        whenever(contentDescriptionHelper.buildContentDescription(
+                any(),
+                any<String>(),
+                any(),
+                any()
+        )).thenReturn("title, views")
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCaseTest.kt
@@ -79,8 +79,7 @@ class CountryViewsUseCaseTest : BaseUnitTest() {
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
                 any<String>(),
-                any(),
-                any<Int>()
+                any()
         )).thenReturn("title, views")
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCaseTest.kt
@@ -82,7 +82,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 eq(string.stats_posts_and_pages_title_label),
                 any<String>(),
                 eq(string.stats_posts_and_pages_views_label),
-                any()
+                any<Int>()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCaseTest.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
@@ -8,6 +10,7 @@ import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.R.string
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel
@@ -36,6 +39,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.HEADER
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -51,7 +55,9 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
     @Mock lateinit var site: SiteModel
     @Mock lateinit var selectedDateProvider: SelectedDateProvider
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
+    @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
     private lateinit var useCase: PostsAndPagesUseCase
+    private val contentDescription = "title, views"
     @Before
     fun setUp() {
         useCase = PostsAndPagesUseCase(
@@ -61,6 +67,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 siteModelProvider,
                 selectedDateProvider,
                 tracker,
+                contentDescriptionHelper,
                 BLOCK
         )
         whenever(siteModelProvider.siteModel).thenReturn(site)
@@ -71,6 +78,12 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                         listOf(selectedDate)
                 )
         )
+        whenever(contentDescriptionHelper.buildContentDescription(
+                eq(string.stats_posts_and_pages_title_label),
+                any<String>(),
+                eq(string.stats_posts_and_pages_views_label),
+                any()
+        )).thenReturn(contentDescription)
     }
 
     @Test
@@ -159,6 +172,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
         assertThat(item.text).isEqualTo(post.title)
         assertThat(item.value).isEqualTo("10")
         assertThat(item.barWidth).isEqualTo(100)
+        assertThat(item.contentDescription).isEqualTo(contentDescription)
     }
 
     @Test
@@ -202,6 +216,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
         assertThat(item.text).isEqualTo(title)
         assertThat(item.value).isEqualTo(views.toString())
         assertThat(item.barWidth).isEqualTo(100)
+        assertThat(item.contentDescription).isEqualTo(contentDescription)
     }
 
     @Test
@@ -244,6 +259,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
         assertThat(item.icon).isEqualTo(R.drawable.ic_pages_white_24dp)
         assertThat(item.text).isEqualTo(title)
         assertThat(item.value).isEqualTo(views.toFormattedString())
+        assertThat(item.contentDescription).isEqualTo(contentDescription)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCaseTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 
 import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
@@ -10,7 +9,6 @@ import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
-import org.wordpress.android.R.string
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel
@@ -79,10 +77,9 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 )
         )
         whenever(contentDescriptionHelper.buildContentDescription(
-                eq(string.stats_posts_and_pages_title_label),
+                any(),
                 any<String>(),
-                eq(string.stats_posts_and_pages_views_label),
-                any<Int>()
+                any()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCaseTest.kt
@@ -87,7 +87,7 @@ class ReferrersUseCaseTest : BaseUnitTest() {
                 any(),
                 any<String>(),
                 any(),
-                any()
+                any<Int>()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCaseTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
@@ -37,6 +38,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -53,12 +55,14 @@ class ReferrersUseCaseTest : BaseUnitTest() {
     @Mock lateinit var site: SiteModel
     @Mock lateinit var selectedDateProvider: SelectedDateProvider
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
+    @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
     private lateinit var useCase: ReferrersUseCase
     private val firstGroupViews = 50
     private val secondGroupViews = 30
     private val singleReferrer = Group("group1", "Group 1", "group1.jpg", "group1.com", firstGroupViews, listOf())
     private val referrer = Referrer("Referrer 1", 20, "referrer.jpg", "referrer.com")
     private val group = Group("group2", "Group 2", "group2.jpg", "group2.com", secondGroupViews, listOf(referrer))
+    private val contentDescription = "title, views"
     @Before
     fun setUp() {
         useCase = ReferrersUseCase(
@@ -68,6 +72,7 @@ class ReferrersUseCaseTest : BaseUnitTest() {
                 statsSiteProvider,
                 selectedDateProvider,
                 tracker,
+                contentDescriptionHelper,
                 BLOCK
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
@@ -78,6 +83,12 @@ class ReferrersUseCaseTest : BaseUnitTest() {
                         listOf(selectedDate)
                 )
         )
+        whenever(contentDescriptionHelper.buildContentDescription(
+                any(),
+                any<String>(),
+                any(),
+                any()
+        )).thenReturn(contentDescription)
     }
 
     @Test
@@ -221,6 +232,7 @@ class ReferrersUseCaseTest : BaseUnitTest() {
             assertThat(item.value).isNull()
         }
         assertThat(item.iconUrl).isEqualTo(icon)
+        assertThat(item.contentDescription).isEqualTo(contentDescription)
     }
 
     private fun assertExpandableItem(
@@ -233,6 +245,7 @@ class ReferrersUseCaseTest : BaseUnitTest() {
         assertThat((item as ExpandableItem).header.text).isEqualTo(label)
         assertThat(item.header.value).isEqualTo(views.toFormattedString())
         assertThat(item.header.iconUrl).isEqualTo(icon)
+        assertThat(item.header.contentDescription).isEqualTo(contentDescription)
         return item
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCaseTest.kt
@@ -86,8 +86,7 @@ class ReferrersUseCaseTest : BaseUnitTest() {
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
                 any<String>(),
-                any(),
-                any<Int>()
+                any()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCaseTest.kt
@@ -86,7 +86,7 @@ class SearchTermsUseCaseTest : BaseUnitTest() {
                 any(),
                 any<String>(),
                 any(),
-                any()
+                any<Int>()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCaseTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
@@ -34,6 +35,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import java.util.Date
@@ -48,8 +50,10 @@ class SearchTermsUseCaseTest : BaseUnitTest() {
     @Mock lateinit var site: SiteModel
     @Mock lateinit var selectedDateProvider: SelectedDateProvider
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
+    @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
     private lateinit var useCase: SearchTermsUseCase
     private val searchTerm = SearchTerm("search term", 10)
+    private val contentDescription = "title, views"
 
     private val limitMode = Top(ITEMS_TO_LOAD)
     @Before
@@ -61,6 +65,7 @@ class SearchTermsUseCaseTest : BaseUnitTest() {
                 statsSiteProvider,
                 selectedDateProvider,
                 tracker,
+                contentDescriptionHelper,
                 BLOCK
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
@@ -71,6 +76,18 @@ class SearchTermsUseCaseTest : BaseUnitTest() {
                         listOf(selectedDate)
                 )
         )
+        whenever(contentDescriptionHelper.buildContentDescription(
+                any(),
+                any<Int>(),
+                any(),
+                any()
+        )).thenReturn(contentDescription)
+        whenever(contentDescriptionHelper.buildContentDescription(
+                any(),
+                any<String>(),
+                any(),
+                any()
+        )).thenReturn(contentDescription)
     }
 
     @Test
@@ -223,6 +240,7 @@ class SearchTermsUseCaseTest : BaseUnitTest() {
         } else {
             assertThat(item.value).isNull()
         }
+        assertThat(item.contentDescription).isEqualTo(contentDescription)
     }
 
     private fun assertLink(item: BlockListItem) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCaseTest.kt
@@ -79,14 +79,12 @@ class SearchTermsUseCaseTest : BaseUnitTest() {
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
                 any<Int>(),
-                any(),
                 any()
         )).thenReturn(contentDescription)
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
                 any<String>(),
-                any(),
-                any<Int>()
+                any()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCaseTest.kt
@@ -79,7 +79,7 @@ class VideoPlaysUseCaseTest : BaseUnitTest() {
                 eq(R.string.stats_videos_title_label),
                 any<String>(),
                 eq(R.string.stats_videos_views_label),
-                any()
+                any<Int>()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCaseTest.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
@@ -33,6 +35,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import java.util.Date
@@ -48,8 +51,10 @@ class VideoPlaysUseCaseTest : BaseUnitTest() {
     @Mock lateinit var site: SiteModel
     @Mock lateinit var selectedDateProvider: SelectedDateProvider
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
+    @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
     private lateinit var useCase: VideoPlaysUseCase
     private val videoPlay = VideoPlays("post1", "Video 1", "group2.jpg", 100)
+    private val contentDescription = "title, views"
     @Before
     fun setUp() {
         useCase = VideoPlaysUseCase(
@@ -59,6 +64,7 @@ class VideoPlaysUseCaseTest : BaseUnitTest() {
                 siteModelProvider,
                 selectedDateProvider,
                 tracker,
+                contentDescriptionHelper,
                 BLOCK
         )
         whenever(siteModelProvider.siteModel).thenReturn(site)
@@ -69,6 +75,12 @@ class VideoPlaysUseCaseTest : BaseUnitTest() {
                         listOf(selectedDate)
                 )
         )
+        whenever(contentDescriptionHelper.buildContentDescription(
+                eq(R.string.stats_videos_title_label),
+                any<String>(),
+                eq(R.string.stats_videos_views_label),
+                any()
+        )).thenReturn(contentDescription)
     }
 
     @Test
@@ -193,6 +205,7 @@ class VideoPlaysUseCaseTest : BaseUnitTest() {
         } else {
             assertThat(item.value).isNull()
         }
+        assertThat(item.contentDescription).isEqualTo(contentDescription)
     }
 
     private fun assertLink(item: BlockListItem) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/VideoPlaysUseCaseTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 
 import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
@@ -76,10 +75,9 @@ class VideoPlaysUseCaseTest : BaseUnitTest() {
                 )
         )
         whenever(contentDescriptionHelper.buildContentDescription(
-                eq(R.string.stats_videos_title_label),
+                any(),
                 any<String>(),
-                eq(R.string.stats_videos_views_label),
-                any<Int>()
+                any()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AnnualStatsMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AnnualStatsMapperTest.kt
@@ -27,7 +27,7 @@ class AnnualStatsMapperTest {
         annualStatsMapper = AnnualStatsMapper(contentDescriptionHelper)
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
-                any()
+                any<String>()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AnnualStatsMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AnnualStatsMapperTest.kt
@@ -1,8 +1,12 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.stats.YearsInsightsModel.YearInsights
@@ -11,10 +15,22 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListI
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.QuickScanItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM_WITH_ICON
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.QUICK_SCAN_ITEM
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 
 @RunWith(MockitoJUnitRunner::class)
 class AnnualStatsMapperTest {
-    private val annualStatsMapper = AnnualStatsMapper()
+    @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
+    private lateinit var annualStatsMapper: AnnualStatsMapper
+    private val contentDescription = "title, views"
+    @Before
+    fun setUp() {
+        annualStatsMapper = AnnualStatsMapper(contentDescriptionHelper)
+        whenever(contentDescriptionHelper.buildContentDescription(
+                any(),
+                any()
+        )).thenReturn(contentDescription)
+    }
+
     @Test
     fun `maps year insights for the card`() {
         val mappedYear = YearInsights(
@@ -104,5 +120,6 @@ class AnnualStatsMapperTest {
         val item = blockListItem as ListItemWithIcon
         assertThat(item.textResource).isEqualTo(label)
         assertThat(item.value).isEqualTo(value)
+        assertThat(item.contentDescription).isEqualTo(contentDescription)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCaseTest.kt
@@ -69,7 +69,7 @@ class CommentsUseCaseTest : BaseUnitTest() {
                 any(),
                 any<String>(),
                 any(),
-                any()
+                any<Int>()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCaseTest.kt
@@ -34,6 +34,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM_WITH_ICON
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -44,6 +45,7 @@ class CommentsUseCaseTest : BaseUnitTest() {
     @Mock lateinit var site: SiteModel
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
     @Mock lateinit var popupMenuHandler: ItemPopupMenuHandler
+    @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
     private lateinit var useCase: CommentsUseCase
     private val postId: Long = 10
     private val postTitle = "Post"
@@ -52,15 +54,23 @@ class CommentsUseCaseTest : BaseUnitTest() {
     private val url = "www.url.com"
     private val totalCount = 50
     private val blockItemCount = 6
+    private val contentDescription = "title, views"
     @Before
     fun setUp() {
         useCase = CommentsUseCase(
                 Dispatchers.Unconfined,
                 insightsStore,
                 statsSiteProvider,
-                popupMenuHandler
+                popupMenuHandler,
+                contentDescriptionHelper
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
+        whenever(contentDescriptionHelper.buildContentDescription(
+                any(),
+                any<String>(),
+                any(),
+                any()
+        )).thenReturn(contentDescription)
     }
 
     @Test
@@ -171,6 +181,7 @@ class CommentsUseCaseTest : BaseUnitTest() {
         assertThat((userItem as ListItem).text).isEqualTo(postTitle)
         assertThat(userItem.showDivider).isEqualTo(false)
         assertThat(userItem.value).isEqualTo(totalCount.toString())
+        assertThat(userItem.contentDescription).isEqualTo(contentDescription)
         return tabsItem
     }
 
@@ -196,6 +207,7 @@ class CommentsUseCaseTest : BaseUnitTest() {
         assertThat(userItem.iconStyle).isEqualTo(AVATAR)
         assertThat(userItem.text).isEqualTo(user)
         assertThat(userItem.value).isEqualTo(totalCount.toString())
+        assertThat(userItem.contentDescription).isEqualTo(contentDescription)
         return tabsItem
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCaseTest.kt
@@ -68,8 +68,7 @@ class CommentsUseCaseTest : BaseUnitTest() {
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
                 any<String>(),
-                any(),
-                any<Int>()
+                any()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTotalsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTotalsUseCaseTest.kt
@@ -62,7 +62,7 @@ class FollowerTotalsUseCaseTest : BaseUnitTest() {
         whenever(publicizeStore.getPublicizeData(site, LimitMode.All)).thenReturn(socialModel)
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
-                any()
+                any<String>()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTotalsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTotalsUseCaseTest.kt
@@ -62,7 +62,7 @@ class FollowerTotalsUseCaseTest : BaseUnitTest() {
         whenever(publicizeStore.getPublicizeData(site, LimitMode.All)).thenReturn(socialModel)
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
-                any<String>()
+                any<Int>()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowersUseCaseTest.kt
@@ -91,9 +91,9 @@ class FollowersUseCaseTest : BaseUnitTest() {
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
-                any<String>(),
                 any(),
-                any()
+                any(),
+                any<String>()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowersUseCaseTest.kt
@@ -37,6 +37,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TabsI
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.FollowersUseCase.FollowersUseCaseFactory
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -51,6 +52,7 @@ class FollowersUseCaseTest : BaseUnitTest() {
     @Mock lateinit var site: SiteModel
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
     @Mock lateinit var popupMenuHandler: ItemPopupMenuHandler
+    @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
     private lateinit var useCaseFactory: FollowersUseCaseFactory
     private lateinit var useCase: FollowersUseCase
     private val avatar = "avatar.jpg"
@@ -65,7 +67,8 @@ class FollowersUseCaseTest : BaseUnitTest() {
     private val blockInitialMode = PagedMode(blockPageSize, false)
     private val viewAllInitialLoadMode = PagedMode(viewAllPageSize, false)
     private val viewAllMoreLoadMode = PagedMode(viewAllPageSize, true)
-    val message = "Total followers count is 50"
+    private val message = "Total followers count is 50"
+    private val contentDescription = "title, views"
     @Before
     fun setUp() {
         useCaseFactory = FollowersUseCaseFactory(
@@ -76,7 +79,8 @@ class FollowersUseCaseTest : BaseUnitTest() {
                 statsUtilsWrapper,
                 resourceProvider,
                 popupMenuHandler,
-                tracker
+                tracker,
+                contentDescriptionHelper
         )
         useCase = useCaseFactory.build(BLOCK)
         whenever(statsUtilsWrapper.getSinceLabelLowerCase(dateSubscribed)).thenReturn(sinceLabel)
@@ -85,6 +89,12 @@ class FollowersUseCaseTest : BaseUnitTest() {
                 message
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
+        whenever(contentDescriptionHelper.buildContentDescription(
+                any(),
+                any<String>(),
+                any(),
+                any()
+        )).thenReturn(contentDescription)
     }
 
     @Test
@@ -328,6 +338,7 @@ class FollowersUseCaseTest : BaseUnitTest() {
         assertThat(follower.text).isEqualTo(user)
         assertThat(follower.value).isEqualTo(sinceLabel)
         assertThat(follower.showDivider).isEqualTo(true)
+        assertThat(follower.contentDescription).isEqualTo(contentDescription)
 
         assertThat(this[12] is ListItemWithIcon).isTrue()
 
@@ -362,6 +373,7 @@ class FollowersUseCaseTest : BaseUnitTest() {
         assertThat(follower.text).isEqualTo(user)
         assertThat(follower.value).isEqualTo(sinceLabel)
         assertThat(follower.showDivider).isEqualTo(false)
+        assertThat(follower.contentDescription).isEqualTo(contentDescription)
         return tabsItem
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowersUseCaseTest.kt
@@ -91,9 +91,8 @@ class FollowersUseCaseTest : BaseUnitTest() {
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
-                any(),
-                any(),
-                any<String>()
+                any<String>(),
+                any()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCaseTest.kt
@@ -59,7 +59,7 @@ class LatestPostSummaryUseCaseTest : BaseUnitTest() {
         useCase.navigationTarget.observeForever {}
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
-                any()
+                any<String>()
         )).thenReturn("likes: 10")
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCaseTest.kt
@@ -59,7 +59,7 @@ class LatestPostSummaryUseCaseTest : BaseUnitTest() {
         useCase.navigationTarget.observeForever {}
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
-                any<String>()
+                any<Long>()
         )).thenReturn("likes: 10")
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCaseTest.kt
@@ -59,7 +59,7 @@ class LatestPostSummaryUseCaseTest : BaseUnitTest() {
         useCase.navigationTarget.observeForever {}
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
-                any<Long>()
+                any<Int>()
         )).thenReturn("likes: 10")
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCaseTest.kt
@@ -9,6 +9,7 @@ import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.R.string
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.PublicizeModel
@@ -71,7 +72,11 @@ class PublicizeUseCaseTest : BaseUnitTest() {
                 )
         )
         val mockedItem = mock<ListItemWithIcon>()
-        whenever(serviceMapper.map(services)).thenReturn(listOf(mockedItem))
+        whenever(serviceMapper.map(
+                services,
+                string.stats_publicize_service_label,
+                string.stats_publicize_followers_label
+        )).thenReturn(listOf(mockedItem))
 
         val result = loadPublicizeModel(true, forced)
 
@@ -102,7 +107,11 @@ class PublicizeUseCaseTest : BaseUnitTest() {
                 )
         )
         val mockedItem = mock<ListItemWithIcon>()
-        whenever(serviceMapper.map(services.take(5))).thenReturn(listOf(mockedItem))
+        whenever(serviceMapper.map(
+                services.take(5),
+                string.stats_publicize_service_label,
+                string.stats_publicize_followers_label
+        )).thenReturn(listOf(mockedItem))
 
         val result = loadPublicizeModel(true, forced)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PublicizeUseCaseTest.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
@@ -9,7 +11,6 @@ import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
-import org.wordpress.android.R.string
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.PublicizeModel
@@ -73,9 +74,8 @@ class PublicizeUseCaseTest : BaseUnitTest() {
         )
         val mockedItem = mock<ListItemWithIcon>()
         whenever(serviceMapper.map(
-                services,
-                string.stats_publicize_service_label,
-                string.stats_publicize_followers_label
+                eq(services),
+                any()
         )).thenReturn(listOf(mockedItem))
 
         val result = loadPublicizeModel(true, forced)
@@ -108,9 +108,8 @@ class PublicizeUseCaseTest : BaseUnitTest() {
         )
         val mockedItem = mock<ListItemWithIcon>()
         whenever(serviceMapper.map(
-                services.take(5),
-                string.stats_publicize_service_label,
-                string.stats_publicize_followers_label
+                eq(services.take(5)),
+                any()
         )).thenReturn(listOf(mockedItem))
 
         val result = loadPublicizeModel(true, forced)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCaseTest.kt
@@ -73,7 +73,7 @@ class TagsAndCategoriesUseCaseTest : BaseUnitTest() {
                 any(),
                 any<String>(),
                 any(),
-                any()
+                any<Int>()
         )).thenReturn(contentDescription)
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCaseTest.kt
@@ -77,7 +77,7 @@ class TagsAndCategoriesUseCaseTest : BaseUnitTest() {
         )).thenReturn(contentDescription)
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
-                any()
+                any<String>()
         )).thenReturn(contentDescription)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCaseTest.kt
@@ -34,6 +34,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LINK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM_WITH_ICON
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -46,6 +47,7 @@ class TagsAndCategoriesUseCaseTest : BaseUnitTest() {
     @Mock lateinit var resourceProvider: ResourceProvider
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
     @Mock lateinit var popupMenuHandler: ItemPopupMenuHandler
+    @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
     private lateinit var useCase: TagsAndCategoriesUseCase
     private val blockItemCount = 6
     private val singleTagViews: Long = 10
@@ -53,6 +55,7 @@ class TagsAndCategoriesUseCaseTest : BaseUnitTest() {
     private val secondTag = TagModel.Item("tag2", "tag", "url2.com")
     private val singleTag = TagModel(listOf(firstTag), singleTagViews)
     private val categoryViews: Long = 20
+    private val contentDescription = "title, views"
     @Before
     fun setUp() {
         useCase = TagsAndCategoriesUseCase(
@@ -62,9 +65,20 @@ class TagsAndCategoriesUseCaseTest : BaseUnitTest() {
                 resourceProvider,
                 tracker,
                 popupMenuHandler,
+                contentDescriptionHelper,
                 BLOCK
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
+        whenever(contentDescriptionHelper.buildContentDescription(
+                any(),
+                any<String>(),
+                any(),
+                any()
+        )).thenReturn(contentDescription)
+        whenever(contentDescriptionHelper.buildContentDescription(
+                any(),
+                any()
+        )).thenReturn(contentDescription)
     }
 
     @Test
@@ -209,6 +223,7 @@ class TagsAndCategoriesUseCaseTest : BaseUnitTest() {
             assertThat(item.barWidth).isNull()
         }
         assertThat(item.icon).isEqualTo(R.drawable.ic_tag_white_24dp)
+        assertThat(item.contentDescription).isEqualTo(contentDescription)
     }
 
     private fun assertCategory(
@@ -222,6 +237,7 @@ class TagsAndCategoriesUseCaseTest : BaseUnitTest() {
         assertThat(item.header.value).isEqualTo(views.toString())
         assertThat(item.header.icon).isEqualTo(R.drawable.ic_folder_multiple_white_24dp)
         assertThat(item.header.barWidth).isEqualTo(bar)
+        assertThat(item.header.contentDescription).isEqualTo(contentDescription)
         return item
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCaseTest.kt
@@ -72,8 +72,7 @@ class TagsAndCategoriesUseCaseTest : BaseUnitTest() {
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),
                 any<String>(),
-                any(),
-                any<Int>()
+                any()
         )).thenReturn(contentDescription)
         whenever(contentDescriptionHelper.buildContentDescription(
                 any(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/ServiceMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/ServiceMapperTest.kt
@@ -23,7 +23,7 @@ class ServiceMapperTest : BaseUnitTest() {
                 eq(R.string.stats_publicize_service_label),
                 any<String>(),
                 eq(R.string.stats_publicize_followers_label),
-                any()
+                any<Int>()
         )).thenReturn("title, views")
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/ServiceMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/ServiceMapperTest.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.stats.refresh.utils
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -12,10 +14,17 @@ import org.wordpress.android.viewmodel.ResourceProvider
 
 class ServiceMapperTest : BaseUnitTest() {
     @Mock lateinit var resourceProvider: ResourceProvider
+    @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
     private lateinit var serviceMapper: ServiceMapper
     @Before
     fun setUp() {
-        serviceMapper = ServiceMapper(resourceProvider)
+        serviceMapper = ServiceMapper(resourceProvider, contentDescriptionHelper)
+        whenever(contentDescriptionHelper.buildContentDescription(
+                eq(R.string.stats_publicize_service_label),
+                any<String>(),
+                eq(R.string.stats_publicize_followers_label),
+                any()
+        )).thenReturn("title, views")
     }
 
     @Test
@@ -24,7 +33,11 @@ class ServiceMapperTest : BaseUnitTest() {
         val pixelSize = 10
         whenever(resourceProvider.getDimensionPixelSize(R.dimen.avatar_sz_small)).thenReturn(pixelSize)
 
-        val result = serviceMapper.map(listOf(service))
+        val result = serviceMapper.map(
+                listOf(service),
+                R.string.stats_publicize_service_label,
+                R.string.stats_publicize_followers_label
+        )
 
         assertThat(result).hasSize(1)
         result[0].apply {
@@ -44,7 +57,11 @@ class ServiceMapperTest : BaseUnitTest() {
         val pixelSize = 10
         whenever(resourceProvider.getDimensionPixelSize(R.dimen.avatar_sz_small)).thenReturn(pixelSize)
 
-        val result = serviceMapper.map(listOf(service))
+        val result = serviceMapper.map(
+                listOf(service),
+                R.string.stats_publicize_service_label,
+                R.string.stats_publicize_followers_label
+        )
 
         assertThat(result).hasSize(1)
         result[0].apply {
@@ -64,7 +81,11 @@ class ServiceMapperTest : BaseUnitTest() {
         val pixelSize = 10
         whenever(resourceProvider.getDimensionPixelSize(R.dimen.avatar_sz_small)).thenReturn(pixelSize)
 
-        val result = serviceMapper.map(listOf(service))
+        val result = serviceMapper.map(
+                listOf(service),
+                R.string.stats_publicize_service_label,
+                R.string.stats_publicize_followers_label
+        )
 
         assertThat(result).hasSize(1)
         result[0].apply {
@@ -84,7 +105,11 @@ class ServiceMapperTest : BaseUnitTest() {
         val pixelSize = 10
         whenever(resourceProvider.getDimensionPixelSize(R.dimen.avatar_sz_small)).thenReturn(pixelSize)
 
-        val result = serviceMapper.map(listOf(service))
+        val result = serviceMapper.map(
+                listOf(service),
+                R.string.stats_publicize_service_label,
+                R.string.stats_publicize_followers_label
+        )
 
         assertThat(result).hasSize(1)
         result[0].apply {
@@ -104,7 +129,11 @@ class ServiceMapperTest : BaseUnitTest() {
         val pixelSize = 10
         whenever(resourceProvider.getDimensionPixelSize(R.dimen.avatar_sz_small)).thenReturn(pixelSize)
 
-        val result = serviceMapper.map(listOf(service))
+        val result = serviceMapper.map(
+                listOf(service),
+                R.string.stats_publicize_service_label,
+                R.string.stats_publicize_followers_label
+        )
 
         assertThat(result).hasSize(1)
         result[0].apply {
@@ -124,7 +153,11 @@ class ServiceMapperTest : BaseUnitTest() {
         val pixelSize = 10
         whenever(resourceProvider.getDimensionPixelSize(R.dimen.avatar_sz_small)).thenReturn(pixelSize)
 
-        val result = serviceMapper.map(listOf(service))
+        val result = serviceMapper.map(
+                listOf(service),
+                R.string.stats_publicize_service_label,
+                R.string.stats_publicize_followers_label
+        )
 
         assertThat(result).hasSize(1)
         result[0].apply {
@@ -145,7 +178,11 @@ class ServiceMapperTest : BaseUnitTest() {
         val pixelSize = 10
         whenever(resourceProvider.getDimensionPixelSize(R.dimen.avatar_sz_small)).thenReturn(pixelSize)
 
-        val result = serviceMapper.map(listOf(service))
+        val result = serviceMapper.map(
+                listOf(service),
+                R.string.stats_publicize_service_label,
+                R.string.stats_publicize_followers_label
+        )
 
         assertThat(result).hasSize(1)
         result[0].apply {
@@ -166,7 +203,11 @@ class ServiceMapperTest : BaseUnitTest() {
         val pixelSize = 10
         whenever(resourceProvider.getDimensionPixelSize(R.dimen.avatar_sz_small)).thenReturn(pixelSize)
 
-        val result = serviceMapper.map(listOf(service1, service2, service3))
+        val result = serviceMapper.map(
+                listOf(service1, service2, service3),
+                R.string.stats_publicize_service_label,
+                R.string.stats_publicize_followers_label
+        )
 
         assertThat(result).hasSize(3)
         assertThat(result[0].showDivider).isTrue()

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/ServiceMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/ServiceMapperTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.utils
 
 import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -10,6 +9,7 @@ import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.stats.PublicizeModel.Service
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
 import org.wordpress.android.viewmodel.ResourceProvider
 
 class ServiceMapperTest : BaseUnitTest() {
@@ -20,10 +20,9 @@ class ServiceMapperTest : BaseUnitTest() {
     fun setUp() {
         serviceMapper = ServiceMapper(resourceProvider, contentDescriptionHelper)
         whenever(contentDescriptionHelper.buildContentDescription(
-                eq(R.string.stats_publicize_service_label),
+                any(),
                 any<String>(),
-                eq(R.string.stats_publicize_followers_label),
-                any<Int>()
+                any()
         )).thenReturn("title, views")
     }
 
@@ -35,8 +34,7 @@ class ServiceMapperTest : BaseUnitTest() {
 
         val result = serviceMapper.map(
                 listOf(service),
-                R.string.stats_publicize_service_label,
-                R.string.stats_publicize_followers_label
+                Header(R.string.stats_publicize_service_label, R.string.stats_publicize_followers_label)
         )
 
         assertThat(result).hasSize(1)
@@ -59,8 +57,7 @@ class ServiceMapperTest : BaseUnitTest() {
 
         val result = serviceMapper.map(
                 listOf(service),
-                R.string.stats_publicize_service_label,
-                R.string.stats_publicize_followers_label
+                Header(R.string.stats_publicize_service_label, R.string.stats_publicize_followers_label)
         )
 
         assertThat(result).hasSize(1)
@@ -83,8 +80,7 @@ class ServiceMapperTest : BaseUnitTest() {
 
         val result = serviceMapper.map(
                 listOf(service),
-                R.string.stats_publicize_service_label,
-                R.string.stats_publicize_followers_label
+                Header(R.string.stats_publicize_service_label, R.string.stats_publicize_followers_label)
         )
 
         assertThat(result).hasSize(1)
@@ -107,8 +103,7 @@ class ServiceMapperTest : BaseUnitTest() {
 
         val result = serviceMapper.map(
                 listOf(service),
-                R.string.stats_publicize_service_label,
-                R.string.stats_publicize_followers_label
+                Header(R.string.stats_publicize_service_label, R.string.stats_publicize_followers_label)
         )
 
         assertThat(result).hasSize(1)
@@ -131,8 +126,7 @@ class ServiceMapperTest : BaseUnitTest() {
 
         val result = serviceMapper.map(
                 listOf(service),
-                R.string.stats_publicize_service_label,
-                R.string.stats_publicize_followers_label
+                Header(R.string.stats_publicize_service_label, R.string.stats_publicize_followers_label)
         )
 
         assertThat(result).hasSize(1)
@@ -155,8 +149,7 @@ class ServiceMapperTest : BaseUnitTest() {
 
         val result = serviceMapper.map(
                 listOf(service),
-                R.string.stats_publicize_service_label,
-                R.string.stats_publicize_followers_label
+                Header(R.string.stats_publicize_service_label, R.string.stats_publicize_followers_label)
         )
 
         assertThat(result).hasSize(1)
@@ -180,8 +173,7 @@ class ServiceMapperTest : BaseUnitTest() {
 
         val result = serviceMapper.map(
                 listOf(service),
-                R.string.stats_publicize_service_label,
-                R.string.stats_publicize_followers_label
+                Header(R.string.stats_publicize_service_label, R.string.stats_publicize_followers_label)
         )
 
         assertThat(result).hasSize(1)
@@ -205,8 +197,7 @@ class ServiceMapperTest : BaseUnitTest() {
 
         val result = serviceMapper.map(
                 listOf(service1, service2, service3),
-                R.string.stats_publicize_service_label,
-                R.string.stats_publicize_followers_label
+                Header(R.string.stats_publicize_service_label, R.string.stats_publicize_followers_label)
         )
 
         assertThat(result).hasSize(3)


### PR DESCRIPTION
This PR looks rather big but it needed to be this way because I had to add the content description to all the `ListItems` and I didn't want to create a temp solution where the content description would be nullable. If you'd rather have that, I can try to split this PR into 2.

This covers all the list items in the Stats. For example the following screenshot:

<img width="485" alt="Screenshot 2019-07-24 at 15 39 02" src="https://user-images.githubusercontent.com/1079756/61798207-2f2ed000-ae29-11e9-813b-d1cfe926928b.png">

would now have the header (`Title ... Views`) marked as not important for accessibility and selecting any item in the list would read as: `Title: Home page / Archives, Views: 24`. This should help the users with keeping the context. 

There was quite a few of these list items in the Stats but all the changes should be almost the same~

To test:
* Go to Stats with Talkback turned on
* Click on all the list items to check the content description
* Check that the headers are not selectable

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
