### PR TITLE
Fix infinite queued post label on post list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2862,6 +2862,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
     private void setFeaturedImageId(final long mediaId) {
         mPost.setFeaturedImageId(mediaId);
+        mPost.setIsLocallyChanged(true);
         savePostAsync(() -> EditPostActivity.this.runOnUiThread(() -> {
             if (mEditPostSettingsFragment != null) {
                 mEditPostSettingsFragment.updateFeaturedImage(mediaId);


### PR DESCRIPTION
Fixes #10601 

When the featured image upload completes, the post is enqueued for upload -> however, the post is not marked as locally changed and the UploadActionUseCase decides that there is no reason to upload the post. I've fixed this issue by marking the post as locally changed.

To test:
1. Open a post
2. Don't make any changes to the post
3. Open Post Settings
4. Add a featured image and wait until the upload completes
5. Go back to the Post List and notice the post gets uploaded and the "queued post" label isn't shown

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


cc @jkmassel This is just a visual bug, but in case you'd be releasing a new beta, we might want to consider cherry-picking it into 13.4. I'll leave the final decision to you. Thanks!

| Before  | After |
| ------------- | ------------- |
| ![queued-post-issue-2](https://user-images.githubusercontent.com/2261188/66646158-ab190700-ec25-11e9-845d-d078e0be27d5.gif)  | ![queued-post-issue-fixed](https://user-images.githubusercontent.com/2261188/66646157-aa807080-ec25-11e9-8906-d03bc735d7bb.gif)  |


