### PR TITLE
Minor EditorMedia improvements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -955,7 +955,7 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override
     public void onPhotoPickerIconClicked(@NonNull PhotoPickerIcon icon, boolean allowMultipleSelection) {
         mEditorPhotoPicker.hidePhotoPicker();
-        mEditorMedia.setAllowMultipleSelection(allowMultipleSelection);
+        mEditorPhotoPicker.setAllowMultipleSelection(allowMultipleSelection);
         switch (icon) {
             case ANDROID_CAPTURE_PHOTO:
                 launchCamera();
@@ -1520,11 +1520,11 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private void launchPictureLibrary() {
-        WPMediaUtils.launchPictureLibrary(this, mEditorMedia.getAllowMultipleSelection());
+        WPMediaUtils.launchPictureLibrary(this, mEditorPhotoPicker.getAllowMultipleSelection());
     }
 
     private void launchVideoLibrary() {
-        WPMediaUtils.launchVideoLibrary(this, mEditorMedia.getAllowMultipleSelection());
+        WPMediaUtils.launchVideoLibrary(this, mEditorPhotoPicker.getAllowMultipleSelection());
     }
 
     private void launchVideoCamera() {
@@ -2605,9 +2605,9 @@ public class EditPostActivity extends AppCompatActivity implements
             showInsertMediaDialog(ids);
         } else {
             // if allowMultipleSelection and gutenberg editor, pass all ids to addExistingMediaToEditor at once
-            if (mShowGutenbergEditor && mEditorMedia.getAllowMultipleSelection()) {
+            if (mShowGutenbergEditor && mEditorPhotoPicker.getAllowMultipleSelection()) {
                 mEditorMedia.addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, ids);
-                mEditorMedia.setAllowMultipleSelection(false);
+                mEditorPhotoPicker.setAllowMultipleSelection(false);
             } else {
                 for (Long id : ids) {
                     mEditorMedia.addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, id);
@@ -2724,19 +2724,19 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onAddMediaImageClicked(boolean allowMultipleSelection) {
-        mEditorMedia.setAllowMultipleSelection(allowMultipleSelection);
+        mEditorPhotoPicker.setAllowMultipleSelection(allowMultipleSelection);
         ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.GUTENBERG_IMAGE_PICKER);
     }
 
     @Override
     public void onAddMediaVideoClicked(boolean allowMultipleSelection) {
-        mEditorMedia.setAllowMultipleSelection(allowMultipleSelection);
+        mEditorPhotoPicker.setAllowMultipleSelection(allowMultipleSelection);
         ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.GUTENBERG_VIDEO_PICKER);
     }
 
     @Override
     public void onAddLibraryMediaClicked(boolean allowMultipleSelection) {
-        mEditorMedia.setAllowMultipleSelection(allowMultipleSelection);
+        mEditorPhotoPicker.setAllowMultipleSelection(allowMultipleSelection);
         if (allowMultipleSelection) {
             ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.EDITOR_PICKER);
         } else {
@@ -2761,7 +2761,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onAddDeviceMediaClicked(boolean allowMultipleSelection) {
-        mEditorMedia.setAllowMultipleSelection(allowMultipleSelection);
+        mEditorPhotoPicker.setAllowMultipleSelection(allowMultipleSelection);
         WPMediaUtils.launchMediaLibrary(this, allowMultipleSelection);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -69,15 +69,13 @@ class EditorMedia(
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) {
-    private var addMediaToEditorUseCase: OptimizeAndAddMediaToEditorUseCase = OptimizeAndAddMediaToEditorUseCase(
+    private val addMediaToEditorUseCase: OptimizeAndAddMediaToEditorUseCase = OptimizeAndAddMediaToEditorUseCase(
             editorTracker,
             mediaUtilsWrapper,
             fluxCUtilsWrapper,
             mainDispatcher,
             bgDispatcher
     )
-    // TODO this fields is not used here anymore - it seems more related to the photoPicker
-    var allowMultipleSelection: Boolean = false
     val uiState: LiveData<AddMediaToEditorUiState> = addMediaToEditorUseCase.uiState
     val snackBarMessage: LiveData<SnackbarMessageHolder> = addMediaToEditorUseCase.snackBarMessage
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -148,24 +148,17 @@ class EditorMedia(
     }
 
     fun addMediaItemGroupOrSingleItem(data: Intent) {
-        val clipData = data.clipData
-        if (clipData != null) {
-            val uriList = ArrayList<Uri>()
-            for (i in 0 until clipData.itemCount) {
-                val item = clipData.getItemAt(i)
-                uriList.add(item.uri)
+        val uriList: List<Uri> = data.clipData?.let { clipData ->
+            (0 until clipData.itemCount).mapNotNull {
+                clipData.getItemAt(it)?.uri
             }
-            addMediaList(uriList, false)
-        } else {
-            addMedia(data.data, false)
-        }
+        } ?: listOf(data.data)
+        addMediaList(uriList, false)
     }
 
     fun advertiseImageOptimisationAndAddMedia(data: Intent) {
         if (WPMediaUtils.shouldAdvertiseImageOptimization(activity)) {
-            WPMediaUtils.advertiseImageOptimization(
-                    activity
-            ) { addMediaItemGroupOrSingleItem(data) }
+            WPMediaUtils.advertiseImageOptimization(activity) { addMediaItemGroupOrSingleItem(data) }
         } else {
             addMediaItemGroupOrSingleItem(data)
         }
@@ -319,8 +312,7 @@ class EditorMedia(
     }
 
     fun cancelMediaUpload(localMediaId: Int, delete: Boolean) {
-        val mediaModel = mediaStore.getMediaWithLocalId(localMediaId)
-        if (mediaModel != null) {
+        mediaStore.getMediaWithLocalId(localMediaId)?.let { mediaModel ->
             val payload = CancelMediaPayload(site, mediaModel, delete)
             dispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload))
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
@@ -38,6 +38,7 @@ class EditorPhotoPicker(
     private var photoPickerContainer: View? = null
     private var photoPickerFragment: PhotoPickerFragment? = null
     private var photoPickerOrientation = Configuration.ORIENTATION_UNDEFINED
+    var allowMultipleSelection: Boolean = false
 
     /*
      * loads the photo picker fragment, which is hidden until the user taps the media icon

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorTracker.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.net.Uri
 import dagger.Reusable
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.posts.editor.EditorMedia.AddExistingMediaSource
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.analytics.AnalyticsUtils
@@ -46,5 +48,22 @@ class EditorTracker @Inject constructor(private val context: Context) {
         }
 
         AnalyticsUtils.trackWithSiteDetails(currentStat, site, properties)
+    }
+
+    /**
+     * Analytics about media already available in the blog's library.
+     * @param source where the media is being added from
+     * @param media media being added
+     */
+    fun trackAddMediaEvent(site: SiteModel, source: AddExistingMediaSource, media: MediaModel) {
+        val stat = when (source) {
+            AddExistingMediaSource.WP_MEDIA_LIBRARY -> if (media.isVideo) {
+                Stat.EDITOR_ADDED_VIDEO_VIA_WP_MEDIA_LIBRARY
+            } else {
+                Stat.EDITOR_ADDED_PHOTO_VIA_WP_MEDIA_LIBRARY
+            }
+            AddExistingMediaSource.STOCK_PHOTO_LIBRARY -> Stat.EDITOR_ADDED_PHOTO_VIA_STOCK_MEDIA_LIBRARY
+        }
+        AnalyticsUtils.trackWithSiteDetails(stat, site, null)
     }
 }


### PR DESCRIPTION
This PR makes some very minor improvements to `EditorMedia`:

* Moves `EditorMedia.allowMultipleSelection` to `EditorPhotoPicker`
* Moves `EditorMedia.trackAddMediaEvent` to `EditorTracker`
* Improves the Kotlin code in `fetchMediaList`, `addMediaItemGroupOrSingleItem` and `cancelMediaUpload` methods

@malinajirka I thought it'd be good to get these small issues out of the way and make the code a bit more readable. Hope you find it useful.

To test:
It's not necessary to test this PR as it's being merged to a WIP branch which we'll test later.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

