### PR TITLE
IA Project: create post/page from My Site

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -84,20 +84,20 @@ android {
                 versionName "13.5-rc-1"
             }
             versionCode 785
-            buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
+            buildConfigField "boolean", "INFORMATION_ARCHITECTURE_AVAILABLE", "false"
         }
 
         zalpha { // alpha version - enable experimental features
             applicationId "org.wordpress.android"
             dimension "buildType"
             buildConfigField "boolean", "VIDEO_OPTIMIZATION_AVAILABLE", "true"
-            buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
+            buildConfigField "boolean", "INFORMATION_ARCHITECTURE_AVAILABLE", "false"
         }
 
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
             applicationId "org.wordpress.android.beta"
             dimension "buildType"
-            buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
+            buildConfigField "boolean", "INFORMATION_ARCHITECTURE_AVAILABLE", "true"
         }
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -91,13 +91,13 @@ android {
             applicationId "org.wordpress.android"
             dimension "buildType"
             buildConfigField "boolean", "VIDEO_OPTIMIZATION_AVAILABLE", "true"
-            buildConfigField "boolean", "INFORMATION_ARCHITECTURE_AVAILABLE", "false"
+            buildConfigField "boolean", "INFORMATION_ARCHITECTURE_AVAILABLE", "true"
         }
 
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
             applicationId "org.wordpress.android.beta"
             dimension "buildType"
-            buildConfigField "boolean", "INFORMATION_ARCHITECTURE_AVAILABLE", "true"
+            buildConfigField "boolean", "INFORMATION_ARCHITECTURE_AVAILABLE", "false"
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -40,6 +40,7 @@ import org.wordpress.android.ui.domains.DomainSuggestionsFragment;
 import org.wordpress.android.ui.giphy.GiphyPickerActivity;
 import org.wordpress.android.ui.history.HistoryAdapter;
 import org.wordpress.android.ui.history.HistoryDetailContainerFragment;
+import org.wordpress.android.ui.main.MainBottomSheetFragment;
 import org.wordpress.android.ui.main.MeFragment;
 import org.wordpress.android.ui.main.MySiteFragment;
 import org.wordpress.android.ui.main.SitePickerActivity;
@@ -471,6 +472,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(PostNotificationScheduleTimeDialogFragment object);
 
     void inject(PublishNotificationReceiver object);
+
+    void inject(MainBottomSheetFragment object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -38,6 +38,7 @@ import org.wordpress.android.viewmodel.domains.DomainRegistrationDetailsViewMode
 import org.wordpress.android.viewmodel.domains.DomainSuggestionsViewModel;
 import org.wordpress.android.viewmodel.giphy.GiphyPickerViewModel;
 import org.wordpress.android.viewmodel.history.HistoryViewModel;
+import org.wordpress.android.viewmodel.main.WPMainActivityViewModel;
 import org.wordpress.android.viewmodel.pages.PageListViewModel;
 import org.wordpress.android.viewmodel.pages.PageParentViewModel;
 import org.wordpress.android.viewmodel.pages.PagesViewModel;
@@ -257,6 +258,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(ReaderCommentListViewModel.class)
     abstract ViewModel readerCommentListViewModel(ReaderCommentListViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(WPMainActivityViewModel.class)
+    abstract ViewModel wpMainActivityViewModel(WPMainActivityViewModel viewModel);
 
     @Binds
     abstract ViewModelProvider.Factory provideViewModelFactory(ViewModelFactory viewModelFactory);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -550,6 +550,14 @@ public class ActivityLauncher {
         fragment.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 
+    public static void addNewPageForResult(@NonNull Activity activity, @NonNull SiteModel site) {
+        Intent intent = new Intent(activity, EditPostActivity.class);
+        intent.putExtra(WordPress.SITE, site);
+        intent.putExtra(EditPostActivity.EXTRA_IS_PAGE, true);
+        intent.putExtra(EditPostActivity.EXTRA_IS_PROMO, false);
+        activity.startActivityForResult(intent, RequestCodes.EDIT_POST);
+    }
+
     public static void addNewPageForResult(@NonNull Fragment fragment, @NonNull SiteModel site) {
         Intent intent = new Intent(fragment.getContext(), EditPostActivity.class);
         intent.putExtra(WordPress.SITE, site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPBottomSheetDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPBottomSheetDialogFragment.kt
@@ -1,0 +1,5 @@
+package org.wordpress.android.ui
+
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+open class WPBottomSheetDialogFragment : BottomSheetDialogFragment()

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPBottomSheetDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPBottomSheetDialogFragment.kt
@@ -1,5 +1,0 @@
-package org.wordpress.android.ui
-
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-
-open class WPBottomSheetDialogFragment : BottomSheetDialogFragment()

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ActionListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ActionListItemViewHolder.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.ui.main
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import org.wordpress.android.R
+import org.wordpress.android.ui.main.MainActionListItem.CreateAction
+
+open class ActionListItemViewHolder(
+    internal val parent: ViewGroup
+) : ViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.main_action_list_item, parent, false)) {
+    open fun bind(action: CreateAction) {
+        val actionIcon: ImageView = this.itemView.findViewById(R.id.action_icon)
+        val actionTitle: TextView = this.itemView.findViewById(R.id.action_title)
+
+        actionIcon.setImageResource(action.iconRes)
+        actionTitle.setText(action.labelRes)
+
+        this.itemView.setOnClickListener {
+            action.onClickAction?.invoke(action.actionType)
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ActionListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ActionListItemViewHolder.kt
@@ -8,7 +8,7 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import org.wordpress.android.R
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 
-open class ActionListItemViewHolder(
+class ActionListItemViewHolder(
     internal val parent: ViewGroup
 ) : ViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.main_action_list_item, parent, false)) {
     open fun bind(action: CreateAction) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/AddContentAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/AddContentAdapter.kt
@@ -28,7 +28,7 @@ class AddContentAdapter : Adapter<ActionListItemViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ActionListItemViewHolder {
         // Currently we have only one ViewHolder type
-        return  ActionListItemViewHolder(parent)
+        return ActionListItemViewHolder(parent)
     }
 
     override fun getItemViewType(position: Int): Int {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/AddContentAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/AddContentAdapter.kt
@@ -1,0 +1,37 @@
+package org.wordpress.android.ui.main
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView.Adapter
+import org.wordpress.android.ui.main.MainActionListItem.CreateAction
+
+class AddContentAdapter : Adapter<ActionListItemViewHolder>() {
+    private var items: List<MainActionListItem> = listOf()
+    fun update(newItems: List<MainActionListItem>) {
+        val diffResult = DiffUtil.calculateDiff(
+                MainActionDiffCallback(
+                        items,
+                        newItems
+                )
+        )
+        items = newItems
+        diffResult.dispatchUpdatesTo(this)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: ActionListItemViewHolder, position: Int) {
+        val item = items[position]
+        // Currently we have only one ViewHolder type
+        holder.bind(item as CreateAction)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ActionListItemViewHolder {
+        // Currently we have only one ViewHolder type
+        return  ActionListItemViewHolder(parent)
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return items[position].actionType.ordinal
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionDiffCallback.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.ui.main
+
+import androidx.recyclerview.widget.DiffUtil.Callback
+
+class MainActionDiffCallback(
+    private val oldList: List<MainActionListItem>,
+    private val newList: List<MainActionListItem>
+) : Callback() {
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        val newItem = newList[newItemPosition]
+        val oldItem = oldList[oldItemPosition]
+
+        return (oldItem.actionType == newItem.actionType)
+    }
+
+    override fun getOldListSize(): Int = oldList.size
+
+    override fun getNewListSize(): Int = newList.size
+
+    override fun areContentsTheSame(
+        oldItemPosition: Int,
+        newItemPosition: Int
+    ): Boolean = true
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionDiffCallback.kt
@@ -20,5 +20,5 @@ class MainActionDiffCallback(
     override fun areContentsTheSame(
         oldItemPosition: Int,
         newItemPosition: Int
-    ): Boolean = true
+    ): Boolean = oldList[oldItemPosition] == newList[newItemPosition]
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionListItem.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.main
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import org.wordpress.android.ui.utils.UiString
 
 sealed class MainActionListItem {
     abstract val actionType: ActionType
@@ -16,5 +15,6 @@ sealed class MainActionListItem {
         override val actionType: ActionType,
         @DrawableRes val iconRes: Int,
         @StringRes val labelRes: Int,
-        val onClickAction: (actionType: ActionType) -> Unit) : MainActionListItem()
+        val onClickAction: (actionType: ActionType) -> Unit
+    ) : MainActionListItem()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionListItem.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.ui.main
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import org.wordpress.android.ui.utils.UiString
+
+sealed class MainActionListItem {
+    abstract val actionType: ActionType
+
+    enum class ActionType {
+        CREATE_NEW_PAGE,
+        CREATE_NEW_POST
+    }
+
+    data class CreateAction(
+        override val actionType: ActionType,
+        @DrawableRes val iconRes: Int,
+        @StringRes val labelRes: Int,
+        val onClickAction: (actionType: ActionType) -> Unit) : MainActionListItem()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainBottomSheetFragment.kt
@@ -1,0 +1,52 @@
+package org.wordpress.android.ui.main
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProviders
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.synthetic.main.add_content_bottom_sheet.*
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.ui.WPBottomSheetDialogFragment
+import org.wordpress.android.viewmodel.main.WPMainActivityViewModel
+import javax.inject.Inject
+
+class MainBottomSheetFragment : WPBottomSheetDialogFragment() {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var viewModel: WPMainActivityViewModel
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.add_content_bottom_sheet, container)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val recyclerView = view.findViewById<RecyclerView>(R.id.create_actions_recycler_view)
+        recyclerView.layoutManager = LinearLayoutManager(requireActivity())
+        recyclerView.adapter = AddContentAdapter()
+
+        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory).get(WPMainActivityViewModel::class.java)
+
+        viewModel.mainActions.observe(this, Observer {
+            (dialog.create_actions_recycler_view.adapter as? AddContentAdapter)?.update(it ?: listOf())
+        })
+
+        //viewModel.loadMainActions()
+    }
+
+    override fun onAttach(context: Context?) {
+        super.onAttach(context)
+        (requireActivity().applicationContext as WordPress).component().inject(this)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainBottomSheetFragment.kt
@@ -41,8 +41,6 @@ class MainBottomSheetFragment : WPBottomSheetDialogFragment() {
         viewModel.mainActions.observe(this, Observer {
             (dialog.create_actions_recycler_view.adapter as? AddContentAdapter)?.update(it ?: listOf())
         })
-
-        //viewModel.loadMainActions()
     }
 
     override fun onAttach(context: Context?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainBottomSheetFragment.kt
@@ -10,14 +10,14 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import kotlinx.android.synthetic.main.add_content_bottom_sheet.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
-import org.wordpress.android.ui.WPBottomSheetDialogFragment
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel
 import javax.inject.Inject
 
-class MainBottomSheetFragment : WPBottomSheetDialogFragment() {
+class MainBottomSheetFragment : BottomSheetDialogFragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: WPMainActivityViewModel
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -372,7 +372,7 @@ public class MySiteFragment extends Fragment implements
 
         mToolbar = rootView.findViewById(R.id.toolbar_main);
         mToolbar.setTitle(mToolbarTitle);
-        if (BuildConfig.ME_ACTIVITY_AVAILABLE) {
+        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
             mToolbar.inflateMenu(R.menu.my_site_menu);
             mToolbar.setOnMenuItemClickListener(item -> {
                 if (item.getItemId() == R.id.me_item) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -202,7 +202,7 @@ public class WPMainActivity extends AppCompatActivity implements
 
         mBottomNav = findViewById(R.id.bottom_navigation);
 
-        if (BuildConfig.ME_ACTIVITY_AVAILABLE) {
+        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
             mBottomNav.getMenu().removeItem(R.id.nav_me);
         }
         mBottomNav.init(getSupportFragmentManager(), this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -11,7 +11,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.text.TextUtils;
 import android.view.View;
-import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.TextView;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.text.TextUtils;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
@@ -20,9 +21,12 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.RemoteInput;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelProviders;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -108,6 +112,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.service.InstallationReferrerServiceStarter;
+import org.wordpress.android.viewmodel.main.WPMainActivityViewModel;
 import org.wordpress.android.widgets.AppRatingDialog;
 import org.wordpress.android.widgets.WPDialogSnackbar;
 
@@ -159,6 +164,10 @@ public class WPMainActivity extends AppCompatActivity implements
     private boolean mIsMagicLinkSignup;
 
     private SiteModel mSelectedSite;
+    private WPMainActivityViewModel mViewModel;
+    private FloatingActionButton mFloatingActionButton;
+    private MainBottomSheetFragment mMainBottomSheetFragment;
+    private static final String MAIN_BOTTOM_SHEET_TAG = "MAIN_BOTTOM_SHEET_TAG";
 
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
@@ -170,6 +179,7 @@ public class WPMainActivity extends AppCompatActivity implements
     @Inject NewsManager mNewsManager;
     @Inject QuickStartStore mQuickStartStore;
     @Inject UploadActionUseCase mUploadActionUseCase;
+    @Inject ViewModelProvider.Factory mViewModelFactory;
 
     /*
      * fragments implement this if their contents can be scrolled, called when user
@@ -204,6 +214,7 @@ public class WPMainActivity extends AppCompatActivity implements
 
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
             mBottomNav.getMenu().removeItem(R.id.nav_me);
+            mBottomNav.getMenu().removeItem(R.id.nav_write);
         }
         mBottomNav.init(getSupportFragmentManager(), this);
 
@@ -332,6 +343,8 @@ public class WPMainActivity extends AppCompatActivity implements
         if (canShowAppRatingPrompt) {
             AppRatingDialog.INSTANCE.showRateDialogIfNeeded(getFragmentManager());
         }
+
+        initViewModel();
     }
 
     public boolean isGooglePlayServicesAvailable(Activity activity) {
@@ -356,6 +369,46 @@ public class WPMainActivity extends AppCompatActivity implements
                                    + googleApiAvailability.getErrorString(connectionResult));
         }
         return false;
+    }
+
+    private void initViewModel() {
+        mFloatingActionButton = findViewById(R.id.fab_button);
+
+        mViewModel = ViewModelProviders.of(this, mViewModelFactory).get(WPMainActivityViewModel.class);
+
+        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
+            // Setup Observers
+            mViewModel.getShowMainActionFab().observe(this, shouldShow -> {
+                if (shouldShow) {
+                    mFloatingActionButton.show();
+                } else {
+                    mFloatingActionButton.hide();
+                }
+            });
+
+            mViewModel.getCreateAction().observe(this, createAction -> {
+                switch (createAction) {
+                    case CREATE_NEW_POST:
+                        handleNewPostAction();
+                        break;
+                    case CREATE_NEW_PAGE:
+                        handleNewPageAction();
+                        break;
+                }
+
+                if (mMainBottomSheetFragment != null) {
+                    mMainBottomSheetFragment.dismiss();
+                    mMainBottomSheetFragment = null;
+                }
+            });
+
+            mFloatingActionButton.setOnClickListener(v -> {
+                mMainBottomSheetFragment = new MainBottomSheetFragment();
+                mMainBottomSheetFragment.show(getSupportFragmentManager(), MAIN_BOTTOM_SHEET_TAG);
+            });
+        }
+
+        mViewModel.start(mBottomNav.getCurrentSelectedPage() == PageType.MY_SITE);
     }
 
     private @Nullable String getAuthToken() {
@@ -646,11 +699,31 @@ public class WPMainActivity extends AppCompatActivity implements
                 getMySiteFragment().requestNextStepOfActiveQuickStartTask();
             }
         }
+
+        mViewModel.onPageChanged(pageType == PageType.MY_SITE);
     }
 
     // user tapped the new post button in the bottom navbar
     @Override
     public void onNewPostButtonClicked() {
+        handleNewPostAction();
+    }
+
+    private void handleNewPageAction() {
+        if (!mSiteStore.hasSite()) {
+            // No site yet - Move to My Sites fragment that shows the create new site screen
+            mBottomNav.setCurrentSelectedPage(PageType.MY_SITE);
+            return;
+        }
+
+        SiteModel site = getSelectedSite();
+        if (site != null) {
+            // TODO: evaluate to include the QuickStart logic like in the handleNewPostAction
+            ActivityLauncher.addNewPageForResult(this, site);
+        }
+    }
+
+    public void handleNewPostAction() {
         if (!mSiteStore.hasSite()) {
             // No site yet - Move to My Sites fragment that shows the create new site screen
             mBottomNav.setCurrentSelectedPage(PageType.MY_SITE);
@@ -749,6 +822,8 @@ public class WPMainActivity extends AppCompatActivity implements
                 final SiteModel site = (SiteModel) data.getSerializableExtra(WordPress.SITE);
                 final PostModel post = mPostStore.getPostByLocalPostId(localId);
 
+                boolean isPage = data.getBooleanExtra(EditPostActivity.EXTRA_IS_PAGE, false);
+
                 if (EditPostActivity.checkToRestart(data)) {
                     ActivityLauncher.editPostOrPageForResult(data, WPMainActivity.this, site,
                             data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0));
@@ -757,7 +832,7 @@ public class WPMainActivity extends AppCompatActivity implements
                     break;
                 }
 
-                if (site != null && post != null) {
+                if (!isPage && site != null && post != null) {
                     UploadUtils.handleEditPostResultSnackbars(
                             this,
                             mDispatcher,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -821,8 +821,6 @@ public class WPMainActivity extends AppCompatActivity implements
                 final SiteModel site = (SiteModel) data.getSerializableExtra(WordPress.SITE);
                 final PostModel post = mPostStore.getPostByLocalPostId(localId);
 
-                boolean isPage = data.getBooleanExtra(EditPostActivity.EXTRA_IS_PAGE, false);
-
                 if (EditPostActivity.checkToRestart(data)) {
                     ActivityLauncher.editPostOrPageForResult(data, WPMainActivity.this, site,
                             data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0));
@@ -831,7 +829,7 @@ public class WPMainActivity extends AppCompatActivity implements
                     break;
                 }
 
-                if (!isPage && site != null && post != null) {
+                if (site != null && post != null) {
                     UploadUtils.handleEditPostResultSnackbars(
                             this,
                             mDispatcher,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -358,8 +358,7 @@ class WPMainNavigationView @JvmOverloads constructor(
 
     companion object {
         private val defaultPages = listOf(MY_SITE, READER, NEW_POST, ME, NOTIFS)
-        // TODO: rename "pagesWithoutMe" when removing also the NEW_POST in the IA Project
-        private val pagesWithoutMe = listOf(MY_SITE, READER, NEW_POST, NOTIFS)
+        private val pages = listOf(MY_SITE, READER, NOTIFS)
 
         private const val TAG_MY_SITE = "tag-mysite"
         private const val TAG_READER = "tag-reader"
@@ -368,7 +367,7 @@ class WPMainNavigationView @JvmOverloads constructor(
 
         private fun numPages(): Int {
             return if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-                pagesWithoutMe.size
+                pages.size
             } else {
                 defaultPages.size
             }
@@ -376,7 +375,7 @@ class WPMainNavigationView @JvmOverloads constructor(
 
         private fun pages(): List<PageType> {
             return if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-                pagesWithoutMe
+                pages
             } else {
                 defaultPages
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -357,7 +357,7 @@ class WPMainNavigationView @JvmOverloads constructor(
     }
 
     companion object {
-        private val defaultPages = listOf(MY_SITE, READER, NEW_POST, ME, NOTIFS)
+        private val oldPages = listOf(MY_SITE, READER, NEW_POST, ME, NOTIFS)
         private val pages = listOf(MY_SITE, READER, NOTIFS)
 
         private const val TAG_MY_SITE = "tag-mysite"
@@ -369,7 +369,7 @@ class WPMainNavigationView @JvmOverloads constructor(
             return if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
                 pages.size
             } else {
-                defaultPages.size
+                oldPages.size
             }
         }
 
@@ -377,7 +377,7 @@ class WPMainNavigationView @JvmOverloads constructor(
             return if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
                 pages
             } else {
-                defaultPages
+                oldPages
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -367,7 +367,7 @@ class WPMainNavigationView @JvmOverloads constructor(
         private const val TAG_NOTIFS = "tag-notifs"
 
         private fun numPages(): Int {
-            return if (BuildConfig.ME_ACTIVITY_AVAILABLE) {
+            return if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
                 pagesWithoutMe.size
             } else {
                 defaultPages.size
@@ -375,7 +375,7 @@ class WPMainNavigationView @JvmOverloads constructor(
         }
 
         private fun pages(): List<PageType> {
-            return if (BuildConfig.ME_ACTIVITY_AVAILABLE) {
+            return if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
                 pagesWithoutMe
             } else {
                 defaultPages

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -1,0 +1,61 @@
+package org.wordpress.android.viewmodel.main
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import org.wordpress.android.R
+import org.wordpress.android.ui.main.MainActionListItem
+import org.wordpress.android.ui.main.MainActionListItem.ActionType
+import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_PAGE
+import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
+import org.wordpress.android.ui.main.MainActionListItem.CreateAction
+import org.wordpress.android.viewmodel.SingleLiveEvent
+import javax.inject.Inject
+
+class WPMainActivityViewModel @Inject constructor() : ViewModel() {
+    private var isStarted = false
+
+    private val _showMainActionFab = MutableLiveData<Boolean>()
+    val showMainActionFab: LiveData<Boolean> = _showMainActionFab
+
+    private val _mainActions = MutableLiveData<List<MainActionListItem>>()
+    val mainActions: LiveData<List<MainActionListItem>> = _mainActions
+
+    private val _createAction = SingleLiveEvent<ActionType>()
+    val createAction: LiveData<ActionType> = _createAction
+
+    fun start(isFabVisible: Boolean) {
+        if (isStarted) return
+        isStarted = true
+
+        _showMainActionFab.value = isFabVisible
+        loadMainActions()
+    }
+
+    private fun loadMainActions() {
+        val actionsList = ArrayList<MainActionListItem>()
+
+        actionsList.add(CreateAction(
+                actionType = CREATE_NEW_POST,
+                iconRes = R.drawable.ic_posts_white_24dp,
+                labelRes = R.string.my_site_bottom_sheet_add_post,
+                onClickAction = ::onCreateActionClicked
+        ))
+        actionsList.add(CreateAction(
+                actionType = CREATE_NEW_PAGE,
+                iconRes = R.drawable.ic_pages_white_24dp,
+                labelRes = R.string.my_site_bottom_sheet_add_page,
+                onClickAction = ::onCreateActionClicked
+        ))
+
+        _mainActions.postValue(actionsList)
+    }
+
+    private fun onCreateActionClicked(actionType: ActionType) {
+        _createAction.postValue(actionType)
+    }
+
+    fun onPageChanged(showFab: Boolean) {
+        _showMainActionFab.value = showFab
+    }
+}

--- a/WordPress/src/main/res/layout/add_content_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout/add_content_bottom_sheet.xml
@@ -12,6 +12,8 @@
         android:layout_width="match_parent"
         android:clipToPadding="false"
         android:descendantFocusability="beforeDescendants"
-        android:scrollbars="vertical"/>
+        android:scrollbars="vertical"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:layout_marginBottom="@dimen/margin_extra_large"/>
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/add_content_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout/add_content_bottom_sheet.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:animateLayoutChanges="true">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/create_actions_recycler_view"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:clipToPadding="false"
+        android:descendantFocusability="beforeDescendants"
+        android:scrollbars="vertical"/>
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/main_action_list_item.xml
+++ b/WordPress/src/main/res/layout/main_action_list_item.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/MySiteListRowLayout">
+
+    <ImageView
+        android:id="@+id/action_icon"
+        tools:src="@drawable/ic_posts_white_24dp"
+        android:visibility="visible"
+        android:contentDescription="@null"
+        style="@style/MainBottomSheetRowIcon"/>
+
+    <TextView
+        android:id="@+id/action_title"
+        style="@style/MainBottomSheetRowTextView"
+        tools:text="@string/my_site_bottom_sheet_add_post" />
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/main_activity.xml
+++ b/WordPress/src/main/res/layout/main_activity.xml
@@ -56,4 +56,19 @@
             app:menu="@menu/bottom_nav_main"/>
     </LinearLayout>
 
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/bottom_container"
+        android:layout_alignParentEnd="true"
+        android:layout_marginBottom="@dimen/fab_margin"
+        android:layout_marginEnd="@dimen/fab_margin"
+        android:visibility="gone"
+        tools:visibility="visible"
+        android:contentDescription="@string/fab_create_desc"
+        android:src="@drawable/ic_create_white_24dp"
+        app:borderWidth="0dp"/>
+
+
 </RelativeLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -432,6 +432,6 @@
     <dimen name="settings_username_changer_confirm_dialog_padding">20dp</dimen>
 
     <!--Main bottom sheet icon size -->
-    <dimen name="main_bottom_sheet_list_row_icon_size">48dp</dimen>
+    <dimen name="main_bottom_sheet_list_row_icon_size">32dp</dimen>
 
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -431,4 +431,7 @@
     <!--settings username changer-->
     <dimen name="settings_username_changer_confirm_dialog_padding">20dp</dimen>
 
+    <!--Main bottom sheet icon size -->
+    <dimen name="main_bottom_sheet_list_row_icon_size">48dp</dimen>
+
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1760,6 +1760,9 @@
     <string name="my_site_icon_dialog_cancel_button">Cancel</string>
     <string name="my_site_icon_content_description">Change site icon</string>
 
+    <string name="my_site_bottom_sheet_add_post">Create new post</string>
+    <string name="my_site_bottom_sheet_add_page">Create new page</string>
+
     <!-- site picker -->
     <string name="site_picker_title">Choose site</string>
     <string name="site_picker_edit_visibility">Show/hide sites</string>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1043,4 +1043,13 @@
         <item name="colorControlHighlight">@android:color/transparent</item>
     </style>
 
+    <!-- Main actions styles -->
+    <style name="MainBottomSheetRowIcon" parent="MySiteListRowIcon">
+        <item name="android:layout_height">@dimen/main_bottom_sheet_list_row_icon_size</item>
+    </style>
+
+    <style name="MainBottomSheetRowTextView" parent="MySiteListRowTextView">
+        <item name="android:layout_gravity">center_vertical</item>
+    </style>
+
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -1,0 +1,54 @@
+package org.wordpress.android.viewmodel.main
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_PAGE
+import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
+import org.wordpress.android.ui.main.MainActionListItem.CreateAction
+
+@RunWith(MockitoJUnitRunner::class)
+class WPMainActivityViewModelTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    private lateinit var viewModel: WPMainActivityViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = WPMainActivityViewModel()
+        viewModel.start(true)
+    }
+
+    @Test
+    fun `fab visible when asked`() {
+        viewModel.onPageChanged(true)
+        assertThat(viewModel.showMainActionFab.value).isEqualTo(true)
+    }
+
+    @Test
+    fun `fab hidden when asked`() {
+        viewModel.onPageChanged(false)
+        assertThat(viewModel.showMainActionFab.value).isEqualTo(false)
+    }
+
+    @Test
+    fun `bottom sheet action is new post when new post is tapped`() {
+        val action = viewModel.mainActions.value?.first { it.actionType == CREATE_NEW_POST } as CreateAction
+        assertThat(action).isNotNull
+        action.onClickAction.invoke(CREATE_NEW_POST)
+        assertThat(viewModel.createAction.value).isEqualTo(CREATE_NEW_POST)
+    }
+
+    @Test
+    fun `bottom sheet action is new page when new page is tapped`() {
+        val action = viewModel.mainActions.value?.first { it.actionType == CREATE_NEW_PAGE } as CreateAction
+        assertThat(action).isNotNull
+        action.onClickAction.invoke(CREATE_NEW_PAGE)
+        assertThat(viewModel.createAction.value).isEqualTo(CREATE_NEW_PAGE)
+    }
+}


### PR DESCRIPTION
Fixes  #10618 and supersedes PR #10617

As part of the Information Architecture project this PR adds the possibility to add a new post or page from the My Site screen.

This modifications are currently behind a feature flag together with the modifications for the Me Move. The common feature flag was renamed accordingly from ME_ACTIVITY_AVAILABLE to INFORMATION_ARCHITECTURE_AVAILABLE

We introduced visually two modifications highlighted below:

| 3 items bottom menus + fab | bottom sheet on fab tap |
|---|---|
| ![image](https://user-images.githubusercontent.com/47797566/67953822-256af480-fbf0-11e9-8078-6ade39d53f09.png) | ![image](https://user-images.githubusercontent.com/47797566/67953879-40d5ff80-fbf0-11e9-8fdd-b5942f5cb615.png)|




## NOTES
1. The feature flag is active only in the zalpha flavor that reaches internal testers for now if we merge in develop (cc @designsimply )

## To test


1. Compile and run the zalpha flavor
2. Check that the Me and the new post menu items are not in the bottom nav bar
<p align="center">
  <img width="300" src="https://user-images.githubusercontent.com/47797566/67002460-3ee24b80-f0dc-11e9-8109-f616b8e12703.png">
</p>

3. Switch between My site/Reader/Notifications pages and check that the FAB is only available in the My site screen
4. Tap on each menu item in the bottom navbar to check that the correct screen is visualized
5. Select the FAB and check that a bottom sheet is opened. The Editor is opened when selecting the Create new Page/Post from the bottom sheet
6. Create a post/page and tap on the back arrow. You should be back on the main screen and notified by a snackbar that the post was saved on line.
7. Access to the Pages/Posts list and check the new created Page/Post was created and available in the correct list (Published/Draft).
8. Compile and run vanilla flavor
9. Check that you have all the 5 menu item in the Bottom nav bar and the FAB is not present
10. Smoke test to check that the menus activate the expected screens and the app works as usual. 

PS: i think we do not need to include notes in the RELEASE NOTES for the above since it is still behind a feature flag, but not fully sure about it. Let me know wdyt. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.