### PR TITLE
Remove static calls and android dependencies from FeaturedImageHelper

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/SnackbarMessageHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/SnackbarMessageHolder.kt
@@ -1,10 +1,12 @@
 package org.wordpress.android.ui.pages
 
 import androidx.annotation.StringRes
+import com.google.android.material.snackbar.Snackbar
 
 data class SnackbarMessageHolder(
     @StringRes val messageRes: Int,
     @StringRes val buttonTitleRes: Int? = null,
     val buttonAction: () -> Unit = {},
-    val onDismissAction: () -> Unit = {}
+    val onDismissAction: () -> Unit = {},
+    val duration: Int = Snackbar.LENGTH_LONG
 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/SnackbarMessageHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/SnackbarMessageHolder.kt
@@ -1,12 +1,10 @@
 package org.wordpress.android.ui.pages
 
 import androidx.annotation.StringRes
-import com.google.android.material.snackbar.Snackbar
 
 data class SnackbarMessageHolder(
     @StringRes val messageRes: Int,
     @StringRes val buttonTitleRes: Int? = null,
     val buttonAction: () -> Unit = {},
-    val onDismissAction: () -> Unit = {},
-    val duration: Int = Snackbar.LENGTH_LONG
+    val onDismissAction: () -> Unit = {}
 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -27,7 +27,6 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaBrowserType;
-import org.wordpress.android.ui.pages.SnackbarMessageHolder;
 import org.wordpress.android.ui.posts.FeaturedImageHelper;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ListUtils;
@@ -256,16 +255,15 @@ public class PhotoPickerActivity extends AppCompatActivity
                                              new WPMediaUtils.MediaFetchDoNext() {
                                                  @Override
                                                  public void doNext(Uri uri) {
-                                                     SnackbarMessageHolder snackbarMessageHolder = mFeaturedImageHelper
+                                                     boolean imageQueued = mFeaturedImageHelper
                                                              .queueFeaturedImageForUpload(mLocalPostId, mSite, uri,
                                                                      mimeType);
-                                                     if (snackbarMessageHolder != null) {
+                                                     if (!imageQueued) {
                                                          // we intentionally display a toast instead of a snackbar as a
                                                          // Snackbar is tied to an Activity and the activity is finished
                                                          // right after this call
                                                          Toast.makeText(getApplicationContext(),
-                                                                 snackbarMessageHolder.getMessageRes(),
-                                                                 snackbarMessageHolder.getDuration()).show();
+                                                                 R.string.file_not_found, Toast.LENGTH_SHORT).show();
                                                      }
                                                      Intent intent = new Intent()
                                                              .putExtra(EXTRA_MEDIA_QUEUED, true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.MenuItem;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -26,6 +27,7 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaBrowserType;
+import org.wordpress.android.ui.pages.SnackbarMessageHolder;
 import org.wordpress.android.ui.posts.FeaturedImageHelper;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ListUtils;
@@ -254,9 +256,17 @@ public class PhotoPickerActivity extends AppCompatActivity
                                              new WPMediaUtils.MediaFetchDoNext() {
                                                  @Override
                                                  public void doNext(Uri uri) {
-                                                     mFeaturedImageHelper
-                                                             .queueFeaturedImageForUpload(PhotoPickerActivity.this,
-                                                                     mLocalPostId, mSite, uri, mimeType);
+                                                     SnackbarMessageHolder snackbarMessageHolder = mFeaturedImageHelper
+                                                             .queueFeaturedImageForUpload(mLocalPostId, mSite, uri,
+                                                                     mimeType);
+                                                     if (snackbarMessageHolder != null) {
+                                                         // we intentionally display a toast instead of a snackbar as a
+                                                         // Snackbar is tied to an Activity and the activity is finished
+                                                         // right after this call
+                                                         Toast.makeText(getApplicationContext(),
+                                                                 snackbarMessageHolder.getMessageRes(),
+                                                                 snackbarMessageHolder.getDuration()).show();
+                                                     }
                                                      Intent intent = new Intent()
                                                              .putExtra(EXTRA_MEDIA_QUEUED, true);
                                                      setResult(RESULT_OK, intent);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1653,7 +1653,7 @@ public class EditPostActivity extends AppCompatActivity implements
         switch (instanceTag) {
             case TAG_FAILED_MEDIA_UPLOADS_DIALOG:
                 // Clear failed uploads
-                mFeaturedImageHelper.cancelFeaturedImageUpload(this, mSite, mPost, true);
+                mFeaturedImageHelper.cancelFeaturedImageUpload(mSite, mPost, true);
                 mEditorFragment.removeAllFailedMediaUploads();
                 break;
             case TAG_PUBLISH_CONFIRMATION_DIALOG:

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -404,27 +404,33 @@ public class EditPostSettingsFragment extends Fragment {
 
     @Override
     public boolean onContextItemSelected(MenuItem item) {
+        SiteModel site = getSite();
+        PostModel post = getPost();
+        if (site == null || post == null) {
+            AppLog.w(T.POSTS, "Unexpected state: Post or Site is null.");
+            return false;
+        }
         switch (item.getItemId()) {
             case CHOOSE_FEATURED_IMAGE_MENU_ID:
-                mFeaturedImageHelper.cancelFeaturedImageUpload(getContext(), getSite(), getPost(), false);
+                mFeaturedImageHelper.cancelFeaturedImageUpload(site, post, false);
                 launchFeaturedMediaPicker();
                 return true;
             case REMOVE_FEATURED_IMAGE_UPLOAD_MENU_ID:
             case REMOVE_FEATURED_IMAGE_MENU_ID:
-                mFeaturedImageHelper.cancelFeaturedImageUpload(getContext(), getSite(), getPost(), false);
+                mFeaturedImageHelper.cancelFeaturedImageUpload(site, post, false);
                 clearFeaturedImage();
                 return true;
             case RETRY_FEATURED_IMAGE_UPLOAD_MENU_ID:
-                retryFeaturedImageUpload();
+                retryFeaturedImageUpload(site, post);
                 return true;
             default:
                 return false;
         }
     }
 
-    private void retryFeaturedImageUpload() {
+    private void retryFeaturedImageUpload(@NonNull SiteModel site, @NonNull PostModel post) {
         MediaModel mediaModel =
-                mFeaturedImageHelper.retryFeaturedImageUpload(getContext(), getSite(), getPost());
+                mFeaturedImageHelper.retryFeaturedImageUpload(site, post);
         if (mediaModel == null) {
             clearFeaturedImage();
         }
@@ -867,7 +873,7 @@ public class EditPostSettingsFragment extends Fragment {
             return;
         }
         final FeaturedImageData currentFeaturedImageState =
-                mFeaturedImageHelper.createCurrentFeaturedImageState(context, site, post);
+                mFeaturedImageHelper.createCurrentFeaturedImageState(site, post);
 
         FeaturedImageState uiState = currentFeaturedImageState.getUiState();
         updateFeaturedImageViews(currentFeaturedImageState.getUiState());

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/FeaturedImageHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/FeaturedImageHelper.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.posts
 
 import android.net.Uri
-import com.google.android.material.snackbar.Snackbar
 import dagger.Reusable
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
@@ -13,7 +12,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.MediaStore.CancelMediaPayload
 import org.wordpress.android.fluxc.store.UploadStore
-import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.uploads.UploadServiceFacade
 import org.wordpress.android.util.AppLog
@@ -80,9 +78,9 @@ internal class FeaturedImageHelper @Inject constructor(
         site: SiteModel,
         uri: Uri,
         mimeType: String?
-    ): SnackbarMessageHolder? {
+    ): Boolean {
         val media = fluxCUtilsWrapper.mediaModelFromLocalUri(uri, mimeType, mediaStore, site.id)
-                ?: return SnackbarMessageHolder(R.string.file_not_found, duration = Snackbar.LENGTH_SHORT)
+                ?: return false
         if (localPostId != EMPTY_LOCAL_POST_ID) {
             media.localPostId = localPostId
         } else {
@@ -92,7 +90,7 @@ internal class FeaturedImageHelper @Inject constructor(
 
         dispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media))
         startUploadService(media)
-        return null
+        return true
     }
 
     fun cancelFeaturedImageUpload(site: SiteModel, post: PostModel, cancelFailedOnly: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/FeaturedImageHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/FeaturedImageHelper.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.ui.posts
 
-import android.content.Context
 import android.net.Uri
+import com.google.android.material.snackbar.Snackbar
 import dagger.Reusable
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
@@ -13,14 +13,15 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.MediaStore.CancelMediaPayload
 import org.wordpress.android.fluxc.store.UploadStore
-import org.wordpress.android.ui.reader.utils.ReaderUtils
-import org.wordpress.android.ui.uploads.UploadService
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
+import org.wordpress.android.ui.uploads.UploadServiceFacade
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import org.wordpress.android.util.FluxCUtils
-import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.FluxCUtilsWrapper
+import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.util.StringUtils
-import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.ArrayList
 import javax.inject.Inject
 
@@ -36,6 +37,11 @@ const val EMPTY_LOCAL_POST_ID = -1
 internal class FeaturedImageHelper @Inject constructor(
     private val uploadStore: UploadStore,
     private val mediaStore: MediaStore,
+    private val uploadServiceFacade: UploadServiceFacade,
+    private val resourceProvider: ResourceProvider,
+    private val readerUtilsWrapper: ReaderUtilsWrapper,
+    private val fluxCUtilsWrapper: FluxCUtilsWrapper,
+    private val siteUtilsWrapper: SiteUtilsWrapper,
     private val dispatcher: Dispatcher
 ) {
     fun getFailedFeaturedImageUpload(post: PostModel): MediaModel? {
@@ -49,39 +55,34 @@ internal class FeaturedImageHelper @Inject constructor(
     }
 
     fun retryFeaturedImageUpload(
-        context: Context,
         site: SiteModel,
         post: PostModel
     ): MediaModel? {
         val mediaModel = getFailedFeaturedImageUpload(post)
         if (mediaModel != null) {
-            UploadService.cancelFinalNotification(context, post)
-            UploadService.cancelFinalNotificationForMedia(context, site)
+            uploadServiceFacade.cancelFinalNotification(post)
+            uploadServiceFacade.cancelFinalNotificationForMedia(site)
             mediaModel.setUploadState(MediaUploadState.QUEUED)
             dispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel))
-            startUploadService(context, mediaModel)
+            startUploadService(mediaModel)
         }
         return mediaModel
     }
 
-    private fun startUploadService(context: Context, media: MediaModel) {
+    private fun startUploadService(media: MediaModel) {
         val mediaList = ArrayList<MediaModel>()
         mediaList.add(media)
-        UploadService.uploadMedia(context, mediaList)
+        uploadServiceFacade.uploadMedia(mediaList)
     }
 
     fun queueFeaturedImageForUpload(
-        context: Context,
         localPostId: Int,
         site: SiteModel,
         uri: Uri,
         mimeType: String?
-    ) {
-        val media = FluxCUtils.mediaModelFromLocalUri(context, uri, mimeType, mediaStore, site.id)
-        if (media == null) {
-            ToastUtils.showToast(context, R.string.file_not_found, ToastUtils.Duration.SHORT)
-            return
-        }
+    ): SnackbarMessageHolder? {
+        val media = fluxCUtilsWrapper.mediaModelFromLocalUri(uri, mimeType, mediaStore, site.id)
+                ?: return SnackbarMessageHolder(R.string.file_not_found, duration = Snackbar.LENGTH_SHORT)
         if (localPostId != EMPTY_LOCAL_POST_ID) {
             media.localPostId = localPostId
         } else {
@@ -90,24 +91,25 @@ internal class FeaturedImageHelper @Inject constructor(
         media.markedLocallyAsFeatured = true
 
         dispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media))
-        startUploadService(context, media)
+        startUploadService(media)
+        return null
     }
 
-    fun cancelFeaturedImageUpload(context: Context, site: SiteModel, post: PostModel, cancelFailedOnly: Boolean) {
+    fun cancelFeaturedImageUpload(site: SiteModel, post: PostModel, cancelFailedOnly: Boolean) {
         var mediaModel: MediaModel? = getFailedFeaturedImageUpload(post)
         if (!cancelFailedOnly && mediaModel == null) {
-            mediaModel = UploadService.getPendingOrInProgressFeaturedImageUploadForPost(post)
+            mediaModel = uploadServiceFacade.getPendingOrInProgressFeaturedImageUploadForPost(post)
         }
         if (mediaModel != null) {
             val payload = CancelMediaPayload(site, mediaModel, true)
             dispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload))
-            UploadService.cancelFinalNotification(context, post)
-            UploadService.cancelFinalNotificationForMedia(context, site)
+            uploadServiceFacade.cancelFinalNotification(post)
+            uploadServiceFacade.cancelFinalNotificationForMedia(site)
         }
     }
 
-    fun createCurrentFeaturedImageState(context: Context, site: SiteModel, post: PostModel): FeaturedImageData {
-        var uploadModel: MediaModel? = UploadService.getPendingOrInProgressFeaturedImageUploadForPost(post)
+    fun createCurrentFeaturedImageState(site: SiteModel, post: PostModel): FeaturedImageData {
+        var uploadModel: MediaModel? = uploadServiceFacade.getPendingOrInProgressFeaturedImageUploadForPost(post)
         if (uploadModel != null) {
             return FeaturedImageData(FeaturedImageState.IMAGE_UPLOAD_IN_PROGRESS, uploadModel.filePath)
         }
@@ -125,10 +127,15 @@ internal class FeaturedImageHelper @Inject constructor(
         )
 
         // Get max width/height for photon thumbnail - we load a smaller image so it's loaded quickly
-        val maxDimen = context.resources.getDimension(R.dimen.post_settings_featured_image_height_min).toInt()
+        val maxDimen = resourceProvider.getDimension(R.dimen.post_settings_featured_image_height_min).toInt()
 
         val mediaUri = StringUtils.notNullStr(media.thumbnailUrl)
-        val photonUrl = ReaderUtils.getResizedImageUrl(mediaUri, maxDimen, maxDimen, !SiteUtils.isPhotonCapable(site))
+        val photonUrl = readerUtilsWrapper.getResizedImageUrl(
+                mediaUri,
+                maxDimen,
+                maxDimen,
+                !siteUtilsWrapper.isPhotonCapable(site)
+        )
         return FeaturedImageData(FeaturedImageState.REMOTE_IMAGE_LOADING, photonUrl)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
@@ -1,7 +1,10 @@
 package org.wordpress.android.ui.uploads
 
 import android.content.Context
+import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import java.util.ArrayList
 import javax.inject.Inject
 
 /**
@@ -10,11 +13,21 @@ import javax.inject.Inject
  * The main purpose of this is to provide testability for classes that use [UploadService]. This should never
  * contain any static methods.
  */
-class UploadServiceFacade @Inject constructor() {
+class UploadServiceFacade @Inject constructor(private val appContext: Context) {
     fun uploadPost(context: Context, post: PostModel, trackAnalytics: Boolean) {
         val intent = UploadService.getRetryUploadServiceIntent(context, post, trackAnalytics)
         context.startService(intent)
     }
 
     fun isPostUploadingOrQueued(post: PostModel) = UploadService.isPostUploadingOrQueued(post)
+    fun cancelFinalNotification(post: PostModel) = UploadService.cancelFinalNotification(appContext, post)
+
+    fun cancelFinalNotificationForMedia(site: SiteModel) =
+            UploadService.cancelFinalNotificationForMedia(appContext, site)
+
+    fun uploadMedia(mediaList: ArrayList<MediaModel>) =
+            UploadService.uploadMedia(appContext, mediaList)
+
+    fun getPendingOrInProgressFeaturedImageUploadForPost(post: PostModel): MediaModel? =
+            UploadService.getPendingOrInProgressFeaturedImageUploadForPost(post)
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtilsWrapper.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.util
+
+import android.content.Context
+import android.net.Uri
+import dagger.Reusable
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.store.MediaStore
+import javax.inject.Inject
+
+/**
+ * Injectable wrapper around FluxCUtilsWrapper.
+ *
+ * FluxCUtilsWrapper interface is consisted of static methods, which make the client code difficult to test/mock.
+ * Main purpose of this wrapper is to make testing easier.
+ *
+ */
+@Reusable
+class FluxCUtilsWrapper @Inject constructor(private val appContext: Context) {
+    fun mediaModelFromLocalUri(
+        uri: Uri,
+        mimeType: String?,
+        mediaStore: MediaStore,
+        id: Int
+    ): MediaModel? = FluxCUtils.mediaModelFromLocalUri(appContext, uri, mimeType, mediaStore, id)
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.util
+
+import dagger.Reusable
+import org.wordpress.android.fluxc.model.SiteModel
+import javax.inject.Inject
+
+/**
+ * Injectable wrapper around SiteUtilsWrapper.
+ *
+ * SiteUtilsWrapper interface is consisted of static methods, which make the client code difficult to test/mock.
+ * Main purpose of this wrapper is to make testing easier.
+ *
+ */
+@Reusable
+class SiteUtilsWrapper @Inject constructor() {
+    fun isPhotonCapable(site: SiteModel):  Boolean = SiteUtils.isPhotonCapable(site)
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
@@ -13,5 +13,5 @@ import javax.inject.Inject
  */
 @Reusable
 class SiteUtilsWrapper @Inject constructor() {
-    fun isPhotonCapable(site: SiteModel):  Boolean = SiteUtils.isPhotonCapable(site)
+    fun isPhotonCapable(site: SiteModel): Boolean = SiteUtils.isPhotonCapable(site)
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/ResourceProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/ResourceProvider.kt
@@ -23,4 +23,9 @@ class ResourceProvider @Inject constructor(private val contextProvider: ContextP
         val resources = contextProvider.getContext().resources
         return resources.getDimensionPixelSize(dimen)
     }
+
+    fun getDimension(@DimenRes dimen: Int): Float {
+        val resources = contextProvider.getContext().resources
+        return resources.getDimension(dimen)
+    }
 }


### PR DESCRIPTION
Fixes #10660 

This PR removes static calls and Android dependencies from FeaturedImageHelper.

To test:
Test1: Add a featured image to a post and verify it's uploaded correctly
Test2: Add a featured image to a post in offline and verify it's uploaded correctly when you click on retry while your device is online

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

