### PR TITLE
Add additional properties to the Block Editor activation events

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -227,7 +227,7 @@ public class SitePickerActivity extends AppCompatActivity
             case RequestCodes.CREATE_SITE:
                 if (data != null) {
                     int newSiteLocalID = data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1);
-                    SiteUtils.enableBlockEditor(mDispatcher, mSiteStore, newSiteLocalID);
+                    SiteUtils.enableBlockEditorOnSiteCreation(mDispatcher, mSiteStore, newSiteLocalID);
                     // Mark the site to show the GB popup at first editor run
                     SiteModel newSiteModel = mSiteStore.getSiteByLocalId(newSiteLocalID);
                     if (newSiteModel != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -775,7 +775,7 @@ public class WPMainActivity extends AppCompatActivity implements
                 // Enable the block editor on sites created on mobile
                 if (data != null) {
                     int newSiteLocalID = data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1);
-                    SiteUtils.enableBlockEditor(mDispatcher, mSiteStore, newSiteLocalID);
+                    SiteUtils.enableBlockEditorOnSiteCreation(mDispatcher, mSiteStore, newSiteLocalID);
                     // Mark the site to show the GB popup at first editor run
                     SiteModel newSiteModel = mSiteStore.getSiteByLocalId(newSiteLocalID);
                     if (newSiteModel != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1156,6 +1156,9 @@ public class WPMainActivity extends AppCompatActivity implements
             return;
         }
 
+        // Need to update the user property about GB enabled on any of the sites
+        AnalyticsUtils.refreshMetadata(mAccountStore, mSiteStore);
+
         // "Reload" selected site from the db
         // It would be better if the OnSiteChanged provided the list of changed sites.
         if (getSelectedSite() == null && mSiteStore.hasSite()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1550,10 +1550,17 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private void setGutenbergEnabledIfNeeded() {
+        boolean newSitePopupNeeded = AppPrefs.shouldShowGutenbergInfoPopup(mSite.getUrl());
         if ((TextUtils.isEmpty(mSite.getMobileEditor()) && !mIsNewPost)
-            || AppPrefs.shouldShowGutenbergInfoPopup(mSite.getUrl())) {
+            || newSitePopupNeeded) {
             SiteUtils.enableBlockEditor(mDispatcher, mSite);
-            AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_GUTENBERG_ENABLED, mSite);
+            Map<String, Object> properties = new HashMap<>();
+            if (!newSitePopupNeeded) {
+                // Don't track the activation of the block editor on new sites.
+                // The flip to GB happened at site creation time, and the flip is tracked there with proper details
+                properties.put("source", "on-block-post-open");
+                AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_GUTENBERG_ENABLED, mSite, properties);
+            }
             showGutenbergInformativeDialog();
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -161,6 +161,7 @@ import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.util.WPPermissionUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.android.util.helpers.MediaGalleryImageSpan;
@@ -1558,7 +1559,7 @@ public class EditPostActivity extends AppCompatActivity implements
             if (!newSitePopupNeeded) {
                 // Don't track the activation of the block editor on new sites.
                 // The flip to GB happened at site creation time, and the flip is tracked there with proper details
-                properties.put("source", "on-block-post-open");
+                properties.put("source", BlockEditorEnabledSource.ON_BLOCK_POST_OPENING.name());
                 AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_GUTENBERG_ENABLED, mSite, properties);
             }
             showGutenbergInformativeDialog();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1555,12 +1555,12 @@ public class EditPostActivity extends AppCompatActivity implements
         if ((TextUtils.isEmpty(mSite.getMobileEditor()) && !mIsNewPost)
             || newSitePopupNeeded) {
             SiteUtils.enableBlockEditor(mDispatcher, mSite);
-            Map<String, Object> properties = new HashMap<>();
+
             if (!newSitePopupNeeded) {
                 // Don't track the activation of the block editor on new sites.
                 // The flip to GB happened at site creation time, and the flip is tracked there with proper details
-                properties.put("source", BlockEditorEnabledSource.ON_BLOCK_POST_OPENING.name());
-                AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_GUTENBERG_ENABLED, mSite, properties);
+                AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_GUTENBERG_ENABLED, mSite,
+                        BlockEditorEnabledSource.ON_BLOCK_POST_OPENING.asPropertyMap());
             }
             showGutenbergInformativeDialog();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1551,17 +1551,16 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private void setGutenbergEnabledIfNeeded() {
-        boolean newSitePopupNeeded = AppPrefs.shouldShowGutenbergInfoPopup(mSite.getUrl());
-        if ((TextUtils.isEmpty(mSite.getMobileEditor()) && !mIsNewPost)
-            || newSitePopupNeeded) {
-            SiteUtils.enableBlockEditor(mDispatcher, mSite);
+        boolean showPopup = AppPrefs.shouldShowGutenbergInfoPopup(mSite.getUrl());
 
-            if (!newSitePopupNeeded) {
-                // Don't track the activation of the block editor on new sites.
-                // The flip to GB happened at site creation time, and the flip is tracked there with proper details
-                AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_GUTENBERG_ENABLED, mSite,
-                        BlockEditorEnabledSource.ON_BLOCK_POST_OPENING.asPropertyMap());
-            }
+        if (TextUtils.isEmpty(mSite.getMobileEditor()) && !mIsNewPost) {
+            SiteUtils.enableBlockEditor(mDispatcher, mSite);
+            AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_GUTENBERG_ENABLED, mSite,
+                    BlockEditorEnabledSource.ON_BLOCK_POST_OPENING.asPropertyMap());
+            showPopup = true;
+        }
+
+        if (showPopup) {
             showGutenbergInformativeDialog();
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -83,6 +83,7 @@ import org.wordpress.android.util.ValidationUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPPrefUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource;
 import org.wordpress.android.widgets.WPSnackbar;
 
 import java.util.HashMap;
@@ -741,7 +742,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                 SiteUtils.disableBlockEditor(mDispatcher, mSite);
             }
             Map<String, Object> properties = new HashMap<>();
-            properties.put("source", "via-site-settings");
+            properties.put("source", BlockEditorEnabledSource.VIA_SITE_SETTINGS.name());
             AnalyticsUtils.trackWithSiteDetails(
                     ((Boolean) newValue) ? Stat.EDITOR_GUTENBERG_ENABLED : Stat.EDITOR_GUTENBERG_DISABLED,
                     mSite, properties);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -741,11 +741,9 @@ public class SiteSettingsFragment extends PreferenceFragment
             } else {
                 SiteUtils.disableBlockEditor(mDispatcher, mSite);
             }
-            Map<String, Object> properties = new HashMap<>();
-            properties.put("source", BlockEditorEnabledSource.VIA_SITE_SETTINGS.name());
             AnalyticsUtils.trackWithSiteDetails(
                     ((Boolean) newValue) ? Stat.EDITOR_GUTENBERG_ENABLED : Stat.EDITOR_GUTENBERG_DISABLED,
-                    mSite, properties);
+                    mSite, BlockEditorEnabledSource.VIA_SITE_SETTINGS.asPropertyMap());
             // we need to refresh metadata as gutenberg_enabled is now part of the user data
             AnalyticsUtils.refreshMetadata(mAccountStore, mSiteStore);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -740,9 +740,11 @@ public class SiteSettingsFragment extends PreferenceFragment
             } else {
                 SiteUtils.disableBlockEditor(mDispatcher, mSite);
             }
+            Map<String, Object> properties = new HashMap<>();
+            properties.put("source", "via-site-settings");
             AnalyticsUtils.trackWithSiteDetails(
                     ((Boolean) newValue) ? Stat.EDITOR_GUTENBERG_ENABLED : Stat.EDITOR_GUTENBERG_DISABLED,
-                    mSite);
+                    mSite, properties);
             // we need to refresh metadata as gutenberg_enabled is now part of the user data
             AnalyticsUtils.refreshMetadata(mAccountStore, mSiteStore);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnPostFormatsChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteEditorsChanged;
@@ -31,6 +32,7 @@ import org.wordpress.android.util.LanguageUtils;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.analytics.AnalyticsUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -171,6 +173,7 @@ public abstract class SiteSettingsInterface {
 
     @Inject SiteStore mSiteStore;
     @Inject Dispatcher mDispatcher;
+    @Inject AccountStore mAccountStore;
 
     protected SiteSettingsInterface(Context host, SiteModel site, SiteSettingsListener listener) {
         ((WordPress) host.getApplicationContext()).component().inject(this);
@@ -1136,6 +1139,9 @@ public abstract class SiteSettingsInterface {
         if (event.isError()) {
             return;
         }
+
+        // Need to update the user property about GB enabled on any of the sites
+        AnalyticsUtils.refreshMetadata(mAccountStore, mSiteStore);
 
         notifyUpdatedOnUiThread();
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -16,7 +16,9 @@ import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.helpers.Version;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class SiteUtils {
     public static final String GB_EDITOR_NAME = "gutenberg";
@@ -68,10 +70,14 @@ public class SiteUtils {
         }).start();
     }
 
-    public static boolean enableBlockEditor(Dispatcher dispatcher, SiteStore siteStore, int siteLocalSiteID) {
+    public static boolean enableBlockEditorOnSiteCreation(Dispatcher dispatcher, SiteStore siteStore,
+                                                          int siteLocalSiteID) {
         SiteModel newSiteModel = siteStore.getSiteByLocalId(siteLocalSiteID);
         if (newSiteModel != null) {
-           enableBlockEditor(dispatcher, newSiteModel);
+            enableBlockEditor(dispatcher, newSiteModel);
+            Map<String, Object> properties = new HashMap<>();
+            properties.put("source", "on-site-creation");
+
             return true;
         }
         return false;

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -13,6 +14,7 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.DesignateMobileEditorPayload;
 import org.wordpress.android.ui.plans.PlansConstants;
 import org.wordpress.android.ui.prefs.AppPrefs;
+import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.helpers.Version;
 
 import java.util.ArrayList;
@@ -77,7 +79,7 @@ public class SiteUtils {
             enableBlockEditor(dispatcher, newSiteModel);
             Map<String, Object> properties = new HashMap<>();
             properties.put("source", "on-site-creation");
-
+            AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_GUTENBERG_ENABLED, newSiteModel, properties);
             return true;
         }
         return false;

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.store.SiteStore.DesignateMobileEditorPayload;
 import org.wordpress.android.ui.plans.PlansConstants;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource;
 import org.wordpress.android.util.helpers.Version;
 
 import java.util.ArrayList;
@@ -78,7 +79,8 @@ public class SiteUtils {
         if (newSiteModel != null) {
             enableBlockEditor(dispatcher, newSiteModel);
             Map<String, Object> properties = new HashMap<>();
-            properties.put("source", "on-site-creation");
+            properties.put("source", BlockEditorEnabledSource.ON_SITE_CREATION.name());
+
             AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_GUTENBERG_ENABLED, newSiteModel, properties);
             return true;
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -19,9 +19,7 @@ import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSou
 import org.wordpress.android.util.helpers.Version;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class SiteUtils {
     public static final String GB_EDITOR_NAME = "gutenberg";
@@ -78,10 +76,8 @@ public class SiteUtils {
         SiteModel newSiteModel = siteStore.getSiteByLocalId(siteLocalSiteID);
         if (newSiteModel != null) {
             enableBlockEditor(dispatcher, newSiteModel);
-            Map<String, Object> properties = new HashMap<>();
-            properties.put("source", BlockEditorEnabledSource.ON_SITE_CREATION.name());
-
-            AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_GUTENBERG_ENABLED, newSiteModel, properties);
+            AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_GUTENBERG_ENABLED, newSiteModel,
+                    BlockEditorEnabledSource.ON_SITE_CREATION.asPropertyMap());
             return true;
         }
         return false;

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -77,7 +77,7 @@ public class AnalyticsUtils {
 
         public Map<String, Object> asPropertyMap() {
             Map<String, Object> properties = new HashMap<>();
-            properties.put("source", name().toLowerCase());
+            properties.put("source", name().toLowerCase(Locale.ROOT));
             return properties;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -70,6 +70,12 @@ public class AnalyticsUtils {
 
     public static final String HAS_GUTENBERG_BLOCKS_KEY = "has_gutenberg_blocks";
 
+    public enum BlockEditorEnabledSource {
+        VIA_SITE_SETTINGS,
+        ON_SITE_CREATION,
+        ON_BLOCK_POST_OPENING
+    }
+
     public static void updateAnalyticsPreference(Context ctx,
                                                  Dispatcher mDispatcher,
                                                  AccountStore mAccountStore,

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -122,8 +122,8 @@ public class AnalyticsUtils {
         if (siteLocalId != -1) {
             // Site previously selected, use it
             SiteModel selectedSite = siteStore.getSiteByLocalId(siteLocalId);
-            // If saved site exist, then add info
-            if (selectedSite != null) {
+            // If saved site exist, then add editor info
+            if (selectedSite != null && !TextUtils.isEmpty(selectedSite.getMobileEditor())) {
                 metadata.setGutenbergEnabled(
                         SiteUtils.isBlockEditorDefaultForNewPost(selectedSite));
             }

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -73,7 +73,13 @@ public class AnalyticsUtils {
     public enum BlockEditorEnabledSource {
         VIA_SITE_SETTINGS,
         ON_SITE_CREATION,
-        ON_BLOCK_POST_OPENING
+        ON_BLOCK_POST_OPENING;
+
+        public Map<String, Object> asPropertyMap() {
+            Map<String, Object> properties = new HashMap<>();
+            properties.put("source", name().toLowerCase());
+            return properties;
+        }
     }
 
     public static void updateAnalyticsPreference(Context ctx,

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -27,7 +27,6 @@ import org.wordpress.android.fluxc.store.AccountStore.PushAccountSettingsPayload
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.ui.posts.PostListViewLayoutType;
-import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.ImageUtils;
@@ -117,15 +116,10 @@ public class AnalyticsUtils {
         metadata.setNumBlogs(siteStore.getSitesCount());
         metadata.setUsername(accountStore.getAccount().getUserName());
         metadata.setEmail(accountStore.getAccount().getEmail());
-
-        int siteLocalId = AppPrefs.getSelectedSite();
-        if (siteLocalId != -1) {
-            // Site previously selected, use it
-            SiteModel selectedSite = siteStore.getSiteByLocalId(siteLocalId);
-            // If saved site exist, then add editor info
-            if (selectedSite != null && !TextUtils.isEmpty(selectedSite.getMobileEditor())) {
-                metadata.setGutenbergEnabled(
-                        SiteUtils.isBlockEditorDefaultForNewPost(selectedSite));
+        for (SiteModel currentSite : siteStore.getSites()) {
+            if (SiteUtils.GB_EDITOR_NAME.equals(currentSite.getMobileEditor())) {
+                metadata.setGutenbergEnabled(true);
+                break;
             }
         }
 

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsMetadata.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsMetadata.java
@@ -9,6 +9,7 @@ public class AnalyticsMetadata {
     private String mUsername = "";
     private String mEmail = "";
     private boolean mIsGutenbergEnabled;
+    private boolean mIsGutenbergEnabledVariableSet;
 
     public AnalyticsMetadata() {
     }
@@ -73,7 +74,12 @@ public class AnalyticsMetadata {
         return mIsGutenbergEnabled;
     }
 
+    public boolean isGutenbergEnabledVariableSet() {
+        return mIsGutenbergEnabledVariableSet;
+    }
+
     public void setGutenbergEnabled(boolean gutenbergEnabled) {
         this.mIsGutenbergEnabled = gutenbergEnabled;
+        this.mIsGutenbergEnabledVariableSet = true;
     }
 }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -524,7 +524,11 @@ public class AnalyticsTrackerNosara extends Tracker {
             properties.put(JETPACK_USER, metadata.isJetpackUser());
             properties.put(NUMBER_OF_BLOGS, metadata.getNumBlogs());
             properties.put(WPCOM_USER, metadata.isWordPressComUser());
-            properties.put(IS_GUTENBERG_ENABLED, metadata.isGutenbergEnabled());
+            // Only add the editor information if it was set before.
+            // See: https://github.com/wordpress-mobile/WordPress-Android/pull/10300#discussion_r309145514
+            if (metadata.isGutenbergEnabledVariableSet()) {
+                properties.put(IS_GUTENBERG_ENABLED, metadata.isGutenbergEnabled());
+            }
             mNosaraClient.registerUserProperties(properties);
         } catch (JSONException e) {
             AppLog.e(AppLog.T.UTILS, e);


### PR DESCRIPTION
Add additional properties to  `gutenberg_enabled` , and `gutenberg_disabled` analytics events:
The property `source` can now have the following values:
- via-site-settings
- on-block-post-open
- on-site-creation

Test 1:
- Flip the block editor setting in Site settings and make sure the property is added correctly

Test 2:
- Create a new site, and make sure the property is added with the correct value
- Tap on new post, and make sure nothing is tracked

Test 3:
- Clear your editor settings on the web
- Re-install the app
- open a block based post
- the popup should appear, and the correct property value bumped with analytics


cc @etoledom Since we need the iOS counterpart of this PR


Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
