### PR TITLE
WPWebViewViewModel: Remove log call on WebView errors

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/wpwebview/WPWebViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/wpwebview/WPWebViewViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
-import org.wordpress.android.util.CrashLoggingUtils
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/wpwebview/WPWebViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/wpwebview/WPWebViewViewModel.kt
@@ -113,11 +113,6 @@ class WPWebViewViewModel
      */
     fun onReceivedError() {
         if (uiState.value is WebPreviewContentUiState) {
-            CrashLoggingUtils.log(
-                    IllegalStateException(
-                            "WPWebViewViewModel.onReceivedError() called with uiState WebPreviewContentUiState"
-                    )
-            )
             return
         }
         if (uiState.value !is WebPreviewFullscreenErrorUiState) {


### PR DESCRIPTION
Closes #10191.

This call was causing too many logs in Sentry that caused false positive alarms. As @maxme suggested, I just removed it. 

I was tempted to try and show the empty view or do some caching but decided against it since there is a significant amount of changes coming from the [`master-auto-upload`](https://github.com/wordpress-mobile/WordPress-Android/tree/master-auto-upload) branch which will be merged soon. 

## Testing

Please do a quick regression test on the WebView shown in Post List → View. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.

