### PR TITLE
Issue/9538 publish post pending review

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -4,7 +4,6 @@ import androidx.annotation.ColorRes
 import org.apache.commons.text.StringEscapeUtils
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
-import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_BUTTON_PRESSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_ITEM_SELECTED
@@ -209,10 +208,10 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
     private fun getErrorLabel(uploadError: UploadError, postStatus: PostStatus): UiString? {
         return when {
             uploadError.mediaError != null -> when (postStatus) {
-                PRIVATE, PUBLISHED -> UiStringRes(string.error_media_recover_post_not_published)
-                SCHEDULED -> UiStringRes(string.error_media_recover_post_not_scheduled)
-                PENDING -> UiStringRes(string.error_media_recover_post_not_submitted)
-                DRAFT, TRASHED, UNKNOWN -> UiStringRes(string.error_media_recover_post)
+                PRIVATE, PUBLISHED -> UiStringRes(R.string.error_media_recover_post_not_published)
+                SCHEDULED -> UiStringRes(R.string.error_media_recover_post_not_scheduled)
+                PENDING -> UiStringRes(R.string.error_media_recover_post_not_submitted)
+                DRAFT, TRASHED, UNKNOWN -> UiStringRes(R.string.error_media_recover_post)
             }
             uploadError.postError != null -> UploadUtils.getErrorMessageResIdFromPostError(
                     false,
@@ -267,9 +266,11 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
     ): List<PostListButtonType> {
         val canRetryUpload = uploadUiState is PostUploadUiState.UploadFailed
         val canPublishPost = (canRetryUpload || uploadUiState is NothingToUpload) &&
-                (isLocallyChanged || isLocalDraft || postStatus == PostStatus.DRAFT)
+                (isLocallyChanged || isLocalDraft || postStatus == DRAFT ||
+                        (siteHasCapabilitiesToPublish && postStatus == PENDING))
+
         val canShowStats = statsSupported &&
-                postStatus == PostStatus.PUBLISHED &&
+                postStatus == PUBLISHED &&
                 !isLocalDraft &&
                 !isLocallyChanged
         val canShowViewButton = !canRetryUpload
@@ -303,11 +304,11 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
 
         when {
             isLocalDraft -> buttonTypes.add(PostListButtonType.BUTTON_DELETE)
-            postStatus == PostStatus.TRASHED -> {
+            postStatus == TRASHED -> {
                 buttonTypes.add(PostListButtonType.BUTTON_DELETE)
                 buttonTypes.add(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
             }
-            postStatus != PostStatus.TRASHED -> buttonTypes.add(PostListButtonType.BUTTON_TRASH)
+            postStatus != TRASHED -> buttonTypes.add(PostListButtonType.BUTTON_TRASH)
         }
 
         if (canShowStats) {
@@ -363,7 +364,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
     ): PostUploadUiState {
         return when {
             uploadStatus.hasInProgressMediaUpload -> UploadingMedia(uploadStatus.mediaUploadProgress)
-            uploadStatus.isUploading -> UploadingPost(postStatus == PostStatus.DRAFT)
+            uploadStatus.isUploading -> UploadingPost(postStatus == DRAFT)
             // the upload error is not null on retry -> it needs to be evaluated after UploadingMedia and UploadingPost
             uploadStatus.uploadError != null -> PostUploadUiState.UploadFailed(uploadStatus.uploadError)
             uploadStatus.hasPendingMediaUpload ||

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -294,6 +294,31 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
+    fun `verify post pending review with publishing rights actions`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_PENDING)
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_PUBLISH)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
+        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
+        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+    }
+
+    @Test
+    fun `verify post pending review without publishing rights`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_PENDING),
+                capabilitiesToPublish = false
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+    }
+
+    @Test
     fun `label has progress color when post queued`() {
         val state = createPostListItemUiState(uploadStatus = createUploadStatus(isQueued = true))
         assertThat(state.data.statusesColor).isEqualTo(PROGRESS_INFO_COLOR)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.store.PostStore.PostErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.UploadStore.UploadError
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.viewmodel.posts.PostListItemAction.MoreItem
 import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
 import org.wordpress.android.widgets.PostListButtonType
 
@@ -28,6 +29,7 @@ private val POST_STATE_SCHEDULED = PostStatus.SCHEDULED.toString()
 private val POST_STATE_PRIVATE = PostStatus.PRIVATE.toString()
 private val POST_STATE_PENDING = PostStatus.PENDING.toString()
 private val POST_STATE_DRAFT = PostStatus.DRAFT.toString()
+private val POST_STATE_TRASHED = PostStatus.TRASHED.toString()
 
 @RunWith(MockitoJUnitRunner::class)
 class PostListItemUiStateHelperTest {
@@ -62,6 +64,233 @@ class PostListItemUiStateHelperTest {
                 )
         )
         assertThat(state.data.statusesColor).isEqualTo(PROGRESS_INFO_COLOR)
+    }
+
+    @Test
+    fun `verify draft actions`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_DRAFT)
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_PUBLISH)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
+        assertThat(state.actions).hasSize(3)
+
+        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
+        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
+    }
+
+    @Test
+    fun `verify local draft actions`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_DRAFT, isLocalDraft = true)
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_PUBLISH)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
+        assertThat(state.actions).hasSize(3)
+
+        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_PREVIEW)
+        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_DELETE)
+        assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
+    }
+
+    @Test
+    fun `verify draft actions without publishing rights`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_DRAFT),
+                capabilitiesToPublish = false
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_SUBMIT)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
+        assertThat(state.actions).hasSize(3)
+
+        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
+        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
+    }
+
+    @Test
+    fun `verify local draft actions without publishing rights`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_DRAFT, isLocalDraft = true),
+                capabilitiesToPublish = false
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_SUBMIT)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
+        assertThat(state.actions).hasSize(3)
+
+        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_PREVIEW)
+        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_DELETE)
+        assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
+    }
+
+    @Test
+    fun `verify draft actions on failed upload`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_DRAFT),
+                uploadStatus = createUploadStatus(uploadError = UploadError(PostError(GENERIC_ERROR)))
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_RETRY)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(state.actions).hasSize(3)
+    }
+
+    @Test
+    fun `verify local draft actions on failed upload`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_DRAFT, isLocalDraft = true),
+                uploadStatus = createUploadStatus(uploadError = UploadError(PostError(GENERIC_ERROR)))
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_RETRY)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_DELETE)
+        assertThat(state.actions).hasSize(3)
+    }
+
+    @Test
+    fun `verify draft actions on failed upload without publishing rights`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_DRAFT),
+                capabilitiesToPublish = false,
+                uploadStatus = createUploadStatus(uploadError = UploadError(PostError(GENERIC_ERROR)))
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        // TODO We probably want to show RETRY button in this scenario
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_SUBMIT)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(state.actions).hasSize(3)
+    }
+
+    @Test
+    fun `verify local draft actions on failed upload without publishing rights`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_DRAFT, isLocalDraft = true),
+                capabilitiesToPublish = false,
+                uploadStatus = createUploadStatus(uploadError = UploadError(PostError(GENERIC_ERROR)))
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        // TODO We probably want to show RETRY button in this scenario
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_SUBMIT)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_DELETE)
+        assertThat(state.actions).hasSize(3)
+    }
+
+    @Test
+    fun `verify published post actions`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_PUBLISH)
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
+        assertThat(state.actions).hasSize(3)
+
+        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_STATS)
+        assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
+    }
+
+    @Test
+    fun `verify published post with changes actions`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_PUBLISH, isLocallyChanged = true)
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_PUBLISH)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
+        assertThat(state.actions).hasSize(3)
+
+        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_PREVIEW)
+        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
+    }
+
+    @Test
+    fun `verify published post with failed upload actions`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_PUBLISH, isLocallyChanged = true),
+                uploadStatus = createUploadStatus(uploadError = UploadError(PostError(GENERIC_ERROR)))
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_RETRY)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(state.actions).hasSize(3)
+
+    }
+
+    @Test
+    fun `verify trashed post actions`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_TRASHED)
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
+        assertThat(state.actions).hasSize(3)
+
+        assertThat((state.actions[2] as MoreItem).actions[0].buttonType)
+                .isEqualTo(PostListButtonType.BUTTON_DELETE)
+        assertThat((state.actions[2] as MoreItem).actions[1].buttonType)
+                .isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
+        assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
+    }
+
+    @Test
+    fun `verify scheduled post actions`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_SCHEDULED)
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(state.actions).hasSize(3)
+    }
+
+    @Test
+    fun `verify scheduled post with changes actions`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_SCHEDULED, isLocallyChanged = true)
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_SYNC)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
+        assertThat(state.actions).hasSize(3)
+
+        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_PREVIEW)
+        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
+    }
+
+    @Test
+    fun `verify scheduled post with failed upload actions`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_SCHEDULED, isLocallyChanged = true),
+                uploadStatus = createUploadStatus(uploadError = UploadError(PostError(GENERIC_ERROR)))
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_RETRY)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(state.actions).hasSize(3)
     }
 
     @Test
@@ -286,8 +515,8 @@ class PostListItemUiStateHelperTest {
         post: PostModel = PostModel(),
         uploadStatus: PostListItemUploadStatus = createUploadStatus(),
         unhandledConflicts: Boolean = false,
-        capabilitiesToPublish: Boolean = false,
-        statsSupported: Boolean = false,
+        capabilitiesToPublish: Boolean = true,
+        statsSupported: Boolean = true,
         featuredImageUrl: String? = null,
         formattedDate: String = FORMATTER_DATE,
         performingCriticalAction: Boolean = false,

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -231,7 +231,6 @@ class PostListItemUiStateHelperTest {
         assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_RETRY)
         assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(state.actions).hasSize(3)
-
     }
 
     @Test


### PR DESCRIPTION
Fixes #9538 

When a user has publishing rights we should allow them to publish a post pending review directly from the post list.
SideNote: I added bunch of "unrelated" tests for actions available on post list items.

To test:
1. Log in as Contributor
2. Create a draft and exit the editor
3. Click on "Submit" button on the post list
4. Notice when the post status changes to "Pending review" and View action is available
5. Log in as Admin
6. Go to Post list - drafts
7. Notice posts pending review have Publish action available
8. Click on Publish and make sure the posts gets published


Update release notes:

- The changes are too minor

|  <img width="398" alt="Screenshot 2019-07-25 at 13 51 19" src="https://user-images.githubusercontent.com/2261188/61872337-5a75f580-aee3-11e9-9fd5-43f6faf33a7a.png"> |
<img width="398" alt="Screenshot 2019-07-25 at 13 52 55" src="https://user-images.githubusercontent.com/2261188/61872415-85f8e000-aee3-11e9-9ead-cf4662059bc8.png"> |
|---|---|




