### PR TITLE
Fix NPE on login screen when tapping Help icon

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -88,6 +88,9 @@ public class SiteUtils {
     }
 
     public static boolean isBlockEditorDefaultForNewPost(SiteModel site) {
+        if (site == null) {
+            return false;
+        }
         if (TextUtils.isEmpty(site.getMobileEditor())) {
             return AppPrefs.isGutenbergDefaultForNewPosts();
         } else {


### PR DESCRIPTION
Fix a crash on the help screen (issue reported at login screen) where we were accessing the selected site, but there isn't any site in the app yet.

To test:
- Start a clean app
- Tap on Login
- Tap on the help icon (top right of the screen)

cc @jtreanor 

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
