### PR TITLE
Gutenberg progressive rollout

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -895,7 +895,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
             }
 
             // Let's migrate the old editor preference if available in AppPrefs to the remote backend
-            SiteUtils.migrateAppWideMobileEditorPreferenceToRemote(mContext, mDispatcher);
+            SiteUtils.migrateAppWideMobileEditorPreferenceToRemote(mAccountStore, mSiteStore, mDispatcher);
 
             if (mFirstActivityResumed) {
                 deferredInit();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -609,11 +609,11 @@ public class AppPrefs {
     }
 
     public static boolean isUserInGutenbergRolloutGroup() {
-        return getBoolean(DeletablePrefKey.GUTENBERG_DEFAULT_FOR_NEW_POSTS, false);
+        return getBoolean(DeletablePrefKey.USER_IN_GUTENBERG_ROLLOUT_GROUP, false);
     }
 
     public static void setUserInGutenbergRolloutGroup() {
-        setBoolean(DeletablePrefKey.GUTENBERG_DEFAULT_FOR_NEW_POSTS, true);
+        setBoolean(DeletablePrefKey.USER_IN_GUTENBERG_ROLLOUT_GROUP, true);
     }
 
     public static void removeAppWideEditorPreference() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -115,6 +115,7 @@ public class AppPrefs {
         NEWS_CARD_SHOWN_VERSION,
         AVATAR_VERSION,
         GUTENBERG_DEFAULT_FOR_NEW_POSTS,
+        USER_IN_GUTENBERG_ROLLOUT_GROUP,
         SHOULD_AUTO_ENABLE_GUTENBERG_FOR_THE_NEW_POSTS,
         GUTENBERG_OPT_IN_DIALOG_SHOWN,
 
@@ -605,6 +606,14 @@ public class AppPrefs {
     public static boolean isDefaultAppWideEditorPreferenceSet() {
         // Check if the default editor pref was previously set
         return !"".equals(getString(DeletablePrefKey.GUTENBERG_DEFAULT_FOR_NEW_POSTS));
+    }
+
+    public static boolean isUserInGutenbergRolloutGroup() {
+        return getBoolean(DeletablePrefKey.GUTENBERG_DEFAULT_FOR_NEW_POSTS, false);
+    }
+
+    public static void setUserInGutenbergRolloutGroup() {
+        setBoolean(DeletablePrefKey.GUTENBERG_DEFAULT_FOR_NEW_POSTS, true);
     }
 
     public static void removeAppWideEditorPreference() {

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -5,6 +5,7 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
@@ -65,6 +66,11 @@ public class SiteUtils {
         if (accountStore.getAccount().getUserId() % 100 >= (100 - GB_ROLLOUT_PERCENTAGE)) {
             if (atLeastOneSiteHasAztecEnabled(siteStore)) {
                 // If the user has opt-ed out from at least one of their site, then exclude them from the cohort
+                return;
+            }
+
+            if (!NetworkUtils.isNetworkAvailable(WordPress.getContext())) {
+                // If the network is not available, abort. We can't update the remote setting.
                 return;
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.util;
 
-import android.content.Context;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
@@ -10,6 +9,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.DesignateMobileEditorForAllSitesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.DesignateMobileEditorPayload;
@@ -25,6 +25,7 @@ import java.util.List;
 public class SiteUtils {
     public static final String GB_EDITOR_NAME = "gutenberg";
     public static final String AZTEC_EDITOR_NAME = "aztec";
+    private static final int GB_ROLLOUT_PERCENTAGE = 5;
 
     /**
      * Migrate the old app-wide editor preference value to per-site setting. wpcom sites will make a network call
@@ -35,8 +36,43 @@ public class SiteUtils {
      * -- 12.9 OPTED OUT (were auto-opted in but turned it OFF) -> turn all sites OFF in 13.0
      *
      */
-    public static void migrateAppWideMobileEditorPreferenceToRemote(final Context context,
+    public static void migrateAppWideMobileEditorPreferenceToRemote(final AccountStore accountStore,
+                                                                    final SiteStore siteStore,
                                                                     final Dispatcher dispatcher) {
+        // In a later version we might override mobile_editor setting if it's set to `aztec` and show a specific notice
+        // for these users ("We made a lot of progress on the block editor and we think it's now better than
+        // the classic editor, we switched it on, but you can change the configuration in your Site Settings").
+        // ^ This code should be here.
+
+        // If the user is already in the rollout group, we can skip this the migration.
+        if (AppPrefs.isUserInGutenbergRolloutGroup()) {
+            return;
+        }
+
+        // Check if the user has been "randomly" selected to enter the rollout group.
+        //
+        // For self hosted sites, there are often one or two users, and the user id is probably 0, 1 in these cases.
+        // If we exclude low ids, we won't get an not an homogeneous distribution over self hosted and WordPress.com users,
+        // but the purpose of this is to do a progressive rollout, not an necessarily an homogeneous rollout.
+        //
+        // To exclude ids 0 and 1, to rollout for 10% users, we'll use a test like `id % 100 >= 90` instead of `id % 100 < 10`.
+        if (accountStore.getAccount().getUserId() % 100 >= (100 - GB_ROLLOUT_PERCENTAGE)) {
+            // We want to make sure to enable Gutenberg only on the sites they didn't opt-out.
+            for (SiteModel site : siteStore.getSites()) {
+                if (TextUtils.isEmpty(site.getMobileEditor())) {
+                    // Enable Gutenberg
+                    enableBlockEditor(dispatcher, site);
+                    AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_GUTENBERG_ENABLED, site,
+                            BlockEditorEnabledSource.ON_PROGRESSIVE_ROLLOUT.asPropertyMap());
+                    // Show the info popup when the user creates a new post for the first time on this site
+                    AppPrefs.setShowGutenbergInfoPopupForTheNewPosts(site.getUrl(), true);
+                }
+            }
+
+            // After enabling Gutenberg on these sites, we consider the user entered the rollout group
+            AppPrefs.setUserInGutenbergRolloutGroup();
+        }
+
         if (!AppPrefs.isDefaultAppWideEditorPreferenceSet()) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -52,10 +52,11 @@ public class SiteUtils {
         // Check if the user has been "randomly" selected to enter the rollout group.
         //
         // For self hosted sites, there are often one or two users, and the user id is probably 0, 1 in these cases.
-        // If we exclude low ids, we won't get an not an homogeneous distribution over self hosted and WordPress.com users,
-        // but the purpose of this is to do a progressive rollout, not an necessarily an homogeneous rollout.
+        // If we exclude low ids, we won't get an not an homogeneous distribution over self hosted and WordPress.com
+        // users, but the purpose of this is to do a progressive rollout, not an necessarily an homogeneous rollout.
         //
-        // To exclude ids 0 and 1, to rollout for 10% users, we'll use a test like `id % 100 >= 90` instead of `id % 100 < 10`.
+        // To exclude ids 0 and 1, to rollout for 10% users,
+        // we'll use a test like `id % 100 >= 90` instead of `id % 100 < 10`.
         if (accountStore.getAccount().getUserId() % 100 >= (100 - GB_ROLLOUT_PERCENTAGE)) {
             // We want to make sure to enable Gutenberg only on the sites they didn't opt-out.
             for (SiteModel site : siteStore.getSites()) {

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -73,7 +73,8 @@ public class AnalyticsUtils {
     public enum BlockEditorEnabledSource {
         VIA_SITE_SETTINGS,
         ON_SITE_CREATION,
-        ON_BLOCK_POST_OPENING;
+        ON_BLOCK_POST_OPENING,
+        ON_PROGRESSIVE_ROLLOUT;
 
         public Map<String, Object> asPropertyMap() {
             Map<String, Object> properties = new HashMap<>();


### PR DESCRIPTION
Fixes #10747 - Implement a client only way to make a progressive rollout for the Gutenberg editor. I currently set an arbitrary number of 5%, but since we already have ~30% of users posting with Gutenberg, this should only move the needle to 3.5% ((100%-30%) x %5 = 3.5%) ie. when adding someone to the rollout group, there is a 30% chance they're already using Gutenberg. This number is even more skewed that this code exclude most self hosted users. It's arbitrary anyway and we only want to make this progressive (5% now, then 10%, 20%, 50%, 100% later).

I targeted 13.7, our target release for v2.

Test 1:
1. Make sure your the remote mobile editor setting is unset for the user/site you're testing (ping me if you need help for this).
2. Optional step: Clear your app data or uninstall the app (only required if you updated the remote mobile editor setting).
3. Set `GB_ROLLOUT_PERCENTAGE` to `0`
4. Run the app.
5. Create a new post, you will get Aztec.

Test 2:
1. Make sure your the remote mobile editor setting is unset for the user/site you're testing (ping me if you need help for this).
1. Set `GB_ROLLOUT_PERCENTAGE` to `100`
1. Run the app (on startup, your test user should be enrolled).
1. Go to the post list, tap the Create a new post button, you will get Gutenberg and you will see the info dialog.
1. (Note: if you try to create a post right after the switch on the main screen, you'll get Aztec. The site is not updated on the main screen, and it wasn't updated on purpose. I'm not sure why it was done that way, but to be safe I won't update it. It's not a big deal when the switch actually happen).

Notes:
- I added a new analytic parameter to the `EDITOR_GUTENBERG_ENABLED` event: `ON_PROGRESSIVE_ROLLOUT`.
- I was tempted to move [this logic](https://github.com/wordpress-mobile/WordPress-Android/blob/48c886ef6734254a20cf6479bb36014f889adb35/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L1448-L1453) out of the `EditPostActivity` but we'll remove all of this at some point, so I'm not touching it.
- I preferred a modulo logic on the user id over random number generation as the user might use the app on different devices and eventually uninstall/reinstall the app. In these cases, they should have the same default editors.
- I added a new pref `AppPrefs.isUserInGutenbergRolloutGroup` to avoid re-doing the same logic. This might also be reused later if we want to change the rollout strategy.


Checks:
- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

