### PR TITLE
Move GoogleApiClient.Builder to onStart/Stop methods

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -52,9 +52,9 @@ import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import dagger.android.support.AndroidSupportInjection;
-
 import static android.app.Activity.RESULT_OK;
+
+import dagger.android.support.AndroidSupportInjection;
 
 public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> implements TextWatcher,
         OnEditorCommitListener, ConnectionCallbacks, OnConnectionFailedListener {
@@ -280,12 +280,25 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             mHideLoginWithSiteOption = args.getBoolean(ARG_HIDE_LOGIN_BY_SITE_OPTION, false);
             mLoginSiteUrl = args.getString(ARG_LOGIN_SITE_URL, "");
         }
+    }
 
+    @Override
+    public void onStart() {
+        super.onStart();
         mGoogleApiClient = new GoogleApiClient.Builder(getActivity())
                 .addConnectionCallbacks(LoginEmailFragment.this)
                 .enableAutoManage(getActivity(), GOOGLE_API_CLIENT_ID, LoginEmailFragment.this)
                 .addApi(Auth.CREDENTIALS_API)
                 .build();
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        mGoogleApiClient.stopAutoManage(getActivity());
+        if (mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
+            mGoogleApiClient.disconnect();
+        }
     }
 
     @Override

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -346,11 +346,6 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     public void onDetach() {
         super.onDetach();
         mLoginListener = null;
-
-        mGoogleApiClient.stopAutoManage(getActivity());
-        if (mGoogleApiClient.isConnected()) {
-            mGoogleApiClient.disconnect();
-        }
     }
 
     private String getCleanedEmail() {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -295,9 +295,11 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     @Override
     public void onStop() {
         super.onStop();
-        mGoogleApiClient.stopAutoManage(getActivity());
-        if (mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
-            mGoogleApiClient.disconnect();
+        if (mGoogleApiClient != null) {
+            mGoogleApiClient.stopAutoManage(getActivity());
+            if (mGoogleApiClient.isConnected()) {
+                mGoogleApiClient.disconnect();
+            }
         }
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupEmailFragment.java
@@ -155,9 +155,11 @@ public class SignupEmailFragment extends LoginBaseFormFragment<LoginListener> im
     @Override
     public void onStop() {
         super.onStop();
-        mGoogleApiClient.stopAutoManage(getActivity());
-        if (mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
-            mGoogleApiClient.disconnect();
+        if (mGoogleApiClient != null) {
+            mGoogleApiClient.stopAutoManage(getActivity());
+            if (mGoogleApiClient.isConnected()) {
+                mGoogleApiClient.disconnect();
+            }
         }
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupEmailFragment.java
@@ -45,9 +45,9 @@ import org.wordpress.android.util.NetworkUtils;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import dagger.android.support.AndroidSupportInjection;
-
 import static android.app.Activity.RESULT_OK;
+
+import dagger.android.support.AndroidSupportInjection;
 
 public class SignupEmailFragment extends LoginBaseFormFragment<LoginListener> implements TextWatcher,
         OnEditorCommitListener, ConnectionCallbacks, OnConnectionFailedListener {
@@ -143,14 +143,22 @@ public class SignupEmailFragment extends LoginBaseFormFragment<LoginListener> im
         super.onAttach(context);
     }
 
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    @Override public void onStart() {
+        super.onStart();
         mGoogleApiClient = new GoogleApiClient.Builder(getActivity())
                 .addConnectionCallbacks(SignupEmailFragment.this)
                 .enableAutoManage(getActivity(), GOOGLE_API_CLIENT_ID, SignupEmailFragment.this)
                 .addApi(Auth.CREDENTIALS_API)
                 .build();
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        mGoogleApiClient.stopAutoManage(getActivity());
+        if (mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
+            mGoogleApiClient.disconnect();
+        }
     }
 
     @Override
@@ -190,11 +198,6 @@ public class SignupEmailFragment extends LoginBaseFormFragment<LoginListener> im
     public void onDetach() {
         super.onDetach();
         mLoginListener = null;
-
-        if (mGoogleApiClient.isConnected()) {
-            mGoogleApiClient.stopAutoManage(getActivity());
-            mGoogleApiClient.disconnect();
-        }
     }
 
     private String getCleanedEmail() {


### PR DESCRIPTION
Fixes #10357

I think (and I might be wrong) that there are 2 possible issues. One is that sometimes `onDestroy` and `onDetach` are not called. The other one is that in the `SignupEmailFragment` we were checking whether the client is connected before we called `stopAutoManage` and I don't think that's always the case (I was able to make that crash after moving the logic to `onStart` and `onStop`). 

This PR is not really based on evidence so I might be very wrong :-).

To test:
* Test Login and Signup
* Try to move the app to the background in the middle of the process and come back

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
