### PR TITLE
Updated hint text for moved notification settings

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1752,7 +1752,7 @@
     <string name="me_btn_login_logout">Login/Logout</string>
     <string name="me_connect_to_wordpress_com">Log in to WordPress.com</string>
     <string name="me_disconnect_from_wordpress_com">Log out of WordPress.com</string>
-    <string name="notification_settings_moved_notices">Looking for notification settings? They’re in the Notifications tab — tap the cog.</string>
+    <string name="notification_settings_moved_notices">Notification Settings can now be found in the Notifications tab.</string>
 
     <!--TabBar Accessibility Labels-->
     <string name="tabbar_accessibility_label_my_site">My Site. View your site and manage it, including stats.</string>


### PR DESCRIPTION
Updated the hint text from 

> Looking for notification settings? They’re in the Notifications tab — tap the cog.

to 

> Notification Settings can now be found in the Notifications tab.

![Screenshot_1566404890](https://user-images.githubusercontent.com/728822/63450043-0254e500-c3f6-11e9-94c1-216d1ec3d550.png)


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
