### PR TITLE
Extract photo picker logic from EditPostActivity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -115,6 +115,7 @@ import org.wordpress.android.ui.posts.InsertMediaDialog.InsertMediaCallback;
 import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Editor;
 import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Outcome;
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.PreviewLogicOperationResult;
+import org.wordpress.android.ui.posts.editor.PostLoadingState;
 import org.wordpress.android.ui.posts.editor.PrimaryEditorAction;
 import org.wordpress.android.ui.posts.editor.SecondaryEditorAction;
 import org.wordpress.android.ui.posts.services.AztecImageLoader;
@@ -294,57 +295,6 @@ public class EditPostActivity extends AppCompatActivity implements
     private boolean mIsPage;
     private boolean mHasSetPostContent;
     private PostLoadingState mPostLoadingState = PostLoadingState.NONE;
-
-
-    private enum PostLoadingState {
-        NONE(0, ProgressDialogUiState.HiddenProgressDialog.INSTANCE),
-        LOADING_REVISION(3, new ProgressDialogUiState.VisibleProgressDialog(
-                new UiStringRes(R.string.history_loading_revision),
-                false,
-                true)),
-        UPLOADING_FOR_PREVIEW(4, new ProgressDialogUiState.VisibleProgressDialog(
-                new UiStringRes(R.string.post_preview_saving_draft),
-                false,
-                true)),
-        REMOTE_AUTO_SAVING_FOR_PREVIEW(5, new ProgressDialogUiState.VisibleProgressDialog(
-                new UiStringRes(R.string.post_preview_remote_auto_saving_post),
-                false,
-                true)),
-        PREVIEWING(6, ProgressDialogUiState.HiddenProgressDialog.INSTANCE),
-        REMOTE_AUTO_SAVE_PREVIEW_ERROR(7, ProgressDialogUiState.HiddenProgressDialog.INSTANCE);
-
-        PostLoadingState(int value, ProgressDialogUiState dialogUiState) {
-            mValue = value;
-            mDialogUiState = dialogUiState;
-        }
-
-        private final int mValue;
-        private final ProgressDialogUiState mDialogUiState;
-
-        public int getValue() {
-            return mValue;
-        }
-
-        public ProgressDialogUiState getProgressDialogUiState() {
-            return mDialogUiState;
-        }
-
-        public static PostLoadingState fromInt(int value) {
-            PostLoadingState state = null;
-
-            for (PostLoadingState item : values()) {
-                if (item.mValue == value) {
-                    state = item;
-                    break;
-                }
-            }
-
-            if (state == null) {
-                throw new IllegalArgumentException("PostLoadingState wrong value " + value);
-            }
-            return state;
-        }
-    }
 
     private View mPhotoPickerContainer;
     private PhotoPickerFragment mPhotoPickerFragment;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -286,7 +286,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private EditorFragmentAbstract mEditorFragment;
     private EditPostSettingsFragment mEditPostSettingsFragment;
     private EditorMediaUploadListener mEditorMediaUploadListener;
-    private EditorPhotoPicker mEditorPhotoPicker = new EditorPhotoPicker<>(this);
+    private EditorPhotoPicker mEditorPhotoPicker;
 
     private ProgressDialog mProgressDialog;
 
@@ -397,6 +397,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // Check whether to show the visual editor
         PreferenceManager.setDefaultValues(this, R.xml.account_settings, false);
         mShowAztecEditor = AppPrefs.isAztecEditorEnabled();
+        mEditorPhotoPicker = new EditorPhotoPicker<>(this, mShowAztecEditor);
 
         // TODO when aztec is the only editor, remove this part and set the overlay bottom margin in xml
         if (mShowAztecEditor) {
@@ -809,7 +810,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
         mHtmlModeMenuStateOn = savedInstanceState.getBoolean(STATE_KEY_HTML_MODE_ON);
         if (savedInstanceState.getBoolean(STATE_KEY_IS_PHOTO_PICKER_VISIBLE, false)) {
-            mEditorPhotoPicker.showPhotoPicker(mSite, mShowAztecEditor, mEditorFragment);
+            mEditorPhotoPicker.showPhotoPicker(mSite, mEditorFragment);
         }
     }
 
@@ -3097,7 +3098,7 @@ public class EditPostActivity extends AppCompatActivity implements
         if (mEditorPhotoPicker.isPhotoPickerShowing()) {
             mEditorPhotoPicker.hidePhotoPicker(mEditorFragment);
          } else if (WPMediaUtils.currentUserCanUploadMedia(mSite)) {
-            mEditorPhotoPicker.showPhotoPicker(mSite, mShowAztecEditor, mEditorFragment);
+            mEditorPhotoPicker.showPhotoPicker(mSite, mEditorFragment);
         } else {
             // show the WP media library instead of the photo picker if the user doesn't have upload permission
             ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.EDITOR_PICKER);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -64,7 +64,6 @@ import org.wordpress.android.editor.EditorMediaUploadListener;
 import org.wordpress.android.editor.EditorMediaUtils;
 import org.wordpress.android.editor.GutenbergEditorFragment;
 import org.wordpress.android.editor.ImageSettingsDialogFragment;
-import org.wordpress.android.editor.MediaToolbarAction;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
@@ -398,7 +397,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // Check whether to show the visual editor
         PreferenceManager.setDefaultValues(this, R.xml.account_settings, false);
         mShowAztecEditor = AppPrefs.isAztecEditorEnabled();
-        mEditorPhotoPicker = new EditorPhotoPicker<>(this, this, mShowAztecEditor);
+        mEditorPhotoPicker = new EditorPhotoPicker(this, this, this, mShowAztecEditor);
 
         // TODO when aztec is the only editor, remove this part and set the overlay bottom margin in xml
         if (mShowAztecEditor) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -129,6 +129,7 @@ import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.ui.uploads.VideoOptimizer;
 import org.wordpress.android.ui.utils.UiHelpers;
 import org.wordpress.android.util.ActivityUtils;
+import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.AutolinkUtils;
@@ -872,8 +873,28 @@ public class EditPostActivity extends AppCompatActivity implements
         return hasBlocks || (SiteUtils.isBlockEditorDefaultForNewPost(site) && isEmpty);
     }
 
+    /*
+     * shows/hides the overlay which appears atop the editor, which effectively disables it
+     */
+    private void showOverlay(boolean animate) {
+        View overlay = findViewById(R.id.view_overlay);
+        if (animate) {
+            AniUtils.fadeIn(overlay, AniUtils.Duration.MEDIUM);
+        } else {
+            overlay.setVisibility(View.VISIBLE);
+        }
+    }
+
+    private void hideOverlay() {
+        View overlay = findViewById(R.id.view_overlay);
+        overlay.setVisibility(View.GONE);
+    }
+
     @Override
     public void onPhotoPickerShown() {
+        // animate in the editor overlay
+        showOverlay(true);
+
         if (mEditorFragment instanceof AztecEditorFragment) {
             ((AztecEditorFragment) mEditorFragment).enableMediaMode(true);
         }
@@ -881,6 +902,8 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onPhotoPickerHidden() {
+        hideOverlay();
+
         if (mEditorFragment instanceof AztecEditorFragment) {
             ((AztecEditorFragment) mEditorFragment).enableMediaMode(false);
         }
@@ -2530,14 +2553,14 @@ public class EditPostActivity extends AppCompatActivity implements
         AddMediaListThread(@NonNull List<Uri> uriList, boolean isNew) {
             this.mUriList.addAll(uriList);
             this.mIsNew = isNew;
-            mEditorPhotoPicker.showOverlay(false);
+            showOverlay(false);
         }
 
         AddMediaListThread(@NonNull List<Uri> uriList, boolean isNew, boolean allowMultipleSelection) {
             this.mUriList.addAll(uriList);
             this.mIsNew = isNew;
             this.mAllowMultipleSelection = allowMultipleSelection;
-            mEditorPhotoPicker.showOverlay(false);
+            showOverlay(false);
         }
 
         private void showProgressDialog(final boolean show) {
@@ -2586,7 +2609,7 @@ public class EditPostActivity extends AppCompatActivity implements
             runOnUiThread(() -> {
                 if (!isInterrupted()) {
                     savePostAsync(null);
-                    mEditorPhotoPicker.hideOverlay();
+                    hideOverlay();
                     if (mDidAnyFail) {
                         ToastUtils.showToast(EditPostActivity.this, R.string.gallery_error,
                                              Duration.SHORT);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -186,7 +186,6 @@ public class EditPostActivity extends AppCompatActivity implements
         EditorImageSettingsListener,
         EditorDragAndDropListener,
         EditorFragmentListener,
-        MediaToolbarAction.MediaToolbarButtonClickListener,
         OnRequestPermissionsResultCallback,
         PhotoPickerFragment.PhotoPickerListener,
         EditPostSettingsFragment.EditPostActivityHook,
@@ -896,11 +895,6 @@ public class EditPostActivity extends AppCompatActivity implements
         addMediaList(uriList, false);
     }
 
-    @Override
-    public void onMediaToolbarButtonClicked(MediaToolbarAction action) {
-        mEditorPhotoPicker.onMediaToolbarButtonClicked(action);
-    }
-
     /*
      * called by PhotoPickerFragment when user clicks an icon to launch the camera, native
      * picker, or WP media picker
@@ -1556,7 +1550,7 @@ public class EditPostActivity extends AppCompatActivity implements
         if (mEditorFragment instanceof AztecEditorFragment) {
             AztecEditorFragment aztecEditorFragment = (AztecEditorFragment) mEditorFragment;
             aztecEditorFragment.setEditorImageSettingsListener(EditPostActivity.this);
-            aztecEditorFragment.setMediaToolbarButtonClickListener(EditPostActivity.this);
+            aztecEditorFragment.setMediaToolbarButtonClickListener(mEditorPhotoPicker);
 
             // Here we should set the max width for media, but the default size is already OK. No need
             // to customize it further

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -115,6 +115,7 @@ import org.wordpress.android.ui.posts.InsertMediaDialog.InsertMediaCallback;
 import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Editor;
 import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Outcome;
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.PreviewLogicOperationResult;
+import org.wordpress.android.ui.posts.editor.EditorPhotoPicker;
 import org.wordpress.android.ui.posts.editor.PostLoadingState;
 import org.wordpress.android.ui.posts.editor.PrimaryEditorAction;
 import org.wordpress.android.ui.posts.editor.SecondaryEditorAction;
@@ -127,15 +128,12 @@ import org.wordpress.android.ui.uploads.UploadService;
 import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.ui.uploads.VideoOptimizer;
 import org.wordpress.android.ui.utils.UiHelpers;
-import org.wordpress.android.ui.utils.UiString.UiStringRes;
 import org.wordpress.android.util.ActivityUtils;
-import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.AutolinkUtils;
 import org.wordpress.android.util.CrashLoggingUtils;
 import org.wordpress.android.util.DateTimeUtils;
-import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.ListUtils;
@@ -288,6 +286,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private EditorFragmentAbstract mEditorFragment;
     private EditPostSettingsFragment mEditPostSettingsFragment;
     private EditorMediaUploadListener mEditorMediaUploadListener;
+    private EditorPhotoPicker mEditorPhotoPicker = new EditorPhotoPicker<>(this);
 
     private ProgressDialog mProgressDialog;
 
@@ -295,10 +294,6 @@ public class EditPostActivity extends AppCompatActivity implements
     private boolean mIsPage;
     private boolean mHasSetPostContent;
     private PostLoadingState mPostLoadingState = PostLoadingState.NONE;
-
-    private View mPhotoPickerContainer;
-    private PhotoPickerFragment mPhotoPickerFragment;
-    private int mPhotoPickerOrientation = Configuration.ORIENTATION_UNDEFINED;
 
     // For opening the context menu after permissions have been granted
     private View mMenuView = null;
@@ -554,13 +549,13 @@ public class EditPostActivity extends AppCompatActivity implements
                     setTitle(SiteUtils.getSiteNameOrHomeURL(mSite));
                 } else if (position == PAGE_SETTINGS) {
                     setTitle(mPost.isPage() ? R.string.page_settings : R.string.post_settings);
-                    hidePhotoPicker();
+                    mEditorPhotoPicker.hidePhotoPicker(mEditorFragment);
                 } else if (position == PAGE_PUBLISH_SETTINGS) {
                     setTitle(R.string.publish_date);
-                    hidePhotoPicker();
+                    mEditorPhotoPicker.hidePhotoPicker(mEditorFragment);
                 } else if (position == PAGE_HISTORY) {
                     setTitle(R.string.history_title);
-                    hidePhotoPicker();
+                    mEditorPhotoPicker.hidePhotoPicker(mEditorFragment);
                 }
             }
         });
@@ -791,7 +786,7 @@ public class EditPostActivity extends AppCompatActivity implements
         }
         outState.putInt(STATE_KEY_POST_LOADING_STATE, mPostLoadingState.getValue());
         outState.putBoolean(STATE_KEY_IS_NEW_POST, mIsNewPost);
-        outState.putBoolean(STATE_KEY_IS_PHOTO_PICKER_VISIBLE, isPhotoPickerShowing());
+        outState.putBoolean(STATE_KEY_IS_PHOTO_PICKER_VISIBLE, mEditorPhotoPicker.isPhotoPickerShowing());
         outState.putBoolean(STATE_KEY_HTML_MODE_ON, mHtmlModeMenuStateOn);
         outState.putSerializable(WordPress.SITE, mSite);
         outState.putParcelable(STATE_KEY_REVISION, mRevision);
@@ -814,7 +809,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
         mHtmlModeMenuStateOn = savedInstanceState.getBoolean(STATE_KEY_HTML_MODE_ON);
         if (savedInstanceState.getBoolean(STATE_KEY_IS_PHOTO_PICKER_VISIBLE, false)) {
-            showPhotoPicker();
+            mEditorPhotoPicker.showPhotoPicker(mSite, mShowAztecEditor, mEditorFragment);
         }
     }
 
@@ -822,11 +817,7 @@ public class EditPostActivity extends AppCompatActivity implements
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
 
-        // resize the photo picker if the user rotated the device
-        int orientation = newConfig.orientation;
-        if (orientation != mPhotoPickerOrientation) {
-            resizePhotoPicker();
-        }
+        mEditorPhotoPicker.onOrientationChanged(newConfig.orientation);
     }
 
     private PrimaryEditorAction getPrimaryAction() {
@@ -844,115 +835,6 @@ public class EditPostActivity extends AppCompatActivity implements
     private @Nullable String getSecondaryActionText() {
         @StringRes Integer titleResource = getSecondaryAction().getTitleResource();
         return titleResource != null ? getString(titleResource) : null;
-    }
-
-    private boolean isPhotoPickerShowing() {
-        return mPhotoPickerContainer != null
-               && mPhotoPickerContainer.getVisibility() == View.VISIBLE;
-    }
-
-    /*
-     * resizes the photo picker based on device orientation - full height in landscape, half
-     * height in portrait
-     */
-    private void resizePhotoPicker() {
-        if (mPhotoPickerContainer == null) {
-            return;
-        }
-
-        if (DisplayUtils.isLandscape(this)) {
-            mPhotoPickerOrientation = Configuration.ORIENTATION_LANDSCAPE;
-            mPhotoPickerContainer.getLayoutParams().height = ViewGroup.LayoutParams.MATCH_PARENT;
-        } else {
-            mPhotoPickerOrientation = Configuration.ORIENTATION_PORTRAIT;
-            int displayHeight = DisplayUtils.getDisplayPixelHeight(this);
-            mPhotoPickerContainer.getLayoutParams().height = (int) (displayHeight * 0.5f);
-        }
-
-        if (mPhotoPickerFragment != null) {
-            mPhotoPickerFragment.reload();
-        }
-    }
-
-    /*
-     * loads the photo picker fragment, which is hidden until the user taps the media icon
-     */
-    private void initPhotoPicker() {
-        mPhotoPickerContainer = findViewById(R.id.photo_fragment_container);
-
-        // size the picker before creating the fragment to avoid having it load media now
-        resizePhotoPicker();
-
-        mPhotoPickerFragment = (PhotoPickerFragment) getSupportFragmentManager().findFragmentByTag(PHOTO_PICKER_TAG);
-        if (mPhotoPickerFragment == null) {
-            MediaBrowserType mediaBrowserType =
-                    mShowAztecEditor ? MediaBrowserType.AZTEC_EDITOR_PICKER : MediaBrowserType.EDITOR_PICKER;
-            mPhotoPickerFragment = PhotoPickerFragment.newInstance(this, mediaBrowserType, getSite());
-            getSupportFragmentManager()
-                    .beginTransaction()
-                    .add(R.id.photo_fragment_container, mPhotoPickerFragment, PHOTO_PICKER_TAG)
-                    .commit();
-        }
-    }
-
-    /*
-     * shows/hides the overlay which appears atop the editor, which effectively disables it
-     */
-    private void showOverlay(boolean animate) {
-        View overlay = findViewById(R.id.view_overlay);
-        if (animate) {
-            AniUtils.fadeIn(overlay, AniUtils.Duration.MEDIUM);
-        } else {
-            overlay.setVisibility(View.VISIBLE);
-        }
-    }
-
-    private void hideOverlay() {
-        View overlay = findViewById(R.id.view_overlay);
-        overlay.setVisibility(View.GONE);
-    }
-
-    /*
-     * user has requested to show the photo picker
-     */
-    private void showPhotoPicker() {
-        boolean isAlreadyShowing = isPhotoPickerShowing();
-
-        // make sure we initialized the photo picker
-        if (mPhotoPickerFragment == null) {
-            initPhotoPicker();
-        }
-
-        // hide soft keyboard
-        ActivityUtils.hideKeyboard(this);
-
-        // slide in the photo picker
-        if (!isAlreadyShowing) {
-            AniUtils.animateBottomBar(mPhotoPickerContainer, true, AniUtils.Duration.MEDIUM);
-            mPhotoPickerFragment.refresh();
-            mPhotoPickerFragment.setPhotoPickerListener(this);
-        }
-
-        // animate in the editor overlay
-        showOverlay(true);
-
-        if (mEditorFragment instanceof AztecEditorFragment) {
-            ((AztecEditorFragment) mEditorFragment).enableMediaMode(true);
-        }
-    }
-
-    private void hidePhotoPicker() {
-        if (isPhotoPickerShowing()) {
-            mPhotoPickerFragment.finishActionMode();
-            mPhotoPickerFragment.setPhotoPickerListener(null);
-            AniUtils.animateBottomBar(mPhotoPickerContainer, false);
-        }
-
-        hideOverlay();
-
-        if (mEditorFragment instanceof AztecEditorFragment) {
-            ((AztecEditorFragment) mEditorFragment).enableMediaMode(false);
-        }
     }
 
     private boolean shouldSwitchToGutenbergBeVisible(
@@ -994,7 +876,7 @@ public class EditPostActivity extends AppCompatActivity implements
      */
     @Override
     public void onPhotoPickerMediaChosen(@NonNull final List<Uri> uriList) {
-        hidePhotoPicker();
+        mEditorPhotoPicker.hidePhotoPicker(mEditorFragment);
 
         if (WPMediaUtils.shouldAdvertiseImageOptimization(this)) {
             boolean hasSelectedPicture = false;
@@ -1015,21 +897,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onMediaToolbarButtonClicked(MediaToolbarAction action) {
-        if (!isPhotoPickerShowing()) {
-            return;
-        }
-
-        switch (action) {
-            case CAMERA:
-                mPhotoPickerFragment.showCameraPopupMenu(findViewById(action.getButtonId()));
-                break;
-            case GALLERY:
-                mPhotoPickerFragment.showPickerPopupMenu(findViewById(action.getButtonId()));
-                break;
-            case LIBRARY:
-                mPhotoPickerFragment.doIconClicked(PhotoPickerIcon.WP_MEDIA);
-                break;
-        }
+        mEditorPhotoPicker.onMediaToolbarButtonClicked(action);
     }
 
     /*
@@ -1038,7 +906,7 @@ public class EditPostActivity extends AppCompatActivity implements
      */
     @Override
     public void onPhotoPickerIconClicked(@NonNull PhotoPickerIcon icon, boolean allowMultipleSelection) {
-        hidePhotoPicker();
+        mEditorPhotoPicker.hidePhotoPicker(mEditorFragment);
         mAllowMultipleSelection = allowMultipleSelection;
         switch (icon) {
             case ANDROID_CAPTURE_PHOTO:
@@ -1191,8 +1059,8 @@ public class EditPostActivity extends AppCompatActivity implements
 
             mViewPager.setCurrentItem(PAGE_CONTENT);
             invalidateOptionsMenu();
-        } else if (isPhotoPickerShowing()) {
-            hidePhotoPicker();
+        } else if (mEditorPhotoPicker.isPhotoPickerShowing()) {
+            mEditorPhotoPicker.hidePhotoPicker(mEditorFragment);
         } else {
             mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
             savePostAndOptionallyFinish(true);
@@ -1256,7 +1124,7 @@ public class EditPostActivity extends AppCompatActivity implements
             return handleBackPressed();
         }
 
-        hidePhotoPicker();
+        mEditorPhotoPicker.hidePhotoPicker(mEditorFragment);
 
         if (itemId == R.id.menu_primary_action) {
             performPrimaryAction();
@@ -2652,14 +2520,14 @@ public class EditPostActivity extends AppCompatActivity implements
         AddMediaListThread(@NonNull List<Uri> uriList, boolean isNew) {
             this.mUriList.addAll(uriList);
             this.mIsNew = isNew;
-            showOverlay(false);
+            mEditorPhotoPicker.showOverlay(false);
         }
 
         AddMediaListThread(@NonNull List<Uri> uriList, boolean isNew, boolean allowMultipleSelection) {
             this.mUriList.addAll(uriList);
             this.mIsNew = isNew;
             this.mAllowMultipleSelection = allowMultipleSelection;
-            showOverlay(false);
+            mEditorPhotoPicker.showOverlay(false);
         }
 
         private void showProgressDialog(final boolean show) {
@@ -2708,7 +2576,7 @@ public class EditPostActivity extends AppCompatActivity implements
             runOnUiThread(() -> {
                 if (!isInterrupted()) {
                     savePostAsync(null);
-                    hideOverlay();
+                    mEditorPhotoPicker.hideOverlay();
                     if (mDidAnyFail) {
                         ToastUtils.showToast(EditPostActivity.this, R.string.gallery_error,
                                              Duration.SHORT);
@@ -3226,10 +3094,10 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onAddMediaClicked() {
-        if (isPhotoPickerShowing()) {
-            hidePhotoPicker();
+        if (mEditorPhotoPicker.isPhotoPickerShowing()) {
+            mEditorPhotoPicker.hidePhotoPicker(mEditorFragment);
          } else if (WPMediaUtils.currentUserCanUploadMedia(mSite)) {
-            showPhotoPicker();
+            mEditorPhotoPicker.showPhotoPicker(mSite, mShowAztecEditor, mEditorFragment);
         } else {
             // show the WP media library instead of the photo picker if the user doesn't have upload permission
             ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.EDITOR_PICKER);
@@ -3630,7 +3498,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 break;
             case HTML_BUTTON_TAPPED:
                 currentStat = Stat.EDITOR_TAPPED_HTML;
-                hidePhotoPicker();
+                mEditorPhotoPicker.hidePhotoPicker(mEditorFragment);
                 break;
             case IMAGE_EDITED:
                 currentStat = Stat.EDITOR_EDITED_IMAGE;
@@ -3640,7 +3508,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 break;
             case LINK_ADDED_BUTTON_TAPPED:
                 currentStat = Stat.EDITOR_TAPPED_LINK_ADDED;
-                hidePhotoPicker();
+                mEditorPhotoPicker.hidePhotoPicker(mEditorFragment);
                 break;
             case LINK_REMOVED_BUTTON_TAPPED:
                 currentStat = Stat.EDITOR_TAPPED_LINK_REMOVED;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
@@ -24,29 +24,31 @@ class EditorPhotoPicker<T>(
     private val activity: T,
     private val showAztecEditor: Boolean
 ) where T : AppCompatActivity, T : PhotoPickerListener {
-    private var mPhotoPickerContainer: View? = null
-    private var mPhotoPickerFragment: PhotoPickerFragment? = null
-    private var mPhotoPickerOrientation = Configuration.ORIENTATION_UNDEFINED
+    private var photoPickerContainer: View? = null
+    private var photoPickerFragment: PhotoPickerFragment? = null
+    private var photoPickerOrientation = Configuration.ORIENTATION_UNDEFINED
 
     /*
      * loads the photo picker fragment, which is hidden until the user taps the media icon
      */
     private fun initPhotoPicker(site: SiteModel) {
-        mPhotoPickerContainer = activity.findViewById(R.id.photo_fragment_container)
+        photoPickerContainer = activity.findViewById(R.id.photo_fragment_container)
 
         // size the picker before creating the fragment to avoid having it load media now
         resizePhotoPicker()
 
-        mPhotoPickerFragment = activity.supportFragmentManager.findFragmentByTag(PHOTO_PICKER_TAG) as PhotoPickerFragment
-        if (mPhotoPickerFragment == null) {
-            val mediaBrowserType = if (showAztecEditor) MediaBrowserType.AZTEC_EDITOR_PICKER else MediaBrowserType.EDITOR_PICKER
-            mPhotoPickerFragment = PhotoPickerFragment.newInstance(
+        photoPickerFragment = activity.supportFragmentManager.findFragmentByTag(PHOTO_PICKER_TAG) as PhotoPickerFragment
+        if (photoPickerFragment == null) {
+            val mediaBrowserType = if (showAztecEditor) {
+                MediaBrowserType.AZTEC_EDITOR_PICKER
+            } else MediaBrowserType.EDITOR_PICKER
+            photoPickerFragment = PhotoPickerFragment.newInstance(
                     activity,
                     mediaBrowserType,
                     site
             )
         }
-        mPhotoPickerFragment?.let { photoPickerFragment ->
+        photoPickerFragment?.let { photoPickerFragment ->
             activity.supportFragmentManager
                     .beginTransaction()
                     .add(R.id.photo_fragment_container, photoPickerFragment, PHOTO_PICKER_TAG)
@@ -55,17 +57,17 @@ class EditorPhotoPicker<T>(
     }
 
     fun isPhotoPickerShowing(): Boolean {
-        return mPhotoPickerContainer != null && mPhotoPickerContainer?.visibility == View.VISIBLE
+        return photoPickerContainer != null && photoPickerContainer?.visibility == View.VISIBLE
     }
 
     /*
      * user has requested to show the photo picker
      */
-    fun showPhotoPicker(site: SiteModel, mEditorFragment: Any) {
+    fun showPhotoPicker(site: SiteModel, editorFragment: Any) {
         val isAlreadyShowing = isPhotoPickerShowing()
 
         // make sure we initialized the photo picker
-        if (mPhotoPickerFragment == null) {
+        if (photoPickerFragment == null) {
             initPhotoPicker(site)
         }
 
@@ -74,27 +76,27 @@ class EditorPhotoPicker<T>(
 
         // slide in the photo picker
         if (!isAlreadyShowing) {
-            AniUtils.animateBottomBar(mPhotoPickerContainer, true, AniUtils.Duration.MEDIUM)
-            mPhotoPickerFragment?.refresh()
-            mPhotoPickerFragment?.setPhotoPickerListener(activity)
+            AniUtils.animateBottomBar(photoPickerContainer, true, AniUtils.Duration.MEDIUM)
+            photoPickerFragment?.refresh()
+            photoPickerFragment?.setPhotoPickerListener(activity)
         }
 
         // animate in the editor overlay
         showOverlay(true)
 
-        (mEditorFragment as? AztecEditorFragment)?.enableMediaMode(true)
+        (editorFragment as? AztecEditorFragment)?.enableMediaMode(true)
     }
 
-    fun hidePhotoPicker(mEditorFragment: Any) {
+    fun hidePhotoPicker(editorFragment: Any) {
         if (isPhotoPickerShowing()) {
-            mPhotoPickerFragment?.finishActionMode()
-            mPhotoPickerFragment?.setPhotoPickerListener(null)
-            AniUtils.animateBottomBar(mPhotoPickerContainer, false)
+            photoPickerFragment?.finishActionMode()
+            photoPickerFragment?.setPhotoPickerListener(null)
+            AniUtils.animateBottomBar(photoPickerContainer, false)
         }
 
         hideOverlay()
 
-        (mEditorFragment as? AztecEditorFragment)?.enableMediaMode(false)
+        (editorFragment as? AztecEditorFragment)?.enableMediaMode(false)
     }
 
     /*
@@ -102,26 +104,26 @@ class EditorPhotoPicker<T>(
      * height in portrait
      */
     private fun resizePhotoPicker() {
-        if (mPhotoPickerContainer == null) {
+        if (photoPickerContainer == null) {
             return
         }
 
         val updatePickerContainerHeight = { newHeight: Int ->
-            mPhotoPickerContainer?.let {
+            photoPickerContainer?.let {
                 it.layoutParams.height = newHeight
             }
         }
 
         if (DisplayUtils.isLandscape(activity)) {
-            mPhotoPickerOrientation = Configuration.ORIENTATION_LANDSCAPE
+            photoPickerOrientation = Configuration.ORIENTATION_LANDSCAPE
             updatePickerContainerHeight(ViewGroup.LayoutParams.MATCH_PARENT)
         } else {
-            mPhotoPickerOrientation = Configuration.ORIENTATION_PORTRAIT
+            photoPickerOrientation = Configuration.ORIENTATION_PORTRAIT
             val displayHeight = DisplayUtils.getDisplayPixelHeight(activity)
             updatePickerContainerHeight((displayHeight * 0.5f).toInt())
         }
 
-        mPhotoPickerFragment?.reload()
+        photoPickerFragment?.reload()
     }
 
     /*
@@ -146,7 +148,7 @@ class EditorPhotoPicker<T>(
             return
         }
 
-        mPhotoPickerFragment?.let { photoPickerFragment ->
+        photoPickerFragment?.let { photoPickerFragment ->
             when (action) {
                 MediaToolbarAction.CAMERA -> photoPickerFragment.showCameraPopupMenu(
                         activity.findViewById(action.buttonId)
@@ -161,7 +163,7 @@ class EditorPhotoPicker<T>(
 
     fun onOrientationChanged(@Orientation newOrientation: Int) {
         // resize the photo picker if the user rotated the device
-        if (newOrientation != mPhotoPickerOrientation) {
+        if (newOrientation != photoPickerOrientation) {
             resizePhotoPicker()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
@@ -23,7 +23,12 @@ interface EditorPhotoPickerListener {
     fun onPhotoPickerHidden()
 }
 
-// TODO: We shouldn't have a reference to the activity
+/**
+ * This class is extracted from EditPostActivity as part of a huge refactor. Although some effort was made to improve
+ * the code, it still contains the full logic from EditPostActivity to make the refactor less error-prone. As such,
+ * it is heavily coupled with the `EditPostActivity` and contains logic and dependencies it shouldn't and in dire need
+ * of further refactoring.
+ */
 class EditorPhotoPicker(
     private val activity: AppCompatActivity,
     private val photoPickerListener: PhotoPickerListener,
@@ -85,7 +90,6 @@ class EditorPhotoPicker(
         if (!isAlreadyShowing) {
             AniUtils.animateBottomBar(photoPickerContainer, true, AniUtils.Duration.MEDIUM)
             photoPickerFragment?.refresh()
-            // TODO: Why do we need this?
             photoPickerFragment?.setPhotoPickerListener(photoPickerListener)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
@@ -89,9 +89,6 @@ class EditorPhotoPicker(
             photoPickerFragment?.setPhotoPickerListener(photoPickerListener)
         }
 
-        // animate in the editor overlay
-        showOverlay(true)
-
         editorPhotoPickerListener.onPhotoPickerShown()
     }
 
@@ -101,9 +98,6 @@ class EditorPhotoPicker(
             photoPickerFragment?.setPhotoPickerListener(null)
             AniUtils.animateBottomBar(photoPickerContainer, false)
         }
-
-        hideOverlay()
-
         editorPhotoPickerListener.onPhotoPickerHidden()
     }
 
@@ -132,23 +126,6 @@ class EditorPhotoPicker(
         }
 
         photoPickerFragment?.reload()
-    }
-
-    /*
-     * shows/hides the overlay which appears atop the editor, which effectively disables it
-     */
-    fun showOverlay(animate: Boolean) {
-        val overlay = activity.findViewById<View>(R.id.view_overlay)
-        if (animate) {
-            AniUtils.fadeIn(overlay, AniUtils.Duration.MEDIUM)
-        } else {
-            overlay.visibility = View.VISIBLE
-        }
-    }
-
-    fun hideOverlay() {
-        val overlay = activity.findViewById<View>(R.id.view_overlay)
-        overlay.visibility = View.GONE
     }
 
     override fun onMediaToolbarButtonClicked(action: MediaToolbarAction?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
@@ -1,0 +1,137 @@
+package org.wordpress.android.ui.posts.editor
+
+import android.content.res.Configuration
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import org.wordpress.android.R
+import org.wordpress.android.editor.AztecEditorFragment
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.media.MediaBrowserType
+import org.wordpress.android.ui.photopicker.PhotoPickerFragment
+import org.wordpress.android.ui.photopicker.PhotoPickerFragment.PhotoPickerListener
+import org.wordpress.android.util.ActivityUtils
+import org.wordpress.android.util.AniUtils
+import org.wordpress.android.util.DisplayUtils
+
+private const val PHOTO_PICKER_TAG = "photo_picker"
+
+// TODO: We shouldn't have a reference to the activity
+class EditorPhotoPicker<T>(private val activity: T) where T : AppCompatActivity, T: PhotoPickerListener {
+    private var mPhotoPickerContainer: View? = null
+    private var mPhotoPickerFragment: PhotoPickerFragment? = null
+    private var mPhotoPickerOrientation = Configuration.ORIENTATION_UNDEFINED
+
+    private fun isPhotoPickerShowing(): Boolean {
+        return mPhotoPickerContainer != null && mPhotoPickerContainer?.visibility == View.VISIBLE
+    }
+
+    /*
+     * resizes the photo picker based on device orientation - full height in landscape, half
+     * height in portrait
+     */
+    private fun resizePhotoPicker() {
+        if (mPhotoPickerContainer == null) {
+            return
+        }
+
+        val updatePickerContainerHeight = { newHeight: Int ->
+            mPhotoPickerContainer?.let {
+                it.layoutParams.height = newHeight
+            }
+        }
+
+        if (DisplayUtils.isLandscape(activity)) {
+            mPhotoPickerOrientation = Configuration.ORIENTATION_LANDSCAPE
+            updatePickerContainerHeight(ViewGroup.LayoutParams.MATCH_PARENT)
+        } else {
+            mPhotoPickerOrientation = Configuration.ORIENTATION_PORTRAIT
+            val displayHeight = DisplayUtils.getDisplayPixelHeight(activity)
+            updatePickerContainerHeight((displayHeight * 0.5f).toInt())
+        }
+
+        mPhotoPickerFragment?.reload()
+    }
+
+    /*
+     * loads the photo picker fragment, which is hidden until the user taps the media icon
+     */
+    private fun initPhotoPicker(site: SiteModel, showAztecEditor: Boolean) {
+        mPhotoPickerContainer = activity.findViewById(R.id.photo_fragment_container)
+
+        // size the picker before creating the fragment to avoid having it load media now
+        resizePhotoPicker()
+
+        mPhotoPickerFragment = activity.supportFragmentManager.findFragmentByTag(PHOTO_PICKER_TAG) as PhotoPickerFragment
+        if (mPhotoPickerFragment == null) {
+            val mediaBrowserType = if (showAztecEditor) MediaBrowserType.AZTEC_EDITOR_PICKER else MediaBrowserType.EDITOR_PICKER
+            mPhotoPickerFragment = PhotoPickerFragment.newInstance(
+                    activity,
+                    mediaBrowserType,
+                    site
+            )
+        }
+        mPhotoPickerFragment?.let { photoPickerFragment ->
+            activity.supportFragmentManager
+                    .beginTransaction()
+                    .add(R.id.photo_fragment_container, photoPickerFragment, PHOTO_PICKER_TAG)
+                    .commit()
+        }
+    }
+
+    /*
+     * shows/hides the overlay which appears atop the editor, which effectively disables it
+     */
+    private fun showOverlay(animate: Boolean) {
+        val overlay = activity.findViewById<View>(R.id.view_overlay)
+        if (animate) {
+            AniUtils.fadeIn(overlay, AniUtils.Duration.MEDIUM)
+        } else {
+            overlay.visibility = View.VISIBLE
+        }
+    }
+
+    private fun hideOverlay() {
+        val overlay = activity.findViewById<View>(R.id.view_overlay)
+        overlay.visibility = View.GONE
+    }
+
+    /*
+     * user has requested to show the photo picker
+     */
+    private fun showPhotoPicker(site: SiteModel, showAztecEditor: Boolean, mEditorFragment: Any) {
+        val isAlreadyShowing = isPhotoPickerShowing()
+
+        // make sure we initialized the photo picker
+        if (mPhotoPickerFragment == null) {
+            initPhotoPicker(site, showAztecEditor)
+        }
+
+        // hide soft keyboard
+        ActivityUtils.hideKeyboard(activity)
+
+        // slide in the photo picker
+        if (!isAlreadyShowing) {
+            AniUtils.animateBottomBar(mPhotoPickerContainer, true, AniUtils.Duration.MEDIUM)
+            mPhotoPickerFragment?.refresh()
+            mPhotoPickerFragment?.setPhotoPickerListener(activity)
+        }
+
+        // animate in the editor overlay
+        showOverlay(true)
+
+        (mEditorFragment as? AztecEditorFragment)?.enableMediaMode(true)
+    }
+
+    fun hidePhotoPicker(mEditorFragment: Any) {
+        if (isPhotoPickerShowing()) {
+            mPhotoPickerFragment?.finishActionMode()
+            mPhotoPickerFragment?.setPhotoPickerListener(null)
+            AniUtils.animateBottomBar(mPhotoPickerContainer, false)
+        }
+
+        hideOverlay()
+
+        (mEditorFragment as? AztecEditorFragment)?.enableMediaMode(false)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
@@ -6,7 +6,6 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView.Orientation
 import org.wordpress.android.R
-import org.wordpress.android.editor.AztecEditorFragment
 import org.wordpress.android.editor.MediaToolbarAction
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.media.MediaBrowserType
@@ -19,9 +18,15 @@ import org.wordpress.android.util.DisplayUtils
 
 private const val PHOTO_PICKER_TAG = "photo_picker"
 
+interface EditorPhotoPickerListener {
+    fun onPhotoPickerShown()
+    fun onPhotoPickerHidden()
+}
+
 // TODO: We shouldn't have a reference to the activity
 class EditorPhotoPicker<T>(
     private val activity: T,
+    private val editorPhotoPickerListener: EditorPhotoPickerListener,
     private val showAztecEditor: Boolean
 ) : MediaToolbarAction.MediaToolbarButtonClickListener where T : AppCompatActivity, T : PhotoPickerListener {
     private var photoPickerContainer: View? = null
@@ -37,7 +42,8 @@ class EditorPhotoPicker<T>(
         // size the picker before creating the fragment to avoid having it load media now
         resizePhotoPicker()
 
-        photoPickerFragment = activity.supportFragmentManager.findFragmentByTag(PHOTO_PICKER_TAG) as PhotoPickerFragment
+        photoPickerFragment = activity.supportFragmentManager.findFragmentByTag(PHOTO_PICKER_TAG)
+                as? PhotoPickerFragment
         if (photoPickerFragment == null) {
             val mediaBrowserType = if (showAztecEditor) {
                 MediaBrowserType.AZTEC_EDITOR_PICKER
@@ -63,7 +69,7 @@ class EditorPhotoPicker<T>(
     /*
      * user has requested to show the photo picker
      */
-    fun showPhotoPicker(site: SiteModel, editorFragment: Any) {
+    fun showPhotoPicker(site: SiteModel) {
         val isAlreadyShowing = isPhotoPickerShowing()
 
         // make sure we initialized the photo picker
@@ -84,10 +90,10 @@ class EditorPhotoPicker<T>(
         // animate in the editor overlay
         showOverlay(true)
 
-        (editorFragment as? AztecEditorFragment)?.enableMediaMode(true)
+        editorPhotoPickerListener.onPhotoPickerShown()
     }
 
-    fun hidePhotoPicker(editorFragment: Any) {
+    fun hidePhotoPicker() {
         if (isPhotoPickerShowing()) {
             photoPickerFragment?.finishActionMode()
             photoPickerFragment?.setPhotoPickerListener(null)
@@ -96,7 +102,7 @@ class EditorPhotoPicker<T>(
 
         hideOverlay()
 
-        (editorFragment as? AztecEditorFragment)?.enableMediaMode(false)
+        editorPhotoPickerListener.onPhotoPickerHidden()
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
@@ -20,7 +20,10 @@ import org.wordpress.android.util.DisplayUtils
 private const val PHOTO_PICKER_TAG = "photo_picker"
 
 // TODO: We shouldn't have a reference to the activity
-class EditorPhotoPicker<T>(private val activity: T) where T : AppCompatActivity, T: PhotoPickerListener {
+class EditorPhotoPicker<T>(
+    private val activity: T,
+    private val showAztecEditor: Boolean
+) where T : AppCompatActivity, T : PhotoPickerListener {
     private var mPhotoPickerContainer: View? = null
     private var mPhotoPickerFragment: PhotoPickerFragment? = null
     private var mPhotoPickerOrientation = Configuration.ORIENTATION_UNDEFINED
@@ -28,7 +31,7 @@ class EditorPhotoPicker<T>(private val activity: T) where T : AppCompatActivity,
     /*
      * loads the photo picker fragment, which is hidden until the user taps the media icon
      */
-    private fun initPhotoPicker(site: SiteModel, showAztecEditor: Boolean) {
+    private fun initPhotoPicker(site: SiteModel) {
         mPhotoPickerContainer = activity.findViewById(R.id.photo_fragment_container)
 
         // size the picker before creating the fragment to avoid having it load media now
@@ -58,12 +61,12 @@ class EditorPhotoPicker<T>(private val activity: T) where T : AppCompatActivity,
     /*
      * user has requested to show the photo picker
      */
-    fun showPhotoPicker(site: SiteModel, showAztecEditor: Boolean, mEditorFragment: Any) {
+    fun showPhotoPicker(site: SiteModel, mEditorFragment: Any) {
         val isAlreadyShowing = isPhotoPickerShowing()
 
         // make sure we initialized the photo picker
         if (mPhotoPickerFragment == null) {
-            initPhotoPicker(site, showAztecEditor)
+            initPhotoPicker(site)
         }
 
         // hide soft keyboard

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
@@ -54,17 +54,18 @@ class EditorPhotoPicker(
             val mediaBrowserType = if (showAztecEditor) {
                 MediaBrowserType.AZTEC_EDITOR_PICKER
             } else MediaBrowserType.EDITOR_PICKER
-            photoPickerFragment = PhotoPickerFragment.newInstance(
+
+            PhotoPickerFragment.newInstance(
                     photoPickerListener,
                     mediaBrowserType,
                     site
-            )
-        }
-        photoPickerFragment?.let { photoPickerFragment ->
-            activity.supportFragmentManager
-                    .beginTransaction()
-                    .add(R.id.photo_fragment_container, photoPickerFragment, PHOTO_PICKER_TAG)
-                    .commit()
+            ).let {
+                photoPickerFragment = it
+                activity.supportFragmentManager
+                        .beginTransaction()
+                        .add(R.id.photo_fragment_container, it, PHOTO_PICKER_TAG)
+                        .commit()
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
@@ -23,7 +23,7 @@ private const val PHOTO_PICKER_TAG = "photo_picker"
 class EditorPhotoPicker<T>(
     private val activity: T,
     private val showAztecEditor: Boolean
-) where T : AppCompatActivity, T : PhotoPickerListener {
+) : MediaToolbarAction.MediaToolbarButtonClickListener where T : AppCompatActivity, T : PhotoPickerListener {
     private var photoPickerContainer: View? = null
     private var photoPickerFragment: PhotoPickerFragment? = null
     private var photoPickerOrientation = Configuration.ORIENTATION_UNDEFINED
@@ -143,7 +143,7 @@ class EditorPhotoPicker<T>(
         overlay.visibility = View.GONE
     }
 
-    fun onMediaToolbarButtonClicked(action: MediaToolbarAction?) {
+    override fun onMediaToolbarButtonClicked(action: MediaToolbarAction?) {
         if (action == null || !isPhotoPickerShowing()) {
             return
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
@@ -24,11 +24,12 @@ interface EditorPhotoPickerListener {
 }
 
 // TODO: We shouldn't have a reference to the activity
-class EditorPhotoPicker<T>(
-    private val activity: T,
+class EditorPhotoPicker(
+    private val activity: AppCompatActivity,
+    private val photoPickerListener: PhotoPickerListener,
     private val editorPhotoPickerListener: EditorPhotoPickerListener,
     private val showAztecEditor: Boolean
-) : MediaToolbarAction.MediaToolbarButtonClickListener where T : AppCompatActivity, T : PhotoPickerListener {
+) : MediaToolbarAction.MediaToolbarButtonClickListener {
     private var photoPickerContainer: View? = null
     private var photoPickerFragment: PhotoPickerFragment? = null
     private var photoPickerOrientation = Configuration.ORIENTATION_UNDEFINED
@@ -49,7 +50,7 @@ class EditorPhotoPicker<T>(
                 MediaBrowserType.AZTEC_EDITOR_PICKER
             } else MediaBrowserType.EDITOR_PICKER
             photoPickerFragment = PhotoPickerFragment.newInstance(
-                    activity,
+                    photoPickerListener,
                     mediaBrowserType,
                     site
             )
@@ -84,7 +85,8 @@ class EditorPhotoPicker<T>(
         if (!isAlreadyShowing) {
             AniUtils.animateBottomBar(photoPickerContainer, true, AniUtils.Duration.MEDIUM)
             photoPickerFragment?.refresh()
-            photoPickerFragment?.setPhotoPickerListener(activity)
+            // TODO: Why do we need this?
+            photoPickerFragment?.setPhotoPickerListener(photoPickerListener)
         }
 
         // animate in the editor overlay

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/PostLoadingState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/PostLoadingState.kt
@@ -1,0 +1,56 @@
+package org.wordpress.android.ui.posts.editor
+
+import org.wordpress.android.R.string
+import org.wordpress.android.ui.posts.ProgressDialogUiState
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+
+enum class PostLoadingState(
+    val value: Int,
+    val progressDialogUiState: ProgressDialogUiState
+) {
+    NONE(
+            value = 0,
+            progressDialogUiState = ProgressDialogUiState.HiddenProgressDialog
+    ),
+    LOADING_REVISION(
+            value = 3,
+            progressDialogUiState = ProgressDialogUiState.VisibleProgressDialog(
+                    UiStringRes(string.history_loading_revision),
+                    cancelable = false,
+                    indeterminate = true
+            )
+    ),
+    UPLOADING_FOR_PREVIEW(
+            value = 4,
+            progressDialogUiState = ProgressDialogUiState.VisibleProgressDialog(
+                    UiStringRes(string.post_preview_saving_draft),
+                    cancelable = false,
+                    indeterminate = true
+            )
+    ),
+    REMOTE_AUTO_SAVING_FOR_PREVIEW(
+            value = 5,
+            progressDialogUiState = ProgressDialogUiState.VisibleProgressDialog(
+                    UiStringRes(string.post_preview_remote_auto_saving_post),
+                    cancelable = false,
+                    indeterminate = true
+            )
+    ),
+    PREVIEWING(
+            value = 6,
+            progressDialogUiState = ProgressDialogUiState.HiddenProgressDialog
+    ),
+    REMOTE_AUTO_SAVE_PREVIEW_ERROR(
+            value = 7,
+            progressDialogUiState = ProgressDialogUiState.HiddenProgressDialog
+    );
+
+    companion object {
+        @JvmStatic
+        fun fromInt(value: Int): PostLoadingState {
+            return requireNotNull(
+                    values().firstOrNull { it.value == value },
+                    { "PostLoadingState wrong value $value" })
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/PostLoadingState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/PostLoadingState.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.ui.posts.editor
 
-import org.wordpress.android.R.string
+import org.wordpress.android.R
 import org.wordpress.android.ui.posts.ProgressDialogUiState
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 
@@ -15,7 +15,7 @@ enum class PostLoadingState(
     LOADING_REVISION(
             value = 3,
             progressDialogUiState = ProgressDialogUiState.VisibleProgressDialog(
-                    UiStringRes(string.history_loading_revision),
+                    UiStringRes(R.string.history_loading_revision),
                     cancelable = false,
                     indeterminate = true
             )
@@ -23,7 +23,7 @@ enum class PostLoadingState(
     UPLOADING_FOR_PREVIEW(
             value = 4,
             progressDialogUiState = ProgressDialogUiState.VisibleProgressDialog(
-                    UiStringRes(string.post_preview_saving_draft),
+                    UiStringRes(R.string.post_preview_saving_draft),
                     cancelable = false,
                     indeterminate = true
             )
@@ -31,7 +31,7 @@ enum class PostLoadingState(
     REMOTE_AUTO_SAVING_FOR_PREVIEW(
             value = 5,
             progressDialogUiState = ProgressDialogUiState.VisibleProgressDialog(
-                    UiStringRes(string.post_preview_remote_auto_saving_post),
+                    UiStringRes(R.string.post_preview_remote_auto_saving_post),
                     cancelable = false,
                     indeterminate = true
             )


### PR DESCRIPTION
This PR extracts photo picker related logic from `EditPostActivity` into a new class `EditorPhotoPicker`. The extraction is almost a one to one conversion where the old implementation is kept the same, sometimes (possibly) to a fault. The goal is moving common logic into new components rather than improving said components, so the review should be done with this in mind. Having said that, some basic improvements are made where it's obvious that the previous logic is untouched.

The first commit where `PostLoadingState` is moved to a different file does NOT belong to this PR. However, before I started working on photo picker, I made that change and forgot to branch off. I can definitely remove that commit, but it's such a straightforward change that I think it'll be easier to review it as part of this PR rather than doing a separate one. Let me know if you disagree @malinajirka.

I suggest reviewing commit by commit instead of as a whole. At least checking out each commit should help with the general review.

**To test:**
* Test the photo picking capabilities in the editor. I've tested adding media from both the editor itself and post settings, but further testing might be necessary, I am just not sure where. @malinajirka If you know what else we should test, could you also let me know so I can do it as well?

**PR submission checklist:**

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

