### PR TITLE
Fix scroll in comments from notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -8,6 +8,7 @@ import org.wordpress.android.ui.domains.DomainRegistrationMainViewModel;
 import org.wordpress.android.ui.plans.PlansViewModel;
 import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel;
 import org.wordpress.android.ui.posts.PostListMainViewModel;
+import org.wordpress.android.ui.reader.ReaderCommentListViewModel;
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel;
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM;
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel;
@@ -251,6 +252,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(EditPostPublishSettingsViewModel.class)
     abstract ViewModel editPostPublishedSettingsViewModel(EditPostPublishSettingsViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(ReaderCommentListViewModel.class)
+    abstract ViewModel readerCommentListViewModel(ReaderCommentListViewModel viewModel);
 
     @Binds
     abstract ViewModelProvider.Factory provideViewModelFactory(ViewModelFactory viewModelFactory);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -28,6 +28,7 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.LinearSmoothScroller;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.recyclerview.widget.RecyclerView.LayoutManager;
 
 import com.google.android.material.snackbar.Snackbar;
 
@@ -147,17 +148,18 @@ public class ReaderCommentListActivity extends AppCompatActivity {
 
         mViewModel.getScrollTo().observe(this, scrollPositionEvent -> {
             ScrollPosition content = scrollPositionEvent.getContentIfNotHandled();
-            if (content != null) {
+            LayoutManager layoutManager = mRecyclerView.getLayoutManager();
+            if (content != null && layoutManager != null) {
                 if (content.isSmooth()) {
-                    RecyclerView.SmoothScroller scrollerSnappedToStart = new LinearSmoothScroller(this) {
+                    RecyclerView.SmoothScroller smoothScrollerToTop = new LinearSmoothScroller(this) {
                         @Override protected int getVerticalSnapPreference() {
                             return LinearSmoothScroller.SNAP_TO_START;
                         }
                     };
-                    scrollerSnappedToStart.setTargetPosition(content.getPosition());
-                    mRecyclerView.getLayoutManager().startSmoothScroll(scrollerSnappedToStart);
+                    smoothScrollerToTop.setTargetPosition(content.getPosition());
+                    layoutManager.startSmoothScroll(smoothScrollerToTop);
                 } else {
-                    mRecyclerView.scrollToPosition(content.getPosition());
+                    ((LinearLayoutManager) layoutManager).scrollToPositionWithOffset(content.getPosition(), 0);
                 }
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListViewModel.kt
@@ -1,0 +1,34 @@
+package org.wordpress.android.ui.reader
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.util.distinct
+import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+class ReaderCommentListViewModel
+@Inject constructor(@Named(UI_THREAD) mainDispatcher: CoroutineDispatcher) : ScopedViewModel(
+        mainDispatcher
+) {
+    private val _scrollTo = MutableLiveData<Event<ScrollPosition>>()
+    val scrollTo: LiveData<Event<ScrollPosition>> = _scrollTo.distinct()
+
+    private var scrollJob: Job? = null
+
+    fun scrollToPosition(position: Int, isSmooth: Boolean) {
+        scrollJob?.cancel()
+        scrollJob = launch {
+            delay(300)
+            _scrollTo.postValue(Event(ScrollPosition(position, isSmooth)))
+        }
+    }
+
+    data class ScrollPosition(val position: Int, val isSmooth: Boolean)
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderCommentListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderCommentListViewModelTest.kt
@@ -1,0 +1,32 @@
+package org.wordpress.android.ui.reader
+
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.ui.reader.ReaderCommentListViewModel.ScrollPosition
+import org.wordpress.android.viewmodel.Event
+
+@InternalCoroutinesApi
+class ReaderCommentListViewModelTest : BaseUnitTest() {
+    private val viewModel: ReaderCommentListViewModel = ReaderCommentListViewModel(TEST_DISPATCHER)
+
+    @Test
+    fun `emits scroll event on scroll`() {
+        var scrollEvent: Event<ScrollPosition>? = null
+        viewModel.scrollTo.observeForever {
+            scrollEvent = it
+        }
+
+        val expectedPosition = 10
+        val isSmooth = true
+
+        viewModel.scrollToPosition(expectedPosition, isSmooth)
+
+        val scrollPosition = scrollEvent?.getContentIfNotHandled()!!
+
+        assertThat(scrollPosition.isSmooth).isEqualTo(isSmooth)
+        assertThat(scrollPosition.position).isEqualTo(expectedPosition)
+    }
+}


### PR DESCRIPTION
Fixes #6370

This PR does 3 things. One is introducing a ViewModel which is there mostly to throttle the number of scrolls. In the previous code the `scrollTo` was called 2-3 times and that caused some random behaviour and jumping around in the list.

The second thing is the `SmoothScroller` which scrolls to the top of the comment instead of the bottom when smooth scrolling.

The third thing is that now we scroll to the top of the comment even when the scrolling is not smooth. This was achieved by the `scrollToPositionWithOffset` method. This is useful when you're rotating the phone while on the `Comments` screen. TBH I don't think this is a correct solution. We should be storing the Layout manager state instead but that would require more refactoring. This whole class deserves to be transformed to MVVM.

To test:
* Go to Notifications
* Find a notification pointing to a comment on a post with lot of comments
* Click on the notification
* Click on the comment linked in the notification
* Notice that the app scrolls to the top of the comment smoothly
* Rotate the device
* The app stays on top of the comment.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

