### PR TITLE
Use FluxC 1.2.0-beta-1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.1.0-beta-3'
+    fluxCVersion = '1.2.0-beta-1'
 }


### PR DESCRIPTION
This PR corrects an issue where FluxC wasn't tagged with a new version for the 13.0 release. 

The FluxC `1.2.0-beta-1` tag is applied to the same commit as the `1.1.0-beta-3` tag, so the code is identical – this change is purely semantic.

It requires just one approval, but I'm tagging:
@maxme because it's your FluxC tag I'm updating
@daniloercoli because you brought the issue to my attention (thanks!!)

**To test:**
- Verify that https://github.com/wordpress-mobile/WordPress-FluxC-Android/releases/tag/1.2.0-beta-1 and https://github.com/wordpress-mobile/WordPress-FluxC-Android/releases/tag/1.1.0-beta-3 both reference commit hash `f42f85e` to validate that the code is identical.
- Verify that CI tests pass (which means that Jitpack is able to fetch and deliver the new tagged version).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.