### PR TITLE
Sign up username changer shows suggestions error

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/UsernameChangerFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/UsernameChangerFullScreenDialogFragment.java
@@ -133,7 +133,8 @@ public class UsernameChangerFullScreenDialogFragment extends Fragment implements
             mShouldWatchText = true;
             mUsernameSelected = mUsername;
             mUsernameSelectedIndex = 0;
-            getUsernameSuggestions(getUsernameQueryFromDisplayName());
+            mUsernameSuggestionInput = getUsernameQueryFromDisplayName();
+            getUsernameSuggestions(mUsernameSuggestionInput);
         }
 
         mHeaderView = getView().findViewById(R.id.header);


### PR DESCRIPTION
Fixes #10427

To test:

**Testing on release build version**

1. Sign Up For WordPress. 
2. Once you have reached the New Account screen, ensure you have a short Display Name of three letters or less. 
3.  click the username control.
4. The error should then appear with a query instead of null.

**Testing using the debug app.** 

1. Utilize the testing steps to modify code from [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/10409) so that you are able to reach the new account screen from the login page since during development the app can't access signup functionality. 
2. Follow steps 2 to 4 from above.

Below is an example where I used a single letter _j_ as my display name and it's shown instead of _null_

![Webp net-resizeimage (2)](https://user-images.githubusercontent.com/1509205/64015393-0d8ccc80-caea-11e9-93e6-0d5c0b40ba7f.png)


Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
