### PR TITLE
Gutenberg/1.12.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,10 @@
 13.3
 -----
 * Significant performance improvements to Stats
+* Block Editor: Add rich text styling to video captions
+* Block Editor: Prevent keyboard dismissal when switching between caption and text block
+* Block Editor: Blocks that would be replaced are now hidden when add block bottom sheet displays
+* Block Editor: Tapping on empty editor area now always inserts new block at end of post
  
 13.2
 -----


### PR DESCRIPTION
Update gutenberg to v1.12.0 ([gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1358))

#### To test:

- Smoke test gutenberg editor.

#### Remaining tasks:
- [ ] Update to reference gutenberg-mobile release tag instead of commit hash

#### Update release notes

- [X] I have considered if this change warrants user-facing release notes and have added them to RELEASE-NOTES.txt if necessary.