### PR TITLE
Do not upload post without local changes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -187,7 +187,11 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
         uploadNextPost();
     }
 
-    private class UploadPostTask extends AsyncTask<PostModel, Boolean, Boolean> {
+    private enum UploadPostTaskResult {
+        PUSH_POST_DISPATCHED, ERROR, NOTHING_TO_UPLOAD
+    }
+
+    private class UploadPostTask extends AsyncTask<PostModel, Boolean, UploadPostTaskResult> {
         private Context mContext;
 
         private PostModel mPost;
@@ -201,25 +205,32 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
         private boolean mHasImage, mHasVideo, mHasCategory;
 
         @Override
-        protected void onPostExecute(Boolean pushActionWasDispatched) {
-            if (!pushActionWasDispatched) {
-                // This block only runs if the PUSH_POST action was never dispatched - if it was dispatched, any error
-                // will be handled in OnPostChanged instead of here
-                mPostUploadNotifier.incrementUploadedPostCountFromForegroundNotification(mPost);
-                mPostUploadNotifier.updateNotificationErrorForPost(mPost, mSite, mErrorMessage, 0);
-                finishUpload();
+        protected void onPostExecute(UploadPostTaskResult result) {
+            switch (result) {
+                case ERROR:
+                    mPostUploadNotifier.incrementUploadedPostCountFromForegroundNotification(mPost);
+                    mPostUploadNotifier.updateNotificationErrorForPost(mPost, mSite, mErrorMessage, 0);
+                    finishUpload();
+                    break;
+                case NOTHING_TO_UPLOAD:
+                    mPostUploadNotifier.incrementUploadedPostCountFromForegroundNotification(mPost);
+                    finishUpload();
+                    break;
+                case PUSH_POST_DISPATCHED:
+                    // will be handled in OnPostChanged
+                    break;
             }
         }
 
         @Override
-        protected Boolean doInBackground(PostModel... posts) {
+        protected UploadPostTaskResult doInBackground(PostModel... posts) {
             mContext = WordPress.getContext();
             mPost = posts[0];
 
             mSite = mSiteStore.getSiteByLocalId(mPost.getLocalSiteId());
             if (mSite == null) {
                 mErrorMessage = mContext.getString(R.string.blog_not_found);
-                return false;
+                return UploadPostTaskResult.ERROR;
             }
 
             if (TextUtils.isEmpty(mPost.getStatus())) {
@@ -239,7 +250,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
 
             // If media file upload failed, let's stop here and prompt the user
             if (mIsMediaError) {
-                return false;
+                return UploadPostTaskResult.ERROR;
             }
 
             if (mPost.getCategoryIdList().size() > 0) {
@@ -275,9 +286,15 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
                     mDispatcher.dispatch(PostActionBuilder.newRemoteAutoSavePostAction(payload));
                     break;
                 case DO_NOTHING:
-                    throw new RuntimeException("UploadService started but getPostUploadAction() returned DO_NOTHING.");
+                    // A single post might be enqueued twice for upload. It might cause some side-effects when the
+                    // post is a local draft.
+                    // The first upload request pushes the post to the server and sets `isLocalDraft` to `false`.
+                    // The second request would have invoked `Remote_auto_save` on a post which didn't contain any local
+                    // changes - they were uploaded during the first upload request.
+                    // This branch takes care of this situations and simply ignores the second request.
+                    return UploadPostTaskResult.NOTHING_TO_UPLOAD;
             }
-            return true;
+            return UploadPostTaskResult.PUSH_POST_DISPATCHED;
         }
 
         private boolean hasGallery() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -192,11 +192,15 @@ class PostUploadNotifier {
     }
 
     void incrementUploadedPostCountFromForegroundNotification(@NonNull PostModel post) {
+        incrementUploadedPostCountFromForegroundNotification(post, false);
+    }
+
+    void incrementUploadedPostCountFromForegroundNotification(@NonNull PostModel post, boolean force) {
         // first we need to check that we only count this post once as "ended" (either successfully or with error)
         // for every error we get. We'll then try to increment the Post count as it's been cancelled/failed because the
         // related media was cancelled or has failed too (i.e. we can't upload a Post with failed media, therefore
         // it needs to be cancelled).
-        if (isPostAlreadyInPostCount(post)) {
+        if (!force && isPostAlreadyInPostCount(post)) {
             return;
         } else {
             addPostToPostCount(post);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
@@ -71,6 +71,9 @@ class UploadActionUseCase @Inject constructor(
             post.isLocalDraft ->
                 // Local draft can always be uploaded as DRAFT as it doesn't exist on the server yet
                 UPLOAD_AS_DRAFT
+            !post.isLocallyChanged ->
+                // the post isn't local draft and isn't locally changed -> there is nothing new to upload
+                DO_NOTHING
             else -> REMOTE_AUTO_SAVE
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadActionUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadActionUseCaseTest.kt
@@ -49,7 +49,7 @@ class UploadActionUseCaseTest {
     }
 
     @Test
-    fun `uploadAction is REMOTE_AUTO_SAVE when changes not confirmed and isn't local draft`() {
+    fun `uploadAction is REMOTE_AUTO_SAVE when changes not confirmed and is not local draft`() {
         val uploadActionUseCase = createUploadActionUseCase()
 
         val post = createPostModel(changesConfirmed = false, isLocalDraft = false)
@@ -58,6 +58,18 @@ class UploadActionUseCaseTest {
 
         // Assert
         assertThat(action).isEqualTo(UploadAction.REMOTE_AUTO_SAVE)
+    }
+
+    @Test
+    fun `uploadAction is DO_NOTHING when the post does not contain any local changes and is not local draft`() {
+        val uploadActionUseCase = createUploadActionUseCase()
+
+        val post = createPostModel(isLocallyChanged = false, isLocalDraft = false)
+        // Act
+        val action = uploadActionUseCase.getUploadAction(post)
+
+        // Assert
+        assertThat(action).isEqualTo(UploadAction.DO_NOTHING)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
@@ -34,11 +34,11 @@ class UploadStarterConcurrentTest {
 
     private val site = createSiteModel()
     private val draftPosts = listOf(
-            createDraftPostModel(),
-            createDraftPostModel(),
-            createDraftPostModel(),
-            createDraftPostModel(),
-            createDraftPostModel()
+            createLocallyChangedPostModel(),
+            createLocallyChangedPostModel(),
+            createLocallyChangedPostModel(),
+            createLocallyChangedPostModel(),
+            createLocallyChangedPostModel()
     )
 
     private val postStore = mock<PostStore> {
@@ -93,7 +93,7 @@ class UploadStarterConcurrentTest {
             on { isPostInConflictWithRemote(any()) } doReturn false
         }
 
-        fun createDraftPostModel() = PostModel().apply {
+        fun createLocallyChangedPostModel() = PostModel().apply {
             status = PostStatus.DRAFT.toString()
             setIsLocallyChanged(true)
             dateLocallyChanged = DateTimeUtils.iso8601FromTimestamp(Date().time / 1000)

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
@@ -95,6 +95,7 @@ class UploadStarterConcurrentTest {
 
         fun createDraftPostModel() = PostModel().apply {
             status = PostStatus.DRAFT.toString()
+            setIsLocallyChanged(true)
             dateLocallyChanged = DateTimeUtils.iso8601FromTimestamp(Date().time / 1000)
         }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -501,6 +501,7 @@ class UploadStarterTest {
             id = Random.nextInt()
             title = UUID.randomUUID().toString()
             status = postStatus.toString()
+            setIsLocallyChanged(true)
             dateLocallyChanged = DateTimeUtils.iso8601FromTimestamp(Date().time / 1000)
         }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -62,24 +62,24 @@ class UploadStarterTest {
     private val sites = listOf(createSiteModel(), createSiteModel())
     private val sitesAndDraftPosts: Map<SiteModel, List<PostModel>> = mapOf(
             sites[0] to listOf(
-                    createDraftPostModel(DRAFT),
-                    createDraftPostModel(PUBLISHED),
-                    createDraftPostModel(SCHEDULED),
-                    createDraftPostModel(SCHEDULED),
-                    createDraftPostModel(PENDING),
-                    createDraftPostModel(PRIVATE),
-                    createDraftPostModel(PUBLISHED),
-                    createDraftPostModel(UNKNOWN)
+                    createLocallyChangedPostModel(DRAFT),
+                    createLocallyChangedPostModel(PUBLISHED),
+                    createLocallyChangedPostModel(SCHEDULED),
+                    createLocallyChangedPostModel(SCHEDULED),
+                    createLocallyChangedPostModel(PENDING),
+                    createLocallyChangedPostModel(PRIVATE),
+                    createLocallyChangedPostModel(PUBLISHED),
+                    createLocallyChangedPostModel(UNKNOWN)
             ),
             sites[1] to listOf(
-                    createDraftPostModel(DRAFT),
-                    createDraftPostModel(DRAFT),
-                    createDraftPostModel(PUBLISHED),
-                    createDraftPostModel(SCHEDULED),
-                    createDraftPostModel(PENDING),
-                    createDraftPostModel(PRIVATE),
-                    createDraftPostModel(PRIVATE),
-                    createDraftPostModel(UNKNOWN)
+                    createLocallyChangedPostModel(DRAFT),
+                    createLocallyChangedPostModel(DRAFT),
+                    createLocallyChangedPostModel(PUBLISHED),
+                    createLocallyChangedPostModel(SCHEDULED),
+                    createLocallyChangedPostModel(PENDING),
+                    createLocallyChangedPostModel(PRIVATE),
+                    createLocallyChangedPostModel(PRIVATE),
+                    createLocallyChangedPostModel(UNKNOWN)
             )
     )
     private val draftPosts = sitesAndDraftPosts.values.flatten()
@@ -285,7 +285,7 @@ class UploadStarterTest {
     fun `Do not invoke remote-auto-save on self-hosted sites`() = test {
         // Given
         val siteModel = createSiteModel(isWpCom = false)
-        val postModel = createDraftPostModel()
+        val postModel = createLocallyChangedPostModel()
         defaultSetup(siteModel, postModel)
 
         // When
@@ -303,7 +303,7 @@ class UploadStarterTest {
     fun `Invoke remote-auto-save on wp-com sites`() = test {
         // Given
         val siteModel = createSiteModel(isWpCom = true)
-        val postModel = createDraftPostModel()
+        val postModel = createLocallyChangedPostModel()
         defaultSetup(siteModel, postModel)
 
         // When
@@ -321,7 +321,7 @@ class UploadStarterTest {
     fun `Do not invoke remote auto save on posts older than 2 days`() = test {
         // Given
         val siteModel = createSiteModel()
-        val postModel = createDraftPostModel()
+        val postModel = createLocallyChangedPostModel()
         defaultSetup(siteModel, postModel)
 
         val twoDaysInSeconds = 60 * 60 * 24 * 2
@@ -343,7 +343,7 @@ class UploadStarterTest {
     fun `Invoke remote auto save on a post changed 1,99days ago`() = test {
         // Given
         val siteModel = createSiteModel()
-        val postModel = createDraftPostModel()
+        val postModel = createLocallyChangedPostModel()
         defaultSetup(siteModel, postModel)
 
         val twoDaysInSeconds = 60 * 60 * 24 * 2
@@ -365,7 +365,7 @@ class UploadStarterTest {
     fun `Do not auto-upload a post which is in conflict with remote`() = test {
         // Given
         val siteModel = createSiteModel()
-        val postModel = createDraftPostModel()
+        val postModel = createLocallyChangedPostModel()
         defaultSetup(siteModel, postModel)
 
         val postUtilsWrapper = createMockedPostUtilsWrapper()
@@ -386,7 +386,7 @@ class UploadStarterTest {
     fun `Do not auto-upload a post which is being uploaded or pending upload`() = test {
         // Given
         val siteModel = createSiteModel()
-        val postModel = createDraftPostModel()
+        val postModel = createLocallyChangedPostModel()
         defaultSetup(siteModel, postModel)
 
         whenever(uploadServiceFacade.isPostUploadingOrQueued(any())).thenReturn(true)
@@ -406,7 +406,7 @@ class UploadStarterTest {
     fun `Do not remote-auto-save a post which has already been remote-auto=saved`() = test {
         // Given
         val siteModel = createSiteModel()
-        val postModel = createDraftPostModel()
+        val postModel = createLocallyChangedPostModel()
         defaultSetup(siteModel, postModel)
 
         // Set autosaveModified to a newer date than dateLocallyChanged to indicate the changes were remotely-auto-saved
@@ -429,7 +429,7 @@ class UploadStarterTest {
     fun `verify number of auto upload attempts count is incremented when upload invoked`() = test {
         // Given
         val siteModel = createSiteModel()
-        val postModel = createDraftPostModel()
+        val postModel = createLocallyChangedPostModel()
         defaultSetup(siteModel, postModel)
         val dispatcher: Dispatcher = mock()
 
@@ -497,7 +497,7 @@ class UploadStarterTest {
             on { this.lifecycle } doReturn lifecycle
         }
 
-        fun createDraftPostModel(postStatus: PostStatus = DRAFT) = PostModel().apply {
+        fun createLocallyChangedPostModel(postStatus: PostStatus = DRAFT) = PostModel().apply {
             id = Random.nextInt()
             title = UUID.randomUUID().toString()
             status = postStatus.toString()


### PR DESCRIPTION
Fixes #10526, btw it also fixes/hides https://github.com/wordpress-mobile/WordPress-Android/issues/10525.

The issue is explained [here](https://github.com/wordpress-mobile/WordPress-Android/issues/10526#issuecomment-535517436).

To test - test it multiple times as the issue doesn't always occur
1. Turn on airplane mode
2. Go to post list - drafts
3. Add a new draft with some title and/or content
4. Tap back which should say "Local draft"
5. Turn off airplane mode and wait for the post to be uploaded
6. Make sure the post doesn't contain "Unhadled Auto save" label

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
