### PR TITLE
Re-add update-metadata-source action

### DIFF
--- a/fastlane/actions/android_update_metadata_source.rb
+++ b/fastlane/actions/android_update_metadata_source.rb
@@ -1,0 +1,83 @@
+module Fastlane
+    module Actions
+      class AndroidUpdateMetadataSourceAction < Action
+        def self.run(params)
+          # Check local repo status
+          other_action.ensure_git_status_clean()
+  
+          other_action.an_update_metadata_source(po_file_path: params[:po_file_path],
+            source_files: params[:source_files], 
+            release_version: params[:release_version])
+  
+          Action.sh("git add #{params[:po_file_path]}")
+          params[:source_files].each do | key, file |
+            Action.sh("git add #{file}")
+          end
+  
+          repo_status = Actions.sh("git status --porcelain")
+          repo_clean = repo_status.empty?
+          if (!repo_clean) then
+            Action.sh("git commit -m \"Update metadata strings\"")
+            Action.sh("git push")
+          end
+        end
+  
+        #####################################################
+        # @!group Documentation
+        #####################################################
+  
+        def self.description
+          "Updates the PlayStoreStrings.po file with the data from text source files"
+        end
+  
+        def self.details
+          "Updates the PlayStoreStrings.po file with the data from text source files"
+        end
+  
+        def self.available_options
+          # Define all options your action supports. 
+          
+          # Below a few examples
+          [
+            FastlaneCore::ConfigItem.new(key: :po_file_path,
+                                          env_name: "FL_ANDROID_UPDATE_METADATA_SOURCE_PO_FILE_PATH", 
+                                          description: "The path of the .po file to update", 
+                                          is_string: true,
+                                          verify_block: proc do |value|
+                                            UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless (value and not value.empty?)
+                                            UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
+                                          end),
+            FastlaneCore::ConfigItem.new(key: :release_version,
+                                          env_name: "FL_ANDROID_UPDATE_METADATA_SOURCE_RELEASE_VERSION",
+                                          description: "The release version of the app (to use to mark the release notes)",
+                                          verify_block: proc do |value|
+                                            UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless (value and not value.empty?) 
+                                          end),
+            FastlaneCore::ConfigItem.new(key: :source_files,
+                                          env_name: "FL_ANDROID_UPDATE_METADATA_SOURCE_SOURCE_FILES",
+                                          description: "The hash with the path to the source files and the key to use to include their content",
+                                          is_string: false,
+                                          verify_block: proc do |value|
+                                            UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless (value and not value.empty?)
+                                          end)
+          ]
+        end
+  
+        def self.output
+  
+        end
+  
+        def self.return_value
+          
+        end
+  
+        def self.authors
+          ["loremattei"]
+        end
+  
+        def self.is_supported?(platform)
+          platform == :android
+        end
+      end
+    end
+  end


### PR DESCRIPTION
This PR re-adds the `android_udpate_metadata_source` Fastlane action that was mistakenly delete by this commit: https://github.com/wordpress-mobile/WordPress-Android/commit/04c2fad5c4f640a057b3684f5f11b813bdd79031#diff-fe4d9cd6ddf309346e73cb856b478254.

The action should be probably moved to the `release-toolkit`, but a bit more of work is required to share this with the other Android apps, so I'm now adding this to fix the `update_appstore_strings` lane that's currently broken. 

### To test:
1. Checkout a new branch from this one.
2. Run `bundle exec fastlane update_appstore_strings version:13.1` and verify that the lane runs without errors. 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
