### PR TITLE
Default transition animation for site picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -11,7 +11,6 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
-import androidx.core.app.ActivityOptionsCompat;
 import androidx.core.app.TaskStackBuilder;
 import androidx.fragment.app.Fragment;
 
@@ -119,11 +118,7 @@ public class ActivityLauncher {
     public static void showSitePickerForResult(Activity activity, SiteModel site) {
         Intent intent = new Intent(activity, SitePickerActivity.class);
         intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, site.getId());
-        ActivityOptionsCompat options = ActivityOptionsCompat.makeCustomAnimation(
-                activity,
-                R.anim.activity_slide_in_from_left,
-                R.anim.do_nothing);
-        ActivityCompat.startActivityForResult(activity, intent, RequestCodes.SITE_PICKER, options.toBundle());
+        ActivityCompat.startActivityForResult(activity, intent, RequestCodes.SITE_PICKER, null);
     }
 
     public static void showPhotoPickerForResult(Activity activity,

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -10,7 +10,6 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.app.ActivityCompat;
 import androidx.core.app.TaskStackBuilder;
 import androidx.fragment.app.Fragment;
 
@@ -118,7 +117,7 @@ public class ActivityLauncher {
     public static void showSitePickerForResult(Activity activity, SiteModel site) {
         Intent intent = new Intent(activity, SitePickerActivity.class);
         intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, site.getId());
-        ActivityCompat.startActivityForResult(activity, intent, RequestCodes.SITE_PICKER, null);
+        activity.startActivityForResult(intent, RequestCodes.SITE_PICKER);
     }
 
     public static void showPhotoPickerForResult(Activity activity,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -91,7 +91,6 @@ public class SitePickerActivity extends AppCompatActivity
     private MenuItem mMenuSearch;
     private SearchView mSearchView;
     private int mCurrentLocalId;
-    private boolean mDidUserSelectSite;
     private Debouncer mDebouncer = new Debouncer();
 
     @Inject AccountStore mAccountStore;
@@ -540,7 +539,6 @@ public class SitePickerActivity extends AppCompatActivity
             hideSoftKeyboard();
             AppPrefs.addRecentlyPickedSiteId(siteRecord.getLocalId());
             setResult(RESULT_OK, new Intent().putExtra(KEY_LOCAL_ID, siteRecord.getLocalId()));
-            mDidUserSelectSite = true;
             // If the site is hidden, make sure to make it visible
             if (siteRecord.isHidden()) {
                 siteRecord.setHidden(false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -137,14 +137,6 @@ public class SitePickerActivity extends AppCompatActivity
     }
 
     @Override
-    public void finish() {
-        super.finish();
-        if (mDidUserSelectSite) {
-            overridePendingTransition(R.anim.do_nothing, R.anim.activity_slide_out_to_left);
-        }
-    }
-
-    @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
         getMenuInflater().inflate(R.menu.site_picker, menu);


### PR DESCRIPTION
Since we switched to Quick Actions layout, it doesn't make sense to slide site picker from the left anymore, so I reverted it to default transition (from bottom).

gif linked to HD version.
[![Image from Gyazo](https://i.gyazo.com/83ee8d34820eeba754f4998aff892db0.gif)](https://gyazo.com/83ee8d34820eeba754f4998aff892db0)

To test:
- Tap on SWITCH SITE on My Site screen.
- Notice the default transition.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
