### PR TITLE
Accessibility : Reader Improvements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui
 
 import android.content.Context
+import android.text.TextUtils
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
@@ -36,7 +37,11 @@ class ActionableEmptyView : LinearLayout {
         initView(context, attrs)
     }
 
-    constructor(context: Context, attrs: AttributeSet, defStyle: Int) : super(context, attrs, defStyle) {
+    constructor(context: Context, attrs: AttributeSet, defStyle: Int) : super(
+            context,
+            attrs,
+            defStyle
+    ) {
         initView(context, attrs)
     }
 
@@ -55,9 +60,17 @@ class ActionableEmptyView : LinearLayout {
         bottomImage = layout.findViewById(R.id.bottom_image)
 
         attrs.let {
-            val typedArray = context.obtainStyledAttributes(it, R.styleable.ActionableEmptyView, 0, 0)
+            val typedArray = context.obtainStyledAttributes(
+                    it,
+                    R.styleable.ActionableEmptyView,
+                    0,
+                    0
+            )
 
-            val imageResource = typedArray.getResourceId(R.styleable.ActionableEmptyView_aevImage, 0)
+            val imageResource = typedArray.getResourceId(
+                    R.styleable.ActionableEmptyView_aevImage,
+                    0
+            )
             val titleAttribute = typedArray.getString(R.styleable.ActionableEmptyView_aevTitle)
             val subtitleAttribute = typedArray.getString(R.styleable.ActionableEmptyView_aevSubtitle)
             val buttonAttribute = typedArray.getString(R.styleable.ActionableEmptyView_aevButton)
@@ -99,17 +112,38 @@ class ActionableEmptyView : LinearLayout {
         val params: RelativeLayout.LayoutParams
 
         if (isSearching) {
-            params = RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
-            layout.setPadding(0, context.resources.getDimensionPixelSize(R.dimen.margin_extra_extra_large), 0, 0)
+            params = RelativeLayout.LayoutParams(
+                    LayoutParams.MATCH_PARENT,
+                    LayoutParams.WRAP_CONTENT
+            )
+            layout.setPadding(
+                    0,
+                    context.resources.getDimensionPixelSize(R.dimen.margin_extra_extra_large),
+                    0,
+                    0
+            )
 
             image.visibility = View.GONE
             button.visibility = View.GONE
         } else {
-            params = RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+            params = RelativeLayout.LayoutParams(
+                    LayoutParams.MATCH_PARENT,
+                    LayoutParams.MATCH_PARENT
+            )
             layout.setPadding(0, 0, 0, 0)
         }
 
         params.topMargin = topMargin
         layout.layoutParams = params
+    }
+
+    fun announceEmptyStateForAccessibility() {
+        val subTitle = if (!TextUtils.isEmpty(subtitle.contentDescription)) {
+            subtitle.contentDescription
+        } else {
+            subtitle.text
+        }
+
+        announceForAccessibility(String.format("%s... %s", title.text, subTitle))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
@@ -144,6 +144,6 @@ class ActionableEmptyView : LinearLayout {
             subtitle.text
         }
 
-        announceForAccessibility(String.format("%s... %s", title.text, subTitle))
+        announceForAccessibility("${title.text}.$subTitle")
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1375,10 +1375,14 @@ public class ReaderPostListFragment extends Fragment
     private void showEmptyView() {
         if (isAdded()) {
             mActionableEmptyView.setVisibility(View.VISIBLE);
-            mActionableEmptyView.announceForAccessibility(
-                    String.format("%s... %s", mActionableEmptyView.title.getText(),
-                            mActionableEmptyView.subtitle.getText()));
+            announceEmptyStateForAccessibility();
         }
+    }
+
+    private void announceEmptyStateForAccessibility() {
+        mActionableEmptyView.announceForAccessibility(
+                String.format("%s... %s", mActionableEmptyView.title.getText(),
+                        mActionableEmptyView.subtitle.getText()));
     }
 
     private void hideEmptyView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1432,6 +1432,7 @@ public class ReaderPostListFragment extends Fragment
                 }
             } else {
                 hideEmptyView();
+                announceListStateForAccessibility();
                 if (mRestorePosition > 0) {
                     AppLog.d(T.READER, "reader post list > restoring position");
                     mRecyclerView.scrollRecycleViewToPosition(mRestorePosition);
@@ -1473,6 +1474,13 @@ public class ReaderPostListFragment extends Fragment
                     }
                 }
             };
+
+    private void announceListStateForAccessibility() {
+        if (getView() != null) {
+            getView().announceForAccessibility(getString(R.string.reader_acessibility_list_loaded,
+                    getPostAdapter().getItemCount()));
+        }
+    }
 
     private void showBookmarksSavedLocallyDialog() {
         mBookmarksSavedLocallyDialog = new AlertDialog.Builder(getActivity())
@@ -2309,7 +2317,6 @@ public class ReaderPostListFragment extends Fragment
     public static void resetLastUpdateDate() {
         mLastAutoUpdateDt = null;
     }
-
     private class LoadTagsTask extends AsyncTask<Void, Void, ReaderTagList> {
         private final FilteredRecyclerView.FilterCriteriaAsyncLoaderListener mFilterCriteriaLoaderListener;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1377,17 +1377,8 @@ public class ReaderPostListFragment extends Fragment
     private void showEmptyView() {
         if (isAdded()) {
             mActionableEmptyView.setVisibility(View.VISIBLE);
-            announceEmptyStateForAccessibility();
+            mActionableEmptyView.announceEmptyStateForAccessibility();
         }
-    }
-
-    private void announceEmptyStateForAccessibility() {
-        CharSequence title = mActionableEmptyView.title.getText();
-
-        CharSequence subTitle = !TextUtils.isEmpty(mActionableEmptyView.subtitle.getContentDescription())
-                ? mActionableEmptyView.subtitle.getContentDescription() : mActionableEmptyView.subtitle.getText();
-
-        mActionableEmptyView.announceForAccessibility(String.format("%s... %s", title, subTitle));
     }
 
     private void hideEmptyView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1375,6 +1375,9 @@ public class ReaderPostListFragment extends Fragment
     private void showEmptyView() {
         if (isAdded()) {
             mActionableEmptyView.setVisibility(View.VISIBLE);
+            mActionableEmptyView.announceForAccessibility(
+                    String.format("%s... %s", mActionableEmptyView.title.getText(),
+                            mActionableEmptyView.subtitle.getText()));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1312,6 +1312,8 @@ public class ReaderPostListFragment extends Fragment
         mActionableEmptyView.image.setVisibility(View.VISIBLE);
         mActionableEmptyView.title.setText(R.string.reader_empty_saved_posts_title);
         mActionableEmptyView.subtitle.setText(ssb);
+        mActionableEmptyView.subtitle
+                .setContentDescription(getString(R.string.reader_empty_saved_posts_content_description));
         mActionableEmptyView.subtitle.setVisibility(View.VISIBLE);
         mActionableEmptyView.button.setText(R.string.reader_empty_followed_blogs_button_followed);
         mActionableEmptyView.button.setVisibility(View.VISIBLE);
@@ -1380,9 +1382,12 @@ public class ReaderPostListFragment extends Fragment
     }
 
     private void announceEmptyStateForAccessibility() {
-        mActionableEmptyView.announceForAccessibility(
-                String.format("%s... %s", mActionableEmptyView.title.getText(),
-                        mActionableEmptyView.subtitle.getText()));
+        CharSequence title = mActionableEmptyView.title.getText();
+
+        CharSequence subTitle = !TextUtils.isEmpty(mActionableEmptyView.subtitle.getContentDescription())
+                ? mActionableEmptyView.subtitle.getContentDescription() : mActionableEmptyView.subtitle.getText();
+
+        mActionableEmptyView.announceForAccessibility(String.format("%s... %s", title, subTitle));
     }
 
     private void hideEmptyView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -77,8 +77,6 @@ public class ReaderSubsActivity extends AppCompatActivity
 
     private static final int NUM_TABS = 3;
 
-    private static final int ADD_BUTTON_EXTRA_DPS = 24;
-
     private static final int TAB_IDX_FOLLOWED_TAGS = 0;
     private static final int TAB_IDX_FOLLOWED_BLOGS = 1;
     private static final int TAB_IDX_RECOMMENDED_BLOGS = 2;
@@ -145,7 +143,7 @@ public class ReaderSubsActivity extends AppCompatActivity
             }
         });
 
-        ViewUtilsKt.expandTouchTargetArea(mBtnAdd, ADD_BUTTON_EXTRA_DPS, false);
+        ViewUtilsKt.expandTouchTargetArea(mBtnAdd, R.dimen.reader_add_button_extra_padding, false);
 
         if (savedInstanceState == null) {
             // return to the page the user was on the last time they viewed this activity

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -52,6 +52,7 @@ import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
+import org.wordpress.android.util.ViewUtilsKt;
 import org.wordpress.android.widgets.WPViewPager;
 
 import java.util.ArrayList;
@@ -75,6 +76,8 @@ public class ReaderSubsActivity extends AppCompatActivity
     private static final String KEY_LAST_ADDED_TAG_NAME = "last_added_tag_name";
 
     private static final int NUM_TABS = 3;
+
+    private static final int ADD_BUTTON_EXTRA_DPS = 24;
 
     private static final int TAB_IDX_FOLLOWED_TAGS = 0;
     private static final int TAB_IDX_FOLLOWED_BLOGS = 1;
@@ -141,6 +144,8 @@ public class ReaderSubsActivity extends AppCompatActivity
                 addCurrentEntry();
             }
         });
+
+        ViewUtilsKt.expandTouchTargetArea(mBtnAdd, ADD_BUTTON_EXTRA_DPS, false);
 
         if (savedInstanceState == null) {
             // return to the page the user was on the last time they viewed this activity

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -52,7 +52,6 @@ import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
-import org.wordpress.android.util.ViewUtilsKt;
 import org.wordpress.android.widgets.WPViewPager;
 
 import java.util.ArrayList;
@@ -142,8 +141,6 @@ public class ReaderSubsActivity extends AppCompatActivity
                 addCurrentEntry();
             }
         });
-
-        ViewUtilsKt.expandTouchTargetArea(mBtnAdd, R.dimen.reader_add_button_extra_padding, false);
 
         if (savedInstanceState == null) {
             // return to the page the user was on the last time they viewed this activity

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -123,10 +123,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     private static final int NEWS_CARD_POSITION = 0;
 
-    private static final int LAYOUT_DISCOVER_EXTRA_DPS = 16;
-    private static final int LAYOUT_VISIT_EXTRA_DPS = 12;
-    private static final int IMAGE_MORE_EXTRA_DPS = 12;
-
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
 
@@ -242,9 +238,9 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             ViewGroup postHeaderView = itemView.findViewById(R.id.layout_post_header);
             mFollowButton = postHeaderView.findViewById(R.id.follow_button);
 
-            ViewUtilsKt.expandTouchTargetArea(mLayoutDiscover, LAYOUT_DISCOVER_EXTRA_DPS, true);
-            ViewUtilsKt.expandTouchTargetArea(mVisit, LAYOUT_VISIT_EXTRA_DPS, false);
-            ViewUtilsKt.expandTouchTargetArea(mImgMore, IMAGE_MORE_EXTRA_DPS, false);
+            ViewUtilsKt.expandTouchTargetArea(mLayoutDiscover, R.dimen.reader_discover_layout_extra_padding, true);
+            ViewUtilsKt.expandTouchTargetArea(mVisit, R.dimen.reader_visit_layout_extra_padding, false);
+            ViewUtilsKt.expandTouchTargetArea(mImgMore, R.dimen.reader_more_image_extra_padding, false);
 
             // show post in internal browser when "visit" is clicked
             View.OnClickListener visitListener = new View.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -125,6 +125,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     private static final int LAYOUT_DISCOVER_EXTRA_DPS = 16;
     private static final int LAYOUT_VISIT_EXTRA_DPS = 12;
+    private static final int IMAGE_MORE_EXTRA_DPS = 12;
 
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
@@ -243,6 +244,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
             ViewUtilsKt.expandTouchTargetArea(mLayoutDiscover, LAYOUT_DISCOVER_EXTRA_DPS, true);
             ViewUtilsKt.expandTouchTargetArea(mVisit, LAYOUT_VISIT_EXTRA_DPS, false);
+            ViewUtilsKt.expandTouchTargetArea(mImgMore, IMAGE_MORE_EXTRA_DPS, false);
 
             // show post in internal browser when "visit" is clicked
             View.OnClickListener visitListener = new View.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -66,6 +66,7 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.ViewUtilsKt;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
@@ -121,6 +122,9 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private static final long ITEM_ID_NEWS_CARD = -3L;
 
     private static final int NEWS_CARD_POSITION = 0;
+
+    private static final int LAYOUT_DISCOVER_EXTRA_DPS = 16;
+    private static final int LAYOUT_VISIT_EXTRA_DPS = 12;
 
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
@@ -236,6 +240,9 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
             ViewGroup postHeaderView = itemView.findViewById(R.id.layout_post_header);
             mFollowButton = postHeaderView.findViewById(R.id.follow_button);
+
+            ViewUtilsKt.expandTouchTargetArea(mLayoutDiscover, LAYOUT_DISCOVER_EXTRA_DPS, true);
+            ViewUtilsKt.expandTouchTargetArea(mVisit, LAYOUT_VISIT_EXTRA_DPS, false);
 
             // show post in internal browser when "visit" is clicked
             View.OnClickListener visitListener = new View.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
@@ -37,8 +37,6 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
     private TagDeletedListener mTagDeletedListener;
     private ReaderInterfaces.DataLoadedListener mDataLoadedListener;
 
-    private static final int REMOVE_BUTTON_EXTRA_DPS = 12;
-
     public ReaderTagAdapter(Context context) {
         super();
         setHasStableIds(true);
@@ -139,7 +137,7 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
             mTxtTagName = (TextView) view.findViewById(R.id.text_topic);
             mBtnRemove = (ImageButton) view.findViewById(R.id.btn_remove);
             ReaderUtils.setBackgroundToRoundRipple(mBtnRemove);
-            ViewUtilsKt.expandTouchTargetArea(mBtnRemove, REMOVE_BUTTON_EXTRA_DPS, false);
+            ViewUtilsKt.expandTouchTargetArea(mBtnRemove, R.dimen.reader_remove_button_extra_padding, false);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
@@ -23,6 +23,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.ViewUtilsKt;
 
 import java.lang.ref.WeakReference;
 
@@ -35,6 +36,8 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
     private final ReaderTagList mTags = new ReaderTagList();
     private TagDeletedListener mTagDeletedListener;
     private ReaderInterfaces.DataLoadedListener mDataLoadedListener;
+
+    private static final int REMOVE_BUTTON_EXTRA_DPS = 12;
 
     public ReaderTagAdapter(Context context) {
         super();
@@ -136,6 +139,7 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
             mTxtTagName = (TextView) view.findViewById(R.id.text_topic);
             mBtnRemove = (ImageButton) view.findViewById(R.id.btn_remove);
             ReaderUtils.setBackgroundToRoundRipple(mBtnRemove);
+            ViewUtilsKt.expandTouchTargetArea(mBtnRemove, REMOVE_BUTTON_EXTRA_DPS, false);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -46,8 +46,6 @@ public class ReaderSiteHeaderView extends LinearLayout {
     private OnBlogInfoLoadedListener mBlogInfoListener;
     private OnFollowListener mFollowListener;
 
-    private static final int FOLLOW_BUTTON_EXTRA_DPS = 32;
-
     @Inject AccountStore mAccountStore;
     @Inject ImageManager mImageManager;
 
@@ -69,7 +67,7 @@ public class ReaderSiteHeaderView extends LinearLayout {
     private void initView(Context context) {
         View view = inflate(context, R.layout.reader_site_header_view, this);
         mFollowButton = view.findViewById(R.id.follow_button);
-        ViewUtilsKt.expandTouchTargetArea(mFollowButton, FOLLOW_BUTTON_EXTRA_DPS, false);
+        ViewUtilsKt.expandTouchTargetArea(mFollowButton, R.dimen.reader_follow_button_extra_padding, false);
     }
 
     public void setOnFollowListener(OnFollowListener listener) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -22,6 +22,7 @@ import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.PhotonUtils.Quality;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
+import org.wordpress.android.util.ViewUtilsKt;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
 
@@ -45,6 +46,8 @@ public class ReaderSiteHeaderView extends LinearLayout {
     private OnBlogInfoLoadedListener mBlogInfoListener;
     private OnFollowListener mFollowListener;
 
+    private static final int FOLLOW_BUTTON_EXTRA_DPS = 32;
+
     @Inject AccountStore mAccountStore;
     @Inject ImageManager mImageManager;
 
@@ -66,6 +69,7 @@ public class ReaderSiteHeaderView extends LinearLayout {
     private void initView(Context context) {
         View view = inflate(context, R.layout.reader_site_header_view, this);
         mFollowButton = view.findViewById(R.id.follow_button);
+        ViewUtilsKt.expandTouchTargetArea(mFollowButton, FOLLOW_BUTTON_EXTRA_DPS, false);
     }
 
     public void setOnFollowListener(OnFollowListener listener) {

--- a/WordPress/src/main/java/org/wordpress/android/util/ViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ViewUtils.kt
@@ -34,4 +34,3 @@ fun View.expandTouchTargetArea(dps: Int, heightOnly: Boolean = false) {
         parent.touchDelegate = TouchDelegate(touchTargetRect, this)
     }
 }
-

--- a/WordPress/src/main/java/org/wordpress/android/util/ViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ViewUtils.kt
@@ -5,6 +5,7 @@ import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.view.TouchDelegate
 import android.view.View
+import androidx.annotation.DimenRes
 
 fun View.setVisible(visible: Boolean) {
     this.visibility = if (visible) View.VISIBLE else View.GONE
@@ -16,8 +17,8 @@ fun View.redirectContextClickToLongPressListener() {
     }
 }
 
-fun View.expandTouchTargetArea(dps: Int, heightOnly: Boolean = false) {
-    val pixels = DisplayUtils.dpToPx(context, dps)
+fun View.expandTouchTargetArea(@DimenRes dimenRes: Int, heightOnly: Boolean = false) {
+    val pixels = context.resources.getDimensionPixelSize(dimenRes)
     val parent = this.parent as View
 
     parent.post {

--- a/WordPress/src/main/java/org/wordpress/android/util/ViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ViewUtils.kt
@@ -1,7 +1,9 @@
 package org.wordpress.android.util
 
+import android.graphics.Rect
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
+import android.view.TouchDelegate
 import android.view.View
 
 fun View.setVisible(visible: Boolean) {
@@ -13,3 +15,24 @@ fun View.redirectContextClickToLongPressListener() {
         this.setOnContextClickListener { it.performLongClick() }
     }
 }
+
+
+fun View.expandTouchTargetArea(dps: Int, heightOnly: Boolean = false) {
+    val pixels = DisplayUtils.dpToPx(context, dps)
+    val parent = this.parent as View
+
+    parent.post {
+        val touchTargetRect = Rect()
+        getHitRect(touchTargetRect)
+        touchTargetRect.top -= pixels
+        touchTargetRect.bottom += pixels
+
+        if (!heightOnly) {
+            touchTargetRect.right += pixels
+            touchTargetRect.left -= pixels
+        }
+
+        parent.touchDelegate = TouchDelegate(touchTargetRect, this)
+    }
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/util/ViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ViewUtils.kt
@@ -16,7 +16,6 @@ fun View.redirectContextClickToLongPressListener() {
     }
 }
 
-
 fun View.expandTouchTargetArea(dps: Int, heightOnly: Boolean = false) {
     val pixels = DisplayUtils.dpToPx(context, dps)
     val parent = this.parent as View

--- a/WordPress/src/main/res/layout/actionable_empty_view.xml
+++ b/WordPress/src/main/res/layout/actionable_empty_view.xml
@@ -11,6 +11,7 @@
         android:layout_width="match_parent" >
 
         <LinearLayout
+            android:importantForAccessibility="yes"
             android:layout_height="wrap_content"
             android:layout_width="match_parent"
             android:gravity="center"
@@ -19,7 +20,7 @@
             <ImageView
                 android:id="@+id/image"
                 android:adjustViewBounds="true"
-                android:contentDescription="@string/content_description_person_reading_device_notification"
+                android:importantForAccessibility="no"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/margin_extra_large"
                 android:layout_marginTop="@dimen/margin_extra_large"

--- a/WordPress/src/main/res/layout/filtered_list_component.xml
+++ b/WordPress/src/main/res/layout/filtered_list_component.xml
@@ -24,6 +24,7 @@
                 android:id="@+id/filter_spinner"
                 style="@style/FilteredRecyclerViewSpinner.WordPress"
                 android:layout_width="wrap_content"
+                android:minHeight="@dimen/min_touch_target_sz"
                 android:layout_height="wrap_content"
                 android:overlapAnchor="false"
                 tools:ignore="UnusedAttribute"/>

--- a/WordPress/src/main/res/layout/filtered_list_component.xml
+++ b/WordPress/src/main/res/layout/filtered_list_component.xml
@@ -46,7 +46,9 @@
                 android:id="@+id/recycler_view"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:scrollbars="vertical"/>
+                android:scrollbars="vertical"
+                android:importantForAccessibility="no"
+                />
 
         </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 

--- a/WordPress/src/main/res/layout/reader_activity_subs.xml
+++ b/WordPress/src/main/res/layout/reader_activity_subs.xml
@@ -46,12 +46,11 @@
         android:layout_alignParentBottom="true"
         android:gravity="center_vertical"
         android:orientation="horizontal"
-        android:paddingBottom="@dimen/margin_medium"
-        android:paddingTop="@dimen/margin_small"
-        android:paddingStart="@dimen/margin_medium"
-        android:paddingEnd="@dimen/margin_extra_large">
+        >
 
         <EditText
+            android:paddingStart="@dimen/margin_large"
+            android:paddingEnd="@dimen/margin_medium"
             android:textSize="@dimen/text_sz_medium"
             android:textAlignment="viewStart"
             android:id="@+id/edit_add"
@@ -64,10 +63,10 @@
 
         <ImageButton
             android:id="@+id/btn_add"
+            android:padding="24dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:background="?android:selectableItemBackground"
-            android:layout_marginStart="@dimen/margin_medium"
             android:contentDescription="@string/add"
             android:src="@drawable/ic_reader_follow_white_24dp"
             android:tint="@color/primary_40" />

--- a/WordPress/src/main/res/layout/reader_activity_subs.xml
+++ b/WordPress/src/main/res/layout/reader_activity_subs.xml
@@ -54,10 +54,10 @@
         <EditText
             android:textSize="@dimen/text_sz_medium"
             android:textAlignment="viewStart"
-            android:gravity="start"
             android:id="@+id/edit_add"
             style="@style/ReaderEditText.Topic"
             android:layout_width="0dp"
+            android:minHeight="@dimen/min_touch_target_sz"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:hint="@string/reader_hint_add_tag_or_url" />
@@ -67,7 +67,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:background="?android:selectableItemBackground"
-            android:padding="@dimen/margin_small"
+            android:layout_marginStart="@dimen/margin_medium"
             android:contentDescription="@string/add"
             android:src="@drawable/ic_reader_follow_white_24dp"
             android:tint="@color/primary_40" />

--- a/WordPress/src/main/res/layout/reader_activity_subs.xml
+++ b/WordPress/src/main/res/layout/reader_activity_subs.xml
@@ -63,7 +63,7 @@
 
         <ImageButton
             android:id="@+id/btn_add"
-            android:padding="24dp"
+            android:padding="@dimen/margin_extra_medium_large"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:background="?android:selectableItemBackground"

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -192,7 +192,7 @@
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content"
                 android:maxLines="3"
-                android:textColor="@color/neutral_30"
+                android:textColor="@color/neutral_50"
                 android:textSize="@dimen/text_sz_medium"
                 tools:text="text_attribution"
                 style="@style/ReaderTextView" >

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -35,7 +35,7 @@
                 android:layout_centerVertical="true"
                 android:layout_marginEnd="@dimen/reader_card_avatar_margin_end"
                 android:src="@drawable/bg_rectangle_neutral_10_globe_32dp"
-                android:contentDescription="@string/reader_blavatar_desc"
+                android:importantForAccessibility="no"
                 style="@style/ReaderImageView.Avatar">
             </ImageView>
 

--- a/WordPress/src/main/res/layout/reader_site_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_site_header_view.xml
@@ -46,7 +46,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_below="@+id/text_blog_name"
-            android:textColor="@color/neutral_40"
+            android:textColor="@color/neutral_50"
             android:textSize="@dimen/text_sz_small"
             tools:text="text_domain"
             android:layout_toStartOf="@+id/follow_button"
@@ -103,7 +103,7 @@
                 android:id="@+id/text_blog_follow_count"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="@color/neutral_40"
+                android:textColor="@color/neutral_50"
                 android:textSize="@dimen/text_sz_small"
                 tools:text="12 followers" />
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -164,6 +164,14 @@
     <!-- max size for images in Reader comments -->
     <dimen name="reader_comment_max_image_size">160dp</dimen>
 
+    <!-- Increased touch targets to make views more accessible -->
+    <dimen name="reader_discover_layout_extra_padding">16dp</dimen>
+    <dimen name="reader_visit_layout_extra_padding">12dp</dimen>
+    <dimen name="reader_remove_button_extra_padding">12dp</dimen>
+    <dimen name="reader_more_image_extra_padding">12dp</dimen>
+    <dimen name="reader_follow_button_extra_padding">32dp</dimen>
+    <dimen name="reader_add_button_extra_padding">24dp</dimen>
+
     <dimen name="empty_list_title_text_size">24sp</dimen>
     <dimen name="empty_list_title_side_margin">32dp</dimen>
     <dimen name="empty_list_title_bottom_margin">8dp</dimen>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -170,7 +170,6 @@
     <dimen name="reader_remove_button_extra_padding">12dp</dimen>
     <dimen name="reader_more_image_extra_padding">12dp</dimen>
     <dimen name="reader_follow_button_extra_padding">32dp</dimen>
-    <dimen name="reader_add_button_extra_padding">24dp</dimen>
 
     <dimen name="empty_list_title_text_size">24sp</dimen>
     <dimen name="empty_list_title_side_margin">32dp</dimen>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -62,7 +62,7 @@
     <!-- EditTexts -->
     <style name="ReaderEditText" parent="android:Widget.EditText">
         <item name="android:textSize">@dimen/text_sz_large</item>
-        <item name="android:textColorHint">@color/neutral_40</item>
+        <item name="android:textColorHint">@color/neutral_50</item>
     </style>
     <style name="ReaderEditText.Topic" parent="ReaderEditText">
         <item name="android:background">@android:color/transparent</item>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1689,7 +1689,7 @@
     <string name="reader_empty_posts_liked_description">Posts that you like will appear here</string>
     <string name="reader_empty_saved_posts_title">No posts saved — yet!</string>
     <string name="reader_empty_saved_posts_description">Tap %s to save a post to your list.</string>
-    <string name="reader_empty_saved_posts_content_description">Tap the bookmark icon to save a post to your list.</string>
+    <string name="reader_empty_saved_posts_content_description">Tap the Add to Save Posts button to save a post to your list.</string>
     <string name="reader_empty_comments">No comments yet</string>
     <string name="reader_empty_posts_in_blog">This site is empty</string>
     <string name="reader_empty_search_title">No results found</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1555,6 +1555,9 @@
     <!-- title shown for untitled posts and blogs -->
     <string name="reader_untitled_post">(Untitled)</string>
 
+    <!-- accessibility announcement when list loads -->
+    <string name="reader_acessibility_list_loaded">"The list has loaded with %1$d items."</string>
+
     <!-- activity titles -->
     <string name="reader_title_deeplink">WordPress Reader</string>
     <string name="reader_title_applog">Application log</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1689,6 +1689,7 @@
     <string name="reader_empty_posts_liked_description">Posts that you like will appear here</string>
     <string name="reader_empty_saved_posts_title">No posts saved — yet!</string>
     <string name="reader_empty_saved_posts_description">Tap %s to save a post to your list.</string>
+    <string name="reader_empty_saved_posts_content_description">Tap the bookmark icon to save a post to your list.</string>
     <string name="reader_empty_comments">No comments yet</string>
     <string name="reader_empty_posts_in_blog">This site is empty</string>
     <string name="reader_empty_search_title">No results found</string>


### PR DESCRIPTION
Fixes #10734 #10731 

Below are the improvements that were made on the reader post list.

###### Accessibility Scanner Audit 

#### To Test

To verify this works all these improvements were made you can simply run the Accessibility Scanner on the screen and the issues below won't be shown. Another means of verification is simply running the app to see the changes are shown below. 

- [x] Filter `org.wordpress.android:id/filter_spinner` - Touch target

	This item's height is 47dp. Consider making the height of this touch target 48dp or larger.

- [x] Follow Button org.wordpress.android:id/follow_button - Touch target

	This item's height is 30dp. Consider making the height of this touch target 48dp or larger.

- [x] Discover's Domain - `org.wordpress.android:id/text_domain` - Text contrast

	The item's text contrast ratio is 4.20. This ratio is based on an estimated foreground color of #787C82 and an estimated background color of `#FFFFFF`. Consider using a contrast ratio greater than 4.50 for small text, or 3.00 for large text.

- [x] Follow Count `org.wordpress.android:id/text_blog_follow_count` - Text contrast

	The item's text contrast ratio is 3.91. This ratio is based on an estimated foreground color of `#787C82` and an estimated background color of `#F6F7F7.` Consider using a contrast ratio greater than 4.50 for small text, or 3.00 for large text.

- [x] Discover Text `org.wordpress.android:id/text_discover` - Text contrast

	The item's text contrast ratio is 3.16. This ratio is based on an estimated foreground color of #8E9196 and an estimated background color of #FFFFFF. Consider using a contrast ratio greater than 4.50 for small text, or 3.00 for large text.

- [x] Discover List Item's Visit Layout - `org.wordpress.android:id/layout_discover` - Touch target

	This item's height is 32dp. Consider making the height of this touch target 48dp or larger. A parent container may be handling touch events for this item. If selecting the larger container performs the same action as selecting this item, consider defining this item as not clickable. If a different action is performed, consider increasing the size of this item.

- [x] Visit Button `org.wordpress.android:id/visit`- Touch target

	This item's height is 36dp. Consider making the height of this touch target 48dp or larger. A parent container may be handling touch events for this item. If selecting the larger container performs the same action as selecting this item, consider defining this item as not clickable. If a different action is performed, consider increasing the size of this item.

- [x] More Button `org.wordpress.android:id/image_more` - Touch target

	This item's size is 36dp x 36dp. Consider making this touch target 48dp wide and 48dp high or larger. A parent container may be handling touch events for this item. If selecting the larger container performs the same action as selecting this item, consider defining this item as not clickable. If a different action is performed, consider increasing the size of this item.

##### Talkback Audit

#### To Test

Enable TalkBack and put the app in the states described below. 

<img src="https://user-images.githubusercontent.com/1509205/68091986-53904480-fe3b-11e9-9297-055067676852.png" alt="Screenshot_20191030-224532" width="400" />

- [x] The words "site icon" are being read out loud when the user however over the header of a post in the Reader view. The post title and other pertinent information can be made available but it's okay to disregard the author's profile image since their name is being announced.

- [x] Empty states should be read aloud. If enter has to be pressed that should also be expressed. 

* Saved posts : 

<img src="https://user-images.githubusercontent.com/1509205/68092022-ac5fdd00-fe3b-11e9-86d4-b70f9756653e.png" alt="Screenshot_20191101-201554"  width="400"/>

- [x] Empty state should be announced. 

- [x] Tap to save post to your list. Icon shouldn't be read because the user wont know what it means anyway. 


## Reader Settings 
Below are the improvements that were made on the reader settings.

###### Accessibility Scanner Audit


#### To Test

To verify this works all these improvements were made you can simply run the Accessibility Scanner on the screen and the issues below won't be shown. Another means of verification is simply running the app to see the changes are shown below. 

<img src="https://user-images.githubusercontent.com/1509205/68079747-d5389180-fdab-11e9-9c2e-879189447169.png" width="400" alt="settings" />	
	
- [x] Remove Button `org.wordpress.android:id/btn_remove` - Touch target
	
	This item's size is 32dp x 32dp. Consider making this touch target 48dp wide and 48dp high or larger.
	
- [] Add URL or Tag EditText org.wordpress.android:id/edit_add - Touch target

	This item's height is 38dp. Consider making the height of this touch target 48dp or larger.
	
- [x] Add Button org.wordpress.android:id/btn_add - Touch target

	This item's size is 32dp x 32dp. Consider making this touch target 48dp wide and 48dp high or larger.
	
- [x] Add URL or Tag EditText `org.wordpress.android:id/edit_add` - Text contrast

	The item's text contrast ratio is 4.20. This ratio is based on an estimated foreground color of `#787C82` and an estimated background color of `#FFFFFF`. Consider using a contrast ratio greater than 4.50 for small text, or 3.00 for large text.
		
### Contains tabs: 
 
### Followed Sites Tab
    	
###### Talkback Audit 

#### To Test

Enable TalkBack and put the app in the states described below. 
    	
* Search  
<img src="https://user-images.githubusercontent.com/1509205/68091812-5b4ee980-fe39-11e9-8bca-e893b2ff0d21.png" alt="Screenshot_20191102-200643" width="400" />

- [x] Search input doesn't tell when no results have been returned. Return results after waiting for at least 4 - 5 seconds to ensure query was properly entered. 	
	
- [ ] When search returns results the user won't know if results are actually present. The app should announce that two items actually exist. (It actually announces this the first time the user selects an item in the list.)

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

