### PR TITLE
Remove usages of buggy DateTimeUtils methods

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
@@ -65,8 +65,8 @@ public class ReaderCommentActions {
         newComment.pageNumber = pageNumber;
         newComment.setText(commentText);
 
-        Date dtPublished = DateTimeUtils.nowUTC();
-        newComment.setPublished(DateTimeUtils.iso8601FromDate(dtPublished));
+        Date dtPublished = new Date();
+        newComment.setPublished(DateTimeUtils.iso8601UTCFromDate(dtPublished));
         newComment.timestamp = dtPublished.getTime();
 
         ReaderUser currentUser = ReaderUserTable.getCurrentUser(wpComUserId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -42,6 +42,7 @@ import org.wordpress.android.util.JSONUtils;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.VolleyUtils;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -426,7 +427,7 @@ public class ReaderPostActions {
             ReaderTagList bookmarkTags = ReaderTagTable.getBookmarkTags();
 
             for (ReaderTag tag : bookmarkTags) {
-                post.setDateTagged(DateTimeUtils.iso8601FromDate(DateTimeUtils.nowUTC()));
+                post.setDateTagged(DateTimeUtils.iso8601UTCFromDate(new Date()));
                 ReaderPostTable.addOrUpdatePosts(tag, readerPosts);
             }
             ReaderPostTable.setBookmarkFlag(post.blogId, post.postId, true);

--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.1.0-beta-2'
+    fluxCVersion = '1.1.0-beta-3'
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -13,10 +13,12 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.NoSuchElementException;
+import java.util.TimeZone;
 
 import static java.lang.String.format;
 
@@ -60,6 +62,11 @@ public class AppLog {
     public static final int HEADER_LINE_COUNT = 2;
     private static boolean mEnableRecording = false;
     private static List<AppLogListener> mListeners = new ArrayList<>(0);
+    private static final SimpleDateFormat DEFAULT_UTC_FORMAT = new SimpleDateFormat("MMM-dd kk:mm", Locale.US);
+
+    static {
+        DEFAULT_UTC_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
 
     private AppLog() {
         throw new AssertionError();
@@ -224,7 +231,7 @@ public class AppLog {
 
         LogEntry(LogLevel logLevel, String logText, T logTag) {
             mLogLevel = logLevel;
-            mDate = DateTimeUtils.nowUTC();
+            mDate = new Date();
             if (logText == null) {
                 mLogText = "null";
             } else {
@@ -234,7 +241,7 @@ public class AppLog {
         }
 
         private String formatLogDate() {
-            return new SimpleDateFormat("MMM-dd kk:mm", Locale.US).format(mDate);
+            return DEFAULT_UTC_FORMAT.format(mDate);
         }
 
         private String toHtml() {


### PR DESCRIPTION
Fixes #10303 

The `DateTimeUtils.nowUTC()` and `DateTimeUtils.localDateToUTC` don't work as expected and as a result we were setting a wrong date. More info https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/25


To test:
- I'm not sure how to reliably test this without a debugger
1. Set breakpoints at the changed lines
2. Go to Reader -> Open comments list on a post
3. Post a comment -> check the date using debugger
4. Go to Reader
5. Save a post for later - bookmark it -> check the date using debugger
6. Go to Me section
7. Click on Help & Support
8. Click on Application log -> check the date using debugger

Update release notes:

- The changes are too minor


~This should be merged at the same time as https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1327 - after we update FluxC's version of course.~