### PR TITLE
Only hide featured image when posts starts with an image

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -252,9 +252,7 @@ public class ReaderPostRenderer {
      * the top of the content
      */
     private boolean shouldAddFeaturedImage() {
-        return mPost.hasFeaturedImage()
-               && !mPost.getText().startsWith("<img")
-               && !PhotonUtils.isMshotsUrl(mPost.getFeaturedImage());
+        return mPost.hasFeaturedImage() && !PhotonUtils.isMshotsUrl(mPost.getFeaturedImage());
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -253,7 +253,7 @@ public class ReaderPostRenderer {
      */
     private boolean shouldAddFeaturedImage() {
         return mPost.hasFeaturedImage()
-               && !mPost.getText().contains("<img")
+               && !mPost.getText().startsWith("<img")
                && !PhotonUtils.isMshotsUrl(mPost.getFeaturedImage());
     }
 


### PR DESCRIPTION
Fixes #7587 

This piece of logic seems to be wrong. We're not adding the featured image any time the post contains any image. That can't be right. I think maybe originally it was supposed to not add the featured image only when the post starts with an image? I'd also be fine with removing the whole check because why not show the featured image on each post. 

Any idea about this @designsimply ?

To test:
* Go to Reader
* Click on an item with a featured image
* You see the featured image under the title
* Go back to Reader
* Click on an item without a featured image
* You don't see the featured image under the title
* Repeat with various sites/posts

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

