### PR TITLE
Don't save post when it wasn't edited during the current session

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2319,7 +2319,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
                 boolean isPublishable = PostUtils.isPublishable(mPost);
 
-                // if post was modified or has unpublished local changes, save it
+                // if post was modified during this editing session, save it
                 boolean shouldSave = shouldSavePost() || forceSave;
 
                 // if post is publishable or not new, sync it
@@ -2364,16 +2364,11 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private boolean shouldSavePost() {
-        boolean hasLocalChanges = mPost.isLocallyChanged() || mPost.isLocalDraft();
         boolean hasChanges = PostUtils.postHasEdits(mPostSnapshotWhenEditorOpened, mPost);
         boolean isPublishable = PostUtils.isPublishable(mPost);
-        boolean hasUnpublishedLocalDraftChanges = (PostStatus.fromPost(mPost) == PostStatus.DRAFT
-                                                   || PostStatus.fromPost(mPost) == PostStatus.PENDING)
-                                                      && isPublishable && hasLocalChanges;
 
-        // if post was modified or has unpublished local changes, save it
-        return (mPostSnapshotWhenEditorOpened != null && hasChanges)
-                             || hasUnpublishedLocalDraftChanges || (isPublishable && isNewPost());
+        // if post was modified during this editing session, save it
+        return (mPostSnapshotWhenEditorOpened != null && hasChanges) || (isPublishable && isNewPost());
     }
 
 


### PR DESCRIPTION
Fixes #10350 

Note: It's up to us if we want to merge this PR into `issue/10174-update-changes-confirmed-at` or wait until it is merged and merge it into `master-auto-upload`.

This PR fixes an issue raised [here](https://github.com/wordpress-mobile/WordPress-Android/pull/10319#pullrequestreview-272116795).

We always wanted to try to upload a post with local modification before introduction of UploadStarter and Remote-auto-save. However, when the post is remote-auto-saved the `hasLocalChanges` flag isn't cleared - because remote-auto-save supports only title, content, excerpt fields. Before this PR the code would remote-auto-saved the post if the user opened a draft with `hasLocalChanges = true` even when the changes didn't happen during this editing session.
However, with these changes the `shouldSave` method should return true only if the current version of the post isn't saved in the database -> which means only when the post was edited during the current editing session.
 
To test:

1. Create a draft and exit the editor.
2. After uploading, edit the draft.
3. Exit the editor. Remote auto-save will happen.
4. Open the draft but do not make any changes.
5. When exiting the editor make sure the draft doesn't get remote-auto-saved again


Update release notes:

- This feature hasn't been released yet, so there is no need to update release-notes.
