### PR TITLE
Reduce icon size in Widgets to fix crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
@@ -33,6 +33,7 @@ import javax.inject.Inject
 import kotlin.random.Random
 
 private const val MIN_WIDTH = 250
+private const val ICON_MAX_DIMENSION = 100
 
 class WidgetUtils
 @Inject constructor(val imageManager: ImageManager) {
@@ -62,7 +63,15 @@ class WidgetUtils
         views.setViewVisibility(R.id.widget_site_icon, View.VISIBLE)
         GlobalScope.launch(Dispatchers.Main) {
             val awt = AppWidgetTarget(context, R.id.widget_site_icon, views, appWidgetId)
-            imageManager.load(awt, context, ICON, siteModel?.iconUrl ?: "", FIT_START)
+            imageManager.load(
+                    awt,
+                    context,
+                    ICON,
+                    siteModel?.iconUrl ?: "",
+                    FIT_START,
+                    ICON_MAX_DIMENSION,
+                    ICON_MAX_DIMENSION
+            )
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -91,7 +91,9 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
         context: Context,
         imageType: ImageType,
         imgUrl: String = "",
-        scaleType: ScaleType = CENTER
+        scaleType: ScaleType = CENTER,
+        width: Int? = null,
+        height: Int? = null
     ) {
         if (!context.isAvailable()) return
         GlideApp.with(context)
@@ -100,6 +102,7 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
                 .addFallback(imageType)
                 .addPlaceholder(imageType)
                 .applyScaleType(scaleType)
+                .applySize(width, height)
                 .into(awt)
     }
 
@@ -268,6 +271,14 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
                 AppLog.e(AppLog.T.UTILS, String.format("ScaleType %s is not supported.", scaleType.toString()))
                 this
             }
+        }
+    }
+
+    private fun <T : Any> GlideRequest<T>.applySize(width: Int?, height: Int?): GlideRequest<T> {
+        return if (width != null && height != null) {
+            this.override(width, height)
+        } else {
+            this
         }
     }
 


### PR DESCRIPTION
Fixes #10472

I couldn't reproduce this crash but according to [this SO issue](https://stackoverflow.com/questions/13494898/remoteviews-for-widget-update-exceeds-max-bitmap-memory-usage-error) it's caused by the `iconUrl` being too big. Using Glide override on the icon to reduce the size should fix this issue. 

To test:
* Try widgets
* The icons loads without any issues

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
