### PR TITLE
Fix #10219 restore page before edit or view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
@@ -23,7 +23,8 @@ sealed class PageItem(open val type: Type) {
         open var indent: Int,
         open var imageUrl: String?,
         open val actions: Set<Action>,
-        open var actionsEnabled: Boolean
+        open var actionsEnabled: Boolean,
+        open val tapActionEnabled: Boolean
     ) : PageItem(PAGE)
 
     data class PublishedPage(
@@ -42,7 +43,8 @@ sealed class PageItem(open val type: Type) {
             indent = indent,
             imageUrl = imageUrl,
             actions = setOf(VIEW_PAGE, SET_PARENT, MOVE_TO_DRAFT, MOVE_TO_TRASH),
-            actionsEnabled = actionsEnabled
+            actionsEnabled = actionsEnabled,
+            tapActionEnabled = true
     )
 
     data class DraftPage(
@@ -60,7 +62,8 @@ sealed class PageItem(open val type: Type) {
             indent = 0,
             imageUrl = imageUrl,
             actions = setOf(VIEW_PAGE, SET_PARENT, PUBLISH_NOW, MOVE_TO_TRASH),
-            actionsEnabled = actionsEnabled
+            actionsEnabled = actionsEnabled,
+            tapActionEnabled = true
     )
 
     data class ScheduledPage(
@@ -78,7 +81,8 @@ sealed class PageItem(open val type: Type) {
             indent = 0,
             imageUrl = imageUrl,
             actions = setOf(VIEW_PAGE, SET_PARENT, MOVE_TO_DRAFT, MOVE_TO_TRASH),
-            actionsEnabled = actionsEnabled
+            actionsEnabled = actionsEnabled,
+            tapActionEnabled = true
     )
 
     data class TrashedPage(
@@ -95,7 +99,8 @@ sealed class PageItem(open val type: Type) {
             indent = 0,
             imageUrl = imageUrl,
             actions = setOf(MOVE_TO_DRAFT, DELETE_PERMANENTLY),
-            actionsEnabled = actionsEnabled
+            actionsEnabled = actionsEnabled,
+            tapActionEnabled = false
     )
 
     data class ParentPage(

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
@@ -94,7 +94,7 @@ sealed class PageItem(open val type: Type) {
             labels = emptyList(),
             indent = 0,
             imageUrl = imageUrl,
-            actions = setOf(VIEW_PAGE, MOVE_TO_DRAFT, DELETE_PERMANENTLY),
+            actions = setOf(MOVE_TO_DRAFT, DELETE_PERMANENTLY),
             actionsEnabled = actionsEnabled
     )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.pages
 
+import android.graphics.drawable.Drawable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -22,6 +23,7 @@ import org.wordpress.android.ui.reader.utils.ReaderUtils
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.ImageUtils
+import org.wordpress.android.util.getDrawableFromAttribute
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType
 import java.util.Date
@@ -43,6 +45,10 @@ sealed class PageItemViewHolder(internal val parent: ViewGroup, @LayoutRes layou
         private val labels = itemView.findViewById<TextView>(R.id.labels)
         private val featuredImage = itemView.findViewById<ImageView>(R.id.featured_image)
         private val pageItemContainer = itemView.findViewById<ViewGroup>(R.id.page_item)
+        private val pageLayout = itemView.findViewById<ViewGroup>(R.id.page_layout)
+        private val selectableBackground: Drawable? = parent.context.getDrawableFromAttribute(
+                android.R.attr.selectableItemBackground
+        )
 
         companion object {
             const val FEATURED_IMAGE_THUMBNAIL_SIZE_DP = 40
@@ -71,7 +77,16 @@ sealed class PageItemViewHolder(internal val parent: ViewGroup, @LayoutRes layou
                 pageMore.visibility =
                         if (page.actions.isNotEmpty() && page.actionsEnabled) View.VISIBLE else View.INVISIBLE
 
+                setBackground(page.tapActionEnabled)
                 showFeaturedImage(page.imageUrl)
+            }
+        }
+
+        private fun setBackground(tapActionEnabled: Boolean) {
+            if (tapActionEnabled) {
+                pageLayout.background = selectableBackground
+            } else {
+                pageLayout.background = null
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -117,7 +117,9 @@ class PageListViewModel @Inject constructor(
     }
 
     fun onItemTapped(pageItem: Page) {
-        pagesViewModel.onItemTapped(pageItem)
+        if (pageItem.tapActionEnabled) {
+            pagesViewModel.onItemTapped(pageItem)
+        }
     }
 
     fun onEmptyListNewPageButtonTapped() {

--- a/WordPress/src/main/res/layout/page_list_item.xml
+++ b/WordPress/src/main/res/layout/page_list_item.xml
@@ -9,6 +9,7 @@
     android:background="@android:color/white">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/page_layout"
         android:layout_width="match_parent"
         android:layout_height="@dimen/two_line_list_item_height"
         android:background="?attr/selectableItemBackground">


### PR DESCRIPTION
Fix #10219 restore page before edit or view.

- Remove the view button on trashed page
- Disable tap action on trashed page
- Remove selectable backgroun on trashed page

To test:

- Open the Page List
- Go to the TRASHED tab
- Make sure the "..." menu only includes 2 items: restore / delete permanently
- Make sure the list item is not tappable (won't open the editor)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
