### PR TITLE
Add labels to bottom navigation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -12,6 +12,7 @@ import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import com.google.android.material.bottomnavigation.BottomNavigationItemView
@@ -86,7 +87,15 @@ class WPMainNavigationView @JvmOverloads constructor(
                 customView = inflater.inflate(R.layout.navbar_post_item, menuView, false)
                 customView.id = R.id.bottom_nav_new_post_button // identify view for QuickStart
             } else {
-                customView = inflater.inflate(R.layout.navbar_item, menuView, false)
+                customView = inflater.inflate(
+                        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE)
+                            R.layout.navbar_item
+                        else
+                            R.layout.navbar_item_old,
+                        menuView,
+                        false
+                )
+
                 val txtLabel = customView.findViewById<TextView>(R.id.nav_label)
                 val imgIcon = customView.findViewById<ImageView>(R.id.nav_icon)
                 txtLabel.text = getTitleForPosition(i)
@@ -185,12 +194,20 @@ class WPMainNavigationView @JvmOverloads constructor(
 
         // remove the title and selected state from the previously selected item
         if (prevPosition > -1) {
-            showTitleForPosition(prevPosition, false)
+            if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
+                setTitleViewSelected(prevPosition, false)
+            } else {
+                showTitleForPosition(prevPosition, false)
+            }
             setImageViewSelected(prevPosition, false)
         }
 
         // set the title and selected state from the newly selected item
-        showTitleForPosition(position, true)
+        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
+            setTitleViewSelected(position, true)
+        } else {
+            showTitleForPosition(position, true)
+        }
         setImageViewSelected(position, true)
 
         AppPrefs.setMainPageIndex(position)
@@ -215,6 +232,12 @@ class WPMainNavigationView @JvmOverloads constructor(
 
     private fun setImageViewSelected(position: Int, isSelected: Boolean) {
         getImageViewForPosition(position)?.isSelected = isSelected
+    }
+
+    private fun setTitleViewSelected(position: Int, isSelected: Boolean) {
+        getTitleViewForPosition(position)?.setTextColor(
+                ContextCompat.getColor(context, if (isSelected) R.color.primary_40 else R.color.neutral_20)
+        )
     }
 
     @DrawableRes

--- a/WordPress/src/main/res/layout/navbar_item.xml
+++ b/WordPress/src/main/res/layout/navbar_item.xml
@@ -14,8 +14,8 @@
 
         <ImageView
             android:id="@+id/nav_icon"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
+            android:layout_width="@dimen/bottom_nav_bar_icon_size"
+            android:layout_height="@dimen/bottom_nav_bar_icon_size"
             android:layout_gravity="center"
             android:contentDescription="@string/tabbar_accessibility_label_my_site"
             android:tint="@drawable/nav_bar_button_selector"
@@ -23,8 +23,8 @@
 
         <View
             android:id="@+id/badge"
-            android:layout_width="12dp"
-            android:layout_height="12dp"
+            android:layout_width="@dimen/bottom_nav_bar_badge_size"
+            android:layout_height="@dimen/bottom_nav_bar_badge_size"
             android:layout_gravity="top"
             android:background="@drawable/bg_oval_accent_stroke_white"
             android:visibility="gone"
@@ -40,7 +40,7 @@
         android:duplicateParentState="true"
         android:singleLine="true"
         android:textColor="@color/neutral_20"
-        android:textSize="12sp"
+        android:textSize="@dimen/text_sz_small"
         android:visibility="visible"
         tools:text="label"/>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/navbar_item_old.xml
+++ b/WordPress/src/main/res/layout/navbar_item_old.xml
@@ -39,8 +39,9 @@
         android:layout_gravity="center_horizontal"
         android:duplicateParentState="true"
         android:singleLine="true"
-        android:textColor="@color/neutral_20"
+        android:textColor="@color/primary_40"
         android:textSize="12sp"
-        android:visibility="visible"
-        tools:text="label"/>
+        android:visibility="gone"
+        tools:text="label"
+        tools:visibility="visible"/>
 </LinearLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -45,6 +45,10 @@
     <dimen name="default_cardview_radius">2dp</dimen>
     <dimen name="default_cardview_elevation">2dp</dimen>
 
+    <!-- bottom navigation bar -->
+    <dimen name="bottom_nav_bar_icon_size">24dp</dimen>
+    <dimen name="bottom_nav_bar_badge_size">12dp</dimen>
+
     <!-- featured image in post list -->
     <dimen name="postlist_featured_image_height">98dp</dimen>
 


### PR DESCRIPTION
Fixes #10590 

This PR adds the labels to the bottom navigation menu items when the INFORMATION_ARCHITECTURE_AVAILABLE feature flag is active (currently in zalpha flavor).

The following show the menus without and with the active feature flag:

| Standard current nav bar  | ia project revised nav bar |
|---|---|
|![image](https://user-images.githubusercontent.com/47797566/68166499-d19b3b00-ff62-11e9-9d62-2bccc57aabba.png) |![image](https://user-images.githubusercontent.com/47797566/68166639-3e163a00-ff63-11e9-8970-234ba609dc98.png)|

cc @osullivanchris 

## To test

1. Compile and run the zalpha flavor
2. Check that you have 3 items in the bottom nav with labels (labels color equal to icon color)
<p align="center">
  <img width="300" src="https://user-images.githubusercontent.com/47797566/68166849-f80da600-ff63-11e9-8a25-bd2c91f7e292.png">
</p>
3. Switch between the menus and check the correct pages are presented. Also notice that the label color stays the same as the icon color. 
4. Do the same check triggering configuration change (rotating the device)
5. Compile and run vanilla flavor
6. Check you have the 5 menus as below with the label only in the selected menu with the same color as the icon
<p align="center">
  <img width="300" src="https://user-images.githubusercontent.com/47797566/68167047-7d915600-ff64-11e9-99e0-536c1da1f664.png">
</p>
7. Smoke test to check the bottom nav menus activate the expected screens and the app behaves as usual

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

