### PR TITLE
Enable likes in reader post web view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -257,6 +257,15 @@ public class ReaderActivityLauncher {
         openUrl(context, url, OpenUrlType.INTERNAL);
     }
 
+    public static void openPost(Context context, ReaderPost post) {
+        String url = post.getUrl();
+        if (WPUrlUtils.isWordPressCom(url) || post.isWP()) {
+            WPWebViewActivity.openUrlByUsingGlobalWPCOMCredentials(context, url);
+        } else {
+            WPWebViewActivity.openURL(context, url, ReaderConstants.HTTP_REFERER_URL);
+        }
+    }
+
     public static void openUrl(Context context, String url, OpenUrlType openUrlType) {
         if (context == null || TextUtils.isEmpty(url)) {
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -259,7 +259,7 @@ public class ReaderActivityLauncher {
 
     public static void openPost(Context context, ReaderPost post) {
         String url = post.getUrl();
-        if (WPUrlUtils.isWordPressCom(url) || post.isWP()) {
+        if (WPUrlUtils.isWordPressCom(url) || (post.isWP() && !post.isJetpack)) {
             WPWebViewActivity.openUrlByUsingGlobalWPCOMCredentials(context, url);
         } else {
             WPWebViewActivity.openURL(context, url, ReaderConstants.HTTP_REFERER_URL);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -245,7 +245,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     ReaderPost post = getItem(position);
                     if (post != null) {
                         AnalyticsTracker.track(Stat.READER_ARTICLE_VISITED);
-                        ReaderActivityLauncher.openUrl(view.getContext(), post.getUrl());
+                        ReaderActivityLauncher.openPost(view.getContext(), post);
                     }
                 }
             };


### PR DESCRIPTION
Fixes #9451

This PR fixes an issue where you couldn't like a post from inside of a webview when the site had a custom domain. We were checking if the domain ended with `.wordpress.com` in order to send our credentials to the site (and that allows the like action). I'm changing this logic to match the likes from the reader post list. In the list we're checking `post.isWP()` to decide whether we show or hide a like. I'm now using the same field to determine whether we send credentials to the site. 

To test:
* Go to Reader
* Click on a post on a WP.com site with custom domain
* Like the post
* The like is successful 

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

