### PR TITLE
Download audio files when clicked

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.reader;
 import android.app.Activity;
 import android.content.Intent;
 import android.graphics.Rect;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.text.Html;
@@ -1369,6 +1370,14 @@ public class ReaderPostDetailFragment extends Fragment
     @Override
     public boolean onImageUrlClick(String imageUrl, View view, int x, int y) {
         return showPhotoViewer(imageUrl, view, x, y);
+    }
+
+    @Override
+    public boolean onFileDownloadClick(String fileUrl) {
+        Intent i = new Intent(Intent.ACTION_VIEW);
+        i.setData(Uri.parse(fileUrl));
+        startActivity(i);
+        return true;
     }
 
     private ActionBar getActionBar() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -85,6 +85,7 @@ import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
+import org.wordpress.android.util.WPPermissionUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
@@ -111,7 +112,6 @@ public class ReaderPostDetailFragment extends Fragment
         ReaderWebViewUrlClickListener,
         BasicFragmentDialog.BasicDialogPositiveClickInterface {
     private static final String BOOKMARKS_SAVED_LOCALLY_DIALOG = "bookmarks_saved_locally_dialog";
-    private static final int FILE_DOWNLOAD_PERMISSION_REQUEST_CODE = 123;
     private long mPostId;
     private long mBlogId;
     private DirectOperation mDirectOperation;
@@ -1387,7 +1387,7 @@ public class ReaderPostDetailFragment extends Fragment
         FragmentActivity activity = getActivity();
         if (activity != null
             && fileUrl != null
-            && PermissionUtils.checkAndRequestStoragePermission(this, FILE_DOWNLOAD_PERMISSION_REQUEST_CODE)) {
+            && PermissionUtils.checkAndRequestStoragePermission(this, WPPermissionUtils.READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE)) {
             downloadFile(fileUrl, activity);
             return true;
         } else {
@@ -1401,7 +1401,7 @@ public class ReaderPostDetailFragment extends Fragment
                                            @NonNull int[] grantResults) {
         FragmentActivity activity = getActivity();
         if (activity != null
-            && requestCode == FILE_DOWNLOAD_PERMISSION_REQUEST_CODE
+            && requestCode == WPPermissionUtils.READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE
             && (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
             downloadFile(mFileForDownload, activity);
             mFileForDownload = null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -85,7 +85,6 @@ import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
-import org.wordpress.android.util.WPPermissionUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -101,6 +101,7 @@ import javax.inject.Inject;
 
 import static android.content.Context.DOWNLOAD_SERVICE;
 import static org.wordpress.android.fluxc.generated.AccountActionBuilder.newUpdateSubscriptionNotificationPostAction;
+import static org.wordpress.android.util.WPPermissionUtils.READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE;
 import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
 
 public class ReaderPostDetailFragment extends Fragment
@@ -1387,7 +1388,7 @@ public class ReaderPostDetailFragment extends Fragment
         FragmentActivity activity = getActivity();
         if (activity != null
             && fileUrl != null
-            && PermissionUtils.checkAndRequestStoragePermission(this, WPPermissionUtils.READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE)) {
+            && PermissionUtils.checkAndRequestStoragePermission(this, READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE)) {
             downloadFile(fileUrl, activity);
             return true;
         } else {
@@ -1401,7 +1402,7 @@ public class ReaderPostDetailFragment extends Fragment
                                            @NonNull int[] grantResults) {
         FragmentActivity activity = getActivity();
         if (activity != null
-            && requestCode == WPPermissionUtils.READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE
+            && requestCode == READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE
             && (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
             downloadFile(mFileForDownload, activity);
             mFileForDownload = null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -36,6 +36,8 @@ public class ReaderWebView extends WebView {
         boolean onUrlClick(String url);
 
         boolean onImageUrlClick(String imageUrl, View view, int x, int y);
+
+        boolean onFileDownloadClick(String fileUrl);
     }
 
     public interface ReaderCustomViewListener {
@@ -100,6 +102,12 @@ public class ReaderWebView extends WebView {
             // Enable third-party cookies since they are disabled by default;
             // we need third-party cookies to support authenticated images
             CookieManager.getInstance().setAcceptThirdPartyCookies(this, true);
+            this.setDownloadListener(
+                    (url, userAgent, contentDisposition, mimetype, contentLength) -> {
+                        if (hasUrlClickListener()) {
+                            mUrlClickListener.onFileDownloadClick(url);
+                        }
+                    });
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
@@ -32,6 +32,7 @@ public class WPPermissionUtils {
     public static final int EDITOR_LOCATION_PERMISSION_REQUEST_CODE = 50;
     public static final int EDITOR_MEDIA_PERMISSION_REQUEST_CODE = 60;
     public static final int EDITOR_DRAG_DROP_PERMISSION_REQUEST_CODE = 70;
+    public static final int READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE = 80;
 
     /**
      * called by the onRequestPermissionsResult() of various activities and fragments - tracks


### PR DESCRIPTION
Fixes #9879 

This PR adds a download listener to the Reader web view. This allows us to catch the audio file URL when the user clicks the "Download" button. The app asks for a permission to download the file and downloads it if approved.

To test:
* Go to a post with audio files
* Click on the overflow button and click "Download"
* Notice that the app asks for permission to write to storage
* The file gets downloaded 
* The file has the name from URL
* Try denying the permission
* Nothing gets downloaded and the app doesn't crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

