### PR TITLE
Fix string translation in Stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWi
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetSiteSelectionDialogFragment;
 import org.wordpress.android.ui.stats.refresh.lists.widget.minified.StatsMinifiedWidgetConfigureFragment;
 import org.wordpress.android.util.wizard.WizardManager;
+import org.wordpress.android.viewmodel.ContextProvider;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatusLiveData;
 
@@ -40,8 +41,8 @@ public abstract class ApplicationModule {
     abstract Context bindContext(Application application);
 
     @Provides
-    public static NewsService provideLocalNewsService(Context context) {
-        return new LocalNewsService(context);
+    public static NewsService provideLocalNewsService(ContextProvider contextProvider) {
+        return new LocalNewsService(contextProvider);
     }
 
     @ContributesAndroidInjector

--- a/WordPress/src/main/java/org/wordpress/android/ui/news/LocalNewsService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/news/LocalNewsService.kt
@@ -1,10 +1,10 @@
 package org.wordpress.android.ui.news
 
-import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import org.wordpress.android.models.news.LocalNewsItem
 import org.wordpress.android.models.news.NewsItem
+import org.wordpress.android.viewmodel.ContextProvider
 import javax.inject.Inject
 
 /**
@@ -12,7 +12,7 @@ import javax.inject.Inject
  *
  * This is just a temporary solution until News Cards are supported on the server.
  */
-class LocalNewsService @Inject constructor(private val context: Context) : NewsService {
+class LocalNewsService @Inject constructor(private val contextProvider: ContextProvider) : NewsService {
     val data: MutableLiveData<NewsItem> = MutableLiveData()
 
     override fun newsItemSource(): LiveData<NewsItem> {
@@ -29,10 +29,10 @@ class LocalNewsService @Inject constructor(private val context: Context) : NewsS
 
     private fun loadCardFromResources(): NewsItem {
         return NewsItem(
-                context.getString(LocalNewsItem.titleResId),
-                context.getString(LocalNewsItem.contentResId),
-                context.getString(LocalNewsItem.actionResId),
-                context.getString(LocalNewsItem.urlResId),
+                contextProvider.getContext().getString(LocalNewsItem.titleResId),
+                contextProvider.getContext().getString(LocalNewsItem.contentResId),
+                contextProvider.getContext().getString(LocalNewsItem.actionResId),
+                contextProvider.getContext().getString(LocalNewsItem.urlResId),
                 LocalNewsItem.version
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -38,6 +38,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPPrefUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.viewmodel.ContextProvider;
 
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -65,6 +66,7 @@ public class AppSettingsFragment extends PreferenceFragment
     @Inject SiteStore mSiteStore;
     @Inject AccountStore mAccountStore;
     @Inject Dispatcher mDispatcher;
+    @Inject ContextProvider mContextProvider;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -317,6 +319,7 @@ public class AppSettingsFragment extends PreferenceFragment
         LocaleManager.setNewLocale(WordPress.getContext(), languageCode);
         WordPress.updateContextLocale();
         updateLanguagePreference(languageCode);
+        mContextProvider.refreshContext();
 
         // Track language change on Analytics because we have both the device language and app selected language
         // data in Tracks metadata.

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateUtils.kt
@@ -1,15 +1,18 @@
 package org.wordpress.android.ui.stats.refresh.utils
 
-import android.content.Context
 import android.text.format.DateFormat
 import android.text.format.DateUtils
 import org.wordpress.android.util.DateTimeUtils
+import org.wordpress.android.util.LocaleManagerWrapper
+import org.wordpress.android.viewmodel.ContextProvider
 import java.text.SimpleDateFormat
 import java.util.Calendar
-import java.util.Locale
 import javax.inject.Inject
 
-class DateUtils @Inject constructor(private val context: Context) {
+class DateUtils @Inject constructor(
+    private val contextProvider: ContextProvider,
+    private val localeManagerWrapper: LocaleManagerWrapper
+) {
     fun getWeekDay(dayOfTheWeek: Int): String {
         val c = Calendar.getInstance()
         c.firstDayOfWeek = Calendar.MONDAY
@@ -24,12 +27,12 @@ class DateUtils @Inject constructor(private val context: Context) {
             6 -> c.set(Calendar.DAY_OF_WEEK, Calendar.SUNDAY)
         }
 
-        val formatter = SimpleDateFormat("EEEE", Locale.getDefault())
+        val formatter = SimpleDateFormat("EEEE", localeManagerWrapper.getLocale())
         return formatter.format(c.time).capitalize()
     }
 
     fun getHour(hour: Int): String {
-        val formatter = DateFormat.getTimeFormat(context)
+        val formatter = DateFormat.getTimeFormat(contextProvider.getContext())
         val c = Calendar.getInstance()
         c.set(Calendar.HOUR_OF_DAY, hour)
         c.set(Calendar.MINUTE, 0)
@@ -38,7 +41,7 @@ class DateUtils @Inject constructor(private val context: Context) {
 
     fun formatDateTime(dateIso8601: String): String {
         return DateUtils.formatDateTime(
-                context,
+                contextProvider.getContext(),
                 DateTimeUtils.timestampFromIso8601Millis(dateIso8601),
                 getDateTimeFlags()
         )

--- a/WordPress/src/main/java/org/wordpress/android/util/LocaleManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/LocaleManagerWrapper.kt
@@ -1,14 +1,13 @@
 package org.wordpress.android.util
 
-import android.content.Context
 import java.util.Calendar
 import java.util.Locale
 import java.util.TimeZone
 import javax.inject.Inject
 
 class LocaleManagerWrapper
-@Inject constructor(private val context: Context) {
-    fun getLocale(): Locale = LocaleManager.getSafeLocale(context)
+@Inject constructor() {
+    fun getLocale(): Locale = Locale.getDefault()
     fun getTimeZone(): TimeZone = TimeZone.getDefault()
     fun getCurrentCalendar(): Calendar = Calendar.getInstance(getLocale())
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/ContextProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/ContextProvider.kt
@@ -12,7 +12,5 @@ class ContextProvider
         this.context = LocaleManager.setLocale(this.context)
     }
 
-    fun getContext(): Context {
-        return context
-    }
+    fun getContext(): Context = context
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/ContextProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/ContextProvider.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.viewmodel
+
+import android.content.Context
+import org.wordpress.android.util.LocaleManager
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ContextProvider
+@Inject constructor(private var context: Context) {
+    fun refreshContext() {
+        this.context = LocaleManager.setLocale(this.context)
+    }
+
+    fun getContext(): Context {
+        return context
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/ResourceProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/ResourceProvider.kt
@@ -1,27 +1,26 @@
 package org.wordpress.android.viewmodel
 
-import android.content.Context
 import androidx.annotation.ColorRes
 import androidx.annotation.DimenRes
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import javax.inject.Inject
 
-class ResourceProvider @Inject constructor(private val context: Context) {
+class ResourceProvider @Inject constructor(private val contextProvider: ContextProvider) {
     fun getString(@StringRes resourceId: Int): String {
-        return context.getString(resourceId)
+        return contextProvider.getContext().getString(resourceId)
     }
 
     fun getString(@StringRes resourceId: Int, vararg formatArgs: Any): String {
-        return context.getString(resourceId, *formatArgs)
+        return contextProvider.getContext().getString(resourceId, *formatArgs)
     }
 
     fun getColor(@ColorRes resourceId: Int): Int {
-        return ContextCompat.getColor(context, resourceId)
+        return ContextCompat.getColor(contextProvider.getContext(), resourceId)
     }
 
     fun getDimensionPixelSize(@DimenRes dimen: Int): Int {
-        val resources = context.resources
+        val resources = contextProvider.getContext().resources
         return resources.getDimensionPixelSize(dimen)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/news/LocalNewsServiceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/news/LocalNewsServiceTest.kt
@@ -15,6 +15,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.models.news.LocalNewsItem
 import org.wordpress.android.models.news.NewsItem
+import org.wordpress.android.viewmodel.ContextProvider
 
 @RunWith(MockitoJUnitRunner::class)
 class LocalNewsServiceTest {
@@ -23,6 +24,7 @@ class LocalNewsServiceTest {
     val rule = InstantTaskExecutorRule()
 
     @Mock private lateinit var observer: Observer<NewsItem>
+    @Mock private lateinit var contextProvider: ContextProvider
     @Mock private lateinit var context: Context
 
     private lateinit var newsItem: NewsItem
@@ -32,7 +34,8 @@ class LocalNewsServiceTest {
 
     @Before
     fun setUp() {
-        localNewsService = LocalNewsService(context)
+        localNewsService = LocalNewsService(contextProvider)
+        whenever(contextProvider.getContext()).thenReturn(context)
         whenever(context.getString(any())).thenReturn(dummyString)
         newsItem = NewsItem(dummyString, dummyString, dummyString, dummyString, LocalNewsItem.version)
     }


### PR DESCRIPTION
Fixes #8114

This fixes the issue with dates and other strings not being translated when the user changes the language within the App settings. This uses the injected `ContextProvider` instead of `Context`. The `ContextProvider` keeps a copy of the context which gets updated whenever the user selects a new language. 

To test:
* Have system language in English
* Go to Me/App settings
* Change language to something with different Month names (Czech)
* Go to Stats
* Check that all the strings are translated to your new language (except the strings which are missing translations in your selected language)

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
