### PR TITLE
Refresh widgets on stats refresh

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCase.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Value
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.OverviewUseCase.UiState
+import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater.StatsWidgetUpdaters
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
@@ -38,6 +39,7 @@ constructor(
     private val overviewMapper: OverviewMapper,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val statsWidgetUpdaters: StatsWidgetUpdaters,
     private val resourceProvider: ResourceProvider
 ) : BaseStatsUseCase<VisitsAndViewsModel, UiState>(
         OVERVIEW,
@@ -61,6 +63,7 @@ constructor(
             )
 
     override suspend fun loadCachedData(): VisitsAndViewsModel? {
+        statsWidgetUpdaters.updateViewsWidget(statsSiteProvider.siteModel.siteId)
         return visitsAndViewsStore.getVisits(
                 statsSiteProvider.siteModel,
                 statsGranularity,
@@ -175,6 +178,7 @@ constructor(
         private val overviewMapper: OverviewMapper,
         private val visitsAndViewsStore: VisitsAndViewsStore,
         private val analyticsTracker: AnalyticsTrackerWrapper,
+        private val statsWidgetUpdaters: StatsWidgetUpdaters,
         private val resourceProvider: ResourceProvider
     ) : GranularUseCaseFactory {
         override fun build(granularity: StatsGranularity, useCaseMode: UseCaseMode) =
@@ -187,6 +191,7 @@ constructor(
                         overviewMapper,
                         mainDispatcher,
                         analyticsTracker,
+                        statsWidgetUpdaters,
                         resourceProvider
                 )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AllTimeStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AllTimeStatsUseCase.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.QuickScanItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.QuickScanItem.Column
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
+import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater.StatsWidgetUpdaters
 import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
@@ -26,6 +27,7 @@ class AllTimeStatsUseCase
     private val allTimeStore: AllTimeInsightsStore,
     private val statsSiteProvider: StatsSiteProvider,
     private val statsDateFormatter: StatsDateFormatter,
+    private val statsWidgetUpdaters: StatsWidgetUpdaters,
     private val popupMenuHandler: ItemPopupMenuHandler
 ) : StatelessUseCase<InsightsAllTimeModel>(ALL_TIME_STATS, mainDispatcher) {
     override fun buildLoadingItem(): List<BlockListItem> = listOf(Title(R.string.stats_insights_all_time_stats))
@@ -35,6 +37,7 @@ class AllTimeStatsUseCase
     }
 
     override suspend fun loadCachedData(): InsightsAllTimeModel? {
+        statsWidgetUpdaters.updateAllTimeWidget(statsSiteProvider.siteModel.siteId)
         return allTimeStore.getAllTimeInsights(statsSiteProvider.siteModel)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TodayStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TodayStatsUseCase.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.QuickScanItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.QuickScanItem.Column
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
+import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater.StatsWidgetUpdaters
 import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
@@ -25,9 +26,11 @@ class TodayStatsUseCase
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     private val todayStore: TodayInsightsStore,
     private val statsSiteProvider: StatsSiteProvider,
+    private val statsWidgetUpdaters: StatsWidgetUpdaters,
     private val popupMenuHandler: ItemPopupMenuHandler
 ) : StatelessUseCase<VisitsModel>(TODAY_STATS, mainDispatcher) {
     override suspend fun loadCachedData(): VisitsModel? {
+        statsWidgetUpdaters.updateTodayWidget(statsSiteProvider.siteModel.siteId)
         return todayStore.getTodayInsights(statsSiteProvider.siteModel)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/WidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/WidgetUpdater.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.stats.refresh.lists.widget
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.AllTimeWidgetUpdater
 import org.wordpress.android.ui.stats.refresh.lists.widget.minified.MinifiedWidgetUpdater
 import org.wordpress.android.ui.stats.refresh.lists.widget.today.TodayWidgetUpdater
@@ -22,10 +23,12 @@ interface WidgetUpdater {
 
     class StatsWidgetUpdaters
     @Inject constructor(
-        viewsWidgetUpdater: ViewsWidgetUpdater,
-        allTimeWidgetUpdater: AllTimeWidgetUpdater,
-        todayWidgetUpdater: TodayWidgetUpdater,
-        minifiedWidgetUpdater: MinifiedWidgetUpdater
+        private val viewsWidgetUpdater: ViewsWidgetUpdater,
+        private val allTimeWidgetUpdater: AllTimeWidgetUpdater,
+        private val todayWidgetUpdater: TodayWidgetUpdater,
+        private val minifiedWidgetUpdater: MinifiedWidgetUpdater,
+        private val appPrefsWrapper: AppPrefsWrapper,
+        private val context: Context
     ) {
         private val widgetUpdaters = listOf(
                 viewsWidgetUpdater,
@@ -40,6 +43,32 @@ interface WidgetUpdater {
                 val allWidgetIds = appWidgetManager.getAppWidgetIds(it.componentName(context))
                 for (appWidgetId in allWidgetIds) {
                     it.updateAppWidget(context, appWidgetId, appWidgetManager)
+                }
+            }
+        }
+
+        fun updateViewsWidget(siteId: Long) {
+            viewsWidgetUpdater.update(siteId)
+        }
+
+        fun updateTodayWidget(siteId: Long) {
+            todayWidgetUpdater.update(siteId)
+            minifiedWidgetUpdater.update(siteId)
+        }
+
+        fun updateAllTimeWidget(siteId: Long) {
+            allTimeWidgetUpdater.update(siteId)
+        }
+
+        private fun WidgetUpdater.update(
+            siteId: Long
+        ) {
+            val appWidgetManager = AppWidgetManager.getInstance(context)
+            val allWidgetIds = appWidgetManager.getAppWidgetIds(this.componentName(context))
+            for (appWidgetId in allWidgetIds) {
+                val widgetSiteId = appPrefsWrapper.getAppWidgetSiteId(appWidgetId)
+                if (siteId == widgetSiteId) {
+                    this.updateAppWidget(context, appWidgetId, appWidgetManager)
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
@@ -144,6 +144,7 @@ class WidgetUtils
                 listIntent.toUri(Intent.URI_INTENT_SCHEME)
         )
         views.setRemoteAdapter(R.id.widget_content, listIntent)
+        appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetId, R.id.widget_content)
         appWidgetManager.updateAppWidget(appWidgetId, views)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewUseCaseTest.kt
@@ -3,6 +3,8 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.isNull
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
@@ -29,6 +31,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarCh
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Columns
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
+import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater.StatsWidgetUpdaters
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -42,12 +45,14 @@ class OverviewUseCaseTest : BaseUnitTest() {
     @Mock lateinit var overviewMapper: OverviewMapper
     @Mock lateinit var statsSiteProvider: StatsSiteProvider
     @Mock lateinit var resourceProvider: ResourceProvider
-    @Mock lateinit var site: SiteModel
     @Mock lateinit var columns: Columns
     @Mock lateinit var title: ValueItem
     @Mock lateinit var barChartItem: BarChartItem
     @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    @Mock lateinit var statsWidgetUpdaters: StatsWidgetUpdaters
     private lateinit var useCase: OverviewUseCase
+    private val site = SiteModel()
+    private val siteId = 1L
     private val periodData = PeriodData("2018-10-08", 10, 15, 20, 25, 30, 35)
     private val modelPeriod = "2018-10-10"
     private val limitMode = Top(15)
@@ -66,8 +71,10 @@ class OverviewUseCaseTest : BaseUnitTest() {
                 overviewMapper,
                 Dispatchers.Unconfined,
                 analyticsTrackerWrapper,
+                statsWidgetUpdaters,
                 resourceProvider
         )
+        site.siteId = siteId
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         whenever(selectedDateProvider.getCurrentDate()).thenReturn(currentDate)
         whenever(overviewMapper.buildTitle(any(), isNull(), any(), any(), any(), any())).thenReturn(title)
@@ -95,6 +102,7 @@ class OverviewUseCaseTest : BaseUnitTest() {
             assertThat(this[1]).isEqualTo(barChartItem)
             assertThat(this[2]).isEqualTo(columns)
         }
+        verify(statsWidgetUpdaters, times(2)).updateViewsWidget(siteId)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AllTimeStatsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AllTimeStatsUseCaseTest.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases
 
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
@@ -23,6 +25,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.Us
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.QuickScanItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
+import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater.StatsWidgetUpdaters
 import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
@@ -32,10 +35,12 @@ class AllTimeStatsUseCaseTest : BaseUnitTest() {
     @Mock lateinit var statsDateFormatter: StatsDateFormatter
     @Mock lateinit var statsSiteProvider: StatsSiteProvider
     @Mock lateinit var popupMenuHandler: ItemPopupMenuHandler
-    @Mock lateinit var site: SiteModel
+    @Mock lateinit var statsWidgetUpdaters: StatsWidgetUpdaters
+    private val site = SiteModel()
     private lateinit var useCase: AllTimeStatsUseCase
     private val bestDay = "2018-11-25"
     private val bestDayTransformed = "Nov 25, 2018"
+    private val siteId = 1L
     @Before
     fun setUp() {
         useCase = AllTimeStatsUseCase(
@@ -43,8 +48,10 @@ class AllTimeStatsUseCaseTest : BaseUnitTest() {
                 insightsStore,
                 statsSiteProvider,
                 statsDateFormatter,
+                statsWidgetUpdaters,
                 popupMenuHandler
         )
+        site.siteId = siteId
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         whenever(statsDateFormatter.printDate(bestDay)).thenReturn(bestDayTransformed)
     }
@@ -128,6 +135,7 @@ class AllTimeStatsUseCaseTest : BaseUnitTest() {
             assertThat(this.endColumn.value).isEqualTo(viewsBestDayTotal.toString())
             assertThat(this.endColumn.tooltip).isEqualTo(bestDayTransformed)
         }
+        verify(statsWidgetUpdaters, times(2)).updateAllTimeWidget(siteId)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TodayStatsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TodayStatsUseCaseTest.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases
 
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
@@ -23,6 +25,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Quick
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.QUICK_SCAN_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
+import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater.StatsWidgetUpdaters
 import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 
@@ -30,20 +33,24 @@ class TodayStatsUseCaseTest : BaseUnitTest() {
     @Mock lateinit var insightsStore: TodayInsightsStore
     @Mock lateinit var statsSiteProvider: StatsSiteProvider
     @Mock lateinit var popupMenuHandler: ItemPopupMenuHandler
-    @Mock lateinit var site: SiteModel
+    @Mock lateinit var statsWidgetUpdaters: StatsWidgetUpdaters
     private lateinit var useCase: TodayStatsUseCase
     private val views = 10
     private val visitors = 15
     private val likes = 20
     private val comments = 30
+    private val site = SiteModel()
+    private val siteId = 1L
     @Before
     fun setUp() {
         useCase = TodayStatsUseCase(
                 Dispatchers.Unconfined,
                 insightsStore,
                 statsSiteProvider,
+                statsWidgetUpdaters,
                 popupMenuHandler
         )
+        site.siteId = siteId
         whenever(statsSiteProvider.siteModel).thenReturn(site)
     }
 
@@ -69,6 +76,7 @@ class TodayStatsUseCaseTest : BaseUnitTest() {
             assertViewsAndVisitors(this[1])
             assertLikesAndComments(this[2])
         }
+        verify(statsWidgetUpdaters, times(2)).updateTodayWidget(siteId)
     }
 
     @Test


### PR DESCRIPTION
Fixes #10262

This PR should update the widgets when either the Overview, Today or All-time card loads new data. The actual magic is this line `appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetId, R.id.widget_content)` which lets the widget redraw once it gets visible. 

To test:
* Add a widget (the `Weekly Views` is the easiest one to test)
* Check today's views
* Check that there is a matching value in the Stats in the app (in the Overview card)
* Visit the site (to increase the views)
* Go to the Stats
* Refresh the data
* The `Views` are increased by 1
* Check the widget
* The widget value is the same as in the Stats

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
