### PR TITLE
Update aztec to v1.3.29

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     ext {
-        aztecVersion = '0fa41a08efef6092a6bd8c7b31e948cb21144d02'
+        aztecVersion = 'v1.3.29'
     }
 
     repositories {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     ext {
-        aztecVersion = 'v1.3.28'
+        aztecVersion = '0fa41a08efef6092a6bd8c7b31e948cb21144d02'
     }
 
     repositories {


### PR DESCRIPTION
**Summary:**

While working on Chromebook issues we have made some fixes on https://github.com/wordpress-mobile/AztecEditor-Android repository and before we tag `v1.3.29`, we need to make sure that nothing is broken.

PR's that were resolved: 

- https://github.com/wordpress-mobile/AztecEditor-Android/pull/840
- https://github.com/wordpress-mobile/AztecEditor-Android/pull/838
- https://github.com/wordpress-mobile/AztecEditor-Android/pull/835

**To test:**

We should test Aztec Editor in general so that we can be sure that above PR's didn't expose any regression.

Following `gb-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1260

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
