### PR TITLE
Issue/improving mobile desktop previews

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -346,7 +346,13 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
         mViewModel.getPreviewModeSelector().observe(this, new Observer<PreviewModeSelectorStatus>() {
             @Override
             public void onChanged(final @Nullable PreviewModeSelectorStatus previewModelSelectorStatus) {
-                if (previewModelSelectorStatus != null && previewModelSelectorStatus.isVisible()) {
+                if (previewModelSelectorStatus != null) {
+                    mPreviewModeButton.setEnabled(previewModelSelectorStatus.isEnabled());
+
+                    if (!previewModelSelectorStatus.isVisible()) {
+                        return;
+                    }
+
                     mPreviewModeButton.post(new Runnable() {
                         @Override public void run() {
                             int popupWidth = getResources().getDimensionPixelSize(R.dimen.web_preview_mode_popup_width);
@@ -388,6 +394,7 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
                 mWebView.getSettings().setLoadWithOverviewMode(previewMode == PreviewMode.DESKTOP);
                 mWebView.getSettings().setUseWideViewPort(previewMode != PreviewMode.DESKTOP);
                 mWebView.setInitialScale(100);
+                mWebView.reload();
             }
         });
         mViewModel.start();

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -272,7 +272,6 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
                             webPreviewUiState.getActionableEmptyView());
                     mUiHelpers.updateVisibility(mFullScreenProgressLayout,
                             webPreviewUiState.getFullscreenProgressLayoutVisibility());
-                    mUiHelpers.updateVisibility(mWebView, webPreviewUiState.getWebViewVisibility());
                 }
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/wpwebview/WPWebViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/wpwebview/WPWebViewViewModel.kt
@@ -194,12 +194,9 @@ class WPWebViewViewModel
 
     sealed class WebPreviewUiState(
         val fullscreenProgressLayoutVisibility: Boolean = false,
-        val webViewVisibility: Boolean = false,
         val actionableEmptyView: Boolean = false
     ) {
-        object WebPreviewContentUiState : WebPreviewUiState(
-                webViewVisibility = true
-        )
+        object WebPreviewContentUiState : WebPreviewUiState()
 
         object WebPreviewFullscreenProgressUiState : WebPreviewUiState(
                 fullscreenProgressLayoutVisibility = true

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/wpwebview/WPWebViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/wpwebview/WPWebViewViewModel.kt
@@ -77,7 +77,11 @@ class WPWebViewViewModel
         )
 
         _previewMode.value = DEFAULT
-        _previewModeSelector.value = PreviewModeSelectorStatus(false, DEFAULT)
+        _previewModeSelector.value = PreviewModeSelectorStatus(
+                isVisible = false,
+                isEnabled = false,
+                selectedPreviewMode = DEFAULT
+        )
 
         // If there is no internet show the error screen
         if (networkUtils.isNetworkAvailable()) {
@@ -104,6 +108,7 @@ class WPWebViewViewModel
     fun onUrlLoaded() {
         if (uiState.value !is WebPreviewContentUiState) {
             updateUiState(WebPreviewContentUiState)
+            _previewModeSelector.value = _previewModeSelector.value?.copy(isEnabled = true)
         }
         _loadNeeded.value = false
     }
@@ -158,7 +163,7 @@ class WPWebViewViewModel
     }
 
     fun togglePreviewModeSelectorVisibility(isVisible: Boolean) {
-        _previewModeSelector.value = PreviewModeSelectorStatus(isVisible, previewMode.value!!)
+        _previewModeSelector.value = PreviewModeSelectorStatus(isVisible, true, previewMode.value!!)
     }
 
     fun selectPreviewMode(selectedPreviewMode: PreviewMode) {
@@ -166,6 +171,7 @@ class WPWebViewViewModel
             _previewMode.value = selectedPreviewMode
             _navbarUiState.value =
                     navbarUiState.value!!.copy(desktopPreviewHintVisible = selectedPreviewMode == DESKTOP)
+            updateUiState(WebPreviewFullscreenProgressUiState)
         }
     }
 
@@ -180,7 +186,11 @@ class WPWebViewViewModel
         DESKTOP
     }
 
-    data class PreviewModeSelectorStatus(val isVisible: Boolean, val selectedPreviewMode: PreviewMode)
+    data class PreviewModeSelectorStatus(
+        val isVisible: Boolean,
+        val isEnabled: Boolean,
+        val selectedPreviewMode: PreviewMode
+    )
 
     sealed class WebPreviewUiState(
         val fullscreenProgressLayoutVisibility: Boolean = false,

--- a/WordPress/src/main/res/layout/progress_layout.xml
+++ b/WordPress/src/main/res/layout/progress_layout.xml
@@ -5,6 +5,7 @@
     android:id="@+id/progress_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/background_default"
     android:gravity="center"
     android:orientation="vertical">
 

--- a/WordPress/src/main/res/layout/wpwebview_activity.xml
+++ b/WordPress/src/main/res/layout/wpwebview_activity.xml
@@ -41,7 +41,6 @@
             android:layout_height="match_parent"
             android:layout_above="@+id/navbar_container"
             android:layout_alignParentTop="true"
-            android:layout_below="@+id/toolbar"
             tools:visibility="gone"/>
 
         <TextView

--- a/WordPress/src/main/res/layout/wpwebview_activity.xml
+++ b/WordPress/src/main/res/layout/wpwebview_activity.xml
@@ -21,12 +21,6 @@
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
         app:theme="@style/ThemeOverlay.AppCompat.Light"/>
 
-    <include
-        layout="@layout/progress_layout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_below="@+id/toolbar"
-        tools:visibility="gone"/>
 
     <RelativeLayout
         android:id="@+id/preview_container"
@@ -40,6 +34,15 @@
             android:layout_height="match_parent"
             android:layout_above="@+id/navbar_container"
             android:layout_alignParentTop="true"/>
+
+        <include
+            layout="@layout/progress_layout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_above="@+id/navbar_container"
+            android:layout_alignParentTop="true"
+            android:layout_below="@+id/toolbar"
+            tools:visibility="gone"/>
 
         <TextView
             android:id="@+id/desktop_preview_hint"

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/WPWebViewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/WPWebViewViewModelTest.kt
@@ -78,7 +78,7 @@ class WPWebViewViewModelTest {
     }
 
     @Test
-    fun `initially navigation is not enabled, preview mode is set to default and disabled`() {
+    fun `initially navigation is not enabled and preview mode is set to default and disabled`() {
         viewModel.start()
         assertThat(viewModel.navbarUiState.value).isNotNull()
         assertThat(viewModel.navbarUiState.value!!.backNavigationEnabled).isFalse()

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/WPWebViewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/WPWebViewViewModelTest.kt
@@ -63,10 +63,11 @@ class WPWebViewViewModelTest {
     }
 
     @Test
-    fun `show content on UrlLoaded`() {
+    fun `show content on UrlLoaded and enable prview mode switch`() {
         viewModel.start()
         viewModel.onUrlLoaded()
         assertThat(viewModel.uiState.value).isInstanceOf(WebPreviewContentUiState::class.java)
+        assertThat(viewModel.previewModeSelector.value!!.isEnabled).isTrue()
     }
 
     @Test
@@ -77,7 +78,7 @@ class WPWebViewViewModelTest {
     }
 
     @Test
-    fun `initially navigation is not enabled and preview mode is set to default`() {
+    fun `initially navigation is not enabled, preview mode is set to default and disabled`() {
         viewModel.start()
         assertThat(viewModel.navbarUiState.value).isNotNull()
         assertThat(viewModel.navbarUiState.value!!.backNavigationEnabled).isFalse()
@@ -86,6 +87,7 @@ class WPWebViewViewModelTest {
         assertThat(viewModel.previewMode.value).isEqualTo(DEFAULT)
         assertThat(viewModel.previewModeSelector.value).isNotNull()
         assertThat(viewModel.previewModeSelector.value!!.isVisible).isFalse()
+        assertThat(viewModel.previewModeSelector.value!!.isEnabled).isFalse()
         assertThat(viewModel.previewModeSelector.value!!.selectedPreviewMode).isEqualTo(DEFAULT)
     }
 
@@ -215,6 +217,17 @@ class WPWebViewViewModelTest {
         assertThat(previewModeSelectorStatus).isNotNull()
         assertThat(previewModeSelectorStatus!!.isVisible).isTrue()
         assertThat(previewModeSelectorStatus!!.selectedPreviewMode).isEqualTo(DESKTOP)
+    }
+
+    @Test
+    fun `selecting preview mode triggers progress indicator`() {
+        viewModel.start()
+
+        viewModel.selectPreviewMode(DESKTOP)
+        assertThat(viewModel.uiState.value).isInstanceOf(WebPreviewFullscreenProgressUiState::class.java)
+
+        viewModel.onUrlLoaded()
+        assertThat(viewModel.uiState.value).isInstanceOf(WebPreviewContentUiState::class.java)
     }
 
     @Test


### PR DESCRIPTION
This PR improves the accuracy of mobile/desktop preview.
After changing WebView settings we reload a page, which results in a more accurate representation of the layout (especially media items).

Unfortunately, we can't do it while initial page loading is in progress, so the preview model switch is disabled until the first page is loaded.

To test:
- Try site preview with a couple of site with different themes.
- Make sure the preview mode switch is disabled when initial request to load a page is in progress.
- Make sure the preview mode switch is enabled when initial request to load a page is complete.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
