### PR TITLE
Update FluxC to 1.2.1-beta-2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'ba3fd2e9972861f844362317250de640ace4fbd5'
+    fluxCVersion = '1.2.1-beta-2'
 }


### PR DESCRIPTION
This PR updates FluxC to the latest develop with tag `1.2.1-beta-2`. This tag points to the merge commit to develop.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
