### PR TITLE
Hide remote auto save completed notification

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -654,7 +654,6 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
             PostModel post = mPostStore.getPostByLocalPostId(postLocalId);
             SiteModel site = mSiteStore.getSiteByLocalId(post.getLocalSiteId());
             mPostUploadNotifier.incrementUploadedPostCountFromForegroundNotification(post);
-            mPostUploadNotifier.updateNotificationSuccessForPost(post, site, false);
             finishUpload();
         }
     }


### PR DESCRIPTION
Fixes #10518 

Do not show notification on completed remote-auto-save.

@maxme I can't think of any scenario where we'd want to show the notification. Any ideas?

To test:

1. Add media item to a published post
2. Click on back
3. Click on home
4. Notice "Post changed" notification is NOT shown

Update release notes:

- [ x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
