### PR TITLE
Update release toolkit to 0.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: b57127b313fd06519cbebfd4a3f6784eec1ef5fc
-  tag: 0.7.1
+  revision: 21400012da8c2ceafa8ea2ce23d8a88233a97838
+  tag: 0.7.2
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.7.1)
+    fastlane-plugin-wpmreleasetoolkit (0.7.2)
       diffy (~> 3.3)
       git (~> 1.3)
       jsonlint

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.7.1' 
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.7.2' 
 
 
 


### PR DESCRIPTION
This PR updates `release-toolkit` to `0.7.2` in order to incorporate the latest fixes. 

To test:
1. Run `bundle install`.
2. Run `bundle exec fastlane build_pre_releases` (or any other Fastlane command) and verify that the version code and name are correctly read.
3. Abort the command. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
