### PR TITLE
Track details about editor on editor related analytics events

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3933,18 +3933,18 @@ public class EditPostActivity extends AppCompatActivity implements
 
         if (currentStat != null) {
             Map<String, String> properties = new HashMap<>();
-            String editorname = null;
+            String editorName = null;
             if (mEditorFragment instanceof GutenbergEditorFragment) {
-                editorname = "gutenberg";
+                editorName = "gutenberg";
             } else if (mEditorFragment instanceof AztecEditorFragment) {
-                editorname = "aztec";
+                editorName = "aztec";
             }
-            if (editorname == null) {
+            if (editorName == null) {
                 throw new IllegalArgumentException("Unexpected Editor Fragment - got "
                                                    + mEditorFragment.getClass().getName()
                                                    + " but expected GutenbergEditorFragment or AztecEditorFragment");
             }
-            properties.put("editor", mEditorFragment instanceof GutenbergEditorFragment ? "gutenberg" : "aztec");
+            properties.put("editor", editorName);
             AnalyticsTracker.track(currentStat, properties);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3841,7 +3841,7 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void onTrackableEvent(TrackableEvent event) {
+    public void onTrackableEvent(TrackableEvent event) throws IllegalArgumentException {
         AnalyticsTracker.Stat currentStat = null;
         switch (event) {
             case BOLD_BUTTON_TAPPED:
@@ -3933,7 +3933,17 @@ public class EditPostActivity extends AppCompatActivity implements
 
         if (currentStat != null) {
             Map<String, String> properties = new HashMap<>();
-            // Not the cleanest way to track GB, but easier without changing to many methods calls
+            String editorname = null;
+            if (mEditorFragment instanceof GutenbergEditorFragment) {
+                editorname = "gutenberg";
+            } else if (mEditorFragment instanceof AztecEditorFragment) {
+                editorname = "aztec";
+            }
+            if (editorname == null) {
+                throw new IllegalArgumentException("Unexpected Editor Fragment - got "
+                                                   + mEditorFragment.getClass().getName()
+                                                   + " but expected GutenbergEditorFragment or AztecEditorFragment");
+            }
             properties.put("editor", mEditorFragment instanceof GutenbergEditorFragment ? "gutenberg" : "aztec");
             AnalyticsTracker.track(currentStat, properties);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3842,92 +3842,100 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onTrackableEvent(TrackableEvent event) {
+        AnalyticsTracker.Stat currentStat = null;
         switch (event) {
             case BOLD_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_BOLD);
+                currentStat = Stat.EDITOR_TAPPED_BOLD;
                 break;
             case BLOCKQUOTE_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_BLOCKQUOTE);
+                currentStat = Stat.EDITOR_TAPPED_BLOCKQUOTE;
                 break;
             case ELLIPSIS_COLLAPSE_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_ELLIPSIS_COLLAPSE);
+                currentStat = Stat.EDITOR_TAPPED_ELLIPSIS_COLLAPSE;
                 AppPrefs.setAztecEditorToolbarExpanded(false);
                 break;
             case ELLIPSIS_EXPAND_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_ELLIPSIS_EXPAND);
+                currentStat = Stat.EDITOR_TAPPED_ELLIPSIS_EXPAND;
                 AppPrefs.setAztecEditorToolbarExpanded(true);
                 break;
             case HEADING_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HEADING);
+                currentStat = Stat.EDITOR_TAPPED_HEADING;
                 break;
             case HEADING_1_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HEADING_1);
+                currentStat = Stat.EDITOR_TAPPED_HEADING_1;
                 break;
             case HEADING_2_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HEADING_2);
+                currentStat = Stat.EDITOR_TAPPED_HEADING_2;
                 break;
             case HEADING_3_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HEADING_3);
+                currentStat = Stat.EDITOR_TAPPED_HEADING_3;
                 break;
             case HEADING_4_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HEADING_4);
+                currentStat = Stat.EDITOR_TAPPED_HEADING_4;
                 break;
             case HEADING_5_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HEADING_5);
+                currentStat = Stat.EDITOR_TAPPED_HEADING_5;
                 break;
             case HEADING_6_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HEADING_6);
+                currentStat = Stat.EDITOR_TAPPED_HEADING_6;
                 break;
             case HORIZONTAL_RULE_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HORIZONTAL_RULE);
+                currentStat = Stat.EDITOR_TAPPED_HORIZONTAL_RULE;
                 break;
             case HTML_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_HTML);
+                currentStat = Stat.EDITOR_TAPPED_HTML;
                 hidePhotoPicker();
                 break;
             case IMAGE_EDITED:
-                AnalyticsTracker.track(Stat.EDITOR_EDITED_IMAGE);
+                currentStat = Stat.EDITOR_EDITED_IMAGE;
                 break;
             case ITALIC_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_ITALIC);
+                currentStat = Stat.EDITOR_TAPPED_ITALIC;
                 break;
             case LINK_ADDED_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_LINK_ADDED);
+                currentStat = Stat.EDITOR_TAPPED_LINK_ADDED;
                 hidePhotoPicker();
                 break;
             case LINK_REMOVED_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_LINK_REMOVED);
+                currentStat = Stat.EDITOR_TAPPED_LINK_REMOVED;
                 break;
             case LIST_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_LIST);
+                currentStat = Stat.EDITOR_TAPPED_LIST;
                 break;
             case LIST_ORDERED_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_LIST_ORDERED);
+                currentStat = Stat.EDITOR_TAPPED_LIST_ORDERED;
                 break;
             case LIST_UNORDERED_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_LIST_UNORDERED);
+                currentStat = Stat.EDITOR_TAPPED_LIST_UNORDERED;
                 break;
             case MEDIA_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_IMAGE);
+                currentStat = Stat.EDITOR_TAPPED_IMAGE;
                 break;
             case NEXT_PAGE_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_NEXT_PAGE);
+                currentStat = Stat.EDITOR_TAPPED_NEXT_PAGE;
                 break;
             case PARAGRAPH_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_PARAGRAPH);
+                currentStat = Stat.EDITOR_TAPPED_PARAGRAPH;
                 break;
             case PREFORMAT_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_PREFORMAT);
+                currentStat = Stat.EDITOR_TAPPED_PREFORMAT;
                 break;
             case READ_MORE_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_READ_MORE);
+                currentStat = Stat.EDITOR_TAPPED_READ_MORE;
                 break;
             case STRIKETHROUGH_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_STRIKETHROUGH);
+                currentStat = Stat.EDITOR_TAPPED_STRIKETHROUGH;
                 break;
             case UNDERLINE_BUTTON_TAPPED:
-                AnalyticsTracker.track(Stat.EDITOR_TAPPED_UNDERLINE);
+                currentStat = Stat.EDITOR_TAPPED_UNDERLINE;
                 break;
+        }
+
+        if (currentStat != null) {
+            Map<String, String> properties = new HashMap<>();
+            // Not the cleanest way to track GB, but easier without changing to many methods calls
+            properties.put("editor", mEditorFragment instanceof GutenbergEditorFragment ? "gutenberg" : "aztec");
+            AnalyticsTracker.track(currentStat, properties);
         }
     }
 


### PR DESCRIPTION
This is part of the work required for https://github.com/wordpress-mobile/WordPress-Android/issues/10360 and adds the `editor` property to TrackableEvent(s).

Note: this [here](https://github.com/wordpress-mobile/WordPress-Android/compare/add/editor-src-property-to-editor-analytics-event?expand=1#diff-38b6aea9cfff5f3e0e4b7389b44de602R3937) is not the cleanest approach, but it was the easier to avoid to change many files, and it works fine anyway.

I've also seen there are still Legacy and Hybrid editor around. Are we still using it somewhere? 

To test:
- use Aztec and tap around the editor interface
- see that the proper `editor` src is bumped with LiveView or by putting a breakpoint in place

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
