### PR TITLE
Improve v13.0 editor opt-in migration strategy

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1168,6 +1168,11 @@ public class WPMainActivity extends AppCompatActivity implements
             return;
         }
 
+        if (getSelectedSite().getId() != event.site.getId()) {
+            // No need to refresh the UI, since the current selected site is another site
+            return;
+        }
+
         SiteModel site = mSiteStore.getSiteByLocalId(getSelectedSite().getId());
         if (site != null) {
             mSelectedSite = site;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -952,7 +952,11 @@ public abstract class SiteSettingsInterface {
         if (fetchRemote) {
             fetchRemoteData();
             mDispatcher.dispatch(SiteActionBuilder.newFetchPostFormatsAction(mSite));
-            mDispatcher.dispatch(SiteActionBuilder.newFetchSiteEditorsAction(mSite));
+            if (!AppPrefs.isDefaultAppWideEditorPreferenceSet()) {
+                // Check if the migration from app-wide to per-site setting has already happened - v12.9->13.0
+                // before fetching site editors from the remote
+                mDispatcher.dispatch(SiteActionBuilder.newFetchSiteEditorsAction(mSite));
+            }
         }
 
         return this;


### PR DESCRIPTION
This PR improves the editor opt-in migration strategy by changing a couple of important things:

- The selected site is the first to be migrated to server side opt-it
- The delay between calls is set to 500ms 
- There is no need to synch editor settings if the local app-wide flag is still set in the app and the migration still need to happens

To test:
- Install 12.9, and turn block editor to ON
- Install 13.0 and check that everything is fine since the first launch

**Note:** This PR does target the analytics PR that needs to be merged to v13.0 first. We can change the base branch later



Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
