### PR TITLE
Respect allowMultipleSelection flag for media-text block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -657,7 +657,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         if (mBrowserType.isBrowser() && !isLongClick
                 || mBrowserType.isPicker() && isLongClick) {
             showMediaSettings(media);
-        } else if (mBrowserType.isSingleImagePicker() && !isLongClick) {
+        } else if ((mBrowserType.isSingleImagePicker() || mBrowserType.isSingleMediaPicker()) && !isLongClick) {
             // if we're picking a single image, we're done
             Intent intent = new Intent();
             ArrayList<Long> remoteMediaIds = new ArrayList<>();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserType.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserType.java
@@ -8,7 +8,8 @@ public enum MediaBrowserType {
     GRAVATAR_IMAGE_PICKER, // select a single image as a gravatar
     SITE_ICON_PICKER, // select a single image as a site icon
     GUTENBERG_IMAGE_PICKER, // select image from Gutenberg editor
-    GUTENBERG_VIDEO_PICKER; // select video from Gutenberg editor
+    GUTENBERG_VIDEO_PICKER, // select video from Gutenberg editor
+    GUTENBERG_SINGLE_MEDIA_PICKER; // select multiple images or videos to insert into a post
 
     public boolean isPicker() {
         return this != BROWSER;
@@ -20,6 +21,10 @@ public enum MediaBrowserType {
 
     public boolean isSingleImagePicker() {
         return this == FEATURED_IMAGE_PICKER || this == GRAVATAR_IMAGE_PICKER || this == SITE_ICON_PICKER;
+    }
+
+    public boolean isSingleMediaPicker() {
+        return this == GUTENBERG_SINGLE_MEDIA_PICKER;
     }
 
     public boolean canMultiselect() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3539,7 +3539,11 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override
     public void onAddLibraryMediaClicked(boolean allowMultipleSelection) {
         mAllowMultipleSelection = allowMultipleSelection;
-        ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.EDITOR_PICKER);
+        if (mAllowMultipleSelection) {
+            ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.EDITOR_PICKER);
+        } else {
+            ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.GUTENBERG_SINGLE_MEDIA_PICKER);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes wordpress-mobile/gutenberg-mobile#1403

### Description
This PR adds a `GUTENBERG_SINGLE_MEDIA_PICKER` `MediaBrowserType`, which is used to respect the `allowMultipleSelection` flag within the `MediaBrowserActivity`.

#### To test:
Follow steps listed here: https://github.com/WordPress/gutenberg/pull/17537#issue-320518695
and make sure videos and images can be selected from the picker after choosing "Choose from device".

Also, it should be possible to select videos and images after selecting "WordPress Media Library".

When selecting via "WordPress Media Library", only a single item should be selectable. When tapping a video or image, the item should be inserted into the media-text block (without allowing multiple items to be selected).

#### Screencasts

|Single Image|Single Video|
|:-|:-|
|<img src="https://user-images.githubusercontent.com/8507675/66623286-4ca45680-ec2e-11e9-968e-add7c80e32c7.gif" width="360">|<img src="https://user-images.githubusercontent.com/8507675/66623292-529a3780-ec2e-11e9-831b-32e24893e1a8.gif" width="360">|

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

