### PR TITLE
Make the page ordering case insensitive

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 13.6
 -----
+* Pages ordering is case insensitive now
  
 13.5
 -----

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.pages.PageItem.PublishedPage
 import org.wordpress.android.ui.pages.PageItem.ScheduledPage
 import org.wordpress.android.ui.pages.PageItem.TrashedPage
 import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.toFormattedDateString
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -46,6 +47,7 @@ private const val DEFAULT_INDENT = 0
 class PageListViewModel @Inject constructor(
     private val mediaStore: MediaStore,
     private val dispatcher: Dispatcher,
+    private val localeManagerWrapper: LocaleManagerWrapper,
     @Named(BG_THREAD) private val coroutineDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(coroutineDispatcher) {
     private val _pages: MutableLiveData<List<PageItem>> = MutableLiveData()
@@ -151,7 +153,7 @@ class PageListViewModel @Inject constructor(
 
     private fun loadPagesAsync(pages: List<PageModel>) = launch {
         val pageItems = pages
-                .sortedBy { it.title }
+                .sortedBy { it.title.toLowerCase(localeManagerWrapper.getLocale()) }
                 .filter { listType.pageStatuses.contains(it.status) }
                 .let {
                     when (listType) {


### PR DESCRIPTION
Fixes #10707 

Makes the page ordering case insensitive.

To test:
1. Publish page "Z"
2. Publish page "a"
3. Notice page "a" is first in the pages list

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

