### PR TITLE
Fix alert window size on Chromebooks and Tablets

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DetailListPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DetailListPreference.java
@@ -22,6 +22,7 @@ import androidx.appcompat.app.AlertDialog;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.wordpress.android.R;
+import org.wordpress.android.ui.utils.UiHelpers;
 
 import java.util.Locale;
 
@@ -149,6 +150,8 @@ public class DetailListPreference extends ListPreference
             //noinspection deprecation
             negative.setTextColor(res.getColor(R.color.primary_40));
         }
+
+        UiHelpers.Companion.adjustDialogSize(mDialog);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFormatDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFormatDialog.java
@@ -24,6 +24,7 @@ import androidx.core.widget.CompoundButtonCompat;
 import org.wordpress.android.Constants;
 import org.wordpress.android.R;
 import org.wordpress.android.ui.ActivityLauncher;
+import org.wordpress.android.ui.utils.UiHelpers;
 import org.wordpress.android.util.EditTextUtils;
 
 /**
@@ -179,6 +180,12 @@ public class SiteSettingsFormatDialog extends DialogFragment implements DialogIn
             return EditTextUtils.getText(mEditCustomFormat);
         }
         return mValues[id];
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        UiHelpers.Companion.adjustDialogSize(getDialog());
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -1,7 +1,10 @@
 package org.wordpress.android.ui.utils
 
+import android.app.Dialog
 import android.content.Context
+import android.graphics.Point
 import android.view.View
+import android.view.WindowManager.LayoutParams
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.DrawableRes
@@ -51,6 +54,29 @@ class UiHelpers @Inject constructor() {
         updateVisibility(imageView, resId != null)
         resId?.let {
             imageView.setImageResource(resId)
+        }
+    }
+
+    companion object {
+        fun adjustDialogSize(dialog: Dialog) {
+
+            val window = dialog.window
+            val point = Point()
+
+            val display = window!!.windowManager.defaultDisplay
+            display.getSize(point)
+
+            val displayWidth = point.x
+            val displayHeight = point.y
+
+            val width: Int
+            if (displayWidth > displayHeight) {
+                width = (displayHeight * 0.4).toInt()
+            } else {
+                width = (displayWidth * 0.4).toInt()
+            }
+
+            window!!.setLayout(width, LayoutParams.WRAP_CONTENT)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.ui.utils
 
+import org.wordpress.android.R
 import android.app.Dialog
 import android.content.Context
-import android.graphics.Point
 import android.view.View
 import android.view.WindowManager.LayoutParams
 import android.widget.ImageView
@@ -60,22 +60,8 @@ class UiHelpers @Inject constructor() {
     companion object {
         fun adjustDialogSize(dialog: Dialog) {
             val window = dialog.window
-            val point = Point()
-
-            val display = window!!.windowManager.defaultDisplay
-            display.getSize(point)
-
-            val displayWidth = point.x
-            val displayHeight = point.y
-
-            val width: Int
-            if (displayWidth > displayHeight) {
-                width = (displayHeight * 0.4).toInt()
-            } else {
-                width = (displayWidth * 0.8).toInt()
-            }
-
-            window!!.setLayout(width, LayoutParams.WRAP_CONTENT)
+            val defaultDialogWidth: Int = window.context.resources.getDimension(R.dimen.alert_dialog_max_width).toInt()
+            window!!.setLayout(defaultDialogWidth, LayoutParams.WRAP_CONTENT)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
 import android.graphics.Point
 
-
 class UiHelpers @Inject constructor() {
     fun getPxOfUiDimen(context: Context, uiDimen: UiDimen): Int =
             when (uiDimen) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -72,7 +72,7 @@ class UiHelpers @Inject constructor() {
             if (displayWidth > displayHeight) {
                 width = (displayHeight * 0.4).toInt()
             } else {
-                width = (displayWidth * 0.4).toInt()
+                width = (displayWidth * 0.8).toInt()
             }
 
             window!!.setLayout(width, LayoutParams.WRAP_CONTENT)

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -59,7 +59,6 @@ class UiHelpers @Inject constructor() {
 
     companion object {
         fun adjustDialogSize(dialog: Dialog) {
-
             val window = dialog.window
             val point = Point()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -15,6 +15,8 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
+import android.graphics.Point
+
 
 class UiHelpers @Inject constructor() {
     fun getPxOfUiDimen(context: Context, uiDimen: UiDimen): Int =
@@ -60,8 +62,21 @@ class UiHelpers @Inject constructor() {
     companion object {
         fun adjustDialogSize(dialog: Dialog) {
             val window = dialog.window
-            val defaultDialogWidth: Int = window.context.resources.getDimension(R.dimen.alert_dialog_max_width).toInt()
-            window!!.setLayout(defaultDialogWidth, LayoutParams.WRAP_CONTENT)
+            val size = Point()
+
+            val display = window.windowManager.defaultDisplay
+            display.getSize(size)
+
+            val width = size.x
+
+            val maximumWidth = window.context.resources.getDimension(R.dimen.alert_dialog_max_width).toInt()
+            var proposedWidth = (width * 0.8).toInt()
+
+            if (proposedWidth > maximumWidth) {
+                proposedWidth = maximumWidth
+            }
+
+            window.setLayout(proposedWidth, LayoutParams.WRAP_CONTENT)
         }
     }
 }

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -41,6 +41,7 @@
 
     <dimen name="default_dialog_button_height">36dp</dimen>
     <dimen name="default_dialog_width">280dp</dimen>
+    <dimen name="alert_dialog_max_width">300dp</dimen>
 
     <dimen name="post_editor_content_side_margin">20dp</dimen>
 


### PR DESCRIPTION
Fixes #10329 

To test:

1. Install WordPressAndroid application on Android Tablet or Chromebook
2. Open WordPressAndroid application
3. Open Site settings
4. Click on Date Format, Time Format, Week Starts On ...

The result -> Window dialog size should be normal

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
