### PR TITLE
Enable downloads from private sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFileDownloadManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFileDownloadManager.kt
@@ -1,0 +1,57 @@
+package org.wordpress.android.ui.reader
+
+import android.app.DownloadManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Environment
+import org.wordpress.android.ui.utils.AuthenticationUtils
+import org.wordpress.android.ui.utils.DownloadManagerWrapper
+import javax.inject.Inject
+
+class ReaderFileDownloadManager
+@Inject constructor(
+    private val authenticationUtils: AuthenticationUtils,
+    private val downloadManager: DownloadManagerWrapper
+) : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (DownloadManager.ACTION_DOWNLOAD_COMPLETE == intent.action) {
+            val downloadId = intent.getLongExtra(
+                    DownloadManager.EXTRA_DOWNLOAD_ID, 0
+            )
+            openDownloadedAttachment(context, downloadId)
+        }
+    }
+
+    fun downloadFile(fileUrl: String) {
+        val request = downloadManager.buildRequest(fileUrl)
+
+        for (entry in authenticationUtils.getAuthHeaders(fileUrl).entries) {
+            request.addRequestHeader(entry.key, entry.value)
+        }
+
+        val fileName = downloadManager.guessUrl(fileUrl)
+        request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)
+        request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+        request.setMimeType(downloadManager.getMimeType(fileUrl))
+        request.setTitle(fileName)
+        request.allowScanningByMediaScanner()
+
+        downloadManager.enqueue(request)
+    }
+
+    private fun openDownloadedAttachment(context: Context, downloadId: Long) {
+        val query = downloadManager.buildQuery()
+        query.setFilterById(downloadId)
+        val cursor = downloadManager.query(query)
+        if (cursor.moveToFirst()) {
+            val downloadStatus = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_STATUS))
+            val downloadLocalUri = cursor.getString(cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI))
+            val downloadMimeType = cursor.getString(cursor.getColumnIndex(DownloadManager.COLUMN_MEDIA_TYPE))
+            if (downloadStatus == DownloadManager.STATUS_SUCCESSFUL && downloadLocalUri != null) {
+                downloadManager.openDownloadedAttachment(context, downloadLocalUri, downloadMimeType)
+            }
+        }
+        cursor.close()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -3,12 +3,11 @@ package org.wordpress.android.ui.reader;
 import android.app.Activity;
 import android.app.DownloadManager;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.graphics.Rect;
-import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.os.Environment;
 import android.text.Html;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -17,7 +16,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.webkit.URLUtil;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
@@ -76,6 +74,7 @@ import org.wordpress.android.ui.reader.views.ReaderWebView;
 import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderCustomViewListener;
 import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderWebViewPageFinishedListener;
 import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderWebViewUrlClickListener;
+import org.wordpress.android.ui.utils.AuthenticationUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -98,7 +97,6 @@ import java.util.EnumSet;
 
 import javax.inject.Inject;
 
-import static android.content.Context.DOWNLOAD_SERVICE;
 import static org.wordpress.android.fluxc.generated.AccountActionBuilder.newUpdateSubscriptionNotificationPostAction;
 import static org.wordpress.android.util.WPPermissionUtils.READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE;
 import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
@@ -160,6 +158,8 @@ public class ReaderPostDetailFragment extends Fragment
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
     @Inject Dispatcher mDispatcher;
+    @Inject AuthenticationUtils mAuthenticationUtils;
+    @Inject ReaderFileDownloadManager mReaderFileDownloadManager;
 
     public static ReaderPostDetailFragment newInstance(long blogId, long postId) {
         return newInstance(false, blogId, postId, null, 0, false, null, null, false);
@@ -431,6 +431,11 @@ public class ReaderPostDetailFragment extends Fragment
         super.onStart();
         mDispatcher.register(this);
         EventBus.getDefault().register(this);
+        FragmentActivity activity = getActivity();
+        if (activity != null) {
+            activity.registerReceiver(mReaderFileDownloadManager,
+                    new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
+        }
     }
 
     @Override
@@ -438,6 +443,10 @@ public class ReaderPostDetailFragment extends Fragment
         super.onStop();
         mDispatcher.unregister(this);
         EventBus.getDefault().unregister(this);
+        FragmentActivity activity = getActivity();
+        if (activity != null) {
+            activity.unregisterReceiver(mReaderFileDownloadManager);
+        }
     }
 
     /*
@@ -1351,8 +1360,12 @@ public class ReaderPostDetailFragment extends Fragment
             return true;
         }
 
-        OpenUrlType openUrlType = shouldOpenExternal(url) ? OpenUrlType.EXTERNAL : OpenUrlType.INTERNAL;
-        ReaderActivityLauncher.openUrl(getActivity(), url, openUrlType);
+        if (isFile(url)) {
+            onFileDownloadClick(url);
+        } else {
+            OpenUrlType openUrlType = shouldOpenExternal(url) ? OpenUrlType.EXTERNAL : OpenUrlType.INTERNAL;
+            ReaderActivityLauncher.openUrl(getActivity(), url, openUrlType);
+        }
         return true;
     }
 
@@ -1368,12 +1381,17 @@ public class ReaderPostDetailFragment extends Fragment
         // if the mime type starts with "application" open it externally - this will either
         // open it in the associated app or the default browser (which will enable the user
         // to download it)
+        if (isFile(url)) return true;
+
+        // open all other urls using an AuthenticatedWebViewActivity
+        return false;
+    }
+
+    private boolean isFile(String url) {
         String mimeType = UrlUtils.getUrlMimeType(url);
         if (mimeType != null && mimeType.startsWith("application")) {
             return true;
         }
-
-        // open all other urls using an AuthenticatedWebViewActivity
         return false;
     }
 
@@ -1388,7 +1406,7 @@ public class ReaderPostDetailFragment extends Fragment
         if (activity != null
             && fileUrl != null
             && PermissionUtils.checkAndRequestStoragePermission(this, READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE)) {
-            downloadFile(fileUrl, activity);
+            mReaderFileDownloadManager.downloadFile(fileUrl);
             return true;
         } else {
             mFileForDownload = fileUrl;
@@ -1403,21 +1421,11 @@ public class ReaderPostDetailFragment extends Fragment
         if (activity != null
             && requestCode == READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE
             && (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
-            downloadFile(mFileForDownload, activity);
+            mReaderFileDownloadManager.downloadFile(mFileForDownload);
             mFileForDownload = null;
         } else {
             mFileForDownload = null;
         }
-    }
-
-    private void downloadFile(String fileUrl, FragmentActivity activity) {
-        DownloadManager.Request r = new DownloadManager.Request(Uri.parse(fileUrl));
-        String fileName = URLUtil.guessUrl(fileUrl);
-        r.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName);
-        r.allowScanningByMediaScanner();
-        r.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
-        DownloadManager dm = (DownloadManager) activity.getSystemService(DOWNLOAD_SERVICE);
-        dm.enqueue(r);
     }
 
     private ActionBar getActionBar() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/AuthenticationUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/AuthenticationUtils.kt
@@ -6,7 +6,9 @@ import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.util.WPUrlUtils
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class AuthenticationUtils
 @Inject constructor(
     private val accessToken: AccessToken,

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/AuthenticationUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/AuthenticationUtils.kt
@@ -1,0 +1,34 @@
+package org.wordpress.android.ui.utils
+
+import android.util.Base64
+import org.wordpress.android.fluxc.network.HTTPAuthManager
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.util.WPUrlUtils
+import javax.inject.Inject
+
+class AuthenticationUtils
+@Inject constructor(
+    private val accessToken: AccessToken,
+    private val httpAuthManager: HTTPAuthManager,
+    private val userAgent: UserAgent
+) {
+    fun getAuthHeaders(url: String): Map<String, String> {
+        val headers = mutableMapOf<String, String>()
+        headers["User-Agent"] = userAgent.userAgent
+        if (WPUrlUtils.safeToAddWordPressComAuthToken(url)) {
+            if (accessToken.exists()) {
+                headers["Authorization"] = "Bearer " + accessToken.get()
+            }
+        } else {
+            // Check if we had HTTP Auth credentials for the root url
+            val httpAuthModel = httpAuthManager.getHTTPAuthModel(url)
+            if (httpAuthModel != null) {
+                val creds = String.format("%s:%s", httpAuthModel.username, httpAuthModel.password)
+                val auth = "Basic " + Base64.encodeToString(creds.toByteArray(), Base64.NO_WRAP)
+                headers["Authorization"] = auth
+            }
+        }
+        return headers
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/DownloadManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/DownloadManagerWrapper.kt
@@ -60,7 +60,7 @@ class DownloadManagerWrapper
 
         val openAttachmentIntent = Intent(Intent.ACTION_VIEW)
         openAttachmentIntent.setDataAndType(attachmentUri, attachmentMimeType)
-        openAttachmentIntent.flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+        openAttachmentIntent.flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK
         context.startActivity(openAttachmentIntent)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/DownloadManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/DownloadManagerWrapper.kt
@@ -17,7 +17,9 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import java.io.File
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class DownloadManagerWrapper
 @Inject constructor(private val context: Context) {
     fun enqueue(request: Request): Long = downloadManager().enqueue(request)

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/DownloadManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/DownloadManagerWrapper.kt
@@ -1,0 +1,69 @@
+package org.wordpress.android.ui.utils
+
+import android.app.DownloadManager
+import android.app.DownloadManager.Query
+import android.app.DownloadManager.Request
+import android.content.ContentResolver
+import android.content.Context
+import android.content.Intent
+import android.database.Cursor
+import android.net.Uri
+import android.webkit.MimeTypeMap
+import android.webkit.URLUtil
+import androidx.core.content.FileProvider
+import org.wordpress.android.BuildConfig
+import java.io.File
+import javax.inject.Inject
+
+class DownloadManagerWrapper
+@Inject constructor(private val context: Context) {
+    fun enqueue(request: Request): Long = downloadManager().enqueue(request)
+
+    fun buildRequest(fileUrl: String) = Request(Uri.parse(fileUrl))
+
+    fun query(query: Query): Cursor = downloadManager().query(query)
+
+    fun buildQuery() = Query()
+
+    fun guessUrl(fileUrl: String): String = URLUtil.guessUrl(fileUrl)
+
+    fun getMimeType(url: String): String? {
+        var type: String? = null
+        val extension = MimeTypeMap.getFileExtensionFromUrl(url)
+        if (extension != null) {
+            val mime = MimeTypeMap.getSingleton()
+            type = mime.getMimeTypeFromExtension(extension)
+        }
+        return type
+    }
+
+    private fun toPublicUri(fileUrl: String): Uri {
+        val fileUri = Uri.parse(fileUrl)
+        return if (ContentResolver.SCHEME_FILE == fileUri.scheme) {
+            val file = File(fileUri.path)
+            FileProvider.getUriForFile(
+                    context,
+                    "${BuildConfig.APPLICATION_ID}.provider",
+                    file
+            )
+        } else {
+            fileUri
+        }
+    }
+
+    fun openDownloadedAttachment(
+        context: Context,
+        fileUrl: String,
+        attachmentMimeType: String
+    ) {
+        val attachmentUri = toPublicUri(fileUrl)
+
+        val openAttachmentIntent = Intent(Intent.ACTION_VIEW)
+        openAttachmentIntent.setDataAndType(attachmentUri, attachmentMimeType)
+        openAttachmentIntent.flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+        context.startActivity(openAttachmentIntent)
+    }
+
+    private fun downloadManager() =
+            (context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager)
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/DownloadManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/DownloadManagerWrapper.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.utils
 import android.app.DownloadManager
 import android.app.DownloadManager.Query
 import android.app.DownloadManager.Request
+import android.content.ActivityNotFoundException
 import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
@@ -12,6 +13,8 @@ import android.webkit.MimeTypeMap
 import android.webkit.URLUtil
 import androidx.core.content.FileProvider
 import org.wordpress.android.BuildConfig
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
 import java.io.File
 import javax.inject.Inject
 
@@ -61,7 +64,11 @@ class DownloadManagerWrapper
         val openAttachmentIntent = Intent(Intent.ACTION_VIEW)
         openAttachmentIntent.setDataAndType(attachmentUri, attachmentMimeType)
         openAttachmentIntent.flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK
-        context.startActivity(openAttachmentIntent)
+        try {
+            context.startActivity(openAttachmentIntent)
+        } catch (e: ActivityNotFoundException) {
+            AppLog.e(T.READER, "No browser found on the device: ${e.message}")
+        }
     }
 
     private fun downloadManager() =

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderFileDownloadManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderFileDownloadManagerTest.kt
@@ -1,0 +1,88 @@
+package org.wordpress.android.ui.reader
+
+import android.app.DownloadManager
+import android.content.Context
+import android.content.Intent
+import android.database.Cursor
+import android.os.Environment
+import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.ui.utils.AuthenticationUtils
+import org.wordpress.android.ui.utils.DownloadManagerWrapper
+
+@RunWith(MockitoJUnitRunner::class)
+class ReaderFileDownloadManagerTest {
+    @Mock lateinit var authenticationUtils: AuthenticationUtils
+    @Mock lateinit var downloadManager: DownloadManagerWrapper
+    @Mock lateinit var request: DownloadManager.Request
+    @Mock lateinit var query: DownloadManager.Query
+    @Mock lateinit var context: Context
+    @Mock lateinit var intent: Intent
+    @Mock lateinit var cursor: Cursor
+    private lateinit var readerFileDownloadManager: ReaderFileDownloadManager
+    private lateinit var intentCaptor: KArgumentCaptor<Intent>
+    @Before
+    fun setUp() {
+        readerFileDownloadManager = ReaderFileDownloadManager(authenticationUtils, downloadManager)
+        intentCaptor = argumentCaptor()
+    }
+
+    @Test
+    fun `enqueues file for download`() {
+        val url = "http://wordpress.com/file_name.pdf"
+        val header = "Authentication"
+        val headerValue = "token123"
+        val fileName = "file_name.pdf"
+        val mimeType = "application/pdf"
+        whenever(authenticationUtils.getAuthHeaders(url)).thenReturn(mapOf(header to headerValue))
+        whenever(downloadManager.buildRequest(url)).thenReturn(request)
+        whenever(downloadManager.guessUrl(url)).thenReturn(fileName)
+        whenever(downloadManager.getMimeType(url)).thenReturn(mimeType)
+
+        readerFileDownloadManager.downloadFile(url)
+
+        verify(downloadManager).enqueue(request)
+
+        verify(request).addRequestHeader(header, headerValue)
+        verify(request).setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)
+        verify(request).allowScanningByMediaScanner()
+        verify(request).setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+        verify(request).setMimeType(mimeType)
+        verify(request).setTitle(fileName)
+    }
+
+    @Test
+    fun `opens file on download complete`() {
+        val downloadId = 1L
+        whenever(intent.action).thenReturn(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
+        whenever(intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, 0)).thenReturn(downloadId)
+        whenever(downloadManager.buildQuery()).thenReturn(query)
+        whenever(downloadManager.query(any())).thenReturn(cursor)
+        whenever(cursor.moveToFirst()).thenReturn(true)
+        val statusColumnIndex = 1
+        val localUriColumnIndex = 2
+        val mediaTypeColumnIndex = 3
+        whenever(cursor.getColumnIndex(DownloadManager.COLUMN_STATUS)).thenReturn(statusColumnIndex)
+        whenever(cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI)).thenReturn(localUriColumnIndex)
+        whenever(cursor.getColumnIndex(DownloadManager.COLUMN_MEDIA_TYPE)).thenReturn(mediaTypeColumnIndex)
+        whenever(cursor.getInt(statusColumnIndex)).thenReturn(DownloadManager.STATUS_SUCCESSFUL)
+        val localUri = "/sdcard/file_name.pdf"
+        val mediaType = "pdf"
+        whenever(cursor.getString(localUriColumnIndex)).thenReturn(localUri)
+        whenever(cursor.getString(mediaTypeColumnIndex)).thenReturn(mediaType)
+
+        readerFileDownloadManager.onReceive(context, intent)
+
+        verify(downloadManager).query(any())
+        verify(cursor).close()
+        verify(downloadManager).openDownloadedAttachment(context, localUri, mediaType)
+    }
+}


### PR DESCRIPTION
Fixes #8208 

The main step that in this PR is reusing the logic we use in Glide library to load images on private sites. I've extracted this logic in `authenticationUtils.getAuthHeaders(url)`. This function adds authentication headers for private requests for both image loading and file download. As an additional step I've added logic to open the file after it's downloaded (otherwise it can be confusing as nothing happens when you click a file - in Android 10 you don't even get a notification). 

To test:
* On the web, create a post on a private site and add a PDF file to the post (you can use the Media Library for that)
* On the web, like the post so you can easily find it in the mobile Reader
* On the mobile Reader, go to the "My Likes" drop-down option, look for your new post and tap to open it
* While viewing the post in the Reader, tap on the PDF link. 
* The file is saved on opened
* Test the same flow on a public site to check nothing is broken

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

