### PR TITLE
Stats - missing view all data

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -72,6 +72,7 @@ import org.wordpress.android.ui.stats.StatsViewType;
 import org.wordpress.android.ui.stats.refresh.StatsActivity;
 import org.wordpress.android.ui.stats.refresh.StatsViewAllActivity;
 import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailActivity;
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate;
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.management.InsightsManagementActivity;
 import org.wordpress.android.ui.stockmedia.StockMediaPickerActivity;
 import org.wordpress.android.ui.themes.ThemeBrowserActivity;
@@ -303,9 +304,9 @@ public class ActivityLauncher {
         StatsViewAllActivity.startForInsights(context, statsType, localSiteId);
     }
 
-    public static void viewAllGranularStats(Context context, StatsGranularity granularity, StatsViewType statsType,
-                                            int localSiteId) {
-        StatsViewAllActivity.startForGranularStats(context, statsType, granularity, localSiteId);
+    public static void viewAllGranularStats(Context context, StatsGranularity granularity, SelectedDate selectedDate,
+                                            StatsViewType statsType, int localSiteId) {
+        StatsViewAllActivity.startForGranularStats(context, statsType, granularity, selectedDate, localSiteId);
     }
 
     public static void viewInsightsManagement(Context context, int localSiteId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -55,12 +55,13 @@ class StatsFragment : DaggerFragment() {
 
         val nonNullActivity = checkNotNull(activity)
 
-        initializeViewModels(nonNullActivity, savedInstanceState == null)
+        initializeViewModels(nonNullActivity, savedInstanceState == null, savedInstanceState)
         initializeViews(nonNullActivity)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putInt(WordPress.LOCAL_SITE_ID, activity?.intent?.getIntExtra(WordPress.LOCAL_SITE_ID, 0) ?: 0)
+        viewModel.onSaveInstanceState(outState)
         super.onSaveInstanceState(outState)
     }
 
@@ -75,8 +76,16 @@ class StatsFragment : DaggerFragment() {
         }
     }
 
-    private fun initializeViewModels(activity: FragmentActivity, isFirstStart: Boolean) {
+    private fun initializeViewModels(
+        activity: FragmentActivity,
+        isFirstStart: Boolean,
+        savedInstanceState: Bundle?
+    ) {
         viewModel = ViewModelProviders.of(activity, viewModelFactory).get(StatsViewModel::class.java)
+
+        savedInstanceState?.let {
+            viewModel.onRestoreInstanceState(it)
+        }
 
         setupObservers(activity)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -83,9 +83,7 @@ class StatsFragment : DaggerFragment() {
     ) {
         viewModel = ViewModelProviders.of(activity, viewModelFactory).get(StatsViewModel::class.java)
 
-        savedInstanceState?.let {
-            viewModel.onRestoreInstanceState(it)
-        }
+        viewModel.onRestoreInstanceState(savedInstanceState)
 
         setupObservers(activity)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllActivity.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.ui.stats.StatsViewType
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate
 
 class StatsViewAllActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -40,9 +41,10 @@ class StatsViewAllActivity : AppCompatActivity() {
             context: Context,
             statsType: StatsViewType,
             granularity: StatsGranularity,
+            selectedDate: SelectedDate,
             localSiteId: Int
         ) {
-            start(context, statsType, granularity, localSiteId = localSiteId)
+            start(context, statsType, granularity, selectedDate, localSiteId = localSiteId)
         }
 
         @JvmStatic
@@ -64,6 +66,7 @@ class StatsViewAllActivity : AppCompatActivity() {
             context: Context,
             statsType: StatsViewType,
             granularity: StatsGranularity? = null,
+            selectedDate: SelectedDate? = null,
             selectedTab: Int? = null,
             localSiteId: Int
         ) {
@@ -74,6 +77,9 @@ class StatsViewAllActivity : AppCompatActivity() {
             }
             granularity?.let {
                 intent.putExtra(StatsViewAllFragment.ARGS_TIMEFRAME, granularity)
+            }
+            selectedDate?.let {
+                intent.putExtra(StatsViewAllFragment.ARGS_SELECTED_DATE, selectedDate)
             }
             intent.putExtra(WordPress.LOCAL_SITE_ID, localSiteId)
             AnalyticsTracker.track(Stat.STATS_VIEW_ALL_ACCESSED)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -146,9 +146,9 @@ class StatsViewAllFragment : DaggerFragment() {
         viewModel = ViewModelProviders.of(activity, viewModelFactory).get(StatsViewAllViewModel::class.java)
 
         val selectedDate = if (savedInstanceState == null) {
-            nonNullIntent.getSerializableExtra(ARGS_SELECTED_DATE) as SelectedDate?
+            nonNullIntent.getParcelableExtra(ARGS_SELECTED_DATE) as SelectedDate?
         } else {
-            savedInstanceState.getSerializable(ARGS_SELECTED_DATE) as SelectedDate?
+            savedInstanceState.getParcelable(ARGS_SELECTED_DATE) as SelectedDate?
         }
         setupObservers(activity)
 
@@ -215,7 +215,7 @@ class StatsViewAllFragment : DaggerFragment() {
         })
 
         viewModel.selectedDate.observe(this, Observer { event ->
-            if (event?.getContentIfNotHandled() != null) {
+            if (event != null) {
                 viewModel.onDateChanged()
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllViewModel.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.Us
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.ERROR
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.LOADING
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.SUCCESS
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateSelector
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.map
@@ -58,8 +59,11 @@ class StatsViewAllViewModel(
 
     val toolbarHasShadow = dateSelectorData.map { !it.isVisible }
 
-    fun start() {
+    fun start(startDate: SelectedDate?) {
         launch {
+            startDate?.let {
+                dateSelector.start(startDate)
+            }
             loadData(refresh = false, forced = false)
             dateSelector.updateDateSelector()
         }
@@ -121,5 +125,9 @@ class StatsViewAllViewModel(
         loadData {
             loadData(refresh = true, forced = true)
         }
+    }
+
+    fun getSelectedDate(): SelectedDate {
+        return dateSelector.getSelectedDate()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -93,8 +93,13 @@ class StatsViewModel
         selectedDateProvider.onSaveInstanceState(outState)
     }
 
-    fun onRestoreInstanceState(savedState: Bundle) {
-        selectedDateProvider.onRestoreInstanceState(savedState)
+    fun onRestoreInstanceState(savedState: Bundle?) {
+        if (savedState != null) {
+            selectedDateProvider.onRestoreInstanceState(savedState)
+        } else {
+            selectedDateProvider.clear()
+            statsSiteProvider.reset()
+        }
     }
 
     private fun getInitialTimeFrame(intent: Intent): StatsSection? {
@@ -194,8 +199,6 @@ class StatsViewModel
     override fun onCleared() {
         super.onCleared()
         _showSnackbarMessage.value = null
-        selectedDateProvider.clear()
-        statsSiteProvider.reset()
     }
 
     data class DateSelectorUiModel(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.stats.refresh
 
 import android.content.Intent
+import android.os.Bundle
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
@@ -86,6 +87,14 @@ class StatsViewModel
         val initialTimeFrame = getInitialTimeFrame(intent)
         val initialSelectedPeriod = intent.getStringExtra(StatsActivity.INITIAL_SELECTED_PERIOD_KEY)
         start(localSiteId, launchedFromWidget, initialTimeFrame, initialSelectedPeriod, restart)
+    }
+
+    fun onSaveInstanceState(outState: Bundle) {
+        selectedDateProvider.onSaveInstanceState(outState)
+    }
+
+    fun onRestoreInstanceState(savedState: Bundle) {
+        selectedDateProvider.onRestoreInstanceState(savedState)
     }
 
     private fun getInitialTimeFrame(intent: Intent): StatsSection? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -123,11 +123,6 @@ class StatsListFragment : DaggerFragment() {
         initializeViewModels(nonNullActivity)
     }
 
-    override fun onResume() {
-        super.onResume()
-        viewModel.onResume()
-    }
-
     private fun initializeViewModels(activity: FragmentActivity) {
         val statsSection = arguments?.getSerializable(LIST_TYPE) as? StatsSection
                 ?: activity.intent?.getSerializableExtra(LIST_TYPE) as? StatsSection
@@ -182,7 +177,7 @@ class StatsListFragment : DaggerFragment() {
         })
 
         viewModel.selectedDate.observe(this, Observer { event ->
-            if (event?.getContentIfNotHandled() != null) {
+            if (event != null) {
                 viewModel.onDateChanged()
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -123,6 +123,11 @@ class StatsListFragment : DaggerFragment() {
         initializeViewModels(nonNullActivity)
     }
 
+    override fun onResume() {
+        super.onResume()
+        viewModel.onResume()
+    }
+
     private fun initializeViewModels(activity: FragmentActivity) {
         val statsSection = arguments?.getSerializable(LIST_TYPE) as? StatsSection
                 ?: activity.intent?.getSerializableExtra(LIST_TYPE) as? StatsSection

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -149,10 +149,6 @@ abstract class StatsListViewModel(
             statsUseCase.refreshTypes()
         }
     }
-
-    fun onResume() {
-        dateSelector.updateDateSelector()
-    }
 }
 
 class InsightsListViewModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -149,6 +149,10 @@ abstract class StatsListViewModel(
             statsUseCase.refreshTypes()
         }
     }
+
+    fun onResume() {
+        dateSelector.updateDateSelector()
+    }
 }
 
 class InsightsListViewModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
@@ -78,7 +78,7 @@ class StatsDetailFragment : DaggerFragment() {
         })
 
         viewModel.selectedDateChanged.observe(this, Observer { event ->
-            if (event?.getContentIfNotHandled() != null) {
+            if (event != null) {
                 viewModel.onDateChanged()
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
@@ -1,7 +1,11 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.granular
 
+import android.os.Bundle
+import android.os.Parcelable
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_NEXT_DATE_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_PREVIOUS_DATE_TAPPED
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
@@ -20,6 +24,8 @@ import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 
+private const val SELECTED_DATE_STATE_KEY = "selected_date_key"
+
 @Singleton
 class SelectedDateProvider
 @Inject constructor(
@@ -36,14 +42,17 @@ class SelectedDateProvider
     private val selectedDateChanged = MutableLiveData<Event<SectionChange>>()
 
     fun granularSelectedDateChanged(statsGranularity: StatsGranularity): LiveData<Event<SectionChange>> {
+        log(statsGranularity, "granularSelectedDateChanged")
         return selectedDateChanged.filter { it.peekContent().selectedSection == statsGranularity.toStatsSection() }
     }
 
     fun granularSelectedDateChanged(statsSection: StatsSection): LiveData<Event<SectionChange>> {
+        log(statsSection, "granularSelectedDateChanged")
         return selectedDateChanged.filter { it.peekContent().selectedSection == statsSection }
     }
 
     fun selectDate(date: Date, statsSection: StatsSection) {
+        log(statsSection, "selectDate: $date")
         val selectedDate = getSelectedDateState(statsSection)
         updateSelectedDate(selectedDate.copy(dateValue = date), statsSection)
     }
@@ -53,6 +62,7 @@ class SelectedDateProvider
     }
 
     fun selectDate(updatedDate: Date, availableDates: List<Date>, statsSection: StatsSection) {
+        log(statsSection, "selectDate: $updatedDate")
         val selectedDate = getSelectedDateState(statsSection)
         if (selectedDate.dateValue != updatedDate || selectedDate.availableDates != availableDates) {
             updateSelectedDate(
@@ -66,10 +76,11 @@ class SelectedDateProvider
         selectDate(updatedDate, availableDates, statsGranularity.toStatsSection())
     }
 
-    private fun updateSelectedDate(selectedDate: SelectedDate, statsSection: StatsSection) {
+    fun updateSelectedDate(selectedDate: SelectedDate, statsSection: StatsSection) {
         val currentDate = mutableDates[statsSection]
         mutableDates[statsSection] = selectedDate
         if (selectedDate != currentDate) {
+            log(statsSection, "update selected date: $selectedDate")
             selectedDateChanged.postValue(Event(SectionChange(statsSection)))
         }
     }
@@ -77,6 +88,7 @@ class SelectedDateProvider
     fun setInitialSelectedPeriod(statsGranularity: StatsGranularity, period: String) {
         val updatedDate = statsDateFormatter.parseStatsDate(statsGranularity, period)
         val selectedDate = getSelectedDateState(statsGranularity)
+        log(statsGranularity, "setInitialSelectedPeriod: $period")
         updateSelectedDate(selectedDate.copy(dateValue = updatedDate), statsGranularity.toStatsSection())
     }
 
@@ -111,6 +123,7 @@ class SelectedDateProvider
         val selectedDateState = getSelectedDateState(statsSection)
         if (selectedDateState.hasData()) {
             analyticsTrackerWrapper.trackWithSection(STATS_PREVIOUS_DATE_TAPPED, statsSection)
+            log(statsSection, "selectPreviousDate: ${selectedDateState.getPreviousDate()}")
             updateSelectedDate(selectedDateState.copy(dateValue = selectedDateState.getPreviousDate()), statsSection)
         }
     }
@@ -119,6 +132,7 @@ class SelectedDateProvider
         val selectedDateState = getSelectedDateState(statsSection)
         if (selectedDateState.hasData()) {
             analyticsTrackerWrapper.trackWithSection(STATS_NEXT_DATE_TAPPED, statsSection)
+            log(statsSection, "selectNextDate: ${selectedDateState.getNextDate()}")
             updateSelectedDate(selectedDateState.copy(dateValue = selectedDateState.getNextDate()), statsSection)
         }
     }
@@ -151,24 +165,66 @@ class SelectedDateProvider
     fun clear() {
         mutableDates.clear()
         selectedDateChanged.value = null
+        Log.d("vojta", "clear")
     }
 
     fun clear(statsSection: StatsSection) {
         mutableDates[statsSection] = SelectedDate(loading = true)
         selectedDateChanged.value = null
+        log(statsSection, "clear for section")
     }
 
+    private fun log(statsSection: StatsSection, message: String) {
+        Log.d("vojta", "$statsSection, m: $message")
+    }
+
+    private fun log(statsGranularity: StatsGranularity, message: String) {
+        Log.d("vojta", "$statsGranularity, m: $message")
+    }
+
+    fun onSaveInstanceState(outState: Bundle) {
+        mutableDates.entries.forEach { (key, value) ->
+            outState.putParcelable(buildStateKey(key), value)
+        }
+    }
+
+    fun onSaveInstanceState(statsSection: StatsSection, outState: Bundle) {
+        mutableDates[statsSection]?.let { value ->
+            outState.putParcelable(buildStateKey(statsSection), value)
+        }
+    }
+
+    fun onRestoreInstanceState(savedState: Bundle) {
+        for (period in listOf(DAYS, WEEKS, MONTHS, YEARS)) {
+            val selectedDate: SelectedDate? = savedState.getParcelable(buildStateKey(period)) as SelectedDate?
+            if (selectedDate != null) {
+                mutableDates[period] = selectedDate
+            }
+        }
+    }
+
+    fun onRestoreInstanceState(statsSection: StatsSection, savedState: Bundle) {
+        val selectedDate: SelectedDate? = savedState.getParcelable(buildStateKey(statsSection)) as SelectedDate?
+        if (selectedDate != null) {
+            mutableDates[statsSection] = selectedDate
+        }
+    }
+
+    private fun buildStateKey(key: StatsSection) = SELECTED_DATE_STATE_KEY + key
+
+    @Parcelize
     data class SelectedDate(
         val dateValue: Date? = null,
         val availableDates: List<Date> = listOf(),
         val loading: Boolean = false,
         val error: Boolean = false
-    ) {
+    ) : Parcelable {
         fun hasData(): Boolean = dateValue != null && availableDates.contains(dateValue)
         fun getDate() = dateValue!!
         fun getDateIndex(): Int {
             return availableDates.indexOf(dateValue)
         }
+
         fun getPreviousDate(): Date? {
             val dateIndex = getDateIndex()
             return if (dateIndex > 0) {
@@ -177,6 +233,7 @@ class SelectedDateProvider
                 null
             }
         }
+
         fun getNextDate(): Date? {
             val dateIndex = getDateIndex()
             return if (dateIndex > -1 && dateIndex < availableDates.size - 1) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate
 import org.wordpress.android.util.perform
 import javax.inject.Inject
 
@@ -30,6 +31,10 @@ constructor(
                     updateDateSelector()
                 }
             }
+
+    fun start(startDate: SelectedDate) {
+        selectedDateProvider.updateSelectedDate(startDate, statsSection)
+    }
 
     fun updateDateSelector() {
         val shouldShowDateSelection = this.statsSection != INSIGHTS
@@ -89,6 +94,10 @@ constructor(
 
     fun clear() {
         selectedDateProvider.clear(statsSection)
+    }
+
+    fun getSelectedDate(): SelectedDate {
+        return selectedDateProvider.getSelectedDateState(statsSection)
     }
 
     class Factory

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
@@ -27,9 +27,7 @@ constructor(
 
     val selectedDate = selectedDateProvider.granularSelectedDateChanged(this.statsSection)
             .perform {
-                if (!it.hasBeenHandled) {
-                    updateDateSelector()
-                }
+                updateDateSelector()
             }
 
     fun start(startDate: SelectedDate) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
@@ -46,13 +46,17 @@ import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTagsAndCatego
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewUrl
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewVideoPlays
 import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailActivity
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class StatsNavigator
-@Inject constructor(private val siteProvider: StatsSiteProvider) {
+@Inject constructor(
+    private val siteProvider: StatsSiteProvider,
+    private val selectedDateProvider: SelectedDateProvider
+) {
     fun navigate(activity: FragmentActivity, target: NavigationTarget) {
         when (target) {
             is AddNewPost -> ActivityLauncher.addNewPostForResult(activity, siteProvider.siteModel, false)
@@ -121,6 +125,7 @@ class StatsNavigator
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         target.statsGranularity,
+                        selectedDateProvider.getSelectedDateState(target.statsGranularity),
                         TOP_POSTS_AND_PAGES,
                         siteProvider.siteModel.id
                 )
@@ -129,6 +134,7 @@ class StatsNavigator
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         target.statsGranularity,
+                        selectedDateProvider.getSelectedDateState(target.statsGranularity),
                         REFERRERS,
                         siteProvider.siteModel.id
                 )
@@ -137,6 +143,7 @@ class StatsNavigator
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         target.statsGranularity,
+                        selectedDateProvider.getSelectedDateState(target.statsGranularity),
                         CLICKS,
                         siteProvider.siteModel.id
                 )
@@ -145,6 +152,7 @@ class StatsNavigator
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         target.statsGranularity,
+                        selectedDateProvider.getSelectedDateState(target.statsGranularity),
                         GEOVIEWS,
                         siteProvider.siteModel.id
                 )
@@ -153,6 +161,7 @@ class StatsNavigator
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         target.statsGranularity,
+                        selectedDateProvider.getSelectedDateState(target.statsGranularity),
                         VIDEO_PLAYS,
                         siteProvider.siteModel.id
                 )
@@ -161,6 +170,7 @@ class StatsNavigator
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         target.statsGranularity,
+                        selectedDateProvider.getSelectedDateState(target.statsGranularity),
                         SEARCH_TERMS,
                         siteProvider.siteModel.id
                 )
@@ -169,6 +179,7 @@ class StatsNavigator
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         target.statsGranularity,
+                        selectedDateProvider.getSelectedDateState(target.statsGranularity),
                         AUTHORS,
                         siteProvider.siteModel.id
                 )
@@ -177,12 +188,19 @@ class StatsNavigator
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         target.statsGranularity,
+                        selectedDateProvider.getSelectedDateState(target.statsGranularity),
                         FILE_DOWNLOADS,
                         siteProvider.siteModel.id
                 )
             }
             is ViewAnnualStats -> {
-                ActivityLauncher.viewAllGranularStats(activity, YEARS, ANNUAL_STATS, siteProvider.siteModel.id)
+                ActivityLauncher.viewAllGranularStats(
+                        activity,
+                        YEARS,
+                        selectedDateProvider.getSelectedDateState(YEARS),
+                        ANNUAL_STATS,
+                        siteProvider.siteModel.id
+                )
             }
             is ViewUrl -> {
                 WPWebViewActivity.openURL(activity, target.url)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/StatsDateSelectorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/StatsDateSelectorTest.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDa
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateSelector
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
-import org.wordpress.android.viewmodel.Event
 import java.util.Date
 
 class StatsDateSelectorTest : BaseUnitTest() {
@@ -32,13 +31,13 @@ class StatsDateSelectorTest : BaseUnitTest() {
     private val siteTimeZone = "GMT"
     private val site = SiteModel()
 
-    private val dateProviderSelectedDate = MutableLiveData<Event<SectionChange>>()
+    private val dateProviderSelectedDate = MutableLiveData<SectionChange>()
 
     private lateinit var dateSelector: StatsDateSelector
 
     @Before
     fun setUp() {
-        dateProviderSelectedDate.value = Event(SectionChange(statsSection))
+        dateProviderSelectedDate.value = SectionChange(statsSection)
         whenever(selectedDateProvider.granularSelectedDateChanged(statsSection)).thenReturn(dateProviderSelectedDate)
 
         dateSelector = StatsDateSelector(


### PR DESCRIPTION
This PR fixes a bug that happens when you have "Do not keep activities" setting set. When you leave the `StatsActivity` to open the `StatsViewAllActivity`, the `StatsActivity` gets killed and clears the `SelectedDateProvider`. The result is that the view all activity never loads the data. 

The fix for this is to pass the selected date as a parameter to the `StatsViewAllActivity`. I've also added saving and restoring of the `SelectedDateProvider` instance state to the `StatsActivity`. The selected date change is no longer an `Event` because it has to be consumed twice, by both the 
`StatsActivity` and the `StatsViewAllActivity`. 

There is one thing that's not 100% behaviour and that's when you turn on "Do not keep activities", the selected time period is not passed back from the "View all" activity back to the "Stats activity". This would require a bigger change (passing the selected date as an activity result) and it's such an edge case that I've decided to not implement it now. 

To test 1:
* Turn off "Do not keep activities" setting
* Go to Stats DWMY
* Select time period A
* Go to View all
* Select time period B
* Go back
* The time period B is selected and all the data is loaded correctly

To test 2:
* Turn on "Do not keep activities" setting
* Go to Stats DWMY
* Select time period A
* Go to View all
* The data is loaded for time period A
* Select time period B
* Go back
* The time period A is selected and all the data is loaded correctly

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
