### PR TITLE
Enable media-text in all builds

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,7 @@
 13.5
 -----
+
+* Block Editor: New "Media & Text" block available
  
 13.4
 -----


### PR DESCRIPTION
Updates gutenberg so that Media & Text is enabled for all builds

See https://github.com/WordPress/gutenberg/pull/17903

To test:

- Run the app without a metro server running
- Create a new post
- Verify that you can insert a media-text block

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

