### PR TITLE
Enable using a local copy of WordPressMocks

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -234,7 +234,7 @@ dependencies {
     }
     androidTestImplementation 'org.apache.httpcomponents:httpclient-android:4.3.5.1'
 
-    androidTestImplementation project(path:':libs:mocks:WordPressMocks')
+    androidTestImplementation project(path:':WordPressMocks')
 
     androidTestImplementation 'androidx.test:runner:1.1.0'
     androidTestImplementation 'androidx.test:rules:1.1.0'

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -31,9 +31,9 @@ wp.sentry.dsn=https://00000000000000000000000000000000@sentry.io/00000000
 # Needed to use the Google Maps component aka the PlacePicker (Post Settings -> Location)
 wp.res.com.google.android.geo.api.key = geo-api-key
 
-# Uncomment this and update the path to use a local copy of WordPressMocks
-# Note the path should be relative to the project root
-# wp.wordpress_mocks_path = ../WordPressMocks/WordPressMocks
+# Uncomment and edit the line below to use a local copy of WordPressMocks
+# You should specify a relative path to the root of your WordPressMocks repo
+# wp.wordpress_mocks_path = ../WordPressMocks
 
 # Optional: Needed for the end to end tests
 wp.e2e.wp_com_user.email=e2eflowtestingmobile@example.com

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -31,6 +31,10 @@ wp.sentry.dsn=https://00000000000000000000000000000000@sentry.io/00000000
 # Needed to use the Google Maps component aka the PlacePicker (Post Settings -> Location)
 wp.res.com.google.android.geo.api.key = geo-api-key
 
+# Uncomment this and update the path to use a local copy of WordPressMocks
+# Note the path should be relative to the project root
+# wp.wordpress_mocks_path = ../WordPressMocks/WordPressMocks
+
 # Optional: Needed for the end to end tests
 wp.e2e.wp_com_user.email=e2eflowtestingmobile@example.com
 wp.e2e.wp_com_user.password=mocked_password

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,9 @@ include ':libs:networking:WordPressNetworking'
 include ':libs:analytics:WordPressAnalytics'
 include ':libs:editor:WordPressEditor'
 include ':libs:login:WordPressLoginFlow'
-include ':libs:mocks:WordPressMocks'
+
+include ':WordPressMocks'
+project(':WordPressMocks').projectDir = new File(rootProject.projectDir, properties.getOrDefault('wp.wordpress_mocks_path', 'libs/mocks/WordPressMocks'))
 
 if (properties.getOrDefault('wp.BUILD_GUTENBERG_FROM_SOURCE', false).toBoolean()) {
     include ':react-native-svg'

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ include ':libs:editor:WordPressEditor'
 include ':libs:login:WordPressLoginFlow'
 
 include ':WordPressMocks'
-project(':WordPressMocks').projectDir = new File(rootProject.projectDir, properties.getOrDefault('wp.wordpress_mocks_path', 'libs/mocks/WordPressMocks'))
+project(':WordPressMocks').projectDir = new File(rootProject.projectDir, properties.getOrDefault('wp.wordpress_mocks_path', 'libs/mocks') + '/WordPressMocks')
 
 if (properties.getOrDefault('wp.BUILD_GUTENBERG_FROM_SOURCE', false).toBoolean()) {
     include ':react-native-svg'


### PR DESCRIPTION
This makes testing changes to the WordPressMocks repo easier by allowing WPAndroidn to be pointed to your local copy.

To test:

- Update your `gradle.properties` with a line like the one I added to `gradle.properties-example`.
- Run `./gradlew WordPressMocks:build`. You will see in the output that it used the path you specified.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
