### PR TITLE
Update Jitpack dependency urls to use the www subdomain

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -16,7 +16,7 @@ repositories {
     jcenter()
     maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
     maven { url "https://giphy.bintray.com/giphy-sdk" }
-    maven { url "https://jitpack.io" }
+    maven { url "https://www.jitpack.io" }
 }
 
 apply plugin: 'com.android.application'

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 repositories {
     google()
     jcenter()
-    maven { url "https://jitpack.io" }
+    maven { url "https://www.jitpack.io" }
     maven { url "https://dl.bintray.com/wordpress-mobile/react-native-mirror/" }
 }
 

--- a/libs/editor/example/build.gradle
+++ b/libs/editor/example/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'com.android.application'
 repositories {
     google()
     jcenter()
-    maven { url "https://jitpack.io" }
+    maven { url "https://www.jitpack.io" }
     maven { url "https://dl.bintray.com/wordpress-mobile/react-native-mirror/" }
 }
 

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'com.android.library'
 repositories {
     google()
     jcenter()
-    maven { url "https://jitpack.io" }
+    maven { url "https://www.jitpack.io" }
 }
 
 android {


### PR DESCRIPTION
This PR fixes an occasional build issue I am having where the Gradle can't find the Jitpack build without it. It turns out other people have experienced the same issue and adding `www` subdomain fixed it for them. I have had this issue 3 times in the last 2 days and in all of them this was an effective solution.

To test:
* Do a fresh build with refreshed dependencies

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
