### PR TITLE
CircleCI: Use shallow clone to checkout repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 orbs:
-  android: wordpress-mobile/android@0.0.27
+  android: wordpress-mobile/android@0.0.32
+  git: wordpress-mobile/git@0.0.32
   bundle-install: toshimaru/bundle-install@0.3.1
   slack: circleci/slack@2.5.0
 
@@ -17,7 +18,7 @@ jobs:
       name: android/default
       api-version: "28"
     steps:
-      - checkout
+      - git/shallow-checkout
       - android/restore-gradle-cache
       - copy-gradle-properties
       - run:
@@ -30,7 +31,7 @@ jobs:
       name: android/default
       api-version: "28"
     steps:
-      - checkout
+      - git/shallow-checkout
       - android/restore-gradle-cache
       - copy-gradle-properties
       - run:
@@ -58,7 +59,7 @@ jobs:
       name: android/default
       api-version: "28"
     steps:
-      - checkout
+      - git/shallow-checkout
       - bundle-install/bundle-install:
           cache_key_prefix: installable-build
       - run:
@@ -93,7 +94,7 @@ jobs:
       name: android/default
       api-version: "28"
     steps:
-      - checkout
+      - git/shallow-checkout
       - android/restore-gradle-cache
       - copy-gradle-properties
       - run:
@@ -117,7 +118,7 @@ jobs:
     docker:
       - image: circleci/ruby:2.3
     steps:
-      - checkout
+      - git/shallow-checkout
       - bundle-install/bundle-install:
           cache_key_prefix: strings-check
       - run:


### PR DESCRIPTION
This gives a modest speedup on every CI job by doing a shallow clone of the repo instead of fetching the entire history.

To test:

- CI is still green.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
