### PR TITLE
[GB] Fix for content is missing on long posts in HTML mode

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -106,7 +106,7 @@ public class GutenbergContainerFragment extends Fragment {
     public void toggleHtmlMode() {
         mHtmlModeEnabled = !mHtmlModeEnabled;
 
-        mWPAndroidGlueCode.toggleEditorMode();
+        mWPAndroidGlueCode.toggleEditorMode(mHtmlModeEnabled);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1268

To test:

Follow the steps in the gb-mobile PR here:
https://github.com/wordpress-mobile/gutenberg-mobile/pull/1401

PR submission checklist:

- [ x ] I have considered adding unit tests where possible.

- [ x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

