### PR TITLE
Add _container_ id to post_list_item_compact

### DIFF
--- a/WordPress/src/main/res/layout/post_list_item_compact.xml
+++ b/WordPress/src/main/res/layout/post_list_item_compact.xml
@@ -11,6 +11,7 @@
     android:background="@color/white">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="?selectableItemBackground">


### PR DESCRIPTION
This bug was introduced in #10185 

Bug before the patch:
- on `feature/master-remote-previews` branch
- Go to the post list
- Tap "compact list" button
- 💥 

After the patch:
- Go to the post list
- Tap "compact list" button
- 🏖 
