### PR TITLE
Sharing Settings: Hide Learn More button everywhere except for FB.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -122,6 +122,10 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
             TextView txtDescription = (TextView) mServiceCardView.findViewById(R.id.text_description);
             txtDescription.setText(description);
 
+            // Hide the Learn More button by default as at the moment it is only used for the Facebook warning below.
+            TextView learnMoreButton = (TextView) mServiceCardView.findViewById(R.id.learn_more_button);
+            learnMoreButton.setVisibility(View.GONE);
+
             if (isFacebook()) {
                 showFacebookWarning();
             }


### PR DESCRIPTION
Fixes #9828

The "Learn More" button is only used for displaying the Facebook warning, and there's nothing to show for other social media (LinkedIn, Tumblr, Twitter), hence we hide them by default on those.

To test:
1. Go to Sharing > Connections.
2. Tap on Facebook. "Learn More" option should be visible and tappable.
3. Go back and tap on Twitter. There should be no "Learn more" button.
4. Go back and tap on Tumblr. There should be no "Learn more" button.
5. Go back and tap on LinkedIn. There should be no "Learn more" button.


PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

