### PR TITLE
Fixes Publicize connection flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+13.2
+-----
+* Fix issue where establishing LinkedIn connection would always fail
+
 13.1
 -----
 * Added ability to switch between Desktop and Mobile versions of the content for Site and Page preview.

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
@@ -182,8 +182,7 @@ public class PublicizeActions {
         Map<String, String> params = new HashMap<>();
         params.put("keyring_connection_ID", Long.toString(keyringConnectionId));
         // Sending the external id for Twitter and LinkedIn connections result in an error
-        if (!TextUtils.isEmpty(externalUserId) && !PublicizeConstants.TWITTER_ID.equals(serviceId)
-            && !PublicizeConstants.LINKEDIN_ID.equals(serviceId)) {
+        if (!TextUtils.isEmpty(externalUserId) && PublicizeConstants.FACEBOOK_ID.equals(serviceId)) {
             params.put("external_user_ID", externalUserId);
         }
         String path = String.format(Locale.ROOT, "/sites/%d/publicize-connections/new", siteId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
@@ -181,8 +181,9 @@ public class PublicizeActions {
 
         Map<String, String> params = new HashMap<>();
         params.put("keyring_connection_ID", Long.toString(keyringConnectionId));
-        // Sending the external id for Twitter connections result in an error
-        if (!TextUtils.isEmpty(externalUserId) && !PublicizeConstants.TWITTER_ID.equals(serviceId)) {
+        // Sending the external id for Twitter and LinkedIn connections result in an error
+        if (!TextUtils.isEmpty(externalUserId) && !PublicizeConstants.TWITTER_ID.equals(serviceId)
+            && !PublicizeConstants.LINKEDIN_ID.equals(serviceId)) {
             params.put("external_user_ID", externalUserId);
         }
         String path = String.format(Locale.ROOT, "/sites/%d/publicize-connections/new", siteId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
@@ -8,6 +8,7 @@ public class PublicizeConstants {
     public static final String GOOGLE_PLUS_ID = "google_plus";
     public static final String FACEBOOK_ID = "facebook";
     public static final String TWITTER_ID = "twitter";
+    public static final String LINKEDIN_ID = "linkedin";
 
     public enum ConnectAction {
         CONNECT,


### PR DESCRIPTION
Fixes #10252 

[This line of code](https://github.com/wordpress-mobile/WordPress-Android/blob/b620788b3669e4ba38cfee2b06a6d914ee15a4c0/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java#L138) was introduce in https://github.com/wordpress-mobile/WordPress-Android/pull/8115. The server responds with Http Error code 400 when we pass `external_user_ID` parameter to a service which doesn't support it. However, the only service supporting this parameter is Facebook. Therefore the PR mentioned above broke connecting flows to all the other services. 
Our users mostly connect Facebook (which works) and Twitter accounts. We introduce a workaround for Twitter in https://github.com/wordpress-mobile/WordPress-Android/pull/9629. However, we didn't realize other connections might be also broken due to the same bug.
This PR fixes this issue once and for all by making sure we send `external_user_ID` to Facebook only. 

To test:
1. My Site
2. Sharing
3. Linked In
4. Connect 
5. Complete the flow and notice the connection is successfully established

Perform the same steps for Tumblr and Twitter.

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
