### PR TITLE
Do not show publish confirmation dialog on submit for review

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -70,9 +70,10 @@ class PostActionHandler(
             BUTTON_MOVE_TO_DRAFT -> {
                 moveTrashedPostToDraft(post)
             }
-            BUTTON_SUBMIT, BUTTON_SYNC, BUTTON_PUBLISH -> {
+            BUTTON_SYNC, BUTTON_PUBLISH -> {
                 postListDialogHelper.showPublishConfirmationDialog(post)
             }
+            BUTTON_SUBMIT -> publishPost(post.id)
             BUTTON_VIEW -> triggerPostListAction.invoke(ViewPost(site, post))
             BUTTON_PREVIEW -> triggerPostListAction.invoke(PreviewPost(site, post))
             BUTTON_STATS -> triggerPostListAction.invoke(ViewStats(site, post))


### PR DESCRIPTION
Fixes #10298 

Do not show publish confirmation dialog when the user clicks on Submit button on a post list item.

To test:
1. Log in as contributor
2. Create a draft and do not upload it (leave the editor by pressing back button)
3. Click on the Submit button on the post list item
4. Notice the post gets submitted for review and the publish confirmation dialog is not shown

Update release notes:

- the changes are too minor
