### PR TITLE
Show stock photos only for wpcom or jetpack sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2159,7 +2159,11 @@ public class EditPostActivity extends AppCompatActivity implements
                         String languageString = LocaleManager.getLanguage(EditPostActivity.this);
                         String wpcomLocaleSlug = languageString.replace("_", "-").toLowerCase(Locale.ENGLISH);
                         boolean supportsStockPhotos = mSite.isUsingWpComRestApi();
-                        return GutenbergEditorFragment.newInstance("", "", mIsNewPost, wpcomLocaleSlug, supportsStockPhotos);
+                        return GutenbergEditorFragment.newInstance("",
+                                "",
+                                mIsNewPost,
+                                wpcomLocaleSlug,
+                                supportsStockPhotos);
                     } else {
                         // If gutenberg editor is not selected, default to Aztec.
                         return AztecEditorFragment.newInstance("", "", AppPrefs.isAztecEditorToolbarExpanded());

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2158,7 +2158,8 @@ public class EditPostActivity extends AppCompatActivity implements
                         setGutenbergEnabledIfNeeded();
                         String languageString = LocaleManager.getLanguage(EditPostActivity.this);
                         String wpcomLocaleSlug = languageString.replace("_", "-").toLowerCase(Locale.ENGLISH);
-                        return GutenbergEditorFragment.newInstance("", "", mIsNewPost, wpcomLocaleSlug);
+                        boolean supportsStockPhotos = mSite.isUsingWpComRestApi();
+                        return GutenbergEditorFragment.newInstance("", "", mIsNewPost, wpcomLocaleSlug, supportsStockPhotos);
                     } else {
                         // If gutenberg editor is not selected, default to Aztec.
                         return AztecEditorFragment.newInstance("", "", AppPrefs.isAztecEditorToolbarExpanded());

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -64,6 +64,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     private static final String KEY_EDITOR_DID_MOUNT = "KEY_EDITOR_DID_MOUNT";
     private static final String ARG_IS_NEW_POST = "param_is_new_post";
     private static final String ARG_LOCALE_SLUG = "param_locale_slug";
+    private static final String ARG_SUPPORT_STOCK_PHOTOS = "param_support_stock_photos";
 
     private static final int CAPTURE_PHOTO_PERMISSION_REQUEST_CODE = 101;
     private static final int CAPTURE_VIDEO_PERMISSION_REQUEST_CODE = 102;
@@ -94,13 +95,15 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     public static GutenbergEditorFragment newInstance(String title,
                                                       String content,
                                                       boolean isNewPost,
-                                                      String localeSlug) {
+                                                      String localeSlug,
+                                                      boolean supportStockPhotos) {
         GutenbergEditorFragment fragment = new GutenbergEditorFragment();
         Bundle args = new Bundle();
         args.putString(ARG_PARAM_TITLE, title);
         args.putString(ARG_PARAM_CONTENT, content);
         args.putBoolean(ARG_IS_NEW_POST, isNewPost);
         args.putString(ARG_LOCALE_SLUG, localeSlug);
+        args.putBoolean(ARG_SUPPORT_STOCK_PHOTOS, supportStockPhotos);
         fragment.setArguments(args);
         return fragment;
     }
@@ -361,10 +364,13 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     private ArrayList<MediaOption> initOtherMediaImageOptions() {
         ArrayList<MediaOption> otherMediaOptions = new ArrayList<>();
 
-        String packageName = getActivity().getApplication().getPackageName();
-        int stockMediaResourceId = getResources().getIdentifier("photo_picker_stock_media", "string", packageName);
+        boolean supportStockPhotos = getArguments().getBoolean(ARG_SUPPORT_STOCK_PHOTOS);
+        if (supportStockPhotos) {
+            String packageName = getActivity().getApplication().getPackageName();
+            int stockMediaResourceId = getResources().getIdentifier("photo_picker_stock_media", "string", packageName);
 
-        otherMediaOptions.add(new MediaOption(MEDIA_SOURCE_STOCK_MEDIA, getString(stockMediaResourceId)));
+            otherMediaOptions.add(new MediaOption(MEDIA_SOURCE_STOCK_MEDIA, getString(stockMediaResourceId)));
+        }
 
         return otherMediaOptions;
     }


### PR DESCRIPTION
Fixes # https://github.com/wordpress-mobile/gutenberg-mobile/pull/1539#issuecomment-550173180

We should not show the Free Media Library option on Self Hosted site, since this is a WPCom/Jetpack-only feature.

To test:

Test 1:

1. The easiest way is to create a Jurassic Ninja instance:
https://jurassic.ninja
2. Then delete the Jetpack plugin from it
3. Log in with a self-hosted site
4. Create a new Post
5. Create a new Image block
6. Tap on the Image block
7. `Choose from Free Photo Library` shouldn't be visible

Test 2:
1. Use wp.com site
2. Create a new Post
3. Create a new Image block
4. Tap on the Image block
5. `Choose from Free Photo Library` should be visible

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

