### PR TITLE
Using content margin instead of normal one.

### DIFF
--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -214,8 +214,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_extra_large"
-                android:paddingEnd="@dimen/margin_large"
-                android:paddingStart="@dimen/margin_large"
+                android:layout_marginEnd="@dimen/content_margin"
+                android:layout_marginStart="@dimen/content_margin"
                 android:text="@string/notification_settings_moved_notices"
                 android:textColor="@color/gray_50"
                 android:textSize="@dimen/text_sz_small"/>

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -213,12 +213,13 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_extra_large"
+                android:layout_marginBottom="@dimen/margin_large"
                 android:layout_marginEnd="@dimen/content_margin"
                 android:layout_marginStart="@dimen/content_margin"
+                android:layout_marginTop="@dimen/margin_extra_large"
                 android:text="@string/notification_settings_moved_notices"
                 android:textColor="@color/gray_50"
-                android:textSize="@dimen/text_sz_small"/>
+                android:textSize="@dimen/text_sz_small" />
 
         </LinearLayout>
     </ScrollView>


### PR DESCRIPTION
Fixes #10469

Switched to using content marging for Notification Settings hint.

![Screenshot_1567195206](https://user-images.githubusercontent.com/728822/64048347-4e0a3b80-cb26-11e9-8115-2dd66b0116b6.png)
![Screenshot_1567195293](https://user-images.githubusercontent.com/728822/64048348-4e0a3b80-cb26-11e9-981c-18f1d10f5785.png)

To test:
- Open Me tab on Tablet. Notice that Notification Settings hint has correct margin.

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
