### PR TITLE
CircleCI: Update caching for installable build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ jobs:
             echo "export VERSION_NAME=$VERSION_NAME" >> $BASH_ENV
 
             ./gradlew --stacktrace assembleVanillaRelease -PversionName="$VERSION_NAME"
+      - android/save-gradle-cache
       - run:
           name: Prepare APK
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 orbs:
   android: wordpress-mobile/android@0.0.27
-  bundle-install: toshimaru/bundle-install@0.1.1
+  bundle-install: toshimaru/bundle-install@0.3.1
   slack: circleci/slack@2.5.0
 
 commands:
@@ -59,7 +59,8 @@ jobs:
       api-version: "28"
     steps:
       - checkout
-      - bundle-install/bundle-install
+      - bundle-install/bundle-install:
+          cache_key_prefix: installable-build
       - run:
           name: Copy Secrets
           command: bundle exec fastlane run configure_apply
@@ -120,7 +121,8 @@ jobs:
       - image: circleci/ruby:2.3
     steps:
       - checkout
-      - bundle-install/bundle-install
+      - bundle-install/bundle-install:
+          cache_key_prefix: strings-check
       - run:
           name: Validate login strings
           command: bundle exec fastlane validate_login_strings pr_url:$CIRCLE_PULL_REQUEST


### PR DESCRIPTION
This fixes a small oversight with installable builds from https://github.com/wordpress-mobile/WordPress-Android/pull/10404. I forgot to save the cache. It should speed up slightly now.

It also updates how the bundler caching works. Since both `strings-check` and `Installable Build` use the cache but don't run on the same container type, the shared cache was not valid. It is fixed now.

Combined, this reduces the run time of the "Installable Build" job from ~7.5 minutes to 4 minutes, which is actually faster than the lint job.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
