### PR TITLE
Hotfix 13.0 - Do not override editor preference already set on the remote on update 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '47c14d665fcc00aeea6121ae2ad318c18f72856b'
+    fluxCVersion = '1.1.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.1.1'
+    fluxCVersion = '47c14d665fcc00aeea6121ae2ad318c18f72856b'
 }


### PR DESCRIPTION
This PR does update FluxC hash to include the latest version that uses the parameter `set_only_if_empty` when bulk migrating editor preference from v12.9 to 13.0.

To test:
- install 12.9
- open App Settings
- switch the editor toggle to use the Block Editor
- install 13.0 and migrate the settings
- go on the RC card and see `gutenberg` everywhere
- re-install 12.9
- open App Settings
- switch the editor toggle to use the Block Editor
- re-open app setting switch it back to OFF
- install 13.0 and migrate the settings
- go on the RC card and see `gutenberg` is still everywhere
- try to create a new post. Gutenberg is the editor.


Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
