### PR TITLE
Don't override local changes unless user edits unpublished revision

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -513,10 +513,21 @@ public class ActivityLauncher {
     }
 
     public static void editPostOrPageForResult(Activity activity, SiteModel site, PostModel post) {
-        editPostOrPageForResult(new Intent(activity, EditPostActivity.class), activity, site, post.getId());
+        editPostOrPageForResult(new Intent(activity, EditPostActivity.class), activity, site, post.getId(), false);
+    }
+
+    public static void editPostOrPageForResult(Activity activity, SiteModel site, PostModel post,
+                                               boolean loadAutoSaveRevision) {
+        editPostOrPageForResult(new Intent(activity, EditPostActivity.class), activity, site, post.getId(),
+                loadAutoSaveRevision);
     }
 
     public static void editPostOrPageForResult(Intent intent, Activity activity, SiteModel site, int postLocalId) {
+        editPostOrPageForResult(intent, activity, site, postLocalId, false);
+    }
+
+    public static void editPostOrPageForResult(Intent intent, Activity activity, SiteModel site, int postLocalId,
+                                               boolean loadAutoSaveRevision) {
         if (site == null) {
             return;
         }
@@ -526,6 +537,8 @@ public class ActivityLauncher {
         // in order to avoid issues like TransactionTooLargeException it's better to pass the id of the post.
         // However, we still want to keep passing the SiteModel to avoid confusion around local & remote ids.
         intent.putExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, postLocalId);
+        intent.putExtra(EditPostActivity.EXTRA_LOAD_AUTO_SAVE_REVISION, loadAutoSaveRevision);
+
         activity.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -214,6 +214,7 @@ public class EditPostActivity extends AppCompatActivity implements
         HistoryListFragment.HistoryItemClickInterface,
         EditPostSettingsCallback {
     public static final String EXTRA_POST_LOCAL_ID = "postModelLocalId";
+    public static final String EXTRA_LOAD_AUTO_SAVE_REVISION = "loadAutosaveRevision";
     public static final String EXTRA_POST_REMOTE_ID = "postModelRemoteId";
     public static final String EXTRA_IS_PAGE = "isPage";
     public static final String EXTRA_IS_PROMO = "isPromo";
@@ -520,6 +521,15 @@ public class EditPostActivity extends AppCompatActivity implements
                 mPost = mPostStore.getPostByLocalPostId(extras.getInt(EXTRA_POST_LOCAL_ID)); // Load post from extras
 
                 if (mPost != null) {
+                    if (extras.getBoolean(EXTRA_LOAD_AUTO_SAVE_REVISION)) {
+                        mPost.setTitle(TextUtils.isEmpty(mPost.getAutoSaveTitle()) ? mPost.getTitle()
+                                : mPost.getAutoSaveTitle());
+                        mPost.setContent(TextUtils.isEmpty(mPost.getAutoSaveContent()) ? mPost.getContent()
+                                : mPost.getAutoSaveContent());
+                        mPost.setExcerpt(TextUtils.isEmpty(mPost.getAutoSaveExcerpt()) ? mPost.getExcerpt()
+                                : mPost.getAutoSaveExcerpt());
+                    }
+
                     initializePostObject();
                 } else if (isRestarting) {
                     newPostSetup();
@@ -752,9 +762,11 @@ public class EditPostActivity extends AppCompatActivity implements
                         updatePostObject(true);
                     } catch (EditorFragmentNotAddedException e) {
                         AppLog.e(T.EDITOR, "Impossible to save the post, we weren't able to update it.");
-                        return;
                     }
-                    savePostToDb();
+                    // make sure we save the post only after the user made some changes
+                    if (mPostSnapshotWhenEditorOpened == null || !mPostSnapshotWhenEditorOpened.equals(mPost)) {
+                        savePostToDb();
+                    }
                 }
             }).start();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -192,7 +192,7 @@ class PostActionHandler(
             // post itself when they finish (since we're about to edit it again)
             UploadService.cancelQueuedPostUpload(post)
         }
-        triggerPostListAction.invoke(PostListAction.EditPost(site, post))
+        triggerPostListAction.invoke(PostListAction.EditPost(site, post, loadAutoSaveRevision = false))
     }
 
     fun deletePost(localPostId: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
 
 sealed class PostListAction {
-    class EditPost(val site: SiteModel, val post: PostModel) : PostListAction()
+    class EditPost(val site: SiteModel, val post: PostModel, val loadAutoSaveRevision: Boolean) : PostListAction()
     class NewPost(val site: SiteModel, val isPromo: Boolean = false) : PostListAction()
     class PreviewPost(
         val site: SiteModel,
@@ -42,7 +42,7 @@ fun handlePostListAction(
 ) {
     when (action) {
         is PostListAction.EditPost -> {
-            ActivityLauncher.editPostOrPageForResult(activity, action.site, action.post)
+            ActivityLauncher.editPostOrPageForResult(activity, action.site, action.post, action.loadAutoSaveRevision)
         }
         is PostListAction.NewPost -> {
             ActivityLauncher.addNewPostForResult(activity, action.site, action.isPromo)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -19,7 +19,6 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_SEARCH_AC
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_TAB_CHANGED
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.ListActionBuilder
-import org.wordpress.android.fluxc.generated.PostActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.list.PostListDescriptor
@@ -364,11 +363,7 @@ class PostListMainViewModel @Inject constructor(
     private fun editRestoredAutoSavePost(localPostId: Int) {
         val post = postStore.getPostByLocalPostId(localPostId)
         if (post != null) {
-            post.title = post.autoSaveTitle ?: post.title
-            post.content = post.autoSaveContent ?: post.content
-            post.excerpt = post.autoSaveExcerpt ?: post.excerpt
-            dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post))
-            _postListAction.postValue(PostListAction.EditPost(site, post))
+            _postListAction.postValue(PostListAction.EditPost(site, post, loadAutoSaveRevision = true))
         } else {
             _snackBarMessage.value = SnackbarMessageHolder(R.string.error_post_does_not_exist)
         }
@@ -377,7 +372,7 @@ class PostListMainViewModel @Inject constructor(
     private fun editLocalPost(localPostId: Int) {
         val post = postStore.getPostByLocalPostId(localPostId)
         if (post != null) {
-            _postListAction.postValue(PostListAction.EditPost(site, post))
+            _postListAction.postValue(PostListAction.EditPost(site, post, loadAutoSaveRevision = false))
         } else {
             _snackBarMessage.value = SnackbarMessageHolder(R.string.error_post_does_not_exist)
         }


### PR DESCRIPTION
Fixes #10450 

This PR changes two related things
1. When the user chooses "More recent version/The version from another device" on the unpublished revision dialog, we were saving the restored version into the db right away (`dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post)`). However, after this PR the restored version is loaded into the editor, but it's not saved unless the user makes some changes.

2. The local-auto-save in the EditPostActivity would always save the post into the db periodically. However, after this PR [it doesn't save the post into the db unless the user makes some changes](https://github.com/wordpress-mobile/WordPress-Android/blob/7a65b680d957cff0c19772284f8d4371472999ee/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L767).

To test:

1. Create an unpublished revision in Calypso
2. Open Post List in the app
3. Notice the "Unhandled auto save" label
4. Click on the post
5. Choose "More recent version/The version from another device"
6. Click back (don't change the post)
7. Click on the post again
8. Choose "Current version/The version from this device"
9. Make sure the content of the post is equal to the "Current version/The version from this device"


Update release notes:

- [ x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
