### PR TITLE
Android P: add data directory suffix for WebViews

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -20,6 +20,7 @@ import android.preference.PreferenceManager;
 import android.text.TextUtils;
 import android.util.AndroidRuntimeException;
 import android.webkit.WebSettings;
+import android.webkit.WebView;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatDelegate;
@@ -219,6 +220,9 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         long startDate = SystemClock.elapsedRealtime();
 
         CrashLoggingUtils.startCrashLogging(getContext());
+
+        // This call needs be made before accessing any methods in android.webkit package
+        setWebViewDataDirectorySuffixOnAndroidP();
 
         initWellSql();
 
@@ -664,6 +668,34 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
             }
         }
         return mUserAgent;
+    }
+
+    /*
+     * Since Android P:
+     * "Apps can no longer share a single WebView data directory across processes.
+     * If your app has more than one process using WebView, CookieManager, or any other API in the android.webkit
+     * package, your app will crash when the second process calls a WebView method."
+     *
+     * (see https://developer.android.com/about/versions/pie/android-9.0-migration)
+     *
+     * Also here: https://developer.android.com/about/versions/pie/android-9.0-changes-28#web-data-dirs
+     *
+     * "If your app must use instances of WebView in more than one process, you must assign a unique data
+     * directory suffix for each process, using the WebView.setDataDirectorySuffix() method, before
+     * using a given instance of WebView in that process."
+     *
+     * While we don't explicitly use a different process other than the default, making the directory suffix be
+     * the actual process name will ensure there's one directory per process, should the Application's
+     * onCreate() method be called from a different process any time.
+     *
+    */
+    private void setWebViewDataDirectorySuffixOnAndroidP() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            String procName = getProcessName();
+            if (!TextUtils.isEmpty(procName)) {
+                WebView.setDataDirectorySuffix(procName);
+            }
+        }
     }
 
     /*


### PR DESCRIPTION
Fixes #10494 

This is a tricky issue.

### Information gathered
- This is a warning pre API 28 (Android 9) and behaves as a `RuntimeException` from Android 9 (P) and on https://developer.android.com/about/versions/pie/android-9.0-changes-28#web-data-dirs

- Relevant discussion on the topic on Chromium site https://bugs.chromium.org/p/chromium/issues/detail?id=558377

- According to the documentation (see [this](https://developer.android.com/about/versions/pie/android-9.0-changes-28#web-data-dirs) and 
the [Android 9 migration guide](https://developer.android.com/about/versions/pie/android-9.0-migration)), Android P doesn't allow two different processes of the same app to use the same data directory

> In most cases, your app should use classes from the android.webkit package, such as WebView and CookieManager, in only one process.
Using WebView from more than one process at once with the same data directory is not supported


- The issue started appearing on https://github.com/wordpress-mobile/WordPress-Android/tree/12.9-rc-2, when `targetSdkVersion` was changed to `28` (see [diff from previous release to the first version where the issue has been observed](https://github.com/wordpress-mobile/WordPress-Android/compare/12.8...12.9-rc-1) and see the original PR #10142).

I've been checking the WordPress Android source code to see if we're explicitly setting anything to work on a separate process and I couldn't find anything relevant (i.e. no `android:process` attributes in the main or library [Manifests](https://developer.android.com/guide/topics/manifest/activity-element.html)). Given the crash happens in the Application's `onCreate()` method, if we solely rely on the documentation then it would be apparent that the Application's `onCreate()` method is being called more than once by different processes (there's no way the exception would be thrown otherwise). But, this is actually counter-intuitive, I'm doubting there would be another process of the same app running before the first attempt to run `WebSettings.getDefaultUserAgent(getContext());` (where the WPAndroid app is currently crashing as per the report in #10494).

So let's check where the actual Exception comes from. The implementation of Chromium actually checks this by obtaining a lock on a random file on the given data directory, and throwing a `RuntimeException` if it cannot obtain such a lock (see Chromium's source code [here](https://chromium.googlesource.com/chromium/src/+/master/android_webview/java/src/org/chromium/android_webview/AwBrowserProcess.java#150)). So, things are a bit clearer now: this does not necessarily mean 2 different processes are being used - the actual check only means the process has a lock on a random file it creates for the sole purpose of making this check.

While it's clearer what the problem is (as the Runtime crash is made on purpose by WebKit), I had a hard time trying to figure out how users can run into this problem (a way to reproduce).

Whatever the reproducible case is, this PR goes and sets a data directory suffix on WebView, with the suffix being the current process name (taking advantage that [this API exists on Android P](https://developer.android.com/reference/android/app/Application#getProcessName())):

With this, we'd be covering all of the possibilities I can think of:
1. if the app is being run by a different process (which I believe is highly unlikely - we should be able to see some other activity on Sentry and we just have the immediate crash after `onCreate()` is called), it will have a different name and thus the file lock will be obtained (and the Exception won't occur)
2. if the lock was being obtained by some other dependency on the default directory, we'll now set it correctly by having it set for all WebView-wide as early as possible (i.e. in the `onCreate()` method of the Application.

With this, I believe we should be able to get rid of the problem.

To test:
I haven't been able to reproduce, but at least this branch should run without a problem
1. try opening the app on Android 9
2. test opening WebViews (for example choose a site and tap on Visit Site, or see a Post's preview, etc.)

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

