### PR TITLE
Issue/10370 auto upload error labels

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <option name="RIGHT_MARGIN" value="120" />
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="RIGHT_MARGIN" value="120" />
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListUploadStatusTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListUploadStatusTracker.kt
@@ -36,7 +36,7 @@ class PostListUploadStatusTracker(
                 hasInProgressMediaUpload = hasInProgressMediaUpload,
                 hasPendingMediaUpload = UploadService.hasPendingMediaUploadsForPost(post),
                 isEligibleForAutoUpload = isEligibleForAutoUpload(siteModel, post),
-                changesExplicitlyConfirmed = post.changesConfirmedContentHashcode == post.contentHashcode()
+                retryWillPushChanges = post.changesConfirmedContentHashcode == post.contentHashcode()
         )
         uploadStatusMap[post.id] = newStatus
         return newStatus

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListUploadStatusTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListUploadStatusTracker.kt
@@ -4,10 +4,6 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.UploadStore
 import org.wordpress.android.ui.uploads.UploadActionUseCase
-import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction.DO_NOTHING
-import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction.REMOTE_AUTO_SAVE
-import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction.UPLOAD
-import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction.UPLOAD_AS_DRAFT
 import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.viewmodel.posts.PostListItemUploadStatus
 
@@ -35,18 +31,11 @@ class PostListUploadStatusTracker(
                 isUploadFailed = uploadStore.isFailedPost(post),
                 hasInProgressMediaUpload = hasInProgressMediaUpload,
                 hasPendingMediaUpload = UploadService.hasPendingMediaUploadsForPost(post),
-                isEligibleForAutoUpload = isEligibleForAutoUpload(siteModel, post),
-                retryWillPushChanges = post.changesConfirmedContentHashcode == post.contentHashcode()
+                isEligibleForAutoUpload = uploadActionUseCase.isEligibleForAutoUpload(siteModel, post),
+                uploadWillPushChanges = uploadActionUseCase.willUploadPushChanges(post)
         )
         uploadStatusMap[post.id] = newStatus
         return newStatus
-    }
-
-    private fun isEligibleForAutoUpload(site: SiteModel, post: PostModel): Boolean {
-        return when (uploadActionUseCase.getAutoUploadAction(post, site)) {
-            UPLOAD -> true
-            UPLOAD_AS_DRAFT, REMOTE_AUTO_SAVE, DO_NOTHING -> false
-        }
     }
 
     fun invalidateUploadStatus(localPostIds: List<Int>) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListUploadStatusTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListUploadStatusTracker.kt
@@ -35,7 +35,8 @@ class PostListUploadStatusTracker(
                 isUploadFailed = uploadStore.isFailedPost(post),
                 hasInProgressMediaUpload = hasInProgressMediaUpload,
                 hasPendingMediaUpload = UploadService.hasPendingMediaUploadsForPost(post),
-                isEligibleForAutoUpload = isEligibleForAutoUpload(siteModel, post)
+                isEligibleForAutoUpload = isEligibleForAutoUpload(siteModel, post),
+                changesExplicitlyConfirmed = post.changesConfirmedContentHashcode == post.contentHashcode()
         )
         uploadStatusMap[post.id] = newStatus
         return newStatus

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListUploadStatusTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListUploadStatusTracker.kt
@@ -32,7 +32,7 @@ class PostListUploadStatusTracker(
                 hasInProgressMediaUpload = hasInProgressMediaUpload,
                 hasPendingMediaUpload = UploadService.hasPendingMediaUploadsForPost(post),
                 isEligibleForAutoUpload = uploadActionUseCase.isEligibleForAutoUpload(siteModel, post),
-                uploadWillPushChanges = uploadActionUseCase.willUploadPushChanges(post)
+                uploadWillPushChanges = uploadActionUseCase.uploadWillPushChanges(post)
         )
         uploadStatusMap[post.id] = newStatus
         return newStatus

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -608,7 +608,8 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
                               + event.error.message);
             Context context = WordPress.getContext();
             String errorMessage = mUiHelpers.getTextOfUiString(context,
-                    UploadUtils.getErrorMessageResIdFromPostError(event.post.isPage(), event.error, false));
+                    UploadUtils.getErrorMessageResIdFromPostError(PostStatus.fromPost(event.post), event.post.isPage(),
+                            event.error, mUploadActionUseCase.isEligibleForAutoUpload(site, event.post)));
             String notificationMessage = UploadUtils.getErrorMessage(context, event.post, errorMessage, false);
             mPostUploadNotifier.removePostInfoFromForegroundNotification(event.post,
                     mMediaStore.getMediaForPost(event.post));

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -608,7 +608,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
                               + event.error.message);
             Context context = WordPress.getContext();
             String errorMessage = mUiHelpers.getTextOfUiString(context,
-                    UploadUtils.getErrorMessageResIdFromPostError(event.post.isPage(), event.error));
+                    UploadUtils.getErrorMessageResIdFromPostError(event.post.isPage(), event.error, false));
             String notificationMessage = UploadUtils.getErrorMessage(context, event.post, errorMessage, false);
             mPostUploadNotifier.removePostInfoFromForegroundNotification(event.post,
                     mMediaStore.getMediaForPost(event.post));

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
@@ -65,7 +65,7 @@ class UploadActionUseCase @Inject constructor(
 
     fun getUploadAction(post: PostModel): UploadAction {
         return when {
-            willUploadPushChanges(post) ->
+            uploadWillPushChanges(post) ->
                 // We are sure we can push the post as the user has explicitly confirmed the changes
                 UPLOAD
             post.isLocalDraft ->
@@ -82,5 +82,5 @@ class UploadActionUseCase @Inject constructor(
         }
     }
 
-    fun willUploadPushChanges(post: PostModel) = post.changesConfirmedContentHashcode == post.contentHashcode()
+    fun uploadWillPushChanges(post: PostModel) = post.changesConfirmedContentHashcode == post.contentHashcode()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
@@ -65,7 +65,7 @@ class UploadActionUseCase @Inject constructor(
 
     fun getUploadAction(post: PostModel): UploadAction {
         return when {
-            post.changesConfirmedContentHashcode == post.contentHashcode() ->
+            willUploadPushChanges(post) ->
                 // We are sure we can push the post as the user has explicitly confirmed the changes
                 UPLOAD
             post.isLocalDraft ->
@@ -74,4 +74,13 @@ class UploadActionUseCase @Inject constructor(
             else -> REMOTE_AUTO_SAVE
         }
     }
+
+    fun isEligibleForAutoUpload(site: SiteModel, post: PostModel): Boolean {
+        return when (getAutoUploadAction(post, site)) {
+            UPLOAD -> true
+            UPLOAD_AS_DRAFT, REMOTE_AUTO_SAVE, DO_NOTHING -> false
+        }
+    }
+
+    fun willUploadPushChanges(post: PostModel) = post.changesConfirmedContentHashcode == post.contentHashcode()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
@@ -44,7 +44,7 @@ class UploadActionUseCase @Inject constructor(
         }
 
         // Do not auto-upload post which we already tried to upload certain number of times
-        if (uploadStore.getNumberOfPostUploadErrorsOrCancellations(post) >= MAXIMUM_AUTO_UPLOAD_RETRIES) {
+        if (uploadStore.getNumberOfPostAutoUploadAttempts(post) >= MAXIMUM_AUTO_UPLOAD_RETRIES) {
             return DO_NOTHING
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
@@ -13,7 +13,7 @@ import org.wordpress.android.util.DateTimeUtils
 import java.util.Date
 import javax.inject.Inject
 
-const val MAXIMUM_AUTO_UPLOAD_RETRIES = 10
+const val MAXIMUM_AUTO_UPLOAD_RETRIES = 3
 private const val TWO_DAYS_IN_MILLIS = 1000 * 60 * 60 * 24 * 2
 
 @Reusable

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -147,7 +147,6 @@ class UploadStarter @Inject constructor(
             mutex.lock()
             val posts = postStore.getPostsWithLocalChanges(site)
 
-            // TODO Set Retry = false when autosaving or perhaps check `getNumberOfPostUploadErrorsOrCancellations != 0`
             posts
                     .asSequence()
                     .filter {
@@ -166,8 +165,6 @@ class UploadStarter @Inject constructor(
                         uploadServiceFacade.uploadPost(
                                 context = context,
                                 post = post,
-                                // TODO Should we track analytics in certain cases ?!? We don't know if it's
-                                //  firstTimePublish since we don't have the original status of the post
                                 trackAnalytics = false
                         )
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -71,7 +71,7 @@ public class UploadUtils {
      * Returns an error message string for a failed post upload.
      */
     public static @NonNull
-    UiString getErrorMessageResIdFromPostError(boolean isPage, PostError error) {
+    UiString getErrorMessageResIdFromPostError(boolean isPage, PostError error, boolean eligibleForAutoUpload) {
         switch (error.type) {
             case UNKNOWN_POST:
                 return isPage ? new UiStringRes(R.string.error_unknown_page)
@@ -86,7 +86,8 @@ public class UploadUtils {
             case GENERIC_ERROR:
             default:
                 AppLog.w(T.MAIN, "Error message: " + error.message + " ,Error Type: " + error.type);
-                return new UiStringRes(R.string.error_generic_error);
+                return eligibleForAutoUpload ? new UiStringRes(R.string.error_generic_error_retrying)
+                        : new UiStringRes(R.string.error_generic_error);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -71,7 +71,7 @@ public class UploadUtils {
      * Returns an error message string for a failed post upload.
      */
     public static @NonNull
-    UiString getErrorMessageResIdFromPostError(boolean isPage, PostError error, boolean eligibleForAutoUpload) {
+    UiString getErrorMessageResIdFromPostError(PostStatus postStatus, boolean isPage, PostError error, boolean eligibleForAutoUpload) {
         switch (error.type) {
             case UNKNOWN_POST:
                 return isPage ? new UiStringRes(R.string.error_unknown_page)
@@ -86,8 +86,38 @@ public class UploadUtils {
             case GENERIC_ERROR:
             default:
                 AppLog.w(T.MAIN, "Error message: " + error.message + " ,Error Type: " + error.type);
-                return eligibleForAutoUpload ? new UiStringRes(R.string.error_generic_error_retrying)
-                        : new UiStringRes(R.string.error_generic_error);
+                if (eligibleForAutoUpload) {
+                    switch (postStatus) {
+                        case PRIVATE:
+                            return new UiStringRes(R.string.error_post_not_published_retrying_private);
+                        case PUBLISHED:
+                            return new UiStringRes(R.string.error_post_not_published_retrying);
+                        case SCHEDULED:
+                            return new UiStringRes(R.string.error_post_not_scheduled_retrying);
+                        case PENDING:
+                            return new UiStringRes(R.string.error_post_not_submitted_retrying);
+                        case UNKNOWN:
+                        case DRAFT:
+                        case TRASHED:
+                            return new UiStringRes(R.string.error_generic_error_retrying);
+                    }
+                } else {
+                    switch (postStatus) {
+                        case PRIVATE:
+                            return new UiStringRes(R.string.error_post_not_published_private);
+                        case PUBLISHED:
+                            return new UiStringRes(R.string.error_post_not_published);
+                        case SCHEDULED:
+                            return new UiStringRes(R.string.error_post_not_scheduled);
+                        case PENDING:
+                            return new UiStringRes(R.string.error_post_not_submitted);
+                        case UNKNOWN:
+                        case DRAFT:
+                        case TRASHED:
+                            return new UiStringRes(R.string.error_generic_error);
+                    }
+                }
+                return new UiStringRes(R.string.error_generic_error);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -71,7 +71,8 @@ public class UploadUtils {
      * Returns an error message string for a failed post upload.
      */
     public static @NonNull
-    UiString getErrorMessageResIdFromPostError(PostStatus postStatus, boolean isPage, PostError error, boolean eligibleForAutoUpload) {
+    UiString getErrorMessageResIdFromPostError(PostStatus postStatus, boolean isPage, PostError error,
+                                               boolean eligibleForAutoUpload) {
         switch (error.type) {
             case UNKNOWN_POST:
                 return isPage ? new UiStringRes(R.string.error_unknown_page)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -209,7 +209,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         val labels: MutableList<UiString> = ArrayList()
         when {
             uploadUiState is PostUploadUiState.UploadFailed -> {
-                getErrorLabel(uploadUiState.error, postStatus)?.let { labels.add(it) }
+                getErrorLabel(uploadUiState, postStatus)?.let { labels.add(it) }
             }
             uploadUiState is UploadingPost -> if (uploadUiState.isDraft) {
                 labels.add(UiStringRes(R.string.post_uploading_draft))
@@ -253,17 +253,27 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         return labels
     }
 
-    private fun getErrorLabel(uploadError: UploadError, postStatus: PostStatus): UiString? {
+    private fun getErrorLabel(uploadUiState: PostUploadUiState.UploadFailed, postStatus: PostStatus): UiString? {
         return when {
-            uploadError.mediaError != null -> when (postStatus) {
-                PRIVATE, PUBLISHED -> UiStringRes(R.string.error_media_recover_post_not_published)
-                SCHEDULED -> UiStringRes(R.string.error_media_recover_post_not_scheduled)
-                PENDING -> UiStringRes(R.string.error_media_recover_post_not_submitted)
-                DRAFT, TRASHED, UNKNOWN -> UiStringRes(R.string.error_media_recover_post)
-            }
-            uploadError.postError != null -> UploadUtils.getErrorMessageResIdFromPostError(
+            uploadUiState.error.mediaError != null ->
+                if (uploadUiState.autoRetry) {
+                    when (postStatus) {
+                        PRIVATE, PUBLISHED -> UiStringRes(R.string.error_media_recover_post_not_published_retrying)
+                        SCHEDULED -> UiStringRes(R.string.error_media_recover_post_not_scheduled_retrying)
+                        PENDING -> UiStringRes(R.string.error_media_recover_post_not_submitted_retrying)
+                        DRAFT, TRASHED, UNKNOWN -> UiStringRes(R.string.error_media_recover_post_retrying)
+                    }
+                } else {
+                    when (postStatus) {
+                        PRIVATE, PUBLISHED -> UiStringRes(R.string.error_media_recover_post_not_published)
+                        SCHEDULED -> UiStringRes(R.string.error_media_recover_post_not_scheduled)
+                        PENDING -> UiStringRes(R.string.error_media_recover_post_not_submitted)
+                        DRAFT, TRASHED, UNKNOWN -> UiStringRes(R.string.error_media_recover_post)
+                    }
+                }
+            uploadUiState.error.postError != null -> UploadUtils.getErrorMessageResIdFromPostError(
                     false,
-                    uploadError.postError
+                    uploadUiState.error.postError
             )
             else -> {
                 val errorMsg = "MediaError and postError are both null."
@@ -409,7 +419,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
     private sealed class PostUploadUiState {
         data class UploadingMedia(val progress: Int) : PostUploadUiState()
         data class UploadingPost(val isDraft: Boolean) : PostUploadUiState()
-        data class UploadFailed(val error: UploadError) : PostUploadUiState()
+        data class UploadFailed(val error: UploadError, val autoRetry: Boolean) : PostUploadUiState()
         data class UploadWaitingForConnection(val postStatus: PostStatus) : PostUploadUiState()
         object UploadQueued : PostUploadUiState()
         object NothingToUpload : PostUploadUiState()
@@ -424,7 +434,10 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
             uploadStatus.hasInProgressMediaUpload -> UploadingMedia(uploadStatus.mediaUploadProgress)
             uploadStatus.isUploading -> UploadingPost(postStatus == DRAFT)
             // the upload error is not null on retry -> it needs to be evaluated after UploadingMedia and UploadingPost
-            uploadStatus.uploadError != null -> PostUploadUiState.UploadFailed(uploadStatus.uploadError)
+            uploadStatus.uploadError != null -> PostUploadUiState.UploadFailed(
+                    uploadStatus.uploadError,
+                    uploadStatus.isEligibleForAutoUpload
+            )
             uploadStatus.hasPendingMediaUpload ||
                     uploadStatus.isQueued ||
                     uploadStatus.isUploadingOrQueued -> UploadQueued

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -308,7 +308,8 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         hasUnhandledConflicts: Boolean,
         hasAutoSave: Boolean
     ): Int? {
-        val isError = (uploadUiState is UploadFailed && !uploadUiState.isEligibleForAutoUpload) || hasUnhandledConflicts || hasAutoSave
+        val isError = (uploadUiState is UploadFailed && !uploadUiState.isEligibleForAutoUpload) ||
+                hasUnhandledConflicts || hasAutoSave
         val isProgressInfo = uploadUiState is UploadingPost || uploadUiState is UploadingMedia ||
                 uploadUiState is UploadQueued
         val isStateInfo = (uploadUiState is UploadFailed && uploadUiState.isEligibleForAutoUpload) ||

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -19,23 +19,17 @@ import org.wordpress.android.fluxc.model.post.PostStatus.PUBLISHED
 import org.wordpress.android.fluxc.model.post.PostStatus.SCHEDULED
 import org.wordpress.android.fluxc.model.post.PostStatus.TRASHED
 import org.wordpress.android.fluxc.model.post.PostStatus.UNKNOWN
-import org.wordpress.android.fluxc.store.PostStore.PostErrorType.GENERIC_ERROR
-import org.wordpress.android.fluxc.store.PostStore.PostErrorType.INVALID_RESPONSE
-import org.wordpress.android.fluxc.store.PostStore.PostErrorType.UNAUTHORIZED
-import org.wordpress.android.fluxc.store.PostStore.PostErrorType.UNKNOWN_POST
-import org.wordpress.android.fluxc.store.PostStore.PostErrorType.UNKNOWN_POST_TYPE
-import org.wordpress.android.fluxc.store.PostStore.PostErrorType.UNSUPPORTED_ACTION
 import org.wordpress.android.fluxc.store.UploadStore.UploadError
 import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
 import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
 import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.uploads.UploadUtils
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
-import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.AppLog.T.POSTS
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.LocalPostId
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.RemotePostId
@@ -263,7 +257,11 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
     private fun getErrorLabel(uploadUiState: UploadFailed, postStatus: PostStatus): UiString? {
         return when {
             uploadUiState.error.mediaError != null -> getMediaUploadErrorMessage(uploadUiState, postStatus)
-            uploadUiState.error.postError != null -> getPostUploadErrorMessage(uploadUiState)
+            uploadUiState.error.postError != null -> UploadUtils.getErrorMessageResIdFromPostError(
+                    false,
+                    uploadUiState.error.postError,
+                    uploadUiState.isEligibleForAutoUpload
+            )
             else -> {
                 val errorMsg = "MediaError and postError are both null."
                 if (BuildConfig.DEBUG) {
@@ -278,38 +276,19 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
 
     private fun getMediaUploadErrorMessage(uploadUiState: UploadFailed, postStatus: PostStatus): UiStringRes {
         return when {
-            uploadUiState.autoRetry -> when (postStatus) {
+            uploadUiState.isEligibleForAutoUpload -> when (postStatus) {
                 PRIVATE, PUBLISHED -> UiStringRes(R.string.error_media_recover_post_not_published_retrying)
                 SCHEDULED -> UiStringRes(R.string.error_media_recover_post_not_scheduled_retrying)
                 PENDING -> UiStringRes(R.string.error_media_recover_post_not_submitted_retrying)
                 DRAFT, TRASHED, UNKNOWN -> UiStringRes(R.string.error_media_recover_post_retrying)
             }
-            uploadUiState.changesExplicitlyConfirmed -> when (postStatus) {
+            uploadUiState.retryWillPushChanges -> when (postStatus) {
                 PRIVATE, PUBLISHED -> UiStringRes(R.string.error_media_recover_post_not_published)
                 SCHEDULED -> UiStringRes(R.string.error_media_recover_post_not_scheduled)
                 PENDING -> UiStringRes(R.string.error_media_recover_post_not_submitted)
                 DRAFT, TRASHED, UNKNOWN -> UiStringRes(R.string.error_media_recover_post)
             }
             else -> UiStringRes(R.string.error_media_recover_post)
-        }
-    }
-
-    private fun getPostUploadErrorMessage(uploadUiState: UploadFailed): UiStringRes {
-        val error = uploadUiState.error.postError
-        return when (error.type ?: GENERIC_ERROR) {
-            UNKNOWN_POST -> UiStringRes(R.string.error_unknown_post)
-            UNKNOWN_POST_TYPE -> UiStringRes(R.string.error_unknown_post_type)
-            UNAUTHORIZED -> UiStringRes(R.string.error_refresh_unauthorized_posts)
-            UNSUPPORTED_ACTION,
-            INVALID_RESPONSE,
-            GENERIC_ERROR -> {
-                AppLog.w(T.MAIN, "Error message: " + error.message + " ,Error Type: " + error.type)
-                if (uploadUiState.autoRetry) {
-                    UiStringRes(R.string.error_generic_error_retrying)
-                } else {
-                    UiStringRes(R.string.error_generic_error)
-                }
-            }
         }
     }
 
@@ -447,8 +426,8 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         data class UploadingPost(val isDraft: Boolean) : PostUploadUiState()
         data class UploadFailed(
             val error: UploadError,
-            val autoRetry: Boolean,
-            val changesExplicitlyConfirmed: Boolean
+            val isEligibleForAutoUpload: Boolean,
+            val retryWillPushChanges: Boolean
         ) : PostUploadUiState()
 
         data class UploadWaitingForConnection(val postStatus: PostStatus) : PostUploadUiState()
@@ -465,10 +444,10 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
             uploadStatus.hasInProgressMediaUpload -> UploadingMedia(uploadStatus.mediaUploadProgress)
             uploadStatus.isUploading -> UploadingPost(postStatus == DRAFT)
             // the upload error is not null on retry -> it needs to be evaluated after UploadingMedia and UploadingPost
-            uploadStatus.uploadError != null -> PostUploadUiState.UploadFailed(
+            uploadStatus.uploadError != null -> UploadFailed(
                     uploadStatus.uploadError,
                     uploadStatus.isEligibleForAutoUpload,
-                    uploadStatus.changesExplicitlyConfirmed
+                    uploadStatus.retryWillPushChanges
             )
             uploadStatus.hasPendingMediaUpload ||
                     uploadStatus.isQueued ||

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -333,8 +333,8 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
     ): List<PostListButtonType> {
         val canRetryUpload = uploadUiState is PostUploadUiState.UploadFailed
         val canCancelPendingAutoUpload = (uploadUiState is UploadWaitingForConnection ||
-                (uploadUiState is PostUploadUiState.UploadFailed && uploadUiState.isEligibleForAutoUpload))
-                && postStatus != DRAFT
+                (uploadUiState is PostUploadUiState.UploadFailed && uploadUiState.isEligibleForAutoUpload)) &&
+                postStatus != DRAFT
         val canPublishPost = (canRetryUpload || uploadUiState is NothingToUpload || !canCancelPendingAutoUpload) &&
                 (isLocallyChanged || isLocalDraft || postStatus == DRAFT ||
                         (siteHasCapabilitiesToPublish && postStatus == PENDING))

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -303,9 +303,10 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         hasUnhandledConflicts: Boolean
     ): Int? {
         val isError = (uploadUiState is UploadFailed && !uploadUiState.isEligibleForAutoUpload) || hasUnhandledConflicts
-        val isProgressInfo = (uploadUiState is UploadFailed && uploadUiState.isEligibleForAutoUpload) ||
-                uploadUiState is UploadingPost || uploadUiState is UploadingMedia || uploadUiState is UploadQueued
-        val isStateInfo = isLocalDraft || isLocallyChanged || postStatus == PRIVATE || postStatus == PENDING ||
+        val isProgressInfo = uploadUiState is UploadingPost || uploadUiState is UploadingMedia ||
+                uploadUiState is UploadQueued
+        val isStateInfo = (uploadUiState is UploadFailed && uploadUiState.isEligibleForAutoUpload) ||
+                isLocalDraft || isLocallyChanged || postStatus == PRIVATE || postStatus == PENDING ||
                 uploadUiState is UploadWaitingForConnection
 
         return when {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -263,6 +263,8 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
                         PENDING -> UiStringRes(R.string.error_media_recover_post_not_submitted_retrying)
                         DRAFT, TRASHED, UNKNOWN -> UiStringRes(R.string.error_media_recover_post_retrying)
                     }
+                } else if (!uploadUiState.changesExplicitlyConfirmed) {
+                    UiStringRes(R.string.error_media_recover_post)
                 } else {
                     when (postStatus) {
                         PRIVATE, PUBLISHED -> UiStringRes(R.string.error_media_recover_post_not_published)
@@ -419,7 +421,12 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
     private sealed class PostUploadUiState {
         data class UploadingMedia(val progress: Int) : PostUploadUiState()
         data class UploadingPost(val isDraft: Boolean) : PostUploadUiState()
-        data class UploadFailed(val error: UploadError, val autoRetry: Boolean) : PostUploadUiState()
+        data class UploadFailed(
+            val error: UploadError,
+            val autoRetry: Boolean,
+            val changesExplicitlyConfirmed: Boolean
+        ) : PostUploadUiState()
+
         data class UploadWaitingForConnection(val postStatus: PostStatus) : PostUploadUiState()
         object UploadQueued : PostUploadUiState()
         object NothingToUpload : PostUploadUiState()
@@ -436,7 +443,8 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
             // the upload error is not null on retry -> it needs to be evaluated after UploadingMedia and UploadingPost
             uploadStatus.uploadError != null -> PostUploadUiState.UploadFailed(
                     uploadStatus.uploadError,
-                    uploadStatus.isEligibleForAutoUpload
+                    uploadStatus.isEligibleForAutoUpload,
+                    uploadStatus.changesExplicitlyConfirmed
             )
             uploadStatus.hasPendingMediaUpload ||
                     uploadStatus.isQueued ||

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUploadStatus.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUploadStatus.kt
@@ -11,5 +11,6 @@ data class PostListItemUploadStatus(
     val isUploadFailed: Boolean,
     val hasInProgressMediaUpload: Boolean,
     val hasPendingMediaUpload: Boolean,
-    val isEligibleForAutoUpload: Boolean
+    val isEligibleForAutoUpload: Boolean,
+    val changesExplicitlyConfirmed: Boolean
 )

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUploadStatus.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUploadStatus.kt
@@ -12,5 +12,5 @@ data class PostListItemUploadStatus(
     val hasInProgressMediaUpload: Boolean,
     val hasPendingMediaUpload: Boolean,
     val isEligibleForAutoUpload: Boolean,
-    val retryWillPushChanges: Boolean
+    val uploadWillPushChanges: Boolean
 )

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUploadStatus.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUploadStatus.kt
@@ -12,5 +12,5 @@ data class PostListItemUploadStatus(
     val hasInProgressMediaUpload: Boolean,
     val hasPendingMediaUpload: Boolean,
     val isEligibleForAutoUpload: Boolean,
-    val changesExplicitlyConfirmed: Boolean
+    val retryWillPushChanges: Boolean
 )

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1473,6 +1473,10 @@
     <string name="error_media_recover_post_not_published">Could not upload media. Post not published.</string>
     <string name="error_media_recover_post_not_scheduled">Could not upload media. Post not scheduled.</string>
     <string name="error_media_recover_post_not_submitted">Could not upload media. Post not submitted.</string>
+    <string name="error_media_recover_post_retrying">Could not upload media. Trying again</string>
+    <string name="error_media_recover_post_not_published_retrying">Could not publish. Trying again</string>
+    <string name="error_media_recover_post_not_scheduled_retrying">Could not schedule. Trying again</string>
+    <string name="error_media_recover_post_not_submitted_retrying">Could not submit. Trying again</string>
     <string name="error_post_does_not_exist">This post no longer exists</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
     <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1469,14 +1469,6 @@
     <string name="error_media_load">Unable to load media</string>
     <string name="error_media_save">Unable to save media</string>
     <string name="error_media_canceled">Uploading media were canceled</string>
-    <string name="error_media_recover_post">Could not upload media</string>
-    <string name="error_media_recover_post_not_published">Could not upload media. Post not published.</string>
-    <string name="error_media_recover_post_not_scheduled">Could not upload media. Post not scheduled.</string>
-    <string name="error_media_recover_post_not_submitted">Could not upload media. Post not submitted.</string>
-    <string name="error_media_recover_post_retrying">Could not upload media. Trying again</string>
-    <string name="error_media_recover_post_not_published_retrying">Could not publish. Trying again</string>
-    <string name="error_media_recover_post_not_scheduled_retrying">Could not schedule. Trying again</string>
-    <string name="error_media_recover_post_not_submitted_retrying">Could not submit. Trying again</string>
     <string name="error_post_does_not_exist">This post no longer exists</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
     <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>
@@ -1495,7 +1487,7 @@
     <string name="error_notif_q_action_approve">Could not approve comment. Please try again later.</string>
     <string name="error_notif_q_action_reply">Could not reply to comment. Please try again later.</string>
     <string name="error_generic_error">Couldn\'t perform operation</string>
-    <string name="error_generic_error_retrying">Couldn\'t perform operation. Trying again</string>
+    <string name="error_generic_error_retrying">Couldn\'t perform operation. We\'ll try again later</string>
     <string name="error_browser_no_network">Unable to load this page right now.</string>
     <string name="error_network_connection">Check your network connection and try again.</string>
 
@@ -1503,6 +1495,25 @@
     <string name="error_unknown_post">Could not find the post on the server</string>
     <string name="error_unknown_page">Could not find the page on the server</string>
     <string name="error_unknown_post_type">Unknown post format</string>
+
+    <string name="error_media_recover_post">Couldn\'t upload media</string>
+    <string name="error_media_recover_post_not_published">Couldn\'t upload media. Post not published</string>
+    <string name="error_media_recover_post_not_published_private">Couldn\'t upload media. Private post not published</string>
+    <string name="error_media_recover_post_not_scheduled">Couldn\'t upload media. Post not scheduled</string>
+    <string name="error_media_recover_post_not_submitted">Couldn\'t upload media. Post not submitted</string>
+    <string name="error_media_recover_post_not_published_retrying" translatable="false">@string/error_post_not_published_retrying</string>
+    <string name="error_media_recover_post_not_published_retrying_private" translatable="false">@string/error_post_not_published_retrying_private</string>
+    <string name="error_media_recover_post_not_scheduled_retrying" translatable="false">@string/error_post_not_scheduled_retrying</string>
+    <string name="error_media_recover_post_not_submitted_retrying" translatable="false">@string/error_post_not_submitted_retrying</string>
+
+    <string name="error_post_not_published">Couldn\'t perform operation. Post not published</string>
+    <string name="error_post_not_published_private">Couldn\'t perform operation. Private post not published</string>
+    <string name="error_post_not_scheduled">Couldn\'t perform operation. Post not scheduled</string>
+    <string name="error_post_not_submitted">Couldn\'t perform operation. Post not submitted</string>
+    <string name="error_post_not_published_retrying">Post couldn\'t be published. We\'ll try again later</string>
+    <string name="error_post_not_published_retrying_private">Private post couldn\'t be published. We\'ll try again later</string>
+    <string name="error_post_not_scheduled_retrying">Post couldn\'t be scheduled. We\'ll try again later</string>
+    <string name="error_post_not_submitted_retrying">Post couldn\'t be submitted. We\'ll try again later</string>
 
     <!-- Image Descriptions for Accessibility -->
     <string name="error_load_comment">Couldn\'t load the comment</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1495,6 +1495,7 @@
     <string name="error_notif_q_action_approve">Could not approve comment. Please try again later.</string>
     <string name="error_notif_q_action_reply">Could not reply to comment. Please try again later.</string>
     <string name="error_generic_error">Couldn\'t perform operation</string>
+    <string name="error_generic_error_retrying">Couldn\'t perform operation. Trying again</string>
     <string name="error_browser_no_network">Unable to load this page right now.</string>
     <string name="error_network_connection">Check your network connection and try again.</string>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadActionUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadActionUseCaseTest.kt
@@ -488,9 +488,9 @@ class UploadActionUseCaseTest {
             uploadServiceFacade: UploadServiceFacade = createdMockedUploadServiceFacade()
         ) = UploadActionUseCase(uploadStore, postUtilsWrapper, uploadServiceFacade)
 
-        private fun createdMockedUploadStore(numberOfPostUploadErrors: Int = 0): UploadStore {
+        private fun createdMockedUploadStore(numberOfAutoUploadAttempts: Int = 0): UploadStore {
             val uploadStore: UploadStore = mock()
-            whenever(uploadStore.getNumberOfPostUploadErrorsOrCancellations(any())).thenReturn(numberOfPostUploadErrors)
+            whenever(uploadStore.getNumberOfPostAutoUploadAttempts(any())).thenReturn(numberOfAutoUploadAttempts)
             return uploadStore
         }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
@@ -80,7 +80,8 @@ class UploadStarterConcurrentTest {
             connectionStatus = mock(),
             uploadServiceFacade = uploadServiceFacade,
             uploadActionUseCase = UploadActionUseCase(mock(), createMockedPostUtilsWrapper(), uploadServiceFacade),
-            tracker = mock()
+            tracker = mock(),
+            dispatcher = mock()
     )
 
     private companion object Fixtures {

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -483,7 +483,8 @@ class UploadStarterTest {
             connectionStatus = connectionStatus,
             uploadServiceFacade = uploadServiceFacade,
             uploadActionUseCase = UploadActionUseCase(uploadStore, postUtilsWrapper, uploadServiceFacade),
-            tracker = mock()
+            tracker = mock(),
+            dispatcher = mock()
     )
 
     private companion object Fixtures {

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -298,7 +298,7 @@ class UploadStarterTest {
         val connectionStatus = createConnectionStatusLiveData(null)
         val uploadServiceFacade = createMockedUploadServiceFacade()
 
-        // This UploadStore.getNumberOfPostUploadErrorsOrCancellations mocked method will always return that
+        // This UploadStore.getNumberOfAutoUploadAttempts mocked method will always return that
         // any post was cancelled 1000 times. The auto upload should not be started.
         val starter = createUploadStarter(
                 connectionStatus, uploadServiceFacade,
@@ -502,8 +502,8 @@ class UploadStarterTest {
             on { isPostInConflictWithRemote(any()) } doReturn false
         }
 
-        fun createMockedUploadStore(numberOfPostErrors: Int) = mock<UploadStore> {
-            on { getNumberOfPostUploadErrorsOrCancellations(any()) } doReturn numberOfPostErrors
+        fun createMockedUploadStore(numberOfAutoUploadAttempts: Int) = mock<UploadStore> {
+            on { getNumberOfPostAutoUploadAttempts(any()) } doReturn numberOfAutoUploadAttempts
         }
 
         fun createMockedUploadServiceFacade() = mock<UploadServiceFacade> {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -22,8 +22,8 @@ import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
 import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.viewmodel.posts.PostListItemAction.MoreItem
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.viewmodel.posts.PostListItemAction.MoreItem
 import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
 import org.wordpress.android.widgets.PostListButtonType
 
@@ -500,28 +500,73 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `media upload error shown with specific message for pending post`() {
+    fun `media upload error shown with specific message for pending post when pending auto-upload`() {
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_PENDING),
-                uploadStatus = createUploadStatus(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
+                uploadStatus = createUploadStatus(
+                        uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        isEligibleForAutoUpload = true
+                )
+        )
+        assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post_not_submitted_retrying))
+    }
+
+    @Test
+    fun `media upload error shown with specific message for pending post when auto-upload disabled`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(isLocallyChanged = true, status = POST_STATE_PENDING),
+                uploadStatus = createUploadStatus(
+                        uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        isEligibleForAutoUpload = false
+                )
         )
         assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post_not_submitted))
     }
 
     @Test
-    fun `media upload error shown with specific message for scheduled post`() {
+    fun `media upload error shown with specific message for scheduled post when pending auto-upload`() {
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_SCHEDULED),
-                uploadStatus = createUploadStatus(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
+                uploadStatus = createUploadStatus(
+                        uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        isEligibleForAutoUpload = true
+                )
+        )
+        assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post_not_scheduled_retrying))
+    }
+
+    @Test
+    fun `media upload error shown with specific message for scheduled post when auto-upload disabled`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(isLocallyChanged = true, status = POST_STATE_SCHEDULED),
+                uploadStatus = createUploadStatus(
+                        uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        isEligibleForAutoUpload = false
+                )
         )
         assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post_not_scheduled))
     }
 
     @Test
-    fun `base media upload error shown for draft`() {
+    fun `retrying media upload shown for draft when pending auto-upload`() {
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_DRAFT),
-                uploadStatus = createUploadStatus(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
+                uploadStatus = createUploadStatus(
+                        uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        isEligibleForAutoUpload = true
+                )
+        )
+        assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post_retrying))
+    }
+
+    @Test
+    fun `base media upload error shown for draft when auto-upload disabled`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(isLocallyChanged = true, status = POST_STATE_DRAFT),
+                uploadStatus = createUploadStatus(
+                        uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        isEligibleForAutoUpload = false
+                )
         )
         assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post))
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -518,7 +518,7 @@ class PostListItemUiStateHelperTest {
                 uploadStatus = createUploadStatus(
                         uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
                         isEligibleForAutoUpload = false,
-                        changesExplicitlyConfirmed = true
+                        retryWillPushChanges = true
                 )
         )
         assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post_not_submitted))
@@ -543,7 +543,7 @@ class PostListItemUiStateHelperTest {
                 uploadStatus = createUploadStatus(
                         uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
                         isEligibleForAutoUpload = false,
-                        changesExplicitlyConfirmed = true
+                        retryWillPushChanges = true
                 )
         )
         assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post_not_scheduled))
@@ -568,7 +568,7 @@ class PostListItemUiStateHelperTest {
                 uploadStatus = createUploadStatus(
                         uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
                         isEligibleForAutoUpload = false,
-                        changesExplicitlyConfirmed = false
+                        retryWillPushChanges = false
                 )
         )
         assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post))
@@ -581,7 +581,7 @@ class PostListItemUiStateHelperTest {
                 uploadStatus = createUploadStatus(
                         uploadError = UploadError(PostError(GENERIC_ERROR)),
                         isEligibleForAutoUpload = false,
-                        changesExplicitlyConfirmed = false
+                        retryWillPushChanges = false
                 )
         )
         assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_generic_error))
@@ -594,7 +594,7 @@ class PostListItemUiStateHelperTest {
                 uploadStatus = createUploadStatus(
                         uploadError = UploadError(PostError(GENERIC_ERROR)),
                         isEligibleForAutoUpload = true,
-                        changesExplicitlyConfirmed = true
+                        retryWillPushChanges = true
                 )
         )
         assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_generic_error_retrying))
@@ -853,7 +853,7 @@ class PostListItemUiStateHelperTest {
         hasInProgressMediaUpload: Boolean = false,
         hasPendingMediaUpload: Boolean = false,
         isEligibleForAutoUpload: Boolean = false,
-        changesExplicitlyConfirmed: Boolean = false
+        retryWillPushChanges: Boolean = false
     ): PostListItemUploadStatus =
             PostListItemUploadStatus(
                     uploadError = uploadError,
@@ -865,7 +865,7 @@ class PostListItemUiStateHelperTest {
                     hasInProgressMediaUpload = hasInProgressMediaUpload,
                     hasPendingMediaUpload = hasPendingMediaUpload,
                     isEligibleForAutoUpload = isEligibleForAutoUpload,
-                    changesExplicitlyConfirmed = changesExplicitlyConfirmed
+                    retryWillPushChanges = retryWillPushChanges
                     )
 
     private fun createGenericError(): UploadError = UploadError(PostError(GENERIC_ERROR))

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -496,7 +496,7 @@ class PostListItemUiStateHelperTest {
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_PRIVATE),
                 uploadStatus = createUploadStatus(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
         )
-        assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post_not_published))
+        assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post))
     }
 
     @Test
@@ -517,7 +517,8 @@ class PostListItemUiStateHelperTest {
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_PENDING),
                 uploadStatus = createUploadStatus(
                         uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
-                        isEligibleForAutoUpload = false
+                        isEligibleForAutoUpload = false,
+                        changesExplicitlyConfirmed = true
                 )
         )
         assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post_not_submitted))
@@ -541,7 +542,8 @@ class PostListItemUiStateHelperTest {
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_SCHEDULED),
                 uploadStatus = createUploadStatus(
                         uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
-                        isEligibleForAutoUpload = false
+                        isEligibleForAutoUpload = false,
+                        changesExplicitlyConfirmed = true
                 )
         )
         assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post_not_scheduled))
@@ -565,10 +567,37 @@ class PostListItemUiStateHelperTest {
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_DRAFT),
                 uploadStatus = createUploadStatus(
                         uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
-                        isEligibleForAutoUpload = false
+                        isEligibleForAutoUpload = false,
+                        changesExplicitlyConfirmed = false
                 )
         )
         assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post))
+    }
+
+    @Test
+    fun `base upload error shown on GENERIC ERROR and disabled auto upload`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(isLocallyChanged = true, status = POST_STATE_DRAFT),
+                uploadStatus = createUploadStatus(
+                        uploadError = UploadError(PostError(GENERIC_ERROR)),
+                        isEligibleForAutoUpload = false,
+                        changesExplicitlyConfirmed = false
+                )
+        )
+        assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_generic_error))
+    }
+
+    @Test
+    fun `retrying upload shown for draft when pending auto-upload`() {
+        val state = createPostListItemUiState(
+                post = createPostModel(isLocallyChanged = true, status = POST_STATE_DRAFT),
+                uploadStatus = createUploadStatus(
+                        uploadError = UploadError(PostError(GENERIC_ERROR)),
+                        isEligibleForAutoUpload = true,
+                        changesExplicitlyConfirmed = true
+                )
+        )
+        assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_generic_error_retrying))
     }
 
     @Test
@@ -823,7 +852,8 @@ class PostListItemUiStateHelperTest {
         isUploadFailed: Boolean = false,
         hasInProgressMediaUpload: Boolean = false,
         hasPendingMediaUpload: Boolean = false,
-        isEligibleForAutoUpload: Boolean = false
+        isEligibleForAutoUpload: Boolean = false,
+        changesExplicitlyConfirmed: Boolean = false
     ): PostListItemUploadStatus =
             PostListItemUploadStatus(
                     uploadError = uploadError,
@@ -834,7 +864,8 @@ class PostListItemUiStateHelperTest {
                     isUploadFailed = isUploadFailed,
                     hasInProgressMediaUpload = hasInProgressMediaUpload,
                     hasPendingMediaUpload = hasPendingMediaUpload,
-                    isEligibleForAutoUpload = isEligibleForAutoUpload
+                    isEligibleForAutoUpload = isEligibleForAutoUpload,
+                    changesExplicitlyConfirmed = changesExplicitlyConfirmed
                     )
 
     private fun createGenericError(): UploadError = UploadError(PostError(GENERIC_ERROR))

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -427,7 +427,7 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `label has info color after failed upload but eligible for auto upload`() {
+    fun `label has state info color after failed upload but eligible for auto upload`() {
         val state = createPostListItemUiState(
                 post = createPostModel(status = POST_STATE_PUBLISH, isLocallyChanged = true),
                 uploadStatus = createUploadStatus(
@@ -435,7 +435,7 @@ class PostListItemUiStateHelperTest {
                         uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED))
                 )
         )
-        assertThat(state.data.statusesColor).isEqualTo(PROGRESS_INFO_COLOR)
+        assertThat(state.data.statusesColor).isEqualTo(STATE_INFO_COLOR)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -508,7 +508,8 @@ class PostListItemUiStateHelperTest {
                         isEligibleForAutoUpload = true
                 )
         )
-        assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post_not_submitted_retrying))
+        assertThat(state.data.statuses)
+                .containsOnly(UiStringRes(R.string.error_media_recover_post_not_submitted_retrying))
     }
 
     @Test
@@ -533,7 +534,8 @@ class PostListItemUiStateHelperTest {
                         isEligibleForAutoUpload = true
                 )
         )
-        assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post_not_scheduled_retrying))
+        assertThat(state.data.statuses)
+                .containsOnly(UiStringRes(R.string.error_media_recover_post_not_scheduled_retrying))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -545,7 +545,7 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `media upload error shown with specific message for pending post when pending auto-upload`() {
+    fun `media upload error shown with specific message for pending post eligible for auto-upload`() {
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_PENDING),
                 uploadStatus = createUploadStatus(
@@ -558,7 +558,7 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `media upload error shown with specific message for pending post when auto-upload disabled`() {
+    fun `media upload error shown with specific message for pending post not eligible for auto-upload`() {
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_PENDING),
                 uploadStatus = createUploadStatus(
@@ -571,7 +571,7 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `media upload error shown with specific message for scheduled post when pending auto-upload`() {
+    fun `media upload error shown with specific message for scheduled post eligible for auto-upload`() {
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_SCHEDULED),
                 uploadStatus = createUploadStatus(
@@ -584,7 +584,7 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `media upload error shown with specific message for scheduled post when auto-upload disabled`() {
+    fun `media upload error shown with specific message for scheduled post not eligible for auto-upload`() {
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_SCHEDULED),
                 uploadStatus = createUploadStatus(
@@ -597,7 +597,7 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `retrying media upload shown for draft when pending auto-upload`() {
+    fun `retrying media upload shown for draft eligible for auto-upload`() {
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_DRAFT),
                 uploadStatus = createUploadStatus(
@@ -609,7 +609,7 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `base media upload error shown for draft when auto-upload disabled`() {
+    fun `base media upload error shown for draft not eligible for auto-upload`() {
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_DRAFT),
                 uploadStatus = createUploadStatus(
@@ -622,7 +622,7 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `base upload error shown on GENERIC ERROR and disabled auto upload`() {
+    fun `base upload error shown on GENERIC ERROR and not eligible for auto upload`() {
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_DRAFT),
                 uploadStatus = createUploadStatus(
@@ -635,7 +635,7 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `retrying upload shown for draft when pending auto-upload`() {
+    fun `retrying upload shown for draft eligible for auto-upload`() {
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_DRAFT),
                 uploadStatus = createUploadStatus(

--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'e753be91d88e3fb6632dd580968576203c1f383c'
+    fluxCVersion = 'a546e39bc4c71408522a4fb3dc41f639a2fee89d'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'c91d9539fcdac830382a582e795ed55bcf72a0af'
+    fluxCVersion = 'e753be91d88e3fb6632dd580968576203c1f383c'
 }


### PR DESCRIPTION
Fixes #10370 

- Replaces `getNumberOfPostUploadErrorsOrCancellations` with `getNumberOfPostAutoUploadAttempts`. The `getNumberOfPostUploadErrorsOrCancellations` counter was used as a guard so we don't keep auto-uploading a post indefinitely. However, the counter was incremented whenever a media or post upload failed (even in offline). So if the user added 10 images in offline, the counter would be incremented ten times. Whereas `getNumberOfPostAutoUploadAttempts` is incremented only when the UploadStarter actually initiates the auto-upload. More info https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1366

- Decreases the number of auto-upload attempts to 3 (MAXIMUM_AUTO_UPLOAD_RETRIES)

- Updates the error messages when upload fails as desribed in #10370  - `Decision 2019-Aug-27`


To test:
1. Turn on airplane mode
2. Create a post
3. Add some media files
4. Click on publish
5. Notice "Post couldn't be published. We'll try again later" label is shown. Also notice both Cancel and Retry (under more) buttons are visible. The Label and Cancel button should be yellow.
------
1. Turn on airplane mode
2. Create a post
3. Add some media files
4. Change the post status to pending in Post settings and click on Submit
5. Notice "Post couldn't be submitted. We'll try again later" label is shown. Also notice both Cancel and Retry (under more) buttons are visible. The Label and Cancel button should be yellow.
6. Make the auto-upload fail 3 times (eg. turn the airplane mode off and on)
7. Notice after three attempts the message changes to "Couldn't perform operation. Post not submitted.". The cancel button should disappear and the label and Retry should be red.
------------
1. Create a post while online
2. Add some title and content (no media files)
3. Click on publish
4. Turn on airplane mode before the upload finishes
5. Notice "Post couldn't be published. We'll try again later" label is shown. Also notice both Cancel and Retry (under more) buttons are visible. The Label and Cancel button should be yellow.

Update release notes:

- [ x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
