### PR TITLE
Fix retry media upload on self hosted site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -30,7 +30,6 @@ import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged;
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
-import org.wordpress.android.fluxc.store.PostStore.PostErrorType;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.UploadStore;
 import org.wordpress.android.fluxc.store.UploadStore.ClearMediaPayload;
@@ -39,7 +38,6 @@ import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
-import org.wordpress.android.util.CrashLoggingUtils;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.NetworkUtils;
@@ -1087,12 +1085,6 @@ public class UploadService extends Service {
     @Subscribe(threadMode = ThreadMode.MAIN, priority = 7)
     public void onPostChanged(OnPostChanged event) {
         if (event.causeOfChange instanceof CauseOfOnPostChanged.RemoteAutoSavePost) {
-            if (event.isError() && event.error.type == PostErrorType.UNSUPPORTED_ACTION) {
-                CrashLoggingUtils
-                        .log("RemoteAutoSavePost failed with UNSUPPORTED_ACTION error. This shouldn't happen. We "
-                             + "have tried to invoke remoteAutoSave on an unsupported site (eg. self-hosted).");
-            }
-
             PostModel post =
                     mPostStore.getPostByLocalPostId(((RemoteAutoSavePost) event.causeOfChange).getLocalPostId());
             stopServiceIfUploadsComplete(event.isError(), post);

--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'ba71241677104e652d6e626d1c2dca3a53fa717c'
+    fluxCVersion = '3da9391867cab2d6d4ab84912e8365078d61a645'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'a546e39bc4c71408522a4fb3dc41f639a2fee89d'
+    fluxCVersion = 'ba71241677104e652d6e626d1c2dca3a53fa717c'
 }


### PR DESCRIPTION
Fixes #10513 

Notes:
- This PR is dependant on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1385
- Target branch is `issue/10370-auto-upload-error-labels` -> if https://github.com/wordpress-mobile/WordPress-Android/pull/10446 is merged before this PR, update its target branch to `master-auto-upload`

See https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1385 for info

To test:
1. Create a draft on a self-hosted site (make sure it's uploaded to the server)
2. Turn on airplane mode
3. Add a media item into the draft
4. Leave the editor without confirming the changes (press back or up button)
5. Turn off airplane mode
6. Click on retry
7. Notice the media upload is retried but when it finishes the draft has "local changes" label
----------------
1. Create a draft on a self-hosted site (make sure it's uploaded to the server)
2. Turn on airplane mode
3. Add a media item into the draft
4. Click on "Publish"
5. Turn off airplane mode
6. Notice the post gets published with its media

Update release notes:

- [ x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
