### PR TITLE
Fixes broken desktop preview on some pages

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -388,6 +388,7 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
                 mWebView.getSettings().setLoadWithOverviewMode(previewMode == PreviewMode.DESKTOP);
                 mWebView.getSettings().setUseWideViewPort(previewMode != PreviewMode.DESKTOP);
                 mWebView.setInitialScale(100);
+                mWebView.reload();
             }
         });
         mViewModel.start();


### PR DESCRIPTION
This PR fixes desktop preview on some sites.

<img width="300" alt="desktop-preview" src="https://user-images.githubusercontent.com/2261188/63090447-97219380-bf5b-11e9-8c1e-3e08894fb56e.png">

<img width="150" alt="desktop-preview" src="https://user-images.githubusercontent.com/2261188/63090479-b1f40800-bf5b-11e9-9d95-8e48f42eca76.png">

As you can see the desktop preview on the mobile is broken - there is a huge vertical empty space.

I was curious whether the same thing would happen if I opened the same site in the default system browser and selected "Desktop site". As it turned out the system browser would always reload the page after modifying webview's settings. I tried to use the same approach in the app and it worked;). 

Only downside of this approach is that the site may automatically run "re-arrange" animation which might be interrupted in the middle by the reload. However, the system browser behaves the same way so I don't think we need to worry about it too much.

Default system browser:
<img width="150" alt="desktop-preview" src="https://user-images.githubusercontent.com/2261188/63090741-858cbb80-bf5c-11e9-9f55-dd2f1dd3eeda.gif">



WPAndroid app:
<img width="150" alt="desktop-preview" src="https://user-images.githubusercontent.com/2261188/63090745-87ef1580-bf5c-11e9-883c-3feca5d5094b.gif">


To test:
1. Click on View Site
2. Make sure the site is loaded
3. Switch to desktop view
4. Make sure the site is loaded
5. Switch back to mobile view
6. Make sure the site is loaded

Update release notes:

- The feature hasn't been released yet.


cc @loremattei This is a minor bug imho, but might be worth merging into the frozen branch. Wdyt?
