### PR TITLE
Remove unnecessary symlinks for values-in, values-iw & values-zh

### DIFF
--- a/WordPress/src/main/res/values-in
+++ b/WordPress/src/main/res/values-in
@@ -1,1 +1,0 @@
-values-id

--- a/WordPress/src/main/res/values-iw
+++ b/WordPress/src/main/res/values-iw
@@ -1,1 +1,0 @@
-values-he

--- a/WordPress/src/main/res/values-zh
+++ b/WordPress/src/main/res/values-zh
@@ -1,1 +1,0 @@
-values-zh-rCN


### PR DESCRIPTION
We have some symbolic links that are checked into the git repo from 4-5 years ago. I am not 100% sure, but I don't think these links are necessary. They also create issues in Windows builds. So, unless they are used, I think we should remove them.

To test:
* I am not entirely sure what's the best way to test this to be honest. I think we just need to make sure that they are not necessary. Any ideas @jkmassel?

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
