### PR TITLE
Stop auto-uploading pages

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,9 +2,9 @@ XX.X
 ----
 * Add Remote Preview support for posts and pages.
 * Post List: Trashed post must now be restored before edit or preview.
-* All changes to posts and pages will be automatically synced with the server.
+* All changes to posts will be automatically synced with the server.
 * Post List: Unhandled conflict with auto saves are now detected and visible. On post opening, the app will let you choose which version you prefer.
-* Clicking on "Publish" on a private post sometimes published the post as public
+* Fixed: Clicking on "Publish" on a private post sometimes published the post as public
 
 13.2
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -10,13 +10,11 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.BG_THREAD
@@ -51,7 +49,6 @@ class UploadStarter @Inject constructor(
      */
     private val context: Context,
     private val postStore: PostStore,
-    private val pageStore: PageStore,
     private val siteStore: SiteStore,
     private val uploadActionUseCase: UploadActionUseCase,
     private val tracker: AnalyticsTrackerWrapper,
@@ -145,13 +142,10 @@ class UploadStarter @Inject constructor(
     private suspend fun upload(site: SiteModel) = coroutineScope {
         try {
             mutex.lock()
-            val posts = async { postStore.getPostsWithLocalChanges(site) }
-            val pages = async { pageStore.getPagesWithLocalChanges(site) }
-
-            val postsAndPages = posts.await() + pages.await()
+            val posts = postStore.getPostsWithLocalChanges(site)
 
             // TODO Set Retry = false when autosaving or perhaps check `getNumberOfPostUploadErrorsOrCancellations != 0`
-            postsAndPages
+            posts
                     .asSequence()
                     .filter {
                         val action = uploadActionUseCase.getAutoUploadAction(it, site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -34,7 +34,7 @@ import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 /**
- * Automatically uploads local drafts.
+ * Automatically remote-auto-save or upload all local modifications to posts.
  *
  * Auto-uploads happen when the app is placed in the foreground or when the internet connection is restored. In
  * addition to this, call sites can also request an immediate execution by calling [checkConnectionAndUpload].

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -177,8 +177,6 @@ class PagesViewModel
             eventBusWrapper.register(this)
 
             loadPagesAsync()
-
-            uploadStarter.queueUploadFromSite(site)
         }
     }
 
@@ -462,8 +460,6 @@ class PagesViewModel
     }
 
     fun onPullToRefresh() {
-        uploadStarter.queueUploadFromSite(site)
-
         launch {
             reloadPages(FETCHING)
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -44,7 +44,6 @@ import org.wordpress.android.ui.posts.PostListRemotePreviewState
 import org.wordpress.android.ui.posts.PreviewStateHelper
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType
 import org.wordpress.android.ui.uploads.PostEvents
-import org.wordpress.android.ui.uploads.UploadStarter
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.EventBusWrapper
@@ -87,7 +86,6 @@ class PagesViewModel
     private val dispatcher: Dispatcher,
     private val actionPerfomer: ActionPerformer,
     private val networkUtils: NetworkUtilsWrapper,
-    private val uploadStarter: UploadStarter,
     private val eventBusWrapper: EventBusWrapper,
     private val previewStateHelper: PreviewStateHelper,
     @Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher,

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
@@ -16,7 +16,6 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.post.PostStatus
-import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.ui.posts.PostUtilsWrapper
 import org.wordpress.android.util.DateTimeUtils
@@ -45,9 +44,6 @@ class UploadStarterConcurrentTest {
     private val postStore = mock<PostStore> {
         on { getPostsWithLocalChanges(eq(site)) } doReturn draftPosts
     }
-    private val pageStore = mock<PageStore> {
-        onBlocking { getPagesWithLocalChanges(any()) } doReturn emptyList()
-    }
 
     @Test
     fun `it uploads local drafts concurrently`() {
@@ -72,7 +68,6 @@ class UploadStarterConcurrentTest {
     private fun createUploadStarter(uploadServiceFacade: UploadServiceFacade) = UploadStarter(
             context = mock(),
             postStore = postStore,
-            pageStore = pageStore,
             siteStore = mock(),
             bgDispatcher = Dispatchers.Default,
             ioDispatcher = Dispatchers.IO,

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded
 import org.wordpress.android.test
 import org.wordpress.android.ui.uploads.PostEvents
-import org.wordpress.android.ui.uploads.UploadStarter
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState.DONE
@@ -46,7 +45,6 @@ class PagesViewModelTest {
     @Mock lateinit var dispatcher: Dispatcher
     @Mock lateinit var actionPerformer: ActionPerformer
     @Mock lateinit var networkUtils: NetworkUtilsWrapper
-    @Mock lateinit var uploadStarter: UploadStarter
     private lateinit var viewModel: PagesViewModel
     private lateinit var listStates: MutableList<PageListState>
     private lateinit var pages: MutableList<List<PageModel>>
@@ -61,7 +59,6 @@ class PagesViewModelTest {
                 dispatcher = dispatcher,
                 actionPerfomer = actionPerformer,
                 networkUtils = networkUtils,
-                uploadStarter = uploadStarter,
                 previewStateHelper = mock(),
                 uiDispatcher = Dispatchers.Unconfined,
                 defaultDispatcher = Dispatchers.Unconfined,

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -2,11 +2,7 @@ package org.wordpress.android.viewmodel.pages
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -155,34 +151,6 @@ class PagesViewModelTest {
         // Assert
         val result = viewModel.searchPages.value
         assertThat(result).isNull()
-    }
-
-    @Test
-    fun `when started, it uploads all local drafts`() = runBlocking {
-        // Arrange
-        setUpPageStoreWithEmptyPages()
-
-        // Act
-        viewModel.start(site)
-
-        // Assert
-        verify(uploadStarter, times(1)).queueUploadFromSite(eq(site))
-        verifyNoMoreInteractions(uploadStarter)
-    }
-
-    @Test
-    fun `when pulling to refresh, it uploads all local drafts`() = runBlocking {
-        // Arrange
-        setUpPageStoreWithEmptyPages()
-        viewModel.start(site)
-
-        // Act
-        viewModel.onPullToRefresh()
-
-        // Assert
-        // We get 2 calls because the `viewModel.start()` also requests an upload
-        verify(uploadStarter, times(2)).queueUploadFromSite(eq(site))
-        verifyNoMoreInteractions(uploadStarter)
     }
 
     @Test


### PR DESCRIPTION
Fixes #10443

Auto-upload for pages was always nice to have feature (seemed like a hanging fruit). But we decided to stop auto-uploading pages, since we didn't have time to properly test all the scenarios and modify the UI/UX (eg. add option to cancel the auto-upload and similar). 

To test:
1. Make sure auto-upload works for posts

Update release notes:

- [ x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
