### PR TITLE
Show an empty screen when all insights are removed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/UiModelMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/UiModelMapper.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.stats.refresh.lists
 
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.StatsStore.InsightType
 import org.wordpress.android.fluxc.store.StatsStore.PostDetailType
 import org.wordpress.android.fluxc.store.StatsStore.StatsType
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsType
@@ -19,11 +20,12 @@ class UiModelMapper
         useCaseModels: List<UseCaseModel>,
         showError: (Int) -> Unit
     ): UiModel {
-        if (useCaseModels.isNotEmpty()) {
-            val allFailing = useCaseModels.fold(true) { acc, useCaseModel ->
+        val insightUseCaseModels = useCaseModels.filter { it.type is InsightType }
+        if (insightUseCaseModels.isNotEmpty()) {
+            val allFailing = insightUseCaseModels.fold(true) { acc, useCaseModel ->
                 acc && useCaseModel.state == ERROR
             }
-            val allFailingWithoutData = useCaseModels.isNotEmpty() && useCaseModels.fold(true) { acc, useCaseModel ->
+            val allFailingWithoutData = insightUseCaseModels.fold(true) { acc, useCaseModel ->
                 acc && useCaseModel.state == ERROR && useCaseModel.data == null
             }
             return if (!allFailing && !allFailingWithoutData) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/UiModelMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/UiModelMapperTest.kt
@@ -1,20 +1,19 @@
 package org.wordpress.android.ui.stats.refresh.lists
 
-import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.FOLLOWER_TOTALS
-import org.wordpress.android.ui.stats.refresh.NavigationTarget
+import org.wordpress.android.fluxc.store.StatsStore.ManagementType
 import org.wordpress.android.ui.stats.refresh.lists.StatsBlock.Success
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.SUCCESS
 import org.wordpress.android.util.NetworkUtilsWrapper
-import org.wordpress.android.viewmodel.Event
 
 class UiModelMapperTest : BaseUnitTest() {
     @Mock lateinit var networkUtilsWrapper: NetworkUtilsWrapper
@@ -28,19 +27,41 @@ class UiModelMapperTest : BaseUnitTest() {
     @Test
     fun `mapInsights returns success ui model when all the inputs are successful`() {
         var error: Int? = null
-        val navigationTarget = MutableLiveData<Event<NavigationTarget>>()
         val uiModel = mapper.mapInsights(
                 listOf(
-                        UseCaseModel(FOLLOWER_TOTALS, data = listOf(), state = SUCCESS))
+                        UseCaseModel(FOLLOWER_TOTALS, data = listOf(), state = SUCCESS),
+                        UseCaseModel(ManagementType.CONTROL, data = listOf(), state = SUCCESS))
         ) {
             error = it
         }
 
         val model = uiModel as UiModel.Success
-        assertThat(model.data).hasSize(1)
+        assertThat(model.data).hasSize(2)
         assertThat((model.data[0] as Success).statsType).isEqualTo(FOLLOWER_TOTALS)
         assertThat(model.data[0].type).isEqualTo(StatsBlock.Type.SUCCESS)
         assertThat(model.data[0].data).isEmpty()
+        assertThat((model.data[1] as Success).statsType).isEqualTo(ManagementType.CONTROL)
+        assertThat(model.data[1].type).isEqualTo(StatsBlock.Type.SUCCESS)
+        assertThat(model.data[1].data).isEmpty()
+        assertThat(error).isNull()
+    }
+
+    @Test
+    fun `mapInsights returns empty when there are only management blocks visible`() {
+        var error: Int? = null
+        val uiModel = mapper.mapInsights(
+                listOf(
+                        UseCaseModel(ManagementType.NEWS_CARD, data = listOf(), state = SUCCESS),
+                        UseCaseModel(ManagementType.CONTROL, data = listOf(), state = SUCCESS))
+        ) {
+            error = it
+        }
+
+        val model = uiModel as UiModel.Empty
+        assertThat(model.title).isEqualTo(R.string.stats_empty_insights_title)
+        assertThat(model.subtitle).isEqualTo(R.string.stats_insights_management_title)
+        assertThat(model.image).isEqualTo(R.drawable.img_illustration_insights_94dp)
+        assertThat(model.showButton).isTrue()
         assertThat(error).isNull()
     }
 }


### PR DESCRIPTION
Fixes #10259 

Currently we're showing only the `EDIT` button when all the Insights cards are removed. This PR fixes this and replaces the view with the `Empty` screen where there are no Insights added. 

To test:
* Go to Stats/Insights
* Remove all the cards
* Notice that you now see the empty screen with the "Manage Insights" button
* Add a card
* The card is visible with the "Edit" button under it.

![empty_insights](https://user-images.githubusercontent.com/1079756/64241462-16bfd400-cf04-11e9-8a3c-2b1b2d370ccd.gif)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
