### PR TITLE
Updated snackbar copy for draft action in Binned Tab on Post List 

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1204,7 +1204,7 @@
     <string name="editor_post_title_placeholder">Post Title</string>
     <string name="editor_page_title_placeholder">Page Title</string>
     <string name="editor_content_placeholder">Share your story here…</string>
-    <string name="editor_post_saved_online">Post saved online</string>
+    <string name="editor_post_saved_online">Post moved to drafts</string>
     <string name="editor_post_saved_locally">Post saved on device</string>
     <string name="editor_draft_saved_online">Draft saved online</string>
     <string name="editor_draft_saved_locally">Draft saved on device</string>


### PR DESCRIPTION
Fixes #9769

To test:
1. Go to a site.
2. Go to its posts. 
3. Go to the binned/trash tab and click on a post's`Move To Draft` button.
4. Once the move has been completed the copy of the snackbar should say `Post moved to drafts`.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

