### PR TITLE
Track signed in event on sign up

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/LoginAnalyticsModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/LoginAnalyticsModule.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.modules;
 
+import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.login.LoginAnalyticsListener;
 import org.wordpress.android.ui.accounts.login.LoginAnalyticsTracker;
 
@@ -9,7 +11,7 @@ import dagger.Provides;
 @Module
 public class LoginAnalyticsModule {
     @Provides
-    public LoginAnalyticsListener provideAnalyticsListener() {
-        return new LoginAnalyticsTracker();
+    public LoginAnalyticsListener provideAnalyticsListener(AccountStore accountStore, SiteStore siteStore) {
+        return new LoginAnalyticsTracker(accountStore, siteStore);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -779,7 +779,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     @Override
     public void onGoogleSignupFinished(String name, String email, String photoUrl, String username) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_SOCIAL_SUCCESS);
-        mLoginAnalyticsListener.trackAnalyticsSignIn(false);
+        mLoginAnalyticsListener.trackAnalyticsSignIn(true);
         if (mIsJetpackConnect) {
             ActivityLauncher.showSignupEpilogueForResult(this, name, email, photoUrl, username, false);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -779,7 +779,6 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     @Override
     public void onGoogleSignupFinished(String name, String email, String photoUrl, String username) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_SOCIAL_SUCCESS);
-        mLoginAnalyticsListener.trackAnalyticsSignIn(true);
         if (mIsJetpackConnect) {
             ActivityLauncher.showSignupEpilogueForResult(this, name, email, photoUrl, username, false);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -779,7 +779,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     @Override
     public void onGoogleSignupFinished(String name, String email, String photoUrl, String username) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_SOCIAL_SUCCESS);
-
+        mLoginAnalyticsListener.trackAnalyticsSignIn(false);
         if (mIsJetpackConnect) {
             ActivityLauncher.showSignupEpilogueForResult(this, name, email, photoUrl, username, false);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -8,14 +8,12 @@ import org.wordpress.android.util.analytics.AnalyticsUtils;
 
 import java.util.Map;
 
-import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
 public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     private AccountStore mAccountStore;
     private SiteStore mSiteStore;
-    @Inject
     public LoginAnalyticsTracker(AccountStore accountStore, SiteStore siteStore) {
         this.mAccountStore = accountStore;
         this.mSiteStore = siteStore;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -8,13 +8,22 @@ import org.wordpress.android.util.analytics.AnalyticsUtils;
 
 import java.util.Map;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
 public class LoginAnalyticsTracker implements LoginAnalyticsListener {
+    private AccountStore mAccountStore;
+    private SiteStore mSiteStore;
+    @Inject
+    public LoginAnalyticsTracker(AccountStore accountStore, SiteStore siteStore) {
+        this.mAccountStore = accountStore;
+        this.mSiteStore = siteStore;
+    }
+
     @Override
-    public void trackAnalyticsSignIn(AccountStore accountStore, SiteStore siteStore, boolean isWpcom) {
-        AnalyticsUtils.trackAnalyticsSignIn(accountStore, siteStore, isWpcom);
+    public void trackAnalyticsSignIn(boolean isWpcom) {
+        AnalyticsUtils.trackAnalyticsSignIn(mAccountStore, mSiteStore, isWpcom);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -283,7 +283,7 @@ public class WPMainActivity extends AppCompatActivity implements
                 if (mIsMagicLinkLogin) {
                     authTokenToSet = getAuthToken();
                     if (mIsMagicLinkSignup && authTokenToSet != null) {
-                        mLoginAnalyticsListener.trackAnalyticsSignIn(false);
+                        mLoginAnalyticsListener.trackAnalyticsSignIn(true);
                     }
                 } else {
                     ActivityLauncher.showSignInForResult(this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -282,9 +282,6 @@ public class WPMainActivity extends AppCompatActivity implements
             } else {
                 if (mIsMagicLinkLogin) {
                     authTokenToSet = getAuthToken();
-                    if (mIsMagicLinkSignup && authTokenToSet != null) {
-                        mLoginAnalyticsListener.trackAnalyticsSignIn(true);
-                    }
                 } else {
                     ActivityLauncher.showSignInForResult(this);
                     finish();
@@ -971,6 +968,7 @@ public class WPMainActivity extends AppCompatActivity implements
         if (!TextUtils.isEmpty(account.getUserName()) && !TextUtils.isEmpty(account.getEmail())) {
             mLoginAnalyticsListener.trackCreatedAccount(account.getUserName(), account.getEmail());
             mLoginAnalyticsListener.trackSignupMagicLinkSucceeded();
+            mLoginAnalyticsListener.trackAnalyticsSignIn(true);
             AppPrefs.removeShouldTrackMagicLinkSignup();
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -282,6 +282,9 @@ public class WPMainActivity extends AppCompatActivity implements
             } else {
                 if (mIsMagicLinkLogin) {
                     authTokenToSet = getAuthToken();
+                    if (mIsMagicLinkSignup && authTokenToSet != null) {
+                        mLoginAnalyticsListener.trackAnalyticsSignIn(false);
+                    }
                 } else {
                     ActivityLauncher.showSignInForResult(this);
                     finish();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -500,7 +500,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
 
     @Override
     protected void onLoginFinished() {
-        mAnalyticsListener.trackAnalyticsSignIn(mAccountStore, mSiteStore, true);
+        mAnalyticsListener.trackAnalyticsSignIn(true);
 
         mLoginListener.startPostLoginServices();
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -1,12 +1,9 @@
 package org.wordpress.android.login;
 
-import org.wordpress.android.fluxc.store.AccountStore;
-import org.wordpress.android.fluxc.store.SiteStore;
-
 import java.util.Map;
 
 public interface LoginAnalyticsListener {
-    void trackAnalyticsSignIn(AccountStore accountStore, SiteStore siteStore, boolean isWpcomLogin);
+    void trackAnalyticsSignIn(boolean isWpcomLogin);
     void trackCreatedAccount(String username, String email);
     void trackEmailFormViewed();
     void trackInsertedInvalidUrl();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -443,7 +443,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
 
     @Override
     protected void onLoginFinished() {
-        mAnalyticsListener.trackAnalyticsSignIn(mAccountStore, mSiteStore, true);
+        mAnalyticsListener.trackAnalyticsSignIn(true);
         mLoginListener.loggedInViaSocialAccount(mOldSitesIDs, false);
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
@@ -253,7 +253,7 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
 
     @Override
     protected void onLoginFinished() {
-        mAnalyticsListener.trackAnalyticsSignIn(mAccountStore, mSiteStore, true);
+        mAnalyticsListener.trackAnalyticsSignIn(true);
         mLoginListener.startPostLoginServices();
 
         if (mIsSocialLogin) {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -445,7 +445,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
 
     @Override
     protected void onLoginFinished() {
-        mAnalyticsListener.trackAnalyticsSignIn(mAccountStore, mSiteStore, mIsWpcom);
+        mAnalyticsListener.trackAnalyticsSignIn(mIsWpcom);
 
         mLoginListener.startPostLoginServices();
 
@@ -453,7 +453,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
     }
 
     private void finishLogin() {
-        mAnalyticsListener.trackAnalyticsSignIn(mAccountStore, mSiteStore, mIsWpcom);
+        mAnalyticsListener.trackAnalyticsSignIn(mIsWpcom);
 
         // mark as finished so any subsequent onSiteChanged (e.g. triggered by WPMainActivity) won't be intercepted
         mLoginFinished = true;

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
@@ -203,6 +203,7 @@ public class SignupGoogleFragment extends GoogleFragment {
             AppLog.d(T.MAIN,
                     "GOOGLE SIGNUP: onAuthenticationChanged - new wordpress account created");
             mAnalyticsListener.trackCreatedAccount(event.userName, mGoogleEmail);
+            mAnalyticsListener.trackAnalyticsSignIn(true);
             mGoogleListener.onGoogleSignupFinished(mDisplayName, mGoogleEmail, mPhotoUrl, event.userName);
             // Continue with login since existing account was selected.
         } else {


### PR DESCRIPTION
Fixes #10230

I've tried to identify the places where we're sure we have a token during the signup. I think there are 2 things that could happen. One is a successful Google signup and the other one is going through the magic link and getting the token there. I've covered these two use cases but there might be something wrong because the flow is really hard to follow. 

As part of this PR I did a very small refactoring where I moved the `AccountStore` and `SiteStore` to the constructor of the `LoginAnalyticsModule` instead of passing it as parameters. I think that's the correct approach since the module is injected.

Let me know if this approach makes sense!

To test:
* Check that the sign-up flow isn't broken.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
