### PR TITLE
Revert "Run connected tests on CI for every PR(round 2)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
           type: instrumentation
           apk-path: WordPress/build/outputs/apk/vanilla/debug/WordPress-vanilla-debug.apk
           test-apk-path: WordPress/build/outputs/apk/androidTest/vanilla/debug/WordPress-vanilla-debug-androidTest.apk
-          test-targets: package org.wordpress.android.e2e
+          test-targets: notPackage org.wordpress.android.ui.screenshots
           device: model=Nexus5X,version=26,locale=en,orientation=portrait
           project: api-project-108380595987
           timeout: 10m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 orbs:
   android: wordpress-mobile/android@0.0.27
   bundle-install: toshimaru/bundle-install@0.1.1
+  slack: circleci/slack@2.5.0
 
 commands:
   copy-gradle-properties:
@@ -71,12 +72,15 @@ jobs:
           type: instrumentation
           apk-path: WordPress/build/outputs/apk/vanilla/debug/WordPress-vanilla-debug.apk
           test-apk-path: WordPress/build/outputs/apk/androidTest/vanilla/debug/WordPress-vanilla-debug-androidTest.apk
-          test-targets: notPackage org.wordpress.android.ui.screenshots
+          test-targets: package org.wordpress.android.e2e
           device: model=Nexus5X,version=26,locale=en,orientation=portrait
           project: api-project-108380595987
           timeout: 10m
           results-history-name: CircleCI WordPress Connected Tests
       - android/save-gradle-cache
+      - slack/status:
+          fail_only: 'true'
+          failure_message: ':red_circle: WordPress Android end to end tests have failed!\nSee https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670'
   strings-check:
     docker:
       - image: circleci/ruby:2.3
@@ -93,4 +97,13 @@ workflows:
       - strings-check
       - test
       - lint
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
       - connected-tests

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
@@ -74,8 +74,6 @@ public class EditorPage {
             // Accept alert for media access
             clickOn(onView(withText("LEAVE OFF")).inRoot(isDialog()));
         }
-
-        waitForElementToBeDisplayed(publishButton);
     }
 
     public void openSettings() {

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
@@ -74,6 +74,8 @@ public class EditorPage {
             // Accept alert for media access
             clickOn(onView(withText("LEAVE OFF")).inRoot(isDialog()));
         }
+
+        waitForElementToBeDisplayed(publishButton);
     }
 
     public void openSettings() {


### PR DESCRIPTION
I fixed some issues with the UI tests in https://github.com/wordpress-mobile/WordPress-Android/pull/10299, but unfortunately there is still a failing flaky test (see [here](https://circleci.com/gh/wordpress-mobile/WordPress-Android/18189)).

I'm disabling the check again so this flakiness does not block people (the other PR to fix broken tests should still be reviewed/merged).

To test:

- There is no connected tests check on this PR.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
