### PR TITLE
Fix potential NPE in WPWebviewActivity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -249,8 +249,10 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
         }
 
         String originalUrl = extras.getString(URL_TO_LOAD);
-        Uri uri = Uri.parse(originalUrl);
-        actionBar.setSubtitle(uri.getHost());
+        if (originalUrl != null) {
+            Uri uri = Uri.parse(originalUrl);
+            actionBar.setSubtitle(uri.getHost());
+        }
     }
 
     private void initRetryButton() {


### PR DESCRIPTION
This case can happen with the updated remote preview code (when we request a preview, don't get any response from the server, and so can't provide any URL to the activity) but shouldn't happen currently in `develop`.  

To prevent any crash (maybe some cases I missed), it's safer to for check it.