### PR TITLE
Add unit tests for UploadActionUseCase

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
@@ -13,7 +13,7 @@ import org.wordpress.android.util.DateTimeUtils
 import java.util.Date
 import javax.inject.Inject
 
-private const val MAXIMUM_AUTO_UPLOAD_RETRIES = 10
+const val MAXIMUM_AUTO_UPLOAD_RETRIES = 10
 private const val TWO_DAYS_IN_MILLIS = 1000 * 60 * 60 * 24 * 2
 
 @Reusable

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -434,7 +434,7 @@ public class UploadUtils {
     }
 
     public static boolean postLocalChangesAlreadyRemoteAutoSaved(PostModel post) {
-        return post.getAutoSaveModified() != null
+        return !TextUtils.isEmpty(post.getAutoSaveModified())
                && DateTimeUtils.dateFromIso8601(post.getDateLocallyChanged())
                                .before(DateTimeUtils.dateFromIso8601(post.getAutoSaveModified()));
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadActionUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadActionUseCaseTest.kt
@@ -78,6 +78,33 @@ class UploadActionUseCaseTest {
     }
 
     @Test
+    fun `autoUploadAction is DO NOTHING when the post is older than 2 days no matter other parameters`() {
+        // Arrange
+        val uploadActionUseCase = createUploadActionUseCase()
+
+        val twoDaysAgoTimestamp = run {
+            val twoDaysInSeconds = 60 * 60 * 24 * 2
+            val twoDaysAgo = (Date().time / 1000) - twoDaysInSeconds
+            DateTimeUtils.iso8601FromTimestamp(twoDaysAgo)
+        }
+
+        val posts = listOf(
+                createPostModel(dateLocallyChanged = twoDaysAgoTimestamp),
+                createPostModel(dateLocallyChanged = twoDaysAgoTimestamp, isLocalDraft = true, changesConfirmed = true),
+                createPostModel(dateLocallyChanged = twoDaysAgoTimestamp, isLocalDraft = false, changesConfirmed = true)
+        )
+
+        val siteModel: SiteModel = createSiteModel()
+
+        // Act and Assert
+        assertThat(posts).allSatisfy { post ->
+            val action = uploadActionUseCase.getAutoUploadAction(post, siteModel)
+
+            assertThat(action).isEqualTo(UploadAction.DO_NOTHING)
+        }
+    }
+
+    @Test
     fun `autoUploadAction is REMOTE_AUTO_SAVE when the post is younger than 2 days and changes are NOT confirmed`() {
         // Arrange
         val uploadActionUseCase = createUploadActionUseCase()

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadActionUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadActionUseCaseTest.kt
@@ -1,0 +1,194 @@
+package org.wordpress.android.ui.uploads
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.store.UploadStore
+import org.wordpress.android.ui.posts.PostUtilsWrapper
+import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction
+import org.wordpress.android.util.DateTimeUtils
+import java.util.Date
+
+private val POST_STATE_PUBLISH = PostStatus.PUBLISHED.toString()
+private val POST_STATE_SCHEDULED = PostStatus.SCHEDULED.toString()
+private val POST_STATE_PRIVATE = PostStatus.PRIVATE.toString()
+private val POST_STATE_PENDING = PostStatus.PENDING.toString()
+private val POST_STATE_DRAFT = PostStatus.DRAFT.toString()
+private val POST_STATE_TRASHED = PostStatus.TRASHED.toString()
+
+@RunWith(MockitoJUnitRunner::class)
+class UploadActionUseCaseTest {
+    @get:Rule val rule = InstantTaskExecutorRule()
+
+    @Test
+    fun `auto upload action is DO NOTHING when the post is older than 2 days`() {
+        // Arrange
+        val uploadActionUseCase = createUploadActionUseCase()
+
+        val twoDaysInSeconds = 60 * 60 * 24 * 2
+        val twoDaysAgo = (Date().time / 1000) - twoDaysInSeconds
+
+        val post = createPostModel(dateLocallyChanged = DateTimeUtils.iso8601FromTimestamp(twoDaysAgo))
+        val siteModel: SiteModel = createSiteModel()
+        // Act
+        val action = uploadActionUseCase.getAutoUploadAction(post, siteModel)
+
+        // Assert
+        assertThat(action).isEqualTo(UploadAction.DO_NOTHING)
+    }
+
+    @Test
+    fun `auto upload action is REMOTE_AUTO_SAVE when the post is younger than 2 days and changes are NOT confirmed`() {
+        // Arrange
+        val uploadActionUseCase = createUploadActionUseCase()
+
+        val twoDaysInSeconds = 60 * 60 * 24 * 2
+        val twoDaysAgo = (Date().time / 1000) - twoDaysInSeconds
+
+        val post = createPostModel(
+                dateLocallyChanged = DateTimeUtils.iso8601FromTimestamp(twoDaysAgo + 99),
+                changesConfirmed = false
+        )
+        val siteModel: SiteModel = createSiteModel()
+        // Act
+        val action = uploadActionUseCase.getAutoUploadAction(post, siteModel)
+
+        // Assert
+        assertThat(action).isEqualTo(UploadAction.REMOTE_AUTO_SAVE)
+    }
+
+    @Test
+    fun `auto upload action is UPLOAD when the post is younger than 2 days and changes are confirmed`() {
+        // Arrange
+        val uploadActionUseCase = createUploadActionUseCase()
+
+        val twoDaysInSeconds = 60 * 60 * 24 * 2
+        val twoDaysAgo = (Date().time / 1000) - twoDaysInSeconds
+
+        val post = createPostModel(
+                dateLocallyChanged = DateTimeUtils.iso8601FromTimestamp(twoDaysAgo + 99),
+                changesConfirmed = true
+        )
+        val siteModel: SiteModel = createSiteModel()
+        // Act
+        val action = uploadActionUseCase.getAutoUploadAction(post, siteModel)
+
+        // Assert
+        assertThat(action).isEqualTo(UploadAction.UPLOAD)
+    }
+
+    @Test
+    fun `auto upload action is DO NOTHING when the post is NOT publishable`() {
+        // Arrange
+        val uploadActionUseCase = createUploadActionUseCase(
+                postUtilsWrapper = createdMockedPostUtilsWrapper(
+                        isPublishable = false
+                )
+        )
+
+        val post = createPostModel()
+        val siteModel: SiteModel = createSiteModel()
+        // Act
+        val action = uploadActionUseCase.getAutoUploadAction(post, siteModel)
+
+        // Assert
+        assertThat(action).isEqualTo(UploadAction.DO_NOTHING)
+    }
+
+    @Test
+    fun `auto upload action is REMOTE AUTO SAVE when the post is publishable and the changes are NOT confirmed`() {
+        // Arrange
+        val uploadActionUseCase = createUploadActionUseCase(
+                postUtilsWrapper = createdMockedPostUtilsWrapper(
+                        isPublishable = true
+                )
+        )
+
+        val post = createPostModel(changesConfirmed = false)
+        val siteModel: SiteModel = createSiteModel()
+        // Act
+        val action = uploadActionUseCase.getAutoUploadAction(post, siteModel)
+
+        // Assert
+        assertThat(action).isEqualTo(UploadAction.REMOTE_AUTO_SAVE)
+    }
+
+    @Test
+    fun `auto upload action is UPLOAD when the post is publishable and the changes are confirmed`() {
+        // Arrange
+        val uploadActionUseCase = createUploadActionUseCase(
+                postUtilsWrapper = createdMockedPostUtilsWrapper(
+                        isPublishable = true
+                )
+        )
+
+        val post = createPostModel(changesConfirmed = true)
+        val siteModel: SiteModel = createSiteModel()
+        // Act
+        val action = uploadActionUseCase.getAutoUploadAction(post, siteModel)
+
+        // Assert
+        assertThat(action).isEqualTo(UploadAction.UPLOAD)
+    }
+
+    // add similar methods for the remaining conditions
+
+    private companion object Fixtures {
+        private fun createUploadActionUseCase(
+            uploadStore: UploadStore = createdMockedUploadStore(),
+            postUtilsWrapper: PostUtilsWrapper = createdMockedPostUtilsWrapper(),
+            uploadServiceFacade: UploadServiceFacade = createdMockedUploadServiceFacade()
+        ) = UploadActionUseCase(uploadStore, postUtilsWrapper, uploadServiceFacade)
+
+        private fun createdMockedUploadStore(numberOfPostUploadErrors: Int = 0): UploadStore {
+            val uploadStore: UploadStore = mock()
+            whenever(uploadStore.getNumberOfPostUploadErrorsOrCancellations(any())).thenReturn(numberOfPostUploadErrors)
+            return uploadStore
+        }
+
+        private fun createdMockedPostUtilsWrapper(
+            isPublishable: Boolean = true,
+            isInConflict: Boolean = false
+        ): PostUtilsWrapper {
+            val postUtilsWrapper: PostUtilsWrapper = mock()
+            whenever(postUtilsWrapper.isPublishable(any())).thenReturn(isPublishable)
+            whenever(postUtilsWrapper.isPostInConflictWithRemote(any())).thenReturn(isInConflict)
+            return postUtilsWrapper
+        }
+
+        private fun createdMockedUploadServiceFacade(isPostUploadingOrQueued: Boolean = false): UploadServiceFacade {
+            val uploadServiceFacade: UploadServiceFacade = mock()
+            whenever(uploadServiceFacade.isPostUploadingOrQueued(any())).thenReturn(isPostUploadingOrQueued)
+            return uploadServiceFacade
+        }
+
+        private fun createPostModel(
+            status: String = POST_STATE_DRAFT,
+            isLocalDraft: Boolean = false,
+            isLocallyChanged: Boolean = true,
+            dateLocallyChanged: String = DateTimeUtils.iso8601FromTimestamp(Date().time / 1000),
+            changesConfirmed: Boolean = false
+        ): PostModel = PostModel().apply {
+            this.status = status
+            this.setIsLocalDraft(isLocalDraft)
+            this.setIsLocallyChanged(isLocallyChanged)
+            this.dateLocallyChanged = dateLocallyChanged
+            if (changesConfirmed) {
+                this.changesConfirmedContentHashcode = this.contentHashcode()
+            }
+        }
+
+        private fun createSiteModel(isWpCom: Boolean = true) = SiteModel().apply {
+            setIsWPCom(isWpCom)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds unit tests for UploadActionUseCase class.

To test:
CircleCI will take care of running the tests.

Update release notes:

- There are no user facing changes
