### PR TITLE
Fix order of processing OnPostChanged event

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -217,6 +217,7 @@ class PostListMainViewModel @Inject constructor(
         postListEventListenerFactory.createAndStartListening(
                 lifecycle = lifecycle,
                 dispatcher = dispatcher,
+                bgDispatcher = bgDispatcher,
                 postStore = postStore,
                 site = site,
                 postActionHandler = postActionHandler,


### PR DESCRIPTION
Fixes #10546 

This PR fixes a race condition which sometimes resulted in an invalid "Uploading post" UI state.

The issue was caused by the order in which the OnPostChanged event was being processed. More detailed explanation with examples can be found [here](https://github.com/wordpress-mobile/WordPress-Android/issues/10546#issuecomment-536997849).

This PR sets a priority to `PostListEventListener.onPostChanged` observer. We also need to change its `threadMode` to Main as the priority is tied to the threadMode (in other words if you have an observer with threadMode Main and another observer with threadMode background, the priorities are ignored). I used a coroutine to make sure the body of the method is processed on a background thread as before. 

To test - use a self-hosted site
1. Airplane mode on, Draft tab selected
2. Add an image to an existing draft from the post list
3. Tap back
4. “Couldn’t upload media” label is visible
5. Turn off airplane mode
6. Nothing should be auto-uploaded
7. Click on “Retry”
8. Media file should be uploaded, but the draft shouldn’t be uploaded
9. Make sure the "Uploading post" label either doesn't appear at all or appears just for a bit -> "Local changes" label should be visible
- perform these steps several times as the issue was caused by a race condition so it occurred just once in a while (cca 1 out of 3 attempts).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
