### PR TITLE
Add Other post type to posts and pages

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCase.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsType.HOMEPAGE
+import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsType.OTHER
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsType.PAGE
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsType.POST
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
@@ -113,7 +114,7 @@ constructor(
             items.addAll(domainModel.views.mapIndexed { index, viewsModel ->
                 val icon = when (viewsModel.type) {
                     POST -> R.drawable.ic_posts_white_24dp
-                    HOMEPAGE, PAGE -> R.drawable.ic_pages_white_24dp
+                    OTHER, HOMEPAGE, PAGE -> R.drawable.ic_pages_white_24dp
                 }
                 ListItemWithIcon(
                         icon = icon,
@@ -157,7 +158,7 @@ constructor(
     private fun onLinkClicked(params: LinkClickParams) {
         val type = when (params.postType) {
             POST -> ITEM_TYPE_POST
-            PAGE, HOMEPAGE -> ITEM_TYPE_HOME_PAGE
+            OTHER, PAGE, HOMEPAGE -> ITEM_TYPE_HOME_PAGE
         }
         analyticsTracker.trackGranular(AnalyticsTracker.Stat.STATS_POSTS_AND_PAGES_ITEM_TAPPED, statsGranularity)
         navigateTo(

--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.3.0'
+    fluxCVersion = '4b5f6cd7a353c7aa5133ad6a5d4790c91f6b110e'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '4b5f6cd7a353c7aa5133ad6a5d4790c91f6b110e'
+    fluxCVersion = '1.4.0-beta-1'
 }


### PR DESCRIPTION
Fixed #9167
FluxC - https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1380

This PR adds the new `OTHER` type to the `PostsAndPagesUseCase`. It behaves the same way as page/homepage.

I need to update the FluxC tag before merging this so please first merge FluxC and let me create the tag and update this PR before merging it.

To test:
* Go to a Site with a post/page with a custom type (portfolio)
* Check the stats for a day where the custom page has a view
* Check that the custom page is showing in the Posts and Pages card

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
