### PR TITLE
Kotlin migration update

### DIFF
--- a/WordPress/src/debug/java/org/wordpress/android/WPWellSqlConfig.kt
+++ b/WordPress/src/debug/java/org/wordpress/android/WPWellSqlConfig.kt
@@ -13,7 +13,7 @@ import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 
-class WPWellSqlConfig(context: Context?) : WellSqlConfig(context) {
+class WPWellSqlConfig(context: Context) : WellSqlConfig(context) {
     /**
      * Detect when the database is downgraded in debug builds, and if the build flag is set recreate all the tables
      * and show a toast alerting to the downgrade. The sole purpose of this is to avoid the hassle of devs switching
@@ -32,7 +32,7 @@ class WPWellSqlConfig(context: Context?) : WellSqlConfig(context) {
             toast.setGravity(Gravity.CENTER, 0, 0)
             toast.show()
 
-            reset(helper)
+            helper?.let { reset(it) }
         } else {
             super.onDowngrade(db, helper, oldVersion, newVersion)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'f7dbf9c34eb1f19ba4e8d79e9e08cd38c81992c9'
+    fluxCVersion = '1.5.1-beta-1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.5.0'
+    fluxCVersion = 'f7dbf9c34eb1f19ba4e8d79e9e08cd38c81992c9'
 }


### PR DESCRIPTION
This PR fixes the build after the Kotlin migration update (wordpress-mobile/WordPress-FluxC-Android#1395).

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

