### PR TITLE
Show all followed sites in notifications fragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTableWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTableWrapper.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.datasets
+
+import org.wordpress.android.models.ReaderBlog
+import javax.inject.Inject
+
+class ReaderBlogTableWrapper
+@Inject constructor() {
+    fun getFollowedBlogs(): List<ReaderBlog> = ReaderBlogTable.getFollowedBlogs()!!
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/FollowedBlogsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/FollowedBlogsProvider.kt
@@ -1,0 +1,88 @@
+package org.wordpress.android.ui.prefs.notifications
+
+import org.wordpress.android.datasets.ReaderBlogTableWrapper
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.ui.prefs.notifications.FollowedBlogsProvider.PreferenceModel.ClickHandler
+import org.wordpress.android.ui.utils.UriUtilsWrapper
+import javax.inject.Inject
+
+class FollowedBlogsProvider
+@Inject constructor(
+    private val accountStore: AccountStore,
+    private val readerBlogTable: ReaderBlogTableWrapper,
+    private val uriUtils: UriUtilsWrapper
+) {
+    fun getAllFollowedBlogs(query: String?): List<PreferenceModel> {
+        val subscriptions = accountStore.subscriptions
+        val allFollowedBlogs = if (query != null) {
+            readerBlogTable.getFollowedBlogs()
+                    .filter { it.name.contains(query) || it.url.contains(query) }
+        } else {
+            readerBlogTable.getFollowedBlogs()
+        }
+        val result = allFollowedBlogs.map { readerBlog ->
+            val match = subscriptions.find { subscription ->
+                subscription.blogId == readerBlog.blogId.toString()
+                        || subscription.feedId == readerBlog.feedId.toString()
+                        || getHostFromSubscriptionUrl(subscription.url) == getHostFromSubscriptionUrl(
+                        readerBlog.url
+                )
+            }
+            if (match != null) {
+                PreferenceModel(
+                        getSiteNameOrHostFromSubscription(readerBlog.name, readerBlog.url),
+                        getHostFromSubscriptionUrl(readerBlog.url),
+                        readerBlog.blogId.toString(),
+                        ClickHandler(
+                                match.shouldNotifyPosts,
+                                match.shouldEmailPosts,
+                                match.emailPostsFrequency,
+                                match.shouldEmailComments
+                        )
+                )
+            } else {
+                PreferenceModel(
+                        getSiteNameOrHostFromSubscription(readerBlog.name, readerBlog.url),
+                        getHostFromSubscriptionUrl(readerBlog.url),
+                        readerBlog.blogId.toString()
+                )
+            }
+        }
+        return result
+    }
+
+    private fun getSiteNameOrHostFromSubscription(
+        blogName: String?,
+        blogUrl: String
+    ): String {
+        var name: String? = blogName
+
+        if (name != null) {
+            if (name.trim { it <= ' ' }.isEmpty()) {
+                name = getHostFromSubscriptionUrl(blogUrl)
+            }
+        } else {
+            name = getHostFromSubscriptionUrl(blogUrl)
+        }
+
+        return name
+    }
+
+    private fun getHostFromSubscriptionUrl(url: String): String {
+        return uriUtils.getHost(url)
+    }
+
+    data class PreferenceModel(
+        val title: String,
+        val summary: String,
+        val blogId: String,
+        val clickHandler: ClickHandler? = null
+    ) {
+        data class ClickHandler(
+            val shouldNotifyPosts: Boolean,
+            val shouldEmailPosts: Boolean,
+            val emailPostFrequency: String?,
+            val shouldEmailComments: Boolean
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/FollowedBlogsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/FollowedBlogsProvider.kt
@@ -20,7 +20,7 @@ class FollowedBlogsProvider
         } else {
             readerBlogTable.getFollowedBlogs()
         }
-        val result = allFollowedBlogs.map { readerBlog ->
+        return allFollowedBlogs.map { readerBlog ->
             val match = subscriptions.find { subscription ->
                 subscription.blogId == readerBlog.blogId.toString() ||
                         subscription.feedId == readerBlog.feedId.toString() ||
@@ -46,7 +46,6 @@ class FollowedBlogsProvider
                 )
             }
         }
-        return result
     }
 
     private fun getSiteNameOrHostFromSubscription(

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/FollowedBlogsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/FollowedBlogsProvider.kt
@@ -26,16 +26,21 @@ class FollowedBlogsProvider
         // Load subscriptions when blogs are not loaded yet
         if (allFollowedBlogs.isEmpty()) {
             return subscriptions.map { subscription ->
+                val clickHandler = if (subscription.blogId != null && subscription.blogId != "false") {
+                    ClickHandler(
+                            subscription.shouldNotifyPosts,
+                            subscription.shouldEmailPosts,
+                            subscription.emailPostsFrequency,
+                            subscription.shouldEmailComments
+                    )
+                } else {
+                    null
+                }
                 PreferenceModel(
                         getSiteNameOrHostFromSubscription(subscription.blogName, subscription.url),
                         uriUtils.getHost(subscription.url),
                         subscription.blogId.toString(),
-                        ClickHandler(
-                                subscription.shouldNotifyPosts,
-                                subscription.shouldEmailPosts,
-                                subscription.emailPostsFrequency,
-                                subscription.shouldEmailComments
-                        )
+                        clickHandler
                 )
             }
         }
@@ -46,25 +51,22 @@ class FollowedBlogsProvider
                         uriUtils.getHost(subscription.url) == uriUtils.getHost(readerBlog.url)
             }
             // We don't have notification settings for feeds
-            if (match != null && match.blogId != null && match.blogId != "false") {
-                PreferenceModel(
-                        getSiteNameOrHostFromSubscription(readerBlog.name, readerBlog.url),
-                        uriUtils.getHost(readerBlog.url),
-                        readerBlog.blogId.toString(),
-                        ClickHandler(
-                                match.shouldNotifyPosts,
-                                match.shouldEmailPosts,
-                                match.emailPostsFrequency,
-                                match.shouldEmailComments
-                        )
+            val clickHandler = if (match != null && match.blogId != null && match.blogId != "false") {
+                ClickHandler(
+                        match.shouldNotifyPosts,
+                        match.shouldEmailPosts,
+                        match.emailPostsFrequency,
+                        match.shouldEmailComments
                 )
             } else {
-                PreferenceModel(
-                        getSiteNameOrHostFromSubscription(readerBlog.name, readerBlog.url),
-                        uriUtils.getHost(readerBlog.url),
-                        readerBlog.blogId.toString()
-                )
+                null
             }
+            PreferenceModel(
+                    getSiteNameOrHostFromSubscription(readerBlog.name, readerBlog.url),
+                    uriUtils.getHost(readerBlog.url),
+                    readerBlog.blogId.toString(),
+                    clickHandler
+            )
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/FollowedBlogsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/FollowedBlogsProvider.kt
@@ -3,14 +3,14 @@ package org.wordpress.android.ui.prefs.notifications
 import org.wordpress.android.datasets.ReaderBlogTableWrapper
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.prefs.notifications.FollowedBlogsProvider.PreferenceModel.ClickHandler
-import org.wordpress.android.ui.utils.UriUtilsWrapper
+import org.wordpress.android.ui.utils.UrlUtilsWrapper
 import javax.inject.Inject
 
 class FollowedBlogsProvider
 @Inject constructor(
     private val accountStore: AccountStore,
     private val readerBlogTable: ReaderBlogTableWrapper,
-    private val uriUtils: UriUtilsWrapper
+    private val urlUtils: UrlUtilsWrapper
 ) {
     fun getAllFollowedBlogs(query: String?): List<PreferenceModel> {
         val subscriptions = accountStore.subscriptions
@@ -38,7 +38,7 @@ class FollowedBlogsProvider
                 }
                 PreferenceModel(
                         getSiteNameOrHostFromSubscription(subscription.blogName, subscription.url),
-                        uriUtils.getHost(subscription.url),
+                        urlUtils.getHost(subscription.url),
                         subscription.blogId.toString(),
                         clickHandler
                 )
@@ -48,7 +48,7 @@ class FollowedBlogsProvider
             val match = subscriptions.find { subscription ->
                 subscription.blogId == readerBlog.blogId.toString() ||
                         subscription.feedId == readerBlog.feedId.toString() ||
-                        uriUtils.getHost(subscription.url) == uriUtils.getHost(readerBlog.url)
+                        urlUtils.getHost(subscription.url) == urlUtils.getHost(readerBlog.url)
             }
             // We don't have notification settings for feeds
             val clickHandler = if (match != null && match.blogId != null && match.blogId != "false") {
@@ -63,7 +63,7 @@ class FollowedBlogsProvider
             }
             PreferenceModel(
                     getSiteNameOrHostFromSubscription(readerBlog.name, readerBlog.url),
-                    uriUtils.getHost(readerBlog.url),
+                    urlUtils.getHost(readerBlog.url),
                     readerBlog.blogId.toString(),
                     clickHandler
             )
@@ -78,10 +78,10 @@ class FollowedBlogsProvider
 
         if (name != null) {
             if (name.trim { it <= ' ' }.isEmpty()) {
-                name = uriUtils.getHost(blogUrl)
+                name = urlUtils.getHost(blogUrl)
             }
         } else {
-            name = uriUtils.getHost(blogUrl)
+            name = urlUtils.getHost(blogUrl)
         }
 
         return name

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/FollowedBlogsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/FollowedBlogsProvider.kt
@@ -22,16 +22,14 @@ class FollowedBlogsProvider
         }
         val result = allFollowedBlogs.map { readerBlog ->
             val match = subscriptions.find { subscription ->
-                subscription.blogId == readerBlog.blogId.toString()
-                        || subscription.feedId == readerBlog.feedId.toString()
-                        || getHostFromSubscriptionUrl(subscription.url) == getHostFromSubscriptionUrl(
-                        readerBlog.url
-                )
+                subscription.blogId == readerBlog.blogId.toString() ||
+                        subscription.feedId == readerBlog.feedId.toString() ||
+                        uriUtils.getHost(subscription.url) == uriUtils.getHost(readerBlog.url)
             }
             if (match != null) {
                 PreferenceModel(
                         getSiteNameOrHostFromSubscription(readerBlog.name, readerBlog.url),
-                        getHostFromSubscriptionUrl(readerBlog.url),
+                        uriUtils.getHost(readerBlog.url),
                         readerBlog.blogId.toString(),
                         ClickHandler(
                                 match.shouldNotifyPosts,
@@ -43,7 +41,7 @@ class FollowedBlogsProvider
             } else {
                 PreferenceModel(
                         getSiteNameOrHostFromSubscription(readerBlog.name, readerBlog.url),
-                        getHostFromSubscriptionUrl(readerBlog.url),
+                        uriUtils.getHost(readerBlog.url),
                         readerBlog.blogId.toString()
                 )
             }
@@ -59,17 +57,13 @@ class FollowedBlogsProvider
 
         if (name != null) {
             if (name.trim { it <= ' ' }.isEmpty()) {
-                name = getHostFromSubscriptionUrl(blogUrl)
+                name = uriUtils.getHost(blogUrl)
             }
         } else {
-            name = getHostFromSubscriptionUrl(blogUrl)
+            name = uriUtils.getHost(blogUrl)
         }
 
         return name
-    }
-
-    private fun getHostFromSubscriptionUrl(url: String): String {
-        return uriUtils.getHost(url)
     }
 
     data class PreferenceModel(

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UriUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UriUtilsWrapper.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.ui.utils
+
+import org.wordpress.android.util.UrlUtils
+import javax.inject.Inject
+
+class UriUtilsWrapper
+@Inject constructor() {
+    fun getHost(url: String) = UrlUtils.getHost(url)
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UriUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UriUtilsWrapper.kt
@@ -5,5 +5,5 @@ import javax.inject.Inject
 
 class UriUtilsWrapper
 @Inject constructor() {
-    fun getHost(url: String) = UrlUtils.getHost(url)
+    fun getHost(url: String): String = UrlUtils.getHost(url)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UrlUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UrlUtilsWrapper.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.ui.utils
 import org.wordpress.android.util.UrlUtils
 import javax.inject.Inject
 
-class UriUtilsWrapper
+class UrlUtilsWrapper
 @Inject constructor() {
     fun getHost(url: String): String = UrlUtils.getHost(url)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/notifications/FollowedBlogsProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/notifications/FollowedBlogsProviderTest.kt
@@ -12,13 +12,13 @@ import org.wordpress.android.fluxc.model.SubscriptionModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.models.ReaderBlog
 import org.wordpress.android.ui.prefs.notifications.FollowedBlogsProvider.PreferenceModel
-import org.wordpress.android.ui.utils.UriUtilsWrapper
+import org.wordpress.android.ui.utils.UrlUtilsWrapper
 
 @RunWith(MockitoJUnitRunner::class)
 class FollowedBlogsProviderTest {
     @Mock lateinit var accountStore: AccountStore
     @Mock lateinit var readerBlogTable: ReaderBlogTableWrapper
-    @Mock lateinit var uriUtils: UriUtilsWrapper
+    @Mock lateinit var urlUtils: UrlUtilsWrapper
     private lateinit var followedBlogsProvider: FollowedBlogsProvider
     private val blogName = "blog name"
     private val url = "http://blog.url.com/feed"
@@ -28,7 +28,7 @@ class FollowedBlogsProviderTest {
 
     @Before
     fun setUp() {
-        followedBlogsProvider = FollowedBlogsProvider(accountStore, readerBlogTable, uriUtils)
+        followedBlogsProvider = FollowedBlogsProvider(accountStore, readerBlogTable, urlUtils)
     }
 
     @Test
@@ -234,7 +234,7 @@ class FollowedBlogsProviderTest {
         feedId?.let {
             subscriptionModel.feedId = it
         }
-        whenever(uriUtils.getHost(subscriptionUrl)).thenReturn(subscriptionUrlHost)
+        whenever(urlUtils.getHost(subscriptionUrl)).thenReturn(subscriptionUrlHost)
         return subscriptionModel
     }
 
@@ -252,7 +252,7 @@ class FollowedBlogsProviderTest {
         feedId?.let {
             readerBlog.feedId = it
         }
-        whenever(uriUtils.getHost(blogUrl)).thenReturn(blogUrlHost)
+        whenever(urlUtils.getHost(blogUrl)).thenReturn(blogUrlHost)
         return readerBlog
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/notifications/FollowedBlogsProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/notifications/FollowedBlogsProviderTest.kt
@@ -1,0 +1,216 @@
+package org.wordpress.android.ui.prefs.notifications
+
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.datasets.ReaderBlogTableWrapper
+import org.wordpress.android.fluxc.model.SubscriptionModel
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.models.ReaderBlog
+import org.wordpress.android.ui.prefs.notifications.FollowedBlogsProvider.PreferenceModel
+import org.wordpress.android.ui.utils.UriUtilsWrapper
+
+@RunWith(MockitoJUnitRunner::class)
+class FollowedBlogsProviderTest {
+    @Mock lateinit var accountStore: AccountStore
+    @Mock lateinit var readerBlogTable: ReaderBlogTableWrapper
+    @Mock lateinit var uriUtils: UriUtilsWrapper
+    private lateinit var followedBlogsProvider: FollowedBlogsProvider
+    private val blogName = "blog name"
+    private val url = "http://blog.url.com/feed"
+    private val subscriptionUrl = "http://unknown.com"
+    private val urlHost = "blog.url.com"
+    private val emailFrequency = "daily"
+
+    @Before
+    fun setUp() {
+        followedBlogsProvider = FollowedBlogsProvider(accountStore, readerBlogTable, uriUtils)
+    }
+
+    @Test
+    fun `maps followed blog and adds click handler when blog id matches`() {
+        val readerBlogId = 12345L
+
+        val blogPost = setupBlogPost(readerBlogId, blogName, url, urlHost)
+        whenever(readerBlogTable.getFollowedBlogs()).thenReturn(listOf(blogPost))
+        val subscriptionModel = setupSubscriptionModel(
+                readerBlogId.toString(),
+                shouldNotifyPosts = true,
+                shouldEmailPosts = false,
+                shouldEmailComments = false,
+                emailFrequency = emailFrequency,
+                subscriptionUrl = subscriptionUrl,
+                subscriptionUrlHost = subscriptionUrl
+        )
+        whenever(accountStore.subscriptions).thenReturn(listOf(subscriptionModel))
+
+        val result = followedBlogsProvider.getAllFollowedBlogs(null)
+
+        assertThat(result).hasSize(1)
+        result.first().assertModel(readerBlogId, blogName, urlHost)
+        result.first().assertClickHandler(
+                shouldNotifyPosts = true,
+                shouldEmailPosts = false,
+                shouldEmailComments = false,
+                emailFrequency = emailFrequency
+        )
+    }
+
+    @Test
+    fun `maps followed blog and adds click handler when feed id matches`() {
+        val readerBlogId = 1L
+        val feedId = 10L
+        val blogPost = setupBlogPost(readerBlogId, feedId = feedId)
+        whenever(readerBlogTable.getFollowedBlogs()).thenReturn(listOf(blogPost))
+        val subscriptionModel = setupSubscriptionModel(
+                "false",
+                shouldNotifyPosts = false,
+                shouldEmailPosts = true,
+                shouldEmailComments = false,
+                feedId = feedId.toString()
+        )
+        whenever(accountStore.subscriptions).thenReturn(listOf(subscriptionModel))
+
+        val result = followedBlogsProvider.getAllFollowedBlogs(null)
+
+        assertThat(result).hasSize(1)
+        result.first().assertModel(readerBlogId, blogName, urlHost)
+        result.first().assertClickHandler(
+                shouldNotifyPosts = false,
+                shouldEmailPosts = true,
+                shouldEmailComments = false,
+                emailFrequency = emailFrequency
+        )
+    }
+
+    @Test
+    fun `maps followed blog and adds click handler when url host matches`() {
+        val readerBlogId = 1L
+        val blogPost = setupBlogPost(readerBlogId, blogUrl = url, blogUrlHost = urlHost)
+        whenever(readerBlogTable.getFollowedBlogs()).thenReturn(listOf(blogPost))
+        val subscriptionModel = setupSubscriptionModel(
+                shouldNotifyPosts = false,
+                shouldEmailPosts = false,
+                shouldEmailComments = true,
+                subscriptionUrl = url,
+                subscriptionUrlHost = urlHost
+        )
+        whenever(accountStore.subscriptions).thenReturn(listOf(subscriptionModel))
+
+        val result = followedBlogsProvider.getAllFollowedBlogs(null)
+
+        assertThat(result).hasSize(1)
+        result.first().assertModel(readerBlogId, blogName, urlHost)
+        result.first().assertClickHandler(
+                shouldNotifyPosts = false,
+                shouldEmailPosts = false,
+                shouldEmailComments = true,
+                emailFrequency = emailFrequency
+        )
+    }
+
+    @Test
+    fun `maps followed blog and does not add click handler when item does not match`() {
+        val readerBlogId = 12345L
+        val blogPost = setupBlogPost(readerBlogId, blogName, url, urlHost)
+        whenever(readerBlogTable.getFollowedBlogs()).thenReturn(listOf(blogPost))
+        val subscriptionModel = setupSubscriptionModel(
+                "false",
+                emailFrequency = emailFrequency,
+                subscriptionUrl = subscriptionUrl,
+                subscriptionUrlHost = subscriptionUrl
+        )
+        whenever(accountStore.subscriptions).thenReturn(listOf(subscriptionModel))
+
+        val result = followedBlogsProvider.getAllFollowedBlogs(null)
+
+        assertThat(result).hasSize(1)
+        result.first().assertModel(readerBlogId, blogName, urlHost)
+        assertThat(result.first().clickHandler).isNull()
+    }
+
+    @Test
+    fun `filters out items by query`() {
+        val readerBlogId = 12345L
+        val query = "query"
+        val blogNameWithQuery = "title with $query"
+        val blogPostWithQuery = setupBlogPost(readerBlogId, blogNameWithQuery, url, urlHost)
+        val blogPostWithoutQuery = setupBlogPost(readerBlogId, "title", url, urlHost)
+        whenever(readerBlogTable.getFollowedBlogs()).thenReturn(listOf(blogPostWithQuery, blogPostWithoutQuery))
+        whenever(accountStore.subscriptions).thenReturn(listOf())
+
+        val result = followedBlogsProvider.getAllFollowedBlogs(query)
+
+        assertThat(result).hasSize(1)
+        result.first().assertModel(readerBlogId, blogNameWithQuery, urlHost)
+        assertThat(result.first().clickHandler).isNull()
+    }
+
+    private fun setupSubscriptionModel(
+        readerBlogId: String = "false",
+        shouldNotifyPosts: Boolean = false,
+        shouldEmailPosts: Boolean = false,
+        shouldEmailComments: Boolean = false,
+        emailFrequency: String = this.emailFrequency,
+        subscriptionUrl: String = this.subscriptionUrl,
+        subscriptionUrlHost: String = this.subscriptionUrl,
+        feedId: String = "false"
+    ): SubscriptionModel {
+        val subscriptionModel = SubscriptionModel()
+        subscriptionModel.blogId = readerBlogId
+        subscriptionModel.shouldNotifyPosts = shouldNotifyPosts
+        subscriptionModel.shouldEmailPosts = shouldEmailPosts
+        subscriptionModel.emailPostsFrequency = emailFrequency
+        subscriptionModel.shouldEmailComments = shouldEmailComments
+        subscriptionModel.url = subscriptionUrl
+        feedId?.let {
+            subscriptionModel.feedId = it
+        }
+        whenever(uriUtils.getHost(subscriptionUrl)).thenReturn(subscriptionUrlHost)
+        return subscriptionModel
+    }
+
+    private fun setupBlogPost(
+        readerBlogId: Long,
+        blogName: String = this.blogName,
+        blogUrl: String = this.url,
+        blogUrlHost: String = this.urlHost,
+        feedId: Long? = null
+    ): ReaderBlog {
+        val readerBlog = ReaderBlog()
+        readerBlog.blogId = readerBlogId
+        readerBlog.name = blogName
+        readerBlog.url = blogUrl
+        feedId?.let {
+            readerBlog.feedId = it
+        }
+        whenever(uriUtils.getHost(blogUrl)).thenReturn(blogUrlHost)
+        return readerBlog
+    }
+
+    private fun PreferenceModel.assertClickHandler(
+        shouldNotifyPosts: Boolean,
+        shouldEmailPosts: Boolean,
+        shouldEmailComments: Boolean,
+        emailFrequency: String
+    ) {
+        assertThat(this.clickHandler!!.emailPostFrequency).isEqualTo(emailFrequency)
+        assertThat(this.clickHandler!!.shouldNotifyPosts).isEqualTo(shouldNotifyPosts)
+        assertThat(this.clickHandler!!.shouldEmailPosts).isEqualTo(shouldEmailPosts)
+        assertThat(this.clickHandler!!.shouldEmailComments).isEqualTo(shouldEmailComments)
+    }
+
+    private fun PreferenceModel.assertModel(
+        readerBlogId: Long,
+        blogName: String,
+        urlHost: String
+    ) {
+        assertThat(this.blogId).isEqualTo(readerBlogId.toString())
+        assertThat(this.title).isEqualTo(blogName)
+        assertThat(this.summary).isEqualTo(urlHost)
+    }
+}


### PR DESCRIPTION
Fixes #9549

We have 2 sources of followed sites. One is `readerBlogTable.getFollowedBlogs()` and the other one is `accountStore.subscriptions`. We were previously using `accountStore.subscriptions` on the Notifications settings site and the `readerBlogTable.getFollowedBlogs()` in the reader. The reader method returns more information and contains more sites. The `accountStore` method returns the data we need to handle notifications. What I've done to fix the issue of missing sites in the `accountStore` method is that I'm taking the followed blogs from reader and iterate through the subscriptions and try to match them, first by `blogId`, then by `feedId` and last by `url` and the host name. This approach seems to work and cover all the cases I see in my followed sites. When I don't find a subscription for a site or the subscription has blogId == "false" (it's a feed) I disable the preference (that makes it grey). 

If the subscriptions list is empty this means that the subscriptions are not loaded yet. In this case I do the same thing as was done before - show an empty list of followed sites. 

When the reader followed blogs are empty, I show the same list as was shown before - subscriptions mapped to items. Loading reader followed sites from notifications seemed hacky. 

To test:
* Follow a Jetpack site
* Check that it's visible in Reader/Followed sites
* Go to Notifications/Settings/All followed sites
* Check that the site is now in the list
* Check that the two lists contain the same sites
* Try the same with an RSS feed

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

