### PR TITLE
Feature/fix follower totals card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTotalsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTotalsUseCase.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases
 
+import android.view.View
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
@@ -21,6 +22,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.F
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.FollowerTotalsUseCase.FollowerType.SOCIAL
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.FollowerTotalsUseCase.FollowerType.WP_COM
 import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
+import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
 import javax.inject.Inject
@@ -33,9 +35,14 @@ class FollowerTotalsUseCase
     private val followersStore: FollowersStore,
     private val publicizeStore: PublicizeStore,
     private val statsSiteProvider: StatsSiteProvider,
-    private val contentDescriptionHelper: ContentDescriptionHelper
+    private val contentDescriptionHelper: ContentDescriptionHelper,
+    private val popupMenuHandler: ItemPopupMenuHandler
 ) : StatelessUseCase<Map<FollowerType, Int>>(FOLLOWER_TOTALS, mainDispatcher) {
     override fun buildLoadingItem(): List<BlockListItem> = listOf(Title(R.string.stats_view_follower_totals))
+
+    override fun buildEmptyItem(): List<BlockListItem> {
+        return listOf(buildTitle(), Empty())
+    }
 
     override suspend fun loadCachedData(): Map<FollowerType, Int>? {
         val wpComFollowers = followersStore.getWpComFollowers(statsSiteProvider.siteModel, LimitMode.Top(0))
@@ -135,7 +142,7 @@ class FollowerTotalsUseCase
 
     override fun buildUiModel(domainModel: Map<FollowerType, Int>): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
-        items.add(Title(R.string.stats_view_follower_totals))
+        items.add(buildTitle())
 
         if (domainModel.isNotEmpty()) {
             domainModel.entries.forEach {
@@ -157,6 +164,12 @@ class FollowerTotalsUseCase
             items.add(Empty())
         }
         return items
+    }
+
+    private fun buildTitle() = Title(R.string.stats_view_follower_totals, menuAction = this::onMenuClick)
+
+    private fun onMenuClick(view: View) {
+        popupMenuHandler.onMenuClick(view, type)
     }
 
     enum class FollowerType { WP_COM, EMAIL, SOCIAL }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -929,7 +929,7 @@
     <string name="stats_view_search_terms">Search Terms</string>
     <string name="stats_view_publicize">Publicize</string>
     <string name="stats_view_followers">Followers</string>
-    <string name="stats_view_follower_totals">Followers Totals</string>
+    <string name="stats_view_follower_totals">Follower Totals</string>
 
     <!-- stats: followers -->
     <string name="stats_followers_seconds_ago">seconds ago</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTotalsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTotalsUseCaseTest.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM_WITH_ICON
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
 import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
+import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 
 class FollowerTotalsUseCaseTest : BaseUnitTest() {
@@ -34,6 +35,7 @@ class FollowerTotalsUseCaseTest : BaseUnitTest() {
     @Mock lateinit var publicizeStore: PublicizeStore
     @Mock lateinit var statsSiteProvider: StatsSiteProvider
     @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
+    @Mock lateinit var popupMenuHandler: ItemPopupMenuHandler
     @Mock lateinit var site: SiteModel
     private lateinit var useCase: FollowerTotalsUseCase
 
@@ -53,7 +55,8 @@ class FollowerTotalsUseCaseTest : BaseUnitTest() {
                 followersStore,
                 publicizeStore,
                 statsSiteProvider,
-                contentDescriptionHelper
+                contentDescriptionHelper,
+                popupMenuHandler
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
 
@@ -67,7 +70,7 @@ class FollowerTotalsUseCaseTest : BaseUnitTest() {
     }
 
     @Test
-    fun `maps follower totals to U`() = test {
+    fun `maps follower totals to UI model`() = test {
         val forced = false
         val refresh = true
 
@@ -107,6 +110,7 @@ class FollowerTotalsUseCaseTest : BaseUnitTest() {
     private fun assertTitle(item: BlockListItem) {
         assertThat(item.type).isEqualTo(TITLE)
         assertThat((item as Title).textResource).isEqualTo(R.string.stats_view_follower_totals)
+        assertThat(item.menuAction).isNotNull
     }
 
     private suspend fun loadFollowerTotalsData(refresh: Boolean, forced: Boolean): UseCaseModel {


### PR DESCRIPTION
Fixes #10258 

This PR adds the ellipsis menu to the "Follower Totals" card and fixes the title of the card from "Followers Totals" to "Follower Totals".

To test:
* Go to Stats/Insights
* Add the "Follower Totals" card in Insights management
* Check that the ellipsis menu is showing on the card
* Check that the title is now "Follower Totals"

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
