### PR TITLE
Fix crash when restoring PostLoadingState

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -339,11 +339,7 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         public static PostLoadingState fromInt(int value) {
-            if (value < 0 || value >= values().length) {
-                throw new IllegalArgumentException("PostLoadingState wrong value " + value);
-            }
-
-            PostLoadingState state = NONE;
+            PostLoadingState state = null;
 
             for (PostLoadingState item : values()) {
                 if (item.mValue == value) {
@@ -352,6 +348,9 @@ public class EditPostActivity extends AppCompatActivity implements
                 }
             }
 
+            if (state == null) {
+                throw new IllegalArgumentException("PostLoadingState wrong value " + value);
+            }
             return state;
         }
     }


### PR DESCRIPTION
Fixes #10547

~I wasn't able to reproduce the crash, but I found an obvious issue in the code.~

<img width="617" alt="Screenshot 2019-10-01 at 09 06 19" src="https://user-images.githubusercontent.com/2261188/65941196-bfd9eb80-e42a-11e9-8c93-7a7af90e8c45.png">
We were throwing an exception, but we weren't using `ordinals` but custom values. `values().length` returns `5` but the values of PostLoadingState are `0,3,4,5,6,7`.

To test:

~1. On the post list, Draft tab selected~
~2. On a Draft without local changes, Tap “… More” -> “View”~
~3. Remote view (webview) should open~
~4. Tap back~
~5. Make sure the app doesn't crash (Note: I wasn't able to reproduce the crash even before this PR)~

Update:
I was able to reproduce the crash
- Check "Don't keep activities" in developer settings
1. On the post list, Draft tab selected
2. **Open the editor on a draft**
2. Tap “… More” -> “View”
3. Remote view (webview) should open
4. Tap back
5. Make sure the app doesn't crash

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
