### PR TITLE
Increase offscreen page limit to fix crash in history

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -554,7 +554,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // Set up the ViewPager with the sections adapter.
         mViewPager = findViewById(R.id.pager);
         mViewPager.setAdapter(mSectionsPagerAdapter);
-        mViewPager.setOffscreenPageLimit(3);
+        mViewPager.setOffscreenPageLimit(4);
         mViewPager.setPagingEnabled(false);
 
         // When swiping between different sections, select the corresponding tab. We can also use ActionBar.Tab#select()


### PR DESCRIPTION
Fixes #10407

The Offscreen page limit in the Edit post activity was 3 but we increased the number of pages in the adapter to 5, that causes the editor not to load when the history is the last page visible (editor has index 0, history 4. 

To test:
* Turn on Don't keep activities in the device's Developer Options.
* Run the app using the release/13.1 branch.
* Edit a published post.
* Navigate to Options → History.
* While the History is open, place the app in the background.
* Open the app again. It doesn't crash.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
