### PR TITLE
Fix fb publicize

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * Added ability to switch between Desktop and Mobile versions of the content for Site and Page preview.
 * Improvement to the functionality and design of Web Preview.
+* Fixed an issue with social media service connections
 
 13.0
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java
@@ -86,6 +86,7 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
         super.onSaveInstanceState(outState);
         outState.putSerializable(WordPress.SITE, mSite);
         outState.putInt(PublicizeConstants.ARG_CONNECTION_ID, mConnectionId);
+        outState.putString(PublicizeConstants.ARG_SERVICE_ID, mServiceId);
         mWebView.saveState(outState);
     }
 


### PR DESCRIPTION
Hopefully fixes #9924

Fixes bug which prevented some users from establishing connection with their social media services.

To test:
- Set "don't keep activities in the System developer settings"
1. My Site
2. Sharing
3. Facebook
4. Connect
5. Enter your Facebook credentials
6. The Webview asks you to provide 2-fa code 
7. Switch to the Facebook app and get the code (this is the place where we lose `mServiceId`)[in case your account isn't 2-fa protected, just move another app into foreground and then bring the WordPress app back]
8. Finish the FB login and give the app access to at least one published fb page
9. A connection to your FB page should be successfully established

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
