### PR TITLE
Defaulting ME_ACTIVITY_AVAILABLE flag to false for all the flavors.

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -91,13 +91,13 @@ android {
             applicationId "org.wordpress.android"
             dimension "buildType"
             buildConfigField "boolean", "VIDEO_OPTIMIZATION_AVAILABLE", "true"
-            buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "true"
+            buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
         }
 
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
             applicationId "org.wordpress.android.beta"
             dimension "buildType"
-            buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "true"
+            buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
         }
     }
 


### PR DESCRIPTION
Fixes #10591 

This is the standard aspect of the main screen with my site selected:

<p align="center">
  <img width="300" src="https://user-images.githubusercontent.com/47797566/64516005-f4f09380-d2ed-11e9-9833-be66c9e351cc.png">
</p>

This is how it appears when the flag is set to true (currently in wasabi and zalpha flavors)

<p align="center">
  <img width="300" src="https://user-images.githubusercontent.com/47797566/64516027-0043bf00-d2ee-11e9-9d8f-00e77d0157a9.png">
</p>

After this modifications all the flavors default to the first image.
## To test:
Please note that the following steps must pass running the app in all the 3 flavors with same behaviour.

1. Compile and run vanilla flavor
2. check that the My site Me option menu is not available
3. Check that you have all the 5 menu item in the Bottom nav bar
4. Smoke test to check that the menus activate the expected screens. 
5. Repeat al the above steps for wasabi and zalpha flavors.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

