### PR TITLE
Add tracks to UploadStarter

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore
@@ -21,10 +22,12 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.IO_THREAD
 import org.wordpress.android.testing.OpenForTesting
+import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction
 import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction.DO_NOTHING
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.CrashLoggingUtils
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.skip
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus
 import javax.inject.Inject
@@ -51,6 +54,7 @@ class UploadStarter @Inject constructor(
     private val pageStore: PageStore,
     private val siteStore: SiteStore,
     private val uploadActionUseCase: UploadActionUseCase,
+    private val tracker: AnalyticsTrackerWrapper,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher,
     private val uploadServiceFacade: UploadServiceFacade,
@@ -150,7 +154,13 @@ class UploadStarter @Inject constructor(
             postsAndPages
                     .asSequence()
                     .filter {
-                        uploadActionUseCase.getAutoUploadAction(it, site) != DO_NOTHING
+                        val action = uploadActionUseCase.getAutoUploadAction(it, site)
+                        if (action == DO_NOTHING) {
+                            false
+                        } else {
+                            trackAutoUploadAction(action)
+                            true
+                        }
                     }
                     .toList()
                     .forEach { post ->
@@ -166,5 +176,9 @@ class UploadStarter @Inject constructor(
         } finally {
             mutex.unlock()
         }
+    }
+
+    private fun trackAutoUploadAction(action: UploadAction) {
+        tracker.track(Stat.AUTO_UPLOAD_POST_INVOKED, mapOf("upload_action" to action.toString()))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -158,7 +158,7 @@ class UploadStarter @Inject constructor(
                         if (action == DO_NOTHING) {
                             false
                         } else {
-                            trackAutoUploadAction(action)
+                            trackAutoUploadAction(action, it.status)
                             true
                         }
                     }
@@ -178,7 +178,13 @@ class UploadStarter @Inject constructor(
         }
     }
 
-    private fun trackAutoUploadAction(action: UploadAction) {
-        tracker.track(Stat.AUTO_UPLOAD_POST_INVOKED, mapOf("upload_action" to action.toString()))
+    private fun trackAutoUploadAction(action: UploadAction, status: String) {
+        tracker.track(
+                Stat.AUTO_UPLOAD_POST_INVOKED,
+                mapOf(
+                        "upload_action" to action.toString(),
+                        "post_status" to status
+                )
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsTrackerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsTrackerWrapper.kt
@@ -1,10 +1,12 @@
 package org.wordpress.android.util.analytics
 
+import dagger.Reusable
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
 
+@Reusable
 class AnalyticsTrackerWrapper
 @Inject constructor() {
     fun track(stat: Stat) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
@@ -79,7 +79,8 @@ class UploadStarterConcurrentTest {
             networkUtilsWrapper = createMockedNetworkUtilsWrapper(),
             connectionStatus = mock(),
             uploadServiceFacade = uploadServiceFacade,
-            uploadActionUseCase = UploadActionUseCase(mock(), createMockedPostUtilsWrapper(), uploadServiceFacade)
+            uploadActionUseCase = UploadActionUseCase(mock(), createMockedPostUtilsWrapper(), uploadServiceFacade),
+            tracker = mock()
     )
 
     private companion object Fixtures {

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -482,7 +482,8 @@ class UploadStarterTest {
             networkUtilsWrapper = createMockedNetworkUtilsWrapper(),
             connectionStatus = connectionStatus,
             uploadServiceFacade = uploadServiceFacade,
-            uploadActionUseCase = UploadActionUseCase(uploadStore, postUtilsWrapper, uploadServiceFacade)
+            uploadActionUseCase = UploadActionUseCase(uploadStore, postUtilsWrapper, uploadServiceFacade),
+            tracker = mock()
     )
 
     private companion object Fixtures {

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -580,7 +580,8 @@ public final class AnalyticsTracker {
         APP_REVIEWS_EVENT_INCREMENTED_BY_OPENING_READER_POST,
         DOMAIN_CREDIT_PROMPT_SHOWN,
         DOMAIN_CREDIT_REDEMPTION_TAPPED,
-        DOMAIN_CREDIT_REDEMPTION_SUCCESS
+        DOMAIN_CREDIT_REDEMPTION_SUCCESS,
+        AUTO_UPLOAD_POST_INVOKED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1632,6 +1632,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "domain_credit_redemption_tapped";
             case DOMAIN_CREDIT_REDEMPTION_SUCCESS:
                 return "domain_credit_redemption_success";
+            case AUTO_UPLOAD_POST_INVOKED:
+                return "auto_upload_post_invoked";
         }
         return null;
     }


### PR DESCRIPTION
Adds simple tracking to UploadStarter.

## Spec

EventName: "auto_upload_post_invoked"
EventProperties: 
- "upload_action - UPLOAD/UPLOAD_AS_DRAFT/REMOTE_AUTO_SAVE"
- "post_status"

I've updated the xls file with all our events.

## Test

To test:
1. Turn on Airplane mode
2. Create a draft and click on Publish
3. Turn off airplane mode
4. Make sure the log contains `Tracked: auto_upload_post_invoked, Properties: {"upload_action":"UPLOAD"}`

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

## Tasks 

- [x] @shiki Could you please create an issue for iOS. -- https://github.com/wordpress-mobile/WordPress-iOS/issues/12359
