### PR TITLE
Fix private post gets published as public

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@ XX.X
 * Add Remote Preview support for posts and pages.
 * Post List: Trashed post must now be restored before edit or preview.
 * All changes to posts and pages will be automatically synced with the server.
+* Clicking on "Publish" on a private post sometimes published the post as public
 
 13.2
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -508,7 +508,9 @@ public class PostUtils {
         // changed the UploadStarter wouldn't upload the post if the only change the user did was clicking on Publish
         // button.
         if (UploadUtils.userCanPublish(site)) {
-            post.setStatus(PostStatus.PUBLISHED.toString());
+            if (PostStatus.fromPost(post) != PostStatus.PRIVATE) {
+                post.setStatus(PostStatus.PUBLISHED.toString());
+            }
         } else {
             post.setStatus(PostStatus.PENDING.toString());
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.util
+package org.wordpress.android.ui.posts
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -9,7 +9,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.model.post.PostStatus.DRAFT
 import org.wordpress.android.fluxc.model.post.PostStatus.PRIVATE
-import org.wordpress.android.ui.posts.PostUtils
 
 @RunWith(MockitoJUnitRunner::class)
 class PostUtilsUnitTest {
@@ -45,8 +44,14 @@ class PostUtilsUnitTest {
 
     @Test
     fun `prepareForPublish updates post status to Publish when on self-hosted site`() {
-        val firstPost = invokePreparePostForPublish(false, isSelfHosted = true)
-        val secondPost = invokePreparePostForPublish(true, isSelfHosted = true)
+        val firstPost = invokePreparePostForPublish(
+                false,
+                isSelfHosted = true
+        )
+        val secondPost = invokePreparePostForPublish(
+                true,
+                isSelfHosted = true
+        )
 
         assertThat(firstPost.status).isEqualTo(PostStatus.PUBLISHED.toString())
         assertThat(secondPost.status).isEqualTo(PostStatus.PUBLISHED.toString())

--- a/WordPress/src/test/java/org/wordpress/android/util/PostUtilsUnitTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/PostUtilsUnitTest.kt
@@ -67,12 +67,14 @@ class PostUtilsUnitTest {
         ): PostModel {
             val post = PostModel()
             post.status = postStatus.toString()
-            val site = SiteModel()
-            site.hasCapabilityPublishPosts = hasCapabilityPublishPosts
-            site.origin = if (isSelfHosted) SiteModel.ORIGIN_XMLRPC else SiteModel.ORIGIN_WPCOM_REST
             if (dateLocallyChanged != null) {
                 post.dateLocallyChanged = dateLocallyChanged
             }
+
+            val site = SiteModel()
+            site.hasCapabilityPublishPosts = hasCapabilityPublishPosts
+            site.origin = if (isSelfHosted) SiteModel.ORIGIN_XMLRPC else SiteModel.ORIGIN_WPCOM_REST
+
             PostUtils.preparePostForPublish(post, site)
             return post
         }

--- a/WordPress/src/test/java/org/wordpress/android/util/PostUtilsUnitTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/PostUtilsUnitTest.kt
@@ -1,0 +1,80 @@
+package org.wordpress.android.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.model.post.PostStatus.DRAFT
+import org.wordpress.android.fluxc.model.post.PostStatus.PRIVATE
+import org.wordpress.android.ui.posts.PostUtils
+
+@RunWith(MockitoJUnitRunner::class)
+class PostUtilsUnitTest {
+    @Test
+    fun `prepareForPublish updates dateLocallyChanged`() {
+        val post = invokePreparePostForPublish()
+        assertThat(post.dateLocallyChanged).isNotEmpty()
+    }
+
+    @Test
+    fun `prepareForPublish marks the post as locally changed`() {
+        val post = invokePreparePostForPublish()
+        assertThat(post.isLocallyChanged).isTrue()
+    }
+
+    @Test
+    fun `prepareForPublish updates changes confirmed hashcode`() {
+        val post = invokePreparePostForPublish()
+        assertThat(post.changesConfirmedContentHashcode).isEqualTo(post.contentHashcode())
+    }
+
+    @Test
+    fun `prepareForPublish updates post status to Pending when the user doesn't have publish rights`() {
+        val post = invokePreparePostForPublish(false)
+        assertThat(post.status).isEqualTo(PostStatus.PENDING.toString())
+    }
+
+    @Test
+    fun `prepareForPublish updates post status to Publish when the user has publish rights`() {
+        val post = invokePreparePostForPublish(true)
+        assertThat(post.status).isEqualTo(PostStatus.PUBLISHED.toString())
+    }
+
+    @Test
+    fun `prepareForPublish updates post status to Publish when on self-hosted site`() {
+        val firstPost = invokePreparePostForPublish(false, isSelfHosted = true)
+        val secondPost = invokePreparePostForPublish(true, isSelfHosted = true)
+
+        assertThat(firstPost.status).isEqualTo(PostStatus.PUBLISHED.toString())
+        assertThat(secondPost.status).isEqualTo(PostStatus.PUBLISHED.toString())
+    }
+
+    @Test
+    fun `prepareForPublish does not change post status when it's a Private post`() {
+        val post = invokePreparePostForPublish(postStatus = PRIVATE)
+        assertThat(post.status).isEqualTo(PostStatus.PRIVATE.toString())
+    }
+
+    private companion object Fixtures {
+        fun invokePreparePostForPublish(
+            hasCapabilityPublishPosts: Boolean = true,
+            isSelfHosted: Boolean = false,
+            postStatus: PostStatus = DRAFT,
+            dateLocallyChanged: String? = null
+        ): PostModel {
+            val post = PostModel()
+            post.status = postStatus.toString()
+            val site = SiteModel()
+            site.hasCapabilityPublishPosts = hasCapabilityPublishPosts
+            site.origin = if (isSelfHosted) SiteModel.ORIGIN_XMLRPC else SiteModel.ORIGIN_WPCOM_REST
+            if (dateLocallyChanged != null) {
+                post.dateLocallyChanged = dateLocallyChanged
+            }
+            PostUtils.preparePostForPublish(post, site)
+            return post
+        }
+    }
+}


### PR DESCRIPTION
Fixes #10365 

I initially thought I'd need to make more changes. But I think this simple change should fix the issue without introducing any side-effects. When the user clicks on Publish and the post has already "Private" status we can simply leave it there and enqueue the post for upload.

To test:
1. Create a private draft in offline and publish it
2. Cancel the auto-upload
3. Click on publish on the post list
4. Enable internet connection
5. Notice the post gets published as Private post


Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.


Note:
I decided to fix the issue in the `master-auto-upload` so we don't create unnecessary conflicts.

## Review Tasks 

- [x] RFC on Snackbar message https://github.com/wordpress-mobile/WordPress-Android/pull/10402#pullrequestreview-277252017
- [x] RFC on unit tests https://github.com/wordpress-mobile/WordPress-Android/pull/10402#pullrequestreview-277252017