### PR TITLE
Add signup flow name parameter to /auth/send-signup-email request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'dc1c8881b3df17772cca89fa98acc0c03159753a'
+    fluxCVersion = '1.5.1-beta-3'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.5.1-beta-2'
+    fluxCVersion = 'dc1c8881b3df17772cca89fa98acc0c03159753a'
 }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
@@ -40,6 +40,7 @@ public class SignupMagicLinkFragment extends Fragment {
     private static final String ARG_EMAIL_ADDRESS = "ARG_EMAIL_ADDRESS";
     private static final String ARG_IS_JETPACK_CONNECT = "ARG_IS_JETPACK_CONNECT";
     private static final String ARG_JETPACK_CONNECT_SOURCE = "ARG_JETPACK_CONNECT_SOURCE";
+    private static final String SIGNUP_FLOW_NAME = "mobile-android";
 
     public static final String TAG = "signup_magic_link_fragment_tag";
 
@@ -198,6 +199,7 @@ public class SignupMagicLinkFragment extends Fragment {
             AuthEmailPayloadSource source = getAuthEmailPayloadSource();
             AuthEmailPayload authEmailPayload = new AuthEmailPayload(mEmail, true,
                     mIsJetpackConnect ? AuthEmailPayloadFlow.JETPACK : null, source);
+            authEmailPayload.signupFlowName = SIGNUP_FLOW_NAME;
             mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(authEmailPayload));
         }
     }


### PR DESCRIPTION
Fixes #10625.

To test:
* Logout of the app
* Tap `SIGN UP FOR WORDPRESS.COM` -> `SIGN UP WITH EMAIL`
* Enter an email and tap `NEXT` (Tip: You can use the `+` suffix for the email as in `example+testsignup@mydomain.com` to avoid using another email address)
* Verify `mobile-android` was sent as `signup_flow_name` parameter in `/auth/send-signup-email` request from Stetho

<img width="601" alt="Capture" src="https://user-images.githubusercontent.com/662023/67122468-de2a4000-f1bb-11e9-98b9-257c4959baf2.PNG">


The PR is opened as a draft PR so the FluxC hash can be updated once FluxC counterpart of this PR is merged.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.