### PR TITLE
CircleCI: Bump Orbs to use any 1.0.x version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 orbs:
-  android: wordpress-mobile/android@0.0.32
-  git: wordpress-mobile/git@0.0.33
+  # Using 1.0 of the Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
+  android: wordpress-mobile/android@1.0
+  git: wordpress-mobile/git@1.0
   bundle-install: toshimaru/bundle-install@0.3.1
   slack: circleci/slack@2.5.0
 


### PR DESCRIPTION
Our [CircleCI Orbs repo](https://github.com/wordpress-mobile/circleci-orbs) has been stabilising and I released version 1.0.0 this week. In this PR, I am bumping the versions we use to `1.0` so that it will pick up any future 1.0.x version. This means we don't need to bump the version for any little change to our Orbs.

To test:

- CircleCI is green

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

