### PR TITLE
CircleCI: Fix installable build job for branches with no PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,8 +67,14 @@ jobs:
       - run:
           name: Build APK
           command: |
-            PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-            VERSION_NAME="pr-${PR_NUMBER}-build-${CIRCLE_BUILD_NUM}"
+            if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
+              PREFIX="pr-${PR_NUMBER}"
+            else
+              PREFIX="$CIRCLE_BRANCH"
+            fi
+
+            VERSION_NAME="${PREFIX}-build-${CIRCLE_BUILD_NUM}"
             echo "export VERSION_NAME=$VERSION_NAME" >> $BASH_ENV
 
             ./gradlew --stacktrace assembleVanillaRelease -PversionName="$VERSION_NAME"


### PR DESCRIPTION
Installable builds are working as expected now that https://github.com/wordpress-mobile/WordPress-Android/pull/10404 is merged. However, the job is failing on `develop` because `CIRCLE_PULL_REQUEST` is not set (see [here](https://circleci.com/gh/wordpress-mobile/WordPress-Android/19928)). This is a small update to allow the build to run even if there is no Pull Request.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
