### PR TITLE
(Almost) removes Activity & static method dependency from EditorMedia

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2346,7 +2346,7 @@ public class EditPostActivity extends AppCompatActivity implements
             if (Intent.ACTION_SEND.equals(action) || Intent.ACTION_SEND_MULTIPLE.equals(action)) {
                 setPostContentFromShareAction();
             } else if (NEW_MEDIA_POST.equals(action)) {
-                mEditorMedia.prepareMediaPost();
+                mEditorMedia.prepareMediaPost(getIntent().getLongArrayExtra(NEW_MEDIA_POST_EXTRA_IDS));
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -580,6 +580,9 @@ public class EditPostActivity extends AppCompatActivity implements
         mEditorMedia.getSnackBarMessage().observe(this, message -> {
             WPSnackbar.make(findViewById(R.id.editor_activity), message.getMessageRes(), Snackbar.LENGTH_SHORT).show();
         });
+        mEditorMedia.getToastMessage().observe(this, toastMessageHolder -> {
+            toastMessageHolder.show(this);
+        });
     }
 
     private void initializePostObject() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -128,6 +128,7 @@ import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.stockmedia.StockMediaPickerActivity;
 import org.wordpress.android.ui.uploads.PostEvents;
 import org.wordpress.android.ui.uploads.UploadService;
+import org.wordpress.android.ui.uploads.UploadServiceFacade;
 import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.ui.uploads.VideoOptimizer;
 import org.wordpress.android.ui.utils.UiHelpers;
@@ -325,6 +326,7 @@ public class EditPostActivity extends AppCompatActivity implements
     @Inject MediaUtilsWrapper mMediaUtilsWrapper;
     @Inject FluxCUtilsWrapper mFluxCUtilsWrapper;
     @Inject NetworkUtilsWrapper mNetworkUtilsWrapper;
+    @Inject UploadServiceFacade mUploadServiceFacade;
 
     private SiteModel mSite;
 
@@ -396,7 +398,7 @@ public class EditPostActivity extends AppCompatActivity implements
         mShowAztecEditor = AppPrefs.isAztecEditorEnabled();
         mEditorPhotoPicker = new EditorPhotoPicker(this, this, this, mShowAztecEditor);
         mEditorMedia = new EditorMedia(this, mSite, this, mDispatcher, mMediaStore, mEditorTracker, mMediaUtilsWrapper,
-                mFluxCUtilsWrapper, mNetworkUtilsWrapper, mMainDispatcher, mBgDispatcher);
+                mFluxCUtilsWrapper, mNetworkUtilsWrapper, mUploadServiceFacade, mMainDispatcher, mBgDispatcher);
 
         startObserving();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -190,13 +190,9 @@ class EditorMedia(
      * Queues a media file for upload and starts the UploadService. Toasts will alert the user
      * if there are issues with the file.
      */
-    fun queueFileForUpload(uri: Uri): MediaModel? {
-        return queueFileForUpload(uri, MediaUploadState.QUEUED)
-    }
-
     fun queueFileForUpload(
         uri: Uri,
-        startingState: MediaUploadState
+        startingState: MediaUploadState = MediaUploadState.QUEUED
     ): MediaModel? {
         val mimeType = activity.contentResolver.getType(uri)
         val path = mediaUtilsWrapper.getRealPathFromURI(uri)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -23,7 +23,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.EditPostActivity.AfterSavePostListener
 import org.wordpress.android.ui.posts.editor.media.OptimizeAndAddMediaToEditorUseCase
 import org.wordpress.android.ui.posts.editor.media.OptimizeAndAddMediaToEditorUseCase.AddMediaToEditorUiState
-import org.wordpress.android.ui.uploads.UploadService
+import org.wordpress.android.ui.uploads.UploadServiceFacade
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.CrashLoggingUtils
@@ -57,6 +57,7 @@ class EditorMedia(
     private val mediaUtilsWrapper: MediaUtilsWrapper,
     private val fluxCUtilsWrapper: FluxCUtilsWrapper,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
+    private val uploadServiceFacade: UploadServiceFacade,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) {
@@ -266,10 +267,7 @@ class EditorMedia(
         // before starting the service, we need to update the posts' contents so we are sure the service
         // can retrieve it from there on
         editorMediaListener.savePostAsyncFromEditorMedia(AfterSavePostListener {
-            UploadService.uploadMediaFromEditor(
-                    activity,
-                    ArrayList(queuedMediaModels)
-            )
+            uploadServiceFacade.uploadMediaFromEditor(ArrayList(queuedMediaModels))
         })
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -193,7 +193,7 @@ class EditorMedia(
         uri: Uri,
         startingState: MediaUploadState = MediaUploadState.QUEUED
     ): MediaModel? {
-        val mimeType = activity.contentResolver.getType(uri)
+        val mimeType = mediaUtilsWrapper.getMimeType(uri)
         val path = mediaUtilsWrapper.getRealPathFromURI(uri)
 
         // Invalid file path

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMedia.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.EditPostActivity.AfterSavePostListener
-import org.wordpress.android.ui.posts.EditPostActivity.NEW_MEDIA_POST_EXTRA_IDS
 import org.wordpress.android.ui.posts.editor.media.OptimizeAndAddMediaToEditorUseCase
 import org.wordpress.android.ui.posts.editor.media.OptimizeAndAddMediaToEditorUseCase.AddMediaToEditorUiState
 import org.wordpress.android.ui.uploads.UploadService
@@ -246,8 +245,8 @@ class EditorMedia(
                 }
     }
 
-    fun prepareMediaPost() {
-        activity.intent.getLongArrayExtra(NEW_MEDIA_POST_EXTRA_IDS)?.forEach { id ->
+    fun prepareMediaPost(mediaIds: LongArray) {
+        mediaIds.forEach { id ->
             addExistingMediaToEditor(AddExistingMediaSource.WP_MEDIA_LIBRARY, id)
         }
         editorMediaListener.savePostAsyncFromEditorMedia()

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
@@ -30,4 +30,8 @@ class UploadServiceFacade @Inject constructor(private val appContext: Context) {
 
     fun getPendingOrInProgressFeaturedImageUploadForPost(post: PostModel): MediaModel? =
             UploadService.getPendingOrInProgressFeaturedImageUploadForPost(post)
+
+    fun uploadMediaFromEditor(mediaList: ArrayList<MediaModel>) {
+        UploadService.uploadMediaFromEditor(appContext, mediaList)
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
@@ -43,4 +43,6 @@ class MediaUtilsWrapper @Inject constructor(private val context: Context) {
             listener.invoke()
         }
     }
+
+    fun getMimeType(uri: Uri): String? = context.contentResolver.getType(uri)
 }


### PR DESCRIPTION
This PR is a part of the ongoing effort to refactor the `EditPostActivity`. It's built on the #10697 branch, which means it needs to be merged before this PR is reviewed. Please mark the PR as ready to review once that's done so.

The PR aims to break the `Activity` dependency in the `EditorMedia` class to make it fully testable. Only remaining usage of `Activity` and static methods after this PR is for the `EditorMediaUtils.getVideoThumbnail` which should be converted to injectable class in a separate PR as mentioned in #10697.

It also hopefully makes it easier to move certain logic to different classes without having to care about the activity dependency.

**To test:**
It's not necessary to test this PR as it's being merged to a WIP branch which we'll test later.

**PR submission checklist:**
- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

