### PR TITLE
Added dismissAfterConfirm flag to FullScreenDialogFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
@@ -47,10 +47,12 @@ public class FullScreenDialogFragment extends DialogFragment {
     private String mTitle;
     private Toolbar mToolbar;
     private boolean mHideActivityBar;
+    private boolean mDismissAfterConfirm;
     private int mToolbarColor;
 
     private static final String ARG_ACTION = "ARG_ACTION";
     private static final String ARG_HIDE_ACTIVITY_BAR = "ARG_HIDE_ACTIVITY_BAR";
+    private static final String ARG_DISMISS_AFTER_CONFIRM = "ARG_DISMISS_AFTER_CONFIRM";
     private static final String ARG_SUBTITLE = "ARG_SUBTITLE";
     private static final String ARG_TITLE = "ARG_TITLE";
     private static final String ARG_TOOLBAR_COLOR = "ARG_TOOLBAR_COLOR";
@@ -87,6 +89,7 @@ public class FullScreenDialogFragment extends DialogFragment {
         dialog.setOnConfirmListener(builder.mOnConfirmListener);
         dialog.setOnDismissListener(builder.mOnDismissListener);
         dialog.setHideActivityBar(builder.mHideActivityBar);
+        dialog.setDismissAfterConfirm(builder.mDismissAfterConfirm);
         return dialog;
     }
 
@@ -97,6 +100,7 @@ public class FullScreenDialogFragment extends DialogFragment {
         bundle.putString(ARG_SUBTITLE, builder.mSubtitle);
         bundle.putInt(ARG_TOOLBAR_COLOR, builder.mToolbarColor);
         bundle.putBoolean(ARG_HIDE_ACTIVITY_BAR, builder.mHideActivityBar);
+        bundle.putBoolean(ARG_DISMISS_AFTER_CONFIRM, builder.mDismissAfterConfirm);
         return bundle;
     }
 
@@ -207,7 +211,9 @@ public class FullScreenDialogFragment extends DialogFragment {
             mOnConfirmListener.onConfirm(result);
         }
 
-        dismiss();
+        if (mDismissAfterConfirm) {
+            dismiss();
+        }
     }
 
     /**
@@ -244,6 +250,7 @@ public class FullScreenDialogFragment extends DialogFragment {
         mSubtitle = bundle.getString(ARG_SUBTITLE);
         mToolbarColor = bundle.getInt(ARG_TOOLBAR_COLOR);
         mHideActivityBar = bundle.getBoolean(ARG_HIDE_ACTIVITY_BAR);
+        mDismissAfterConfirm = bundle.getBoolean(ARG_DISMISS_AFTER_CONFIRM);
     }
 
     /**
@@ -367,6 +374,15 @@ public class FullScreenDialogFragment extends DialogFragment {
     }
 
     /**
+     * Set flag to dismiss fragment after confirm action is clicked.
+     *
+     * @param dismissAfterConfirm boolean to dismiss after confirm click.
+     */
+    public void setDismissAfterConfirm(boolean dismissAfterConfirm) {
+        mDismissAfterConfirm = dismissAfterConfirm;
+    }
+
+    /**
      * Set theme background for {@link FullScreenDialogFragment} view.
      *
      * @param view {@link View} to set background
@@ -412,6 +428,7 @@ public class FullScreenDialogFragment extends DialogFragment {
         String mSubtitle = "";
         String mTitle = "";
         boolean mHideActivityBar = false;
+        boolean mDismissAfterConfirm = true;
         int mToolbarColor = R.color.primary;
 
         /**
@@ -480,6 +497,17 @@ public class FullScreenDialogFragment extends DialogFragment {
          */
         public Builder setHideActivityBar(boolean hide) {
             this.mHideActivityBar = hide;
+            return this;
+        }
+
+        /**
+         * Set flag to dismiss the fragment after confirm action is clicked.
+         *
+         * @param dismiss boolean to dismiss the fragment after confirm click.
+         * @return {@link Builder} object to allow for chaining of calls to set methods
+         */
+        public Builder setDismissAferConfirm(boolean dismiss) {
+            this.mDismissAfterConfirm = dismiss;
             return this;
         }
 


### PR DESCRIPTION
Fixes #8002 
 
**Background**

The `dismissAfterConfirm` flag will determine if the dialog will be dismissed after the confirm action is clicked. Its default behavior is to dismiss after confirm since the existing implementations utilize this. 

This change is being made because the username changer will need to show a confirmation & progress dialog and the result of the associated operations will determine if the dialog should be dismissed or not. 

Main Changes

The builder now has a parameter for the flag, and this is how the functionality is initiated. 

```kotlin
 new FullScreenDialogFragment.Builder(getContext())
                .setTitle(R.string.username_changer_title)
                .setAction(R.string.username_changer_action)
                .setOnConfirmListener(this)
                .setOnDismissListener(this)
                .setDismissAferConfirm(false) // this is the flag.
                .setContent(UsernameChangerFullScreenDialogFragment.class, bundle)
                .build(); 
```

**Testing**

1. Use the same methods described in the **WP Android** block of the [abstract username fragment PR](https://github.com/wordpress-mobile/WordPress-Android/pull/10409) description to access the suggestions screen easily.

2. Simply modify the builder that's used to launch the dialog in the [SignUpEpilogueFragment](https://github.com/wordpress-mobile/WordPress-Android/blob/3960b58c928fb13dceeabb51297fda0c8361f702/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java#L542) with the `dismissAfterConfirm ` flag similar to the example above. 

The result of this will be that clicking the **Save** action will do nothing. 
Notice in the example below that the ripple effect signifying the click is shown on the **Save** action but no dismissal occurs.

**Left**  - Default behaviour.   **Right** -  Dismiss disabled. 
( Sorry for the differences in screen size. Utilized two different devices when testing :sweat_smile:)

![left](https://user-images.githubusercontent.com/1509205/63315682-c163b000-c2d1-11e9-85b2-b593dcbc8aed.gif) ![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/1509205/63315688-ca548180-c2d1-11e9-8d81-2616d2b2555d.gif)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
