### PR TITLE
Sort more than 100 pages chronologically

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 13.3
 -----
+* Sort more than 100 published pages chronologically like Calypso
  
 13.2
 -----

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -4,8 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.Transformations
-import androidx.lifecycle.ViewModel
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -18,6 +17,7 @@ import org.wordpress.android.fluxc.model.page.PageStatus
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged
+import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.pages.PageItem
 import org.wordpress.android.ui.pages.PageItem.Action
 import org.wordpress.android.ui.pages.PageItem.Divider
@@ -30,6 +30,7 @@ import org.wordpress.android.ui.pages.PageItem.TrashedPage
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.toFormattedDateString
+import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState.FETCHING
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.DRAFTS
@@ -37,11 +38,16 @@ import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.PUBL
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.SCHEDULED
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.TRASHED
 import javax.inject.Inject
+import javax.inject.Named
+
+private const val MAX_TOPOLOGICAL_PAGE_COUNT = 100
+private const val DEFAULT_INDENT = 0
 
 class PageListViewModel @Inject constructor(
     private val mediaStore: MediaStore,
-    private val dispatcher: Dispatcher
-) : ViewModel() {
+    private val dispatcher: Dispatcher,
+    @Named(BG_THREAD) private val coroutineDispatcher: CoroutineDispatcher
+) : ScopedViewModel(coroutineDispatcher) {
     private val _pages: MutableLiveData<List<PageItem>> = MutableLiveData()
     val pages: LiveData<Pair<List<PageItem>, Boolean>> = Transformations.map(_pages) {
         Pair(it, isSitePhotonCapable)
@@ -55,7 +61,7 @@ class PageListViewModel @Inject constructor(
 
     private lateinit var pagesViewModel: PagesViewModel
 
-    private val featuredImageMap = HashMap<Long, String>()
+    private val featuredImageMap = mutableMapOf<Long, String>()
 
     private val isSitePhotonCapable: Boolean by lazy {
         SiteUtils.isPhotonCapable(pagesViewModel.site)
@@ -141,7 +147,7 @@ class PageListViewModel @Inject constructor(
         }
     }
 
-    private fun loadPagesAsync(pages: List<PageModel>) = GlobalScope.launch {
+    private fun loadPagesAsync(pages: List<PageModel>) = launch {
         val pageItems = pages
                 .sortedBy { it.title }
                 .filter { listType.pageStatuses.contains(it.status) }
@@ -211,7 +217,13 @@ class PageListViewModel @Inject constructor(
     }
 
     private fun preparePublishedPages(pages: List<PageModel>, actionsEnabled: Boolean): List<PageItem> {
-        return topologicalSort(pages, listType = PUBLISHED)
+        val shouldSortTopologically = pages.size < MAX_TOPOLOGICAL_PAGE_COUNT
+        val sortedPages = if (shouldSortTopologically) {
+            topologicalSort(pages, listType = PUBLISHED)
+        } else {
+            pages.sortedByDescending { it.date }
+        }
+        return sortedPages
                 .map {
                     val labels = mutableListOf<Int>()
                     if (it.status == PageStatus.PRIVATE)
@@ -219,7 +231,12 @@ class PageListViewModel @Inject constructor(
                     if (it.hasLocalChanges)
                         labels.add(R.string.local_changes)
 
-                    PublishedPage(it.remoteId, it.title, it.date, labels, getPageItemIndent(it),
+                    val pageItemIndent = if (shouldSortTopologically) {
+                        getPageItemIndent(it)
+                    } else {
+                        DEFAULT_INDENT
+                    }
+                    PublishedPage(it.remoteId, it.title, it.date, labels, pageItemIndent,
                             getFeaturedImageUrl(it.featuredImageId), actionsEnabled)
                 }
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
@@ -77,9 +77,9 @@ class PageListViewModelTest : BaseUnitTest() {
 
         viewModel.pages.observeForever { result.add(it) }
 
-        val earlyPages = (0 .. 30).map { buildPageModel(it, Date(HOUR_IN_MILLISECONDS * it)) }
-        val latePages = (31 .. 60).map { buildPageModel(it, Date(100 * HOUR_IN_MILLISECONDS * it)) }
-        val middlePages = (61 .. 96).map { buildPageModel(it, Date(10 * HOUR_IN_MILLISECONDS * it)) }
+        val earlyPages = (0..30).map { buildPageModel(it, Date(HOUR_IN_MILLISECONDS * it)) }
+        val latePages = (31..60).map { buildPageModel(it, Date(100 * HOUR_IN_MILLISECONDS * it)) }
+        val middlePages = (61..96).map { buildPageModel(it, Date(10 * HOUR_IN_MILLISECONDS * it)) }
         val earlyChild = buildPageModel(97, Date(40 * HOUR_IN_MILLISECONDS), earlyPages[0])
         val middleChild = buildPageModel(98, Date(1000 * HOUR_IN_MILLISECONDS), middlePages[0])
         val lateChild = buildPageModel(99, Date(7000 * HOUR_IN_MILLISECONDS), latePages[0])
@@ -100,11 +100,11 @@ class PageListViewModelTest : BaseUnitTest() {
             assertPublishedPage(pageItems[index], latePages[latePages.size - index])
         }
         assertPublishedPage(pageItems[31], middleChild)
-        for (index in 1 .. middlePages.size) {
+        for (index in 1..middlePages.size) {
             assertPublishedPage(pageItems[31 + index], middlePages[middlePages.size - index])
         }
         assertPublishedPage(pageItems[68], earlyChild)
-        for (index in 1 .. earlyPages.size) {
+        for (index in 1..earlyPages.size) {
             assertPublishedPage(pageItems[68 + index], earlyPages[earlyPages.size - index])
         }
         assertDivider(pageItems[100])
@@ -122,9 +122,9 @@ class PageListViewModelTest : BaseUnitTest() {
 
         viewModel.pages.observeForever { result.add(it) }
 
-        val earlyPages = (0 .. 30).map { buildPageModel(it, Date(HOUR_IN_MILLISECONDS * it)) }
-        val latePages = (31 .. 60).map { buildPageModel(it, Date(100 * HOUR_IN_MILLISECONDS * it)) }
-        val middlePages = (61 .. 95).map { buildPageModel(it, Date(10 * HOUR_IN_MILLISECONDS * it)) }
+        val earlyPages = (0..30).map { buildPageModel(it, Date(HOUR_IN_MILLISECONDS * it)) }
+        val latePages = (31..60).map { buildPageModel(it, Date(100 * HOUR_IN_MILLISECONDS * it)) }
+        val middlePages = (61..95).map { buildPageModel(it, Date(10 * HOUR_IN_MILLISECONDS * it)) }
         val earlyChild = buildPageModel(96, Date(40 * HOUR_IN_MILLISECONDS), earlyPages[0])
         val middleChild = buildPageModel(97, Date(1000 * HOUR_IN_MILLISECONDS), middlePages[0])
         val lateChild = buildPageModel(98, Date(7000 * HOUR_IN_MILLISECONDS), latePages[0])
@@ -146,12 +146,12 @@ class PageListViewModelTest : BaseUnitTest() {
             assertPublishedPage(pageItems[index + 1], earlyPages[index], 0)
         }
         assertPublishedPage(pageItems[32], latePages[0], 0)
-        assertPublishedPage(pageItems[33], lateChild,  1)
+        assertPublishedPage(pageItems[33], lateChild, 1)
         for (index in 1 until latePages.size) {
             assertPublishedPage(pageItems[index + 33], latePages[index], 0)
         }
         assertPublishedPage(pageItems[63], middlePages[0], 0)
-        assertPublishedPage(pageItems[64], middleChild,  1)
+        assertPublishedPage(pageItems[64], middleChild, 1)
         for (index in 1 until middlePages.size) {
             assertPublishedPage(pageItems[index + 64], middlePages[index], 0)
         }
@@ -170,7 +170,7 @@ class PageListViewModelTest : BaseUnitTest() {
 
     private fun assertPublishedPage(pageItem: PageItem, pageModel: PageModel, indent: Int = 0) {
         val publishedPage = pageItem as PublishedPage
-         assertThat(publishedPage.title).isEqualTo(pageModel.title)
+        assertThat(publishedPage.title).isEqualTo(pageModel.title)
         assertThat(publishedPage.date).isEqualTo(pageModel.date)
         assertThat(publishedPage.indent).isEqualTo(indent)
         assertThat(publishedPage.actionsEnabled).isEqualTo(false)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
@@ -34,7 +34,6 @@ class PageListViewModelTest : BaseUnitTest() {
         viewModel = PageListViewModel(mediaStore, dispatcher, Dispatchers.Unconfined)
 
         whenever(pagesViewModel.arePageActionsEnabled).thenReturn(false)
-        whenever(pagesViewModel.listState).thenReturn(pageListState)
         whenever(pagesViewModel.site).thenReturn(site)
         site.id = 10
         pageListState.value = PageListState.DONE
@@ -59,7 +58,7 @@ class PageListViewModelTest : BaseUnitTest() {
         val pageItems = result[0].first
         assertThat(pageItems).hasSize(3)
         val firstItem = pageItems[0] as PublishedPage
-        assertThat(firstItem.title).isEqualTo("Title 1")
+        assertThat(firstItem.title).isEqualTo("Title 01")
         assertThat(firstItem.date).isEqualTo(date)
         assertThat(firstItem.actionsEnabled).isEqualTo(false)
         assertDivider(pageItems[1])

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
@@ -1,0 +1,178 @@
+package org.wordpress.android.viewmodel.pages
+
+import androidx.lifecycle.MutableLiveData
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.page.PageModel
+import org.wordpress.android.fluxc.model.page.PageStatus
+import org.wordpress.android.fluxc.store.MediaStore
+import org.wordpress.android.ui.pages.PageItem
+import org.wordpress.android.ui.pages.PageItem.Divider
+import org.wordpress.android.ui.pages.PageItem.PublishedPage
+import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState
+import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.PUBLISHED
+import java.util.Date
+
+private const val HOUR_IN_MILLISECONDS = 3600000L
+
+class PageListViewModelTest : BaseUnitTest() {
+    @Mock lateinit var mediaStore: MediaStore
+    @Mock lateinit var dispatcher: Dispatcher
+    @Mock lateinit var pagesViewModel: PagesViewModel
+    private lateinit var viewModel: PageListViewModel
+    private val site = SiteModel()
+    private val pageListState = MutableLiveData<PageListState>()
+    @Before
+    fun setUp() {
+        viewModel = PageListViewModel(mediaStore, dispatcher, Dispatchers.Unconfined)
+
+        whenever(pagesViewModel.arePageActionsEnabled).thenReturn(false)
+        whenever(pagesViewModel.listState).thenReturn(pageListState)
+        whenever(pagesViewModel.site).thenReturn(site)
+        site.id = 10
+        pageListState.value = PageListState.DONE
+    }
+
+    @Test
+    fun `on pages updates published model`() {
+        val pages = MutableLiveData<List<PageModel>>()
+        whenever(pagesViewModel.pages).thenReturn(pages)
+
+        viewModel.start(PUBLISHED, pagesViewModel)
+
+        val result = mutableListOf<Pair<List<PageItem>, Boolean>>()
+
+        viewModel.pages.observeForever { result.add(it) }
+
+        val date = Date()
+
+        pages.value = listOf(buildPageModel(1, date))
+
+        assertThat(result).hasSize(1)
+        val pageItems = result[0].first
+        assertThat(pageItems).hasSize(3)
+        val firstItem = pageItems[0] as PublishedPage
+        assertThat(firstItem.title).isEqualTo("Title 1")
+        assertThat(firstItem.date).isEqualTo(date)
+        assertThat(firstItem.actionsEnabled).isEqualTo(false)
+        assertDivider(pageItems[1])
+        assertDivider(pageItems[2])
+    }
+
+    @Test
+    fun `sorts 100 or more pages by date DESC`() {
+        val pages = MutableLiveData<List<PageModel>>()
+        whenever(pagesViewModel.pages).thenReturn(pages)
+
+        viewModel.start(PUBLISHED, pagesViewModel)
+
+        val result = mutableListOf<Pair<List<PageItem>, Boolean>>()
+
+        viewModel.pages.observeForever { result.add(it) }
+
+        val earlyPages = (0 .. 30).map { buildPageModel(it, Date(HOUR_IN_MILLISECONDS * it)) }
+        val latePages = (31 .. 60).map { buildPageModel(it, Date(100 * HOUR_IN_MILLISECONDS * it)) }
+        val middlePages = (61 .. 96).map { buildPageModel(it, Date(10 * HOUR_IN_MILLISECONDS * it)) }
+        val earlyChild = buildPageModel(97, Date(40 * HOUR_IN_MILLISECONDS), earlyPages[0])
+        val middleChild = buildPageModel(98, Date(1000 * HOUR_IN_MILLISECONDS), middlePages[0])
+        val lateChild = buildPageModel(99, Date(7000 * HOUR_IN_MILLISECONDS), latePages[0])
+        val children = listOf(middleChild, earlyChild, lateChild)
+
+        val pageModels = mutableListOf<PageModel>()
+        pageModels.addAll(middlePages)
+        pageModels.addAll(latePages)
+        pageModels.addAll(children)
+        pageModels.addAll(earlyPages)
+        pages.value = pageModels
+
+        assertThat(result).hasSize(1)
+        val pageItems = result[0].first
+        assertThat(pageItems).hasSize(102)
+        assertPublishedPage(pageItems[0], lateChild)
+        for (index in 1..latePages.size) {
+            assertPublishedPage(pageItems[index], latePages[latePages.size - index])
+        }
+        assertPublishedPage(pageItems[31], middleChild)
+        for (index in 1 .. middlePages.size) {
+            assertPublishedPage(pageItems[31 + index], middlePages[middlePages.size - index])
+        }
+        assertPublishedPage(pageItems[68], earlyChild)
+        for (index in 1 .. earlyPages.size) {
+            assertPublishedPage(pageItems[68 + index], earlyPages[earlyPages.size - index])
+        }
+        assertDivider(pageItems[100])
+        assertDivider(pageItems[101])
+    }
+
+    @Test
+    fun `sorts up to 99 pages topologically`() {
+        val pages = MutableLiveData<List<PageModel>>()
+        whenever(pagesViewModel.pages).thenReturn(pages)
+
+        viewModel.start(PUBLISHED, pagesViewModel)
+
+        val result = mutableListOf<Pair<List<PageItem>, Boolean>>()
+
+        viewModel.pages.observeForever { result.add(it) }
+
+        val earlyPages = (0 .. 30).map { buildPageModel(it, Date(HOUR_IN_MILLISECONDS * it)) }
+        val latePages = (31 .. 60).map { buildPageModel(it, Date(100 * HOUR_IN_MILLISECONDS * it)) }
+        val middlePages = (61 .. 95).map { buildPageModel(it, Date(10 * HOUR_IN_MILLISECONDS * it)) }
+        val earlyChild = buildPageModel(96, Date(40 * HOUR_IN_MILLISECONDS), earlyPages[0])
+        val middleChild = buildPageModel(97, Date(1000 * HOUR_IN_MILLISECONDS), middlePages[0])
+        val lateChild = buildPageModel(98, Date(7000 * HOUR_IN_MILLISECONDS), latePages[0])
+        val children = listOf(middleChild, earlyChild, lateChild)
+
+        val pageModels = mutableListOf<PageModel>()
+        pageModels.addAll(middlePages)
+        pageModels.addAll(latePages)
+        pageModels.addAll(children)
+        pageModels.addAll(earlyPages)
+        pages.value = pageModels
+
+        assertThat(result).hasSize(1)
+        val pageItems = result[0].first
+        assertThat(pageItems).hasSize(101)
+        assertPublishedPage(pageItems[0], earlyPages[0], 0)
+        assertPublishedPage(pageItems[1], earlyChild, 1)
+        for (index in 1 until earlyPages.size) {
+            assertPublishedPage(pageItems[index + 1], earlyPages[index], 0)
+        }
+        assertPublishedPage(pageItems[32], latePages[0], 0)
+        assertPublishedPage(pageItems[33], lateChild,  1)
+        for (index in 1 until latePages.size) {
+            assertPublishedPage(pageItems[index + 33], latePages[index], 0)
+        }
+        assertPublishedPage(pageItems[63], middlePages[0], 0)
+        assertPublishedPage(pageItems[64], middleChild,  1)
+        for (index in 1 until middlePages.size) {
+            assertPublishedPage(pageItems[index + 64], middlePages[index], 0)
+        }
+        assertDivider(pageItems[99])
+        assertDivider(pageItems[100])
+    }
+
+    private fun buildPageModel(id: Int, date: Date, parent: PageModel? = null): PageModel {
+        val title = if (id < 10) "Title 0$id" else "Title $id"
+        return PageModel(site, id, title, PageStatus.PUBLISHED, date, false, id.toLong(), parent, id.toLong())
+    }
+
+    private fun assertDivider(pageItem: PageItem) {
+        assertThat(pageItem is Divider).isTrue()
+    }
+
+    private fun assertPublishedPage(pageItem: PageItem, pageModel: PageModel, indent: Int = 0) {
+        val publishedPage = pageItem as PublishedPage
+         assertThat(publishedPage.title).isEqualTo(pageModel.title)
+        assertThat(publishedPage.date).isEqualTo(pageModel.date)
+        assertThat(publishedPage.indent).isEqualTo(indent)
+        assertThat(publishedPage.actionsEnabled).isEqualTo(false)
+    }
+}


### PR DESCRIPTION
Fixes #10440 

This PR copies the Calypso behaviour where it sorts more than 100 published pages chronologically instead of topologically. In this view we're not showing parent/child relationship between the pages. I've also added unit tests to cover this use case.  

To easier test this you can the `MAX_TOPOLOGICAL_PAGE_COUNT` to a more reasonable number like 10. 

To test:
* Go to a site with < 100 published pages
* Check that they are still ordered topologically 
* Go to a site with >= 100 published pages
* Check that they are ordered chronologically in a descending order by the published date. 
* Check that you can't see the parent/child relationship

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
