### PR TITLE
Extract media related code from EditPostActivity to a new class

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -113,6 +113,7 @@ import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.PreviewLogicOpera
 import org.wordpress.android.ui.posts.editor.EditorMedia;
 import org.wordpress.android.ui.posts.editor.EditorMedia.AddExistingMediaSource;
 import org.wordpress.android.ui.posts.editor.EditorMediaListener;
+import org.wordpress.android.ui.posts.editor.EditorMediaPostData;
 import org.wordpress.android.ui.posts.editor.EditorPhotoPicker;
 import org.wordpress.android.ui.posts.editor.EditorPhotoPickerListener;
 import org.wordpress.android.ui.posts.editor.PostLoadingState;
@@ -375,8 +376,6 @@ public class EditPostActivity extends AppCompatActivity implements
         PreferenceManager.setDefaultValues(this, R.xml.account_settings, false);
         mShowAztecEditor = AppPrefs.isAztecEditorEnabled();
         mEditorPhotoPicker = new EditorPhotoPicker(this, this, this, mShowAztecEditor);
-        // TODO: Make sure local id doesn't change and if it does make it a part of the media listener and same
-        // TODO: thing for isLocalDraft
         mEditorMedia = new EditorMedia(this, mSite, this, mDispatcher, mMediaStore);
 
         // TODO when aztec is the only editor, remove this part and set the overlay bottom margin in xml
@@ -1679,7 +1678,6 @@ public class EditPostActivity extends AppCompatActivity implements
         }
     }
 
-    // TODO: Don't make this public
     public interface AfterSavePostListener {
         void onPostSave();
     }
@@ -3315,18 +3313,8 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     @Override
-    public boolean isPostLocalDraft() {
-        return mPost.isLocalDraft();
-    }
-
-    @Override
-    public int localPostId() {
-        return mPost.getId();
-    }
-
-    @Override
-    public long remotePostId() {
-        return mPost.getRemotePostId();
+    public @NonNull EditorMediaPostData editorMediaPostData() {
+        return new EditorMediaPostData(mPost.getId(), mPost.getRemotePostId(), mPost.isLocalDraft());
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -244,7 +244,6 @@ public class EditPostActivity extends AppCompatActivity implements
     private boolean mShowAztecEditor;
     private boolean mShowGutenbergEditor;
     private boolean mMediaInsertedOnCreation;
-    private boolean mAllowMultipleSelection;
 
     private List<String> mPendingVideoPressInfoRequests;
     private List<String> mAztecBackspaceDeletedOrGbBlockDeletedMediaItemIds = new ArrayList<>();
@@ -921,7 +920,7 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override
     public void onPhotoPickerIconClicked(@NonNull PhotoPickerIcon icon, boolean allowMultipleSelection) {
         mEditorPhotoPicker.hidePhotoPicker();
-        mAllowMultipleSelection = allowMultipleSelection;
+        mEditorMedia.setAllowMultipleSelection(allowMultipleSelection);
         switch (icon) {
             case ANDROID_CAPTURE_PHOTO:
                 launchCamera();
@@ -1486,11 +1485,11 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private void launchPictureLibrary() {
-        WPMediaUtils.launchPictureLibrary(this, mAllowMultipleSelection);
+        WPMediaUtils.launchPictureLibrary(this, mEditorMedia.getAllowMultipleSelection());
     }
 
     private void launchVideoLibrary() {
-        WPMediaUtils.launchVideoLibrary(this, mAllowMultipleSelection);
+        WPMediaUtils.launchVideoLibrary(this, mEditorMedia.getAllowMultipleSelection());
     }
 
     private void launchVideoCamera() {
@@ -2548,10 +2547,10 @@ public class EditPostActivity extends AppCompatActivity implements
         if (ids.size() > 1 && allAreImages && !mShowGutenbergEditor) {
             showInsertMediaDialog(ids);
         } else {
-            // if mAllowMultipleSelection and gutenberg editor, pass all ids to addExistingMediaToEditor at once
-            if (mShowGutenbergEditor && mAllowMultipleSelection) {
+            // if allowMultipleSelection and gutenberg editor, pass all ids to addExistingMediaToEditor at once
+            if (mShowGutenbergEditor && mEditorMedia.getAllowMultipleSelection()) {
                 mEditorMedia.addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, ids);
-                mAllowMultipleSelection = false;
+                mEditorMedia.setAllowMultipleSelection(false);
             } else {
                 for (Long id : ids) {
                     mEditorMedia.addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, id);
@@ -2668,20 +2667,20 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onAddMediaImageClicked(boolean allowMultipleSelection) {
-        mAllowMultipleSelection = allowMultipleSelection;
+        mEditorMedia.setAllowMultipleSelection(allowMultipleSelection);
         ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.GUTENBERG_IMAGE_PICKER);
     }
 
     @Override
     public void onAddMediaVideoClicked(boolean allowMultipleSelection) {
-        mAllowMultipleSelection = allowMultipleSelection;
+        mEditorMedia.setAllowMultipleSelection(allowMultipleSelection);
         ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.GUTENBERG_VIDEO_PICKER);
     }
 
     @Override
     public void onAddLibraryMediaClicked(boolean allowMultipleSelection) {
-        mAllowMultipleSelection = allowMultipleSelection;
-        if (mAllowMultipleSelection) {
+        mEditorMedia.setAllowMultipleSelection(allowMultipleSelection);
+        if (allowMultipleSelection) {
             ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.EDITOR_PICKER);
         } else {
             ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.GUTENBERG_SINGLE_MEDIA_PICKER);
@@ -2705,8 +2704,8 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onAddDeviceMediaClicked(boolean allowMultipleSelection) {
-        mAllowMultipleSelection = allowMultipleSelection;
-        WPMediaUtils.launchMediaLibrary(this, mAllowMultipleSelection);
+        mEditorMedia.setAllowMultipleSelection(allowMultipleSelection);
+        WPMediaUtils.launchMediaLibrary(this, allowMultipleSelection);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -894,7 +894,6 @@ public class EditPostActivity extends AppCompatActivity implements
     public void onPhotoPickerMediaChosen(@NonNull final List<Uri> uriList) {
         mEditorPhotoPicker.hidePhotoPicker();
 
-        // TODO: It looks like we might be calling addMediaList twice
         if (WPMediaUtils.shouldAdvertiseImageOptimization(this)) {
             boolean hasSelectedPicture = false;
             for (Uri uri : uriList) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -111,7 +111,7 @@ import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Editor;
 import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Outcome;
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.PreviewLogicOperationResult;
 import org.wordpress.android.ui.posts.editor.EditorMedia;
-import org.wordpress.android.ui.posts.editor.EditorMedia.AddExistingdMediaSource;
+import org.wordpress.android.ui.posts.editor.EditorMedia.AddExistingMediaSource;
 import org.wordpress.android.ui.posts.editor.EditorMediaListener;
 import org.wordpress.android.ui.posts.editor.EditorPhotoPicker;
 import org.wordpress.android.ui.posts.editor.EditorPhotoPickerListener;
@@ -2488,7 +2488,7 @@ public class EditPostActivity extends AppCompatActivity implements
                         long[] mediaIds =
                                 data.getLongArrayExtra(StockMediaPickerActivity.KEY_UPLOADED_MEDIA_IDS);
                         for (long id : mediaIds) {
-                            mEditorMedia.addExistingMediaToEditor(AddExistingdMediaSource.STOCK_PHOTO_LIBRARY, id);
+                            mEditorMedia.addExistingMediaToEditor(AddExistingMediaSource.STOCK_PHOTO_LIBRARY, id);
                         }
                         savePostAsync(null);
                     }
@@ -2564,11 +2564,11 @@ public class EditPostActivity extends AppCompatActivity implements
         } else {
             // if mAllowMultipleSelection and gutenberg editor, pass all ids to addExistingMediaToEditor at once
             if (mShowGutenbergEditor && mAllowMultipleSelection) {
-                mEditorMedia.addExistingMediaToEditor(AddExistingdMediaSource.WP_MEDIA_LIBRARY, ids);
+                mEditorMedia.addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, ids);
                 mAllowMultipleSelection = false;
             } else {
                 for (Long id : ids) {
-                    mEditorMedia.addExistingMediaToEditor(AddExistingdMediaSource.WP_MEDIA_LIBRARY, id);
+                    mEditorMedia.addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, id);
                 }
             }
             savePostAsync(null);
@@ -2590,7 +2590,7 @@ public class EditPostActivity extends AppCompatActivity implements
                     break;
                 case INDIVIDUALLY:
                     for (Long id : mediaIds) {
-                        mEditorMedia.addExistingMediaToEditor(AddExistingdMediaSource.WP_MEDIA_LIBRARY, id);
+                        mEditorMedia.addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, id);
                     }
                     savePostAsync(null);
                     break;
@@ -2972,7 +2972,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 shouldFinishInit = false;
                 mMediaInsertedOnCreation = true;
                 for (MediaModel media : mediaList) {
-                    mEditorMedia.addExistingMediaToEditor(AddExistingdMediaSource.WP_MEDIA_LIBRARY, media.getMediaId());
+                    mEditorMedia.addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, media.getMediaId());
                 }
                 savePostAsync(() -> runOnUiThread(this::onEditorFinalTouchesBeforeShowing));
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -58,7 +58,7 @@ class EditorMedia(
     private val mediaStore: MediaStore
 ) {
     private var addMediaListThread: AddMediaListThread? = null
-    private var mAllowMultipleSelection: Boolean = false
+    var allowMultipleSelection: Boolean = false
 
     // for keeping the media uri while asking for permissions
     var droppedMediaUris: ArrayList<Uri>? = null
@@ -133,7 +133,7 @@ class EditorMedia(
     fun addMediaList(uriList: List<Uri>, isNew: Boolean) {
         // fetch any shared media first - must be done on the main thread
         val fetchedUriList = fetchMediaList(uriList)
-        AddMediaListThread(fetchedUriList, isNew, mAllowMultipleSelection).let {
+        AddMediaListThread(fetchedUriList, isNew, allowMultipleSelection).let {
             addMediaListThread = it
             it.start()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -39,14 +39,14 @@ import java.io.FileOutputStream
 import java.io.IOException
 import java.util.ArrayList
 
+data class EditorMediaPostData(val localPostId: Int, val remotePostId: Long, val isLocalDraft: Boolean)
+
 interface EditorMediaListener {
     fun showOverlayFromEditorMedia(animate: Boolean)
     fun hideOverlayFromEditorMedia()
     fun appendMediaFiles(mediaMap: ArrayMap<String, MediaFile>)
     fun appendMediaFile(mediaFile: MediaFile, imageUrl: String)
-    fun isPostLocalDraft(): Boolean
-    fun localPostId(): Int
-    fun remotePostId(): Long
+    fun editorMediaPostData(): EditorMediaPostData
     fun savePostAsyncFromEditorMedia(listener: AfterSavePostListener? = null)
 }
 
@@ -412,7 +412,7 @@ class EditorMedia(
             ToastUtils.showToast(activity, R.string.file_not_found, Duration.SHORT)
             return null
         }
-        media.localPostId = editorMediaListener.localPostId()
+        media.localPostId = editorMediaListener.editorMediaPostData().localPostId
         dispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media))
 
         startUploadService(listOf(media))
@@ -438,8 +438,10 @@ class EditorMedia(
         }
 
         media.setUploadState(startingState)
-        if (!editorMediaListener.isPostLocalDraft()) {
-            media.postId = editorMediaListener.remotePostId()
+        editorMediaListener.editorMediaPostData().let {
+            if (!it.isLocalDraft) {
+                media.postId = it.remotePostId
+            }
         }
 
         return media

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -62,7 +62,7 @@ class EditorMedia(
     private var addMediaListThread: AddMediaListThread? = null
     private var mAllowMultipleSelection: Boolean = false
 
-    enum class AddExistingdMediaSource {
+    enum class AddExistingMediaSource {
         WP_MEDIA_LIBRARY,
         STOCK_PHOTO_LIBRARY
     }
@@ -103,14 +103,14 @@ class EditorMedia(
      * @param source where the media is being added from
      * @param media media being added
      */
-    private fun trackAddMediaEvent(source: AddExistingdMediaSource, media: MediaModel) {
+    private fun trackAddMediaEvent(source: AddExistingMediaSource, media: MediaModel) {
         val stat = when (source) {
-            AddExistingdMediaSource.WP_MEDIA_LIBRARY -> if (media.isVideo) {
+            AddExistingMediaSource.WP_MEDIA_LIBRARY -> if (media.isVideo) {
                 Stat.EDITOR_ADDED_VIDEO_VIA_WP_MEDIA_LIBRARY
             } else {
                 Stat.EDITOR_ADDED_PHOTO_VIA_WP_MEDIA_LIBRARY
             }
-            AddExistingdMediaSource.STOCK_PHOTO_LIBRARY -> Stat.EDITOR_ADDED_PHOTO_VIA_STOCK_MEDIA_LIBRARY
+            AddExistingMediaSource.STOCK_PHOTO_LIBRARY -> Stat.EDITOR_ADDED_PHOTO_VIA_STOCK_MEDIA_LIBRARY
         }
         AnalyticsUtils.trackWithSiteDetails(stat, site, null)
     }
@@ -340,7 +340,7 @@ class EditorMedia(
         }
     }
 
-    fun addExistingMediaToEditor(source: AddExistingdMediaSource, mediaId: Long): Boolean {
+    fun addExistingMediaToEditor(source: AddExistingMediaSource, mediaId: Long): Boolean {
         val media = mediaStore.getSiteMediaWithId(site, mediaId)
         if (media == null) {
             AppLog.w(T.MEDIA, "Cannot add null media to post")
@@ -354,7 +354,7 @@ class EditorMedia(
         return true
     }
 
-    fun addExistingMediaToEditor(source: AddExistingdMediaSource, mediaIdList: List<Long>) {
+    fun addExistingMediaToEditor(source: AddExistingMediaSource, mediaIdList: List<Long>) {
         val mediaMap = ArrayMap<String, MediaFile>()
         for (mediaId in mediaIdList) {
             val media = mediaStore.getSiteMediaWithId(site, mediaId)
@@ -459,7 +459,7 @@ class EditorMedia(
     fun prepareMediaPost() {
         val idsArray = activity.intent.getLongArrayExtra(NEW_MEDIA_POST_EXTRA_IDS)
         ListUtils.fromLongArray(idsArray)?.forEach { id ->
-            addExistingMediaToEditor(AddExistingdMediaSource.WP_MEDIA_LIBRARY, id)
+            addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, id)
         }
         editorMediaListener.savePostAsyncFromEditorMedia()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -67,7 +67,7 @@ class EditorMedia(
      * @param isVideo Whether is a video or not
      * @param uri The URI of the media on the device, or null
      */
-    private fun trackAddMediaFromDeviceEvents(isNew: Boolean, isVideo: Boolean, uri: Uri?) {
+    fun trackAddMediaFromDeviceEvents(isNew: Boolean, isVideo: Boolean, uri: Uri?) {
         if (uri == null) {
             AppLog.e(T.MEDIA, "Cannot track new media events if both path and mediaURI are null!!")
             return
@@ -113,7 +113,7 @@ class EditorMedia(
     }
 
     @Suppress("SameParameterValue")
-    private fun addMedia(mediaUri: Uri?, isNew: Boolean): Boolean {
+    fun addMedia(mediaUri: Uri?, isNew: Boolean): Boolean {
         mediaUri?.let {
             addMediaList(listOf(it), isNew)
             return true
@@ -121,14 +121,14 @@ class EditorMedia(
         return false
     }
 
-    private fun addMediaList(uriList: List<Uri>, isNew: Boolean) {
+    fun addMediaList(uriList: List<Uri>, isNew: Boolean) {
         // fetch any shared media first - must be done on the main thread
         val fetchedUriList = fetchMediaList(uriList)
         mAddMediaListThread = AddMediaListThread(fetchedUriList, isNew, mAllowMultipleSelection)
         mAddMediaListThread!!.start()
     }
 
-    private fun cancelAddMediaListThread() {
+    fun cancelAddMediaListThread() {
         if (mAddMediaListThread != null && !mAddMediaListThread!!.isInterrupted) {
             try {
                 mAddMediaListThread!!.interrupt()
@@ -314,7 +314,7 @@ class EditorMedia(
         }
     }
 
-    private fun addMediaItemGroupOrSingleItem(data: Intent) {
+    fun addMediaItemGroupOrSingleItem(data: Intent) {
         val clipData = data.clipData
         if (clipData != null) {
             val uriList = ArrayList<Uri>()
@@ -328,7 +328,7 @@ class EditorMedia(
         }
     }
 
-    private fun advertiseImageOptimisationAndAddMedia(data: Intent) {
+    fun advertiseImageOptimisationAndAddMedia(data: Intent) {
         if (WPMediaUtils.shouldAdvertiseImageOptimization(activity)) {
             WPMediaUtils.advertiseImageOptimization(
                     activity
@@ -338,7 +338,7 @@ class EditorMedia(
         }
     }
 
-    private fun addExistingMediaToEditor(source: AddExistingdMediaSource, mediaId: Long): Boolean {
+    fun addExistingMediaToEditor(source: AddExistingdMediaSource, mediaId: Long): Boolean {
         val media = mediaStore.getSiteMediaWithId(site, mediaId)
         if (media == null) {
             AppLog.w(T.MEDIA, "Cannot add null media to post")
@@ -352,7 +352,7 @@ class EditorMedia(
         return true
     }
 
-    private fun addExistingMediaToEditor(source: AddExistingdMediaSource, mediaIdList: List<Long>) {
+    fun addExistingMediaToEditor(source: AddExistingdMediaSource, mediaIdList: List<Long>) {
         val mediaMap = ArrayMap<String, MediaFile>()
         for (mediaId in mediaIdList) {
             val media = mediaStore.getSiteMediaWithId(site, mediaId)
@@ -376,7 +376,7 @@ class EditorMedia(
     }
 
     @Suppress("SameParameterValue")
-    private fun queueFileForUpload(
+    fun queueFileForUpload(
         uri: Uri,
         mimeType: String?,
         startingState: MediaUploadState

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -34,11 +34,12 @@ import java.util.ArrayList
 
 interface EditorMediaListener {
     fun showOverlay(animate: Boolean)
-    fun hideOverlay(animate: Boolean)
+    fun hideOverlay()
     fun appendMediaFiles(mediaMap: ArrayMap<String, MediaFile>)
     fun appendMediaFile(mediaFile: MediaFile, imageUrl: String)
     fun startUploadService(media: MediaModel)
     fun remotePostId(): Long
+    fun savePostAsync()
 }
 
 class EditorMedia(
@@ -242,7 +243,7 @@ class EditorMedia(
 
             activity.runOnUiThread {
                 if (!isInterrupted) {
-                    savePostAsync(null)
+                    editorMediaListener.savePostAsync()
                     editorMediaListener.hideOverlay()
                     if (mDidAnyFail) {
                         ToastUtils.showToast(activity, R.string.gallery_error, Duration.SHORT)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -1,0 +1,321 @@
+package org.wordpress.android.ui.posts.editor
+
+import android.app.ProgressDialog
+import android.content.Intent
+import android.net.Uri
+import android.util.ArrayMap
+import androidx.appcompat.app.AppCompatActivity
+import org.wordpress.android.R
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.CrashLoggingUtils
+import org.wordpress.android.util.FluxCUtils
+import org.wordpress.android.util.MediaUtils
+import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.util.ToastUtils.Duration
+import org.wordpress.android.util.WPMediaUtils
+import org.wordpress.android.util.analytics.AnalyticsUtils
+import org.wordpress.android.util.helpers.MediaFile
+import java.util.ArrayList
+
+class EditorMedia(private val activity: AppCompatActivity, private val site: SiteModel) {
+    private var mAddMediaListThread: AddMediaListThread? = null
+    private var mAllowMultipleSelection: Boolean = false
+
+    enum class AddExistingdMediaSource {
+        WP_MEDIA_LIBRARY,
+        STOCK_PHOTO_LIBRARY
+    }
+
+    /**
+     * Analytics about media from device
+     *
+     * @param isNew Whether is a fresh media
+     * @param isVideo Whether is a video or not
+     * @param uri The URI of the media on the device, or null
+     */
+    private fun trackAddMediaFromDeviceEvents(isNew: Boolean, isVideo: Boolean, uri: Uri?) {
+        if (uri == null) {
+            AppLog.e(T.MEDIA, "Cannot track new media events if both path and mediaURI are null!!")
+            return
+        }
+
+        val properties = AnalyticsUtils.getMediaProperties(activity, isVideo, uri, null)
+        val currentStat: Stat = if (isVideo) {
+            if (isNew) {
+                Stat.EDITOR_ADDED_VIDEO_NEW
+            } else {
+                Stat.EDITOR_ADDED_VIDEO_VIA_DEVICE_LIBRARY
+            }
+        } else {
+            if (isNew) {
+                Stat.EDITOR_ADDED_PHOTO_NEW
+            } else {
+                Stat.EDITOR_ADDED_PHOTO_VIA_DEVICE_LIBRARY
+            }
+        }
+
+        AnalyticsUtils.trackWithSiteDetails(currentStat, site, properties)
+    }
+
+    /**
+     * Analytics about media already available in the blog's library.
+     * @param source where the media is being added from
+     * @param media media being added
+     */
+    private fun trackAddMediaEvent(source: AddExistingdMediaSource, media: MediaModel) {
+        val stat = when (source) {
+            AddExistingdMediaSource.WP_MEDIA_LIBRARY -> if (media.isVideo) {
+                Stat.EDITOR_ADDED_VIDEO_VIA_WP_MEDIA_LIBRARY
+            } else {
+                Stat.EDITOR_ADDED_PHOTO_VIA_WP_MEDIA_LIBRARY
+            }
+            AddExistingdMediaSource.STOCK_PHOTO_LIBRARY -> Stat.EDITOR_ADDED_PHOTO_VIA_STOCK_MEDIA_LIBRARY
+        }
+        AnalyticsUtils.trackWithSiteDetails(
+                stat,
+                site,
+                null
+        )
+    }
+
+    @Suppress("SameParameterValue")
+    private fun addMedia(mediaUri: Uri?, isNew: Boolean): Boolean {
+        mediaUri?.let {
+            addMediaList(listOf(it), isNew)
+            return true
+        }
+        return false
+    }
+
+    private fun addMediaList(uriList: List<Uri>, isNew: Boolean) {
+        // fetch any shared media first - must be done on the main thread
+        val fetchedUriList = fetchMediaList(uriList)
+        mAddMediaListThread = AddMediaListThread(fetchedUriList, isNew, mAllowMultipleSelection)
+        mAddMediaListThread!!.start()
+    }
+
+    private fun cancelAddMediaListThread() {
+        if (mAddMediaListThread != null && !mAddMediaListThread!!.isInterrupted) {
+            try {
+                mAddMediaListThread!!.interrupt()
+            } catch (e: SecurityException) {
+                AppLog.e(T.MEDIA, e)
+            }
+        }
+    }
+
+    /*
+     * called before we add media to make sure we have access to any media shared from another app (Google Photos, etc.)
+     */
+    private fun fetchMediaList(uriList: List<Uri>): List<Uri> {
+        var didAnyFail = false
+        val fetchedUriList = ArrayList<Uri>()
+        for (i in uriList.indices) {
+            val mediaUri = uriList[i] ?: continue
+            if (!MediaUtils.isInMediaStore(mediaUri)) {
+                // Do not download the file in async task. See
+                // https://github.com/wordpress-mobile/WordPress-Android/issues/5818
+                var fetchedUri: Uri? = null
+                try {
+                    fetchedUri = MediaUtils.downloadExternalMedia(activity, mediaUri)
+                } catch (e: IllegalStateException) {
+                    // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/5823
+                    AppLog.e(AppLog.T.UTILS, "Can't download the image at: $mediaUri", e)
+                    CrashLoggingUtils
+                            .logException(
+                                    e,
+                                    AppLog.T.MEDIA,
+                                    "Can't download the image at: " + mediaUri.toString()
+                                            + " See issue #5823"
+                            )
+                    didAnyFail = true
+                }
+
+                if (fetchedUri != null) {
+                    fetchedUriList.add(fetchedUri)
+                } else {
+                    didAnyFail = true
+                }
+            } else {
+                fetchedUriList.add(mediaUri)
+            }
+        }
+
+        if (didAnyFail) {
+            ToastUtils.showToast(activity, R.string.error_downloading_image, Duration.SHORT)
+        }
+
+        return fetchedUriList
+    }
+
+    /*
+     * processes a list of media in the background (optimizing, resizing, etc.) and adds them to
+     * the editor one at a time
+     */
+    private inner class AddMediaListThread : Thread {
+        private val mUriList = ArrayList<Uri>()
+        private val mIsNew: Boolean
+        @Suppress("DEPRECATION")
+        private var mProgressDialog: ProgressDialog? = null
+        private var mDidAnyFail: Boolean = false
+        private var mFinishedUploads = 0
+        private var mAllowMultipleSelection = false
+        private val mediaMap = ArrayMap<String, MediaFile>()
+
+        internal constructor(uriList: List<Uri>, isNew: Boolean) {
+            this.mUriList.addAll(uriList)
+            this.mIsNew = isNew
+            showOverlay(false)
+        }
+
+        internal constructor(uriList: List<Uri>, isNew: Boolean, allowMultipleSelection: Boolean) {
+            this.mUriList.addAll(uriList)
+            this.mIsNew = isNew
+            this.mAllowMultipleSelection = allowMultipleSelection
+            showOverlay(false)
+        }
+
+        private fun showProgressDialog(show: Boolean) {
+            activity.runOnUiThread {
+                try {
+                    if (show) {
+                        mProgressDialog = ProgressDialog(activity)
+                        mProgressDialog!!.setCancelable(false)
+                        mProgressDialog!!.isIndeterminate = true
+                        mProgressDialog!!.setMessage(activity.getString(R.string.add_media_progress))
+                        mProgressDialog!!.show()
+                    } else if (mProgressDialog != null && mProgressDialog!!.isShowing) {
+                        mProgressDialog!!.dismiss()
+                    }
+                } catch (e: IllegalArgumentException) {
+                    AppLog.e(T.MEDIA, e)
+                }
+            }
+        }
+
+        override fun run() {
+            // adding multiple media items at once can take several seconds on slower devices, so we show a blocking
+            // progress dialog in this situation - otherwise the user could accidentally back out of the process
+            // before all items were added
+            val shouldShowProgress = mUriList.size > 2
+            if (shouldShowProgress) {
+                showProgressDialog(true)
+            }
+            try {
+                for (mediaUri in mUriList) {
+                    if (isInterrupted) {
+                        return
+                    }
+                    if (!processMedia(mediaUri)) {
+                        mDidAnyFail = true
+                    }
+                }
+            } finally {
+                if (shouldShowProgress) {
+                    showProgressDialog(false)
+                }
+            }
+
+
+            activity.runOnUiThread {
+                if (!isInterrupted) {
+                    savePostAsync(null)
+                    hideOverlay()
+                    if (mDidAnyFail) {
+                        ToastUtils.showToast(activity, R.string.gallery_error, Duration.SHORT)
+                    }
+                }
+            }
+        }
+
+        private fun processMedia(mediaUri: Uri?): Boolean {
+            var mediaUri: Uri? = mediaUri ?: return false
+
+            val path = MediaUtils.getRealPathFromURI(activity, mediaUri!!) ?: return false
+
+            val isVideo = MediaUtils.isVideo(mediaUri.toString())
+            val optimizedMedia = WPMediaUtils.getOptimizedMedia(activity, path, isVideo)
+            if (optimizedMedia != null) {
+                mediaUri = optimizedMedia
+            } else {
+                // Fix for the rotation issue https://github.com/wordpress-mobile/WordPress-Android/issues/5737
+                if (!site.isWPCom) {
+                    // If it's not wpcom we must rotate the picture locally
+                    val rotatedMedia = WPMediaUtils.fixOrientationIssue(activity, path, isVideo)
+                    if (rotatedMedia != null) {
+                        mediaUri = rotatedMedia
+                    }
+                }
+            }
+
+            if (isInterrupted) {
+                return false
+            }
+
+            trackAddMediaFromDeviceEvents(mIsNew, isVideo, mediaUri)
+            postProcessMedia(mediaUri, path)
+
+            return true
+        }
+
+        private fun postProcessMedia(mediaUri: Uri, path: String) {
+            if (mAllowMultipleSelection) {
+                val mediaFile = getMediaFile(mediaUri)
+                if (mediaFile != null) {
+                    mediaMap[path] = mediaFile
+                }
+                mFinishedUploads++
+                if (mUriList.size == mFinishedUploads) {
+                    activity.runOnUiThread { mEditorFragment.appendMediaFiles(mediaMap) }
+                }
+            } else {
+                activity.runOnUiThread { addMediaVisualEditor(mediaUri, path) }
+            }
+        }
+    }
+
+    private fun addMediaVisualEditor(uri: Uri, path: String) {
+        val mediaFile = getMediaFile(uri)
+        if (mediaFile != null) {
+            mEditorFragment.appendMediaFile(mediaFile, path, mImageLoader)
+        }
+    }
+
+    private fun getMediaFile(uri: Uri): MediaFile? {
+        val media = queueFileForUpload(uri, activity.contentResolver.getType(uri))
+        val mediaFile = FluxCUtils.mediaFileFromMediaModel(media)
+        return if (media != null) {
+            mediaFile
+        } else {
+            null
+        }
+    }
+
+    private fun addMediaItemGroupOrSingleItem(data: Intent) {
+        val clipData = data.clipData
+        if (clipData != null) {
+            val uriList = ArrayList<Uri>()
+            for (i in 0 until clipData.itemCount) {
+                val item = clipData.getItemAt(i)
+                uriList.add(item.uri)
+            }
+            addMediaList(uriList, false)
+        } else {
+            addMedia(data.data, false)
+        }
+    }
+
+    private fun advertiseImageOptimisationAndAddMedia(data: Intent) {
+        if (WPMediaUtils.shouldAdvertiseImageOptimization(activity)) {
+            WPMediaUtils.advertiseImageOptimization(
+                    activity
+            ) { addMediaItemGroupOrSingleItem(data) }
+        } else {
+            addMediaItemGroupOrSingleItem(data)
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -16,6 +16,8 @@ import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.MediaStore
+import org.wordpress.android.fluxc.store.MediaStore.CancelMediaPayload
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload
 import org.wordpress.android.ui.posts.EditPostActivity.NEW_MEDIA_POST_EXTRA_IDS
 import org.wordpress.android.ui.posts.EditPostActivity.AfterSavePostListener
 import org.wordpress.android.ui.uploads.UploadService
@@ -26,6 +28,7 @@ import org.wordpress.android.util.FluxCUtils
 import org.wordpress.android.util.ImageUtils
 import org.wordpress.android.util.ListUtils
 import org.wordpress.android.util.MediaUtils
+import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.util.WPMediaUtils
@@ -39,6 +42,7 @@ import java.util.ArrayList
 interface EditorMediaListener {
     // Temporary overlay functions
     fun showOverlayFromEditorMedia(animate: Boolean)
+
     fun hideOverlayFromEditorMedia()
     fun appendMediaFiles(mediaMap: ArrayMap<String, MediaFile>)
     fun appendMediaFile(mediaFile: MediaFile, imageUrl: String)
@@ -487,6 +491,26 @@ class EditorMedia(
         })
     }
 
+    fun cancelMediaUpload(localMediaId: Int, delete: Boolean) {
+        val mediaModel = mediaStore.getMediaWithLocalId(localMediaId)
+        if (mediaModel != null) {
+            val payload = CancelMediaPayload(site, mediaModel, delete)
+            dispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload))
+        }
+    }
+
+    fun refreshBlogMedia() {
+        if (NetworkUtils.isNetworkAvailable(activity)) {
+            val payload = FetchMediaListPayload(site, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false)
+            dispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(payload))
+        } else {
+            ToastUtils.showToast(
+                    activity,
+                    R.string.error_media_refresh_no_connection,
+                    Duration.SHORT
+            )
+        }
+    }
 }
 
 private val MediaModel.urlToUse

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -165,13 +165,11 @@ class EditorMedia(
                 } catch (e: IllegalStateException) {
                     // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/5823
                     AppLog.e(T.UTILS, "Can't download the image at: $mediaUri", e)
-                    CrashLoggingUtils
-                            .logException(
-                                    e,
-                                    T.MEDIA,
-                                    "Can't download the image at: " + mediaUri.toString()
-                                            + " See issue #5823"
-                            )
+                    CrashLoggingUtils.logException(
+                            e,
+                            T.MEDIA,
+                            "Can't download the image at: $mediaUri See issue #5823"
+                    )
                     didAnyFail = true
                 }
 
@@ -251,7 +249,6 @@ class EditorMedia(
                     showProgressDialog(false)
                 }
             }
-
 
             activity.runOnUiThread {
                 if (!isInterrupted) {


### PR DESCRIPTION
This PR is a part of the ongoing refactor for the `EditPostActivity`. Borrowing from the very similar [photo picker PR](https://github.com/wordpress-mobile/WordPress-Android/pull/10608):

> The extraction is almost a one to one conversion where the old implementation is kept the same, sometimes (possibly) to a fault. The goal is moving common logic into new components rather than improving said components, so the review should be done with this in mind. Having said that, some basic improvements are made where it's obvious that the previous logic is untouched.

This extraction is a lot trickier than the photo picker one and considering we are planning to refactor the `EditorMedia` component further, I think it's best to merge this PR into a feature branch instead of `develop`. This branch shouldn't live for a long time, so merge conflicts shouldn't be a big deal. I am also unsure about how best to test these changes, I just don't know enough about the `EditPostActivity`.

_P.S: I have not been able to test this PR yet due to a crash I am experiencing in `develop` and in this branch. I'll mark the PR as draft for now._

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

