### PR TITLE
Remove HistoryListFragment.onSaveInstanceState

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -56,11 +56,6 @@ class HistoryListFragment : Fragment() {
         viewModel.onItemClicked(item)
     }
 
-    override fun onSaveInstanceState(outState: Bundle) {
-        outState.putSerializable(WordPress.SITE, viewModel.site)
-        super.onSaveInstanceState(outState)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 


### PR DESCRIPTION
Fixes #10401.

## Findings

This was caused by the “fix” in #10240. The only way I could think of why this happens is this scenario:

1. The user opens the editor and opens the History page.
2. There's a delay in loading the Post data in `HistoryViewModel`.
3. The user immediately puts the app in the background.
4. State saving kicks in and crashes because the `HistoryViewModel` wasn't fully initialized yet.

I can consistently reproduce this scenario by adding a `delay()`. To do that, change the `val post: PostModel?` line in `HistoryViewModel.create()` to this:

```kt
val post: PostModel? = withContext(bgDispatcher) {
    kotlinx.coroutines.delay(5_000)
    postStore.getPostByLocalPostId(localPostId)
}
```

This adds a 5 second delay of the loading. Turn on _Don't keep activities_ in your device's Developer options. And then perform the steps above. The app should crash.

## Solution

I removed the `onSaveInstanceState` of `HistoryListFragment`. It looks like we do not use that key anyway. We rely on the `Fragment` `arguments` to load the `SiteModel`. Using the `arguments` for state restoration should be enough since they should be [retained automatically](https://developer.android.com/reference/android/app/Fragment.html#setArguments(android.os.Bundle)).

## Testing

Please repeat the steps described in the Findings section and validate that the app does not crash anymore.

## Reviewing

Only 1 reviewer is needed but anyone can review.

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.
