### PR TITLE
Fix UI tests: Update Gutenberg opt in/out mocks

### DIFF
--- a/.configure
+++ b/.configure
@@ -1,6 +1,6 @@
 {
   "branch": "master",
-  "pinned_hash": "f4b2b12a064b99d467a893d3f56b3f74fe20b602",
+  "pinned_hash": "98187303a1c3ee20443667fe1ce558f53592fafc",
   "files_to_copy": [
     {
       "file": "android/WPAndroid/gradle.properties",

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/EditorTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/EditorTests.java
@@ -50,7 +50,7 @@ public class EditorTests extends BaseTest {
         mb.clickBlogPosts();
 
         new MySitesPage()
-                .startNewPost(E2E_WP_COM_USER_SITE_ADDRESS);
+                .startNewPost();
 
         EditorPage editorPage = new EditorPage();
         editorPage.enterTitle(title);
@@ -74,7 +74,7 @@ public class EditorTests extends BaseTest {
         mb.clickBlogPosts();
 
         new MySitesPage()
-                .startNewPost(E2E_WP_COM_USER_SITE_ADDRESS);
+                .startNewPost();
 
         EditorPage editorPage = new EditorPage();
         editorPage.enterTitle(title);

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/EditorTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/EditorTests.java
@@ -22,7 +22,6 @@ import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static junit.framework.TestCase.assertTrue;
-import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_SITE_ADDRESS;
 import static org.wordpress.android.support.WPSupportUtils.checkViewHasText;
 import static org.wordpress.android.support.WPSupportUtils.sleep;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToNotBeDisplayed;

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
@@ -20,6 +20,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
+import static org.wordpress.android.support.WPSupportUtils.idleFor;
 import static org.wordpress.android.support.WPSupportUtils.isElementDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.populateTextField;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
@@ -65,6 +65,8 @@ public class EditorPage {
 
         // Click on a random image
         waitForElementToBeDisplayed(onView(withText("WordPress media")));
+        // wait for images to load before clicking
+        idleFor(2000);
         onView(withIndex(withId(R.id.media_grid_item_image), 0)).perform(click());
 
         // Click the confirm button

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
@@ -46,7 +46,7 @@ public class MySitesPage {
         clickOn(android.R.id.button1);
     }
 
-    public void startNewPost(String siteAddress) {
-        clickOn(R.id.fab_button);
+    public void startNewPost() {
+        clickOn("fab_button");
     }
 }

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v2_sites_158396482_gutenberg_opt_in.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v2_sites_158396482_gutenberg_opt_in.json
@@ -1,14 +1,20 @@
 {
     "request": {
         "urlPattern": "/wpcom/v2/sites/158396482/gutenberg(/)?($|\\?.*)",
-        "method": "GET"
+        "method": "POST",
+        "bodyPatterns": [
+            {
+              "equalToJson" : "{ \"editor\": \"gutenberg\" }",
+              "ignoreExtraElements" : true
+            }
+        ]
     },
     "response": {
         "status": 200,
         "jsonBody": {
-            "editor_mobile": "aztec",
+            "editor_mobile": "gutenberg",
             "editor_web": "gutenberg",
-            "opt_in": "{{request.requestLine.baseUrl}}/wpcom/v2/sites/158396482/gutenberg?editor=gutenberg&platform=mobile"
+            "opt_out": "{{request.requestLine.baseUrl}}/wpcom/v2/sites/158396482/gutenberg?editor=classic&platform=mobile"
         },
         "headers": {
             "Content-Type": "application/json",

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v2_sites_158396482_gutenberg_opt_out.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v2_sites_158396482_gutenberg_opt_out.json
@@ -1,7 +1,13 @@
 {
     "request": {
         "urlPattern": "/wpcom/v2/sites/158396482/gutenberg(/)?($|\\?.*)",
-        "method": "GET"
+        "method": "POST",
+        "bodyPatterns": [
+            {
+              "equalToJson" : "{ \"editor\": \"aztec\" }",
+              "ignoreExtraElements" : true
+            }
+        ]
     },
     "response": {
         "status": 200,


### PR DESCRIPTION
Fixes UI test failures. We enabled connected tests on every PR yesterday in https://github.com/wordpress-mobile/WordPress-Android/pull/10294. https://github.com/wordpress-mobile/WordPress-Android/pull/10254 was merged around the same time and broke the tests. This fixes that 😄 

To test:

- UI tests pass on this PR

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
