### PR TITLE
Gutenberg: Update to v1.15.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,8 @@
 13.5
 -----
+ * Block Editor: Fix issue when multiple media selection adds only one image or video block.
+ * Block Editor: Add Link Target (Open in new tab) to Image Block.
+ * Block Editor: New block "Media & Text".
  
 13.4
 -----

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     ext {
-        aztecVersion = 'v1.3.32'
+        aztecVersion = 'v1.3.33'
     }
 
     dependencies {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     ext {
-        aztecVersion = 'v1.3.31'
+        aztecVersion = 'v1.3.32'
     }
 
     dependencies {


### PR DESCRIPTION
This PR updates Gutenberg to v1.15.0
`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1445

**To test:**
* Fix issue when multiple media selection adds only one image or video block.
* Add Link Target (Open in new tab) to Image Block.
* **New block** "Media & Text".
* General Block Editor smoke tests.


- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

