### PR TITLE
Disable HW acceleration on Aztec when it crashes on Android 8 - Release Gutenberg to v1.15.1

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -160,6 +160,7 @@ import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.widgets.AppRatingDialog;
 import org.wordpress.android.widgets.WPSnackbar;
 import org.wordpress.android.widgets.WPViewPager;
+import org.wordpress.aztec.exceptions.DynamicLayoutGetBlockIndexOutOfBoundsException;
 import org.wordpress.aztec.util.AztecLog;
 
 import java.io.File;
@@ -1769,7 +1770,29 @@ public class EditPostActivity extends AppCompatActivity implements
                         }
                 );
             }
+
+            PostModel currentPost = getPost();
+            if (currentPost != null && AppPrefs.isPostWithHWAccelerationOff(currentPost.getLocalSiteId(),
+                    currentPost.getId())) {
+                // We need to disable HW Acc. on this post
+                aztecEditorFragment.disableHWAcceleration();
+            }
             aztecEditorFragment.setExternalLogger(new AztecLog.ExternalLogger() {
+                // This method handles the custom Exception thrown by Aztec to notify the parent app of the error #8828
+                // We don't need to log the error, since it was already logged by Aztec, instead we need to write the
+                // prefs to disable HW acceleration for it.
+                private boolean isError8828(@NotNull Throwable throwable) {
+                    if (!(throwable instanceof DynamicLayoutGetBlockIndexOutOfBoundsException)) {
+                        return false;
+                    }
+                    PostModel currentPost = getPost();
+                    if (currentPost == null) {
+                        return false;
+                    }
+                    AppPrefs.addPostWithHWAccelerationOff(currentPost.getLocalSiteId(), currentPost.getId());
+                    return true;
+                }
+
                 @Override
                 public void log(@NotNull String s) {
                     // For now, we're wrapping up the actual log into an exception to reduce possibility
@@ -1780,11 +1803,17 @@ public class EditPostActivity extends AppCompatActivity implements
 
                 @Override
                 public void logException(@NotNull Throwable throwable) {
+                    if (isError8828(throwable)) {
+                        return;
+                    }
                     CrashLoggingUtils.logException(new AztecEditorFragment.AztecLoggingException(throwable), T.EDITOR);
                 }
 
                 @Override
                 public void logException(@NotNull Throwable throwable, String s) {
+                    if (isError8828(throwable)) {
+                        return;
+                    }
                     CrashLoggingUtils.logException(
                             new AztecEditorFragment.AztecLoggingException(throwable), T.EDITOR, s);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -4,9 +4,11 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.SiteUtils;
+import org.wordpress.android.util.analytics.AnalyticsUtils;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -33,6 +35,7 @@ public class PostEditorAnalyticsSession implements Serializable {
     private Editor mCurrentEditor;
     private boolean mHasUnsupportedBlocks = false;
     private Outcome mOutcome = null;
+    private boolean mHWAccOff = false;
 
     enum Editor {
         GUTENBERG,
@@ -77,6 +80,8 @@ public class PostEditorAnalyticsSession implements Serializable {
         } else {
             mContentType = "classic";
         }
+
+        mHWAccOff = AppPrefs.isPostWithHWAccelerationOff(site.getId(), post.getId());
     }
 
     public void start(ArrayList<Object> unsupportedBlocksList) {
@@ -132,6 +137,8 @@ public class PostEditorAnalyticsSession implements Serializable {
         properties.put(KEY_BLOG_TYPE, mBlogType);
         properties.put(KEY_SESSION_ID, mSessionId);
         properties.put(KEY_HAS_UNSUPPORTED_BLOCKS, mHasUnsupportedBlocks ? "1" : "0");
+        properties.put(AnalyticsUtils.EDITOR_HAS_HW_ACCELERATION_DISABLED_KEY, mHWAccOff ? "1" : "0");
+
         return properties;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.model.post.PostLocation;
 import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.uploads.PostEvents;
 import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.ui.utils.UiString.UiStringText;
@@ -186,6 +187,8 @@ public class PostUtils {
         if (!post.isLocalDraft()) {
             properties.put("post_id", post.getRemotePostId());
         }
+        properties.put(AnalyticsUtils.EDITOR_HAS_HW_ACCELERATION_DISABLED_KEY, AppPrefs.isPostWithHWAccelerationOff(
+                site.getId(), post.getId()) ? "1" : "0");
         properties.put(AnalyticsUtils.HAS_GUTENBERG_BLOCKS_KEY,
                 PostUtils.contentContainsGutenbergBlocks(post.getContent()));
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.EDITOR_OPENED, site,

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -976,7 +976,7 @@ public class AppPrefs {
             return;
         }
         String key = localSiteId + "-" + localPostId;
-        List<String> currentIds = getPostWithHWAccelerationOff();
+        List<String> currentIds = new ArrayList<>(getPostWithHWAccelerationOff());
         currentIds.add(key);
         // store in prefs
         String idsAsString = TextUtils.join(",", currentIds);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -126,7 +126,10 @@ public class AppPrefs {
         // Widget settings
         STATS_WIDGET_SELECTED_SITE_ID,
         STATS_WIDGET_COLOR_MODE,
-        STATS_WIDGET_DATA_TYPE
+        STATS_WIDGET_DATA_TYPE,
+
+        // Keep the local_blog_id + local_post_id values that have HW Acc. turned off
+        AZTEC_EDITOR_DISABLE_HW_ACC_KEYS,
     }
 
     /**
@@ -958,5 +961,37 @@ public class AppPrefs {
 
     public static boolean getSystemNotificationsEnabled() {
         return getBoolean(UndeletablePrefKey.SYSTEM_NOTIFICATIONS_ENABLED, true);
+    }
+
+    private static List<String> getPostWithHWAccelerationOff() {
+        String idsAsString = getString(DeletablePrefKey.AZTEC_EDITOR_DISABLE_HW_ACC_KEYS, "");
+        return Arrays.asList(idsAsString.split(","));
+    }
+
+    /*
+     * adds a local site ID to the top of list of recently chosen sites
+     */
+    public static void addPostWithHWAccelerationOff(int localSiteId, int localPostId) {
+        if (localSiteId == 0 || localPostId == 0 || isPostWithHWAccelerationOff(localSiteId, localPostId)) {
+            return;
+        }
+        String key = localSiteId + "-" + localPostId;
+        List<String> currentIds = getPostWithHWAccelerationOff();
+        currentIds.add(key);
+        // store in prefs
+        String idsAsString = TextUtils.join(",", currentIds);
+        setString(DeletablePrefKey.AZTEC_EDITOR_DISABLE_HW_ACC_KEYS, idsAsString);
+    }
+
+    public static boolean isPostWithHWAccelerationOff(int localSiteId, int localPostId) {
+        if (localSiteId == 0 || localPostId == 0) {
+            return false;
+        }
+        List<String> currentIds = getPostWithHWAccelerationOff();
+        String key = localSiteId + "-" + localPostId;
+        if (currentIds.contains(key)) {
+            return true;
+        }
+        return false;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -68,6 +68,7 @@ public class AnalyticsUtils {
     private static final String NEWS_CARD_VERSION = "version";
 
     public static final String HAS_GUTENBERG_BLOCKS_KEY = "has_gutenberg_blocks";
+    public static final String EDITOR_HAS_HW_ACCELERATION_DISABLED_KEY = "editor_has_hw_disabled";
 
     public enum BlockEditorEnabledSource {
         VIA_SITE_SETTINGS,

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     ext {
-        aztecVersion = '876ac04b4b55304cb81dab7b5025822e4ddec2f8'
+        aztecVersion = 'v1.3.34'
     }
 
     dependencies {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     ext {
-        aztecVersion = 'v1.3.33'
+        aztecVersion = '876ac04b4b55304cb81dab7b5025822e4ddec2f8'
     }
 
     dependencies {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     ext {
-        aztecVersion = 'v1.3.31'
+        aztecVersion = '876ac04b4b55304cb81dab7b5025822e4ddec2f8'
     }
 
     dependencies {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -194,6 +194,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     private LiveTextWatcher mTextWatcher = new LiveTextWatcher();
 
+    private View mFragmentView;
+
     public static AztecEditorFragment newInstance(String title, String content, boolean isExpanded) {
         mIsToolbarExpanded = isExpanded;
         AztecEditorFragment fragment = new AztecEditorFragment();
@@ -219,6 +221,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_aztec_editor, container, false);
+        mFragmentView = view;
 
         mTitle = view.findViewById(R.id.title);
         mContent = view.findViewById(R.id.aztec);
@@ -2349,6 +2352,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     public void disableHWAcceleration() {
-        getView().setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+        mFragmentView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
     }
 }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -2347,4 +2347,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     public void setExternalLogger(AztecLog.ExternalLogger logger) {
         mContent.setExternalLogger(logger);
     }
+
+    public void disableHWAcceleration() {
+        getView().setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+    }
 }


### PR DESCRIPTION
This PR tries to mitigate #8828 by catching the crash reported by Aztec, and disabling HW acceleration on the current post. (The postID is stored in AppPrefs. Next time the users load the same post, the app turns HW acceleration off for the whole Aztec Fragment).

The original problem, as discussed with details in #8828, is deep inside the Android 8 Framework, and there is no way for us to prevent it. We found out that disabling HW acc. does fix it.
Unfortunately we cannot disable HW acc. on all posts, since without HW acc. the Aztec editor is kind of slow even on recent devices. More, the problem doesn't happen all the times, but only when the users follow some edit patterns (we cannot repro it btw) that make it happen.

In details:
- Aztec was modified to report the out of bounds problem `android.text.DynamicLayout.getBlockIndex(DynamicLayout.java:646)` 
- The app catches this exact error, and writes in AppPrefs the id of the post
- When the user will load the same post again, Aztec is started without HW acc.

Note: Unfortunately this PR does act after the fact, and probably we won't see crash report numbers disappear completely. 

As a further improvement to this, we may want to add (?) a global app setting, say "Aztec compatibility mode" that we switch to ON the first this crash happens, and notify the user about that, and give the instructions on how to turn it OFF in App->Settings.

cc @designsimply 

- Aztec side PR: https://github.com/wordpress-mobile/AztecEditor-Android/pull/861
- GB-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1475 it's just a single line that updates the Aztec version since needs to be in synch with the version loaded in the main app.

This PR also updates Gutenberg to v1.15.1
gutenberg-mobile PR: wordpress-mobile/gutenberg-mobile#1479

TODO:
 - [ ] Update gutenberg ref to point at 1.15.1 tag

PR submission checklist:

- [ x ] I have considered adding unit tests where possible.

- [ x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

