### PR TITLE
Issue/10462 unhandled autosave

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -238,7 +238,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
                 }
             }
             hasUnhandledConflicts -> labels.add(UiStringRes(R.string.local_post_is_conflicted))
-            hasAutoSave -> labels.add(UiStringRes(R.string.local_post_autosave_conflict))
+            hasAutoSave -> labels.add(UiStringRes(R.string.local_post_autosave_revision_available))
         }
 
         // we want to show either single error/progress label or 0-n info labels.

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -309,12 +309,12 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         hasAutoSave: Boolean
     ): Int? {
         val isError = (uploadUiState is UploadFailed && !uploadUiState.isEligibleForAutoUpload) ||
-                hasUnhandledConflicts || hasAutoSave
+                hasUnhandledConflicts
         val isProgressInfo = uploadUiState is UploadingPost || uploadUiState is UploadingMedia ||
                 uploadUiState is UploadQueued
         val isStateInfo = (uploadUiState is UploadFailed && uploadUiState.isEligibleForAutoUpload) ||
                 isLocalDraft || isLocallyChanged || postStatus == PRIVATE || postStatus == PENDING ||
-                uploadUiState is UploadWaitingForConnection
+                uploadUiState is UploadWaitingForConnection || hasAutoSave
 
         return when {
             isError -> ERROR_COLOR

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1428,7 +1428,7 @@
 
     <!-- Remote Post has conflicts with local post -->
     <string name="local_post_is_conflicted">Version conflict</string>
-    <string name="local_post_autosave_conflict">Unhandled Auto Save</string>
+    <string name="local_post_autosave_revision_available">You\'ve made unsaved changes to this post</string>
 
     <!-- Post Remote Preview -->
     <string name="post_preview_saving_draft">Saving&#8230;</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -495,7 +495,7 @@ class PostListItemUiStateHelperTest {
     @Test
     fun `unhandled auto-save label shown for posts with existing auto-save`() {
         val state = createPostListItemUiState(hasAutoSave = true)
-        assertThat(state.data.statuses).contains(UiStringRes(R.string.local_post_autosave_conflict))
+        assertThat(state.data.statuses).contains(UiStringRes(R.string.local_post_autosave_revision_available))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -457,9 +457,9 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `label has error color on auto-save conflict`() {
+    fun `label has state info color on auto-save conflict`() {
         val state = createPostListItemUiState(hasAutoSave = true)
-        assertThat(state.data.statusesColor).isEqualTo(ERROR_COLOR)
+        assertThat(state.data.statusesColor).isEqualTo(STATE_INFO_COLOR)
     }
 
     @Test


### PR DESCRIPTION
Fixes #10462 

Updated copy - see copy review suggestion - https://github.com/wordpress-mobile/WordPress-Android/issues/10462#issuecomment-535159330.

Changed color of "Unpublished revision" from red to yellow.


To test:
1. Open a published post in calypso
2. Edit its content and wait for +-30s
3. Open the app
4. Open Post list
5. Notice the label "You've made unsaved changes to this post" and make sure its yellow


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
