### PR TITLE
Issue/10503 overload login module theme

### DIFF
--- a/WordPress/src/main/res/layout/login_epilogue_header.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_header.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/header"
+    android:background="@color/background_default"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"

--- a/WordPress/src/main/res/layout/login_epilogue_header.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_header.xml
@@ -3,7 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/header"
-    android:background="@color/background_default"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"

--- a/WordPress/src/main/res/layout/login_epilogue_screen.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_screen.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  app:theme="@style/LoginTheme">
+  android:layout_height="match_parent">
 
     <androidx.recyclerview.widget.RecyclerView
+        android:theme="@style/LoginEpilogueSitesList"
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -968,4 +968,79 @@
         <item name="android:layout_weight">20</item>
     </style>
 
+    <!-- Overload of Login Theme -->
+    <style name="LoginTheme" parent="WordPress">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="colorPrimary">@color/color_primary</item>
+        <item name="colorAccent">@color/login_theme_accent_color</item>
+        <item name="colorControlHighlight">@android:color/transparent</item>
+
+        <item name="android:statusBarColor" tools:targetApi="21">@color/status_bar</item>
+        <item name="android:windowBackground">@color/login_background_color</item>
+        <item name="actionMenuTextColor">@android:color/white</item>
+    </style>
+
+    <style name="LoginTheme.Toolbar" parent="LoginTheme">
+        <item name="colorControlNormal">@color/color_control_normal</item>
+        <item name="homeAsUpIndicator">@drawable/ic_arrow_left_white_24dp</item>
+    </style>
+
+    <style name="LoginTheme.Button" parent="Widget.AppCompat.Button.Colored">
+        <item name="colorButtonNormal">@color/login_base_button_normal_color</item>
+    </style>
+
+    <style name="LoginTheme.Button.Primary" parent="Widget.AppCompat.Button.Colored">
+        <item name="colorButtonNormal">@color/login_primary_button_normal_color</item>
+        <item name="android:textColor">@color/login_primary_button_text_color</item>
+    </style>
+
+    <style name="LoginTheme.Button.Secondary" parent="Widget.AppCompat.Button.Borderless.Colored">
+        <item name="android:textColor">@color/login_secondary_button_text_color</item>
+        <item name="android:textAppearance">@style/TextAppearance.AppCompat.Caption</item>
+    </style>
+
+    <style name="LoginTheme.Button.Google" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">@color/login_google_button_text_color</item>
+    </style>
+
+    <style name="LoginTheme.TextLabel" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">@color/login_text_label_text_color</item>
+        <item name="android:lineSpacingExtra">2dp</item>
+    </style>
+
+    <style name="LoginTheme.InputLabelStatic" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">@color/login_input_label_static_text_color</item>
+    </style>
+
+    <style name="LoginTheme.EditText" parent="LoginTheme">
+        <item name="colorControlNormal">@color/login_edit_text_color_control_normal</item>
+        <item name="android:textColor">@color/login_edit_text_text_color</item>
+        <item name="android:textColorHint">@color/login_edit_text_text_hint_color</item>
+        <item name="colorControlActivated">@color/login_edit_text_color_control_activated</item>
+        <item name="colorControlHighlight">@color/login_edit_text_color_control_highlight</item>
+    </style>
+
+    <style name="LoginTheme.PromoText" parent="TextAppearance.AppCompat.Title">
+        <item name="android:gravity">center</item>
+        <item name="android:lineSpacingExtra">2dp</item>
+    </style>
+
+    <style name="LoginTheme.Heading" parent="TextAppearance.AppCompat.Body2">
+        <item name="android:textColor">@color/login_heading_text_color</item>
+    </style>
+
+    <style name="LoginTheme.Subhead" parent="TextAppearance.AppCompat.Subhead">
+        <item name="android:textColor">@color/login_subhead_text_color</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="LoginTheme.Username" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">@color/login_username_text_color</item>
+    </style>
+
+    <style name="LoginTheme.Footnote" parent="TextAppearance.AppCompat.Caption">
+        <item name="android:textColor">@color/login_footnote_text_color</item>
+    </style>
+
 </resources>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -972,12 +972,7 @@
     <style name="LoginTheme" parent="WordPress">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
-        <item name="colorPrimary">@color/color_primary</item>
-        <item name="colorAccent">@color/login_theme_accent_color</item>
-        <item name="colorControlHighlight">@android:color/transparent</item>
-
-        <item name="android:statusBarColor" tools:targetApi="21">@color/status_bar</item>
-        <item name="android:windowBackground">@color/login_background_color</item>
+        <item name="colorControlActivated">@color/accent</item>
         <item name="actionMenuTextColor">@android:color/white</item>
     </style>
 

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1038,4 +1038,8 @@
         <item name="android:textColor">@color/login_footnote_text_color</item>
     </style>
 
+    <style name="LoginEpilogueSitesList">
+        <item name="colorControlHighlight">@android:color/transparent</item>
+    </style>
+
 </resources>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -7,7 +7,6 @@
         <item name="colorPrimaryDark">@color/primary_dark</item>
         <item name="colorAccent">@color/accent</item>
         <item name="colorControlActivated">@color/primary_30</item>
-        <item name="colorControlHighlight">@color/neutral_10</item>
 
         <item name="wpColorText">@color/neutral_70</item>
         <item name="wpColorTextSubtle">@color/neutral</item>


### PR DESCRIPTION
Fixes #10503

In this PR we are overloading LoginTheme in `WordPress` module. Now it inherits from the main `WordPress` theme, and we can use it to style login flow in the future.

There should be one visual change related to `colorControlHighlight`.

Pressed color of controls in login flow now match the rest of the app:

**Before**:
[![Image from Gyazo](https://i.gyazo.com/dc683bb04cd2401f7f9d9aa6f8090b55.gif)](https://gyazo.com/dc683bb04cd2401f7f9d9aa6f8090b55)

[![Image from Gyazo](https://i.gyazo.com/bc7994edf3fd23cc2ba92d1bd75b4981.gif)](https://gyazo.com/bc7994edf3fd23cc2ba92d1bd75b4981)

**After**:
[![Image from Gyazo](https://i.gyazo.com/9215bd4d605a47ae3be4a2ee4a71650b.gif)](https://gyazo.com/9215bd4d605a47ae3be4a2ee4a71650b)

[![Image from Gyazo](https://i.gyazo.com/f877ec7aa5db8d9ebc50478d9d7f10ff.gif)](https://gyazo.com/f877ec7aa5db8d9ebc50478d9d7f10ff)


In addition, I fixed issues with the login epilogues sites list:
[![Image from Gyazo](https://i.gyazo.com/a295aaaab01905e21628b895476b3f69.png)](https://gyazo.com/a295aaaab01905e21628b895476b3f69)

Notice the site title is visible, and overall colors do not look muted anymore - for some reason the list sometimes gets highlighted and changes color.


To test:

- Compare login and signup flow of current develop version and this branch side by side.
- Notice that there is no color differences, apart from mentioned above.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
