### PR TITLE
Hide Sharing manage options for non-admins

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter.OnSer
 import org.wordpress.android.ui.quickstart.QuickStartEvent;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.QuickStartUtils;
+import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.widgets.WPDialogSnackbar;
 
@@ -95,18 +96,22 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.publicize_list_fragment, container, false);
 
-        mRecycler = (RecyclerView) rootView.findViewById(R.id.recycler_view);
-        mEmptyView = (TextView) rootView.findViewById(R.id.empty_view);
+        mRecycler = rootView.findViewById(R.id.recycler_view);
+        mEmptyView = rootView.findViewById(R.id.empty_view);
 
-        View manageContainer = rootView.findViewById(R.id.container_manage);
-        manageContainer.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
+        boolean isAdminOrSelfHosted = mSite.getHasCapabilityManageOptions() || !SiteUtils.isAccessedViaWPComRest(mSite);
+        View manageCard = rootView.findViewById(R.id.manage_card);
+        if (isAdminOrSelfHosted) {
+            manageCard.setVisibility(View.VISIBLE);
+            View manageContainer = rootView.findViewById(R.id.container_manage);
+            manageContainer.setOnClickListener(view -> {
                 if (mListener != null) {
                     mListener.onButtonPrefsClicked();
                 }
-            }
-        });
+            });
+        } else {
+            manageCard.setVisibility(View.GONE);
+        }
 
         if (mQuickStartEvent != null) {
             showQuickStartFocusPoint();

--- a/WordPress/src/main/res/layout/publicize_list_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_list_fragment.xml
@@ -75,11 +75,12 @@
             </androidx.cardview.widget.CardView>
 
             <androidx.cardview.widget.CardView
+                android:id="@+id/manage_card"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_large"
-                android:layout_width="match_parent"
                 app:cardBackgroundColor="@android:color/white"
-                app:cardCornerRadius="@dimen/default_cardview_radius" >
+                app:cardCornerRadius="@dimen/default_cardview_radius">
 
                 <RelativeLayout
                     android:id="@+id/sharing_module"


### PR DESCRIPTION
Fixes #10460

This PR shows the Sharing/Manage button only for admins or self-hosted sites. The logic is the same as with showing Site settings. I'm using the `getHasCapabilityManageOptions` flag on a `SiteModel` which should be correct. 

To test:
* Log in as an Editor/Contributor
* Go to My Site/Sharing
* The `Manage` button is gone
* Log in as an Administrator
* Go to My Site/Sharing
* The `Manage` button is present and works as expected

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
