### PR TITLE
Update release toolkit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: c555066402074a527a9853932790da8198eb7f21
-  tag: 0.6.0
+  revision: b57127b313fd06519cbebfd4a3f6784eec1ef5fc
+  tag: 0.7.1
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.6.0)
+    fastlane-plugin-wpmreleasetoolkit (0.7.1)
       diffy (~> 3.3)
       git (~> 1.3)
       jsonlint
-      nokogiri (= 1.10.1)
+      nokogiri (>= 1.10.4)
       octokit (~> 4.13)
       parallel (~> 1.14)
       progress_bar (~> 1.3)
@@ -127,11 +127,11 @@ GEM
     multipart-post (2.0.0)
     nanaimo (0.2.6)
     naturally (2.2.0)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.8.0)
+    oj (3.9.0)
     optimist (3.0.0)
     options (2.3.2)
     os (1.0.1)
@@ -141,7 +141,7 @@ GEM
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
     public_suffix (2.0.5)
-    rake (12.3.2)
+    rake (12.3.3)
     rake-compiler (1.0.7)
       rake
     representable (3.0.4)

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.6.0' 
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.7.1' 
 
 
 


### PR DESCRIPTION
This PR update `release-tookit` in order to fix a bug with `new_betar_release` action where the `versionCode` for `alpha` versions was not correctly evaluated during the pre-checks.

Note that the bug affects only the initial prompt: the version shown during the prompt was wrong, but the one actually put in `build.gradle` was already right. 

### To Test

1. Run `bundle install`.
2. Run `bundle exec fastlane new_beta_release`.
3. When prompted, verify that the `versionCode` shown for the `alpha` release is right.
4. Answer `n`, as the actual version update was not affected by the bug.


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
