### PR TITLE
Fix/9748 npe in EditPostActivity onPrepareOptionsMenu

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1074,6 +1074,40 @@ public class EditPostActivity extends AppCompatActivity implements
         }
     }
 
+    private boolean shouldSwitchToGutenbergBeVisible(
+            PostModel post,
+            EditorFragmentAbstract editorFragment,
+            SiteModel site
+    ) {
+        // Some guard conditions
+        if (post == null) {
+            AppLog.w(T.EDITOR, "shouldSwitchToGutenbergBeVisible got a null post parameter.");
+            return false;
+        }
+
+        if (editorFragment == null) {
+            AppLog.w(T.EDITOR, "shouldSwitchToGutenbergBeVisible got a null editorFragment parameter.");
+            return false;
+        }
+
+        // Check whether the content has blocks.
+        boolean hasBlocks = false;
+        boolean isEmpty = false;
+        try {
+            final String content = (String) editorFragment.getContent(post.getContent());
+            hasBlocks = PostUtils.contentContainsGutenbergBlocks(content);
+            isEmpty = TextUtils.isEmpty(content);
+        } catch (EditorFragmentNotAddedException e) {
+            // legacy exception; just ignore.
+        }
+
+        // if content has blocks or empty, offer the switch to Gutenberg. The block editor doesn't have good
+        //  "Classic Block" support yet so, don't offer a switch to it if content doesn't have blocks. If the post
+        //  is empty but the user hasn't enabled "Use Gutenberg for new posts" in Site Setting,
+        //  don't offer the switch.
+        return hasBlocks || (SiteUtils.isBlockEditorDefaultForNewPost(site) && isEmpty);
+    }
+
     /*
      * called by PhotoPickerFragment when media is selected - may be a single item or a list of items
      */
@@ -1224,31 +1258,22 @@ public class EditPostActivity extends AppCompatActivity implements
         MenuItem switchToAztecMenuItem = menu.findItem(R.id.menu_switch_to_aztec);
         MenuItem switchToGutenbergMenuItem = menu.findItem(R.id.menu_switch_to_gutenberg);
 
-        if (mShowGutenbergEditor) {
-            // we're showing Gutenberg so, just offer the Aztec switch
-            switchToAztecMenuItem.setVisible(true);
-            switchToGutenbergMenuItem.setVisible(false);
-        } else {
-            // we're showing Aztec so, hide the "Switch to Aztec" menu
-            switchToAztecMenuItem.setVisible(false);
+        // The following null checks should basically be redundant but were added to manage
+        // an odd behaviour recorded with Android 8.0.0
+        // (see https://github.com/wordpress-mobile/WordPress-Android/issues/9748 for more information)
+        if (switchToAztecMenuItem != null && switchToGutenbergMenuItem != null) {
+            if (mShowGutenbergEditor) {
+                // we're showing Gutenberg so, just offer the Aztec switch
+                switchToAztecMenuItem.setVisible(true);
+                switchToGutenbergMenuItem.setVisible(false);
+            } else {
+                // we're showing Aztec so, hide the "Switch to Aztec" menu
+                switchToAztecMenuItem.setVisible(false);
 
-            // Check whether the content has blocks.
-            boolean hasBlocks = false;
-            boolean isEmpty = false;
-            try {
-                final String content = (String) mEditorFragment.getContent(mPost.getContent());
-                hasBlocks = PostUtils.contentContainsGutenbergBlocks(content);
-                isEmpty = TextUtils.isEmpty(content);
-            } catch (EditorFragmentNotAddedException e) {
-                // legacy exception; just ignore.
+                switchToGutenbergMenuItem.setVisible(
+                        shouldSwitchToGutenbergBeVisible(mPost, mEditorFragment, mSite)
+                );
             }
-
-            // if content has blocks or empty, offer the switch to Gutenberg. The block editor doesn't have good
-            //  "Classic Block" support yet so, don't offer a switch to it if content doesn't have blocks. If the post
-            //  is empty but the user hasn't enabled "Use Gutenberg for new posts" in Site Setting,
-            //  don't offer the switch.
-            switchToGutenbergMenuItem.setVisible(
-                    hasBlocks || (SiteUtils.isBlockEditorDefaultForNewPost(mSite) && isEmpty));
         }
 
         return super.onPrepareOptionsMenu(menu);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1392,20 +1392,40 @@ public class EditPostActivity extends AppCompatActivity implements
                     });
                 }
             } else if (itemId == R.id.menu_switch_to_aztec) {
-                // let's finish this editing instance and start again, but not letting Gutenberg be used
-                mRestartEditorOption = RestartEditorOptions.RESTART_SUPPRESS_GUTENBERG;
-                mPostEditorAnalyticsSession.switchEditor(Editor.CLASSIC);
-                mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
-                savePostAndOptionallyFinish(true);
+                // The following boolean check should be always redundant but was added to manage
+                // an odd behaviour recorded with Android 8.0.0
+                // (see https://github.com/wordpress-mobile/WordPress-Android/issues/9748 for more information)
+                if (mShowGutenbergEditor) {
+                    // let's finish this editing instance and start again, but not letting Gutenberg be used
+                    mRestartEditorOption = RestartEditorOptions.RESTART_SUPPRESS_GUTENBERG;
+                    mPostEditorAnalyticsSession.switchEditor(Editor.CLASSIC);
+                    mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
+                    savePostAndOptionallyFinish(true);
+                } else {
+                    logWrongMenuState("Wrong state in menu_switch_to_aztec: menu should not be visible.");
+                }
             } else if (itemId == R.id.menu_switch_to_gutenberg) {
-                // let's finish this editing instance and start again, but let GB be used
-                mRestartEditorOption = RestartEditorOptions.RESTART_DONT_SUPPRESS_GUTENBERG;
-                mPostEditorAnalyticsSession.switchEditor(Editor.GUTENBERG);
-                mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
-                savePostAndOptionallyFinish(true);
+                // The following boolean check should be always redundant but was added to manage
+                // an odd behaviour recorded with Android 8.0.0
+                // (see https://github.com/wordpress-mobile/WordPress-Android/issues/9748 for more information)
+                if (shouldSwitchToGutenbergBeVisible(mPost, mEditorFragment, mSite)) {
+                    // let's finish this editing instance and start again, but let GB be used
+                    mRestartEditorOption = RestartEditorOptions.RESTART_DONT_SUPPRESS_GUTENBERG;
+                    mPostEditorAnalyticsSession.switchEditor(Editor.GUTENBERG);
+                    mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
+                    savePostAndOptionallyFinish(true);
+                } else {
+                    logWrongMenuState("Wrong state in menu_switch_to_gutenberg: menu should not be visible.");
+                }
             }
         }
         return false;
+    }
+
+    private void logWrongMenuState(String logMsg) {
+        AppLog.w(T.EDITOR, logMsg);
+        // Lets record this event in Sentry
+        CrashLoggingUtils.logException(new IllegalStateException(logMsg), T.EDITOR);
     }
 
     private void showEmptyPostErrorForSecondaryAction() {


### PR DESCRIPTION
Fixes #9748 

The issue is confined to Android 8.0.0 and does not seems to be logic related.

It was not possible to reproduce the issue, but we decided to extend the defensive coding approach used in `null` check of all the other menu items in the `onPrepareOptionsMenu` also to the `switchToAztecMenuItem` and `switchToGutenbergMenuItem`. Note that the NPE happens on `switchToAztecMenuItem` that is the first not null checked item.

## Notes

- We added redundant checks on menu state coherence about switching between Aztec and Gutenberg editors in `onOptionsItemSelected`. This is a basic attempt to avoid odd conditions where a switch menu is available when it should not and you should not be allowed to switch between editors (AFAIU basically a post/page created in Aztec should not be allowed to be edited in GB; whereas a post/page created in GB can be edited with Aztec but the underline document will for now on contain blocks)
- Only one switch editor menu at a time should be available always!
- We would like to trace this event in Sentry. Currently I was only able to get events in Sentry as exception crashes. The real goal would be to trace events (not crashes) but could not find a way to trigger a normal event (possibly something to better investigate also with platform 9)
- A possible improvement to this PR could be to notify the user with something like a toast or similar in case we are skipping to actuate the editor switch for inconsistent menu states.

## Manual testing

_The following test cases must be completed with and without the current PR patch and give the same results._

### Test case 1 - Use block editor settings
1. Go to My site > Settings and deactivate Use Block Editor
2. Create a new Post/Page and check that no switch editor menu is available

### Test case 2 - Use block editor settings
1. Go to My site > Settings and activate Use Block Editor
2. Create a new Post/Page and check that you are presented with the GB editor and you can switch between editors using menus (only one editor switch menu at a time should be available) 

### Test case 3 - From Aztec no GB
1. Go to My site > Settings and ensure Use Block Editor is activated
2. Create a new Post/Page and check that you are presented with the GB editor and switch to Aztec by menu
3. Edit the document with Aztec and Save it
4. open again the document and check that you do not have the switch to GB menu available

### Test case 4 - From GB to Aztec and return
1. Go to My site > Settings and ensure Use Block Editor is activated
2. Create a new Post/Page and check that you are presented with the GB editor
3. Edit the document with GB and Save it
4. open again the document and check that you get GB editor and you can freely switch and edit to Aztec and again to GB

### Test case 5 - General smoke test on Editor and Menu items
1. Create documents with both editors and reopen them passing from one Editor to another where allowed.
2. Use all menus available trying to cover the various states

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
