### PR TITLE
AS 3.5: Update main style config and project config

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -14,6 +14,8 @@
           <value>
             <package name="android" withSubpackages="true" static="false" />
             <emptyLine />
+            <package name="androidx" withSubpackages="true" static="false" />
+            <emptyLine />
             <package name="com" withSubpackages="true" static="false" />
             <emptyLine />
             <package name="junit" withSubpackages="true" static="false" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,18 +1,13 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="USE_CUSTOM_SETTINGS" value="true" />
-    </AndroidXmlCodeStyleSettings>
+    <option name="RIGHT_MARGIN" value="120" />
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />
       <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />
       <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
-      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
-      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
-      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
-        <value />
-      </option>
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
           <package name="android" withSubpackages="true" static="false" />
@@ -31,10 +26,7 @@
           <emptyLine />
           <package name="javax" withSubpackages="true" static="false" />
           <emptyLine />
-          <package name="" withSubpackages="true" static="false" />
-          <emptyLine />
           <package name="" withSubpackages="true" static="true" />
-          <emptyLine />
         </value>
       </option>
     </JavaCodeStyleSettings>
@@ -54,9 +46,9 @@
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
     <codeStyleSettings language="JAVA">
+      <option name="RIGHT_MARGIN" value="120" />
       <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
       <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
-      <option name="ALIGN_MULTILINE_METHOD_BRACKETS" value="true" />
       <option name="CALL_PARAMETERS_WRAP" value="1" />
       <option name="METHOD_PARAMETERS_WRAP" value="1" />
       <option name="RESOURCE_LIST_WRAP" value="1" />
@@ -73,16 +65,15 @@
       <option name="ARRAY_INITIALIZER_WRAP" value="1" />
       <option name="ASSIGNMENT_WRAP" value="1" />
       <option name="ASSERT_STATEMENT_WRAP" value="1" />
-      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="IF_BRACE_FORCE" value="1" />
       <option name="DOWHILE_BRACE_FORCE" value="1" />
       <option name="WHILE_BRACE_FORCE" value="1" />
-      <option name="FOR_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="1" />
       <option name="WRAP_LONG_LINES" value="true" />
       <option name="METHOD_ANNOTATION_WRAP" value="1" />
       <option name="FIELD_ANNOTATION_WRAP" value="1" />
     </codeStyleSettings>
     <codeStyleSettings language="XML">
-      <option name="FORCE_REARRANGE_MODE" value="1" />
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </indentOptions>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,6 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default (1)" />
   </state>
 </component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Project" />
   </state>
 </component>


### PR DESCRIPTION
I think something changed in AS 3.5, our `Project.xml` file wasn't used by default (was working well with AS < 3.5).  

- I removed `<option name="PREFERRED_PROJECT_CODE_STYLE" value="Default (1)" />` from ` .idea/codeStyles/codeStyleConfig.xml ` which was the main culprit (I guess AS 3.5 created `Default (1)` config if it didn't exist and filled it with default values).
- I updated `.idea/codeStyleSettings.xml` with androidx import order (wasn't set yet).
- I used the "import from checkstyle" feature to update our Project style from our checkstyle configuration (that modified ` .idea/codeStyles/Project.xml `):

<img width="633" alt="Screenshot 2019-08-21 at 10 58 39" src="https://user-images.githubusercontent.com/40213/63419425-16eca980-c405-11e9-9a43-4d8175494dc1.png">

Note that we should update the https://github.com/Automattic/style-config-android project when this is merged and pull it in other projects (Woo/FluxC/etc).


