### PR TITLE
Fix submit/publish button on post list items on self-hosted sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.ui.uploads
+
+import org.wordpress.android.fluxc.model.SiteModel
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Injectable wrapper around UploadUtils.
+ *
+ * UploadUtils interface is consisted of static methods, which makes the client code difficult to test/mock.
+ * Main purpose of this wrapper is to make testing easier.
+ */
+@Singleton
+class UploadUtilsWrapper @Inject constructor() {
+    fun userCanPublish(site: SiteModel): Boolean {
+        return UploadUtils.userCanPublish(site)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.ui.uploads
 
+import dagger.Reusable
 import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
-import javax.inject.Singleton
 
 /**
  * Injectable wrapper around UploadUtils.
@@ -10,7 +10,7 @@ import javax.inject.Singleton
  * UploadUtils interface is consisted of static methods, which makes the client code difficult to test/mock.
  * Main purpose of this wrapper is to make testing easier.
  */
-@Singleton
+@Reusable
 class UploadUtilsWrapper @Inject constructor() {
     fun userCanPublish(site: SiteModel): Boolean {
         return UploadUtils.userCanPublish(site)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -37,6 +37,7 @@ import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.ui.posts.trackPostListAction
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.uploads.UploadStarter
+import org.wordpress.android.ui.uploads.UploadUtilsWrapper
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.SiteUtils
@@ -67,6 +68,7 @@ class PostListViewModel @Inject constructor(
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val uploadStarter: UploadStarter,
     private val readerUtilsWrapper: ReaderUtilsWrapper,
+    private val uploadUtilsWrapper: UploadUtilsWrapper,
     @Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     connectionStatus: LiveData<ConnectionStatus>
@@ -357,7 +359,7 @@ class PostListViewModel @Inject constructor(
                     post = post,
                     uploadStatus = connector.getUploadStatus(post, uploadStarter, connector.site),
                     unhandledConflicts = connector.doesPostHaveUnhandledConflict(post),
-                    capabilitiesToPublish = connector.site.hasCapabilityPublishPosts,
+                    capabilitiesToPublish = uploadUtilsWrapper.userCanPublish(connector.site),
                     statsSupported = isStatsSupported,
                     featuredImageUrl =
                     convertToPhotonUrlIfPossible(connector.getFeaturedImageUrl(post.featuredImageId)),

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
@@ -59,6 +59,7 @@ class PostListViewModelTest : BaseUnitTest() {
                 uploadStarter = uploadStarter,
                 readerUtilsWrapper = mock(),
                 connectionStatus = mock(),
+                uploadUtilsWrapper = mock(),
                 uiDispatcher = TEST_DISPATCHER,
                 bgDispatcher = TEST_DISPATCHER
         )


### PR DESCRIPTION
Fixes #10354 

Fixes issue where "submit" button was shown instead of "Publish" button on self-hosted sites.

To test:
1. Log-in as admin on a self-hosted site.
2. Edit a published post 
3. Press the back button (exit the editor)
4. Notice the item with "Local changes" label contains "Publish" button and not "Submit" as before

Update release notes:

- The changes are too minor.
