### PR TITLE
Issue/fix notification header text color

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -20,7 +19,6 @@ import org.wordpress.android.ui.notifications.utils.FormattableContentClickHandl
 import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
 import org.wordpress.android.ui.posts.BasicFragmentDialog
 import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.util.getColorFromAttribute
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.AVATAR_WITH_BACKGROUND
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_ID_KEY
@@ -83,12 +81,7 @@ class ActivityLogDetailFragment : Fragment() {
                 val noteBlockSpans = spannable?.getSpans(0, spannable.length, NoteBlockClickableSpan::class.java)
 
                 noteBlockSpans?.forEach {
-                    it.setColors(
-                            activity.getColorFromAttribute(R.attr.wpColorText),
-                            ContextCompat.getColor(activity, R.color.primary_5),
-                            ContextCompat.getColor(activity, R.color.primary_40),
-                            activity.getColorFromAttribute(R.attr.wpColorText)
-                    )
+                    it.enableColors(activity)
                 }
 
                 uiHelpers.setTextOrHide(activityMessage, spannable)

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -11,7 +11,6 @@ import android.view.ViewParent;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import androidx.core.content.ContextCompat;
 import androidx.core.text.BidiFormatter;
 import androidx.core.view.ViewCompat;
 import androidx.recyclerview.widget.RecyclerView;
@@ -25,7 +24,6 @@ import org.wordpress.android.ui.comments.CommentUtils;
 import org.wordpress.android.ui.notifications.NotificationsListFragmentPage.OnNoteClickListener;
 import org.wordpress.android.ui.notifications.blocks.NoteBlockClickableSpan;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper;
-import org.wordpress.android.util.ContextExtensionsKt;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.RtlUtils;
 import org.wordpress.android.util.image.ImageManager;

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -254,13 +254,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         NoteBlockClickableSpan[] spans =
                 noteSubjectSpanned.getSpans(0, noteSubjectSpanned.length(), NoteBlockClickableSpan.class);
         for (NoteBlockClickableSpan span : spans) {
-            span.setColors(
-                    ContextExtensionsKt
-                            .getColorFromAttribute(noteViewHolder.mContentView.getContext(), R.attr.wpColorText),
-                    ContextCompat.getColor(noteViewHolder.mContentView.getContext(), R.color.primary_5),
-                    ContextCompat.getColor(noteViewHolder.mContentView.getContext(), R.color.primary_40),
-                    ContextExtensionsKt
-                            .getColorFromAttribute(noteViewHolder.mContentView.getContext(), R.attr.wpColorText));
+            span.enableColors(noteViewHolder.mContentView.getContext());
         }
 
         noteViewHolder.mTxtSubject.setText(noteSubjectSpanned);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
@@ -122,8 +122,13 @@ public class CommentUserNoteBlock extends UserNoteBlock {
         }
         mImageManager.loadIntoCircle(noteBlockHolder.mAvatarImageView, ImageType.AVATAR_WITH_BACKGROUND, imageUrl);
 
-        noteBlockHolder.mCommentTextView
-                .setText(getCommentTextOfNotification(noteBlockHolder));
+        Spannable spannable = getCommentTextOfNotification(noteBlockHolder);
+        NoteBlockClickableSpan[] spans = spannable.getSpans(0, spannable.length(), NoteBlockClickableSpan.class);
+        for (NoteBlockClickableSpan span : spans) {
+            span.enableColors(view.getContext());
+        }
+
+        noteBlockHolder.mCommentTextView.setText(spannable);
 
         // Change display based on comment status and type:
         // 1. Comment replies are indented and have a 'pipe' background

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/FooterNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/FooterNoteBlock.java
@@ -54,7 +54,13 @@ public class FooterNoteBlock extends NoteBlock {
 
         // Note text
         if (!TextUtils.isEmpty(getNoteText())) {
-            noteBlockHolder.getTextView().setText(getNoteText());
+            Spannable spannable = getNoteText();
+            NoteBlockClickableSpan[] spans = spannable.getSpans(0, spannable.length(), NoteBlockClickableSpan.class);
+            for (NoteBlockClickableSpan span : spans) {
+                span.enableColors(view.getContext());
+            }
+
+            noteBlockHolder.getTextView().setText(spannable);
             noteBlockHolder.getTextView().setVisibility(View.VISIBLE);
         } else {
             noteBlockHolder.getTextView().setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/HeaderNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/HeaderNoteBlock.java
@@ -59,6 +59,10 @@ public class HeaderNoteBlock extends NoteBlock {
         final NoteHeaderBlockHolder noteBlockHolder = (NoteHeaderBlockHolder) view.getTag();
 
         Spannable spannable = mNotificationsUtilsWrapper.getSpannableContentForRanges(mHeadersList.get(0));
+        NoteBlockClickableSpan[] spans = spannable.getSpans(0, spannable.length(), NoteBlockClickableSpan.class);
+        for (NoteBlockClickableSpan span : spans) {
+            span.enableColors(view.getContext());
+        }
         noteBlockHolder.mNameTextView.setText(spannable);
         if (mImageType == ImageType.AVATAR_WITH_BACKGROUND) {
             mImageManager.loadIntoCircle(noteBlockHolder.mAvatarImageView, mImageType, getAvatarUrl());

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
@@ -230,6 +230,11 @@ public class NoteBlock {
                     noteBlockHolder.getTextView().setGravity(Gravity.NO_GRAVITY);
                     noteBlockHolder.getTextView().setPadding(0, 0, 0, 0);
                 }
+
+                NoteBlockClickableSpan[] spans = noteText.getSpans(0, noteText.length(), NoteBlockClickableSpan.class);
+                for (NoteBlockClickableSpan span : spans) {
+                    span.enableColors(view.getContext());
+                }
                 noteBlockHolder.getTextView().setText(noteText);
                 noteBlockHolder.getTextView().setVisibility(View.VISIBLE);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlockClickableSpan.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlockClickableSpan.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.notifications.blocks;
 
+import android.content.Context;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.text.TextPaint;
@@ -9,9 +10,12 @@ import android.view.View;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 
+import org.wordpress.android.R;
 import org.wordpress.android.fluxc.tools.FormattableRange;
 import org.wordpress.android.fluxc.tools.FormattableRangeType;
+import org.wordpress.android.util.ContextExtensionsKt;
 
 import java.util.List;
 
@@ -41,6 +45,15 @@ public class NoteBlockClickableSpan extends ClickableSpan {
         mShouldLink = shouldLink;
         mIsFooter = isFooter;
         processRangeData(range);
+    }
+
+    // We need to use theme-styled colors in NoteBlockClickableSpan but current Notifications architecture makes it
+    // difficult to get right type of context to this span to style the colors. We are doing it in this method instead.
+    public void enableColors(Context context) {
+        mTextColor = ContextExtensionsKt.getColorFromAttribute(context, R.attr.wpColorText);
+        mBackgroundColor = ContextCompat.getColor(context, R.color.primary_5);
+        mLinkColor = ContextCompat.getColor(context, R.color.primary_40);
+        mLightTextColor = ContextExtensionsKt.getColorFromAttribute(context, R.attr.wpColorText);
     }
 
     public void setColors(@ColorInt int textColor, @ColorInt int backgroundColor, @ColorInt int linkColor,


### PR DESCRIPTION
While switching to semantic color names, I missed styling of Header and Footer notifications (and `CommentUserNoteBlock`, but no idea where it actually shows).

`NoteBlockClickableSpan` makes my life hard, since it's so far away from proper context, and we have to resort to tricks like this.

To test:
 - Open notification details of comment you replied to.
- Notice at the Header block you see your name.
[![Image from Gyazo](https://i.gyazo.com/a7d40e8ba0da4920e311b36ddce5632c.png)](https://gyazo.com/a7d40e8ba0da4920e311b36ddce5632c)

- Notice at the Footer block `reply` link is visible.
[![Image from Gyazo](https://i.gyazo.com/12f866f1c430e7298ff591b7baace032.png)](https://gyazo.com/12f866f1c430e7298ff591b7baace032)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
