### PR TITLE
Do not add featured image when it's present in the post text

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -12,6 +12,7 @@ import org.wordpress.android.ui.domains.DomainRegistrationDetailsFragment.Countr
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsFragment.StatePickerDialogFragment;
 import org.wordpress.android.ui.news.LocalNewsService;
 import org.wordpress.android.ui.news.NewsService;
+import org.wordpress.android.ui.reader.ReaderPostWebViewCachingFragment;
 import org.wordpress.android.ui.sitecreation.SiteCreationStep;
 import org.wordpress.android.ui.sitecreation.SiteCreationStepsProvider;
 import org.wordpress.android.ui.stats.refresh.StatsFragment;
@@ -89,6 +90,9 @@ public abstract class ApplicationModule {
 
     @ContributesAndroidInjector
     abstract SettingsUsernameChangerFragment contributeSettingsUsernameChangerFragment();
+
+    @ContributesAndroidInjector
+    abstract ReaderPostWebViewCachingFragment contributeReaderPostWebViewCachingFragment();
 
     @Provides
     public static WizardManager<SiteCreationStep> provideWizardManager(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -63,6 +63,7 @@ import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderPostActions;
 import org.wordpress.android.ui.reader.models.ReaderBlogIdPostId;
 import org.wordpress.android.ui.reader.models.ReaderSimplePostList;
+import org.wordpress.android.ui.reader.utils.FeaturedImageUtils;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils;
 import org.wordpress.android.ui.reader.views.ReaderBookmarkButton;
@@ -160,6 +161,7 @@ public class ReaderPostDetailFragment extends Fragment
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
     @Inject Dispatcher mDispatcher;
+    @Inject FeaturedImageUtils mFeaturedImageUtils;
 
     public static ReaderPostDetailFragment newInstance(long blogId, long postId) {
         return newInstance(false, blogId, postId, null, 0, false, null, null, false);
@@ -1215,7 +1217,7 @@ public class ReaderPostDetailFragment extends Fragment
             mScrollView.setVisibility(View.VISIBLE);
 
             // render the post in the webView
-            mRenderer = new ReaderPostRenderer(mReaderWebView, mPost);
+            mRenderer = new ReaderPostRenderer(mReaderWebView, mPost, mFeaturedImageUtils);
             mRenderer.beginRender();
 
             // if we're showing just the excerpt, also show a footer which links to the full post

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -75,7 +75,6 @@ import org.wordpress.android.ui.reader.views.ReaderWebView;
 import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderCustomViewListener;
 import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderWebViewPageFinishedListener;
 import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderWebViewUrlClickListener;
-import org.wordpress.android.ui.utils.AuthenticationUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -8,6 +8,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderPostDiscoverData;
+import org.wordpress.android.ui.reader.utils.FeaturedImageUtils;
 import org.wordpress.android.ui.reader.utils.ImageSizeMap;
 import org.wordpress.android.ui.reader.utils.ImageSizeMap.ImageSize;
 import org.wordpress.android.ui.reader.utils.ReaderEmbedScanner;
@@ -48,9 +49,10 @@ public class ReaderPostRenderer {
     private StringBuilder mRenderBuilder;
     private String mRenderedHtml;
     private ImageSizeMap mAttachmentSizes;
+    private FeaturedImageUtils mFeaturedImageUtils;
 
     @SuppressLint("SetJavaScriptEnabled")
-    public ReaderPostRenderer(ReaderWebView webView, ReaderPost post) {
+    public ReaderPostRenderer(ReaderWebView webView, ReaderPost post, FeaturedImageUtils featuredImageUtils) {
         if (webView == null) {
             throw new IllegalArgumentException("ReaderPostRenderer requires a webView");
         }
@@ -61,6 +63,7 @@ public class ReaderPostRenderer {
         mPost = post;
         mWeakWebView = new WeakReference<>(webView);
         mResourceVars = new ReaderResourceVars(webView.getContext());
+        mFeaturedImageUtils = featuredImageUtils;
 
         mMinFullSizeWidthDp = pxToDp(mResourceVars.mFullSizeImageWidthPx / 3);
         mMinMidSizeWidthDp = mMinFullSizeWidthDp / 2;
@@ -247,12 +250,12 @@ public class ReaderPostRenderer {
     }
 
     /*
-     * returns true if the post has a featured image and there are no images in the
-     * post's content - when this is the case, the featured image is inserted at
-     * the top of the content
+     * returns true if the post has a featured image and the featured image is not found in the post body
      */
     private boolean shouldAddFeaturedImage() {
-        return mPost.hasFeaturedImage() && !PhotonUtils.isMshotsUrl(mPost.getFeaturedImage());
+        return mPost.hasFeaturedImage()
+               && !PhotonUtils.isMshotsUrl(mPost.getFeaturedImage())
+               && mFeaturedImageUtils.showFeaturedImage(mPost.getFeaturedImage(), mPost.getText());
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostWebViewCachingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostWebViewCachingFragment.java
@@ -8,7 +8,6 @@ import android.view.ViewGroup;
 import android.webkit.WebView;
 
 import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
 
 import org.wordpress.android.datasets.ReaderPostTable;
 import org.wordpress.android.models.ReaderPost;
@@ -17,16 +16,22 @@ import org.wordpress.android.ui.reader.views.ReaderWebView;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.UrlUtils;
 
+import javax.inject.Inject;
+
+import dagger.android.support.DaggerFragment;
+
 /**
  * Fragment responsible for caching post content into WebView.
  * Caching happens on UI thread, so any configuration change will restart it from scratch.
  */
-public class ReaderPostWebViewCachingFragment extends Fragment {
+public class ReaderPostWebViewCachingFragment extends DaggerFragment {
     private static final String ARG_BLOG_ID = "blog_id";
     private static final String ARG_POST_ID = "post_id";
 
     private long mBlogId;
     private long mPostId;
+
+    @Inject FeaturedImageUtils mFeaturedImageUtils;
 
     public static ReaderPostWebViewCachingFragment newInstance(long blogId, long postId) {
         ReaderPostWebViewCachingFragment fragment = new ReaderPostWebViewCachingFragment();
@@ -65,7 +70,7 @@ public class ReaderPostWebViewCachingFragment extends Fragment {
             });
 
             ReaderPostRenderer rendered =
-                    new ReaderPostRenderer((ReaderWebView) view, post, FeaturedImageUtils.Companion.getInstance());
+                    new ReaderPostRenderer((ReaderWebView) view, post, mFeaturedImageUtils);
             rendered.beginRender(); // rendering will cache post content using native WebView implementation.
         } else {
             // abort mission if no network is available

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostWebViewCachingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostWebViewCachingFragment.java
@@ -12,6 +12,7 @@ import androidx.fragment.app.Fragment;
 
 import org.wordpress.android.datasets.ReaderPostTable;
 import org.wordpress.android.models.ReaderPost;
+import org.wordpress.android.ui.reader.utils.FeaturedImageUtils;
 import org.wordpress.android.ui.reader.views.ReaderWebView;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.UrlUtils;
@@ -63,7 +64,8 @@ public class ReaderPostWebViewCachingFragment extends Fragment {
                 }
             });
 
-            ReaderPostRenderer rendered = new ReaderPostRenderer((ReaderWebView) view, post);
+            ReaderPostRenderer rendered =
+                    new ReaderPostRenderer((ReaderWebView) view, post, FeaturedImageUtils.Companion.getInstance());
             rendered.beginRender(); // rendering will cache post content using native WebView implementation.
         } else {
             // abort mission if no network is available

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtils.kt
@@ -1,0 +1,30 @@
+package org.wordpress.android.ui.reader.utils
+
+import java.net.MalformedURLException
+import java.net.URL
+import javax.inject.Inject
+
+class FeaturedImageUtils
+@Inject constructor() {
+    fun showFeaturedImage(
+        featuredImage: String,
+        postText: String
+    ): Boolean {
+        return try {
+            val featuredImageUrl = URL(featuredImage)
+            val featuredImagePath = featuredImageUrl.path
+            val featuredImageFile = featuredImageUrl.file
+            when {
+                postText.contains(featuredImage) -> false
+                postText.contains(featuredImagePath) && featuredImagePath != featuredImageFile -> false
+                else -> true
+            }
+        } catch (e: MalformedURLException) {
+            false
+        }
+    }
+
+    companion object {
+        fun getInstance() = FeaturedImageUtils()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtils.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.reader.utils
 
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
 import java.net.MalformedURLException
 import java.net.URL
 import javax.inject.Inject
@@ -25,6 +27,7 @@ class FeaturedImageUtils
                 else -> true
             }
         } catch (e: MalformedURLException) {
+            AppLog.e(T.READER, "Featured image URL is malformed so it's not shown")
             false
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtils.kt
@@ -12,8 +12,13 @@ class FeaturedImageUtils
     ): Boolean {
         return try {
             val featuredImageUrl = URL(featuredImage)
-            val featuredImagePath = featuredImageUrl.path
+            val endIndex = featuredImageUrl.path.lastIndexOf("-", featuredImageUrl.path.lastIndexOf("/"))
             val featuredImageFile = featuredImageUrl.file
+            val featuredImagePath = if (endIndex > 0 && !featuredImageFile.startsWith("-")) {
+                featuredImageUrl.path.substring(0, endIndex)
+            } else {
+                featuredImageUrl.path
+            }
             when {
                 postText.contains(featuredImage) -> false
                 postText.contains(featuredImagePath) && featuredImagePath != featuredImageFile -> false

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtils.kt
@@ -28,8 +28,4 @@ class FeaturedImageUtils
             false
         }
     }
-
-    companion object {
-        fun getInstance() = FeaturedImageUtils()
-    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtilsTest.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.models.ReaderPost
 class FeaturedImageUtilsTest {
     private val featuredImageUtils = FeaturedImageUtils()
     @Test
-    fun `shows exactly the same featured image`() {
+    fun `does not show the same featured image twice`() {
         val image = "https://wordpress.com/image.png"
         val readerPost = initReaderPost(image, image)
 
@@ -20,7 +20,7 @@ class FeaturedImageUtilsTest {
     }
 
     @Test
-    fun `shows featured image with size params`() {
+    fun `does not show featured image twice with only different with size params`() {
         val featuredImage = "https://i0.wp.com/www.subtraction.com/wp-content/uploads/2017/11/" +
                 "2017-11-06-iphone-x.png?quality=80&strip=info&w=1600"
         val bodyImage = "https://i0.wp.com/www.subtraction.com/wp-content/uploads/2017/11/" +
@@ -44,7 +44,7 @@ class FeaturedImageUtilsTest {
     }
 
     @Test
-    fun `does not show featured image with the same name`() {
+    fun `shows featured image with different name`() {
         val featuredImage = "https://wordpress.com/image.png"
         val bodyImage = "https://wordpress.com/image2.png"
         val readerPost = initReaderPost(bodyImage, featuredImage)
@@ -55,7 +55,7 @@ class FeaturedImageUtilsTest {
     }
 
     @Test
-    fun `does not show featured image with the same name from different host`() {
+    fun `shows featured image with the same name from different host`() {
         val featuredImage = "https://wordpress.com/image.png"
         val bodyImage = "https://wordpress2.com/image.png"
         val readerPost = initReaderPost(bodyImage, featuredImage)

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtilsTest.kt
@@ -10,12 +10,9 @@ import org.wordpress.android.models.ReaderPost
 class FeaturedImageUtilsTest {
     private val featuredImageUtils = FeaturedImageUtils()
     @Test
-    fun `finds exactly the same featured image`() {
+    fun `shows exactly the same featured image`() {
         val image = "https://wordpress.com/image.png"
-        val postBody = buildHtml(image)
-        val readerPost = ReaderPost()
-        readerPost.featuredImage = image
-        readerPost.text = postBody
+        val readerPost = initReaderPost(image, image)
 
         val result = featuredImageUtils.showFeaturedImage(readerPost.featuredImage, readerPost.text)
 
@@ -23,15 +20,12 @@ class FeaturedImageUtilsTest {
     }
 
     @Test
-    fun `finds featured image with size params`() {
+    fun `shows featured image with size params`() {
         val featuredImage = "https://i0.wp.com/www.subtraction.com/wp-content/uploads/2017/11/" +
                 "2017-11-06-iphone-x.png?quality=80&strip=info&w=1600"
         val bodyImage = "https://i0.wp.com/www.subtraction.com/wp-content/uploads/2017/11/" +
-                "2017-11-06-iphone-x.png?ssl=1"
-        val postBody = buildHtml(bodyImage)
-        val readerPost = ReaderPost()
-        readerPost.featuredImage = featuredImage
-        readerPost.text = postBody
+                "2017-11-06-iphone-x-725x209.png?ssl=1"
+        val readerPost = initReaderPost(bodyImage, featuredImage)
 
         val result = featuredImageUtils.showFeaturedImage(readerPost.featuredImage, readerPost.text)
 
@@ -39,13 +33,10 @@ class FeaturedImageUtilsTest {
     }
 
     @Test
-    fun `does not find featured image with the same name`() {
+    fun `shows featured image with a different name with dashes`() {
         val featuredImage = "https://wordpress.com/image.png"
-        val bodyImage = "https://wordpress.com/image2.png"
-        val postBody = buildHtml(bodyImage)
-        val readerPost = ReaderPost()
-        readerPost.featuredImage = featuredImage
-        readerPost.text = postBody
+        val bodyImage = "https://wordpress.com/image-dog-10.png"
+        val readerPost = initReaderPost(bodyImage, featuredImage)
 
         val result = featuredImageUtils.showFeaturedImage(readerPost.featuredImage, readerPost.text)
 
@@ -53,17 +44,36 @@ class FeaturedImageUtilsTest {
     }
 
     @Test
-    fun `does not find featured image with the same name from different host`() {
+    fun `does not show featured image with the same name`() {
         val featuredImage = "https://wordpress.com/image.png"
-        val bodyImage = "https://wordpress2.com/image.png"
-        val postBody = buildHtml(bodyImage)
-        val readerPost = ReaderPost()
-        readerPost.featuredImage = featuredImage
-        readerPost.text = postBody
+        val bodyImage = "https://wordpress.com/image2.png"
+        val readerPost = initReaderPost(bodyImage, featuredImage)
 
         val result = featuredImageUtils.showFeaturedImage(readerPost.featuredImage, readerPost.text)
 
         assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `does not show featured image with the same name from different host`() {
+        val featuredImage = "https://wordpress.com/image.png"
+        val bodyImage = "https://wordpress2.com/image.png"
+        val readerPost = initReaderPost(bodyImage, featuredImage)
+
+        val result = featuredImageUtils.showFeaturedImage(readerPost.featuredImage, readerPost.text)
+
+        assertThat(result).isTrue()
+    }
+
+    private fun initReaderPost(
+        bodyImage: String,
+        featuredImage: String
+    ): ReaderPost {
+        val postBody = buildHtml(bodyImage)
+        val readerPost = ReaderPost()
+        readerPost.featuredImage = featuredImage
+        readerPost.text = postBody
+        return readerPost
     }
 
     private fun buildHtml(img: String) = "<html>\n" +

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtilsTest.kt
@@ -1,0 +1,79 @@
+package org.wordpress.android.ui.reader.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.models.ReaderPost
+
+@RunWith(MockitoJUnitRunner::class)
+class FeaturedImageUtilsTest {
+    private val featuredImageUtils = FeaturedImageUtils()
+    @Test
+    fun `finds exactly the same featured image`() {
+        val image = "https://wordpress.com/image.png"
+        val postBody = buildHtml(image)
+        val readerPost = ReaderPost()
+        readerPost.featuredImage = image
+        readerPost.text = postBody
+
+        val result = featuredImageUtils.showFeaturedImage(readerPost.featuredImage, readerPost.text)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `finds featured image with size params`() {
+        val featuredImage = "https://i0.wp.com/www.subtraction.com/wp-content/uploads/2017/11/" +
+                "2017-11-06-iphone-x.png?quality=80&strip=info&w=1600"
+        val bodyImage = "https://i0.wp.com/www.subtraction.com/wp-content/uploads/2017/11/" +
+                "2017-11-06-iphone-x.png?ssl=1"
+        val postBody = buildHtml(bodyImage)
+        val readerPost = ReaderPost()
+        readerPost.featuredImage = featuredImage
+        readerPost.text = postBody
+
+        val result = featuredImageUtils.showFeaturedImage(readerPost.featuredImage, readerPost.text)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `does not find featured image with the same name`() {
+        val featuredImage = "https://wordpress.com/image.png"
+        val bodyImage = "https://wordpress.com/image2.png"
+        val postBody = buildHtml(bodyImage)
+        val readerPost = ReaderPost()
+        readerPost.featuredImage = featuredImage
+        readerPost.text = postBody
+
+        val result = featuredImageUtils.showFeaturedImage(readerPost.featuredImage, readerPost.text)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `does not find featured image with the same name from different host`() {
+        val featuredImage = "https://wordpress.com/image.png"
+        val bodyImage = "https://wordpress2.com/image.png"
+        val postBody = buildHtml(bodyImage)
+        val readerPost = ReaderPost()
+        readerPost.featuredImage = featuredImage
+        readerPost.text = postBody
+
+        val result = featuredImageUtils.showFeaturedImage(readerPost.featuredImage, readerPost.text)
+
+        assertThat(result).isTrue()
+    }
+
+    private fun buildHtml(img: String) = "<html>\n" +
+            "<head>\n" +
+            "<title>Title of the document</title>\n" +
+            "</head>\n" +
+            "\n" +
+            "<body>\n" +
+            "<img alt=\"description\" src=\"$img\">" +
+            "</body>\n" +
+            "\n" +
+            "</html>"
+}


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-Android/pull/10568#issuecomment-541684570

This PR makes the reader not add a featured image if the image is already present in the post body. There are multiple checks here based on Calypso https://github.com/Automattic/wp-calypso/issues/19544 and https://github.com/Automattic/wp-calypso/commit/967d2f1693febdd545f045e71039ff8c85dc6d80
We're checking if the path except the host is matching and stripping anything after the last dash from the image name. 

To test:
* Create a post with a featured image and the same image in the post body
* Click on the post in the reader
* The post doesn't show the same image twice
* Create a post with a featured image and a different image in the post body
* Click on the post in the reader
* Both images are visible

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

