### PR TITLE
Fix NPE in UploadService

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -385,7 +385,8 @@ public class UploadService extends Service {
      * waiting for media to finish uploading counts as 'waiting to be uploaded' until the media uploads complete.
      */
     public static boolean isPostUploadingOrQueued(PostModel post) {
-        if (sInstance == null || post == null) {
+        UploadService instance = sInstance;
+        if (instance == null || post == null) {
             return false;
         }
 
@@ -395,7 +396,7 @@ public class UploadService extends Service {
         }
 
         // Then check the list of posts waiting for media to complete
-        return sInstance.mUploadStore.isPendingPost(post);
+        return instance.mUploadStore.isPendingPost(post);
     }
 
     public static boolean isPostQueued(PostModel post) {
@@ -495,12 +496,13 @@ public class UploadService extends Service {
     }
 
     public static float getMediaUploadProgressForPost(PostModel postModel) {
-        if (postModel == null || sInstance == null) {
+        UploadService instance = sInstance;
+        if (postModel == null || instance == null) {
             // If the UploadService isn't running, there's no progress for this post
             return 0;
         }
 
-        Set<MediaModel> pendingMediaList = sInstance.mUploadStore.getUploadingMediaForPost(postModel);
+        Set<MediaModel> pendingMediaList = instance.mUploadStore.getUploadingMediaForPost(postModel);
 
         if (pendingMediaList.size() == 0) {
             return 1;
@@ -516,12 +518,13 @@ public class UploadService extends Service {
     }
 
     public static float getUploadProgressForMedia(MediaModel mediaModel) {
-        if (mediaModel == null || sInstance == null) {
+        UploadService instance = sInstance;
+        if (mediaModel == null || instance == null) {
             // If the UploadService isn't running, there's no progress for this media
             return 0;
         }
 
-        float uploadProgress = sInstance.mUploadStore.getUploadProgressForMedia(mediaModel);
+        float uploadProgress = instance.mUploadStore.getUploadProgressForMedia(mediaModel);
 
         // If this is a video and video optimization is enabled, include the optimization progress in the outcome
         if (mediaModel.isVideo() && WPMediaUtils.isVideoOptimizationEnabled()) {
@@ -533,10 +536,11 @@ public class UploadService extends Service {
 
     public static @NonNull
     Set<MediaModel> getPendingMediaForPost(PostModel postModel) {
-        if (postModel == null || sInstance == null) {
+        UploadService instance = sInstance;
+        if (postModel == null || instance == null) {
             return Collections.emptySet();
         }
-        return sInstance.mUploadStore.getUploadingMediaForPost(postModel);
+        return instance.mUploadStore.getUploadingMediaForPost(postModel);
     }
 
     public static boolean isPendingOrInProgressMediaUpload(@NonNull MediaModel media) {


### PR DESCRIPTION
Fixes #10001 

Fixes NPE in UploadService. We check that `sInstance` field is not null. However, before we use that field `onDestroy` method which clears the field might be have been called by the system. This PR fixes the issue by temporarily storing the `sInstance` into a local field.

To test:
This issue isn't easy to reproduce. I'd suggest just carefully reviewing the code.

Update release notes:

- The changes are too minor.
