### PR TITLE
Fix crash during auto-upload

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -155,12 +155,15 @@ class UploadStarter @Inject constructor(
                             false
                         } else {
                             trackAutoUploadAction(action, it.status)
+                            AppLog.d(
+                                    AppLog.T.POSTS,
+                                    "UploadStarter for post title: ${it.title}, action: $action"
+                            )
                             true
                         }
                     }
                     .toList()
                     .forEach { post ->
-                        AppLog.d(AppLog.T.POSTS, "UploadStarter for post title: ${post.title}")
                         dispatcher.dispatch(UploadActionBuilder.newIncrementNumberOfAutoUploadAttemptsAction(post))
                         uploadServiceFacade.uploadPost(
                                 context = context,

--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '6875566c14de5c2d12be6ddc6d68d04bb3338e06'
+    fluxCVersion = 'fcd13311de5274cbadb13a9bd611ae65b71c4712'
 }


### PR DESCRIPTION
Fixes #10525 

More info https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1390

To test:
1. Turn on airplane mode
2. Go to post list - drafts
3. Add a new draft with some title and/or content
4. Tap back which should say "Local draft"
5. Turn off airplane mode and immediately pull-to-refresh on the post list

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

SideNote:
If you think this approach is too risky we can implement a simple "workaround" (hide the root of the issue) in WPAndroid app. The issue won't occur if we don't invoke `UploadStarter` twice within a few milliseconds -> once from `UploadWorker` and once from connection status listener in `UploadStarter`. I'll probably fix this issue anyway as it's causing other troubles - eg. https://github.com/wordpress-mobile/WordPress-Android/issues/10526.
