### PR TITLE
Fix simple date format concurrency issue

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -62,11 +62,6 @@ public class AppLog {
     public static final int HEADER_LINE_COUNT = 2;
     private static boolean mEnableRecording = false;
     private static List<AppLogListener> mListeners = new ArrayList<>(0);
-    private static final SimpleDateFormat DEFAULT_UTC_FORMAT = new SimpleDateFormat("MMM-dd kk:mm", Locale.US);
-
-    static {
-        DEFAULT_UTC_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
-    }
 
     private AppLog() {
         throw new AssertionError();
@@ -241,7 +236,9 @@ public class AppLog {
         }
 
         private String formatLogDate() {
-            return DEFAULT_UTC_FORMAT.format(mDate);
+            SimpleDateFormat sdf = new SimpleDateFormat("MMM-dd kk:mm", Locale.US);
+            sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+            return sdf.format(mDate);
         }
 
         private String toHtml() {

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -62,6 +62,7 @@ public class AppLog {
     public static final int HEADER_LINE_COUNT = 2;
     private static boolean mEnableRecording = false;
     private static List<AppLogListener> mListeners = new ArrayList<>(0);
+    private static TimeZone mUtcTimeZone = TimeZone.getTimeZone("UTC");
 
     private AppLog() {
         throw new AssertionError();
@@ -237,7 +238,7 @@ public class AppLog {
 
         private String formatLogDate() {
             SimpleDateFormat sdf = new SimpleDateFormat("MMM-dd kk:mm", Locale.US);
-            sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+            sdf.setTimeZone(mUtcTimeZone);
             return sdf.format(mDate);
         }
 


### PR DESCRIPTION
I introduced a bug in https://github.com/wordpress-mobile/WordPress-Android/pull/10306/files.

The `SimpleDateFormat` class isn't thread safe - it stores the passed date into a local field. It can throw NumberFormatException in concurrent environment as the local field might be cleared by another thread.

