### PR TITLE
UsernameChangerFullScreenDialogFragment made abstract for extensibility

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/accounts/signup/UsernameChangerFullScreenDialogFragmentTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/accounts/signup/UsernameChangerFullScreenDialogFragmentTest.kt
@@ -1,0 +1,160 @@
+package org.wordpress.android.ui.accounts.signup
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.test.InstrumentationRegistry
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.mock
+import dagger.android.AndroidInjector
+import dagger.android.AndroidInjector.Factory
+import dagger.android.DispatchingAndroidInjector
+import dagger.android.DispatchingAndroidInjector_Factory
+import junit.framework.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.wordpress.android.R
+import org.wordpress.android.R.string
+import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.store.AccountStore.OnUsernameSuggestionsFetched
+import org.wordpress.android.support.WPSupportUtils.checkViewHasText
+import org.wordpress.android.ui.FullScreenDialogFragment
+import org.wordpress.android.ui.FullScreenDialogFragment.Builder
+import javax.inject.Provider
+
+/**
+ * Test to verify that the UsernameChanger functionality is still intact.
+ */
+@RunWith(AndroidJUnit4::class)
+class UsernameChangerFullScreenDialogFragmentTest {
+    companion object {
+        const val USERNAME = "john876"
+        const val DISPLAY_NAME = "John"
+        const val USERNAME_TO_BE_SELECTED = "john178"
+        const val USERNAME_ALTERNATIVE = "john1"
+    }
+
+    lateinit var dialog: FullScreenDialogFragment
+    lateinit var fragment: BaseUsernameChangerFullScreenDialogFragment
+    private val suggestions = OnUsernameSuggestionsFetched().apply {
+        suggestions = listOf(USERNAME_TO_BE_SELECTED, USERNAME_ALTERNATIVE)
+    }
+
+    /**
+     * Emulates the behaviour of the dispatcher. Once a request is made for suggestions
+     * and they are returned the fragment is passed the result for processing.
+     */
+    val mockDispatcher: Dispatcher = mock {
+        on { dispatch(any()) } doAnswer {
+            fragment.onUsernameSuggestionsFetched(suggestions)
+        }
+    }
+
+    /**
+     * Utilizes the FragmentActivity as a container to host our fragment in an
+     * isolated environment.
+     */
+    @get:Rule
+    val activityTestRule = object : ActivityTestRule<FragmentActivity>(
+            FragmentActivity::class.java,
+            true,
+            true
+    ) {
+        /**
+         * Replaces the application-wide fragment injector with the test version.
+         */
+        override fun beforeActivityLaunched() {
+            super.beforeActivityLaunched()
+            val wordPressApp = InstrumentationRegistry.getTargetContext().applicationContext as WordPress
+            wordPressApp.setSupportFragmentInjector(
+                    createFakeFragmentInjector<UsernameChangerFullScreenDialogFragment> {
+                        mDispatcher = mockDispatcher
+                    })
+        }
+
+        /**
+         * Opens the dialog in a similar fashion to the production code.
+         */
+        override fun afterActivityLaunched() {
+            super.afterActivityLaunched()
+
+            val bundle = BaseUsernameChangerFullScreenDialogFragment.newBundle(
+                    DISPLAY_NAME, USERNAME
+            )
+
+            dialog = Builder(activity)
+                    .setTitle(string.username_changer_title)
+                    .setAction(string.username_changer_action)
+                    .setOnConfirmListener(null)
+                    .setOnDismissListener(null)
+                    .setContent(UsernameChangerFullScreenDialogFragment::class.java, bundle)
+                    .build()
+
+            dialog.show(activity.supportFragmentManager, FullScreenDialogFragment.TAG)
+            fragment = dialog.content as BaseUsernameChangerFullScreenDialogFragment
+        }
+    }
+
+    @Test
+    fun verifyHeaderTextLiveUpdates() {
+        // Checks to see if see if header's text has the initial username
+        checkViewHasText(
+                onView(withId(R.id.header)), fragment.getHeaderText(
+                USERNAME,
+                DISPLAY_NAME
+        ).toString()
+        )
+
+        // Clicks on the second username suggestion.
+        onView(withId(R.id.suggestions)).perform(
+                RecyclerViewActions.actionOnItemAtPosition<UsernameChangerRecyclerViewAdapter.ViewHolder>(
+                        1,
+                        click()
+                )
+        )
+
+        // Verifies that the username was selected.
+        assertEquals(USERNAME_TO_BE_SELECTED, fragment.mUsernameSelected)
+
+        // Verifies that the header text has updated.
+        checkViewHasText(
+                onView(withId(R.id.header)), fragment.getHeaderText(
+                USERNAME_TO_BE_SELECTED,
+                DISPLAY_NAME
+        ).toString()
+        )
+    }
+
+    /**
+     * Creates a fragment injector that replaces the Application injector and calls
+     * the lambda with the Fragment instance so injection can be done with the mocked instances.
+     *
+     * Inspired by Ronen Sabag
+     * https://proandroiddev.com/fragment-espresso-testing-with-daggers-android-injector-2bd70b6a842d
+     */
+    inline fun <reified F : Fragment> createFakeFragmentInjector(crossinline block: F.() -> Unit): DispatchingAndroidInjector<Fragment> {
+        // obtain the fragment level injector
+        val myApp = InstrumentationRegistry.getTargetContext().applicationContext as WordPress
+        val originalFragmentInjector = myApp.supportFragmentInjector()
+
+        // set the fragment injector which apply the original injector and than apply our block
+        val fragmentInjector = AndroidInjector<Fragment> { fragment ->
+            originalFragmentInjector?.inject(fragment)
+            if (fragment is F) {
+                fragment.block()
+            }
+        }
+        val fragmentFactory = Factory<Fragment> { fragmentInjector }
+        val fragmentMap = mapOf(Pair<Class<*>, Provider<Factory<*>>>(F::class.java, Provider { fragmentFactory }))
+
+        return DispatchingAndroidInjector_Factory.newInstance(fragmentMap, emptyMap())
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/accounts/signup/UsernameChangerFullScreenDialogFragmentTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/accounts/signup/UsernameChangerFullScreenDialogFragmentTest.kt
@@ -139,8 +139,8 @@ class UsernameChangerFullScreenDialogFragmentTest {
      * Inspired by Ronen Sabag
      * https://proandroiddev.com/fragment-espresso-testing-with-daggers-android-injector-2bd70b6a842d
      */
-    inline fun <reified F : Fragment> createFakeFragmentInjector(crossinline block: F.() -> Unit)
-            : DispatchingAndroidInjector<Fragment> {
+    inline fun <reified F : Fragment> createFakeFragmentInjector(crossinline block: F.() -> Unit):
+            DispatchingAndroidInjector<Fragment> {
         // obtain the fragment level injector
         val myApp = InstrumentationRegistry.getTargetContext().applicationContext as WordPress
         val originalFragmentInjector = myApp.supportFragmentInjector()

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/accounts/signup/UsernameChangerFullScreenDialogFragmentTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/accounts/signup/UsernameChangerFullScreenDialogFragmentTest.kt
@@ -42,7 +42,6 @@ class UsernameChangerFullScreenDialogFragmentTest {
         const val USERNAME_ALTERNATIVE = "john1"
     }
 
-    lateinit var dialog: FullScreenDialogFragment
     lateinit var fragment: BaseUsernameChangerFullScreenDialogFragment
     private val suggestions = OnUsernameSuggestionsFetched().apply {
         suggestions = listOf(USERNAME_TO_BE_SELECTED, USERNAME_ALTERNATIVE)
@@ -90,7 +89,7 @@ class UsernameChangerFullScreenDialogFragmentTest {
                     DISPLAY_NAME, USERNAME
             )
 
-            dialog = Builder(activity)
+            val dialog = Builder(activity)
                     .setTitle(string.username_changer_title)
                     .setAction(string.username_changer_action)
                     .setOnConfirmListener(null)
@@ -140,7 +139,8 @@ class UsernameChangerFullScreenDialogFragmentTest {
      * Inspired by Ronen Sabag
      * https://proandroiddev.com/fragment-espresso-testing-with-daggers-android-injector-2bd70b6a842d
      */
-    inline fun <reified F : Fragment> createFakeFragmentInjector(crossinline block: F.() -> Unit): DispatchingAndroidInjector<Fragment> {
+    inline fun <reified F : Fragment> createFakeFragmentInjector(crossinline block: F.() -> Unit)
+            : DispatchingAndroidInjector<Fragment> {
         // obtain the fragment level injector
         val myApp = InstrumentationRegistry.getTargetContext().applicationContext as WordPress
         val originalFragmentInjector = myApp.supportFragmentInjector()

--- a/WordPress/src/debug/AndroidManifest.xml
+++ b/WordPress/src/debug/AndroidManifest.xml
@@ -8,6 +8,8 @@
         tools:replace="android:name,android:supportsRtl"
         android:name=".WordPressDebug"
         android:supportsRtl="true">
+        <activity
+            android:name="androidx.fragment.app.FragmentActivity"/>
     </application>
 
     <!--

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -22,6 +22,7 @@ import android.util.AndroidRuntimeException;
 import android.webkit.WebSettings;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Lifecycle;
@@ -733,6 +734,12 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
 
     @Override public AndroidInjector<Fragment> supportFragmentInjector() {
         return mSupportFragmentInjector;
+    }
+
+    @VisibleForTesting
+    public void setSupportFragmentInjector(
+            DispatchingAndroidInjector<Fragment> supportFragmentInjector) {
+        mSupportFragmentInjector = supportFragmentInjector;
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_START)

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -24,8 +24,8 @@ import org.wordpress.android.ui.accounts.LoginActivity;
 import org.wordpress.android.ui.accounts.LoginEpilogueActivity;
 import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueFragment;
+import org.wordpress.android.ui.accounts.signup.BaseUsernameChangerFullScreenDialogFragment;
 import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment;
-import org.wordpress.android.ui.accounts.signup.UsernameChangerFullScreenDialogFragment;
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailFragment;
 import org.wordpress.android.ui.activitylog.list.ActivityLogListActivity;
 import org.wordpress.android.ui.activitylog.list.ActivityLogListFragment;
@@ -208,7 +208,7 @@ public interface AppComponent extends AndroidInjector<WordPress> {
 
     void inject(SignupEpilogueFragment object);
 
-    void inject(UsernameChangerFullScreenDialogFragment object);
+    void inject(BaseUsernameChangerFullScreenDialogFragment object);
 
     void inject(SiteCreationActivity object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -24,7 +24,6 @@ import org.wordpress.android.ui.accounts.LoginActivity;
 import org.wordpress.android.ui.accounts.LoginEpilogueActivity;
 import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueFragment;
-import org.wordpress.android.ui.accounts.signup.BaseUsernameChangerFullScreenDialogFragment;
 import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment;
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailFragment;
 import org.wordpress.android.ui.activitylog.list.ActivityLogListActivity;
@@ -207,8 +206,6 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(LoginMagicLinkInterceptActivity object);
 
     void inject(SignupEpilogueFragment object);
-
-    void inject(BaseUsernameChangerFullScreenDialogFragment object);
 
     void inject(SiteCreationActivity object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -82,6 +82,7 @@ public abstract class ApplicationModule {
     @ContributesAndroidInjector
     abstract CommentFullScreenDialogFragment contributecommentFullScreenDialogFragment();
 
+    @ContributesAndroidInjector
     abstract UsernameChangerFullScreenDialogFragment contributeUpUsernameChangerFullScreenDialogFragment();
 
     @Provides

--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import androidx.lifecycle.LiveData;
 
 import org.wordpress.android.ui.CommentFullScreenDialogFragment;
+import org.wordpress.android.ui.accounts.signup.UsernameChangerFullScreenDialogFragment;
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsFragment.CountryPickerDialogFragment;
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsFragment.StatePickerDialogFragment;
 import org.wordpress.android.ui.news.LocalNewsService;
@@ -18,8 +19,8 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListFragment;
 import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailFragment;
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.management.InsightsManagementFragment;
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetColorSelectionDialogFragment;
-import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetDataTypeSelectionDialogFragment;
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment;
+import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetDataTypeSelectionDialogFragment;
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetSiteSelectionDialogFragment;
 import org.wordpress.android.ui.stats.refresh.lists.widget.minified.StatsMinifiedWidgetConfigureFragment;
 import org.wordpress.android.util.wizard.WizardManager;
@@ -81,8 +82,11 @@ public abstract class ApplicationModule {
     @ContributesAndroidInjector
     abstract CommentFullScreenDialogFragment contributecommentFullScreenDialogFragment();
 
+    abstract UsernameChangerFullScreenDialogFragment contributeUpUsernameChangerFullScreenDialogFragment();
+
     @Provides
-    public static WizardManager<SiteCreationStep> provideWizardManager(SiteCreationStepsProvider stepsProvider) {
+    public static WizardManager<SiteCreationStep> provideWizardManager(
+            SiteCreationStepsProvider stepsProvider) {
         return new WizardManager<>(stepsProvider.getSteps());
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
@@ -18,7 +18,6 @@ import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
-import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.SimpleItemAnimator;
@@ -28,7 +27,6 @@ import com.google.android.material.textfield.TextInputEditText;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.R;
-import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.Dispatcher;
@@ -48,11 +46,13 @@ import java.util.Locale;
 
 import javax.inject.Inject;
 
+import dagger.android.support.DaggerFragment;
+
 /**
  * Created so that the base suggestions functionality can become shareable as similar functionality is being used in the
  * the Account settings & sign-up flow to change the username.
  */
-public abstract class BaseUsernameChangerFullScreenDialogFragment extends Fragment implements
+public abstract class BaseUsernameChangerFullScreenDialogFragment extends DaggerFragment implements
         FullScreenDialogContent, OnUsernameSelectedListener {
     private ProgressBar mProgressBar;
 
@@ -113,12 +113,6 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Fragme
         bundle.putString(EXTRA_DISPLAY_NAME, displayName);
         bundle.putString(EXTRA_USERNAME, username);
         return bundle;
-    }
-
-    @Override
-    public void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        ((WordPress) getActivity().getApplication()).component().inject(this);
     }
 
     @Nullable

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
@@ -30,6 +30,7 @@ import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore.FetchUsernameSuggestionsPayload;
@@ -47,7 +48,11 @@ import java.util.Locale;
 
 import javax.inject.Inject;
 
-public class UsernameChangerFullScreenDialogFragment extends Fragment implements
+/**
+ * Created so that the base suggestions functionality can become shareable as similar functionality is being used in the
+ * the Account settings & sign-up flow to change the username.
+ */
+public abstract class BaseUsernameChangerFullScreenDialogFragment extends Fragment implements
         FullScreenDialogContent, OnUsernameSelectedListener {
     private ProgressBar mProgressBar;
 
@@ -77,6 +82,31 @@ public class UsernameChangerFullScreenDialogFragment extends Fragment implements
     public static final int GET_SUGGESTIONS_INTERVAL_MS = 1000;
 
     @Inject protected Dispatcher mDispatcher;
+
+    /**
+     * Fragments that extend this class are required to provide the event that should be
+     * tracked in case fetching of the username suggestions fail.
+     *
+     * @return {@link Stat}
+     */
+    abstract Stat getSuggestionsFailedStat();
+
+    /**
+     * Specifies if the header text should be updated when a new username is selected
+     * or if the the initial username should remain.
+     *
+     * @return true or false
+     */
+    abstract boolean canHeaderTextLiveUpdate();
+
+    /**
+     * Creates the text that's displayed in the header.
+     *
+     * @param username
+     * @param display
+     * @return formatted header template
+     */
+    abstract Spanned getHeaderText(String username, String display);
 
     protected static Bundle newBundle(String displayName, String username) {
         Bundle bundle = new Bundle();
@@ -152,7 +182,9 @@ public class UsernameChangerFullScreenDialogFragment extends Fragment implements
             @Override
             public void afterTextChanged(Editable s) {
                 if (s.toString().trim().isEmpty()) {
-                    mHeaderView.setText(getHeaderText(getUsernameOrSelected(), mDisplayName));
+                    if (canHeaderTextLiveUpdate()) {
+                        mHeaderView.setText(getHeaderText(getUsernameOrSelected(), mDisplayName));
+                    }
                     mGetSuggestionsHandler.removeCallbacks(mGetSuggestionsRunnable);
                 } else if (mShouldWatchText) {
                     mGetSuggestionsHandler.removeCallbacks(mGetSuggestionsRunnable);
@@ -225,23 +257,11 @@ public class UsernameChangerFullScreenDialogFragment extends Fragment implements
 
     @Override
     public void onUsernameSelected(String username) {
-        mHeaderView.setText(getHeaderText(username, mDisplayName));
+        if (canHeaderTextLiveUpdate()) {
+            mHeaderView.setText(getHeaderText(username, mDisplayName));
+        }
         mUsernameSelected = username;
         mUsernameSelectedIndex = mUsernamesAdapter.getSelectedItem();
-    }
-
-    protected Spanned getHeaderText(String username, String display) {
-        return Html.fromHtml(
-                String.format(
-                        getString(R.string.username_changer_header),
-                        "<b>",
-                        username,
-                        "</b>",
-                        "<b>",
-                        display,
-                        "</b>"
-                             )
-                            );
     }
 
     protected String getUsernameOrSelected() {
@@ -281,7 +301,7 @@ public class UsernameChangerFullScreenDialogFragment extends Fragment implements
 
     private void setUsernameSuggestions(List<String> suggestions) {
         mUsernamesAdapter = new UsernameChangerRecyclerViewAdapter(getActivity(), suggestions);
-        mUsernamesAdapter.setOnUsernameSelectedListener(UsernameChangerFullScreenDialogFragment.this);
+        mUsernamesAdapter.setOnUsernameSelectedListener(BaseUsernameChangerFullScreenDialogFragment.this);
         mUsernamesAdapter.setSelectedItem(mUsernameSelectedIndex);
         mUsernameSuggestions.setAdapter(mUsernamesAdapter);
     }
@@ -292,19 +312,19 @@ public class UsernameChangerFullScreenDialogFragment extends Fragment implements
         new AlertDialog.Builder(new ContextThemeWrapper(getContext(), R.style.LoginTheme))
                 .setMessage(R.string.username_changer_dismiss_message)
                 .setPositiveButton(R.string.username_changer_dismiss_button_positive,
-                                   new DialogInterface.OnClickListener() {
-                                       @Override
-                                       public void onClick(DialogInterface dialog, int which) {
-                                           mDialogController.dismiss();
-                                       }
-                                   })
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                mDialogController.dismiss();
+                            }
+                        })
                 .setNegativeButton(android.R.string.cancel,
-                                   new DialogInterface.OnClickListener() {
-                                       @Override
-                                       public void onClick(DialogInterface dialog, int which) {
-                                           mIsShowingDismissDialog = false;
-                                       }
-                                   })
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                mIsShowingDismissDialog = false;
+                            }
+                        })
                 .show();
     }
 
@@ -327,7 +347,7 @@ public class UsernameChangerFullScreenDialogFragment extends Fragment implements
         showProgress(false);
 
         if (event.isError()) {
-            AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_SOCIAL_EPILOGUE_USERNAME_SUGGESTIONS_FAILED);
+            AnalyticsTracker.track(getSuggestionsFailedStat());
             AppLog.e(T.API, "onUsernameSuggestionsFetched: " + event.error.type + " - " + event.error.message);
             showErrorDialog(new SpannedString(getString(R.string.username_changer_error_generic)));
         } else if (event.suggestions.size() == 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/UsernameChangerFullScreenDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/UsernameChangerFullScreenDialogFragment.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.ui.accounts.signup
+
+import android.text.Html
+import android.text.Spanned
+import org.wordpress.android.R
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.SIGNUP_SOCIAL_EPILOGUE_USERNAME_SUGGESTIONS_FAILED
+
+/**
+ * Implements functionality specific to the Username Changer functionality in the sign-up flow.
+ */
+class UsernameChangerFullScreenDialogFragment : BaseUsernameChangerFullScreenDialogFragment() {
+    override fun getSuggestionsFailedStat() = SIGNUP_SOCIAL_EPILOGUE_USERNAME_SUGGESTIONS_FAILED
+    override fun canHeaderTextLiveUpdate() = true
+    override fun getHeaderText(username: String?, display: String?): Spanned = Html.fromHtml(
+            String.format(
+                    getString(R.string.username_changer_header),
+                    "<b>",
+                    username,
+                    "</b>",
+                    "<b>",
+                    display,
+                    "</b>"
+            )
+    ) }


### PR DESCRIPTION
Fixes #8002 
This is the second PR in the series that will be implementing the change username functionality.

**Background**

I made the `UsernameChangerFullScreenDialogFragment` abstract and added abstract methods so that the sign-up flow would have an implementation of it that retains the existing functionality while the new functionality for changing of the username in Account Settings would be able to create its own header behavior.

The main difference between the two components is as follows. 

**Sign-up Username Changer**

- The header text should live update as the options are selected.
- The header text should contain both the username and display name. 

**Account Settings Username Changer**

- The header text shouldn't update as the options are selected. 
- The header text template will be similar to that of iOS.

Main Changes 

- Abstract methods `canHeaderTextLiveUpdate()`, `getSuggestionsFailedStat()`, `getHeaderText(username,display)` were created.

- `UsernameChangerFullScreenDialogFragment` implemented the above methods by extending `BaseUsernameChangerFullScreenDialogFragment`

**Testing**

**WPAndroid**
Since the sign-up flow can't be reached in debug mode, the easiest way to test based on @theck13 suggestion is to modify the `LoginActivity` to go to the signup screen. 
I did this modification at [line 240](https://github.com/wordpress-mobile/WordPress-Android/blob/f76d724af0c3fa8e4b32224b12bafc5a7fbe201b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java#L240)

```kotlin 
private void loggedInAndFinish(ArrayList<Integer> oldSitesIds, boolean doLoginUpdate) {
    ActivityLauncher.showMainActivityAndSignupEpilogue(this, "John", "John Doe", "fake_url","johndoe876");
  ... rest of function commented out.
```
There's probably an easier way to do it, but I was hoping that doing it after login would give me a token so I could make changes. 

A gif of the behaviour when tested : 

![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/1509205/63246330-0cc18400-c228-11e9-8481-37665089be0f.gif)

**UI Tests** 
I wrote an Espresso test that created an environment where the fragment could be spun up in isolation in an activity container with a mocked instance of the `dispatcher`. The test basically verifies that the functionality that has been modified is still intact and it will be instrumental in verifying the behavior of the followup settings username changer fragment. 

Main Changes 
To accomplish this these were the steps: 

- The fragment injector on the application class was given a setter so that it could be replaced with a test variant. 
- A `FragmentActivity` element was added to the debug manifest so that a registered activity would be available as a container. 
- `@ContributesAndroidInjector` and `DaggerFragment` was utilized for the fragment DI so the [injector could be replaced easily](https://proandroiddev.com/fragment-espresso-testing-with-daggers-android-injector-2bd70b6a842d) and the mocked `dispatcher` could be injected.  

Update release notes:

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.
