### PR TITLE
Update mocks from WordPressMocks

### DIFF
--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/magic_link-signup.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/magic_link-signup.json
@@ -1,6 +1,6 @@
 {
     "scenarioName": "auth",
-    "requiredScenarioState": "logged-in",
+    "requiredScenarioState": "signed-up",
     "request": {
         "method": "GET",
         "urlPath": "/magic-link"
@@ -9,7 +9,7 @@
         "status": 302,
         "headers": {
             "Content-Type": "text/html;charset=utf-8",
-            "Location": "{{request.query.scheme}}://magic-login?token=valid_token"
+            "Location": "{{request.query.scheme}}://magic-login?token=valid_token&new_user=1"
         }
     }
 }

--- a/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v2_sites_158396482_gutenberg.json
+++ b/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v2_sites_158396482_gutenberg.json
@@ -1,0 +1,30 @@
+{
+  "request": {
+    "urlPattern": "/wpcom/v2/sites/158396482/gutenberg(/)?($|\\?.*)",
+    "method": "POST",
+    "headers": {
+      "Content-Type": {
+        "equalTo": "application/json; charset=UTF-8"
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : {
+        "editor" : "aztec",
+        "platform" : "mobile"
+      }
+    } ]
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "editor_mobile": "aztec",
+      "editor_web": "gutenberg",
+      "opt_in": "{{request.requestLine.baseUrl}}/wpcom/v2/sites/158396482/gutenberg?editor=gutenberg&platform=mobile"
+    },
+    "headers": {
+      "Content-Type": "application/json",
+      "Connection": "keep-alive",
+      "Cache-Control": "no-cache, must-revalidate, max-age=0"
+    }
+  }
+}

--- a/libs/mocks/WordPressMocks.podspec
+++ b/libs/mocks/WordPressMocks.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name           = 'WordPressMocks'
-  s.version        = '0.0.3'
+  s.version        = '0.0.5'
   s.summary        = 'Network mocking for testing the WordPress mobile apps.'
   s.homepage       = 'https://github.com/wordpress-mobile/WordPressMocks'
   s.license        = { type: 'GPLv2', file: 'LICENSE.md' }

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/is-available_email_available.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/is-available_email_available.json
@@ -1,7 +1,7 @@
 {
     "request": {
         "method": "GET",
-        "urlPath": "/is-available/email/",
+        "urlPattern": "/is-available/email(/)?($|\\?.*)",
         "queryParameters": {
             "q": {
                 "matches": "^e2eflowsignuptestingmobile@example.com$"
@@ -10,7 +10,9 @@
     },
     "response": {
         "status": 200,
-        "body": true,
+        "jsonBody": {
+            "available": true
+        },
         "headers": {
             "Content-Type": "text/javascript",
             "Connection": "keep-alive"

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/is-available_email_available_json.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/is-available_email_available_json.json
@@ -1,0 +1,24 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPattern": "/is-available/email(/)?($|\\?.*)",
+        "queryParameters": {
+            "format": {
+                "equalTo": "json"
+            },
+            "q": {
+                "matches": "^e2eflowsignuptestingmobile@example.com$"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "available": true
+        },
+        "headers": {
+            "Content-Type": "text/javascript",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/is-available_email_available_text.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/is-available_email_available_text.json
@@ -3,6 +3,9 @@
         "method": "GET",
         "urlPattern": "/is-available/email(/)?($|\\?.*)",
         "queryParameters": {
+            "format": {
+                "absent": true
+            },
             "q": {
                 "matches": "^e2eflowsignuptestingmobile@example.com$"
             }
@@ -10,9 +13,7 @@
     },
     "response": {
         "status": 200,
-        "jsonBody": {
-            "available": true
-        },
+        "body": true,
         "headers": {
             "Content-Type": "text/javascript",
             "Connection": "keep-alive"

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/is-available_email_not_available.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/is-available_email_not_available.json
@@ -1,7 +1,7 @@
 {
     "request": {
         "method": "GET",
-        "urlPath": "/is-available/email/",
+        "urlPattern": "/is-available/email(/)?($|\\?.*)",
         "queryParameters": {
             "q": {
                 "matches": "^(?!e2eflowsignuptestingmobile@example.com).*$"

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/rest_v11_auth_send-signup-email.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/rest_v11_auth_send-signup-email.json
@@ -2,7 +2,7 @@
     "scenarioName": "auth",
     "newScenarioState": "signed-up",
     "request": {
-        "urlPath": "/rest/v1.1/auth/send-signup-email/",
+        "urlPattern": "/rest/v1.1/auth/send-signup-email.*",
         "method": "POST"
     },
     "response": {

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me.json
@@ -1,7 +1,7 @@
 {
     "scenarioName": "auth",
     "request": {
-        "urlPattern": "/rest/v1.1/me(\\?|/|$).*",
+        "urlPattern": "/rest/v1.1/me(/)?($|\\?.*)",
         "method": "GET"
     },
     "response": {

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_signup.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_signup.json
@@ -2,7 +2,7 @@
     "scenarioName": "auth",
     "requiredScenarioState": "signed-up",
     "request": {
-        "urlPath": "/rest/v1.1/me/",
+        "urlPattern": "/rest/v1.1/me(/)?($|\\?.*)",
         "method": "GET"
     },
     "response": {


### PR DESCRIPTION
This just pulls in the various changes that have been made to https://github.com/wordpress-mobile/WordPressMocks since it was last updated here.

To test:

- UI tests still pass.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
