### PR TITLE
Stats: Make suffixes use the US/Canada/Modern British version

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
@@ -7,10 +7,10 @@ import java.util.TreeMap
 private val SUFFIXES = TreeMap(mapOf(
         1_000L to "k",
         1_000_000L to "M",
-        1_000_000_000L to "G",
+        1_000_000_000L to "B",
         1_000_000_000_000L to "T",
-        1_000_000_000_000_000L to "P",
-        1_000_000_000_000_000_000L to "E"
+        1_000_000_000_000_000L to "Qa",
+        1_000_000_000_000_000_000L to "Qi"
 ))
 
 const val ONE_THOUSAND = 1000

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtilsTest.kt
@@ -41,10 +41,10 @@ class StatsUtilsTest {
                 "92M",
                 "123M",
                 "9.9M",
-                "999P",
-                "1.2P",
-                "-9.2E",
-                "9.2E"
+                "999Qa",
+                "1.2Qa",
+                "-9.2Qi",
+                "9.2Qi"
         )
         for (i in numbers.indices) {
             val number = numbers[i]


### PR DESCRIPTION
Fixes #10709 

Now for a bit of word nerdery.

"k", "M", "B", and "T" are relatively well-known as suffixes for those numbers, but while working on this I found the last two numbers, quadrillion and quintillion, to be quite tricky.

As far as I can research, there are no standardized suffixes for these two numbers yet. Some examples from gaming websites and [Stack Overflow](https://stackoverflow.com/a/35329932) use either the pair of "q" and "Q", or "Qa" and "Qi". I adopted the latter here since they feel more obvious and easily understandable.

This is also likely not something most users will encounter anyway, since these numbers are quite high, so we probably don't need to worry too much about it now. Once the majority of WordPress sites are successful enough to pull these sort of numbers, it will then be a good problem to have and revisit :)

Lastly, it pains me a bit that the suffixes is now made to be based on the US/Canada/Modern British version, but at least it feels more natural now. I hope that in the future we can refactor this into translatable strings instead.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

