### PR TITLE
CircleCI: Don't run installable build/connected tests for forked PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,5 +131,11 @@ workflows:
       - strings-check
       - test
       - lint
-      - Installable Build
-      - connected-tests
+      - Installable Build:
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
+      - connected-tests:
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/


### PR DESCRIPTION
Both the connected tests and installable build CircleCI jobs fail for forked PRs. This is not ideal, but there is not much we can do about that short of publically exposing credentials for Firebase, code signing etc.

Opening this PR from a fork so you can see it works!

You can run the skipped jobs for any forked PR by pushing the commits to a new branch and opening a PR for it (CircleCI only runs on PRs for WPAndroid). CircleCI has documentation about his [here](https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/#testing-out-the-review-workflow-for-forked-prs).

cc @koke 

To test:

- There are no installable build or connected tests check on this PR.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

