### PR TITLE
Synchronize Reader Search adapter

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionAdapter.java
@@ -40,7 +40,7 @@ public class ReaderSearchSuggestionAdapter extends CursorAdapter {
         mSuggestionBgColor = ContextCompat.getColor(context, R.color.neutral_0);
     }
 
-    public void setFilter(String filter) {
+    public synchronized void setFilter(String filter) {
         // skip if unchanged
         if (isCurrentFilter(filter) && getCursor() != null) {
             return;
@@ -74,7 +74,7 @@ public class ReaderSearchSuggestionAdapter extends CursorAdapter {
     /*
      * forces setFilter() to always repopulate by skipping the isCurrentFilter() check
      */
-    private void reload() {
+    private synchronized void reload() {
         String newFilter = mCurrentFilter;
         mCurrentFilter = null;
         setFilter(newFilter);
@@ -180,7 +180,7 @@ public class ReaderSearchSuggestionAdapter extends CursorAdapter {
         alert.show();
     }
 
-    private void clearSavedSearches() {
+    private synchronized void clearSavedSearches() {
         ReaderSearchTable.deleteAllQueries();
         swapCursor(null);
     }


### PR DESCRIPTION
Fixes #9987 

This fix is more of a shot in the dark. We have been seeing this `ChangeObserver is already registered.` exception for the last couple of years and we haven't been able to find steps how to reproduce it. 

I gathered recent crashes
- https://sentry.io/organizations/a8c/issues/1098765930/events/4eb41d6c962e4071a4a3fe11e4f884d4/
- https://sentry.io/organizations/a8c/issues/1101891157/?query=is%3Aunresolved%20IllegalStateException
- https://sentry.io/organizations/a8c/issues/1096892978/?query=is%3Aunresolved%20IllegalStateException
- https://sentry.io/organizations/a8c/issues/1098698974/?query=is%3Aunresolved%20IllegalStateException
And one reoccurring Track event is "reader_search_loaded". I believe this is the line on which the app is crashing https://github.com/wordpress-mobile/WordPress-Android/blob/ac56c495d4f5cecf2a50f349576f23515679d8b1/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionAdapter.java#L71.

I wasn't able to find any other reasonable explanation what is causing the issue other than multiple threads are trying to update the cursor or `mCurrentFilter` at the same time. I decided to synchronize the methods which are changing `mCurrentFilter` or the Cursor. I believe it can't hurt us and there is a chance it might fix the issue.

To test:
1. Open Reader
2. Search some queries -> eg. "a", "an", "and", "andr" ...
3. Type "a" and notice all the previous searches "a", "an", "and", "andr" are suggested to you
4. Type "android" and make sure the search works as expected.


Update release notes:

- The change is too minor
