### PR TITLE
Hotfix - 13.0 - Do not override editors on sites update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.1.2'
+    fluxCVersion = 'd36e1bb25af081a5eb1ad1cdd1e035ffc2cbdc1a'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'd36e1bb25af081a5eb1ad1cdd1e035ffc2cbdc1a'
+    fluxCVersion = '1.1.3'
 }


### PR DESCRIPTION
This PR does fix an issue where the mobile editor value is empty for a short while, resulting in Aztec being shown. Next start of editor does show GB.

Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/10346

To test: 
See details in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1340

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
