### PR TITLE
Invoke remote-auto-save when exiting the editor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2332,10 +2332,8 @@ public class EditPostActivity extends AppCompatActivity implements
                 definitelyDeleteBackspaceDeletedMediaItems();
 
                 if (shouldSave) {
-                    PostStatus status = PostStatus.fromPost(mPost);
                     boolean isNotRestarting = mRestartEditorOption == RestartEditorOptions.NO_RESTART;
-                    if ((status == PostStatus.DRAFT || status == PostStatus.PENDING) && isPublishable
-                            && !hasFailedMedia() && NetworkUtils.isNetworkAvailable(getBaseContext())
+                    if (isPublishable && !hasFailedMedia() && NetworkUtils.isNetworkAvailable(getBaseContext())
                             && isNotRestarting) {
                         mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
                         savePostOnlineAndFinishAsync(isFirstTimePublish, doFinish);


### PR DESCRIPTION
Fixes #10349 

Remote-auto-save is now invoked when the user leaves the editor by pressing back button.

To test:

1. Edit a published post.
2. Make changes.
3. Exit the editor by pressing the Back button.
4. Notice the remote-auto-save is invoked

Update release notes:

- The feature hasn't been released yet, so there is no need to update the release notes.
