### PR TITLE
[GB Mobile] Fix SetSpan ends beyond length 

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     ext {
-        aztecVersion = 'eae2b15b5f169920d65c8e5c3c5230c20b1ff09d'
+        aztecVersion = 'fefb32ce6c132d4524222032bd376b7942ef73d0'
     }
 
     dependencies {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     ext {
-        aztecVersion = 'v1.3.34'
+        aztecVersion = 'eae2b15b5f169920d65c8e5c3c5230c20b1ff09d'
     }
 
     dependencies {


### PR DESCRIPTION
Fixes #9832 by using a version of Aztec that doesn't change the HTML passed in input.
Details of the problem here: https://github.com/wordpress-mobile/WordPress-Android/issues/9832#issuecomment-545564526

Aztec PR: https://github.com/wordpress-mobile/AztecEditor-Android/pull/866
GB-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1490

To test:
**Note, we should test this PR with tons of input since the changes in Aztec may break other part of the GB-Editor.**
- Create a post in GB on the web that does have a para block that ends with an empty line (Shift+Enter)
![Screenshot 2019-10-23 at 19 55 08](https://user-images.githubusercontent.com/518232/67420522-0b695a80-f5cf-11e9-8719-5289d97034ec.png)
- Open this new post in GB mobile
- Tap on the `Plus` symbol to add a new block below the para
- Put the focus into this new block and taps on Backspace to merge this new block with the one above.
- It should not crash, and the 2 blocks merged, with the caret at the end of the block

PR submission checklist:

- [ x ] I have considered adding unit tests where possible.

- [ x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

