### PR TITLE
Gutenberg mobile release v1.10.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,6 @@
 -----
 * Block editor: Adding a block from the post title now shows the add block here indicator.
 * Block editor: Deselect post title any time a block is added
-* Block editor: Fix merging of empty paragraph blocks when added from a post's title
 * Block editor: Fix loss of center alignment in image captions
  
 12.9

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 13.0
 -----
+* Block editor: Adding a block from the post title now shows the add block here indicator.
+* Block editor: Deselect post title any time a block is added
+* Block editor: Fix merging of empty paragraph blocks when added from a post's title
+* Block editor: Fix loss of center alignment in image captions
  
 12.9
 -----


### PR DESCRIPTION
This PR updates the gutenberg-mobile reference to point to the latest release, v1.10.0.

The reference is currently pointing to the release/1.10.0 branch on https://github.com/wordpress-mobile/gutenberg-mobile. Relevant PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1246

To test:
The block editor should work as normal.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
