### PR TITLE
Fix migration in v13.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.2.0'
+    fluxCVersion = '1.2.1'
 }


### PR DESCRIPTION
Fixes migration script in 13.1

The changes were already tested in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1344

Update release notes:

- The bug wasn't released yet so there is no need to update release-notes
