### PR TITLE
Fix media uploaded with local path

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
+import org.greenrobot.eventbus.EventBus;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -19,6 +20,7 @@ import org.wordpress.android.fluxc.model.post.PostLocation;
 import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType;
+import org.wordpress.android.ui.uploads.PostEvents;
 import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.ui.utils.UiString.UiStringText;
 import org.wordpress.android.util.AppLog;
@@ -547,5 +549,12 @@ public class PostUtils {
         AppLog.d(T.POSTS, "User explicitly confirmed changes. Post title: " + post.getTitle());
         // the changes were explicitly confirmed by the user
         post.setChangesConfirmedContentHashcode(post.contentHashcode());
+    }
+
+    public static boolean isPostCurrentlyBeingEdited(PostModel post) {
+        PostEvents.PostOpenedInEditor flag = EventBus.getDefault().getStickyEvent(PostEvents.PostOpenedInEditor.class);
+        return flag != null && post != null
+               && post.getLocalSiteId() == flag.localSiteId
+               && post.getId() == flag.postId;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtilsWrapper.kt
@@ -16,4 +16,6 @@ class PostUtilsWrapper @Inject constructor() {
     fun isPublishable(post: PostModel) = PostUtils.isPublishable(post)
 
     fun isPostInConflictWithRemote(post: PostModel) = PostUtils.isPostInConflictWithRemote(post)
+
+    fun isPostCurrentlyBeingEdited(post: PostModel) = PostUtils.isPostCurrentlyBeingEdited(post)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadActionUseCase.kt
@@ -60,6 +60,11 @@ class UploadActionUseCase @Inject constructor(
             return DO_NOTHING
         }
 
+        // Do not auto-upload post which is being edited
+        if (postUtilsWrapper.isPostCurrentlyBeingEdited(post)) {
+            return DO_NOTHING
+        }
+
         return action
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -732,7 +732,8 @@ public class UploadService extends Service {
             return false;
         }
 
-        if (PostUploadHandler.isPostUploadingOrQueued(postToCancel) && !isPostCurrentlyBeingEdited(postToCancel)) {
+        if (PostUploadHandler.isPostUploadingOrQueued(postToCancel) && !PostUtils
+                .isPostCurrentlyBeingEdited(postToCancel)) {
             // post is not being edited and is currently queued, update the count on the foreground notification
             mPostUploadNotifier.incrementUploadedPostCountFromForegroundNotification(postToCancel);
         }
@@ -970,7 +971,7 @@ public class UploadService extends Service {
         // If this was the last media upload a post was waiting for, update the post content
         // This done for pending as well as cancelled and failed posts
         for (PostModel postModel : mUploadStore.getAllRegisteredPosts()) {
-            if (isPostCurrentlyBeingEdited(postModel)) {
+            if (PostUtils.isPostCurrentlyBeingEdited(postModel)) {
                 // don't touch a Post that is being currently open in the Editor.
                 break;
             }
@@ -1052,16 +1053,6 @@ public class UploadService extends Service {
         }
 
         return failedStandAloneMedia;
-    }
-
-    private boolean isPostCurrentlyBeingEdited(PostModel post) {
-        PostEvents.PostOpenedInEditor flag = EventBus.getDefault().getStickyEvent(PostEvents.PostOpenedInEditor.class);
-        if (flag != null && post != null
-            && post.getLocalSiteId() == flag.localSiteId
-            && post.getId() == flag.postId) {
-            return true;
-        }
-        return false;
     }
 
     /**

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadActionUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadActionUseCaseTest.kt
@@ -493,6 +493,24 @@ class UploadActionUseCaseTest {
         assertThat(action).isEqualTo(UploadAction.UPLOAD)
     }
 
+    @Test
+    fun `autoUploadAction is DO_NOTHING when the post is currently being edited`() {
+        // Arrange
+        val uploadActionUseCase = createUploadActionUseCase(
+                postUtilsWrapper = createdMockedPostUtilsWrapper(
+                        isPostBeingEdited = true
+                )
+        )
+
+        val post = createPostModel()
+        val siteModel: SiteModel = createSiteModel()
+        // Act
+        val action = uploadActionUseCase.getAutoUploadAction(post, siteModel)
+
+        // Assert
+        assertThat(action).isEqualTo(UploadAction.DO_NOTHING)
+    }
+
     private companion object Fixtures {
         private fun createUploadActionUseCase(
             uploadStore: UploadStore = createdMockedUploadStore(),
@@ -508,11 +526,13 @@ class UploadActionUseCaseTest {
 
         private fun createdMockedPostUtilsWrapper(
             isPublishable: Boolean = true,
-            isInConflict: Boolean = false
+            isInConflict: Boolean = false,
+            isPostBeingEdited: Boolean = false
         ): PostUtilsWrapper {
             val postUtilsWrapper: PostUtilsWrapper = mock()
             whenever(postUtilsWrapper.isPublishable(any())).thenReturn(isPublishable)
             whenever(postUtilsWrapper.isPostInConflictWithRemote(any())).thenReturn(isInConflict)
+            whenever(postUtilsWrapper.isPostCurrentlyBeingEdited(any())).thenReturn(isPostBeingEdited)
             return postUtilsWrapper
         }
 


### PR DESCRIPTION
Fixes #10553 

**This PR can be reviewed by a single reviewer. However, I'd like to hear your thoughts if you have any about the other possible solution.**

This issue is a bit tricky:)

When the app comes from foreground [we invoke](https://github.com/wordpress-mobile/WordPress-Android/blob/216a882e5423ff89f3c5a22283952e32d5194383/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt#L81) `UploadStarter`.

1. When we add an image using Gutenberg an OS default media picker is brought to the foreground -> the user picks an image -> the WPAndroid app comes to foreground 
2. The `UploadStarter` enqueues remote-auto-save intent for the UploadService. The UploadService loads the PostModel from the database - it might not contain the local path yet (it might contain just an empty img tag). 
3. Right after that the editor adds the media item into the post content with local path to the image and enqueues media upload intent to the UploadService
4. UploadService [registers the post model for upload](https://github.com/wordpress-mobile/WordPress-Android/blob/33f82311afd9666504b9ebdc1dac3c5723f63f52/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java#L201) and starts uploading the media files.
5. When the remote-auto-save request finishes [the PostUploadModel is removed](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/09962dfa198f6d2ce963a0a4b587a58c4bcbd8c0/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java#L413) (unregistered).
6. When the media upload finishes we'd normally check the posts waiting for upload and we'd replace the local path with the remote path. However, since we unregistered the PostUploadModel in step 5 [this "for" has 0 cycles](https://github.com/wordpress-mobile/WordPress-Android/blob/33f82311afd9666504b9ebdc1dac3c5723f63f52/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java#L973). As a result the local path doesn't get replaced with the remote path.

This issue has several possible solutions. This PR uses imo the least risky approach. Having said that I'm open for suggestions as this solution basically just workarounds a bug in our code. I have a couple of ideas how to improve the code and I'd love to hear your thoughts

1. I'm not sure why we delete the MediaUploadModels [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/09962dfa198f6d2ce963a0a4b587a58c4bcbd8c0/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java#L409). I thought that we are trying to prevent the app from uploading a post without its media files. Was it perhaps added just as a hotfix because we didn't want to leave there dangling MediaUploadModels?
2. If we didn't delete the media files as described above, we could check [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/09962dfa198f6d2ce963a0a4b587a58c4bcbd8c0/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java#L413) if there are any media files associated with this post waiting for upload(or being uploaded) and prevent the deletion/unregistration of the PostUploadModel. <- this would fix our issue

SideNote: We could also make sure there isn't any local path in the content of the post before we start uploading it to the server - check the content of the post directly. This wouldn't fix this issue because when we start the remote-auto-save the post content actually might not contain the local path yet. But I believe it'd solve all the other ["local path" issues we are encountering](https://github.com/wordpress-mobile/WordPress-Android/issues/10203).


To test:

1. Open an existing draft in Gutenberg (on mobile)
2. Add an image and press back before the upload finishes
3. Notice the upload finishes and the post is remote-auto-saved
4. Open the post again and switch to the HTML mode -> make sure src tag contains the correct URL

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.