### PR TITLE
Add unit tests to PR submitter checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,9 @@ Fixes #
 
 To test:
 
-Update release notes:
+PR submission checklist:
+
+- [ ] I have considered adding unit tests where possible.
 
 - [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
+


### PR DESCRIPTION
This PR adds a new item to the PR submitter checklist that reminds about adding unit tests where possible. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
