### PR TITLE
Show retry when submit for review fails

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -280,10 +280,10 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         buttonTypes.add(BUTTON_EDIT)
         if (canShowPublishButton) {
             buttonTypes.add(
-                    if (!siteHasCapabilitiesToPublish) {
-                        BUTTON_SUBMIT
-                    } else if (canRetryUpload) {
+                    if (canRetryUpload) {
                         BUTTON_RETRY
+                    } else if (!siteHasCapabilitiesToPublish) {
+                        BUTTON_SUBMIT
                     } else if (postStatus == SCHEDULED && isLocallyChanged) {
                         BUTTON_SYNC
                     } else {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -167,8 +167,7 @@ class PostListItemUiStateHelperTest {
         )
 
         assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
-        // TODO We probably want to show RETRY button in this scenario
-        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_SUBMIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_RETRY)
         assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(state.actions).hasSize(3)
     }
@@ -182,8 +181,7 @@ class PostListItemUiStateHelperTest {
         )
 
         assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
-        // TODO We probably want to show RETRY button in this scenario
-        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_SUBMIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_RETRY)
         assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_DELETE)
         assertThat(state.actions).hasSize(3)
     }


### PR DESCRIPTION
Fixes #10288 

Show "Retry" instead of "Submit" button when submitting a post for review fails.

To test:
1. Log in as contributor
2. Create a draft
3. Click on Submit and turn on airplane mode before the upload finishes (you might need to change network connection strength in emulator settings)
4. Notice the item in the post list contains "Retry" action
5. Turn off the airplane mode and click on Retry
6. Make sure the post gets uploaded as "Pending Review"

Update release notes:

- The changes are too minor

|  <img width="451" alt="Screenshot 2019-07-26 at 12 05 42" src="https://user-images.githubusercontent.com/2261188/61944332-be5cf480-af9d-11e9-8720-f57019753976.png"> | <img width="452" alt="Screenshot 2019-07-26 at 12 05 12" src="https://user-images.githubusercontent.com/2261188/61944339-bf8e2180-af9d-11e9-9304-0f4d7a970b01.png">  |
|---|---|




