### PR TITLE
Fix media replacement on media-text block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -418,7 +418,8 @@ public class PostUtils {
                 postContent = postContent.replace(oldImgBlockHeader, newImgBlockHeader);
 
                 String oldMediaTextBlockHeader = String.format(GB_MEDIA_TEXT_BLOCK_HEADER_PLACEHOLDER, localMediaId);
-                String newMediaTextBlockHeader = String.format(GB_MEDIA_TEXT_BLOCK_HEADER_PLACEHOLDER, mediaFile.getMediaId());
+                String newMediaTextBlockHeader = String.format(GB_MEDIA_TEXT_BLOCK_HEADER_PLACEHOLDER,
+                        mediaFile.getMediaId());
                 postContent = postContent.replace(oldMediaTextBlockHeader, newMediaTextBlockHeader);
 
                 // replace class wp-image-id with serverMediaId, and url_holder with remoteUrl

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -54,8 +54,9 @@ public class PostUtils {
 
     private static final String GUTENBERG_BLOCK_START = "<!-- wp:";
     private static final int SRC_ATTRIBUTE_LENGTH_PLUS_ONE = 5;
-    private static final String GB_IMG_BLOCK_HEADER_PLACEHOLDER = "<!-- wp:image {\"id\":%s} -->";
+    private static final String GB_IMG_BLOCK_HEADER_PLACEHOLDER = "<!-- wp:image {\"id\":%s";
     private static final String GB_IMG_BLOCK_CLASS_PLACEHOLDER = "class=\"wp-image-%s\"";
+    private static final String GB_MEDIA_TEXT_BLOCK_HEADER_PLACEHOLDER = "<!-- wp:media-text {\"mediaId\":%s";
 
     public static Map<String, Object> addPostTypeToAnalyticsProperties(PostModel post, Map<String, Object> properties) {
         if (properties == null) {
@@ -415,6 +416,10 @@ public class PostUtils {
                 String oldImgBlockHeader = String.format(GB_IMG_BLOCK_HEADER_PLACEHOLDER, localMediaId);
                 String newImgBlockHeader = String.format(GB_IMG_BLOCK_HEADER_PLACEHOLDER, mediaFile.getMediaId());
                 postContent = postContent.replace(oldImgBlockHeader, newImgBlockHeader);
+
+                String oldMediaTextBlockHeader = String.format(GB_MEDIA_TEXT_BLOCK_HEADER_PLACEHOLDER, localMediaId);
+                String newMediaTextBlockHeader = String.format(GB_MEDIA_TEXT_BLOCK_HEADER_PLACEHOLDER, mediaFile.getMediaId());
+                postContent = postContent.replace(oldMediaTextBlockHeader, newMediaTextBlockHeader);
 
                 // replace class wp-image-id with serverMediaId, and url_holder with remoteUrl
                 String oldImgClass = String.format(GB_IMG_BLOCK_CLASS_PLACEHOLDER, localMediaId);


### PR DESCRIPTION
Partially addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/1509

This is not a full solution, but it will at least work for images uploaded via media-text in its default configuration. It still doesn't support video (since support wasn't there for the video block), and it will break if there are any other attributes before the id (such as alignment), but it's still an improvement.

We'll look for a better solution in 13.6.

To test:

- Add media & text block, tap placeholder and choose Choose from device
- Start upload but before it finishes close the post by selecting Update Post
- Wait until the upload finishes
- Re-open the post and verify that there's no red screen / validation error

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

