### PR TITLE
Update FluxC hash to 1.5.0-beta-2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.5.0-beta-1'
+    fluxCVersion = '1.5.0-beta-2'
 }


### PR DESCRIPTION
This PR updates FluxC hash to include the migration fix in: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1394

The migration issue should not affect the release or beta builds since the changes were only merged last Friday (September 27) and no release has been done yet. However, it'll affect the development builds and a fresh install of the app will be necessary.

To test:
* Make sure the app builds & runs with a **clean** build

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
