### PR TITLE
Add release notes for local autosave from #10483

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,6 @@
 13.3
 -----
 * Added ability to change the username via Account Settings
-
 * Add Jetpack performance settings
 * Sort more than 100 published pages chronologically like Calypso
 * Significant performance improvements to Stats
@@ -9,6 +8,7 @@
 * Block Editor: Prevent keyboard dismissal when switching between caption and text block
 * Block Editor: Blocks that would be replaced are now hidden when add block bottom sheet displays
 * Block Editor: Tapping on empty editor area now always inserts new block at end of post
+* Block Editor: Automatically saves post locally after 2 seconds of inactivity
  
 13.2
 -----


### PR DESCRIPTION
Added a release note for local autosave implemented as a part of #10483 

Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
