### PR TITLE
Revert "support multiple prop in gutenberg editor"

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -288,7 +288,7 @@ public class PhotoPickerActivity extends AppCompatActivity
     }
 
     @Override
-    public void onPhotoPickerIconClicked(@NonNull PhotoPickerFragment.PhotoPickerIcon icon, boolean multiple) {
+    public void onPhotoPickerIconClicked(@NonNull PhotoPickerFragment.PhotoPickerIcon icon) {
         switch (icon) {
             case ANDROID_CAPTURE_PHOTO:
                 launchCamera();

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -68,7 +68,7 @@ public class PhotoPickerFragment extends Fragment {
     public interface PhotoPickerListener {
         void onPhotoPickerMediaChosen(@NonNull List<Uri> uriList);
 
-        void onPhotoPickerIconClicked(@NonNull PhotoPickerIcon icon, boolean allowMultipleSelection);
+        void onPhotoPickerIconClicked(@NonNull PhotoPickerIcon icon);
     }
 
     private EmptyViewRecyclerView mRecycler;
@@ -252,7 +252,7 @@ public class PhotoPickerFragment extends Fragment {
         }
 
         if (mListener != null) {
-            mListener.onPhotoPickerIconClicked(icon, false);
+            mListener.onPhotoPickerIconClicked(icon);
         }
     }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -105,7 +105,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -1098,8 +1097,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             mContent.resetAttributedMediaSpan(localMediaIdPredicate);
         }
     }
-
-    @Override public void appendMediaFiles(Map<String, MediaFile> mediaList) { }
 
     private Drawable getLoadingMediaErrorPlaceholder(String msg) {
         if (TextUtils.isEmpty(msg)) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -16,7 +16,6 @@ import org.wordpress.android.util.helpers.MediaGallery;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 
 public abstract class EditorFragmentAbstract extends Fragment {
@@ -29,7 +28,6 @@ public abstract class EditorFragmentAbstract extends Fragment {
     public abstract CharSequence getContent(CharSequence originalContent) throws EditorFragmentNotAddedException;
     public abstract LiveData<Editable> getTitleOrContentChanged();
     public abstract void appendMediaFile(MediaFile mediaFile, String imageUrl, ImageLoader imageLoader);
-    public abstract void appendMediaFiles(Map<String, MediaFile> mediaList);
     public abstract void appendGallery(MediaGallery mediaGallery);
     public abstract void setUrlForVideoPressId(String videoPressId, String url, String posterUrl);
     public abstract boolean isUploadingMedia();
@@ -173,11 +171,11 @@ public abstract class EditorFragmentAbstract extends Fragment {
         void onEditorFragmentInitialized();
         void onEditorFragmentContentReady(ArrayList<Object> unsupportedBlocks);
         void onAddMediaClicked();
-        void onAddMediaImageClicked(boolean allowMultipleSelection);
-        void onAddMediaVideoClicked(boolean allowMultipleSelection);
-        void onAddPhotoClicked(boolean allowMultipleSelection);
+        void onAddMediaImageClicked();
+        void onAddMediaVideoClicked();
+        void onAddPhotoClicked();
         void onCapturePhotoClicked();
-        void onAddVideoClicked(boolean allowMultipleSelection);
+        void onAddVideoClicked();
         void onCaptureVideoClicked();
         boolean onMediaRetryClicked(String mediaId);
         void onMediaRetryAllClicked(Set<String> mediaIdSet);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -5,7 +5,6 @@ import android.view.ViewGroup;
 
 import androidx.fragment.app.Fragment;
 
-import org.wordpress.mobile.WPAndroidGlue.Media;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnAuthHeaderRequestedListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnEditorAutosaveListener;
@@ -13,8 +12,6 @@ import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnEditorMountListene
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnGetContentTimeout;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnMediaLibraryButtonListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnReattachQueryListener;
-
-import java.util.ArrayList;
 
 public class GutenbergContainerFragment extends Fragment {
     public static final String TAG = "gutenberg_container_fragment_tag";
@@ -128,20 +125,12 @@ public class GutenbergContainerFragment extends Fragment {
         mWPAndroidGlueCode.appendMediaFile(mediaId, mediaUrl, isVideo);
     }
 
-    public void appendMediaFiles(ArrayList<Media> mediaList) {
-        mWPAndroidGlueCode.appendMediaFiles(mediaList);
-    }
-
     public void showDevOptionsDialog() {
         mWPAndroidGlueCode.showDevOptionsDialog();
     }
 
     public void appendUploadMediaFile(final int mediaId, final String mediaUri, final boolean isVideo) {
         mWPAndroidGlueCode.appendUploadMediaFile(mediaId, mediaUri, isVideo);
-    }
-
-    public void appendUploadMediaFiles(ArrayList<Media> mediaList) {
-        mWPAndroidGlueCode.appendUploadMediaFiles(mediaList);
     }
 
     public void mediaFileUploadProgress(final int mediaId, final float progress) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -39,7 +39,6 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.aztec.IHistoryListener;
-import org.wordpress.mobile.WPAndroidGlue.Media;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnAuthHeaderRequestedListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnEditorAutosaveListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnEditorMountListener;
@@ -52,7 +51,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -221,25 +219,25 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         ViewGroup gutenbergContainer = view.findViewById(R.id.gutenberg_container);
         getGutenbergContainerFragment().attachToContainer(gutenbergContainer,
                 new OnMediaLibraryButtonListener() {
-                    @Override public void onMediaLibraryImageButtonClicked(boolean allowMultipleSelection) {
+                    @Override public void onMediaLibraryImageButtonClicked() {
                         mEditorFragmentListener.onTrackableEvent(TrackableEvent.MEDIA_BUTTON_TAPPED);
-                        mEditorFragmentListener.onAddMediaImageClicked(allowMultipleSelection);
+                        mEditorFragmentListener.onAddMediaImageClicked();
                     }
 
                     @Override
-                    public void onMediaLibraryVideoButtonClicked(boolean allowMultipleSelection) {
+                    public void onMediaLibraryVideoButtonClicked() {
                         mEditorFragmentListener.onTrackableEvent(TrackableEvent.MEDIA_BUTTON_TAPPED);
-                        mEditorFragmentListener.onAddMediaVideoClicked(allowMultipleSelection);
+                        mEditorFragmentListener.onAddMediaVideoClicked();
                     }
 
                     @Override
-                    public void onUploadPhotoButtonClicked(boolean allowMultipleSelection) {
-                        mEditorFragmentListener.onAddPhotoClicked(allowMultipleSelection);
+                    public void onUploadPhotoButtonClicked() {
+                        mEditorFragmentListener.onAddPhotoClicked();
                     }
 
                     @Override
-                    public void onUploadVideoButtonClicked(boolean allowMultipleSelection) {
-                        mEditorFragmentListener.onAddVideoClicked(allowMultipleSelection);
+                    public void onUploadVideoButtonClicked() {
+                        mEditorFragmentListener.onAddVideoClicked();
                     }
 
                     @Override
@@ -685,53 +683,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                     "file://" + mediaUrl,
                     mediaFile.isVideo());
             mUploadingMediaProgressMax.put(String.valueOf(mediaFile.getId()), 0f);
-        }
-    }
-
-    @Override
-    public void appendMediaFiles(Map<String, MediaFile> mediaList) {
-        if (getActivity() == null) {
-            // appendMediaFile may be called from a background thread (example: EditPostActivity.java#L2165) and
-            // Activity may have already be gone.
-            // Ticket: https://github.com/wordpress-mobile/WordPress-Android/issues/7386
-            AppLog.d(T.MEDIA, "appendMediaFiles() called but Activity is null!");
-            return;
-        }
-
-        ArrayList<Media> rnMediaList = new ArrayList<>();
-
-        // Get media URL of first of media first to check if it is network or local one.
-        String mediaUrl = "";
-        Object[] mediaUrls = mediaList.keySet().toArray();
-        if (mediaUrls != null && mediaUrls.length > 0) {
-            mediaUrl = (String) mediaUrls[0];
-        }
-
-        if (URLUtil.isNetworkUrl(mediaUrl)) {
-            for (Map.Entry<String, MediaFile> mediaEntry : mediaList.entrySet()) {
-                rnMediaList.add(
-                        new Media(
-                                Integer.valueOf(mediaEntry.getValue().getMediaId()),
-                                mediaEntry.getKey(),
-                                mediaEntry.getValue().getMimeType()
-                        )
-                );
-            }
-            getGutenbergContainerFragment().appendMediaFiles(rnMediaList);
-        } else {
-            for (Map.Entry<String, MediaFile> mediaEntry : mediaList.entrySet()) {
-                rnMediaList.add(
-                        new Media(
-                                mediaEntry.getValue().getId(),
-                                "file://" + mediaEntry.getKey(),
-                                mediaEntry.getValue().getMimeType()
-                        )
-                );
-            }
-            getGutenbergContainerFragment().appendUploadMediaFiles(rnMediaList);
-            for (Media media : rnMediaList) {
-                mUploadingMediaProgressMax.put(String.valueOf(media.getId()), 0f);
-            }
         }
     }
 


### PR DESCRIPTION
This reverts changes done by https://github.com/wordpress-mobile/WordPress-Android/pull/10556 since we are in a code freeze on gutenberg mobile and this wasn't supposed to get merged during it.

I used `git diff 4540c6b7c59818d85de3ee59bb45ac68dd076220 569e1b2962589b207903bf60d593038d8760da88` to compare this branch with the previous commit in develop to make sure this is reverting everything.

This reverts commit b93cf48d916f0f43a3df11c6dbee42af783a31fe, reversing
changes made to 569e1b2962589b207903bf60d593038d8760da88.

Fixes #

To test:

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
