### PR TITLE
Rename conflict autosave to autosave revision

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@ XX.X
 * Add Remote Preview support for posts and pages.
 * Post List: Trashed post must now be restored before edit or preview.
 * All changes to posts and pages will be automatically synced with the server.
-* Post List: Unhandled conflict with auto saves are now detected and visible. On post opening, the app will let you choose which version you prefer.
+* Post List: Unsaved changes are automatically backed up on all devices. On post opening, the app will let you choose which version you prefer.
 * Clicking on "Publish" on a private post sometimes published the post as public
 
 13.2

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -177,9 +177,9 @@ class PostActionHandler(
             return
         }
 
-        // Then check if it's in conflicted state with a remote auto-save
+        // Then check if an autosave revision is available
         if (hasUnhandledAutoSave.invoke(post)) {
-            postListDialogHelper.showAutoSaveConflictedPostResolutionDialog(post)
+            postListDialogHelper.showAutoSaveRevisionDialog(post)
             return
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostConflictResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostConflictResolver.kt
@@ -85,7 +85,7 @@ class PostConflictResolver(
     }
 
     fun hasUnhandledAutoSave(post: PostModel): Boolean {
-        return PostUtils.isPostInConflictWithAutoSave(post)
+        return PostUtils.hasAutoSave(post)
     }
 
     fun onPostSuccessfullyUpdated() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
@@ -90,7 +90,7 @@ class PostListDialogHelper(
         val dialogHolder = DialogHolder(
                 tag = CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG,
                 title = UiStringRes(R.string.dialog_confirm_autosave_title),
-                message = UiStringRes(R.string.dialog_confirm_autosave_body),
+                message = PostUtils.getCustomStringForAutosaveRevisionDialog(post),
                 positiveButton = UiStringRes(R.string.dialog_confirm_autosave_restore_button),
                 negativeButton = UiStringRes(R.string.dialog_confirm_autosave_dont_restore_button)
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
@@ -10,7 +10,7 @@ private const val CONFIRM_DELETE_POST_DIALOG_TAG = "CONFIRM_DELETE_POST_DIALOG_T
 private const val CONFIRM_PUBLISH_POST_DIALOG_TAG = "CONFIRM_PUBLISH_POST_DIALOG_TAG"
 private const val CONFIRM_TRASH_POST_WITH_LOCAL_CHANGES_DIALOG_TAG = "CONFIRM_TRASH_POST_WITH_LOCAL_CHANGES_DIALOG_TAG"
 private const val CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG = "CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG"
-private const val CONFIRM_ON_AUTOSAVE_CONFLICT_DIALOG_TAG = "CONFIRM_ON_AUTOSAVE_CONFLICT_DIALOG_TAG"
+private const val CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG = "CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG"
 
 /**
  * This is a temporary class to make the PostListViewModel more manageable. Please feel free to refactor it any way
@@ -25,7 +25,7 @@ class PostListDialogHelper(
     private var localPostIdForPublishDialog: Int? = null
     private var localPostIdForTrashPostWithLocalChangesDialog: Int? = null
     private var localPostIdForConflictResolutionDialog: Int? = null
-    private var localPostIdForAutoSaveConflictResolutionDialog: Int? = null
+    private var localPostIdForAutosaveRevisionResolutionDialog: Int? = null
 
     fun showDeletePostConfirmationDialog(post: PostModel) {
         // We need network connection to delete a remote post, but not a local draft
@@ -86,15 +86,15 @@ class PostListDialogHelper(
         showDialog.invoke(dialogHolder)
     }
 
-    fun showAutoSaveConflictedPostResolutionDialog(post: PostModel) {
+    fun showAutoSaveRevisionDialog(post: PostModel) {
         val dialogHolder = DialogHolder(
-                tag = CONFIRM_ON_AUTOSAVE_CONFLICT_DIALOG_TAG,
+                tag = CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG,
                 title = UiStringRes(R.string.dialog_confirm_autosave_title),
                 message = UiStringRes(R.string.dialog_confirm_autosave_body),
                 positiveButton = UiStringRes(R.string.dialog_confirm_autosave_restore_button),
                 negativeButton = UiStringRes(R.string.dialog_confirm_autosave_dont_restore_button)
         )
-        localPostIdForAutoSaveConflictResolutionDialog = post.id
+        localPostIdForAutosaveRevisionResolutionDialog = post.id
         showDialog.invoke(dialogHolder)
     }
 
@@ -124,9 +124,9 @@ class PostListDialogHelper(
                 localPostIdForTrashPostWithLocalChangesDialog = null
                 trashPostWithLocalChanges(it)
             }
-            CONFIRM_ON_AUTOSAVE_CONFLICT_DIALOG_TAG -> localPostIdForAutoSaveConflictResolutionDialog?.let {
+            CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> localPostIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the restored auto save
-                localPostIdForAutoSaveConflictResolutionDialog = null
+                localPostIdForAutosaveRevisionResolutionDialog = null
                 editRestoredAutoSavePost(it)
             }
             else -> throw IllegalArgumentException("Dialog's positive button click is not handled: $instanceTag")
@@ -145,7 +145,7 @@ class PostListDialogHelper(
             CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG -> localPostIdForConflictResolutionDialog?.let {
                 updateConflictedPostWithLocalVersion(it)
             }
-            CONFIRM_ON_AUTOSAVE_CONFLICT_DIALOG_TAG -> localPostIdForAutoSaveConflictResolutionDialog?.let {
+            CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> localPostIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the local post (don't use the auto save version)
                 editLocalPost(it)
             }
@@ -158,10 +158,10 @@ class PostListDialogHelper(
         updateConflictedPostWithLocalVersion: (Int) -> Unit,
         editLocalPost: (Int) -> Unit
     ) {
-        // Cancel and outside touch dismiss works the same way for all, except for conflict resolution dialogs,
-        // for which tapping outside and actively tapping the "edit local" have different meanings
+        // Cancel and outside touch dismiss works the same way for all, except for conflict and autosave revision
+        // dialogs, for which tapping outside and actively tapping the "edit local" have different meanings
         if (instanceTag != CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG &&
-                instanceTag != CONFIRM_ON_AUTOSAVE_CONFLICT_DIALOG_TAG) {
+                instanceTag != CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG) {
             onNegativeClickedForBasicDialog(
                     instanceTag = instanceTag,
                     updateConflictedPostWithLocalVersion = updateConflictedPostWithLocalVersion,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -453,7 +453,7 @@ public class PostUtils {
         return !post.getLastModified().equals(post.getRemoteLastModified()) && post.isLocallyChanged();
     }
 
-    public static boolean isPostInConflictWithAutoSave(PostModel post) {
+    public static boolean hasAutoSave(PostModel post) {
         // TODO: would be great to check if title, content and excerpt are different,
         // but we currently don't have them when we fetch the post list
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType;
 import org.wordpress.android.ui.uploads.UploadUtils;
+import org.wordpress.android.ui.utils.UiString.UiStringText;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
@@ -474,6 +475,21 @@ public class PostUtils {
                         getFormattedDateForLastModified(
                                 context, DateTimeUtils.timestampFromIso8601Millis(post.getRemoteLastModified())));
         return firstPart + secondPart;
+    }
+
+    public static UiStringText getCustomStringForAutosaveRevisionDialog(PostModel post) {
+        Context context = WordPress.getContext();
+        String firstPart = context.getString(R.string.dialog_confirm_autosave_body);
+
+        String lastModified =
+                TextUtils.isEmpty(post.getDateLocallyChanged()) ? post.getLastModified() : post.getDateLocallyChanged();
+        String secondPart =
+                String.format(context.getString(R.string.dialog_confirm_autosave_body_2),
+                        getFormattedDateForLastModified(
+                                context, DateTimeUtils.timestampFromIso8601Millis(lastModified)),
+                        getFormattedDateForLastModified(
+                                context, DateTimeUtils.timestampFromIso8601Millis(post.getAutoSaveModified())));
+        return new UiStringText(firstPart + secondPart);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -479,12 +479,12 @@ public class PostUtils {
 
     public static UiStringText getCustomStringForAutosaveRevisionDialog(PostModel post) {
         Context context = WordPress.getContext();
-        String firstPart = context.getString(R.string.dialog_confirm_autosave_body);
+        String firstPart = context.getString(R.string.dialog_confirm_autosave_body_first_part);
 
         String lastModified =
                 TextUtils.isEmpty(post.getDateLocallyChanged()) ? post.getLastModified() : post.getDateLocallyChanged();
         String secondPart =
-                String.format(context.getString(R.string.dialog_confirm_autosave_body_2),
+                String.format(context.getString(R.string.dialog_confirm_autosave_body_second_part),
                         getFormattedDateForLastModified(
                                 context, DateTimeUtils.timestampFromIso8601Millis(lastModified)),
                         getFormattedDateForLastModified(

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -356,6 +356,7 @@
     <!-- post autosave revision dialog -->
     <string name="dialog_confirm_autosave_title">Which version would you like to edit?</string>
     <string name="dialog_confirm_autosave_body">You recently made changes to this post but didn\'t save them. Choose version to load\n\n</string>
+    <string name="dialog_confirm_autosave_body_2">On this app\nSaved on %s\n\nFrom another device\nSaved on %s\n</string>
     <string name="dialog_confirm_autosave_restore_button">The version from another device</string>
     <string name="dialog_confirm_autosave_dont_restore_button">The version on this app</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -353,11 +353,11 @@
     <string name="snackbar_conflict_web_version_discarded">Web version discarded</string>
     <string name="snackbar_conflict_undo">Undo</string>
 
-    <!-- post autosave conflict dialog -->
-    <string name="dialog_confirm_autosave_title">More Recent Version Conflict</string>
-    <string name="dialog_confirm_autosave_body">A more recent version exists. Edit current version or most recent version?\n\n</string>
-    <string name="dialog_confirm_autosave_restore_button">More recent version</string>
-    <string name="dialog_confirm_autosave_dont_restore_button">Current version</string>
+    <!-- post autosave revision dialog -->
+    <string name="dialog_confirm_autosave_title">Which version would you like to edit?</string>
+    <string name="dialog_confirm_autosave_body">You recently made changes to this post but didn\'t save them. Choose version to load\n\n</string>
+    <string name="dialog_confirm_autosave_restore_button">The version from another device</string>
+    <string name="dialog_confirm_autosave_dont_restore_button">The version on this app</string>
 
     <!-- trash post with local changes dialog -->
     <string name="dialog_confirm_trash_losing_local_changes_title">Local changes</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -355,10 +355,10 @@
 
     <!-- post autosave revision dialog -->
     <string name="dialog_confirm_autosave_title">Which version would you like to edit?</string>
-    <string name="dialog_confirm_autosave_body">You recently made changes to this post but didn\'t save them. Choose version to load\n\n</string>
-    <string name="dialog_confirm_autosave_body_2">On this app\nSaved on %s\n\nFrom another device\nSaved on %s\n</string>
+    <string name="dialog_confirm_autosave_body_first_part">You recently made changes to this post but didn\'t save them. Choose a version to load:\n\n</string>
+    <string name="dialog_confirm_autosave_body_second_part">From this app\nSaved on %s\n\nFrom another device\nSaved on %s\n</string>
     <string name="dialog_confirm_autosave_restore_button">The version from another device</string>
-    <string name="dialog_confirm_autosave_dont_restore_button">The version on this app</string>
+    <string name="dialog_confirm_autosave_dont_restore_button">The version from this app</string>
 
     <!-- trash post with local changes dialog -->
     <string name="dialog_confirm_trash_losing_local_changes_title">Local changes</string>


### PR DESCRIPTION
Follow up to [Maxime's PR](https://github.com/wordpress-mobile/WordPress-Android/pull/10426).

- Replaces "autosave conflict" with "autosave revision" as it might get confusing when we introduce actual auto-save conflict detection.
- Updates texts on the dialog as proposed during the copy review

<img src="https://user-images.githubusercontent.com/2261188/63844943-642ec500-c989-11e9-95e5-e41a8015600a.png" alt="Example"  height="350">


To test:

1. Edit an existing post in Calypso - > close the browser tab without saving the post
3. Refresh the Post list in WPAndroid.
4. You should see a "Unhandled auto save" label.
5. Click on the list item
6. Notice the unpublished revision dialog is shown - check the texts


I'll fix https://github.com/wordpress-mobile/WordPress-Android/issues/10450 in another PR.


Update release notes:

- [ x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc @osullivanchris @benhuberman I've closed the previous PR. You can see the current version on the screenshot above. However, we can still easily make any change you like. I just wanted to close that PR so I can fix some other issues unrelated to the copy review.
