### PR TITLE
Update FluxC to the latest release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.2.0-beta-3'
+    fluxCVersion = '1.2.0'
 }


### PR DESCRIPTION
This PR updates FluxC to the latest version. `1.2.0` has been cut on the same commit of `1.2.0-beta-3`, so no actual changes here.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
