### PR TITLE
Extract notification action type

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -531,7 +531,7 @@ public class GCMMessageService extends FirebaseMessagingService {
             Intent commentReplyIntent = getCommentActionReplyIntent(context, noteId);
             commentReplyIntent.addCategory(KEY_CATEGORY_COMMENT_REPLY);
             commentReplyIntent.putExtra(NotificationsProcessingService.ARG_ACTION_TYPE,
-                                        NotificationsProcessingService.ARG_ACTION_REPLY);
+                                        NotificationActionType.ARG_ACTION_REPLY);
             if (noteId != null) {
                 commentReplyIntent.putExtra(NotificationsProcessingService.ARG_NOTE_ID, noteId);
             }
@@ -559,7 +559,7 @@ public class GCMMessageService extends FirebaseMessagingService {
             Intent commentLikeIntent = getCommentActionIntent(context);
             commentLikeIntent.addCategory(KEY_CATEGORY_COMMENT_LIKE);
             commentLikeIntent.putExtra(NotificationsProcessingService.ARG_ACTION_TYPE,
-                                       NotificationsProcessingService.ARG_ACTION_LIKE);
+                    NotificationActionType.ARG_ACTION_LIKE);
             if (noteId != null) {
                 commentLikeIntent.putExtra(NotificationsProcessingService.ARG_NOTE_ID, noteId);
             }
@@ -577,7 +577,7 @@ public class GCMMessageService extends FirebaseMessagingService {
             Intent commentApproveIntent = getCommentActionIntent(context);
             commentApproveIntent.addCategory(KEY_CATEGORY_COMMENT_MODERATE);
             commentApproveIntent.putExtra(NotificationsProcessingService.ARG_ACTION_TYPE,
-                                          NotificationsProcessingService.ARG_ACTION_APPROVE);
+                    NotificationActionType.ARG_ACTION_APPROVE);
             if (noteId != null) {
                 commentApproveIntent.putExtra(NotificationsProcessingService.ARG_NOTE_ID, noteId);
             }
@@ -1007,7 +1007,7 @@ public class GCMMessageService extends FirebaseMessagingService {
             Intent authApproveIntent = new Intent(context, WPMainActivity.class);
             authApproveIntent.putExtra(WPMainActivity.ARG_OPENED_FROM_PUSH, true);
             authApproveIntent.putExtra(NotificationsProcessingService.ARG_ACTION_TYPE,
-                                       NotificationsProcessingService.ARG_ACTION_AUTH_APPROVE);
+                    NotificationActionType.ARG_ACTION_AUTH_APPROVE);
             authApproveIntent.putExtra(NotificationsUtils.ARG_PUSH_AUTH_TOKEN, pushAuthToken);
             authApproveIntent.putExtra(NotificationsUtils.ARG_PUSH_AUTH_TITLE, title);
             authApproveIntent.putExtra(NotificationsUtils.ARG_PUSH_AUTH_MESSAGE, message);
@@ -1028,7 +1028,7 @@ public class GCMMessageService extends FirebaseMessagingService {
 
             Intent authIgnoreIntent = new Intent(context, NotificationsProcessingService.class);
             authIgnoreIntent.putExtra(NotificationsProcessingService.ARG_ACTION_TYPE,
-                                      NotificationsProcessingService.ARG_ACTION_AUTH_IGNORE);
+                                      NotificationActionType.ARG_ACTION_AUTH_IGNORE);
             PendingIntent authIgnorePendingIntent = PendingIntent.getService(context,
                                                                              AUTH_PUSH_REQUEST_CODE_IGNORE,
                                                                              authIgnoreIntent,

--- a/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
@@ -8,18 +8,24 @@ import androidx.core.app.NotificationManagerCompat;
 
 import org.wordpress.android.R;
 
+import javax.inject.Inject;
+
 import static org.wordpress.android.push.GCMMessageService.ACTIONS_PROGRESS_NOTIFICATION_ID;
 
 public class NativeNotificationsUtils {
-    public static void showIntermediateMessageToUser(String message, Context context) {
+    @Inject
+    public NativeNotificationsUtils() {
+    }
+
+    public void showIntermediateMessageToUser(String message, Context context) {
         showMessageToUser(message, true, ACTIONS_PROGRESS_NOTIFICATION_ID, context);
     }
 
-    public static void showFinalMessageToUser(String message, int pushId, Context context) {
+    public void showFinalMessageToUser(String message, int pushId, Context context) {
         showMessageToUser(message, false, pushId, context);
     }
 
-    private static void showMessageToUser(String message, boolean intermediateMessage, int pushId, Context context) {
+    private void showMessageToUser(String message, boolean intermediateMessage, int pushId, Context context) {
         NotificationCompat.Builder builder = getBuilder(context,
                 context.getString(R.string.notification_channel_transient_id))
                 .setContentText(message).setTicker(message)
@@ -27,7 +33,7 @@ public class NativeNotificationsUtils {
         showMessageToUserWithBuilder(builder, message, intermediateMessage, pushId, context);
     }
 
-    public static void showMessageToUserWithBuilder(NotificationCompat.Builder builder, String message,
+    public void showMessageToUserWithBuilder(NotificationCompat.Builder builder, String message,
                                                     boolean intermediateMessage, int pushId, Context context) {
         if (!intermediateMessage) {
             builder.setStyle(new NotificationCompat.BigTextStyle().bigText(message));
@@ -38,7 +44,7 @@ public class NativeNotificationsUtils {
         notificationManager.notify(pushId, builder.build());
     }
 
-    public static NotificationCompat.Builder getBuilder(Context context, String channelId) {
+    public NotificationCompat.Builder getBuilder(Context context, String channelId) {
         return new NotificationCompat.Builder(context, channelId)
                 .setSmallIcon(R.drawable.ic_my_sites_white_24dp)
                 .setColor(context.getResources().getColor(R.color.primary_50))
@@ -46,14 +52,14 @@ public class NativeNotificationsUtils {
                 .setAutoCancel(true);
     }
 
-    public static void dismissNotification(int pushId, Context context) {
+    public void dismissNotification(int pushId, Context context) {
         if (context != null) {
             final NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
             notificationManager.cancel(pushId);
         }
     }
 
-    public static void hideStatusBar(Context context) {
+    public void hideStatusBar(Context context) {
         Intent closeIntent = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
         context.sendBroadcast(closeIntent);
     }

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationActionType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationActionType.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.push
+
+enum class NotificationActionType(val value: String) {
+    ARG_ACTION_LIKE("action_like"),
+    ARG_ACTION_REPLY("action_reply"),
+    ARG_ACTION_APPROVE("action_approve"),
+    ARG_ACTION_NOTIFICATION_DISMISS("action_dismiss"),
+    ARG_ACTION_DRAFT_PENDING_DISMISS("action_draft_pending_dismiss"),
+    ARG_ACTION_DRAFT_PENDING_IGNORE("action_draft_pending_ignore"),
+    ARG_ACTION_AUTH_APPROVE("action_auth_aprove"),
+    ARG_ACTION_AUTH_IGNORE("action_auth_ignore"),
+}

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -34,15 +34,7 @@ import javax.inject.Inject;
 
 public class NotificationsProcessingService extends Service {
     public static final String ARG_ACTION_TYPE = "action_type";
-    public static final String ARG_ACTION_LIKE = "action_like";
-    public static final String ARG_ACTION_REPLY = "action_reply";
-    public static final String ARG_ACTION_APPROVE = "action_approve";
-    public static final String ARG_ACTION_AUTH_APPROVE = "action_auth_aprove";
-    public static final String ARG_ACTION_AUTH_IGNORE = "action_auth_ignore";
-    public static final String ARG_ACTION_DRAFT_PENDING_DISMISS = "action_draft_pending_dismiss";
-    public static final String ARG_ACTION_DRAFT_PENDING_IGNORE = "action_draft_pending_ignore";
     public static final String ARG_ACTION_REPLY_TEXT = "action_reply_text";
-    public static final String ARG_ACTION_NOTIFICATION_DISMISS = "action_dismiss";
     public static final String ARG_NOTE_ID = "note_id";
     public static final String ARG_PUSH_ID = "notificationId";
 
@@ -62,7 +54,7 @@ public class NotificationsProcessingService extends Service {
     * */
     public static void startServiceForLike(Context context, String noteId) {
         Intent intent = new Intent(context, NotificationsProcessingService.class);
-        intent.putExtra(ARG_ACTION_TYPE, ARG_ACTION_LIKE);
+        intent.putExtra(ARG_ACTION_TYPE, NotificationActionType.ARG_ACTION_LIKE);
         intent.putExtra(ARG_NOTE_ID, noteId);
         context.startService(intent);
     }
@@ -72,7 +64,7 @@ public class NotificationsProcessingService extends Service {
     * */
     public static void startServiceForApprove(Context context, String noteId) {
         Intent intent = new Intent(context, NotificationsProcessingService.class);
-        intent.putExtra(ARG_ACTION_TYPE, ARG_ACTION_APPROVE);
+        intent.putExtra(ARG_ACTION_TYPE, NotificationActionType.ARG_ACTION_APPROVE);
         intent.putExtra(ARG_NOTE_ID, noteId);
         context.startService(intent);
     }
@@ -82,7 +74,7 @@ public class NotificationsProcessingService extends Service {
     * */
     public static void startServiceForReply(Context context, String noteId, String replyToComment) {
         Intent intent = new Intent(context, NotificationsProcessingService.class);
-        intent.putExtra(ARG_ACTION_TYPE, ARG_ACTION_REPLY);
+        intent.putExtra(ARG_ACTION_TYPE, NotificationActionType.ARG_ACTION_REPLY);
         intent.putExtra(ARG_NOTE_ID, noteId);
         intent.putExtra(ARG_ACTION_REPLY_TEXT, replyToComment);
         context.startService(intent);
@@ -90,9 +82,9 @@ public class NotificationsProcessingService extends Service {
 
     public static PendingIntent getPendingIntentForNotificationDismiss(Context context, int pushId) {
         Intent intent = new Intent(context, NotificationsProcessingService.class);
-        intent.putExtra(ARG_ACTION_TYPE, ARG_ACTION_NOTIFICATION_DISMISS);
+        intent.putExtra(ARG_ACTION_TYPE, NotificationActionType.ARG_ACTION_NOTIFICATION_DISMISS);
         intent.putExtra(ARG_PUSH_ID, pushId);
-        intent.addCategory(ARG_ACTION_NOTIFICATION_DISMISS);
+        intent.addCategory(NotificationActionType.ARG_ACTION_NOTIFICATION_DISMISS.getValue());
         return PendingIntent.getService(context, pushId, intent, PendingIntent.FLAG_CANCEL_CURRENT);
     }
 
@@ -173,9 +165,9 @@ public class NotificationsProcessingService extends Service {
                 for (Long oneEventCommentRemoteId : eventChangedCommentsRemoteIds) {
                     if (mActionedCommentsRemoteIds.contains(oneEventCommentRemoteId)) {
                         if (event.isError()) {
-                            mQuickActionProcessor.requestFailed(ARG_ACTION_APPROVE);
+                            mQuickActionProcessor.requestFailed(NotificationActionType.ARG_ACTION_APPROVE);
                         } else {
-                            mQuickActionProcessor.requestCompleted(ARG_ACTION_APPROVE);
+                            mQuickActionProcessor.requestCompleted(NotificationActionType.ARG_ACTION_APPROVE);
                         }
                     }
                 }
@@ -187,15 +179,15 @@ public class NotificationsProcessingService extends Service {
             }
         } else if (event.causeOfChange == CommentAction.LIKE_COMMENT) {
             if (event.isError()) {
-                mQuickActionProcessor.requestFailed(ARG_ACTION_LIKE);
+                mQuickActionProcessor.requestFailed(NotificationActionType.ARG_ACTION_LIKE);
             } else {
-                mQuickActionProcessor.requestCompleted(ARG_ACTION_LIKE);
+                mQuickActionProcessor.requestCompleted(NotificationActionType.ARG_ACTION_LIKE);
             }
         } else if (event.causeOfChange == CommentAction.CREATE_NEW_COMMENT) {
             if (event.isError()) {
-                mQuickActionProcessor.requestFailed(ARG_ACTION_REPLY);
+                mQuickActionProcessor.requestFailed(NotificationActionType.ARG_ACTION_REPLY);
             } else {
-                mQuickActionProcessor.requestCompleted(ARG_ACTION_REPLY);
+                mQuickActionProcessor.requestCompleted(NotificationActionType.ARG_ACTION_REPLY);
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -48,6 +48,7 @@ public class NotificationsProcessingService extends Service {
     @Inject Dispatcher mDispatcher;
     @Inject SiteStore mSiteStore;
     @Inject CommentStore mCommentStore;
+    @Inject NativeNotificationsUtils mNativeNotificationsUtils;
 
     /*
     * Use this if you want the service to handle a background note Like.
@@ -120,7 +121,9 @@ public class NotificationsProcessingService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         // Offload to a separate thread.
-        mQuickActionProcessor = new QuickActionProcessor(this, mDispatcher, mSiteStore, this, intent, startId);
+        mQuickActionProcessor =
+                new QuickActionProcessor(this, mDispatcher, mNativeNotificationsUtils, mSiteStore, this, intent,
+                        startId);
         new Thread(new Runnable() {
             public void run() {
                 mQuickActionProcessor.process();

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -171,6 +171,7 @@ public class WPMainActivity extends AppCompatActivity implements
     @Inject NewsManager mNewsManager;
     @Inject QuickStartStore mQuickStartStore;
     @Inject UploadActionUseCase mUploadActionUseCase;
+    @Inject NativeNotificationsUtils mNativeNotificationsUtils;
 
     /*
      * fragments implement this if their contents can be scrolled, called when user
@@ -524,7 +525,7 @@ public class WPMainActivity extends AppCompatActivity implements
         }
 
         AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATION_PENDING_DRAFTS_TAPPED);
-        NativeNotificationsUtils
+        mNativeNotificationsUtils
                 .dismissNotification(PendingDraftsNotificationsUtils.makePendingDraftNotificationId(postId), this);
 
         // if no specific post id passed, show the list

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -60,6 +60,7 @@ import org.wordpress.android.networking.ConnectionChangeReceiver;
 import org.wordpress.android.push.GCMMessageService;
 import org.wordpress.android.push.GCMRegistrationIntentService;
 import org.wordpress.android.push.NativeNotificationsUtils;
+import org.wordpress.android.push.NotificationActionType;
 import org.wordpress.android.push.NotificationsProcessingService;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.ActivityLauncher;
@@ -446,9 +447,9 @@ public class WPMainActivity extends AppCompatActivity implements
                             // we do this here instead of using the service in the background so we make sure
                             // the user opens the app by using an activity (and thus unlocks the screen if locked,
                             // for security).
-                            String actionType =
-                                    getIntent().getStringExtra(NotificationsProcessingService.ARG_ACTION_TYPE);
-                            if (NotificationsProcessingService.ARG_ACTION_AUTH_APPROVE.equals(actionType)) {
+                            NotificationActionType actionType = (NotificationActionType) getIntent()
+                                    .getSerializableExtra(NotificationsProcessingService.ARG_ACTION_TYPE);
+                            if (NotificationActionType.ARG_ACTION_AUTH_APPROVE.equals(actionType)) {
                                 // ping the push auth endpoint with the token, wp.com will take care of the rest!
                                 NotificationsUtils.sendTwoFactorAuthToken(token);
                             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/receivers/NotificationsPendingDraftsReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/receivers/NotificationsPendingDraftsReceiver.java
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.push.NativeNotificationsUtils;
+import org.wordpress.android.push.NotificationActionType;
 import org.wordpress.android.push.NotificationsProcessingService;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.notifications.utils.PendingDraftsNotificationsUtils;
@@ -200,7 +201,7 @@ public class NotificationsPendingDraftsReceiver extends BroadcastReceiver {
         // Call processing service when user taps on IGNORE - we should remember this decision for this post
         Intent ignoreIntent = new Intent(context, NotificationsProcessingService.class);
         ignoreIntent.putExtra(NotificationsProcessingService.ARG_ACTION_TYPE,
-                              NotificationsProcessingService.ARG_ACTION_DRAFT_PENDING_IGNORE);
+                              NotificationActionType.ARG_ACTION_DRAFT_PENDING_IGNORE);
         ignoreIntent.putExtra(POST_ID_EXTRA, postId);
         ignoreIntent.putExtra(IS_PAGE_EXTRA, isPage);
         PendingIntent ignorePendingIntent = PendingIntent
@@ -218,7 +219,7 @@ public class NotificationsPendingDraftsReceiver extends BroadcastReceiver {
         // Call processing service when notification is dismissed
         Intent notificationDeletedIntent = new Intent(context, NotificationsProcessingService.class);
         notificationDeletedIntent.putExtra(NotificationsProcessingService.ARG_ACTION_TYPE,
-                                           NotificationsProcessingService.ARG_ACTION_DRAFT_PENDING_DISMISS);
+                NotificationActionType.ARG_ACTION_DRAFT_PENDING_DISMISS);
         notificationDeletedIntent.putExtra(POST_ID_EXTRA, postId);
         notificationDeletedIntent.putExtra(IS_PAGE_EXTRA, isPage);
         PendingIntent dismissPendingIntent = PendingIntent

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/receivers/NotificationsPendingDraftsReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/receivers/NotificationsPendingDraftsReceiver.java
@@ -42,6 +42,7 @@ public class NotificationsPendingDraftsReceiver extends BroadcastReceiver {
 
     @Inject PostStore mPostStore;
     @Inject SiteStore mSiteStore;
+    @Inject NativeNotificationsUtils mNativeNotificationsUtils;
 
     @Override
     public void onReceive(Context context, Intent intent) {
@@ -159,7 +160,7 @@ public class NotificationsPendingDraftsReceiver extends BroadcastReceiver {
 
     private void buildNotificationWithIntent(Context context, PendingIntent intent, String message, int postId,
                                              boolean isPage) {
-        NotificationCompat.Builder builder = NativeNotificationsUtils.getBuilder(context,
+        NotificationCompat.Builder builder = mNativeNotificationsUtils.getBuilder(context,
                 context.getString(R.string.notification_channel_important_id));
         builder.setContentText(message)
                .setPriority(NotificationCompat.PRIORITY_MAX)
@@ -172,7 +173,7 @@ public class NotificationsPendingDraftsReceiver extends BroadcastReceiver {
         }
         addDismissActionForNotification(context, builder, postId, isPage);
 
-        NativeNotificationsUtils.showMessageToUserWithBuilder(builder, message, false,
+        mNativeNotificationsUtils.showMessageToUserWithBuilder(builder, message, false,
                                                               PendingDraftsNotificationsUtils
                                                                       .makePendingDraftNotificationId(postId), context);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
@@ -38,7 +38,8 @@ fun handlePostListAction(
     activity: FragmentActivity,
     action: PostListAction,
     remotePreviewLogicHelper: RemotePreviewLogicHelper,
-    previewStateHelper: PreviewStateHelper
+    previewStateHelper: PreviewStateHelper,
+    nativeNotificationsUtils: NativeNotificationsUtils
 ) {
     when (action) {
         is PostListAction.EditPost -> {
@@ -75,7 +76,7 @@ fun handlePostListAction(
             ActivityLauncher.browsePostOrPage(activity, action.site, action.post)
         }
         is PostListAction.DismissPendingNotification -> {
-            NativeNotificationsUtils.dismissNotification(action.pushId, activity)
+            nativeNotificationsUtils.dismissNotification(action.pushId, activity)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.push.NativeNotificationsUtils
 import org.wordpress.android.ui.ActivityId
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
@@ -62,6 +63,7 @@ class PostsListActivity : AppCompatActivity(),
     @Inject internal lateinit var progressDialogHelper: ProgressDialogHelper
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var uploadActionUseCase: UploadActionUseCase
+    @Inject internal lateinit var nativeNotificationsUtils: NativeNotificationsUtils
 
     private lateinit var site: SiteModel
     private lateinit var viewModel: PostListMainViewModel
@@ -225,7 +227,8 @@ class PostsListActivity : AppCompatActivity(),
                         this@PostsListActivity,
                         action,
                         remotePreviewLogicHelper,
-                        previewStateHelper
+                        previewStateHelper,
+                        nativeNotificationsUtils
                 )
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtilsWrapper.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.util.analytics
+
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.fluxc.model.CommentModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.util.analytics.AnalyticsUtils.QuickActionTrackPropertyValue
+import javax.inject.Inject
+
+class AnalyticsUtilsWrapper
+@Inject constructor() {
+    fun trackWithBlogPostDetails(
+        stat: Stat,
+        siteId: Long,
+        postId: Long
+    ) = AnalyticsUtils.trackWithBlogPostDetails(stat, siteId, postId)
+
+    fun trackQuickActionTouched(
+        type: QuickActionTrackPropertyValue,
+        site: SiteModel,
+        comment: CommentModel
+    ) = AnalyticsUtils.trackQuickActionTouched(type, site, comment)
+
+    fun trackCommentReplyWithDetails(
+        isQuickReply: Boolean,
+        site: SiteModel,
+        comment: CommentModel
+    ) = AnalyticsUtils.trackCommentReplyWithDetails(isQuickReply, site, comment)
+}


### PR DESCRIPTION
This PR extract a notification action type into a separate enum class and creates a wrapper for `NativeNotificationutils` and `AnalyticsUtils`

To test:

PR submission checklist:

- [ ] I have considered adding unit tests where possible.

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

