### PR TITLE
Fix/gb editor translations

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -176,7 +176,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                 translations.putStringArrayList(
                         defaultResourceString,
                         new ArrayList<>(Arrays.asList(currentResourceString))
-                                               );
+                );
             }
         }
         return translations;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -12,7 +12,6 @@ import android.os.Handler;
 import android.os.Looper;
 import android.text.Editable;
 import android.text.Spanned;
-import android.util.DisplayMetrics;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.Menu;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -122,18 +122,20 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         Bundle translations = new Bundle();
         Locale defaultLocale = new Locale("en");
         Resources currentResources = getActivity().getResources();
-        Configuration currentConfiguration = currentResources.getConfiguration();
+        Context localizedContextCurrent = getActivity()
+                .createConfigurationContext(currentResources.getConfiguration());
         // if the current locale of the app is english stop here and return an empty map
+        Configuration currentConfiguration = localizedContextCurrent.getResources().getConfiguration();
         if (currentConfiguration.locale.equals(defaultLocale)) {
             return translations;
         }
 
         // Let's create a Resources object for the default locale (english) to get the original values for our strings
-        DisplayMetrics metrics = new DisplayMetrics();
         Configuration defaultLocaleConfiguration = new Configuration(currentConfiguration);
         defaultLocaleConfiguration.setLocale(defaultLocale);
-        getActivity().getWindowManager().getDefaultDisplay().getMetrics(metrics);
-        Resources defaultResources = new Resources(getActivity().getAssets(), metrics, defaultLocaleConfiguration);
+        Context localizedContextDefault = getActivity()
+                .createConfigurationContext(defaultLocaleConfiguration);
+        Resources defaultResources = localizedContextDefault.getResources();
 
         // Strings are only being translated in the WordPress package
         // thus we need to get a reference of the R class for this package
@@ -175,7 +177,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                 translations.putStringArrayList(
                         defaultResourceString,
                         new ArrayList<>(Arrays.asList(currentResourceString))
-                );
+                                               );
             }
         }
         return translations;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -121,7 +121,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     public Bundle getTranslations() {
         Bundle translations = new Bundle();
         Locale defaultLocale = new Locale("en");
-        Resources currentResources = getActivity().getApplicationContext().getResources();
+        Resources currentResources = getActivity().getResources();
         Configuration currentConfiguration = currentResources.getConfiguration();
         // if the current locale of the app is english stop here and return an empty map
         if (currentConfiguration.locale.equals(defaultLocale)) {


### PR DESCRIPTION
Fixes translation issues in the Editor when using Gutenberg.

### Problem
Working with @daniloercoli  it was found that when using mobile Gutenberg, some strings were defaulted to English even when the device was set to another supported language (for example, Spanish or Italian as per our tests).

Specifically, the overflow menu in the Editor was all in English, and within Gutenberg, the strings such as "ADD BLOCK" separator, or  "Start writing..." hint  on a new post were all in English:

![Screenshot_20190807-083723](https://user-images.githubusercontent.com/6597771/62674602-7f557880-b979-11e9-8101-47a4c45e9c36.png)


Furthermore, after attempting to use GB, the rest of the app would be back to be translated to English (except for the main navigation, for instance).
![device-2019-08-07-143942](https://user-images.githubusercontent.com/6597771/62674637-a2802800-b979-11e9-9b98-e8786a59d5f2.png)

### Research & discovery
So, we _apparently_ had 2 problems.
One problem:
- Options menu is not translated. This is on the native side, so I explored possibilities in which the native context would be re-set to default  or english somehow. I've placed calls to check the application context configuration and each time I always get the correct locale set. I even queried the activity and application context configuration in  `onCreateOptionsMenu()` and it still had the correct locale, but it still showed english.

Another problem:
- I saw the gutenberg mobile strings are all in english as well: "Start writing..." hint, or "ADD BLOCK", etc. all of them are in english. But, the Title placeholder and the block list in the inserter are all translated. That seems weird. Looks like it's not getting translated somehow.

Looking further, found out these two:
```
            String currentResourceString = currentResources.getString(resourceId);
            String defaultResourceString = defaultResources.getString(resourceId);
```
in `getTranslations()` would **both return the english string**, when the `currentResourceString` should be the translated one, even when inspecting both `currentResources` and `deafultResources` had the right locale set (one the current, i.e. spanish, and the other one the default, that is `en`).


### Solution

From testing various things, turned out both problems were the same; it seems these 2 changes were necessary:

- using `createConfigurationContext` in 34257d6f7d to create a "copy" of the current context (both for checking current resources and creating the english reference) based on the configuration object as per the code [shown here](https://issuetracker.google.com/issues/36992422).
- use the Activity's context rather than the [global app context](https://developer.android.com/reference/android/content/ContextWrapper.html#getApplicationContext()).

Doing either thing alone did not prove to work - rationale behind this is given I was still seeing the same default string being retrieved ("problem 2"), it looked like one of the internal references in Context was changed to the default one, in fact affecting the whole app with this change ("problem 1"). Using a more local context (Activity) and copying the configuration from there seems to behave in a good manner, without disrupting the app's context


#### To test:
0. switch your device language to a supported language other than English
1. make sure to opt-in to mobile gutenberg to start new posts in app settings
2. start a new draft
3. observe the strings in the overflow menu and all in Gutenberg show in the selected language.

Here are some various screenshots showing it works:

Italian:
![Screenshot_20190808-013028](https://user-images.githubusercontent.com/6597771/62675320-ee809c00-b97c-11e9-8ca9-3c6810ca4689.png)


Spanish:
![Screenshot_20190808-012854](https://user-images.githubusercontent.com/6597771/62675278-c09b5780-b97c-11e9-9d03-fe6fbae44332.png)

German:
![Screenshot_20190808-012423](https://user-images.githubusercontent.com/6597771/62675263-aeb9b480-b97c-11e9-8578-5e31c90d7f84.png)


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
