### PR TITLE
EditPostActivity: Move editor action enums to their own file

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -29,6 +29,7 @@ import android.widget.RelativeLayout;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
@@ -115,6 +116,7 @@ import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Editor;
 import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Outcome;
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.PreviewLogicOperationResult;
 import org.wordpress.android.ui.posts.editor.PrimaryEditorAction;
+import org.wordpress.android.ui.posts.editor.SecondaryEditorAction;
 import org.wordpress.android.ui.posts.services.AztecImageLoader;
 import org.wordpress.android.ui.posts.services.AztecVideoLoader;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -877,13 +879,6 @@ public class EditPostActivity extends AppCompatActivity implements
         }
     }
 
-    private enum SecondaryAction {
-        SAVE_AS_DRAFT,
-        SAVE,
-        PUBLISH_NOW,
-        NONE
-    }
-
     private PrimaryEditorAction getPrimaryAction() {
         return PrimaryEditorAction.getPrimaryAction(PostStatus.fromPost(mPost), UploadUtils.userCanPublish(mSite));
     }
@@ -892,53 +887,13 @@ public class EditPostActivity extends AppCompatActivity implements
         return getString(getPrimaryAction().getTitleResource());
     }
 
-    private SecondaryAction getSecondaryAction() {
-        if (!UploadUtils.userCanPublish(mSite)) {
-            // User doesn't have publishing permissions
-            switch (PostStatus.fromPost(mPost)) {
-                case SCHEDULED:
-                case DRAFT:
-                case PENDING:
-                case PRIVATE:
-                case PUBLISHED:
-                case UNKNOWN:
-                    return SecondaryAction.NONE;
-                case TRASHED:
-                    return SecondaryAction.SAVE_AS_DRAFT;
-            }
-        }
-
-        switch (PostStatus.fromPost(mPost)) {
-            case DRAFT:
-                return SecondaryAction.SAVE;
-            case PENDING:
-            case SCHEDULED:
-                return SecondaryAction.PUBLISH_NOW;
-            case PRIVATE:
-            case PUBLISHED:
-                return SecondaryAction.NONE;
-            case TRASHED:
-            case UNKNOWN:
-                return SecondaryAction.SAVE_AS_DRAFT;
-        }
-        throw new IllegalStateException(
-                "Switch in getSecondaryAction is missing a required case or the case is missing \"return\" keyword ");
+    private SecondaryEditorAction getSecondaryAction() {
+        return SecondaryEditorAction.getSecondaryAction(PostStatus.fromPost(mPost), UploadUtils.userCanPublish(mSite));
     }
 
-    private String getSecondaryActionText() {
-        switch (getSecondaryAction()) {
-            case SAVE_AS_DRAFT:
-                return getString(R.string.menu_save_as_draft);
-            case SAVE:
-                return getString(R.string.save);
-            case PUBLISH_NOW:
-                return getString(R.string.menu_publish_now);
-            case NONE:
-                throw new IllegalStateException("Switch in `secondaryAction` shouldn't go through the NONE case");
-        }
-        throw new IllegalStateException(
-                "Switch in getSecondaryActionText is missing a required case or the case is missing \"return\" "
-                + "keyword ");
+    private @Nullable String getSecondaryActionText() {
+        @StringRes Integer titleResource = getSecondaryAction().getTitleResource();
+        return titleResource != null ? getString(titleResource) : null;
     }
 
     private boolean isPhotoPickerShowing() {
@@ -1183,17 +1138,8 @@ public class EditPostActivity extends AppCompatActivity implements
         MenuItem settingsMenuItem = menu.findItem(R.id.menu_post_settings);
 
         if (secondaryAction != null && mPost != null) {
-            switch (getSecondaryAction()) {
-                case SAVE_AS_DRAFT:
-                case SAVE:
-                case PUBLISH_NOW:
-                    secondaryAction.setVisible(showMenuItems);
-                    secondaryAction.setTitle(getSecondaryActionText());
-                    break;
-                case NONE:
-                    secondaryAction.setVisible(false);
-                    break;
-            }
+            secondaryAction.setVisible(showMenuItems && getSecondaryAction().isVisible());
+            secondaryAction.setTitle(getSecondaryActionText());
         }
 
         if (previewMenuItem != null) {
@@ -1398,7 +1344,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 ActivityUtils.hideKeyboard(this);
                 mViewPager.setCurrentItem(PAGE_SETTINGS);
             } else if (itemId == R.id.menu_secondary_action) {
-                return secondaryAction();
+                return performSecondaryAction();
             } else if (itemId == R.id.menu_html_mode) {
                 // toggle HTML mode
                 if (mEditorFragment instanceof AztecEditorFragment) {
@@ -1453,7 +1399,8 @@ public class EditPostActivity extends AppCompatActivity implements
 
     private void showEmptyPostErrorForSecondaryAction() {
         String message = getString(mIsPage ? R.string.error_publish_empty_page : R.string.error_publish_empty_post);
-        if (getSecondaryAction() == SecondaryAction.SAVE_AS_DRAFT || getSecondaryAction() == SecondaryAction.SAVE) {
+        if (getSecondaryAction() == SecondaryEditorAction.SAVE_AS_DRAFT
+            || getSecondaryAction() == SecondaryEditorAction.SAVE) {
             message = getString(R.string.error_save_empty_draft);
         }
         ToastUtils.showToast(EditPostActivity.this, message, Duration.SHORT);
@@ -1468,7 +1415,7 @@ public class EditPostActivity extends AppCompatActivity implements
         savePostAndOptionallyFinish(false);
     }
 
-    private boolean secondaryAction() {
+    private boolean performSecondaryAction() {
         if (UploadService.hasInProgressMediaUploadsForPost(mPost)) {
             ToastUtils.showToast(EditPostActivity.this,
                     getString(R.string.editor_toast_uploading_please_wait), Duration.SHORT);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -114,6 +114,7 @@ import org.wordpress.android.ui.posts.InsertMediaDialog.InsertMediaCallback;
 import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Editor;
 import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Outcome;
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.PreviewLogicOperationResult;
+import org.wordpress.android.ui.posts.editor.PrimaryEditorAction;
 import org.wordpress.android.ui.posts.services.AztecImageLoader;
 import org.wordpress.android.ui.posts.services.AztecVideoLoader;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -876,14 +877,6 @@ public class EditPostActivity extends AppCompatActivity implements
         }
     }
 
-    private enum PrimaryAction {
-        SUBMIT_FOR_REVIEW,
-        PUBLISH_NOW,
-        SCHEDULE,
-        UPDATE,
-        SAVE
-    }
-
     private enum SecondaryAction {
         SAVE_AS_DRAFT,
         SAVE,
@@ -891,54 +884,12 @@ public class EditPostActivity extends AppCompatActivity implements
         NONE
     }
 
-    private PrimaryAction getPrimaryAction() {
-        if (!UploadUtils.userCanPublish(mSite)) {
-            // User doesn't have publishing permissions
-            switch (PostStatus.fromPost(mPost)) {
-                case SCHEDULED:
-                case DRAFT:
-                case PENDING:
-                case PRIVATE:
-                case PUBLISHED:
-                case UNKNOWN:
-                    return PrimaryAction.SUBMIT_FOR_REVIEW;
-                case TRASHED:
-                    return PrimaryAction.SAVE;
-            }
-        }
-
-        switch (PostStatus.fromPost(mPost)) {
-            case SCHEDULED:
-                return PrimaryAction.SCHEDULE;
-            case DRAFT:
-                return PrimaryAction.PUBLISH_NOW;
-            case PENDING:
-            case TRASHED:
-                return PrimaryAction.SAVE;
-            case PRIVATE:
-            case PUBLISHED:
-            case UNKNOWN:
-                return PrimaryAction.UPDATE;
-        }
-        throw new IllegalStateException(
-                "Switch in getPrimaryAction is missing a required case or the case is missing \"return\" keyword ");
+    private PrimaryEditorAction getPrimaryAction() {
+        return PrimaryEditorAction.getPrimaryAction(PostStatus.fromPost(mPost), UploadUtils.userCanPublish(mSite));
     }
 
     private String getPrimaryActionText() {
-        switch (getPrimaryAction()) {
-            case SUBMIT_FOR_REVIEW:
-                return getString(R.string.submit_for_review);
-            case PUBLISH_NOW:
-                return getString(R.string.button_publish);
-            case SCHEDULE:
-                return getString(R.string.schedule_verb);
-            case UPDATE:
-                return getString(R.string.update_verb);
-            case SAVE:
-                return getString(R.string.save);
-        }
-        throw new IllegalStateException(
-                "Switch in getPrimaryActionText is missing a required case or the case is missing \"return\" keyword ");
+        return getString(getPrimaryAction().getTitleResource());
     }
 
     private SecondaryAction getSecondaryAction() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1309,7 +1309,7 @@ public class EditPostActivity extends AppCompatActivity implements
         hidePhotoPicker();
 
         if (itemId == R.id.menu_primary_action) {
-            primaryAction();
+            performPrimaryAction();
         } else {
             // Disable other action bar buttons while a media upload is in progress
             // (unnecessary for Aztec since it supports progress reattachment)
@@ -1556,7 +1556,7 @@ public class EditPostActivity extends AppCompatActivity implements
         publishConfirmationDialog.show(getSupportFragmentManager(), identifier);
     }
 
-    private void primaryAction() {
+    private void performPrimaryAction() {
         switch (getPrimaryAction()) {
             case UPDATE:
                 showUpdateConfirmationDialogAndUploadPost();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/PrimaryEditorAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/PrimaryEditorAction.kt
@@ -36,4 +36,3 @@ enum class PrimaryEditorAction(@StringRes val titleResource: Int) {
         }
     }
 }
-

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/PrimaryEditorAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/PrimaryEditorAction.kt
@@ -1,0 +1,39 @@
+package org.wordpress.android.ui.posts.editor
+
+import androidx.annotation.StringRes
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.post.PostStatus
+
+enum class PrimaryEditorAction(@StringRes val titleResource: Int) {
+    SUBMIT_FOR_REVIEW(R.string.submit_for_review),
+    PUBLISH_NOW(R.string.button_publish),
+    SCHEDULE(R.string.schedule_verb),
+    UPDATE(R.string.update_verb),
+    SAVE(R.string.save);
+
+    companion object {
+        @JvmStatic
+        fun getPrimaryAction(postStatus: PostStatus, userCanPublish: Boolean): PrimaryEditorAction {
+            return if (userCanPublish) {
+                when (postStatus) {
+                    PostStatus.SCHEDULED -> SCHEDULE
+                    PostStatus.DRAFT -> PUBLISH_NOW
+                    PostStatus.PENDING, PostStatus.TRASHED -> SAVE
+                    PostStatus.PRIVATE, PostStatus.PUBLISHED, PostStatus.UNKNOWN -> UPDATE
+                }
+            } else {
+                // User doesn't have publishing permissions
+                when (postStatus) {
+                    PostStatus.SCHEDULED,
+                    PostStatus.DRAFT,
+                    PostStatus.PENDING,
+                    PostStatus.PRIVATE,
+                    PostStatus.PUBLISHED,
+                    PostStatus.UNKNOWN -> SUBMIT_FOR_REVIEW
+                    PostStatus.TRASHED -> SAVE
+                }
+            }
+        }
+    }
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/SecondaryEditorAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/SecondaryEditorAction.kt
@@ -1,0 +1,40 @@
+package org.wordpress.android.ui.posts.editor
+
+import androidx.annotation.StringRes
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.post.PostStatus
+
+enum class SecondaryEditorAction(@StringRes val titleResource: Int?, val isVisible: Boolean) {
+    SAVE_AS_DRAFT(R.string.menu_save_as_draft, isVisible = true),
+    SAVE(R.string.save, isVisible = true),
+    PUBLISH_NOW(R.string.menu_publish_now, isVisible = true),
+    NONE(titleResource = null, isVisible = false);
+
+    companion object {
+        @JvmStatic
+        fun getSecondaryAction(
+            postStatus: PostStatus,
+            userCanPublish: Boolean
+        ): SecondaryEditorAction {
+            return if (userCanPublish) {
+                when (postStatus) {
+                    PostStatus.DRAFT -> SAVE
+                    PostStatus.PENDING, PostStatus.SCHEDULED -> PUBLISH_NOW
+                    PostStatus.PRIVATE, PostStatus.PUBLISHED -> NONE
+                    PostStatus.TRASHED, PostStatus.UNKNOWN -> SAVE_AS_DRAFT
+                }
+            } else {
+                // User doesn't have publishing permissions
+                when (postStatus) {
+                    PostStatus.SCHEDULED,
+                    PostStatus.DRAFT,
+                    PostStatus.PENDING,
+                    PostStatus.PRIVATE,
+                    PostStatus.PUBLISHED,
+                    PostStatus.UNKNOWN -> NONE
+                    PostStatus.TRASHED -> SAVE_AS_DRAFT
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a simple PR that attempts to simplify `EditPostActivity` by moving the `PrimaryAction` and `SecondaryAction` `enum`s to their own file. It also simplifies some of the logic around it by using `enum` properties. No other changes or improvements made to keep the PR simple and functionality unchanged.

**To test:**
* Test the primary and secondary actions of the editor to verify that they are unchanged for different post statuses. I am not 100% sure if my tests are covering all the basis. @malinajirka with the offline publishing project I am hoping you have a better understanding of these actions.

**PR submission checklist:**

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

