### PR TITLE
Add speed dial FAB for adding post/page from My site

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -84,20 +84,20 @@ android {
                 versionName "13.4-rc-1"
             }
             versionCode 782
-            buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
+            buildConfigField "boolean", "INFORMATION_ARCHITECTURE_AVAILABLE", "false"
         }
 
         zalpha { // alpha version - enable experimental features
             applicationId "org.wordpress.android"
             dimension "buildType"
             buildConfigField "boolean", "VIDEO_OPTIMIZATION_AVAILABLE", "true"
-            buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
+            buildConfigField "boolean", "INFORMATION_ARCHITECTURE_AVAILABLE", "false"
         }
 
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
             applicationId "org.wordpress.android.beta"
             dimension "buildType"
-            buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
+            buildConfigField "boolean", "INFORMATION_ARCHITECTURE_AVAILABLE", "true"
         }
     }
 
@@ -204,6 +204,12 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.9.0'
     kapt 'com.github.bumptech.glide:compiler:4.9.0'
     implementation 'com.github.bumptech.glide:volley-integration:4.6.1@aar'
+
+    // Speed Dial library
+    implementation("com.leinardi.android:speed-dial:3.1.1", {
+        exclude group: 'androidx.appcompat', module: 'appcompat'
+        exclude group: 'androidx.cardview', module: 'cardview'
+    })
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.6.1'

--- a/WordPress/src/main/assets/licenses.html
+++ b/WordPress/src/main/assets/licenses.html
@@ -34,6 +34,7 @@ libraries are licensed under <a href="http://www.apache.org/licenses/LICENSE-2.0
       <li><a href="https://github.com/square/okio">okio/okhttp</a>: Copyright 2013 Square, Inc.</li>
       <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>: Copyright 2012-2016 Markus Junginger, greenrobot</li>
       <li><a href="https://github.com/INDExOS/media-for-mobile">Mobile 4 Media</a>: Copyright 2016, INDExOS</li>
+      <li><a href="https://github.com/leinardi/FloatingActionButtonSpeedDial">Floating Action Button Speed Dial</a>: Copyright 2019 Roberto Leinardi.</li>
     </ul>
 
     <br>

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelProvider;
 
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel;
 import org.wordpress.android.ui.domains.DomainRegistrationMainViewModel;
+import org.wordpress.android.ui.main.SpeedDialViewModel;
 import org.wordpress.android.ui.plans.PlansViewModel;
 import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel;
 import org.wordpress.android.ui.posts.PostListMainViewModel;
@@ -257,6 +258,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(ReaderCommentListViewModel.class)
     abstract ViewModel readerCommentListViewModel(ReaderCommentListViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(SpeedDialViewModel.class)
+    abstract ViewModel speedDialerViewModel(SpeedDialViewModel viewModel);
 
     @Binds
     abstract ViewModelProvider.Factory provideViewModelFactory(ViewModelFactory viewModelFactory);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -550,6 +550,14 @@ public class ActivityLauncher {
         fragment.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 
+    public static void addNewPageForResult(@NonNull Activity activity, @NonNull SiteModel site) {
+        Intent intent = new Intent(activity, EditPostActivity.class);
+        intent.putExtra(WordPress.SITE, site);
+        intent.putExtra(EditPostActivity.EXTRA_IS_PAGE, true);
+        intent.putExtra(EditPostActivity.EXTRA_IS_PROMO, false);
+        activity.startActivityForResult(intent, RequestCodes.EDIT_POST);
+    }
+
     public static void addNewPageForResult(@NonNull Fragment fragment, @NonNull SiteModel site) {
         Intent intent = new Intent(fragment.getContext(), EditPostActivity.class);
         intent.putExtra(WordPress.SITE, site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -372,7 +372,7 @@ public class MySiteFragment extends Fragment implements
 
         mToolbar = rootView.findViewById(R.id.toolbar_main);
         mToolbar.setTitle(mToolbarTitle);
-        if (BuildConfig.ME_ACTIVITY_AVAILABLE) {
+        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
             mToolbar.inflateMenu(R.menu.my_site_menu);
             mToolbar.setOnMenuItemClickListener(item -> {
                 if (item.getItemId() == R.id.me_item) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SpeedDialAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SpeedDialAction.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.ui.main
+
+enum class SpeedDialAction {
+    SD_ACTION_NEW_POST,
+    SD_ACTION_NEW_PAGE
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SpeedDialUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SpeedDialUiState.kt
@@ -12,7 +12,7 @@ data class SpeedDialUiState(
 )
 
 enum class SpeedDialState {
-    CLOSED,
+    VISIBLE,
     HIDDEN
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SpeedDialUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SpeedDialUiState.kt
@@ -1,0 +1,43 @@
+package org.wordpress.android.ui.main
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.IdRes
+import androidx.annotation.StringRes
+import org.wordpress.android.R
+import org.wordpress.android.ui.main.SpeedDialAction.SD_ACTION_NEW_PAGE
+import org.wordpress.android.ui.main.SpeedDialAction.SD_ACTION_NEW_POST
+
+data class SpeedDialUiState(
+    val speedDialState: SpeedDialState
+)
+
+enum class SpeedDialState {
+    CLOSED,
+    HIDDEN
+}
+
+enum class SpeedDialActionMenuItem(
+    @IdRes val id: Int,
+    @DrawableRes val iconId: Int,
+    @StringRes val labelId: Int,
+    val action: SpeedDialAction
+) {
+    NEW_POST(R.id.fab_add_new_post,
+            R.drawable.ic_posts_white_24dp,
+            R.string.my_site_speed_dial_add_post,
+            SD_ACTION_NEW_POST
+    ),
+    NEW_PAGE(R.id.fab_add_new_page,
+            R.drawable.ic_pages_white_24dp,
+            R.string.my_site_speed_dial_add_page,
+            SD_ACTION_NEW_PAGE
+    );
+
+    companion object {
+        @JvmStatic
+        fun getDefaultActionsList(): List<SpeedDialActionMenuItem> = listOf(NEW_POST, NEW_PAGE)
+
+        fun fromId(@IdRes id: Int): SpeedDialActionMenuItem = values().firstOrNull { it.id == id }
+                    ?: throw IllegalArgumentException("SpeedDialAction wrong id $id")
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SpeedDialUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SpeedDialUiState.kt
@@ -34,9 +34,6 @@ enum class SpeedDialActionMenuItem(
     );
 
     companion object {
-        @JvmStatic
-        fun getDefaultActionsList(): List<SpeedDialActionMenuItem> = listOf(NEW_POST, NEW_PAGE)
-
         fun fromId(@IdRes id: Int): SpeedDialActionMenuItem = values().firstOrNull { it.id == id }
                     ?: throw IllegalArgumentException("SpeedDialAction wrong id $id")
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SpeedDialViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SpeedDialViewModel.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.ui.main.SpeedDialActionMenuItem.NEW_PAGE
+import org.wordpress.android.ui.main.SpeedDialActionMenuItem.NEW_POST
 import org.wordpress.android.ui.main.SpeedDialState.CLOSED
 import org.wordpress.android.ui.main.SpeedDialState.HIDDEN
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -59,6 +61,8 @@ class SpeedDialViewModel @Inject constructor(
                 speedDialFabState = fabNewState
         )
     }
+
+    fun getDefaultActionsList(): List<SpeedDialActionMenuItem> = listOf(NEW_POST, NEW_PAGE)
 
     private fun updateUiState(speedDialFabState: SpeedDialState? = null) {
         val currentState = requireNotNull(uiState.value) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SpeedDialViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SpeedDialViewModel.kt
@@ -3,30 +3,23 @@ package org.wordpress.android.ui.main
 import androidx.annotation.IdRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.main.SpeedDialActionMenuItem.NEW_PAGE
 import org.wordpress.android.ui.main.SpeedDialActionMenuItem.NEW_POST
-import org.wordpress.android.ui.main.SpeedDialState.CLOSED
 import org.wordpress.android.ui.main.SpeedDialState.HIDDEN
+import org.wordpress.android.ui.main.SpeedDialState.VISIBLE
+import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 import javax.inject.Named
-import kotlin.coroutines.CoroutineContext
 
 class SpeedDialViewModel @Inject constructor(
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
-) : ViewModel(), CoroutineScope {
-    private val job = Job()
-    override val coroutineContext: CoroutineContext
-        get() = bgDispatcher + job
-
+) : ScopedViewModel(bgDispatcher) {
     private var isStarted = false
 
     private val _uiState = MutableLiveData<SpeedDialUiState>()
@@ -35,31 +28,29 @@ class SpeedDialViewModel @Inject constructor(
     private val _speedDialAction = SingleLiveEvent<SpeedDialAction>()
     val speedDialAction: LiveData<SpeedDialAction> = _speedDialAction
 
-    fun start(isSpeedDialFabVisible: Boolean) {
-        if (isStarted) return
+    @JvmOverloads
+    fun start(isSpeedDialFabVisible: Boolean, forceVMInit: Boolean = false) {
+        if (isStarted && !forceVMInit) return
         isStarted = true
 
         _uiState.value = SpeedDialUiState(
-                speedDialState = if (isSpeedDialFabVisible) CLOSED else HIDDEN
+                speedDialState = if (isSpeedDialFabVisible) VISIBLE else HIDDEN
         )
     }
 
     fun onSpeedDialAction(@IdRes actionId: Int): Job {
         val action = (SpeedDialActionMenuItem.fromId(actionId)).action
 
-        updateUiState(
-                speedDialFabState = CLOSED
-        )
-        return launch(Dispatchers.Default) {
+        updateUiState(VISIBLE)
+
+        return launch {
             delay(300)
             _speedDialAction.postValue(action)
         }
     }
 
     fun onPageChanged(fabNewState: SpeedDialState) {
-        updateUiState(
-                speedDialFabState = fabNewState
-        )
+        updateUiState(fabNewState)
     }
 
     fun getDefaultActionsList(): List<SpeedDialActionMenuItem> = listOf(NEW_POST, NEW_PAGE)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SpeedDialViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SpeedDialViewModel.kt
@@ -1,0 +1,72 @@
+package org.wordpress.android.ui.main
+
+import androidx.annotation.IdRes
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.ui.main.SpeedDialState.CLOSED
+import org.wordpress.android.ui.main.SpeedDialState.HIDDEN
+import org.wordpress.android.viewmodel.SingleLiveEvent
+import javax.inject.Inject
+import javax.inject.Named
+import kotlin.coroutines.CoroutineContext
+
+class SpeedDialViewModel @Inject constructor(
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+) : ViewModel(), CoroutineScope {
+    private val job = Job()
+    override val coroutineContext: CoroutineContext
+        get() = bgDispatcher + job
+
+    private var isStarted = false
+
+    private val _uiState = MutableLiveData<SpeedDialUiState>()
+    val uiState: LiveData<SpeedDialUiState> = _uiState
+
+    private val _speedDialAction = SingleLiveEvent<SpeedDialAction>()
+    val speedDialAction: LiveData<SpeedDialAction> = _speedDialAction
+
+    fun start(isSpeedDialFabVisible: Boolean) {
+        if (isStarted) return
+        isStarted = true
+
+        _uiState.value = SpeedDialUiState(
+                speedDialState = if (isSpeedDialFabVisible) CLOSED else HIDDEN
+        )
+    }
+
+    fun onSpeedDialAction(@IdRes actionId: Int): Job {
+        val action = (SpeedDialActionMenuItem.fromId(actionId)).action
+
+        updateUiState(
+                speedDialFabState = CLOSED
+        )
+        return launch(Dispatchers.Default) {
+            delay(300)
+            _speedDialAction.postValue(action)
+        }
+    }
+
+    fun onPageChanged(fabNewState: SpeedDialState) {
+        updateUiState(
+                speedDialFabState = fabNewState
+        )
+    }
+
+    private fun updateUiState(speedDialFabState: SpeedDialState? = null) {
+        val currentState = requireNotNull(uiState.value) {
+            "updateUiState can be called only after the initial state is set"
+        }
+
+        _uiState.value = SpeedDialUiState(
+                speedDialFabState ?: currentState.speedDialState
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -388,7 +388,7 @@ public class WPMainActivity extends AppCompatActivity implements
             // Setup Observers
             mViewModel.getUiState().observe(this, speedDialUiState -> {
                 switch (speedDialUiState.getSpeedDialState()) {
-                    case CLOSED:
+                    case VISIBLE:
                         mSpeedDialView.close();
                         mSpeedDialView.show();
                         break;
@@ -713,7 +713,7 @@ public class WPMainActivity extends AppCompatActivity implements
             }
         }
 
-        mViewModel.onPageChanged(pageType == PageType.MY_SITE ? SpeedDialState.CLOSED : SpeedDialState.HIDDEN);
+        mViewModel.onPageChanged(pageType == PageType.MY_SITE ? SpeedDialState.VISIBLE : SpeedDialState.HIDDEN);
     }
 
     private void handleNewPageAction() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -202,7 +202,7 @@ public class WPMainActivity extends AppCompatActivity implements
 
         mBottomNav = findViewById(R.id.bottom_navigation);
 
-        if (BuildConfig.ME_ACTIVITY_AVAILABLE) {
+        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
             mBottomNav.getMenu().removeItem(R.id.nav_me);
         }
         mBottomNav.init(getSupportFragmentManager(), this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -204,6 +204,7 @@ public class WPMainActivity extends AppCompatActivity implements
 
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
             mBottomNav.getMenu().removeItem(R.id.nav_me);
+            mBottomNav.getMenu().removeItem(R.id.nav_write);
         }
         mBottomNav.init(getSupportFragmentManager(), this);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -412,7 +412,7 @@ public class WPMainActivity extends AppCompatActivity implements
         }
 
         // Init speed dial menu
-        for (SpeedDialActionMenuItem speedDialAction : SpeedDialActionMenuItem.getDefaultActionsList()) {
+        for (SpeedDialActionMenuItem speedDialAction : mViewModel.getDefaultActionsList()) {
             mSpeedDialView.addActionItem(createSpeedDialActionItem(speedDialAction));
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -358,8 +358,7 @@ class WPMainNavigationView @JvmOverloads constructor(
 
     companion object {
         private val defaultPages = listOf(MY_SITE, READER, NEW_POST, ME, NOTIFS)
-        // TODO: rename "pagesWithoutMe" when removing also the NEW_POST in the IA Project
-        private val pagesWithoutMe = listOf(MY_SITE, READER, NEW_POST, NOTIFS)
+        private val pages = listOf(MY_SITE, READER, NOTIFS)
 
         private const val TAG_MY_SITE = "tag-mysite"
         private const val TAG_READER = "tag-reader"
@@ -368,7 +367,7 @@ class WPMainNavigationView @JvmOverloads constructor(
 
         private fun numPages(): Int {
             return if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-                pagesWithoutMe.size
+                pages.size
             } else {
                 defaultPages.size
             }
@@ -376,7 +375,7 @@ class WPMainNavigationView @JvmOverloads constructor(
 
         private fun pages(): List<PageType> {
             return if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-                pagesWithoutMe
+                pages
             } else {
                 defaultPages
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -367,7 +367,7 @@ class WPMainNavigationView @JvmOverloads constructor(
         private const val TAG_NOTIFS = "tag-notifs"
 
         private fun numPages(): Int {
-            return if (BuildConfig.ME_ACTIVITY_AVAILABLE) {
+            return if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
                 pagesWithoutMe.size
             } else {
                 defaultPages.size
@@ -375,7 +375,7 @@ class WPMainNavigationView @JvmOverloads constructor(
         }
 
         private fun pages(): List<PageType> {
-            return if (BuildConfig.ME_ACTIVITY_AVAILABLE) {
+            return if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
                 pagesWithoutMe
             } else {
                 defaultPages

--- a/WordPress/src/main/res/layout/main_activity.xml
+++ b/WordPress/src/main/res/layout/main_activity.xml
@@ -56,4 +56,24 @@
             app:menu="@menu/bottom_nav_main"/>
     </LinearLayout>
 
+    <com.leinardi.android.speeddial.SpeedDialOverlayLayout
+        android:id="@+id/speed_dial_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+    <com.leinardi.android.speeddial.SpeedDialView
+        android:id="@+id/speed_dial_fab_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:sdMainFabClosedSrc="@drawable/ic_create_white_24dp"
+        app:sdMainFabClosedIconColor="@color/white"
+        app:sdMainFabOpenedSrc="@drawable/ic_cross_white_24dp"
+        android:layout_above="@+id/bottom_container"
+        android:layout_alignParentEnd="true"
+        app:sdOverlayLayout="@id/speed_dial_overlay"
+        android:scrollbarSize="@dimen/sd_fab_mini_size"
+        app:sdUseReverseAnimationOnClose="true"
+        android:visibility="gone"
+        tools:visibility="visible"/>
+
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/main_activity.xml
+++ b/WordPress/src/main/res/layout/main_activity.xml
@@ -59,7 +59,8 @@
     <com.leinardi.android.speeddial.SpeedDialOverlayLayout
         android:id="@+id/speed_dial_overlay"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:background="@color/black_translucent_40"/>
 
     <com.leinardi.android.speeddial.SpeedDialView
         android:id="@+id/speed_dial_fab_button"

--- a/WordPress/src/main/res/values/ids.xml
+++ b/WordPress/src/main/res/values/ids.xml
@@ -16,4 +16,7 @@
     <item type="id" name="bottom_nav_new_post_button" />
     <item type="id" name="media_grid_file_path_id" />
     <item type="id" name="post_menu_item_view_layout_type" />
+
+    <item name="fab_add_new_page" type="id" />
+    <item name="fab_add_new_post" type="id" />
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1763,6 +1763,9 @@
     <string name="my_site_icon_dialog_cancel_button">Cancel</string>
     <string name="my_site_icon_content_description">Change site icon</string>
 
+    <string name="my_site_speed_dial_add_post">Add new post</string>
+    <string name="my_site_speed_dial_add_page">Add new page</string>
+
     <!-- site picker -->
     <string name="site_picker_title">Choose site</string>
     <string name="site_picker_edit_visibility">Show/hide sites</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/SpeedDialViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/SpeedDialViewModelTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.viewmodel
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.lifecycle.Observer
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -9,12 +8,11 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.R
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.ui.main.SpeedDialAction
-import org.wordpress.android.ui.main.SpeedDialState.CLOSED
+import org.wordpress.android.ui.main.SpeedDialState.VISIBLE
 import org.wordpress.android.ui.main.SpeedDialState.HIDDEN
 import org.wordpress.android.ui.main.SpeedDialUiState
 import org.wordpress.android.ui.main.SpeedDialViewModel
@@ -25,21 +23,18 @@ class SpeedDialViewModelTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
 
-    @Mock private lateinit var uiStateObserver: Observer<SpeedDialUiState>
-
     private lateinit var viewModel: SpeedDialViewModel
 
     @Before
     fun setUp() {
         viewModel = SpeedDialViewModel(TEST_DISPATCHER)
-        viewModel.uiState.observeForever(uiStateObserver)
         viewModel.start(true)
     }
 
     @Test
-    fun `speed dial visible and closed when asked`() {
-        viewModel.onPageChanged(CLOSED)
-        assertThat(viewModel.uiState.value).isEqualTo(SpeedDialUiState(speedDialState = CLOSED))
+    fun `speed dial visible when asked`() {
+        viewModel.onPageChanged(VISIBLE)
+        assertThat(viewModel.uiState.value).isEqualTo(SpeedDialUiState(speedDialState = VISIBLE))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/SpeedDialViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/SpeedDialViewModelTest.kt
@@ -14,7 +14,6 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.R
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.ui.main.SpeedDialAction
-import org.wordpress.android.ui.main.SpeedDialState
 import org.wordpress.android.ui.main.SpeedDialState.CLOSED
 import org.wordpress.android.ui.main.SpeedDialState.HIDDEN
 import org.wordpress.android.ui.main.SpeedDialUiState

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/SpeedDialViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/SpeedDialViewModelTest.kt
@@ -1,0 +1,69 @@
+package org.wordpress.android.viewmodel
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.R
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.ui.main.SpeedDialAction
+import org.wordpress.android.ui.main.SpeedDialState
+import org.wordpress.android.ui.main.SpeedDialState.CLOSED
+import org.wordpress.android.ui.main.SpeedDialState.HIDDEN
+import org.wordpress.android.ui.main.SpeedDialUiState
+import org.wordpress.android.ui.main.SpeedDialViewModel
+
+@InternalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class SpeedDialViewModelTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    @Mock private lateinit var uiStateObserver: Observer<SpeedDialUiState>
+
+    private lateinit var viewModel: SpeedDialViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = SpeedDialViewModel(TEST_DISPATCHER)
+        viewModel.uiState.observeForever(uiStateObserver)
+        viewModel.start(true)
+    }
+
+    @Test
+    fun `speed dial visible and closed when asked`() {
+        viewModel.onPageChanged(CLOSED)
+        assertThat(viewModel.uiState.value).isEqualTo(SpeedDialUiState(speedDialState = CLOSED))
+    }
+
+    @Test
+    fun `speed dial hidden when asked`() {
+        viewModel.onPageChanged(HIDDEN)
+        assertThat(viewModel.uiState.value).isEqualTo(SpeedDialUiState(speedDialState = HIDDEN))
+    }
+
+    @Test
+    fun `speed dial action is new post when new post fab tapped`() {
+        val job = viewModel.onSpeedDialAction(R.id.fab_add_new_post)
+        runBlocking {
+            job.join()
+        }
+        assertThat(viewModel.speedDialAction.value).isEqualTo(SpeedDialAction.SD_ACTION_NEW_POST)
+    }
+
+    @Test
+    fun `speed dial action is new page when new page fab tapped`() {
+        val job = viewModel.onSpeedDialAction(R.id.fab_add_new_page)
+        runBlocking {
+            job.join()
+        }
+        assertThat(viewModel.speedDialAction.value).isEqualTo(SpeedDialAction.SD_ACTION_NEW_PAGE)
+    }
+}


### PR DESCRIPTION
Fixes #10618

As part of the Information Architecture project this PR adds the possibility to add a new post or page from the My Site screen. 

This modifications are currently behind a feature flag together with the modifications for the [Me Move](https://github.com/wordpress-mobile/WordPress-Android/pull/10498). The common feature flag was renamed accordingly from `ME_ACTIVITY_AVAILABLE ` to `INFORMATION_ARCHITECTURE_AVAILABLE`

We introduced visually two modifications highlighted below:

| Before | After |
|---|---|
| ![before](https://user-images.githubusercontent.com/47797566/67001060-3c322700-f0d9-11e9-8f28-52ffed46c424.png) | ![after](https://user-images.githubusercontent.com/47797566/67001559-56b8d000-f0da-11e9-8c39-c8418ccffd5f.png) |

## NOTES

1. We are currently using in this PR [this library](https://github.com/leinardi/FloatingActionButtonSpeedDial) for the speed dial, this is still under some internal approval before to be finally used in the code base. Also some design considerations are under elaboration and could affect this. But let's keep things moving. 
2. Hi @osullivanchris the library speed dial already supports an action in the main FAB, but the label for that is currently not supported (there is a [request for this feature](https://github.com/leinardi/FloatingActionButtonSpeedDial/issues/10) but still not present). For now we used the standard behaviour with the main FAB acting only as a menu dismiss and all the menu items choices on the mini fabs above. Let me know wdyt, thanks.
3. The original design used an Extended FAB; this is currently supported by the material design library only in it's beta version so for now we are skipping it.
4. The feature flag is active only in the wasabi flavor.
5. I introduced some delay between the speed dial closure and the editor opening to sequence a bit the speed dial closing animation and the editor opening. In my test seems ok, but in case we can adjust the timing or change the strategy if you have different suggestions on it.

## To test
1. Compile and run the wasabi flavor
2. Check that the Me and the new post menu items are not in the bottom nav bar
<p align="center">
  <img width="300" src="https://user-images.githubusercontent.com/47797566/67002460-3ee24b80-f0dc-11e9-8109-f616b8e12703.png">
</p>

3. Switch between My site/Reader/Notifications pages and check that the FAB is only available in the My site screen
4. Tap on each menu item in the bottom navbar to check that the correct screen is visualized
5. Select the FAB and check that the Editor is opened when selecting the Add new Page/Post mini fab
6. Create a post/page and tap on the back arrow. You should be back on the main screen and notified by a snackbar that the post was saved on line.
7. Access to the Pages/Posts list and check the new created Page/Post was created and available in the correct list.
8. Compile and run vanilla flavor
9. Check that you have all the 5 menu item in the Bottom nav bar and the FAB is not present
10. Smoke test to check that the menus activate the expected screens and the app works as usual. 

PS: i think we do not need to include notes in the RELEASE NOTES for the above since it is still behind a feature flag, but not fully sure about it so leaving it unchecked. Let me know wdyt. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

