### PR TITLE
Replace noticons with gridicons in Notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/NoticonUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/NoticonUtils.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.models
+
+import org.wordpress.android.R
+import javax.inject.Inject
+
+class NoticonUtils
+@Inject constructor() {
+    fun noticonToGridicon(noticon: String): Int {
+        // Transformation based on Calypso:
+        // https://github.com/Automattic/wp-calypso/blob/master/apps/notifications/src/panel/utils/noticon2gridicon.js
+        return when (noticon) {
+            "\uf814" -> R.drawable.ic_mention_white_24dp
+            "\uf300" -> R.drawable.ic_comment_white_24dp
+            "\uf801" -> R.drawable.ic_add_white_24dp
+            "\uf455" -> R.drawable.ic_info_white_24dp
+            "\uf470" -> R.drawable.ic_lock_white_24dp
+            "\uf806" -> R.drawable.ic_stats_alt_white_24dp
+            "\uf805" -> R.drawable.ic_reblog_white_24dp
+            "\uf408" -> R.drawable.ic_star_white_24dp
+            "\uf804" -> R.drawable.ic_trophy_white_24dp
+            "\uf467" -> R.drawable.ic_reply_white_24dp
+            "\uf414" -> R.drawable.ic_notice_white_24dp
+            "\uf418" -> R.drawable.ic_checkmark_white_24dp
+            "\uf447" -> R.drawable.ic_cart_white_24dp
+            else -> R.drawable.ic_info_white_24dp
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -20,6 +20,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.NotificationsTable;
 import org.wordpress.android.fluxc.model.CommentStatus;
 import org.wordpress.android.models.Note;
+import org.wordpress.android.models.NoticonUtils;
 import org.wordpress.android.ui.comments.CommentUtils;
 import org.wordpress.android.ui.notifications.NotificationsListFragmentPage.OnNoteClickListener;
 import org.wordpress.android.ui.notifications.blocks.NoteBlockClickableSpan;
@@ -28,7 +29,6 @@ import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.RtlUtils;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
-import org.wordpress.android.widgets.NoticonTextView;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -48,6 +48,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
     private final ArrayList<Note> mFilteredNotes = new ArrayList<>();
     @Inject protected ImageManager mImageManager;
     @Inject protected NotificationsUtilsWrapper mNotificationsUtilsWrapper;
+    @Inject protected NoticonUtils mNoticonUtils;
 
     public enum FILTERS {
         FILTER_ALL,
@@ -292,8 +293,8 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
 
         boolean isUnread = note.isUnread();
 
-        String noticonCharacter = note.getNoticonCharacter();
-        noteViewHolder.mNoteIcon.setText(noticonCharacter);
+        int gridicon = mNoticonUtils.noticonToGridicon(note.getNoticonCharacter());
+        mImageManager.load(noteViewHolder.mNoteIcon, gridicon);
         if (commentStatus == CommentStatus.UNAPPROVED) {
             noteViewHolder.mNoteIcon.setBackgroundResource(R.drawable.bg_oval_warning_stroke_white);
         } else if (isUnread) {
@@ -312,10 +313,6 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         if (mOnLoadMoreListener != null && position >= getItemCount() - 1) {
             mOnLoadMoreListener.onLoadMore(note.getTimestamp());
         }
-    }
-
-    public int getPositionForNote(String noteId) {
-        return getPositionForNoteInArray(noteId, mFilteredNotes);
     }
 
     private int getPositionForNoteUnfiltered(String noteId) {
@@ -363,7 +360,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         private final TextView mTxtSubjectNoticon;
         private final TextView mTxtDetail;
         private final ImageView mImgAvatar;
-        private final NoticonTextView mNoteIcon;
+        private final ImageView mNoteIcon;
 
         NoteViewHolder(View view) {
             super(view);

--- a/WordPress/src/main/res/drawable/ic_cart_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_cart_white_24dp.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0"
+    tools:ignore="UnusedResources">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9,20c0,1.1-0.9,2-2,2s-1.99-0.9-1.99-2S5.9,18,7,18S9,18.9,9,20z M17,18c-1.1,0-1.99,0.9-1.99,2s0.89,2,1.99,2s2-0.9,2-2S18.1,18,17,18z M17.396,13c0.937,0,1.749-0.651,1.952-1.566L21,5H7V4c0-1.105-0.895-2-2-2H3v2h2v1v8v2c0,1.105,0.895,2,2,2h12c0-1.105-0.895-2-2-2H7v-2H17.396z"></path>
+
+</vector>

--- a/WordPress/src/main/res/drawable/ic_reblog_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_reblog_white_24dp.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0"
+    tools:ignore="UnusedResources">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M22.086,9.914L20,7.828V18c0,1.105-0.895,2-2,2h-7v-2h7V7.828l-2.086,2.086L14.5,8.5L19,4l4.5,4.5L22.086,9.914z M6,16.172V6h7V4H6C4.895,4,4,4.895,4,6v10.172l-2.086-2.086L0.5,15.5L5,20l4.5-4.5l-1.414-1.414L6,16.172z"></path>
+
+</vector>

--- a/WordPress/src/main/res/drawable/ic_trophy_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_trophy_white_24dp.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0"
+    tools:ignore="UnusedResources">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M18,5.062V3H6v2.062H2V8c0,2.525,1.889,4.598,4.324,4.932C7.024,14.99,8.809,16.542,11,16.91V18c0,1.105-0.895,2-2,2H8v2h1h2h2h2h1v-2h-1c-1.105,0-2-0.895-2-2v-1.09c2.191-0.368,3.976-1.92,4.676-3.978C20.111,12.598,22,10.525,22,8V5.062H18z M4,8V7.062h2v3.766C4.836,10.416,4,9.304,4,8z M20,8c0,1.304-0.836,2.416-2,2.829V7.062h2V8z"></path>
+
+</vector>

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -53,17 +53,16 @@
                 tools:src="@drawable/bg_oval_neutral_30_user_32dp" >
             </ImageView>
 
-            <org.wordpress.android.widgets.NoticonTextView
+            <ImageView
                 android:id="@+id/note_icon"
-                android:background="@drawable/bg_oval_primary_40_stroke_notification_unread"
-                android:gravity="center"
+                android:layout_width="@dimen/note_icon_sz"
                 android:layout_height="@dimen/note_icon_sz"
+                android:padding="4dp"
                 android:layout_marginStart="@dimen/notifications_note_icon_margin"
                 android:layout_marginTop="@dimen/notifications_note_icon_margin"
-                android:layout_width="@dimen/note_icon_sz"
-                android:textColor="@android:color/white"
-                android:textSize="14sp" >
-            </org.wordpress.android.widgets.NoticonTextView>
+                android:background="@drawable/bg_oval_primary_40_stroke_notification_unread"
+                android:contentDescription="@string/icon"
+                android:gravity="center"></ImageView>
 
         </FrameLayout>
 

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -45,24 +45,23 @@
 
             <ImageView
                 android:id="@+id/note_avatar"
-                android:contentDescription="@null"
+                android:layout_width="@dimen/activity_log_icon_size"
                 android:layout_height="@dimen/activity_log_icon_size"
                 android:layout_marginEnd="@dimen/activity_log_icon_margin"
                 android:layout_marginTop="@dimen/margin_small"
-                android:layout_width="@dimen/activity_log_icon_size"
-                tools:src="@drawable/bg_oval_neutral_30_user_32dp" >
-            </ImageView>
+                android:contentDescription="@null"
+                tools:src="@drawable/bg_oval_neutral_30_user_32dp" />
 
             <ImageView
                 android:id="@+id/note_icon"
                 android:layout_width="@dimen/note_icon_sz"
                 android:layout_height="@dimen/note_icon_sz"
-                android:padding="4dp"
                 android:layout_marginStart="@dimen/notifications_note_icon_margin"
                 android:layout_marginTop="@dimen/notifications_note_icon_margin"
                 android:background="@drawable/bg_oval_primary_40_stroke_notification_unread"
                 android:contentDescription="@string/icon"
-                android:gravity="center"></ImageView>
+                android:gravity="center"
+                android:padding="4dp" />
 
         </FrameLayout>
 

--- a/WordPress/src/test/java/org/wordpress/android/models/NoticonUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/models/NoticonUtilsTest.kt
@@ -1,0 +1,110 @@
+package org.wordpress.android.models
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.R
+
+@RunWith(MockitoJUnitRunner::class)
+class NoticonUtilsTest {
+    private val noteUtils = NoticonUtils()
+
+    @Test
+    fun `transforms mention noticon`() {
+        val gridicon = noteUtils.noticonToGridicon("\uf814")
+
+        assertThat(gridicon).isEqualTo(R.drawable.ic_mention_white_24dp)
+    }
+
+    @Test
+    fun `transforms comment noticon`() {
+        val gridicon = noteUtils.noticonToGridicon("\uf300")
+
+        assertThat(gridicon).isEqualTo(R.drawable.ic_comment_white_24dp)
+    }
+
+    @Test
+    fun `transforms add noticon`() {
+        val gridicon = noteUtils.noticonToGridicon("\uf801")
+
+        assertThat(gridicon).isEqualTo(R.drawable.ic_add_white_24dp)
+    }
+
+    @Test
+    fun `transforms info noticon`() {
+        val gridicon = noteUtils.noticonToGridicon("\uf455")
+
+        assertThat(gridicon).isEqualTo(R.drawable.ic_info_white_24dp)
+    }
+
+    @Test
+    fun `transforms lock noticon`() {
+        val gridicon = noteUtils.noticonToGridicon("\uf470")
+
+        assertThat(gridicon).isEqualTo(R.drawable.ic_lock_white_24dp)
+    }
+
+    @Test
+    fun `transforms stats alt noticon`() {
+        val gridicon = noteUtils.noticonToGridicon("\uf806")
+
+        assertThat(gridicon).isEqualTo(R.drawable.ic_stats_alt_white_24dp)
+    }
+
+    @Test
+    fun `transforms reblog noticon`() {
+        val gridicon = noteUtils.noticonToGridicon("\uf805")
+
+        assertThat(gridicon).isEqualTo(R.drawable.ic_reblog_white_24dp)
+    }
+
+    @Test
+    fun `transforms star noticon`() {
+        val gridicon = noteUtils.noticonToGridicon("\uf408")
+
+        assertThat(gridicon).isEqualTo(R.drawable.ic_star_white_24dp)
+    }
+
+    @Test
+    fun `transforms trophy noticon`() {
+        val gridicon = noteUtils.noticonToGridicon("\uf804")
+
+        assertThat(gridicon).isEqualTo(R.drawable.ic_trophy_white_24dp)
+    }
+
+    @Test
+    fun `transforms reply noticon`() {
+        val gridicon = noteUtils.noticonToGridicon("\uf467")
+
+        assertThat(gridicon).isEqualTo(R.drawable.ic_reply_white_24dp)
+    }
+
+    @Test
+    fun `transforms notice noticon`() {
+        val gridicon = noteUtils.noticonToGridicon("\uf414")
+
+        assertThat(gridicon).isEqualTo(R.drawable.ic_notice_white_24dp)
+    }
+
+    @Test
+    fun `transforms checkmark noticon`() {
+        val gridicon = noteUtils.noticonToGridicon("\uf418")
+
+        assertThat(gridicon).isEqualTo(R.drawable.ic_checkmark_white_24dp)
+    }
+
+    @Test
+    fun `transforms cart noticon`() {
+        val gridicon = noteUtils.noticonToGridicon("\uf447")
+
+        assertThat(gridicon).isEqualTo(R.drawable.ic_cart_white_24dp)
+    }
+
+    @Test
+    fun `defaults to info noticon`() {
+        val gridicon = noteUtils.noticonToGridicon("\uabc1")
+
+        assertThat(gridicon).isEqualTo(R.drawable.ic_info_white_24dp)
+    }
+}


### PR DESCRIPTION
Fixes #4921 

This PR removes noticons and replaces them with gridicons. The code is based on [Calypso code](https://github.com/Automattic/wp-calypso/blob/master/apps/notifications/src/panel/utils/noticon2gridicon.js). 

I wasn't sure about the padding and size of the icons. Does it look good @mattmiklic ?

One thing that needs double checking is the `warning` icon. With noticons it shows this:
![image](https://user-images.githubusercontent.com/1079756/66292570-e4c7d600-e8e4-11e9-9c14-12c716c24dac.png)
We don't have that icon in gridicons so I used `gridicons-notice` instead. Does it make sense @mattmiklic ?

To test:
* Go to Notifications
* Check that the icons are visible and look OK
* Compare the icons to Calypso notifications

![Screenshot_1570104699](https://user-images.githubusercontent.com/1079756/66125624-c497ce80-e5e7-11e9-9673-da4aca57dfe9.png)

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

