### PR TITLE
Refactor EditorMedia to remove most static dependencies

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -145,6 +145,7 @@ import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.MediaUtilsWrapper;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.NetworkUtilsWrapper;
 import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.QuickStartUtils;
 import org.wordpress.android.util.ShortcutUtils;
@@ -323,6 +324,7 @@ public class EditPostActivity extends AppCompatActivity implements
     @Inject EditorTracker mEditorTracker;
     @Inject MediaUtilsWrapper mMediaUtilsWrapper;
     @Inject FluxCUtilsWrapper mFluxCUtilsWrapper;
+    @Inject NetworkUtilsWrapper mNetworkUtilsWrapper;
 
     private SiteModel mSite;
 
@@ -394,7 +396,7 @@ public class EditPostActivity extends AppCompatActivity implements
         mShowAztecEditor = AppPrefs.isAztecEditorEnabled();
         mEditorPhotoPicker = new EditorPhotoPicker(this, this, this, mShowAztecEditor);
         mEditorMedia = new EditorMedia(this, mSite, this, mDispatcher, mMediaStore, mEditorTracker, mMediaUtilsWrapper,
-                mFluxCUtilsWrapper, mMainDispatcher, mBgDispatcher);
+                mFluxCUtilsWrapper, mNetworkUtilsWrapper, mMainDispatcher, mBgDispatcher);
 
         startObserving();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -33,7 +33,6 @@ import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration
-import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.helpers.MediaFile
 import java.io.File
 import java.util.ArrayList
@@ -151,8 +150,8 @@ class EditorMedia(
     }
 
     fun advertiseImageOptimisationAndAddMedia(data: Intent) {
-        if (WPMediaUtils.shouldAdvertiseImageOptimization(activity)) {
-            WPMediaUtils.advertiseImageOptimization(activity) { addMediaItemGroupOrSingleItem(data) }
+        if (mediaUtilsWrapper.shouldAdvertiseImageOptimization()) {
+            mediaUtilsWrapper.advertiseImageOptimization { addMediaItemGroupOrSingleItem(data) }
         } else {
             addMediaItemGroupOrSingleItem(data)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -30,7 +30,6 @@ import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.CrashLoggingUtils
 import org.wordpress.android.util.FluxCUtilsWrapper
 import org.wordpress.android.util.ListUtils
-import org.wordpress.android.util.MediaUtils
 import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.ToastUtils
@@ -117,11 +116,11 @@ class EditorMedia(
      */
     private fun fetchMediaList(uriList: List<Uri>): List<Uri> {
         val fetchedUriList = uriList.mapNotNull { mediaUri ->
-            if (!MediaUtils.isInMediaStore(mediaUri)) {
+            if (!mediaUtilsWrapper.isInMediaStore(mediaUri)) {
                 // Do not download the file in async task. See
                 // https://github.com/wordpress-mobile/WordPress-Android/issues/5818
                 try {
-                    return@mapNotNull MediaUtils.downloadExternalMedia(activity, mediaUri)
+                    return@mapNotNull mediaUtilsWrapper.downloadExternalMedia(mediaUri)
                 } catch (e: IllegalStateException) {
                     // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/5823
                     val errorMessage = "Can't download the image at: $mediaUri See issue #5823"
@@ -201,7 +200,7 @@ class EditorMedia(
         startingState: MediaUploadState
     ): MediaModel? {
         val mimeType = activity.contentResolver.getType(uri)
-        val path = MediaUtils.getRealPathFromURI(activity, uri)
+        val path = mediaUtilsWrapper.getRealPathFromURI(uri)
 
         // Invalid file path
         if (TextUtils.isEmpty(path)) {
@@ -237,7 +236,7 @@ class EditorMedia(
     ): MediaModel? {
         val media = fluxCUtilsWrapper.mediaModelFromLocalUri(uri, mimeType, mediaStore, site.id) ?: return null
         if (mediaUtilsWrapper.isVideoMimeType(media.mimeType)) {
-            val path = MediaUtils.getRealPathFromURI(activity, uri)
+            val path = mediaUtilsWrapper.getRealPathFromURI(uri)
             media.thumbnailUrl = EditorMediaUtils.getVideoThumbnail(activity, path)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -29,7 +29,6 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.CrashLoggingUtils
 import org.wordpress.android.util.FluxCUtilsWrapper
-import org.wordpress.android.util.ListUtils
 import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.ToastUtils
@@ -251,8 +250,7 @@ class EditorMedia(
     }
 
     fun prepareMediaPost() {
-        val idsArray = activity.intent.getLongArrayExtra(NEW_MEDIA_POST_EXTRA_IDS)
-        ListUtils.fromLongArray(idsArray)?.forEach { id ->
+        activity.intent.getLongArrayExtra(NEW_MEDIA_POST_EXTRA_IDS)?.forEach { id ->
             addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, id)
         }
         editorMediaListener.savePostAsyncFromEditorMedia()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.posts.editor
 
 import android.content.Intent
-import android.graphics.Bitmap
 import android.net.Uri
 import android.text.TextUtils
 import android.util.ArrayMap
@@ -30,7 +29,6 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.CrashLoggingUtils
 import org.wordpress.android.util.FluxCUtilsWrapper
-import org.wordpress.android.util.ImageUtils
 import org.wordpress.android.util.ListUtils
 import org.wordpress.android.util.MediaUtils
 import org.wordpress.android.util.MediaUtilsWrapper
@@ -40,8 +38,6 @@ import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.helpers.MediaFile
 import java.io.File
-import java.io.FileOutputStream
-import java.io.IOException
 import java.util.ArrayList
 import javax.inject.Named
 
@@ -242,7 +238,7 @@ class EditorMedia(
         val media = fluxCUtilsWrapper.mediaModelFromLocalUri(uri, mimeType, mediaStore, site.id) ?: return null
         if (mediaUtilsWrapper.isVideoMimeType(media.mimeType)) {
             val path = MediaUtils.getRealPathFromURI(activity, uri)
-            media.thumbnailUrl = getVideoThumbnail(path)
+            media.thumbnailUrl = EditorMediaUtils.getVideoThumbnail(activity, path)
         }
 
         media.setUploadState(startingState)
@@ -253,26 +249,6 @@ class EditorMedia(
         }
 
         return media
-    }
-
-    private fun getVideoThumbnail(videoPath: String): String? {
-        var thumbnailPath: String? = null
-        try {
-            val outputFile = File.createTempFile("thumb", ".png", activity.cacheDir)
-            val outputStream = FileOutputStream(outputFile)
-            val thumb = ImageUtils.getVideoFrameFromVideo(
-                    videoPath,
-                    EditorMediaUtils.getMaximumThumbnailSizeForEditor(activity)
-            )
-            if (thumb != null) {
-                thumb.compress(Bitmap.CompressFormat.PNG, 75, outputStream)
-                thumbnailPath = outputFile.absolutePath
-            }
-        } catch (e: IOException) {
-            AppLog.i(T.MEDIA, "Can't create thumbnail for video: $videoPath")
-        }
-
-        return thumbnailPath
     }
 
     fun prepareMediaPost() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -30,7 +30,7 @@ import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.CrashLoggingUtils
 import org.wordpress.android.util.FluxCUtilsWrapper
 import org.wordpress.android.util.MediaUtilsWrapper
-import org.wordpress.android.util.NetworkUtils
+import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.util.WPMediaUtils
@@ -57,6 +57,7 @@ class EditorMedia(
     private val editorTracker: EditorTracker,
     private val mediaUtilsWrapper: MediaUtilsWrapper,
     private val fluxCUtilsWrapper: FluxCUtilsWrapper,
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) {
@@ -285,7 +286,7 @@ class EditorMedia(
     }
 
     fun refreshBlogMedia() {
-        if (NetworkUtils.isNetworkAvailable(activity)) {
+        if (networkUtilsWrapper.isNetworkAvailable()) {
             val payload = FetchMediaListPayload(site, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false)
             dispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(payload))
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -29,7 +29,6 @@ import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.CrashLoggingUtils
-import org.wordpress.android.util.FluxCUtils
 import org.wordpress.android.util.FluxCUtilsWrapper
 import org.wordpress.android.util.ImageUtils
 import org.wordpress.android.util.ListUtils
@@ -62,7 +61,7 @@ class EditorMedia(
     private val dispatcher: Dispatcher,
     private val mediaStore: MediaStore,
     private val editorTracker: EditorTracker,
-    mediaUtilsWrapper: MediaUtilsWrapper,
+    private val mediaUtilsWrapper: MediaUtilsWrapper,
     private val fluxCUtilsWrapper: FluxCUtilsWrapper,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
@@ -240,14 +239,8 @@ class EditorMedia(
         mimeType: String?,
         startingState: MediaUploadState
     ): MediaModel? {
-        val media = FluxCUtils.mediaModelFromLocalUri(
-                activity,
-                uri,
-                mimeType,
-                mediaStore,
-                site.id
-        ) ?: return null
-        if (org.wordpress.android.fluxc.utils.MediaUtils.isVideoMimeType(media.mimeType)) {
+        val media = fluxCUtilsWrapper.mediaModelFromLocalUri(uri, mimeType, mediaStore, site.id) ?: return null
+        if (mediaUtilsWrapper.isVideoMimeType(media.mimeType)) {
             val path = MediaUtils.getRealPathFromURI(activity, uri)
             media.thumbnailUrl = getVideoThumbnail(path)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorTracker.kt
@@ -53,11 +53,11 @@ class EditorTracker @Inject constructor(private val context: Context) {
     /**
      * Analytics about media already available in the blog's library.
      * @param source where the media is being added from
-     * @param media media being added
+     * @param isVideo if media is a video
      */
-    fun trackAddMediaEvent(site: SiteModel, source: AddExistingMediaSource, media: MediaModel) {
+    fun trackAddMediaEvent(site: SiteModel, source: AddExistingMediaSource, isVideo: Boolean) {
         val stat = when (source) {
-            AddExistingMediaSource.WP_MEDIA_LIBRARY -> if (media.isVideo) {
+            AddExistingMediaSource.WP_MEDIA_LIBRARY -> if (isVideo) {
                 Stat.EDITOR_ADDED_VIDEO_VIA_WP_MEDIA_LIBRARY
             } else {
                 Stat.EDITOR_ADDED_PHOTO_VIA_WP_MEDIA_LIBRARY

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorTracker.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.Uri
 import dagger.Reusable
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
-import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.editor.EditorMedia.AddExistingMediaSource
 import org.wordpress.android.util.AppLog

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtilsWrapper.kt
@@ -21,8 +21,8 @@ class FluxCUtilsWrapper @Inject constructor(private val appContext: Context) {
         uri: Uri,
         mimeType: String?,
         mediaStore: MediaStore,
-        id: Int
-    ): MediaModel? = FluxCUtils.mediaModelFromLocalUri(appContext, uri, mimeType, mediaStore, id)
+        localSiteId: Int
+    ): MediaModel? = FluxCUtils.mediaModelFromLocalUri(appContext, uri, mimeType, mediaStore, localSiteId)
 
     fun mediaFileFromMediaModel(mediaModel: MediaModel?): MediaFile? =
             FluxCUtils.mediaFileFromMediaModel(mediaModel)

--- a/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.util
 import android.content.Context
 import android.net.Uri
 import dagger.Reusable
-import org.wordpress.android.util.WPMediaUtils.OnAdvertiseImageOptimizationListener
 import javax.inject.Inject
 
 /**

--- a/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.util
 import android.content.Context
 import android.net.Uri
 import dagger.Reusable
+import org.wordpress.android.util.WPMediaUtils.OnAdvertiseImageOptimizationListener
 import javax.inject.Inject
 
 /**
@@ -34,4 +35,13 @@ class MediaUtilsWrapper @Inject constructor(private val context: Context) {
 
     fun downloadExternalMedia(imageUri: Uri): Uri? =
             MediaUtils.downloadExternalMedia(context, imageUri)
+
+    fun shouldAdvertiseImageOptimization(): Boolean =
+            WPMediaUtils.shouldAdvertiseImageOptimization(context)
+
+    fun advertiseImageOptimization(listener: () -> Unit) {
+        WPMediaUtils.advertiseImageOptimization(context) {
+            listener.invoke()
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
@@ -28,4 +28,10 @@ class MediaUtilsWrapper @Inject constructor(private val context: Context) {
 
     fun isVideoMimeType(mimeType: String): Boolean =
         org.wordpress.android.fluxc.utils.MediaUtils.isVideoMimeType(mimeType)
+
+    fun isInMediaStore(mediaUri: Uri?): Boolean =
+            MediaUtils.isInMediaStore(mediaUri)
+
+    fun downloadExternalMedia(imageUri: Uri): Uri? =
+            MediaUtils.downloadExternalMedia(context, imageUri)
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
@@ -6,7 +6,7 @@ import dagger.Reusable
 import javax.inject.Inject
 
 /**
- * Injectable wrapper around MediaUtils and WPMediaUtils.
+ * Injectable wrapper around MediaUtils, WPMediaUtils & FluxC's MediaUtils.
  *
  * MediaUtils and WPMediaUtils interfaces are consisted of static methods, which makes the client code difficult to
  * test/mock. Main purpose of this wrapper is to make testing easier.
@@ -25,4 +25,7 @@ class MediaUtilsWrapper @Inject constructor(private val context: Context) {
 
     fun fixOrientationIssue(path: String, isVideo: Boolean): Uri? =
             WPMediaUtils.fixOrientationIssue(context, path, isVideo)
+
+    fun isVideoMimeType(mimeType: String): Boolean =
+        org.wordpress.android.fluxc.utils.MediaUtils.isVideoMimeType(mimeType)
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -94,10 +94,10 @@ public class WPMediaUtils {
      * 3) The user has granted storage access to the app.
      * This is because we don't want to ask so much things to users the first time they try to add a picture to the app.
      *
-     * @param act The host activity
+     * @param context The context
      * @return true if we should advertise the feature, false otherwise.
      */
-    public static boolean shouldAdvertiseImageOptimization(final Activity act) {
+    public static boolean shouldAdvertiseImageOptimization(final Context context) {
         boolean isPromoRequired = AppPrefs.isImageOptimizePromoRequired();
         if (!isPromoRequired) {
             return false;
@@ -105,7 +105,7 @@ public class WPMediaUtils {
 
         // Check we can access storage before asking for optimizing image
         boolean hasStoreAccess = ContextCompat.checkSelfPermission(
-                act, android.Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
+                context, android.Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
         if (!hasStoreAccess) {
             return false;
         }
@@ -118,7 +118,7 @@ public class WPMediaUtils {
         void done();
     }
 
-    public static void advertiseImageOptimization(final Activity activity,
+    public static void advertiseImageOptimization(final Context context,
                                                   final OnAdvertiseImageOptimizationListener listener) {
         DialogInterface.OnClickListener onClickListener = new DialogInterface.OnClickListener() {
             @Override
@@ -143,7 +143,7 @@ public class WPMediaUtils {
         };
 
         AlertDialog.Builder builder = new AlertDialog.Builder(
-                new ContextThemeWrapper(activity, R.style.Calypso_Dialog_Alert));
+                new ContextThemeWrapper(context, R.style.Calypso_Dialog_Alert));
         builder.setTitle(org.wordpress.android.R.string.image_optimization_promo_title);
         builder.setMessage(org.wordpress.android.R.string.image_optimization_promo_desc);
         builder.setPositiveButton(R.string.turn_on, onClickListener);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUtils.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUtils.java
@@ -13,8 +13,14 @@ import android.util.DisplayMetrics;
 import androidx.annotation.DrawableRes;
 import androidx.core.content.ContextCompat;
 
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.ImageUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 
 public class EditorMediaUtils {
     public static BitmapDrawable getAztecPlaceholderDrawableFromResID(Context context, @DrawableRes int drawableId,
@@ -45,5 +51,24 @@ public class EditorMediaUtils {
         int padding = DisplayUtils.dpToPx(context, 48) * 2;
         maximumThumbnailWidthForEditor -= padding;
         return maximumThumbnailWidthForEditor;
+    }
+
+    public static String getVideoThumbnail(Context context, String videoPath) {
+        String thumbnailPath = null;
+        try {
+            File outputFile = File.createTempFile("thumb", ".png", context.getCacheDir());
+            FileOutputStream outputStream = new FileOutputStream(outputFile);
+            Bitmap thumb = ImageUtils.getVideoFrameFromVideo(
+                    videoPath,
+                    EditorMediaUtils.getMaximumThumbnailSizeForEditor(context)
+            );
+            if (thumb != null) {
+                thumb.compress(Bitmap.CompressFormat.PNG, 75, outputStream);
+                thumbnailPath = outputFile.getAbsolutePath();
+            }
+        } catch (IOException e) {
+            AppLog.i(T.MEDIA, "Can't create thumbnail for video: " + videoPath);
+        }
+        return thumbnailPath;
     }
 }


### PR DESCRIPTION
This PR is a part of the ongoing effort to refactor the `EditPostActivity`. Similar to #10674 it focuses on `EditorMedia`, specifically removing static method calls as much as possible while refactoring some code to make it more Kotlin-y. The changes are very straightforward, most of it is just using the wrapper injected classes instead of the direct static method calls. This PR gets us very close to making `EditorMedia` unit-testable.

_Added as an edit:_
I didn't add a wrapper for `EditorMediaUtils` because I think we should just replace that whole thing with an injected class instead of wrapping it. It's small enough that it should be fairly easy to do & test. However, I think we should do this in its own PR instead since it touches some unrelated parts such as Aztec editor etc. Maybe it can be done after master WIP branch gets merged into `develop`.

**To test:**
 It's not necessary to test this PR as it's being merged to a WIP branch which we'll test later.

**PR submission checklist:**

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

