### PR TITLE
Update Color 2.2.0

### DIFF
--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -214,7 +214,7 @@
     <color name="purple">#984a9c</color>
     <color name="purple_0">#f2e9ed</color>
     <color name="purple_5">#ebcee0</color>
-    <color name="purple_10">#e3aed4</color>
+    <color name="purple_10">#e3afd5</color>
     <color name="purple_20">#d48fc8</color>
     <color name="purple_30">#c475bd</color>
     <color name="purple_40">#b35eb1</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -227,7 +227,7 @@
     <color name="red">#d63638</color>
     <color name="red_0">#f7ebec</color>
     <color name="red_5">#facfd2</color>
-    <color name="red_10">#ffa6ab</color>
+    <color name="red_10">#ffabaf</color>
     <color name="red_20">#ff8085</color>
     <color name="red_30">#f86368</color>
     <color name="red_40">#e65054</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -187,7 +187,7 @@
     <color name="jetpack_green_100">#001c09</color>
     <color name="orange">#b26200</color>
     <color name="orange_0">#f5ece6</color>
-    <color name="orange_5">#fcd7ba</color>
+    <color name="orange_5">#f7dcc6</color>
     <color name="orange_10">#ffbf86</color>
     <color name="orange_20">#faa754</color>
     <color name="orange_30">#e68b28</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -173,7 +173,7 @@
     <color name="green_90">#003008</color>
     <color name="green_100">#001c05</color>
     <color name="jetpack_green">#2fb41f</color>
-    <color name="jetpack_green_0">#f2f7e7</color>
+    <color name="jetpack_green_0">#f0f2eb</color>
     <color name="jetpack_green_5">#d0efad</color>
     <color name="jetpack_green_10">#9dde73</color>
     <color name="jetpack_green_20">#64ca43</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -226,7 +226,7 @@
     <color name="purple_100">#1e0c21</color>
     <color name="red">#d63638</color>
     <color name="red_0">#f7ebec</color>
-    <color name="red_5">#ffccd0</color>
+    <color name="red_5">#facfd2</color>
     <color name="red_10">#ffa6ab</color>
     <color name="red_20">#ff8085</color>
     <color name="red_30">#f86368</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -238,7 +238,7 @@
     <color name="red_90">#451313</color>
     <color name="red_100">#240a0a</color>
     <color name="woocommerce_purple">#7f54b3</color>
-    <color name="woocommerce_purple_0">#f5e9f5</color>
+    <color name="woocommerce_purple_0">#f7edf7</color>
     <color name="woocommerce_purple_5">#ecccf0</color>
     <color name="woocommerce_purple_10">#ddb0eb</color>
     <color name="woocommerce_purple_100">#140e1f</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -239,7 +239,7 @@
     <color name="red_100">#240a0a</color>
     <color name="woocommerce_purple">#7f54b3</color>
     <color name="woocommerce_purple_0">#f7edf7</color>
-    <color name="woocommerce_purple_5">#ecccf0</color>
+    <color name="woocommerce_purple_5">#e5cfe8</color>
     <color name="woocommerce_purple_10">#ddb0eb</color>
     <color name="woocommerce_purple_100">#140e1f</color>
     <color name="woocommerce_purple_20">#c792e0</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -186,7 +186,7 @@
     <color name="jetpack_green_90">#003010</color>
     <color name="jetpack_green_100">#001c09</color>
     <color name="orange">#b26200</color>
-    <color name="orange_0">#f7f0ea</color>
+    <color name="orange_0">#f5ece6</color>
     <color name="orange_5">#fcd7ba</color>
     <color name="orange_10">#ffbf86</color>
     <color name="orange_20">#faa754</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -135,7 +135,7 @@
     <color name="blue_100">#00131c</color>
     <color name="celadon">#007e65</color>
     <color name="celadon_0">#e4f2ed</color>
-    <color name="celadon_5">#a6ebd6</color>
+    <color name="celadon_5">#a7e8d4</color>
     <color name="celadon_10">#63d6b6</color>
     <color name="celadon_20">#2ebd99</color>
     <color name="celadon_30">#09a884</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -213,7 +213,7 @@
     <color name="pink_100">#260415</color>
     <color name="purple">#984a9c</color>
     <color name="purple_0">#f2e9ed</color>
-    <color name="purple_5">#f0d1e4</color>
+    <color name="purple_5">#ebcee0</color>
     <color name="purple_10">#e3aed4</color>
     <color name="purple_20">#d48fc8</color>
     <color name="purple_30">#c475bd</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -225,7 +225,7 @@
     <color name="purple_90">#35163b</color>
     <color name="purple_100">#1e0c21</color>
     <color name="red">#d63638</color>
-    <color name="red_0">#f7edee</color>
+    <color name="red_0">#f7ebec</color>
     <color name="red_5">#ffccd0</color>
     <color name="red_10">#ffa6ab</color>
     <color name="red_20">#ff8085</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -199,7 +199,7 @@
     <color name="orange_90">#361f00</color>
     <color name="orange_100">#1f1200</color>
     <color name="pink">#c9356e</color>
-    <color name="pink_0">#f5ecef</color>
+    <color name="pink_0">#f5e9ed</color>
     <color name="pink_5">#faccdc</color>
     <color name="pink_10">#f7a6c2</color>
     <color name="pink_20">#f283aa</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -252,7 +252,7 @@
     <color name="woocommerce_purple_90">#271b3d</color>
     <color name="wordpress_blue">#006088</color>
     <color name="wordpress_blue_0">#e6f1f5</color>
-    <color name="wordpress_blue_5">#c1e1ee</color>
+    <color name="wordpress_blue_5">#bedae6</color>
     <color name="wordpress_blue_10">#99cde1</color>
     <color name="wordpress_blue_20">#6ab3d0</color>
     <color name="wordpress_blue_30">#3895ba</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -240,7 +240,7 @@
     <color name="woocommerce_purple">#7f54b3</color>
     <color name="woocommerce_purple_0">#f7edf7</color>
     <color name="woocommerce_purple_5">#e5cfe8</color>
-    <color name="woocommerce_purple_10">#ddb0eb</color>
+    <color name="woocommerce_purple_10">#d6b4e0</color>
     <color name="woocommerce_purple_100">#140e1f</color>
     <color name="woocommerce_purple_20">#c792e0</color>
     <color name="woocommerce_purple_30">#af7dd1</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -251,7 +251,7 @@
     <color name="woocommerce_purple_80">#3c2861</color>
     <color name="woocommerce_purple_90">#271b3d</color>
     <color name="wordpress_blue">#006088</color>
-    <color name="wordpress_blue_0">#e9f3f7</color>
+    <color name="wordpress_blue_0">#e6f1f5</color>
     <color name="wordpress_blue_5">#c1e1ee</color>
     <color name="wordpress_blue_10">#99cde1</color>
     <color name="wordpress_blue_20">#6ab3d0</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -162,7 +162,7 @@
     <color name="green">#008a20</color>
     <color name="green_0">#e6f2e8</color>
     <color name="green_5">#b8e6bf</color>
-    <color name="green_10">#59e38f</color>
+    <color name="green_10">#68de86</color>
     <color name="green_20">#1ed15a</color>
     <color name="green_30">#00ba37</color>
     <color name="green_40">#00a32a</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -253,7 +253,7 @@
     <color name="wordpress_blue">#006088</color>
     <color name="wordpress_blue_0">#e6f1f5</color>
     <color name="wordpress_blue_5">#bedae6</color>
-    <color name="wordpress_blue_10">#99cde1</color>
+    <color name="wordpress_blue_10">#98c6d9</color>
     <color name="wordpress_blue_20">#6ab3d0</color>
     <color name="wordpress_blue_30">#3895ba</color>
     <color name="wordpress_blue_40">#187aa2</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -200,7 +200,7 @@
     <color name="orange_100">#1f1200</color>
     <color name="pink">#c9356e</color>
     <color name="pink_0">#f5e9ed</color>
-    <color name="pink_5">#faccdc</color>
+    <color name="pink_5">#f2ceda</color>
     <color name="pink_10">#f7a6c2</color>
     <color name="pink_20">#f283aa</color>
     <color name="pink_30">#eb6594</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -161,7 +161,7 @@
     <color name="gray_100">#101517</color>
     <color name="green">#008a20</color>
     <color name="green_0">#e6f2e8</color>
-    <color name="green_5">#a4f5c8</color>
+    <color name="green_5">#b8e6bf</color>
     <color name="green_10">#59e38f</color>
     <color name="green_20">#1ed15a</color>
     <color name="green_30">#00ba37</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -123,7 +123,7 @@
     <color name="blue">#2271b1</color>
     <color name="blue_0">#e9eff5</color>
     <color name="blue_5">#c5d9ed</color>
-    <color name="blue_10">#9ac6f0</color>
+    <color name="blue_10">#9ec2e6</color>
     <color name="blue_20">#72aee6</color>
     <color name="blue_30">#5198d9</color>
     <color name="blue_40">#3582c4</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -119,7 +119,7 @@
     <color name="warning_dark">@color/yellow_40</color>
     <color name="warning_light">@color/yellow_5</color>
 
-    <!-- STUDIO 2.1.0 -->
+    <!-- STUDIO 2.2.0 -->
     <color name="blue">#2271b1</color>
     <color name="blue_0">#e9eff5</color>
     <color name="blue_5">#c5d9ed</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -212,7 +212,7 @@
     <color name="pink_90">#4f092a</color>
     <color name="pink_100">#260415</color>
     <color name="purple">#984a9c</color>
-    <color name="purple_0">#f2ecef</color>
+    <color name="purple_0">#f2e9ed</color>
     <color name="purple_5">#f0d1e4</color>
     <color name="purple_10">#e3aed4</color>
     <color name="purple_20">#d48fc8</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -174,7 +174,7 @@
     <color name="green_100">#001c05</color>
     <color name="jetpack_green">#2fb41f</color>
     <color name="jetpack_green_0">#f0f2eb</color>
-    <color name="jetpack_green_5">#d0efad</color>
+    <color name="jetpack_green_5">#d0e6b8</color>
     <color name="jetpack_green_10">#9dde73</color>
     <color name="jetpack_green_20">#64ca43</color>
     <color name="jetpack_green_30">#2fb41f</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -201,7 +201,7 @@
     <color name="pink">#c9356e</color>
     <color name="pink_0">#f5e9ed</color>
     <color name="pink_5">#f2ceda</color>
-    <color name="pink_10">#f7a6c2</color>
+    <color name="pink_10">#f7a8c3</color>
     <color name="pink_20">#f283aa</color>
     <color name="pink_30">#eb6594</color>
     <color name="pink_40">#e34c84</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -121,7 +121,7 @@
 
     <!-- STUDIO 2.1.0 -->
     <color name="blue">#2271b1</color>
-    <color name="blue_0">#eff3f7</color>
+    <color name="blue_0">#e9eff5</color>
     <color name="blue_5">#c6def6</color>
     <color name="blue_10">#9ac6f0</color>
     <color name="blue_20">#72aee6</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -122,7 +122,7 @@
     <!-- STUDIO 2.1.0 -->
     <color name="blue">#2271b1</color>
     <color name="blue_0">#e9eff5</color>
-    <color name="blue_5">#c6def6</color>
+    <color name="blue_5">#c5d9ed</color>
     <color name="blue_10">#9ac6f0</color>
     <color name="blue_20">#72aee6</color>
     <color name="blue_30">#5198d9</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -241,7 +241,6 @@
     <color name="woocommerce_purple_0">#f7edf7</color>
     <color name="woocommerce_purple_5">#e5cfe8</color>
     <color name="woocommerce_purple_10">#d6b4e0</color>
-    <color name="woocommerce_purple_100">#140e1f</color>
     <color name="woocommerce_purple_20">#c792e0</color>
     <color name="woocommerce_purple_30">#af7dd1</color>
     <color name="woocommerce_purple_40">#9a69c7</color>
@@ -250,6 +249,7 @@
     <color name="woocommerce_purple_70">#533582</color>
     <color name="woocommerce_purple_80">#3c2861</color>
     <color name="woocommerce_purple_90">#271b3d</color>
+    <color name="woocommerce_purple_100">#140e1f</color>
     <color name="wordpress_blue">#006088</color>
     <color name="wordpress_blue_0">#e6f1f5</color>
     <color name="wordpress_blue_5">#bedae6</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -160,7 +160,7 @@
     <color name="gray_90">#1d2327</color>
     <color name="gray_100">#101517</color>
     <color name="green">#008a20</color>
-    <color name="green_0">#ebf7f1</color>
+    <color name="green_0">#e6f2e8</color>
     <color name="green_5">#a4f5c8</color>
     <color name="green_10">#59e38f</color>
     <color name="green_20">#1ed15a</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -265,7 +265,7 @@
     <color name="wordpress_blue_100">#00101c</color>
     <color name="yellow">#907300</color>
     <color name="yellow_0">#f5efe4</color>
-    <color name="yellow_5">#f7e1ae</color>
+    <color name="yellow_5">#f5e1b3</color>
     <color name="yellow_10">#f2cf75</color>
     <color name="yellow_20">#f0c443</color>
     <color name="yellow_30">#dbae17</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -264,7 +264,7 @@
     <color name="wordpress_blue_90">#001d2d</color>
     <color name="wordpress_blue_100">#00101c</color>
     <color name="yellow">#907300</color>
-    <color name="yellow_0">#f7f2e6</color>
+    <color name="yellow_0">#f5efe4</color>
     <color name="yellow_5">#f7e1ae</color>
     <color name="yellow_10">#f2cf75</color>
     <color name="yellow_20">#f0c443</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -134,7 +134,7 @@
     <color name="blue_90">#01263a</color>
     <color name="blue_100">#00131c</color>
     <color name="celadon">#007e65</color>
-    <color name="celadon_0">#ecf7f4</color>
+    <color name="celadon_0">#e4f2ed</color>
     <color name="celadon_5">#a6ebd6</color>
     <color name="celadon_10">#63d6b6</color>
     <color name="celadon_20">#2ebd99</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -175,7 +175,7 @@
     <color name="jetpack_green">#2fb41f</color>
     <color name="jetpack_green_0">#f0f2eb</color>
     <color name="jetpack_green_5">#d0e6b8</color>
-    <color name="jetpack_green_10">#9dde73</color>
+    <color name="jetpack_green_10">#9dd977</color>
     <color name="jetpack_green_20">#64ca43</color>
     <color name="jetpack_green_30">#2fb41f</color>
     <color name="jetpack_green_40">#069e08</color>


### PR DESCRIPTION
### Fix
Update the color scheme to [Color Studio v2.2.0](https://color-studio.blog/).  These changes include updating color values of `*_0` and `*_5` shades of every color and some `*_10` shades.  There are no functional changes.

### Test
An alpha build can be downloaded once the continuous integration checks pass.  It will be installed alongside the production build (i.e. two WordPress apps will be on the device; one production and one debug) so changes can be compared on the same device.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.  The code review should not worry about the color names or specific changes to the color of the interface, but it should check that there are no breaking changes.  The interface and color values should be reviewed by a designer.