### PR TITLE
Add Encryption Functionality and Tests

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -297,6 +297,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"
 
     implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0-alpha'
+
+    implementation 'com.github.joshjdevl.libsodiumjni:libsodium-jni-aar:2.0.1'
 }
 
 configurations.all {

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/EncryptionUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/EncryptionUtilsTest.java
@@ -182,17 +182,18 @@ public class EncryptionUtilsTest {
         final byte[] tag = new byte[1];
         final int decryptedLineLength = encryptedLine.length - EncryptionUtils.XCHACHA20POLY1305_ABYTES;
         final byte[] decryptedLine = new byte[decryptedLineLength];
-        final byte[] ad = new byte[0];
-        final int[] len = new int[0];
+        final byte[] additionalData = new byte[0]; // opting not to use this value
+        final int additionalDataLength = 0;
+        final int[] decryptedLineLengthOutput = new int[0]; // opting not to get this value
         final int returnCode = NaCl.sodium().crypto_secretstream_xchacha20poly1305_pull(
                 state,
                 decryptedLine,
-                len,
+                decryptedLineLengthOutput,
                 tag,
                 encryptedLine,
                 encryptedLine.length,
-                ad,
-                0);
+                additionalData,
+                additionalDataLength);
         assertEquals(returnCode, 0);
 
         final int encryptionTag = tag[0];

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/EncryptionUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/EncryptionUtilsTest.java
@@ -1,30 +1,31 @@
 package org.wordpress.android.util;
 
-import android.content.Context;
+import android.util.Base64;
 
-import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import com.android.volley.AuthFailureError;
-import com.android.volley.Request.Method;
-import com.android.volley.Response;
-import com.android.volley.VolleyError;
-import com.android.volley.toolbox.StringRequest;
-import com.android.volley.toolbox.Volley;
-
 import org.json.JSONException;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.concurrent.CountDownLatch;
-import java.util.HashMap;
-import java.util.Map;
+import org.libsodium.jni.NaCl;
 
 import static junit.framework.Assert.fail;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(AndroidJUnit4.class)
 public class EncryptionUtilsTest {
+    byte[] mPublicKey;
+    byte[] mSecretKey;
+
+    static final int BOX_PUBLIC_KEY_BYTES = NaCl.sodium().crypto_box_publickeybytes();
+    static final int BOX_SECRET_KEY_BYTES = NaCl.sodium().crypto_box_secretkeybytes();
+
+    static final int BASE64_DECODE_FLAGS = Base64.DEFAULT;
+
     // test data
     static final String TEST_LOG_STRING = "WordPress - 13.5 - Version code: 789\n"
             + "Android device name: Google Android SDK built for x86\n\n"
@@ -43,71 +44,145 @@ public class EncryptionUtilsTest {
             + "    at com.android.volley.NetworkDispatcher.processRequest(NetworkDispatcher.java:111)\n"
             + "    at com.android.volley.NetworkDispatcher.run(NetworkDispatcher.java:90)\n";
 
-    // for endpoint test
-    static final String END_POINT_TEST_PUBLIC_KEY = "K0y2oQ++gEN00S4CbCH3IYoBIxVF6H86Wz4wi2t2C3M=";
-    static final String END_POINT_TEST_URL = "https://log-encryption-testing.herokuapp.com";
-
-    @Test
-    public void testEncryptionResultIsValidWithTestEndpointDecryption() {
-        final Context context = ApplicationProvider.getApplicationContext();
-
-        final String encryptionDataJson = getEncryptionDataJson(END_POINT_TEST_PUBLIC_KEY);
-        if (encryptionDataJson == null) {
-            fail("unable to encrypt test data");
-        }
-
-        final CountDownLatch countDownLatch = new CountDownLatch(1);
-
-        StringRequest postRequest = new StringRequest(
-                Method.POST,
-                END_POINT_TEST_URL,
-                new Response.Listener<String>() {
-                    @Override
-                    public void onResponse(String response) {
-                        assertEquals(response, TEST_LOG_STRING);
-                        countDownLatch.countDown();
-                    }
-                },
-                new Response.ErrorListener() {
-                    @Override
-                    public void onErrorResponse(VolleyError error) {
-                        fail("PostRequest failed with error: " + error.toString());
-                        countDownLatch.countDown();
-                    }
-                }
-        ) {
-            @Override
-            public Map<String, String> getHeaders() throws AuthFailureError {
-                Map<String, String> headers = new HashMap<String, String>();
-                headers.put("Content-Type", "application/x-www-form-urlencoded");
-                return headers;
-            }
-            @Override
-            public byte[] getBody() throws AuthFailureError {
-                return encryptionDataJson.getBytes();
-            }
-        };
-
-        postRequest.setShouldCache(false);
-        Volley.newRequestQueue(context).add(postRequest);
-
-        try {
-            countDownLatch.await();
-        } catch (InterruptedException e) {
-            fail("CountDownLatch await interrupted for post request: " + e.toString());
-        }
+    @Before
+    public void setup() {
+        mPublicKey = new byte[BOX_PUBLIC_KEY_BYTES];
+        mSecretKey = new byte[BOX_SECRET_KEY_BYTES];
+        NaCl.sodium().crypto_box_keypair(mPublicKey, mSecretKey);
     }
 
-    private String getEncryptionDataJson(String publicKeyBase64) {
-        try {
-            final String encryptionDataJson = EncryptionUtils.encryptStringData(
-                    publicKeyBase64,
-                    TEST_LOG_STRING);
+    @Test
+    public void testLogStringEncryptionResultIsValid() {
+        final JSONObject encryptionDataJson = getEncryptionDataJson(mPublicKey, TEST_LOG_STRING);
+        assertNotNull(encryptionDataJson);
 
-            return encryptionDataJson;
+        /*
+            Expected Contents for JSON:
+            {
+            "keyedWith": "v1",
+            "encryptedKey": "$key_as_base_64",  // The encrypted AES key
+            "header": "base_64_encoded_header", // The xchacha20poly1305 stream header
+            "messages": []                      // the stream elements, base-64 encoded
+            }
+        */
+
+        final byte[] dataSpecificKey = getDataSpecificKey(encryptionDataJson);
+        assertNotNull(dataSpecificKey);
+
+        final byte[] header = getHeader(encryptionDataJson);
+        assertNotNull(header);
+
+        final byte[] state = new byte[EncryptionUtils.XCHACHA20POLY1305_STATEBYTES];
+        final int initPullReturnCode = NaCl.sodium().crypto_secretstream_xchacha20poly1305_init_pull(
+                state,
+                header,
+                dataSpecificKey);
+        assertEquals(initPullReturnCode, 0);
+
+        String decryptedDataString = "";
+        final byte[][] encryptedLines = getEncryptedLines(encryptionDataJson);
+        assertNotNull(encryptedLines);
+        for (int i = 0; i < encryptedLines.length; ++i) {
+            final String decryptedLine = getDecryptedString(state, encryptedLines[i]);
+            if (decryptedLine == null) {
+                // expecting null for the final line in the encryption data
+                assertEquals(encryptedLines.length - 1, i);
+                break;
+            }
+
+            decryptedDataString = decryptedDataString + decryptedLine;
+        }
+
+        assertEquals(TEST_LOG_STRING, decryptedDataString);
+    }
+
+    private JSONObject getEncryptionDataJson(final byte[] publicKey, final String data) {
+        try {
+            final String encryptionDataJsonString = EncryptionUtils.encryptStringData(
+                    Base64.encodeToString(publicKey, Base64.DEFAULT),
+                    data);
+
+            return new JSONObject(encryptionDataJsonString);
         } catch (JSONException e) {
             fail("encryptStringData failed with JSONException: " + e.toString());
         }
+        return null;
+    }
+
+    private byte[] getDataSpecificKey(final JSONObject encryptionDataJson) {
+        try {
+            final byte[] decryptedKey = new byte[EncryptionUtils.XCHACHA20POLY1305_KEYBYTES];
+            final String encryptedKeyBase64 = encryptionDataJson.getString("encryptedKey");
+            final byte[] encryptedKey = Base64.decode(encryptedKeyBase64, BASE64_DECODE_FLAGS);
+            final int returnCode = NaCl.sodium().crypto_box_seal_open(
+                    decryptedKey,
+                    encryptedKey,
+                    EncryptionUtils.XCHACHA20POLY1305_KEYBYTES + EncryptionUtils.BOX_SEALBYTES,
+                    mPublicKey,
+                    mSecretKey);
+            assertEquals(returnCode, 0);
+
+            return decryptedKey;
+        } catch (JSONException e) {
+            fail("failed to get encryptedKey from encrypted data JSON");
+        }
+
+        return null;
+    }
+
+    private byte[] getHeader(final JSONObject encryptionDataJson) {
+        try {
+            final String headerBase64 = encryptionDataJson.getString("header");
+            return Base64.decode(headerBase64, BASE64_DECODE_FLAGS);
+        } catch (JSONException e) {
+            fail("failed to get header from encrypted data JSON");
+        }
+        return null;
+    }
+
+    private byte[][] getEncryptedLines(final JSONObject encryptionDataJson) {
+        try {
+            final JSONArray messages = encryptionDataJson.getJSONArray("messages");
+
+            final int messagesLength = messages.length();
+            final byte[][] encryptedLines = new byte[messagesLength][];
+            for (int i = 0; i < messagesLength; ++i) {
+                final String messageBase64 = messages.getString(i);
+                encryptedLines[i] = Base64.decode(messageBase64, BASE64_DECODE_FLAGS);
+            }
+            return encryptedLines;
+        } catch (JSONException e) {
+            fail("failed to get messages from encrypted data JSON");
+        }
+
+        return null;
+    }
+
+    private String getDecryptedString(final byte[] state, final byte[] encryptedLine) {
+        final byte[] tag = new byte[1];
+        final int decryptedLineLength = encryptedLine.length - EncryptionUtils.XCHACHA20POLY1305_ABYTES;
+        final byte[] decryptedLine = new byte[decryptedLineLength];
+        final byte[] ad = new byte[0];
+        final int[] len = new int[0];
+        final int returnCode = NaCl.sodium().crypto_secretstream_xchacha20poly1305_pull(
+                state,
+                decryptedLine,
+                len,
+                tag,
+                encryptedLine,
+                encryptedLine.length,
+                ad,
+                0);
+        assertEquals(returnCode, 0);
+
+        final int encryptionTag = tag[0];
+        if (encryptionTag == EncryptionUtils.XCHACHA20POLY1305_TAG_MESSAGE) {
+            return new String(decryptedLine);
+        } else if (encryptionTag == EncryptionUtils.XCHACHA20POLY1305_TAG_FINAL) {
+            return null;
+        }
+
+        fail("message decryption failed, unexpected tag.");
         return null;
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/EncryptionUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/EncryptionUtilsTest.java
@@ -43,6 +43,7 @@ public class EncryptionUtilsTest {
             + "    at com.android.volley.NetworkDispatcher.processRequest(NetworkDispatcher.java:131)\n"
             + "    at com.android.volley.NetworkDispatcher.processRequest(NetworkDispatcher.java:111)\n"
             + "    at com.android.volley.NetworkDispatcher.run(NetworkDispatcher.java:90)\n";
+    static final String TEST_EMPTY_STRING = "";
 
     @Before
     public void setup() {
@@ -53,7 +54,16 @@ public class EncryptionUtilsTest {
 
     @Test
     public void testLogStringEncryptionResultIsValid() {
-        final JSONObject encryptionDataJson = getEncryptionDataJson(mPublicKey, TEST_LOG_STRING);
+        testEncryption(TEST_LOG_STRING);
+    }
+
+    @Test
+    public void testEmptyStringEncryptionResultIsValid() {
+        testEncryption(TEST_EMPTY_STRING);
+    }
+
+    private void testEncryption(final String testString) {
+        final JSONObject encryptionDataJson = getEncryptionDataJson(mPublicKey, testString);
         assertNotNull(encryptionDataJson);
 
         /*
@@ -93,9 +103,8 @@ public class EncryptionUtilsTest {
             decryptedDataString = decryptedDataString + decryptedLine;
         }
 
-        assertEquals(TEST_LOG_STRING, decryptedDataString);
+        assertEquals(testString, decryptedDataString);
     }
-
     private JSONObject getEncryptionDataJson(final byte[] publicKey, final String data) {
         try {
             final String encryptionDataJsonString = EncryptionUtils.encryptStringData(

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/EncryptionUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/EncryptionUtilsTest.java
@@ -1,0 +1,115 @@
+package org.wordpress.android.util;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.android.volley.AuthFailureError;
+import com.android.volley.Request.Method;
+import com.android.volley.Response;
+import com.android.volley.VolleyError;
+import com.android.volley.toolbox.StringRequest;
+import com.android.volley.toolbox.Volley;
+
+import org.json.JSONException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.HashMap;
+import java.util.Map;
+
+import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class EncryptionUtilsTest {
+    // test data
+    static final String TEST_DELIMITER = "\n";
+    static final String TEST_LOG_STRING = "WordPress - 13.5 - Version code: 789\n"
+            + "Android device name: Google Android SDK built for x86\n\n"
+            + "01 - [Nov-11 03:04 UTILS] WordPress.onCreate\n"
+            + "02 - [Nov-11 03:04 API] Dispatching action: ListAction-REMOVE_EXPIRED_LISTS\n"
+            + "03 - [Nov-11 03:04 API] QuickStartStore onRegister\n"
+            + "04 - [Nov-11 03:04 STATS] 🔵 Tracked: deep_link_not_default_handler, "
+            + "Properties: {\"interceptor_classname\":\"com.google.android.setupwizard.util.WebDialogActivity\"}\n"
+            + "05 - [Nov-11 03:04 UTILS] App comes from background\n"
+            + "06 - [Nov-11 03:04 STATS] 🔵 Tracked: application_opened\n"
+            + "07 - [Nov-11 03:04 READER] notifications update job service > job scheduled\n"
+            + "08 - [Nov-11 03:04 API] Dispatching action: SiteAction-FETCH_SITES\n"
+            + "09 - [Nov-11 03:04 API] StackTrace: com.android.volley.AuthFailureError\n"
+            + "    at com.android.volley.toolbox.BasicNetwork.performRequest(BasicNetwork.java:195)\n"
+            + "    at com.android.volley.NetworkDispatcher.processRequest(NetworkDispatcher.java:131)\n"
+            + "    at com.android.volley.NetworkDispatcher.processRequest(NetworkDispatcher.java:111)\n"
+            + "    at com.android.volley.NetworkDispatcher.run(NetworkDispatcher.java:90)\n";
+
+    // for endpoint test
+    static final String END_POINT_TEST_PUBLIC_KEY = "K0y2oQ++gEN00S4CbCH3IYoBIxVF6H86Wz4wi2t2C3M=";
+    static final String END_POINT_TEST_URL = "https://log-encryption-testing.herokuapp.com";
+
+    @Test
+    public void testEncryptionResultIsValidWithTestEndpointDecryption() {
+        final Context context = ApplicationProvider.getApplicationContext();
+
+        final String encryptionDataJson = getEncryptionDataJson(END_POINT_TEST_PUBLIC_KEY);
+        if (encryptionDataJson == null) {
+            fail("unable to encrypt test data");
+        }
+
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+        StringRequest postRequest = new StringRequest(
+                Method.POST,
+                END_POINT_TEST_URL,
+                new Response.Listener<String>() {
+                    @Override
+                    public void onResponse(String response) {
+                        assertEquals(response, TEST_LOG_STRING + TEST_DELIMITER);
+                        countDownLatch.countDown();
+                    }
+                },
+                new Response.ErrorListener() {
+                    @Override
+                    public void onErrorResponse(VolleyError error) {
+                        fail("PostRequest failed with error: " + error.toString());
+                        countDownLatch.countDown();
+                    }
+                }
+        ) {
+            @Override
+            public Map<String, String> getHeaders() throws AuthFailureError {
+                Map<String, String> headers = new HashMap<String, String>();
+                headers.put("Content-Type", "application/x-www-form-urlencoded");
+                return headers;
+            }
+            @Override
+            public byte[] getBody() throws AuthFailureError {
+                return encryptionDataJson.getBytes();
+            }
+        };
+
+        postRequest.setShouldCache(false);
+        Volley.newRequestQueue(context).add(postRequest);
+
+        try {
+            countDownLatch.await();
+        } catch (InterruptedException e) {
+            fail("CountDownLatch await interrupted for post request: " + e.toString());
+        }
+    }
+
+    private String getEncryptionDataJson(String publicKeyBase64) {
+        try {
+            final String encryptionDataJson = EncryptionUtils.encryptStringData(
+                    publicKeyBase64,
+                    TEST_LOG_STRING,
+                    TEST_DELIMITER);
+
+            return encryptionDataJson;
+        } catch (JSONException e) {
+            fail("encryptStringData failed with JSONException: " + e.toString());
+        }
+        return null;
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/EncryptionUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/EncryptionUtilsTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertEquals;
 @RunWith(AndroidJUnit4.class)
 public class EncryptionUtilsTest {
     // test data
-    static final String TEST_DELIMITER = "\n";
     static final String TEST_LOG_STRING = "WordPress - 13.5 - Version code: 789\n"
             + "Android device name: Google Android SDK built for x86\n\n"
             + "01 - [Nov-11 03:04 UTILS] WordPress.onCreate\n"
@@ -65,7 +64,7 @@ public class EncryptionUtilsTest {
                 new Response.Listener<String>() {
                     @Override
                     public void onResponse(String response) {
-                        assertEquals(response, TEST_LOG_STRING + TEST_DELIMITER);
+                        assertEquals(response, TEST_LOG_STRING);
                         countDownLatch.countDown();
                     }
                 },
@@ -103,8 +102,7 @@ public class EncryptionUtilsTest {
         try {
             final String encryptionDataJson = EncryptionUtils.encryptStringData(
                     publicKeyBase64,
-                    TEST_LOG_STRING,
-                    TEST_DELIMITER);
+                    TEST_LOG_STRING);
 
             return encryptionDataJson;
         } catch (JSONException e) {

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/EncryptionUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/EncryptionUtilsTest.java
@@ -27,6 +27,7 @@ public class EncryptionUtilsTest {
     static final int BASE64_DECODE_FLAGS = Base64.DEFAULT;
 
     // test data
+    static final String TEST_EMPTY_STRING = "";
     static final String TEST_LOG_STRING = "WordPress - 13.5 - Version code: 789\n"
             + "Android device name: Google Android SDK built for x86\n\n"
             + "01 - [Nov-11 03:04 UTILS] WordPress.onCreate\n"
@@ -43,7 +44,12 @@ public class EncryptionUtilsTest {
             + "    at com.android.volley.NetworkDispatcher.processRequest(NetworkDispatcher.java:131)\n"
             + "    at com.android.volley.NetworkDispatcher.processRequest(NetworkDispatcher.java:111)\n"
             + "    at com.android.volley.NetworkDispatcher.run(NetworkDispatcher.java:90)\n";
-    static final String TEST_EMPTY_STRING = "";
+    static final String TEST_CHAR_SAMPLE = "!\"#$%&' ()*+,- ./{|}~[\\]^_`: ;<=>?Ⓟ @︼︽︾⑳₡\n"
+            + "¢£¤¥¦§¨©ª«¬®¯ °±²ɇɈɉɊɋɌɎɏɐɑɒɓɔ ɕɖɗɘəɚ⤚▓⤜⤝⤞⤟ⰙⰚⰛⰜ⭑⬤⭒‰ ꕢ ꕣꕤ ꕥ￥￦ \n"
+            + "❌ ⛱⛲⛳⛰⛴⛵ ⚡⏰⏱⏲⭐ ✋☕⛩⛺⛪✨ ⚽ ⛄⏳\n"
+            + " ḛḜḝḞṶṷṸẂ ẃ ẄẅẆ ᾃᾄᾅ ᾆ Ṥṥ  ȊȋȌ ȍ Ȏȏ ȐṦṧåæçèéêë ì í ΔƟΘ\n"
+            + "㥯㥰㥱㥲㥳㥴㥵 㥶㥷㥸㥹㥺 俋 俌 俍 俎 俏 俐 俑 俒 俓㞢㞣㞤㞥㞦㞧㞨쨜 쨝쨠쨦걵걷 걸걹걺ﾓﾔﾕ ﾖﾗﾘﾙ\n"
+            + " ﵑﵓﵔ ﵕﵗ ﵘ  ﯿ ﰀﰁﰂ ﰃ ﮁﮂﮃﮄﮅᎹᏪ Ⴥჭᡴᠦᡀ\n";
 
     @Before
     public void setup() {
@@ -53,13 +59,18 @@ public class EncryptionUtilsTest {
     }
 
     @Test
+    public void testEmptyStringEncryptionResultIsValid() {
+        testEncryption(TEST_EMPTY_STRING);
+    }
+
+    @Test
     public void testLogStringEncryptionResultIsValid() {
         testEncryption(TEST_LOG_STRING);
     }
 
     @Test
-    public void testEmptyStringEncryptionResultIsValid() {
-        testEncryption(TEST_EMPTY_STRING);
+    public void testCharacterSampleEncryptionResultIsValid() {
+        testEncryption(TEST_CHAR_SAMPLE);
     }
 
     private void testEncryption(final String testString) {

--- a/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
@@ -99,8 +99,9 @@ public class EncryptionUtils {
     private static String getSecretStreamXchacha20poly1305EncryptedBase64String(final byte[] state,
                                                                                 final String data,
                                                                                 final short tag) {
-        final int[] clen = new int[0];
-        final byte[] ad = new byte[0];
+        final int[] encryptedDataLengthOutput = new int[0]; // opting not to get this value
+        final byte[] additionalData = new byte[0]; // opting not to use this value
+        final int additionalDataLength = 0;
 
         final byte[] dataBytes = data.getBytes();
         final byte[] encryptedData = new byte[dataBytes.length + XCHACHA20POLY1305_ABYTES];
@@ -108,11 +109,11 @@ public class EncryptionUtils {
         NaCl.sodium().crypto_secretstream_xchacha20poly1305_push(
                 state,
                 encryptedData,
-                clen,
+                encryptedDataLengthOutput,
                 dataBytes,
                 dataBytes.length,
-                ad,
-                0,
+                additionalData,
+                additionalDataLength,
                 tag);
 
         return Base64.encodeToString(encryptedData, BASE64_ENCODE_FLAGS);

--- a/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
@@ -17,7 +17,8 @@ public class EncryptionUtils {
 
     static final short XCHACHA20POLY1305_TAG_FINAL = 
             (short) NaCl.sodium().crypto_secretstream_xchacha20poly1305_tag_final();
-    static final short XCHACHA20POLY1305_TAG_0 = (short) 0;
+    static final short XCHACHA20POLY1305_TAG_MESSAGE = 
+            (short) NaCl.sodium().crypto_secretstream_xchacha20poly1305_tag_message();
 
     static final String KEYED_WITH = "v1";
 
@@ -31,8 +32,7 @@ public class EncryptionUtils {
         }
     */
     public static String encryptStringData(final String publicKeyBase64,
-                                           final String stringData,
-                                           final String delimiter) throws JSONException {
+                                           final String stringData) throws JSONException {
         JSONObject encryptionDataJson = new JSONObject();
         encryptionDataJson.put("keyedWith", KEYED_WITH);
 
@@ -51,16 +51,18 @@ public class EncryptionUtils {
         final String headerBase64 = initSecretStreamXchacha20poly1305(state, key);
         encryptionDataJson.put("header", headerBase64);
 
-        String[] splitStringData = stringData.split(delimiter);
+        String[] splitStringData = stringData.split("\n"); // break up the data by line
         JSONArray encryptedElementsJson = new JSONArray();
-  
-
-        for (String element : splitStringData) {
-            element = element + delimiter; // Add delimiter back to the end of the line
+        for (int i = 0; i < splitStringData.length; ++i) {
+            String element = splitStringData[i];
+            // Add newline back to the end of each line but the last
+            if (i < splitStringData.length - 1) {
+                element = element + "\n";
+            }
             String encryptedElementBase64 = getSecretStreamXchacha20poly1305EncryptedBase64String(
                     state,
                     element,
-                    XCHACHA20POLY1305_TAG_0);
+                    XCHACHA20POLY1305_TAG_MESSAGE);
             encryptedElementsJson.put(encryptedElementBase64);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
@@ -1,17 +1,11 @@
 package org.wordpress.android.util;
 
-import android.content.Context;
-import android.os.Environment;
 import android.util.Base64;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.libsodium.jni.NaCl;
-
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.io.IOException;
 
 public class EncryptionUtils {
     static final int BOX_SEALBYTES = NaCl.sodium().crypto_box_sealbytes();
@@ -25,7 +19,6 @@ public class EncryptionUtils {
             (short) NaCl.sodium().crypto_secretstream_xchacha20poly1305_tag_final();
     static final short XCHACHA20POLY1305_TAG_0 = (short) 0;
 
-    static final String PUBLIC_KEY_BASE64 = "K0y2oQ++gEN00S4CbCH3IYoBIxVF6H86Wz4wi2t2C3M=";
     static final String KEYED_WITH = "v1";
 
     /*
@@ -37,89 +30,88 @@ public class EncryptionUtils {
             "messages": []                      // the stream elements, base-64 encoded
         }
     */
-    public static String getEncryptedAppLog(Context context) throws JSONException {
-        JSONObject encryptedLogJson = new JSONObject();
-        encryptedLogJson.put("keyedWith", KEYED_WITH);
 
-        // Create log-specific key
+    public static String encryptStringData(final String publicKeyBase64,
+                                           final String stringData,
+                                           final String delimiter) throws JSONException {
+        JSONObject encryptionDataJson = new JSONObject();
+        encryptionDataJson.put("keyedWith", KEYED_WITH);
+
+        // Create data-specific key
         byte[] key = new byte[XCHACHA20POLY1305_KEYBYTES];
         NaCl.sodium().crypto_secretstream_xchacha20poly1305_keygen(key);
 
-        // Encrypt log-specific key
-        byte[] encryptedKey = new byte[XCHACHA20POLY1305_KEYBYTES + BOX_SEALBYTES];
-        byte[] publicKeyBytes = Base64.decode(PUBLIC_KEY_BASE64, Base64.DEFAULT);
-        NaCl.sodium().crypto_box_seal(encryptedKey, key, XCHACHA20POLY1305_KEYBYTES, publicKeyBytes);
+        final String encryptedKeyBase64 = getBoxSealEncryptedBase64String(
+                publicKeyBase64,
+                key,
+                XCHACHA20POLY1305_KEYBYTES);
+        encryptionDataJson.put("encryptedKey", encryptedKeyBase64);
 
-        encryptedLogJson.put("encryptedKey", Base64.encodeToString(encryptedKey, BASE64_ENCODE_FLAGS));
-
-        // Set up a new stream
         byte[] state = new byte[XCHACHA20POLY1305_STATEBYTES];
+
+        final String headerBase64 = initSecretStreamXchacha20poly1305(state, key);
+        encryptionDataJson.put("header", headerBase64);
+
+        String[] splitStringData = stringData.split(delimiter);
+        JSONArray encryptedElementsJson = new JSONArray();
+  
+
+        for (String element : splitStringData) {
+            element = element + delimiter; // Add delimiter back to the end of the line
+            String encryptedElementBase64 = getSecretStreamXchacha20poly1305EncryptedBase64String(
+                    state,
+                    element,
+                    XCHACHA20POLY1305_TAG_0);
+            encryptedElementsJson.put(encryptedElementBase64);
+        }
+
+        final String encryptedDataBase64 = getSecretStreamXchacha20poly1305EncryptedBase64String(
+                state,
+                "",
+                XCHACHA20POLY1305_TAG_FINAL);
+        encryptedElementsJson.put(encryptedDataBase64);
+
+        encryptionDataJson.put("messages", encryptedElementsJson);
+
+        return encryptionDataJson.toString(4);
+    }
+
+    private static String getBoxSealEncryptedBase64String(final String publicKeyBase64,
+                                                          final byte[] data,
+                                                          final int dataSize) {
+        byte[] encryptedData = new byte[dataSize + BOX_SEALBYTES];
+        byte[] publicKeyBytes = Base64.decode(publicKeyBase64, Base64.DEFAULT);
+        NaCl.sodium().crypto_box_seal(encryptedData, data, dataSize, publicKeyBytes);
+        return Base64.encodeToString(encryptedData, BASE64_ENCODE_FLAGS);
+    }
+
+    private static String initSecretStreamXchacha20poly1305(byte[] state, final byte[] key) {
         byte[] header = new byte[XCHACHA20POLY1305_HEADERBYTES];
         NaCl.sodium().crypto_secretstream_xchacha20poly1305_init_push(state, header, key);
 
-        encryptedLogJson.put("header", Base64.encodeToString(header, BASE64_ENCODE_FLAGS));
+        return Base64.encodeToString(header, BASE64_ENCODE_FLAGS);
+    }
 
-        // Encrypt each log line individually and add them to JSON array
-        String logText = AppLog.toPlainText(context);
-        String[] logLines = logText.split("\n");
-        JSONArray encryptedLogLinesJson = new JSONArray();
+    private static String getSecretStreamXchacha20poly1305EncryptedBase64String(byte[] state,
+                                                                                final String data,
+                                                                                final short tag) {
         int[] clen = new int[0];
         byte[] ad = new byte[0];
 
-        for (String logLine : logLines) {
-            logLine = logLine + "\n"; // Add linebreak back
-            byte[] logLineBytes = logLine.getBytes();
-            byte[] encryptedLogLine = new byte[logLineBytes.length + XCHACHA20POLY1305_ABYTES];
-
-            NaCl.sodium().crypto_secretstream_xchacha20poly1305_push(
-                state,
-                encryptedLogLine,
-                clen,
-                logLineBytes,
-                logLineBytes.length,
-                ad,
-                0,
-                XCHACHA20POLY1305_TAG_0);
-
-            encryptedLogLinesJson.put(Base64.encodeToString(encryptedLogLine, BASE64_ENCODE_FLAGS));
-        }
-
-        // Last element in the JSON array is an encrypted and encoded empty string with the FINAL tag
-        String emptyString = new String();
-        byte[] encryptedLogLine = new byte[XCHACHA20POLY1305_ABYTES];
+        byte[] dataBytes = data.getBytes();
+        byte[] encryptedData = new byte[dataBytes.length + XCHACHA20POLY1305_ABYTES];
 
         NaCl.sodium().crypto_secretstream_xchacha20poly1305_push(
-            state,
-            encryptedLogLine,
-            clen,
-            emptyString.getBytes(),
-            0,
-            ad,
-            0,
-            XCHACHA20POLY1305_TAG_FINAL);
+                state,
+                encryptedData,
+                clen,
+                dataBytes,
+                dataBytes.length,
+                ad,
+                0,
+                tag);
 
-        encryptedLogLinesJson.put(Base64.encodeToString(encryptedLogLine, BASE64_ENCODE_FLAGS));
-
-        encryptedLogJson.put("messages", encryptedLogLinesJson);
-
-        // Write output files for testing
-        try {
-            String path = Environment.getExternalStorageDirectory().getAbsolutePath() + "/";
-
-            BufferedWriter logOutput = new BufferedWriter(new FileWriter(path + "app_log.txt"));
-            logOutput.write(logText);
-            logOutput.close();
-
-            BufferedWriter encryptedLogOut = new BufferedWriter(new FileWriter(path + "app_log_encrypted.json"));
-            encryptedLogOut.write(encryptedLogJson.toString(4));
-            encryptedLogOut.close();
-
-            ToastUtils.showToast(context, "EncryptionUtils test code, test files saved to: " + path);
-        } catch (IOException e) {
-            ToastUtils.showToast(context, "EncryptionUtils test code, IOException: " + e.toString());
-        }
-
-        return encryptedLogJson.toString();
+        return Base64.encodeToString(encryptedData, BASE64_ENCODE_FLAGS);
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
@@ -54,16 +54,19 @@ public class EncryptionUtils {
         final String headerBase64 = initSecretStreamXchacha20poly1305(state, key);
         encryptionDataJson.put("header", headerBase64);
 
-        final String[] splitStringData = stringData.split("\n"); // break up the data by line
         JSONArray encryptedElementsJson = new JSONArray();
-        for (int i = 0; i < splitStringData.length; ++i) {
-            String element = splitStringData[i];
-            element = element + "\n";
-            final String encryptedElementBase64 = getSecretStreamXchacha20poly1305EncryptedBase64String(
-                    state,
-                    element,
-                    XCHACHA20POLY1305_TAG_MESSAGE);
-            encryptedElementsJson.put(encryptedElementBase64);
+        if (!stringData.isEmpty()) {
+            final String[] splitStringData = stringData.split("\n"); // break up the data by line
+            
+            for (int i = 0; i < splitStringData.length; ++i) {
+                String element = splitStringData[i];
+                element = element + "\n";
+                final String encryptedElementBase64 = getSecretStreamXchacha20poly1305EncryptedBase64String(
+                        state,
+                        element,
+                        XCHACHA20POLY1305_TAG_MESSAGE);
+                encryptedElementsJson.put(encryptedElementBase64);
+            }
         }
 
         final String encryptedDataBase64 = getSecretStreamXchacha20poly1305EncryptedBase64String(

--- a/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
@@ -8,17 +8,20 @@ import org.json.JSONObject;
 import org.libsodium.jni.NaCl;
 
 public class EncryptionUtils {
-    static final int BOX_SEALBYTES = NaCl.sodium().crypto_box_sealbytes();
-    static final int XCHACHA20POLY1305_KEYBYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_keybytes();
-    static final int XCHACHA20POLY1305_STATEBYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_statebytes();
-    static final int XCHACHA20POLY1305_HEADERBYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_headerbytes();
-    static final int XCHACHA20POLY1305_ABYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_abytes();
-    static final int BASE64_ENCODE_FLAGS = Base64.DEFAULT;
+    public static final int BOX_SEALBYTES = NaCl.sodium().crypto_box_sealbytes();
+    public static final int XCHACHA20POLY1305_ABYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_abytes();
+    public static final int XCHACHA20POLY1305_KEYBYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_keybytes();
+    public static final int XCHACHA20POLY1305_STATEBYTES = 
+            NaCl.sodium().crypto_secretstream_xchacha20poly1305_statebytes();
 
-    static final short XCHACHA20POLY1305_TAG_FINAL = 
+    public static final short XCHACHA20POLY1305_TAG_FINAL = 
             (short) NaCl.sodium().crypto_secretstream_xchacha20poly1305_tag_final();
-    static final short XCHACHA20POLY1305_TAG_MESSAGE = 
+    public static final short XCHACHA20POLY1305_TAG_MESSAGE = 
             (short) NaCl.sodium().crypto_secretstream_xchacha20poly1305_tag_message();
+
+    static final int XCHACHA20POLY1305_HEADERBYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_headerbytes();
+
+    static final int BASE64_ENCODE_FLAGS = Base64.DEFAULT;
 
     static final String KEYED_WITH = "v1";
 
@@ -37,7 +40,7 @@ public class EncryptionUtils {
         encryptionDataJson.put("keyedWith", KEYED_WITH);
 
         // Create data-specific key
-        byte[] key = new byte[XCHACHA20POLY1305_KEYBYTES];
+        final byte[] key = new byte[XCHACHA20POLY1305_KEYBYTES];
         NaCl.sodium().crypto_secretstream_xchacha20poly1305_keygen(key);
 
         final String encryptedKeyBase64 = getBoxSealEncryptedBase64String(
@@ -46,20 +49,17 @@ public class EncryptionUtils {
                 XCHACHA20POLY1305_KEYBYTES);
         encryptionDataJson.put("encryptedKey", encryptedKeyBase64);
 
-        byte[] state = new byte[XCHACHA20POLY1305_STATEBYTES];
+        final byte[] state = new byte[XCHACHA20POLY1305_STATEBYTES];
 
         final String headerBase64 = initSecretStreamXchacha20poly1305(state, key);
         encryptionDataJson.put("header", headerBase64);
 
-        String[] splitStringData = stringData.split("\n"); // break up the data by line
+        final String[] splitStringData = stringData.split("\n"); // break up the data by line
         JSONArray encryptedElementsJson = new JSONArray();
         for (int i = 0; i < splitStringData.length; ++i) {
             String element = splitStringData[i];
-            // Add newline back to the end of each line but the last
-            if (i < splitStringData.length - 1) {
-                element = element + "\n";
-            }
-            String encryptedElementBase64 = getSecretStreamXchacha20poly1305EncryptedBase64String(
+            element = element + "\n";
+            final String encryptedElementBase64 = getSecretStreamXchacha20poly1305EncryptedBase64String(
                     state,
                     element,
                     XCHACHA20POLY1305_TAG_MESSAGE);
@@ -80,27 +80,27 @@ public class EncryptionUtils {
     private static String getBoxSealEncryptedBase64String(final String publicKeyBase64,
                                                           final byte[] data,
                                                           final int dataSize) {
-        byte[] encryptedData = new byte[dataSize + BOX_SEALBYTES];
-        byte[] publicKeyBytes = Base64.decode(publicKeyBase64, Base64.DEFAULT);
+        final byte[] encryptedData = new byte[dataSize + BOX_SEALBYTES];
+        final byte[] publicKeyBytes = Base64.decode(publicKeyBase64, Base64.DEFAULT);
         NaCl.sodium().crypto_box_seal(encryptedData, data, dataSize, publicKeyBytes);
         return Base64.encodeToString(encryptedData, BASE64_ENCODE_FLAGS);
     }
 
     private static String initSecretStreamXchacha20poly1305(byte[] state, final byte[] key) {
-        byte[] header = new byte[XCHACHA20POLY1305_HEADERBYTES];
+        final byte[] header = new byte[XCHACHA20POLY1305_HEADERBYTES];
         NaCl.sodium().crypto_secretstream_xchacha20poly1305_init_push(state, header, key);
 
         return Base64.encodeToString(header, BASE64_ENCODE_FLAGS);
     }
 
-    private static String getSecretStreamXchacha20poly1305EncryptedBase64String(byte[] state,
+    private static String getSecretStreamXchacha20poly1305EncryptedBase64String(final byte[] state,
                                                                                 final String data,
                                                                                 final short tag) {
-        int[] clen = new int[0];
-        byte[] ad = new byte[0];
+        final int[] clen = new int[0];
+        final byte[] ad = new byte[0];
 
-        byte[] dataBytes = data.getBytes();
-        byte[] encryptedData = new byte[dataBytes.length + XCHACHA20POLY1305_ABYTES];
+        final byte[] dataBytes = data.getBytes();
+        final byte[] encryptedData = new byte[dataBytes.length + XCHACHA20POLY1305_ABYTES];
 
         NaCl.sodium().crypto_secretstream_xchacha20poly1305_push(
                 state,

--- a/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
@@ -30,7 +30,6 @@ public class EncryptionUtils {
             "messages": []                      // the stream elements, base-64 encoded
         }
     */
-
     public static String encryptStringData(final String publicKeyBase64,
                                            final String stringData,
                                            final String delimiter) throws JSONException {
@@ -73,7 +72,7 @@ public class EncryptionUtils {
 
         encryptionDataJson.put("messages", encryptedElementsJson);
 
-        return encryptionDataJson.toString(4);
+        return encryptionDataJson.toString();
     }
 
     private static String getBoxSealEncryptedBase64String(final String publicKeyBase64,

--- a/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
@@ -1,0 +1,131 @@
+package org.wordpress.android.util;
+
+import android.content.Context;
+import android.os.Environment;
+import android.util.Base64;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.libsodium.jni.NaCl;
+import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.AppLog;
+
+public class EncryptionUtils {
+
+    static final int BOX_SEALBYTES = NaCl.sodium().crypto_box_sealbytes();
+    static final int XCHACHA20POLY1305_KEYBYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_keybytes();
+    static final int XCHACHA20POLY1305_STATEBYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_statebytes();
+    static final int XCHACHA20POLY1305_HEADERBYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_headerbytes();
+    static final int XCHACHA20POLY1305_ABYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_abytes();
+
+    static final String PUBLIC_KEY = "K0y2oQ++gEN00S4CbCH3IYoBIxVF6H86Wz4wi2t2C3M=";
+    static final String KEYED_WITH = "v1";
+
+    /**
+     * returns a JSON String with the following:
+     * {
+     * "keyedWith": "v1",
+     * "encryptedKey": "$key_as_base_64",  // The encrypted AES key
+     * "header": "base_64_encoded_header", // The xchacha20poly1305 stream header
+     * "messages": []                      // the stream elements, base-64 encoded
+     *}
+     */
+    public static String getEncryptedAppLog(Context context) throws JSONException {
+
+        JSONObject encryptedLogJson = new JSONObject();
+        encryptedLogJson.put("keyedWith", KEYED_WITH);
+
+        // Shared secret key required to encrypt the stream
+        byte[] key = new byte[XCHACHA20POLY1305_KEYBYTES];
+        NaCl.sodium().crypto_secretstream_xchacha20poly1305_keygen(key);
+
+        // Encrypt, encode and add key to JSON object
+
+        byte[] encryptedKey = new byte[XCHACHA20POLY1305_KEYBYTES + BOX_SEALBYTES];
+        NaCl.sodium().crypto_box_seal(encryptedKey, key, XCHACHA20POLY1305_KEYBYTES, PUBLIC_KEY.getBytes());
+        encryptedLogJson.put("encryptedKey", Base64.encodeToString(encryptedKey, Base64.DEFAULT));
+
+        // Set up a new stream: initialize the state and create the header
+        byte[] state = new byte[XCHACHA20POLY1305_STATEBYTES];
+        byte[] header = new byte[XCHACHA20POLY1305_HEADERBYTES];
+        NaCl.sodium().crypto_secretstream_xchacha20poly1305_init_push(state, header, key);
+
+        encryptedLogJson.put("header", Base64.encodeToString(header, Base64.DEFAULT));
+
+        // encrypt the logs and add to JSON array
+        String logText = AppLog.toPlainText(context);
+        String[] logLines = logText.split("\n");
+        JSONArray encryptedLogLinesJson = new JSONArray();
+        for (String logLine : logLines) {
+
+            byte[] encryptedLogLine = new byte[logLine.length() + XCHACHA20POLY1305_ABYTES];
+            byte[] ad = new byte[1];
+            int[] clen = new int[1];
+
+            NaCl.sodium().crypto_secretstream_xchacha20poly1305_push(
+                state,
+                encryptedLogLine,
+                clen,
+                logLine.getBytes(),
+                logLine.length(),
+                ad,
+                0,
+                (short) 0);
+
+            encryptedLogLinesJson.put(Base64.encodeToString(encryptedLogLine, Base64.DEFAULT));
+        }
+
+        // last element in the JSON array is an encrypted and encoded empty string with FINAL tag
+        String emptyString = new String();
+        byte[] encryptedLogLine = new byte[XCHACHA20POLY1305_ABYTES];
+        byte[] ad = new byte[1];
+        int[] clen = new int[1];
+
+        NaCl.sodium().crypto_secretstream_xchacha20poly1305_push(
+            state,
+            encryptedLogLine,
+            clen,
+            emptyString.getBytes(),
+            0,
+            ad,
+            0,
+            (short) NaCl.sodium().crypto_secretstream_xchacha20poly1305_tag_final());
+
+        encryptedLogLinesJson.put(Base64.encodeToString(encryptedLogLine, Base64.DEFAULT));
+
+        encryptedLogJson.put("messages", encryptedLogLinesJson);
+
+        //******* test code begin
+        // write test output files
+        try {
+            String path = Environment.getExternalStorageDirectory().getAbsolutePath() + "/";
+
+            {
+                BufferedWriter out = new BufferedWriter(new FileWriter(path + "app_log.txt"));
+                out.write(logText);
+                out.close();
+            }
+
+            // write encrypted text output file
+            {
+                BufferedWriter out = new BufferedWriter(new FileWriter(path + "app_log_encrypted.json"));
+                out.write(encryptedLogJson.toString(4));
+                out.close();
+            }
+
+            ToastUtils.showToast(context, "EncryptionUtils test code, test files saved to: " + path);
+        } catch (IOException e) {
+            ToastUtils.showToast(context, "EncryptionUtils test code, IOException: " + e.toString());
+        } 
+        //******* test code end
+
+        return encryptedLogJson.toString();
+    }
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
@@ -4,21 +4,17 @@ import android.content.Context;
 import android.os.Environment;
 import android.util.Base64;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.libsodium.jni.NaCl;
-import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.AppLog;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 
 public class EncryptionUtils {
-
     static final int BOX_SEALBYTES = NaCl.sodium().crypto_box_sealbytes();
     static final int XCHACHA20POLY1305_KEYBYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_keybytes();
     static final int XCHACHA20POLY1305_STATEBYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_statebytes();
@@ -39,7 +35,6 @@ public class EncryptionUtils {
      *}
      */
     public static String getEncryptedAppLog(Context context) throws JSONException, UnsupportedEncodingException {
-
         JSONObject encryptedLogJson = new JSONObject();
         encryptedLogJson.put("keyedWith", KEYED_WITH);
 
@@ -69,7 +64,7 @@ public class EncryptionUtils {
         byte[] ad = new byte[0];
 
         for (String logLine : logLines) {
-            // add the line break back
+            // add the line break back to the log line
             logLine = logLine + "\n";
             byte[] encryptedLogLine = new byte[logLine.length() + XCHACHA20POLY1305_ABYTES];
 
@@ -104,29 +99,25 @@ public class EncryptionUtils {
 
         encryptedLogJson.put("messages", encryptedLogLinesJson);
 
-        //******* test code begin
+        // ******* test code begin
         // write test output files
         try {
             String path = Environment.getExternalStorageDirectory().getAbsolutePath() + "/";
 
-            {
-                BufferedWriter out = new BufferedWriter(new FileWriter(path + "app_log.txt"));
-                out.write(logText);
-                out.close();
-            }
+            BufferedWriter logOutput = new BufferedWriter(new FileWriter(path + "app_log.txt"));
+            logOutput.write(logText);
+            logOutput.close();
 
             // write encrypted text output file
-            {
-                BufferedWriter out = new BufferedWriter(new FileWriter(path + "app_log_encrypted.json"));
-                out.write(encryptedLogJson.toString(4));
-                out.close();
-            }
+            BufferedWriter encryptedLogOut = new BufferedWriter(new FileWriter(path + "app_log_encrypted.json"));
+            encryptedLogOut.write(encryptedLogJson.toString(4));
+            encryptedLogOut.close();
 
             ToastUtils.showToast(context, "EncryptionUtils test code, test files saved to: " + path);
         } catch (IOException e) {
             ToastUtils.showToast(context, "EncryptionUtils test code, IOException: " + e.toString());
         }
-        //******* test code end
+        // ******* test code end
 
         return encryptedLogJson.toString();
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
@@ -12,7 +12,6 @@ import org.libsodium.jni.NaCl;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 
 public class EncryptionUtils {
     static final int BOX_SEALBYTES = NaCl.sodium().crypto_box_sealbytes();
@@ -34,7 +33,7 @@ public class EncryptionUtils {
      * "messages": []                      // the stream elements, base-64 encoded
      *}
      */
-    public static String getEncryptedAppLog(Context context) throws JSONException, UnsupportedEncodingException {
+    public static String getEncryptedAppLog(Context context) throws JSONException {
         JSONObject encryptedLogJson = new JSONObject();
         encryptedLogJson.put("keyedWith", KEYED_WITH);
 
@@ -66,14 +65,15 @@ public class EncryptionUtils {
         for (String logLine : logLines) {
             // add the line break back to the log line
             logLine = logLine + "\n";
-            byte[] encryptedLogLine = new byte[logLine.length() + XCHACHA20POLY1305_ABYTES];
+            byte[] logLineBytes = logLine.getBytes();
+            byte[] encryptedLogLine = new byte[logLineBytes.length + XCHACHA20POLY1305_ABYTES];
 
             NaCl.sodium().crypto_secretstream_xchacha20poly1305_push(
                 state,
                 encryptedLogLine,
                 clen,
-                logLine.getBytes(),
-                logLine.length(),
+                logLineBytes,
+                logLineBytes.length,
                 ad,
                 0,
                 (short) 0);

--- a/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
@@ -21,6 +21,10 @@ public class EncryptionUtils {
     static final int XCHACHA20POLY1305_ABYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_abytes();
     static final int BASE64_ENCODE_FLAGS = Base64.DEFAULT;
 
+    static final short XCHACHA20POLY1305_TAG_FINAL = 
+            (short) NaCl.sodium().crypto_secretstream_xchacha20poly1305_tag_final();
+    static final short XCHACHA20POLY1305_TAG_0 = (short) 0;
+
     static final String PUBLIC_KEY_BASE64 = "K0y2oQ++gEN00S4CbCH3IYoBIxVF6H86Wz4wi2t2C3M=";
     static final String KEYED_WITH = "v1";
 
@@ -75,7 +79,7 @@ public class EncryptionUtils {
                 logLineBytes.length,
                 ad,
                 0,
-                (short) 0);
+                XCHACHA20POLY1305_TAG_0);
 
             encryptedLogLinesJson.put(Base64.encodeToString(encryptedLogLine, BASE64_ENCODE_FLAGS));
         }
@@ -92,7 +96,7 @@ public class EncryptionUtils {
             0,
             ad,
             0,
-            (short) NaCl.sodium().crypto_secretstream_xchacha20poly1305_tag_final());
+            XCHACHA20POLY1305_TAG_FINAL);
 
         encryptedLogLinesJson.put(Base64.encodeToString(encryptedLogLine, BASE64_ENCODE_FLAGS));
 

--- a/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
@@ -24,8 +24,9 @@ public class EncryptionUtils {
     static final int XCHACHA20POLY1305_STATEBYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_statebytes();
     static final int XCHACHA20POLY1305_HEADERBYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_headerbytes();
     static final int XCHACHA20POLY1305_ABYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_abytes();
+    static final int BASE64_FLAGS = Base64.DEFAULT;
 
-    static final String PUBLIC_KEY = "K0y2oQ++gEN00S4CbCH3IYoBIxVF6H86Wz4wi2t2C3M=";
+    static final String PUBLIC_KEY_BASE64 = "K0y2oQ++gEN00S4CbCH3IYoBIxVF6H86Wz4wi2t2C3M=";
     static final String KEYED_WITH = "v1";
     static final String ENCODING = "UTF-8";
 
@@ -50,15 +51,16 @@ public class EncryptionUtils {
         // Encrypt, encode and add key to JSON object
 
         byte[] encryptedKey = new byte[XCHACHA20POLY1305_KEYBYTES + BOX_SEALBYTES];
-        NaCl.sodium().crypto_box_seal(encryptedKey, key, XCHACHA20POLY1305_KEYBYTES, PUBLIC_KEY.getBytes(ENCODING));
-        encryptedLogJson.put("encryptedKey", Base64.encodeToString(encryptedKey, Base64.NO_WRAP));
+        byte[] publicKeyBytes = Base64.decode(PUBLIC_KEY_BASE64, BASE64_FLAGS);
+        NaCl.sodium().crypto_box_seal(encryptedKey, key, XCHACHA20POLY1305_KEYBYTES, publicKeyBytes);
+        encryptedLogJson.put("encryptedKey", Base64.encodeToString(encryptedKey, BASE64_FLAGS));
 
         // Set up a new stream: initialize the state and create the header
         byte[] state = new byte[XCHACHA20POLY1305_STATEBYTES];
         byte[] header = new byte[XCHACHA20POLY1305_HEADERBYTES];
         NaCl.sodium().crypto_secretstream_xchacha20poly1305_init_push(state, header, key);
 
-        encryptedLogJson.put("header", Base64.encodeToString(header, Base64.NO_WRAP));
+        encryptedLogJson.put("header", Base64.encodeToString(header, BASE64_FLAGS));
 
         // encrypt the logs and add to JSON array
         String logText = AppLog.toPlainText(context);
@@ -80,7 +82,7 @@ public class EncryptionUtils {
                 0,
                 (short) 0);
 
-            encryptedLogLinesJson.put(Base64.encodeToString(encryptedLogLine, Base64.NO_WRAP));
+            encryptedLogLinesJson.put(Base64.encodeToString(encryptedLogLine, BASE64_FLAGS));
         }
 
         // last element in the JSON array is an encrypted and encoded empty string with FINAL tag
@@ -99,7 +101,7 @@ public class EncryptionUtils {
             0,
             (short) NaCl.sodium().crypto_secretstream_xchacha20poly1305_tag_final());
 
-        encryptedLogLinesJson.put(Base64.encodeToString(encryptedLogLine, Base64.NO_WRAP));
+        encryptedLogLinesJson.put(Base64.encodeToString(encryptedLogLine, BASE64_FLAGS));
 
         encryptedLogJson.put("messages", encryptedLogLinesJson);
 

--- a/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/EncryptionUtils.java
@@ -63,7 +63,6 @@ public class EncryptionUtils {
         byte[] ad = new byte[0];
 
         for (String logLine : logLines) {
-
             logLine = logLine + "\n"; // Add linebreak back
             byte[] logLineBytes = logLine.getBytes();
             byte[] encryptedLogLine = new byte[logLineBytes.length + XCHACHA20POLY1305_ABYTES];


### PR DESCRIPTION
This PR makes progress towards a solution for issue #10698.

### Description
I added an EncryptionUtils static class which currently has one function:
`public static String getEncryptedAppLog(Context context)`

This function returns a String containing JSON in this format:
```
        {
            "keyedWith": "v1",
            "encryptedKey": "$key_as_base_64",  // The encrypted AES key
            "header": "base_64_encoded_header", // The xchacha20poly1305 stream header
            "messages": []                      // the stream elements, base-64 encoded
        }
```

The `messages` value is a JSON array containing encrypted elements that represent lines in the logs from AppLog.  The last element in the JSON array is an empty string with the `FINAL` tag.

Calling this function will also write out two test output files in the Android device storage:
- `app_log.txt `: the original log text from AppLog
- `app_log_encrypted.json`: JSON with encrypted log data

### Testing Instructions

**Steps:**
1. Call this function from the App after AppLog has accumulated some logs.  (For my tests, the function call was added to the  `void copyAppLogToClipboard()` function in `AppLogViewerActivity.java`.  This way I can view the logs in the app before I generate the test files.)
2. Build the Android app, run the app in the emulator, and trigger the function call to generate the test files.
3. Run the command `adb pull /sdcard/<test file name> <target path>` to copy the files to your hard drive
4. Run the command `curl --data "@<file name>.json" https://log-encryption-testing.herokuapp.com`
5. Compare the output from the test endpoint with the contents of `app_log.txt`

**Expected Results:**
The contents from the test endpoint should be the same as the contents of `app_log.txt`.  (Currently, there is an extra new line at the end of the output from the test endpoint.)

### Next Steps
- Use this function to create encrypted log data associated with Sentry events
    - Need to associate an UUID with the log data and send the UUID with the Sentry Event
    - Where should we store the log data and how will the team access it?
- Use this function to create encrypted log data used for Zendesk ticket creation
    - How will the team decrypt the data once they retrieve it from Zendesk?

### Additional Notes

- I chose the [libsodium-JNI](https://github.com/joshjdevl/libsodium-jni) Java (Android) binding because it had the simplest steps for integration out of all of the bindings for Java (Android) that had the features that we needed.