### PR TITLE
Add cancel pending auto-upload action on post list items

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -752,6 +752,7 @@ public class WPMainActivity extends AppCompatActivity implements
                 if (site != null && post != null) {
                     UploadUtils.handleEditPostResultSnackbars(
                             this,
+                            mDispatcher,
                             findViewById(R.id.coordinator),
                             data,
                             post,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2221,14 +2221,9 @@ public class EditPostActivity extends AppCompatActivity implements
 
                 boolean isPublishable = PostUtils.isPublishable(mPost);
 
-                boolean hasFailedMediaUploads = mEditorFragment.hasFailedMediaUploads()
-                                                || mFeaturedImageHelper.getFailedFeaturedImageUpload(mPost) != null;
-
-                if (!hasFailedMediaUploads) {
-                    AppLog.d(T.POSTS, "User explicitly confirmed changes. Post Title: " + mPost.getTitle());
-                    // the user explicitly confirmed an intention to upload the post
-                    mPost.setChangesConfirmedContentHashcode(mPost.contentHashcode());
-                }
+                AppLog.d(T.POSTS, "User explicitly confirmed changes. Post Title: " + mPost.getTitle());
+                // the user explicitly confirmed an intention to upload the post
+                mPost.setChangesConfirmedContentHashcode(mPost.contentHashcode());
 
                 // if post was modified or has unsaved local changes and is publishable, save it
                 saveResult(isPublishable, false, false);
@@ -2238,7 +2233,8 @@ public class EditPostActivity extends AppCompatActivity implements
                 if (isPublishable) {
                     if (NetworkUtils.isNetworkAvailable(getBaseContext())) {
                         // Show an Alert Dialog asking the user if they want to remove all failed media before upload
-                        if (hasFailedMediaUploads) {
+                        if (mEditorFragment.hasFailedMediaUploads()
+                            || mFeaturedImageHelper.getFailedFeaturedImageUpload(mPost) != null) {
                             EditPostActivity.this.runOnUiThread(new Runnable() {
                                 @Override
                                 public void run() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -120,6 +120,12 @@ class PostActionHandler(
     }
 
     private fun cancelPendingAutoUpload(post: PostModel) {
+        /**
+         * `changesConfirmedContentHashcode` field holds a hashcode of the post content at the time when user pressed
+         * updated/publish/sync/submit/.. buttons. Clearing the hashcode will prevent the PostUploadHandler to
+         * auto-upload the changes - it'll only remote-auto-save them -> which is exactly what the cancel action is
+         * supposed to do.
+         */
         post.changesConfirmedContentHashcode = 0
         dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post))
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.posts
 
 import android.content.Intent
-import android.util.Log
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.PostActionBuilder

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListActionTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListActionTracker.kt
@@ -5,6 +5,20 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.util.analytics.AnalyticsUtils
 import org.wordpress.android.widgets.PostListButtonType
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE_PERMANENTLY
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_EDIT
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_MORE
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_MOVE_TO_DRAFT
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_PREVIEW
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_PUBLISH
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_RETRY
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_STATS
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_SUBMIT
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_SYNC
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_TRASH
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_VIEW
 
 fun trackPostListAction(site: SiteModel, buttonType: PostListButtonType, postData: PostModel, statsEvent: Stat) {
     val properties = HashMap<String, Any?>()
@@ -13,23 +27,24 @@ fun trackPostListAction(site: SiteModel, buttonType: PostListButtonType, postDat
     }
 
     properties["action"] = when (buttonType) {
-        PostListButtonType.BUTTON_EDIT -> {
+        BUTTON_EDIT -> {
             properties[AnalyticsUtils.HAS_GUTENBERG_BLOCKS_KEY] = PostUtils
                     .contentContainsGutenbergBlocks(postData.content)
             "edit"
         }
-        PostListButtonType.BUTTON_RETRY -> "retry"
-        PostListButtonType.BUTTON_SUBMIT -> "submit"
-        PostListButtonType.BUTTON_VIEW -> "view"
-        PostListButtonType.BUTTON_PREVIEW -> "preview"
-        PostListButtonType.BUTTON_STATS -> "stats"
-        PostListButtonType.BUTTON_TRASH -> "trash"
-        PostListButtonType.BUTTON_DELETE,
-        PostListButtonType.BUTTON_DELETE_PERMANENTLY -> "delete"
-        PostListButtonType.BUTTON_PUBLISH -> "publish"
-        PostListButtonType.BUTTON_SYNC -> "sync"
-        PostListButtonType.BUTTON_MORE -> "more"
-        PostListButtonType.BUTTON_MOVE_TO_DRAFT -> "move_to_draft"
+        BUTTON_RETRY -> "retry"
+        BUTTON_SUBMIT -> "submit"
+        BUTTON_VIEW -> "view"
+        BUTTON_PREVIEW -> "preview"
+        BUTTON_STATS -> "stats"
+        BUTTON_TRASH -> "trash"
+        BUTTON_DELETE,
+        BUTTON_DELETE_PERMANENTLY -> "delete"
+        BUTTON_PUBLISH -> "publish"
+        BUTTON_SYNC -> "sync"
+        BUTTON_MORE -> "more"
+        BUTTON_MOVE_TO_DRAFT -> "move_to_draft"
+        BUTTON_CANCEL_PENDING_AUTO_UPLOAD -> "cancel_pending_auto_upload"
     }
 
     AnalyticsUtils.trackWithSiteDetails(statsEvent, site, properties)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadAction.kt
@@ -45,11 +45,12 @@ sealed class PostUploadAction {
     class CancelPostAndMediaUpload(val post: PostModel) : PostUploadAction()
 }
 
-fun handleUploadAction(action: PostUploadAction, activity: Activity, snackbarAttachView: View) {
+fun handleUploadAction(action: PostUploadAction, activity: Activity, dispatcher: Dispatcher, snackbarAttachView: View) {
     when (action) {
         is PostUploadAction.EditPostResult -> {
             UploadUtils.handleEditPostResultSnackbars(
                     activity,
+                    dispatcher,
                     snackbarAttachView,
                     action.data,
                     action.post,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -26,6 +26,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.ActivityId
@@ -58,6 +59,7 @@ class PostsListActivity : AppCompatActivity(),
     @Inject internal lateinit var remotePreviewLogicHelper: RemotePreviewLogicHelper
     @Inject internal lateinit var previewStateHelper: PreviewStateHelper
     @Inject internal lateinit var progressDialogHelper: ProgressDialogHelper
+    @Inject internal lateinit var dispatcher: Dispatcher
 
     private lateinit var site: SiteModel
     private lateinit var viewModel: PostListMainViewModel
@@ -256,6 +258,7 @@ class PostsListActivity : AppCompatActivity(),
                 handleUploadAction(
                         uploadAction,
                         this@PostsListActivity,
+                        dispatcher,
                         findViewById(R.id.coordinator)
                 )
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -821,10 +821,19 @@ public class UploadService extends Service {
             }
 
             if (processWithAztec) {
+                boolean changesConfirmed = post.contentHashcode() == post.getChangesConfirmedContentHashcode();
+
                 // do the same within the Post content itself
                 String postContentWithRestartedUploads =
                         AztecEditorFragment.restartFailedMediaToUploading(this, post.getContent());
                 post.setContent(postContentWithRestartedUploads);
+                if (changesConfirmed) {
+                    /*
+                     * We are updating media upload status, but we don't make any undesired changes to the post. We
+                     * need to make sure to retain the confirmation state.
+                     */
+                    post.setChangesConfirmedContentHashcode(post.contentHashcode());
+                }
                 mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post));
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -113,6 +113,7 @@ public class UploadUtils {
     }
 
     public static void handleEditPostResultSnackbars(@NonNull final Activity activity,
+                                                     @NonNull final Dispatcher dispatcher,
                                                      @NonNull View snackbarAttachView,
                                                      @NonNull Intent data,
                                                      @NonNull final PostModel post,
@@ -129,7 +130,11 @@ public class UploadUtils {
             // The network is not available, we can enqueue a request to upload local changes later
             UploadWorkerKt.enqueueUploadWorkRequestForSite(site);
             // And tell the user about it
-            showSnackbar(snackbarAttachView, getDeviceOfflinePostNotUploadedMessage(post));
+            showSnackbar(snackbarAttachView, getDeviceOfflinePostNotUploadedMessage(post), R.string.cancel,
+                    v -> {
+                        int msgRes = cancelPendingAutoUpload(post, dispatcher);
+                        showSnackbar(snackbarAttachView, msgRes);
+                    });
             return;
         }
 
@@ -436,5 +441,38 @@ public class UploadUtils {
         return post.getAutoSaveModified() != null
                && DateTimeUtils.dateFromIso8601(post.getDateLocallyChanged())
                                .before(DateTimeUtils.dateFromIso8601(post.getAutoSaveModified()));
+    }
+
+    public static int cancelPendingAutoUpload(PostModel post, Dispatcher dispatcher) {
+        /*
+         * `changesConfirmedContentHashcode` field holds a hashcode of the post content at the time when user pressed
+         * updated/publish/sync/submit/.. buttons. Clearing the hashcode will prevent the PostUploadHandler to
+         * auto-upload the changes - it'll only remote-auto-save them -> which is exactly what the cancel action is
+         * supposed to do.
+         */
+        post.setChangesConfirmedContentHashcode(0);
+        dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post));
+
+        int messageRes = 0;
+        switch (PostStatus.fromPost(post)) {
+            case UNKNOWN:
+            case PUBLISHED:
+            case PRIVATE:
+                messageRes = R.string.post_waiting_for_connection_publish_cancel;
+                break;
+            case PENDING:
+                messageRes = R.string.post_waiting_for_connection_pending_cancel;
+                break;
+            case SCHEDULED:
+                messageRes = R.string.post_waiting_for_connection_scheduled_cancel;
+                break;
+            case DRAFT:
+            case TRASHED:
+                AppLog.e(T.POSTS,
+                        "This code should be unreachable. Canceling pending auto-upload on Trashed and Draft posts "
+                        + "isn't supported.");
+                break;
+        }
+        return messageRes;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -36,6 +36,7 @@ import org.wordpress.android.viewmodel.posts.PostListItemUiStateHelper.PostUploa
 import org.wordpress.android.viewmodel.posts.PostListItemUiStateHelper.PostUploadUiState.UploadingMedia
 import org.wordpress.android.viewmodel.posts.PostListItemUiStateHelper.PostUploadUiState.UploadingPost
 import org.wordpress.android.widgets.PostListButtonType
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE_PERMANENTLY
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_EDIT
@@ -293,7 +294,8 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         statsSupported: Boolean
     ): List<PostListButtonType> {
         val canRetryUpload = uploadUiState is PostUploadUiState.UploadFailed
-        val canPublishPost = (canRetryUpload || uploadUiState is NothingToUpload) &&
+        val canCancelPendingAutoUpload = uploadUiState is UploadWaitingForConnection && postStatus != DRAFT
+        val canPublishPost = (canRetryUpload || uploadUiState is NothingToUpload || !canCancelPendingAutoUpload) &&
                 (isLocallyChanged || isLocalDraft || postStatus == DRAFT ||
                         (siteHasCapabilitiesToPublish && postStatus == PENDING))
 
@@ -320,6 +322,10 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
                         BUTTON_PUBLISH
                     }
             )
+        }
+
+        if (canCancelPendingAutoUpload) {
+            buttonTypes.add(BUTTON_CANCEL_PENDING_AUTO_UPLOAD)
         }
 
         if (canShowViewButton) {

--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
@@ -29,7 +29,8 @@ enum class PostListButtonType constructor(
             R.string.button_delete_permanently,
             R.drawable.ic_trash_white_24dp,
             R.color.neutral_50
-    );
+    ),
+    BUTTON_CANCEL_PENDING_AUTO_UPLOAD(14, R.string.cancel, R.drawable.ic_undo_white_24dp, R.color.warning_dark);
 
     companion object {
         fun fromInt(value: Int): PostListButtonType? = values().firstOrNull { it.value == value }

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -96,6 +96,7 @@
             <enum name="retry" value="11" />
             <enum name="moveToDraft" value="12" />
             <enum name="deletePermanently" value="13"/>
+            <enum name="cancelPendingAutoUpload" value="14"/>
         </attr>
     </declare-styleable>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -265,6 +265,9 @@
     <string name="post_waiting_for_connection_pending">Post will be submitted for review next time your device is online</string>
     <string name="post_waiting_for_connection_scheduled">Post will be scheduled next time your device is online</string>
     <string name="post_waiting_for_connection_private">Private post will be published next time your device is online</string>
+    <string name="post_waiting_for_connection_publish_cancel">Changes will not be published</string>
+    <string name="post_waiting_for_connection_pending_cancel">Changes will not be submitted</string>
+    <string name="post_waiting_for_connection_scheduled_cancel">Changes will not be scheduled</string>
 
     <!-- buttons on post cards -->
     <string name="button_edit">Edit</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -293,8 +293,10 @@ class PostListItemUiStateHelperTest {
         assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
         assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_PUBLISH)
         assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
+        assertThat(state.actions).hasSize(3)
         assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
         assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
     }
 
     @Test
@@ -307,7 +309,75 @@ class PostListItemUiStateHelperTest {
         assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
         assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
         assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(state.actions).hasSize(3)
     }
+
+    @Test
+    fun `verify published post with local changes eligible for auto upload`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_PUBLISH, isLocallyChanged = true),
+                uploadStatus = createUploadStatus(isEligibleForAutoUpload = true)
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
+        assertThat(state.actions).hasSize(3)
+        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_PREVIEW)
+        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
+    }
+
+    @Test
+    fun `verify scheduled post with local changes eligible for auto upload`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_SCHEDULED, isLocallyChanged = true),
+                uploadStatus = createUploadStatus(isEligibleForAutoUpload = true)
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
+        assertThat(state.actions).hasSize(3)
+        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_PREVIEW)
+        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
+    }
+
+    @Test
+    fun `verify published private post with local changes eligible for auto upload`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_PRIVATE, isLocallyChanged = true),
+                uploadStatus = createUploadStatus(isEligibleForAutoUpload = true)
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
+        assertThat(state.actions).hasSize(3)
+        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_PREVIEW)
+        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
+    }
+
+    @Test
+    fun `verify draft with local changes eligible for auto upload`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(status = POST_STATE_DRAFT, isLocallyChanged = true),
+                uploadStatus = createUploadStatus(isEligibleForAutoUpload = true)
+        )
+
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_EDIT)
+        assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_PUBLISH)
+        assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
+        assertThat(state.actions).hasSize(3)
+
+        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_PREVIEW)
+        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
+    }
+
+
 
     @Test
     fun `label has progress color when post queued`() {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -377,8 +377,6 @@ class PostListItemUiStateHelperTest {
         assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
     }
 
-
-
     @Test
     fun `label has progress color when post queued`() {
         val state = createPostListItemUiState(uploadStatus = createUploadStatus(isQueued = true))


### PR DESCRIPTION
Fixes #10206  

**This PR should be merged into `master-auto-upload` after https://github.com/wordpress-mobile/WordPress-Android/pull/10342 is merged.**

This PR updates add Cancel action to items pending auto-upload.

To test:
Follow the test cases described [here](https://github.com/wordpress-mobile/WordPress-iOS/issues/12227). The `cancel` button isn't supported yet.
- Test also self-hosted and Jetpack sites - the remote-auto-save should be disabled for them

Update release notes:

- The release-notes were updated in https://github.com/wordpress-mobile/WordPress-Android/pull/10319