### PR TITLE
Make remote preview works for drafts on self hosted sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelper.kt
@@ -46,41 +46,54 @@ class RemotePreviewLogicHelper @Inject constructor(
         post: PostModel,
         helperFunctions: RemotePreviewHelperFunctions
     ): PreviewLogicOperationResult {
-        if (!site.isUsingWpComRestApi) {
-            activityLauncherWrapper.showActionableEmptyView(
-                    activity,
-                    WPWebViewUsageCategory.REMOTE_PREVIEW_NOT_AVAILABLE,
-                    post.title
-            )
-            return PreviewLogicOperationResult.PREVIEW_NOT_AVAILABLE
-        } else if (!networkUtilsWrapper.isNetworkAvailable()) {
+        if (!networkUtilsWrapper.isNetworkAvailable()) {
             activityLauncherWrapper.showActionableEmptyView(
                     activity,
                     WPWebViewUsageCategory.REMOTE_PREVIEW_NO_NETWORK,
                     post.title
             )
             return PreviewLogicOperationResult.NETWORK_NOT_AVAILABLE
-        } else {
-            if (helperFunctions.notifyUploadInProgress(post)) {
-                return PreviewLogicOperationResult.MEDIA_UPLOAD_IN_PROGRESS
-            }
+        }
 
-            val updatedPost = helperFunctions.updatePostIfNeeded() ?: post
+        // If a media upload is currently in progress, we can't upload / auto-save or preview until it's finished.
+        if (helperFunctions.notifyUploadInProgress(post)) {
+            return PreviewLogicOperationResult.MEDIA_UPLOAD_IN_PROGRESS
+        }
 
-            if (shouldUpload(updatedPost)) {
+        // Update the post object (copy title/content from the editor to the post object) when it's needed
+        // (eg. during and editing session)
+        val updatedPost = helperFunctions.updatePostIfNeeded() ?: post
+
+        when {
+            shouldUpload(updatedPost) -> {
+                // We can't upload an unpublishable post (empty), we'll let the user know we can't preview it.
                 if (!postUtilsWrapper.isPublishable(updatedPost)) {
                     helperFunctions.notifyEmptyDraft()
                     return PreviewLogicOperationResult.CANNOT_SAVE_EMPTY_DRAFT
                 }
-
                 helperFunctions.startUploading(false, updatedPost)
-            } else if (shouldRemoteAutoSave(updatedPost)) {
+            }
+            shouldRemoteAutoSave(updatedPost) -> {
+                // We don't support remote auto-save for self hosted sites (accessed via XMLRPC),
+                // we make the preview unavailable in that case.
+                if (!site.isUsingWpComRestApi) {
+                    activityLauncherWrapper.showActionableEmptyView(
+                            activity,
+                            WPWebViewUsageCategory.REMOTE_PREVIEW_NOT_AVAILABLE,
+                            post.title
+                    )
+                    return PreviewLogicOperationResult.PREVIEW_NOT_AVAILABLE
+                }
+
+                // We can't remote auto-save an unpublishable post (empty), we'll let the user know we can't preview it.
                 if (!postUtilsWrapper.isPublishable(updatedPost)) {
                     helperFunctions.notifyEmptyPost()
                     return PreviewLogicOperationResult.CANNOT_REMOTE_AUTO_SAVE_EMPTY_POST
                 }
                 helperFunctions.startUploading(true, updatedPost)
-            } else {
+            }
+            else -> {
+                // If we don't need upload or auto save the post (eg. post not modified), open the preview directly.
                 activityLauncherWrapper.previewPostOrPageForResult(
                         activity,
                         site,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelper.kt
@@ -64,7 +64,7 @@ class RemotePreviewLogicHelper @Inject constructor(
         // (eg. during and editing session)
         val updatedPost = helperFunctions.updatePostIfNeeded() ?: post
 
-        when {
+        return when {
             shouldUpload(updatedPost) -> {
                 // We can't upload an unpublishable post (empty), we'll let the user know we can't preview it.
                 if (!postUtilsWrapper.isPublishable(updatedPost)) {
@@ -72,6 +72,7 @@ class RemotePreviewLogicHelper @Inject constructor(
                     return PreviewLogicOperationResult.CANNOT_SAVE_EMPTY_DRAFT
                 }
                 helperFunctions.startUploading(false, updatedPost)
+                PreviewLogicOperationResult.GENERATING_PREVIEW
             }
             shouldRemoteAutoSave(updatedPost) -> {
                 // We don't support remote auto-save for self hosted sites (accessed via XMLRPC),
@@ -91,6 +92,7 @@ class RemotePreviewLogicHelper @Inject constructor(
                     return PreviewLogicOperationResult.CANNOT_REMOTE_AUTO_SAVE_EMPTY_POST
                 }
                 helperFunctions.startUploading(true, updatedPost)
+                PreviewLogicOperationResult.GENERATING_PREVIEW
             }
             else -> {
                 // If we don't need upload or auto save the post (eg. post not modified), open the preview directly.
@@ -100,10 +102,9 @@ class RemotePreviewLogicHelper @Inject constructor(
                         updatedPost,
                         RemotePreviewType.REMOTE_PREVIEW
                 )
-                return PreviewLogicOperationResult.OPENING_PREVIEW
+                PreviewLogicOperationResult.OPENING_PREVIEW
             }
         }
-        return PreviewLogicOperationResult.GENERATING_PREVIEW
     }
 
     private fun shouldUpload(post: PostModel): Boolean {

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelperTest.kt
@@ -13,6 +13,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
+import org.mockito.Mockito.lenient
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -68,9 +69,11 @@ class RemotePreviewLogicHelperTest {
     }
 
     @Test
-    fun `preview not available for self hosted sites not using WPComRestApi`() {
+    fun `preview not available for self hosted sites not using WPComRestApi on published post with modifications`() {
         // Given
         doReturn(false).whenever(site).isUsingWpComRestApi
+        doReturn(PostStatus.PUBLISHED.toString()).whenever(post).status
+        doReturn(true).whenever(post).isLocallyChanged
 
         // When
         val result = remotePreviewLogicHelper.runPostPreviewLogic(activity, site, post, mock())
@@ -82,6 +85,20 @@ class RemotePreviewLogicHelperTest {
                 WPWebViewUsageCategory.REMOTE_PREVIEW_NOT_AVAILABLE,
                 post.title
         )
+    }
+
+    @Test
+    fun `preview available for self hosted sites not using WPComRestApi on drafts`() {
+        // Given
+        // next stub not used (made lenient) in case we update future logic.
+        lenient().doReturn(false).whenever(site).isUsingWpComRestApi
+
+        // When
+        val result = remotePreviewLogicHelper.runPostPreviewLogic(activity, site, post, helperFunctions)
+
+        // Then
+        assertThat(result).isEqualTo(RemotePreviewLogicHelper.PreviewLogicOperationResult.GENERATING_PREVIEW)
+        verify(helperFunctions, times(1)).startUploading(false, post)
     }
 
     @Test


### PR DESCRIPTION
Make remote preview works for drafts on self hosted sites

Fist discussed here: https://github.com/wordpress-mobile/WordPress-Android/pull/10212#issuecomment-517317029

To test:

Case 1:

- On a self hosted site (not connected via Jetpack)
- Open a published post and modify its content
- Tap the "Preview" button in the overflow menu
- You should get a "Preview unavailable" screen

Case 2:

- On a self hosted site (not connected via Jetpack)
- Create (or edit) a draft
- Tap the "Preview" button in the overflow menu
- You should get a the preview screen (after a "Saving" progress popover).


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
