### PR TITLE
Delete old data on refresh in reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -181,7 +181,7 @@ public class FilteredRecyclerView extends RelativeLayout {
                                     return;
                                 }
                                 if (mFilterListener != null) {
-                                    mFilterListener.onLoadData();
+                                    mFilterListener.onLoadData(true);
                                 }
                             }
                         });
@@ -245,7 +245,7 @@ public class FilteredRecyclerView extends RelativeLayout {
                 if (mFilterListener != null) {
                     mFilterListener.onFilterSelected(position, selectedCriteria);
                     setRefreshing(true);
-                    mFilterListener.onLoadData();
+                    mFilterListener.onLoadData(false);
                 }
             }
 
@@ -568,7 +568,7 @@ public class FilteredRecyclerView extends RelativeLayout {
          * 2 - each time a screen refresh is requested
          * 3 - each time the user changes the filter spinner selection
          */
-        void onLoadData();
+        void onLoadData(boolean forced);
 
         /**
          * Called each time the user changes the Spinner selection (i.e. changes the criteria on which to filter

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -302,7 +302,7 @@ public class CommentsListFragment extends Fragment {
             }
 
             @Override
-            public void onLoadData() {
+            public void onLoadData(boolean forced) {
                 updateComments(false);
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -151,7 +151,7 @@ public class PeopleListFragment extends Fragment {
             }
 
             @Override
-            public void onLoadData() {
+            public void onLoadData(boolean forced) {
                 updatePeople(false);
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -646,8 +646,8 @@ public class ReaderPostListFragment extends Fragment
                     mRecyclerView.setRefreshing(false);
                     mFirstLoad = false;
                 } else {
-                    UpdateAction updateAction = forced ? UpdateAction.REQUEST_NEWER
-                            : UpdateAction.REQUEST_REFRESH;
+                    UpdateAction updateAction = forced ? UpdateAction.REQUEST_REFRESH
+                            : UpdateAction.REQUEST_NEWER;
                     switch (getPostListType()) {
                         case TAG_FOLLOWED:
                             // fall through to TAG_PREVIEW
@@ -1822,7 +1822,8 @@ public class ReaderPostListFragment extends Fragment
             && !isPostAdapterEmpty()
             && (!isAdded() || !mRecyclerView.isFirstItemVisible())) {
             showNewPostsBar();
-        } else if (event.getResult().isNewOrChanged()) {
+        } else if (event.getResult().isNewOrChanged()
+                   || event.getAction() == UpdateAction.REQUEST_REFRESH) {
             refreshPosts();
         } else {
             boolean requestFailed = (event.getResult() == ReaderActions.UpdateResult.FAILED);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -630,7 +630,7 @@ public class ReaderPostListFragment extends Fragment
             }
 
             @Override
-            public void onLoadData() {
+            public void onLoadData(boolean forced) {
                 if (!isAdded()) {
                     return;
                 }
@@ -646,14 +646,16 @@ public class ReaderPostListFragment extends Fragment
                     mRecyclerView.setRefreshing(false);
                     mFirstLoad = false;
                 } else {
+                    UpdateAction updateAction = forced ? UpdateAction.REQUEST_NEWER
+                            : UpdateAction.REQUEST_REFRESH;
                     switch (getPostListType()) {
                         case TAG_FOLLOWED:
                             // fall through to TAG_PREVIEW
                         case TAG_PREVIEW:
-                            updatePostsWithTag(getCurrentTag(), UpdateAction.REQUEST_NEWER);
+                            updatePostsWithTag(getCurrentTag(), updateAction);
                             break;
                         case BLOG_PREVIEW:
-                            updatePostsInCurrentBlogOrFeed(UpdateAction.REQUEST_NEWER);
+                            updatePostsInCurrentBlogOrFeed(updateAction);
                             break;
                         case SEARCH_RESULTS:
                             // no-op

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostLogic.java
@@ -112,6 +112,7 @@ public class ReaderPostLogic {
                 beforeDate = ReaderPostTable.getGapMarkerDateForTag(tag);
                 break;
             case REQUEST_NEWER:
+            case REQUEST_REFRESH:
             default:
                 beforeDate = null;
                 break;
@@ -126,7 +127,7 @@ public class ReaderPostLogic {
             @Override
             public void onResponse(JSONObject jsonObject) {
                 // remember when this tag was updated if newer posts were requested
-                if (updateAction == UpdateAction.REQUEST_NEWER) {
+                if (updateAction == UpdateAction.REQUEST_NEWER || updateAction == UpdateAction.REQUEST_REFRESH) {
                     ReaderTagTable.setTagLastUpdated(tag);
                 }
                 handleUpdatePostsResponse(tag, jsonObject, updateAction, resultListener);
@@ -251,6 +252,9 @@ public class ReaderPostLogic {
                                 // before the one with the gap marker, then remove the existing gap marker
                                 ReaderPostTable.deletePostsBeforeGapMarkerForTag(tag);
                                 ReaderPostTable.removeGapMarkerForTag(tag);
+                                break;
+                            case REQUEST_REFRESH:
+                                ReaderPostTable.deletePostsWithTag(tag);
                                 break;
                             case REQUEST_OLDER:
                                 // no-op

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostServiceStarter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostServiceStarter.java
@@ -28,6 +28,7 @@ public class ReaderPostServiceStarter {
 
     public enum UpdateAction {
         REQUEST_NEWER, // request the newest posts for this tag/blog/feed
+        REQUEST_REFRESH, // request fresh data and get rid of the rest
         REQUEST_OLDER, // request posts older than the oldest existing one for this tag/blog/feed
         REQUEST_OLDER_THAN_GAP // request posts older than the one with the gap marker for this tag
                                // (not supported for blog/feed)


### PR DESCRIPTION
Fixes #7834

This PR removes all data for the selected tag on pull to refresh. The data is removed once we receive the response from the backend.

To test:
* Go to reader
* Scroll to load another page
* Pull to refresh
* Notice that you have only one page visible after the loading is completed

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

