### PR TITLE
Fix date format for non-us locales

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -32,7 +32,7 @@ import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 
 import java.text.BreakIterator;
-import java.text.SimpleDateFormat;
+import java.text.DateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -497,13 +497,20 @@ public class PostUtils {
      */
     public static String getFormattedDateForLastModified(Context context, long timeSinceLastModified) {
         Date date = new Date(timeSinceLastModified);
-        SimpleDateFormat sdf =
-                new SimpleDateFormat("MMM d, yyyy '@' hh:mm a", LocaleManager.getSafeLocale(context));
+
+        DateFormat dateFormat = DateFormat.getDateInstance(
+                DateFormat.MEDIUM,
+                LocaleManager.getSafeLocale(context));
+        DateFormat timeFormat = DateFormat.getTimeInstance(
+                DateFormat.SHORT,
+                LocaleManager.getSafeLocale(context));
+
 
         // The timezone on the website is at GMT
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+        timeFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
 
-        return sdf.format(date);
+        return dateFormat.format(date) + " @ " + timeFormat.format(date);
     }
 
     public static String getPreviewUrlForPost(RemotePreviewType remotePreviewType, PostModel post) {


### PR DESCRIPTION
This PR fixes an issue with date and time format - it's locale dependant now.

English locale
<img width="438" alt="Screenshot 2019-10-03 at 12 43 32" src="https://user-images.githubusercontent.com/2261188/66120682-c065b400-e5db-11e9-851f-42e803bf456f.png">
Czech locale
<img width="434" alt="Screenshot 2019-10-03 at 12 43 11" src="https://user-images.githubusercontent.com/2261188/66120683-c065b400-e5db-11e9-9ba7-c06050794ad2.png">


To test:
1. My Site
2. Post list
3. Click on a post with unsaved changes
4. Make sure the date/time format is ok
---------------
0. Change the language of the app to English/Czech
1. My Site
2. Post list
3. Click on a post with unsaved changes
4. Make sure the date/time format is ok

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

