### PR TITLE
Fix page not found preview on jetpack sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -609,7 +609,7 @@ public class ActivityLauncher {
                     shareSubject,
                     true,
                     startPreviewForResult);
-        } else if (site.isJetpackConnected() && !TextUtils.isEmpty(site.getFrameNonce())) {
+        } else if (site.isJetpackConnected() && site.isUsingWpComRestApi()) {
             WPWebViewActivity
                     .openJetpackBlogPostPreview(
                             context,

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -609,7 +609,7 @@ public class ActivityLauncher {
                     shareSubject,
                     true,
                     startPreviewForResult);
-        } else if (site.isJetpackConnected()) {
+        } else if (site.isJetpackConnected() && !TextUtils.isEmpty(site.getFrameNonce())) {
             WPWebViewActivity
                     .openJetpackBlogPostPreview(
                             context,


### PR DESCRIPTION
Fixes #10544 

Post preview didn't work if you logged into a jetpack site using self-hosted login. The app would try to use `frame_nonce` even though it didn't have it. If you logged into the same site using wpcom login, everything would work.

This PR simply checks whether `frame_nonce` is available and if it's not we try to load the preview using self-hosted sites credentials.

To test:
1. Log in into a Jetpack site using self-hosted login
2. Open Post List on draft tab
3. Click on More -> Preview on a post without local changes
4. Make sure the preview loads

--------------------
1. Log in into a wpcom account and select a jetpack site
2. Open Post List on draft tab
3. Click on More -> Preview on a post without local changes
4. Make sure the preview loads

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

