### PR TITLE
Refactor get upload action methods

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -87,6 +87,7 @@ import org.wordpress.android.ui.prefs.AppSettingsFragment;
 import org.wordpress.android.ui.prefs.SiteSettingsFragment;
 import org.wordpress.android.ui.reader.ReaderPostListFragment;
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity;
+import org.wordpress.android.ui.uploads.UploadActionUseCase;
 import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
@@ -169,6 +170,7 @@ public class WPMainActivity extends AppCompatActivity implements
     @Inject ShortcutUtils mShortcutUtils;
     @Inject NewsManager mNewsManager;
     @Inject QuickStartStore mQuickStartStore;
+    @Inject UploadActionUseCase mUploadActionUseCase;
 
     /*
      * fragments implement this if their contents can be scrolled, called when user
@@ -756,6 +758,7 @@ public class WPMainActivity extends AppCompatActivity implements
                             data,
                             post,
                             site,
+                            mUploadActionUseCase.getUploadAction(post),
                             new View.OnClickListener() {
                                 @Override
                                 public void onClick(View v) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.ui.posts.PostListViewLayoutType.STANDARD
 import org.wordpress.android.ui.posts.PostListViewLayoutTypeMenuUiState.CompactViewLayoutTypeMenuUiState
 import org.wordpress.android.ui.posts.PostListViewLayoutTypeMenuUiState.StandardViewLayoutTypeMenuUiState
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.uploads.UploadActionUseCase
 import org.wordpress.android.ui.uploads.UploadStarter
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
@@ -66,6 +67,7 @@ class PostListMainViewModel @Inject constructor(
     private val dispatcher: Dispatcher,
     private val postStore: PostStore,
     private val accountStore: AccountStore,
+    uploadActionUseCase: UploadActionUseCase,
     uploadStore: UploadStore,
     mediaStore: MediaStore,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
@@ -130,7 +132,10 @@ class PostListMainViewModel @Inject constructor(
     private val _searchQuery = MutableLiveData<String>()
     val searchQuery: LiveData<String> = _searchQuery
 
-    private val uploadStatusTracker = PostListUploadStatusTracker(uploadStore = uploadStore)
+    private val uploadStatusTracker = PostListUploadStatusTracker(
+            uploadStore = uploadStore,
+            uploadActionUseCase = uploadActionUseCase
+    )
     private val featuredImageTracker = PostListFeaturedImageTracker(dispatcher = dispatcher, mediaStore = mediaStore)
 
     private val postFetcher by lazy {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadAction.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.uploads.UploadActionUseCase
 import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.uploads.UploadUtils
 
@@ -45,7 +46,12 @@ sealed class PostUploadAction {
     class CancelPostAndMediaUpload(val post: PostModel) : PostUploadAction()
 }
 
-fun handleUploadAction(action: PostUploadAction, activity: Activity, snackbarAttachView: View) {
+fun handleUploadAction(
+    action: PostUploadAction,
+    activity: Activity,
+    snackbarAttachView: View,
+    uploadActionUseCase: UploadActionUseCase
+) {
     when (action) {
         is PostUploadAction.EditPostResult -> {
             UploadUtils.handleEditPostResultSnackbars(
@@ -53,7 +59,8 @@ fun handleUploadAction(action: PostUploadAction, activity: Activity, snackbarAtt
                     snackbarAttachView,
                     action.data,
                     action.post,
-                    action.site
+                    action.site,
+                    uploadActionUseCase.getUploadAction(action.post)
             ) {
                 action.publishAction()
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -37,6 +37,7 @@ import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogOnDismissBy
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface
 import org.wordpress.android.ui.posts.PostListType.SEARCH
 import org.wordpress.android.ui.posts.adapters.AuthorSelectionAdapter
+import org.wordpress.android.ui.uploads.UploadActionUseCase
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.AppLog
@@ -58,6 +59,7 @@ class PostsListActivity : AppCompatActivity(),
     @Inject internal lateinit var remotePreviewLogicHelper: RemotePreviewLogicHelper
     @Inject internal lateinit var previewStateHelper: PreviewStateHelper
     @Inject internal lateinit var progressDialogHelper: ProgressDialogHelper
+    @Inject internal lateinit var uploadActionUseCase: UploadActionUseCase
 
     private lateinit var site: SiteModel
     private lateinit var viewModel: PostListMainViewModel
@@ -256,7 +258,8 @@ class PostsListActivity : AppCompatActivity(),
                 handleUploadAction(
                         uploadAction,
                         this@PostsListActivity,
-                        findViewById(R.id.coordinator)
+                        findViewById(R.id.coordinator),
+                        uploadActionUseCase
                 )
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelper.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.posts
 
 import android.app.Activity
+import dagger.Reusable
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncherWrapper
@@ -12,9 +13,8 @@ import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction.UPLOAD
 import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction.UPLOAD_AS_DRAFT
 import org.wordpress.android.util.NetworkUtilsWrapper
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
+@Reusable
 class RemotePreviewLogicHelper @Inject constructor(
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val activityLauncherWrapper: ActivityLauncherWrapper,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelper.kt
@@ -5,11 +5,11 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncherWrapper
 import org.wordpress.android.ui.WPWebViewUsageCategory
-import org.wordpress.android.ui.uploads.UploadUtils
-import org.wordpress.android.ui.uploads.UploadUtils.PostUploadAction
-import org.wordpress.android.ui.uploads.UploadUtils.PostUploadAction.REMOTE_AUTO_SAVE
-import org.wordpress.android.ui.uploads.UploadUtils.PostUploadAction.UPLOAD
-import org.wordpress.android.ui.uploads.UploadUtils.PostUploadAction.UPLOAD_AS_DRAFT
+import org.wordpress.android.ui.uploads.UploadActionUseCase
+import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction
+import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction.REMOTE_AUTO_SAVE
+import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction.UPLOAD
+import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction.UPLOAD_AS_DRAFT
 import org.wordpress.android.util.NetworkUtilsWrapper
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -18,7 +18,8 @@ import javax.inject.Singleton
 class RemotePreviewLogicHelper @Inject constructor(
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val activityLauncherWrapper: ActivityLauncherWrapper,
-    private val postUtilsWrapper: PostUtilsWrapper
+    private val postUtilsWrapper: PostUtilsWrapper,
+    private val uploadActionUseCase: UploadActionUseCase
 ) {
     enum class RemotePreviewType {
         NOT_A_REMOTE_PREVIEW,
@@ -68,7 +69,7 @@ class RemotePreviewLogicHelper @Inject constructor(
         // (eg. during and editing session)
         val updatedPost = helperFunctions.updatePostIfNeeded() ?: post
 
-        val uploadAction = UploadUtils.getPostUploadAction(updatedPost)
+        val uploadAction = uploadActionUseCase.getUploadAction(updatedPost)
 
         return when {
             shouldUpload(updatedPost, uploadAction) -> {
@@ -124,11 +125,11 @@ class RemotePreviewLogicHelper @Inject constructor(
         }
     }
 
-    private fun shouldUpload(post: PostModel, action: PostUploadAction): Boolean {
+    private fun shouldUpload(post: PostModel, action: UploadAction): Boolean {
         return (post.isLocallyChanged || post.isLocalDraft) && (action == UPLOAD_AS_DRAFT || action == UPLOAD)
     }
 
-    private fun shouldRemoteAutoSave(post: PostModel, action: PostUploadAction): Boolean {
+    private fun shouldRemoteAutoSave(post: PostModel, action: UploadAction): Boolean {
         return post.isLocallyChanged && action == REMOTE_AUTO_SAVE
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -80,6 +80,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
     @Inject PostStore mPostStore;
     @Inject MediaStore mMediaStore;
     @Inject UiHelpers mUiHelpers;
+    @Inject UploadActionUseCase mUploadActionUseCase;
 
     PostUploadHandler(PostUploadNotifier postUploadNotifier) {
         ((WordPress) WordPress.getContext().getApplicationContext()).component().inject(this);
@@ -266,7 +267,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
 
             RemotePostPayload payload = new RemotePostPayload(mPost, mSite);
 
-            switch (UploadUtils.getPostUploadAction(mPost)) {
+            switch (mUploadActionUseCase.getUploadAction(mPost)) {
                 case UPLOAD:
                     AppLog.d(T.POSTS,
                             "Invoking newPushPostAction. Post: " + mPost.getTitle() + " status: " + mPost.getStatus());

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.uploads
 
+import dagger.Reusable
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.UploadStore
@@ -11,12 +12,11 @@ import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction.UPLOAD_
 import org.wordpress.android.util.DateTimeUtils
 import java.util.Date
 import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val MAXIMUM_AUTO_UPLOAD_RETRIES = 10
 private const val TWO_DAYS_IN_MILLIS = 1000 * 60 * 60 * 24 * 2
 
-@Singleton
+@Reusable
 class UploadActionUseCase @Inject constructor(
     private val uploadStore: UploadStore,
     private val postUtilsWrapper: PostUtilsWrapper,

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
@@ -1,0 +1,77 @@
+package org.wordpress.android.ui.uploads
+
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.UploadStore
+import org.wordpress.android.ui.posts.PostUtilsWrapper
+import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction.DO_NOTHING
+import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction.REMOTE_AUTO_SAVE
+import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction.UPLOAD
+import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction.UPLOAD_AS_DRAFT
+import org.wordpress.android.util.DateTimeUtils
+import java.util.Date
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val MAXIMUM_AUTO_UPLOAD_RETRIES = 10
+private const val TWO_DAYS_IN_MILLIS = 1000 * 60 * 60 * 24 * 2
+
+@Singleton
+class UploadActionUseCase @Inject constructor(
+    private val uploadStore: UploadStore,
+    private val postUtilsWrapper: PostUtilsWrapper,
+    private val uploadServiceFacade: UploadServiceFacade
+) {
+    enum class UploadAction {
+        REMOTE_AUTO_SAVE, UPLOAD_AS_DRAFT, UPLOAD, DO_NOTHING
+    }
+
+    fun getAutoUploadAction(post: PostModel, site: SiteModel): UploadAction {
+        val twoDaysAgoTimestamp = Date().time - TWO_DAYS_IN_MILLIS
+        // Don't auto-upload/save changes which are older than 2 days
+        if (DateTimeUtils.timestampFromIso8601Millis(post.dateLocallyChanged) < twoDaysAgoTimestamp) {
+            return DO_NOTHING
+        }
+
+        // Do not auto-upload empty post
+        if (!postUtilsWrapper.isPublishable(post)) {
+            return DO_NOTHING
+        }
+
+        // Do not auto-upload post which is in conflict with remote
+        if (postUtilsWrapper.isPostInConflictWithRemote(post)) {
+            return DO_NOTHING
+        }
+
+        // Do not auto-upload post which we already tried to upload certain number of times
+        if (uploadStore.getNumberOfPostUploadErrorsOrCancellations(post) >= MAXIMUM_AUTO_UPLOAD_RETRIES) {
+            return DO_NOTHING
+        }
+
+        // Do not auto-upload post which is currently being uploaded
+        if (uploadServiceFacade.isPostUploadingOrQueued(post)) {
+            return DO_NOTHING
+        }
+
+        val action = getUploadAction(post)
+        // Don't remoteAutoSave changes which were already remoteAutoSaved or when on a self-hosted site
+        if (action == REMOTE_AUTO_SAVE &&
+                (UploadUtils.postLocalChangesAlreadyRemoteAutoSaved(post) || !site.isUsingWpComRestApi)) {
+            return DO_NOTHING
+        }
+
+        return action
+    }
+
+    fun getUploadAction(post: PostModel): UploadAction {
+        return when {
+            post.changesConfirmedContentHashcode == post.contentHashcode() ->
+                // We are sure we can push the post as the user has explicitly confirmed the changes
+                UPLOAD
+            post.isLocalDraft ->
+                // Local draft can always be uploaded as DRAFT as it doesn't exist on the server yet
+                UPLOAD_AS_DRAFT
+            else -> REMOTE_AUTO_SAVE
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.prefs.AppPrefs;
+import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction;
 import org.wordpress.android.ui.utils.UiString;
 import org.wordpress.android.ui.utils.UiString.UiStringRes;
 import org.wordpress.android.util.AppLog;
@@ -43,10 +44,6 @@ import java.util.List;
 
 public class UploadUtils {
     private static final int K_SNACKBAR_WAIT_TIME_MS = 5000;
-
-    public enum PostUploadAction {
-        REMOTE_AUTO_SAVE, UPLOAD_AS_DRAFT, UPLOAD, DO_NOTHING
-    }
 
     /**
      * Returns a post-type specific error message string.
@@ -117,6 +114,7 @@ public class UploadUtils {
                                                      @NonNull Intent data,
                                                      @NonNull final PostModel post,
                                                      @NonNull final SiteModel site,
+                                                     @NonNull final UploadAction uploadAction,
                                                      View.OnClickListener publishPostListener) {
         boolean hasChanges = data.getBooleanExtra(EditPostActivity.EXTRA_HAS_CHANGES, false);
         if (!hasChanges) {
@@ -129,7 +127,7 @@ public class UploadUtils {
             // The network is not available, we can enqueue a request to upload local changes later
             UploadWorkerKt.enqueueUploadWorkRequestForSite(site);
             // And tell the user about it
-            showSnackbar(snackbarAttachView, getDeviceOfflinePostNotUploadedMessage(post));
+            showSnackbar(snackbarAttachView, getDeviceOfflinePostNotUploadedMessage(post, uploadAction));
             return;
         }
 
@@ -405,8 +403,9 @@ public class UploadUtils {
     }
 
     @StringRes
-    private static int getDeviceOfflinePostNotUploadedMessage(PostModel post) {
-        if (getPostUploadAction(post) != PostUploadAction.UPLOAD) {
+    private static int getDeviceOfflinePostNotUploadedMessage(@NonNull final PostModel post,
+                                                              @NonNull final UploadAction uploadAction) {
+        if (uploadAction != UploadAction.UPLOAD) {
             return R.string.error_publish_no_network;
         } else {
             switch (PostStatus.fromPost(post)) {
@@ -426,18 +425,6 @@ public class UploadUtils {
             }
         }
         throw new RuntimeException("This code should be unreachable. Missing case in switch statement.");
-    }
-
-    public static PostUploadAction getPostUploadAction(PostModel post) {
-        if (post.getChangesConfirmedContentHashcode() == post.contentHashcode()) {
-            // We are sure we can push the post as the user has explicitly confirmed the changes
-            return PostUploadAction.UPLOAD;
-        } else if (post.isLocalDraft()) {
-            // Local draft can always be uploaded as DRAFT as it doesn't exist on the server yet
-            return PostUploadAction.UPLOAD_AS_DRAFT;
-        } else {
-            return PostUploadAction.REMOTE_AUTO_SAVE;
-        }
     }
 
     public static boolean postLocalChangesAlreadyRemoteAutoSaved(PostModel post) {

--- a/WordPress/src/main/java/org/wordpress/android/util/NetworkUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/NetworkUtilsWrapper.kt
@@ -1,10 +1,10 @@
 package org.wordpress.android.util
 
+import dagger.Reusable
 import org.wordpress.android.WordPress
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
+@Reusable
 class NetworkUtilsWrapper @Inject constructor() {
     /**
      * Returns true if a network connection is available.

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -355,7 +355,7 @@ class PostListViewModel @Inject constructor(
     private fun transformPostModelToPostListItemUiState(post: PostModel) =
             listItemUiStateHelper.createPostListItemUiState(
                     post = post,
-                    uploadStatus = connector.getUploadStatus(post, uploadStarter, connector.site),
+                    uploadStatus = connector.getUploadStatus(post, connector.site),
                     unhandledConflicts = connector.doesPostHaveUnhandledConflict(post),
                     capabilitiesToPublish = connector.site.hasCapabilityPublishPosts,
                     statsSupported = isStatsSupported,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
@@ -4,13 +4,12 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.PostActionHandler
 import org.wordpress.android.ui.posts.PostListType
-import org.wordpress.android.ui.uploads.UploadStarter
 
 class PostListViewModelConnector(
     val site: SiteModel,
     val postListType: PostListType,
     val postActionHandler: PostActionHandler,
-    val getUploadStatus: (PostModel, UploadStarter, SiteModel) -> PostListItemUploadStatus,
+    val getUploadStatus: (PostModel, SiteModel) -> PostListItemUploadStatus,
     val doesPostHaveUnhandledConflict: (PostModel) -> Boolean,
     val postFetcher: PostFetcher,
     private val getFeaturedImageUrl: (site: SiteModel, featuredImageId: Long) -> String?

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
@@ -44,7 +44,8 @@ class PostListMainViewModelTest : BaseUnitTest() {
                 mainDispatcher = Dispatchers.Unconfined,
                 bgDispatcher = Dispatchers.Unconfined,
                 postListEventListenerFactory = mock(),
-                uploadStarter = uploadStarter
+                uploadStarter = uploadStarter,
+                uploadActionUseCase = mock()
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelperTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncherWrapper
 import org.wordpress.android.ui.WPWebViewUsageCategory
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewHelperFunctions
+import org.wordpress.android.ui.uploads.UploadActionUseCase
 import org.wordpress.android.util.NetworkUtilsWrapper
 
 @RunWith(MockitoJUnitRunner::class)
@@ -43,6 +44,8 @@ class RemotePreviewLogicHelperTest {
     @Mock
     private lateinit var postUtilsWrapper: PostUtilsWrapper
 
+    private var uploadActionUseCase = UploadActionUseCase(mock(), mock(), mock())
+
     private lateinit var remotePreviewLogicHelper: RemotePreviewLogicHelper
 
     @Before
@@ -50,7 +53,8 @@ class RemotePreviewLogicHelperTest {
         remotePreviewLogicHelper = RemotePreviewLogicHelper(
                 networkUtilsWrapper,
                 activityLauncherWrapper,
-                postUtilsWrapper
+                postUtilsWrapper,
+                uploadActionUseCase
         )
 
         doReturn(true).whenever(site).isUsingWpComRestApi

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
@@ -74,13 +74,12 @@ class UploadStarterConcurrentTest {
             postStore = postStore,
             pageStore = pageStore,
             siteStore = mock(),
-            uploadStore = mock(),
             bgDispatcher = Dispatchers.Default,
             ioDispatcher = Dispatchers.IO,
             networkUtilsWrapper = createMockedNetworkUtilsWrapper(),
-            postUtilsWrapper = createMockedPostUtilsWrapper(),
             connectionStatus = mock(),
-            uploadServiceFacade = uploadServiceFacade
+            uploadServiceFacade = uploadServiceFacade,
+            uploadActionUseCase = UploadActionUseCase(mock(), createMockedPostUtilsWrapper(), uploadServiceFacade)
     )
 
     private companion object Fixtures {

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -477,13 +477,12 @@ class UploadStarterTest {
             postStore = postStore,
             pageStore = pageStore,
             siteStore = siteStore,
-            uploadStore = uploadStore,
             bgDispatcher = Dispatchers.Unconfined,
             ioDispatcher = Dispatchers.Unconfined,
             networkUtilsWrapper = createMockedNetworkUtilsWrapper(),
-            postUtilsWrapper = postUtilsWrapper,
             connectionStatus = connectionStatus,
-            uploadServiceFacade = uploadServiceFacade
+            uploadServiceFacade = uploadServiceFacade,
+            uploadActionUseCase = UploadActionUseCase(uploadStore, postUtilsWrapper, uploadServiceFacade)
     )
 
     private companion object Fixtures {


### PR DESCRIPTION
This PR refactors getUploadAction and getAutoUploadAction methods as suggested by @shiki in [this comment.](https://github.com/wordpress-mobile/WordPress-Android/pull/10342#discussion_r311685385)

To test:
Running unit tests is enough imo. We'll test all the publishing scenarios in other PRs anyway.

Update release notes:

- There are no user facing changes


Note: I haven't introduced unit tests yet.
