### PR TITLE
Information Architecture: Sync various nav menu items to match Calypso.

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -227,7 +227,7 @@
             android:name=".ui.pages.PagesActivity"
             android:theme="@style/Calypso.NoActionBar"
             android:launchMode="singleTop"
-            android:label="@string/my_site_btn_site_pages" />
+            android:label="@string/my_site_btn_pages" />
         <activity
             android:name=".ui.pages.PageParentActivity"
             android:theme="@style/Calypso.NoActionBar"

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -144,7 +144,7 @@ class PostsListActivity : AppCompatActivity(),
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
 
-        title = getString(R.string.my_site_btn_blog_posts)
+        title = getString(R.string.my_site_btn_posts)
         supportActionBar?.setDisplayShowTitleEnabled(true)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -432,7 +432,7 @@
                     <org.wordpress.android.widgets.WPTextView
                         android:id="@+id/my_site_pages_text_view"
                         style="@style/MySiteListRowTextView"
-                        android:text="@string/my_site_btn_site_pages"/>
+                        android:text="@string/my_site_btn_pages"/>
 
                 </LinearLayout>
 
@@ -454,7 +454,7 @@
                         <org.wordpress.android.widgets.WPTextView
                             android:id="@+id/my_site_blog_posts_text_view"
                             style="@style/MySiteListRowTextView"
-                            android:text="@string/my_site_btn_blog_posts"/>
+                            android:text="@string/my_site_btn_posts"/>
 
                     </LinearLayout>
 
@@ -500,7 +500,7 @@
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/my_site_look_and_feel_header"
                     style="@style/MySiteListHeader"
-                    android:text="@string/my_site_header_look_and_feel">
+                    android:text="@string/my_site_header_design">
                 </org.wordpress.android.widgets.WPTextView>
 
                 <!--Themes-->
@@ -525,7 +525,7 @@
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/my_site_configuration_header"
                     style="@style/MySiteListHeader"
-                    android:text="@string/my_site_header_configuration">
+                    android:text="@string/my_site_header_manage">
                 </org.wordpress.android.widgets.WPTextView>
 
                 <!--People-->

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -933,7 +933,7 @@ Language: ar
     <string name="plugin_byline">بواسطة %s</string>
     <string name="change_photo">تغيير الصورة</string>
     <string name="plugin_fetch_error">تعذر تحميل الإضافات</string>
-    <string name="my_site_btn_site_pages">صفحات الموقع</string>
+    <string name="my_site_btn_pages">صفحات الموقع</string>
     <string name="site_settings_tags_hint">إدارة علامات موقعك</string>
     <string name="dlg_saving_tag">جاري الحفظ</string>
     <string name="dlg_deleting_tag">جاري الحذف</string>
@@ -1728,11 +1728,11 @@ Language: ar
     <string name="my_site_btn_view_site">عرض الموقع</string>
     <string name="my_site_btn_view_admin">عرض المسؤول</string>
     <string name="my_site_header_publish">نشر</string>
-    <string name="my_site_header_look_and_feel">الشكل والطابع</string>
+    <string name="my_site_header_design">الشكل والطابع</string>
     <string name="my_site_btn_site_settings">الإعدادات</string>
-    <string name="my_site_btn_blog_posts">مقالات المدونة</string>
+    <string name="my_site_btn_posts">مقالات المدونة</string>
     <string name="reader_label_new_posts_subtitle">انقر لعرضها</string>
-    <string name="my_site_header_configuration">التكوين</string>
+    <string name="my_site_header_manage">التكوين</string>
     <string name="select_all">اختيار الكل</string>
     <string name="hide">إخفاء</string>
     <string name="show">إظهار</string>

--- a/WordPress/src/main/res/values-az/strings.xml
+++ b/WordPress/src/main/res/values-az/strings.xml
@@ -41,11 +41,11 @@ Language: az
     <string name="my_site_btn_view_site">Sayta Bax</string>
     <string name="site_picker_title">Sayt seç</string>
     <string name="my_site_btn_switch_site">Saytı Dəyişdir</string>
-    <string name="my_site_btn_blog_posts">Bloq Yazıları</string>
+    <string name="my_site_btn_posts">Bloq Yazıları</string>
     <string name="my_site_btn_site_settings">Parametrlər</string>
-    <string name="my_site_header_look_and_feel">Əsas Görünüş</string>
+    <string name="my_site_header_design">Əsas Görünüş</string>
     <string name="my_site_header_publish">Dərc et</string>
-    <string name="my_site_header_configuration">Konfiqurasiya</string>
+    <string name="my_site_header_manage">Konfiqurasiya</string>
     <string name="reader_label_new_posts_subtitle">Göstərmək üçün toxunun</string>
     <string name="deselect_all">Heç birini seçmə</string>
     <string name="show">Göstər</string>

--- a/WordPress/src/main/res/values-bg/strings.xml
+++ b/WordPress/src/main/res/values-bg/strings.xml
@@ -654,10 +654,10 @@ Language: bg
     <string name="my_site_btn_view_site">Преглед на сайта</string>
     <string name="my_site_btn_switch_site">Превключване на сайта</string>
     <string name="my_site_btn_site_settings">Настройки</string>
-    <string name="my_site_header_look_and_feel">Изглед</string>
+    <string name="my_site_header_design">Изглед</string>
     <string name="my_site_header_publish">Публикуване</string>
-    <string name="my_site_btn_blog_posts">Публикации</string>
-    <string name="my_site_header_configuration">Настройки</string>
+    <string name="my_site_btn_posts">Публикации</string>
+    <string name="my_site_header_manage">Настройки</string>
     <string name="reader_label_new_posts_subtitle">Натиснете за да ги прегледате</string>
     <string name="hide">Скриване</string>
     <string name="select_all">Избор на всичко</string>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -594,7 +594,7 @@ Language: cs_CZ
     <string name="plugin_byline">Od %s</string>
     <string name="change_photo">Změnit fotku</string>
     <string name="plugin_fetch_error">Nelze načíst pluginy</string>
-    <string name="my_site_btn_site_pages">Stránky webu</string>
+    <string name="my_site_btn_pages">Stránky webu</string>
     <string name="site_settings_tags_hint">Spravovat štítky webu</string>
     <string name="dlg_saving_tag">Ukládání</string>
     <string name="dlg_deleting_tag">Mazání</string>
@@ -1388,11 +1388,11 @@ Language: cs_CZ
     <string name="my_site_btn_view_site">Zobrazit web</string>
     <string name="my_site_btn_view_admin">Zobrazit administraci</string>
     <string name="my_site_header_publish">Publikovat</string>
-    <string name="my_site_header_look_and_feel">Vzhled</string>
+    <string name="my_site_header_design">Vzhled</string>
     <string name="my_site_btn_site_settings">Nastavení</string>
-    <string name="my_site_btn_blog_posts">Příspěvky</string>
+    <string name="my_site_btn_posts">Příspěvky</string>
     <string name="reader_label_new_posts_subtitle">Klepněte pro jejich zobrazení</string>
-    <string name="my_site_header_configuration">Nastavení</string>
+    <string name="my_site_header_manage">Nastavení</string>
     <string name="select_all">Vybrat vše</string>
     <string name="hide">Skrýt</string>
     <string name="show">Zobrazit</string>

--- a/WordPress/src/main/res/values-cy/strings.xml
+++ b/WordPress/src/main/res/values-cy/strings.xml
@@ -402,12 +402,12 @@ Language: cy_GB
     <string name="my_site_btn_switch_site">Newid Gwefan</string>
     <string name="my_site_btn_view_admin">Gweld Gweinyddu</string>
     <string name="my_site_btn_view_site">Gweld Gwefan</string>
-    <string name="my_site_header_look_and_feel">Golwg a Theimlad</string>
+    <string name="my_site_header_design">Golwg a Theimlad</string>
     <string name="my_site_header_publish">Cyhoeddi</string>
-    <string name="my_site_btn_blog_posts">Cofnodion Blog</string>
+    <string name="my_site_btn_posts">Cofnodion Blog</string>
     <string name="my_site_btn_site_settings">Gosodiadau</string>
     <string name="reader_label_new_posts_subtitle">Tapio i\'w dangos</string>
-    <string name="my_site_header_configuration">Ffurfweddiad</string>
+    <string name="my_site_header_manage">Ffurfweddiad</string>
     <string name="deselect_all">Dad-ddewis y cyfan</string>
     <string name="show">Dangos</string>
     <string name="hide">Cuddio</string>

--- a/WordPress/src/main/res/values-da/strings.xml
+++ b/WordPress/src/main/res/values-da/strings.xml
@@ -82,9 +82,9 @@ Language: da_DK
     <string name="my_site_btn_view_admin">Vis administration</string>
     <string name="my_site_btn_site_settings">Indstillinger</string>
     <string name="my_site_header_publish">Udgiv</string>
-    <string name="my_site_header_look_and_feel">Udseende</string>
-    <string name="my_site_btn_blog_posts">Blogindlæg</string>
-    <string name="my_site_header_configuration">Konfiguration</string>
+    <string name="my_site_header_design">Udseende</string>
+    <string name="my_site_btn_posts">Blogindlæg</string>
+    <string name="my_site_header_manage">Konfiguration</string>
     <string name="deselect_all">Fravælg alle</string>
     <string name="show">Vis</string>
     <string name="hide">Skjul</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -933,7 +933,7 @@ Language: de
     <string name="plugin_byline">von %s</string>
     <string name="change_photo">Foto ändern</string>
     <string name="plugin_fetch_error">Plugins konnten nicht geladen werden</string>
-    <string name="my_site_btn_site_pages">Seiten</string>
+    <string name="my_site_btn_pages">Seiten</string>
     <string name="site_settings_tags_hint">Verwalte deine Website-Schlagwörter</string>
     <string name="dlg_saving_tag">Wird gespeichert …</string>
     <string name="dlg_deleting_tag">Wird gelöscht …</string>
@@ -1728,11 +1728,11 @@ Language: de
     <string name="my_site_btn_view_site">Website ansehen</string>
     <string name="my_site_btn_view_admin">Admin aufrufen</string>
     <string name="my_site_header_publish">Veröffentlichen</string>
-    <string name="my_site_header_look_and_feel">Erscheinungsbild</string>
+    <string name="my_site_header_design">Erscheinungsbild</string>
     <string name="my_site_btn_site_settings">Einstellungen</string>
-    <string name="my_site_btn_blog_posts">Blogbeiträge</string>
+    <string name="my_site_btn_posts">Blogbeiträge</string>
     <string name="reader_label_new_posts_subtitle">Berühren zum Anzeigen</string>
-    <string name="my_site_header_configuration">Einrichtung</string>
+    <string name="my_site_header_manage">Einrichtung</string>
     <string name="select_all">Alle auswählen</string>
     <string name="hide">Ausblenden</string>
     <string name="show">Anzeigen</string>

--- a/WordPress/src/main/res/values-el/strings.xml
+++ b/WordPress/src/main/res/values-el/strings.xml
@@ -340,7 +340,7 @@ Language: el_GR
     <string name="plugin_version">Έκδοση %s</string>
     <string name="plugin_byline">από %s</string>
     <string name="change_photo">Αλλαγή φωτογραφίας</string>
-    <string name="my_site_btn_site_pages">Σελίδες του ιστότοπου</string>
+    <string name="my_site_btn_pages">Σελίδες του ιστότοπου</string>
     <string name="dlg_saving_tag">Αποθήκευση</string>
     <string name="dlg_deleting_tag">Διαγραφή</string>
     <string name="add_new_tag">Προσθήκη Νέας Ετικέτας</string>
@@ -998,11 +998,11 @@ Language: el_GR
     <string name="my_site_btn_view_site">Προβολή ιστότοπου</string>
     <string name="my_site_btn_view_admin">Προβολή Διαχείρισης</string>
     <string name="my_site_header_publish">Δημοσιεύω</string>
-    <string name="my_site_header_look_and_feel">Κοίτα και Νιώσε</string>
+    <string name="my_site_header_design">Κοίτα και Νιώσε</string>
     <string name="my_site_btn_site_settings">Ρυθμίσεις</string>
-    <string name="my_site_btn_blog_posts">Άρθρο ιστολογίου</string>
+    <string name="my_site_btn_posts">Άρθρο ιστολογίου</string>
     <string name="reader_label_new_posts_subtitle">Πατήστε για να τα δείτε</string>
-    <string name="my_site_header_configuration">Ρυθμίσεις</string>
+    <string name="my_site_header_manage">Ρυθμίσεις</string>
     <string name="select_all">Επιλογή όλων</string>
     <string name="hide">Απόκρυψη</string>
     <string name="show">Προβολή</string>

--- a/WordPress/src/main/res/values-en-rAU/strings.xml
+++ b/WordPress/src/main/res/values-en-rAU/strings.xml
@@ -933,7 +933,7 @@ Language: en_AU
     <string name="plugin_byline">by %s</string>
     <string name="change_photo">Change photo</string>
     <string name="plugin_fetch_error">Unable to load plugins</string>
-    <string name="my_site_btn_site_pages">Site Pages</string>
+    <string name="my_site_btn_pages">Site Pages</string>
     <string name="site_settings_tags_hint">Manage your site\'s tags</string>
     <string name="dlg_saving_tag">Saving</string>
     <string name="dlg_deleting_tag">Deleting</string>
@@ -1728,11 +1728,11 @@ Language: en_AU
     <string name="my_site_btn_view_site">View Site</string>
     <string name="my_site_btn_view_admin">View Admin</string>
     <string name="my_site_header_publish">Publish</string>
-    <string name="my_site_header_look_and_feel">Look and Feel</string>
+    <string name="my_site_header_design">Look and Feel</string>
     <string name="my_site_btn_site_settings">Settings</string>
-    <string name="my_site_btn_blog_posts">Blog Posts</string>
+    <string name="my_site_btn_posts">Blog Posts</string>
     <string name="reader_label_new_posts_subtitle">Tap to show them</string>
-    <string name="my_site_header_configuration">Configuration</string>
+    <string name="my_site_header_manage">Configuration</string>
     <string name="select_all">Select all</string>
     <string name="hide">Hide</string>
     <string name="show">Show</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -932,7 +932,7 @@ Language: en_CA
     <string name="plugin_byline">by %s</string>
     <string name="change_photo">Change photo</string>
     <string name="plugin_fetch_error">Unable to load plugins</string>
-    <string name="my_site_btn_site_pages">Site Pages</string>
+    <string name="my_site_btn_pages">Site Pages</string>
     <string name="site_settings_tags_hint">Manage your site\'s tags</string>
     <string name="dlg_saving_tag">Saving</string>
     <string name="dlg_deleting_tag">Deleting</string>
@@ -1727,11 +1727,11 @@ Language: en_CA
     <string name="my_site_btn_view_site">View Site</string>
     <string name="my_site_btn_view_admin">View Admin</string>
     <string name="my_site_header_publish">Publish</string>
-    <string name="my_site_header_look_and_feel">Look and Feel</string>
+    <string name="my_site_header_design">Look and Feel</string>
     <string name="my_site_btn_site_settings">Settings</string>
-    <string name="my_site_btn_blog_posts">Blog Posts</string>
+    <string name="my_site_btn_posts">Blog Posts</string>
     <string name="reader_label_new_posts_subtitle">Tap to show them</string>
-    <string name="my_site_header_configuration">Configuration</string>
+    <string name="my_site_header_manage">Configuration</string>
     <string name="select_all">Select all</string>
     <string name="hide">Hide</string>
     <string name="show">Show</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -933,7 +933,7 @@ Language: en_GB
     <string name="plugin_byline">by %s</string>
     <string name="change_photo">Change photo</string>
     <string name="plugin_fetch_error">Unable to load plugins</string>
-    <string name="my_site_btn_site_pages">Site Pages</string>
+    <string name="my_site_btn_pages">Site Pages</string>
     <string name="site_settings_tags_hint">Manage your site\'s tags</string>
     <string name="dlg_saving_tag">Saving</string>
     <string name="dlg_deleting_tag">Deleting</string>
@@ -1728,11 +1728,11 @@ Language: en_GB
     <string name="my_site_btn_view_site">View Site</string>
     <string name="my_site_btn_view_admin">View Admin</string>
     <string name="my_site_header_publish">Publish</string>
-    <string name="my_site_header_look_and_feel">Look and Feel</string>
+    <string name="my_site_header_design">Look and Feel</string>
     <string name="my_site_btn_site_settings">Settings</string>
-    <string name="my_site_btn_blog_posts">Blog Posts</string>
+    <string name="my_site_btn_posts">Blog Posts</string>
     <string name="reader_label_new_posts_subtitle">Tap to show them</string>
-    <string name="my_site_header_configuration">Configuration</string>
+    <string name="my_site_header_manage">Configuration</string>
     <string name="select_all">Select all</string>
     <string name="hide">Hide</string>
     <string name="show">Show</string>

--- a/WordPress/src/main/res/values-es-rCL/strings.xml
+++ b/WordPress/src/main/res/values-es-rCL/strings.xml
@@ -688,7 +688,7 @@ Language: es_CL
     <string name="plugin_byline">por %s</string>
     <string name="change_photo">Cambiar foto</string>
     <string name="plugin_fetch_error">No se pueden cargar plugins</string>
-    <string name="my_site_btn_site_pages">Páginas del Sitio</string>
+    <string name="my_site_btn_pages">Páginas del Sitio</string>
     <string name="site_settings_tags_hint">Administra las etiquetas de tu sitio</string>
     <string name="dlg_saving_tag">Guardando</string>
     <string name="dlg_deleting_tag">Eliminando</string>
@@ -1479,11 +1479,11 @@ Language: es_CL
     <string name="my_site_btn_view_site">Ver sitio</string>
     <string name="my_site_btn_view_admin">Ver Administrador</string>
     <string name="my_site_header_publish">Publicar</string>
-    <string name="my_site_header_look_and_feel">Aspecto</string>
+    <string name="my_site_header_design">Aspecto</string>
     <string name="my_site_btn_site_settings">Preferencias</string>
-    <string name="my_site_btn_blog_posts">Entradas del blog</string>
+    <string name="my_site_btn_posts">Entradas del blog</string>
     <string name="reader_label_new_posts_subtitle">Toca para mostrarlos</string>
-    <string name="my_site_header_configuration">Configuración</string>
+    <string name="my_site_header_manage">Configuración</string>
     <string name="select_all">Seleccionar todo</string>
     <string name="hide">Ocultar</string>
     <string name="show">Mostrar</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -691,11 +691,11 @@ Language: es_CO
     <string name="my_site_btn_view_site">Ver sitio</string>
     <string name="my_site_btn_view_admin">Ver Administrador</string>
     <string name="my_site_header_publish">Publicar</string>
-    <string name="my_site_header_look_and_feel">Aspecto</string>
+    <string name="my_site_header_design">Aspecto</string>
     <string name="my_site_btn_site_settings">Ajustes</string>
-    <string name="my_site_btn_blog_posts">Entradas del blog</string>
+    <string name="my_site_btn_posts">Entradas del blog</string>
     <string name="reader_label_new_posts_subtitle">Toca para mostrarlos</string>
-    <string name="my_site_header_configuration">Configuración</string>
+    <string name="my_site_header_manage">Configuración</string>
     <string name="select_all">Seleccionar todo</string>
     <string name="hide">Ocultar</string>
     <string name="show">Mostrar</string>

--- a/WordPress/src/main/res/values-es-rVE/strings.xml
+++ b/WordPress/src/main/res/values-es-rVE/strings.xml
@@ -933,7 +933,7 @@ Language: es_VE
     <string name="plugin_byline">por %s</string>
     <string name="change_photo">Cambiar foto</string>
     <string name="plugin_fetch_error">No es posible cargar plugins</string>
-    <string name="my_site_btn_site_pages">Páginas del sitio</string>
+    <string name="my_site_btn_pages">Páginas del sitio</string>
     <string name="site_settings_tags_hint">Gestiona las etiquetas de tu sitio</string>
     <string name="dlg_saving_tag">Guardando</string>
     <string name="dlg_deleting_tag">Borrando</string>
@@ -1728,11 +1728,11 @@ Language: es_VE
     <string name="my_site_btn_view_site">Ver sitio</string>
     <string name="my_site_btn_view_admin">Ver Administrador</string>
     <string name="my_site_header_publish">Publicar</string>
-    <string name="my_site_header_look_and_feel">Aspecto</string>
+    <string name="my_site_header_design">Aspecto</string>
     <string name="my_site_btn_site_settings">Ajustes</string>
-    <string name="my_site_btn_blog_posts">Entradas del blog</string>
+    <string name="my_site_btn_posts">Entradas del blog</string>
     <string name="reader_label_new_posts_subtitle">Toca para mostrarlos</string>
-    <string name="my_site_header_configuration">Configuración</string>
+    <string name="my_site_header_manage">Configuración</string>
     <string name="select_all">Seleccionar todo</string>
     <string name="hide">Ocultar</string>
     <string name="show">Mostrar</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -933,7 +933,7 @@ Language: es
     <string name="plugin_byline">por %s</string>
     <string name="change_photo">Cambiar foto</string>
     <string name="plugin_fetch_error">No es posible cargar plugins</string>
-    <string name="my_site_btn_site_pages">Páginas del sitio</string>
+    <string name="my_site_btn_pages">Páginas del sitio</string>
     <string name="site_settings_tags_hint">Gestiona las etiquetas de tu sitio</string>
     <string name="dlg_saving_tag">Guardando</string>
     <string name="dlg_deleting_tag">Borrando</string>
@@ -1728,11 +1728,11 @@ Language: es
     <string name="my_site_btn_view_site">Ver sitio</string>
     <string name="my_site_btn_view_admin">Ver Administrador</string>
     <string name="my_site_header_publish">Publicar</string>
-    <string name="my_site_header_look_and_feel">Aspecto</string>
+    <string name="my_site_header_design">Aspecto</string>
     <string name="my_site_btn_site_settings">Ajustes</string>
-    <string name="my_site_btn_blog_posts">Entradas del blog</string>
+    <string name="my_site_btn_posts">Entradas del blog</string>
     <string name="reader_label_new_posts_subtitle">Toca para mostrarlos</string>
-    <string name="my_site_header_configuration">Configuración</string>
+    <string name="my_site_header_manage">Configuración</string>
     <string name="select_all">Seleccionar todo</string>
     <string name="hide">Ocultar</string>
     <string name="show">Mostrar</string>

--- a/WordPress/src/main/res/values-eu/strings.xml
+++ b/WordPress/src/main/res/values-eu/strings.xml
@@ -245,11 +245,11 @@ Language: eu_ES
     <string name="my_site_btn_view_site">Ikusi gunea</string>
     <string name="my_site_btn_view_admin">Ikusi Admin</string>
     <string name="my_site_header_publish">Argitaratu</string>
-    <string name="my_site_header_look_and_feel">Itxura</string>
+    <string name="my_site_header_design">Itxura</string>
     <string name="my_site_btn_site_settings">Ezarpenak</string>
-    <string name="my_site_btn_blog_posts">Bidalketak</string>
+    <string name="my_site_btn_posts">Bidalketak</string>
     <string name="reader_label_new_posts_subtitle">Egin tap berauek erakusteko</string>
-    <string name="my_site_header_configuration">Konfigurazioa</string>
+    <string name="my_site_header_manage">Konfigurazioa</string>
     <string name="select_all">Aukeratu denak</string>
     <string name="hide">Ezkutatu</string>
     <string name="show">Ikusi</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -933,7 +933,7 @@ Language: fr
     <string name="plugin_byline">par %s</string>
     <string name="change_photo">Changer la photo</string>
     <string name="plugin_fetch_error">Impossible de charger les extensions</string>
-    <string name="my_site_btn_site_pages">Pages du site</string>
+    <string name="my_site_btn_pages">Pages du site</string>
     <string name="site_settings_tags_hint">Gérez les étiquettes de votre site</string>
     <string name="dlg_saving_tag">Enregistrement</string>
     <string name="dlg_deleting_tag">Suppression</string>
@@ -1728,11 +1728,11 @@ Language: fr
     <string name="my_site_btn_view_site">Afficher le site</string>
     <string name="my_site_btn_view_admin">Afficher l\'Admin</string>
     <string name="my_site_header_publish">Publier</string>
-    <string name="my_site_header_look_and_feel">Personnaliser</string>
+    <string name="my_site_header_design">Personnaliser</string>
     <string name="my_site_btn_site_settings">Réglages</string>
-    <string name="my_site_btn_blog_posts">Articles</string>
+    <string name="my_site_btn_posts">Articles</string>
     <string name="reader_label_new_posts_subtitle">Touchez pour les afficher</string>
-    <string name="my_site_header_configuration">Configuration</string>
+    <string name="my_site_header_manage">Configuration</string>
     <string name="select_all">Tout selectionner</string>
     <string name="hide">Cacher</string>
     <string name="show">Montrer</string>

--- a/WordPress/src/main/res/values-gd/strings.xml
+++ b/WordPress/src/main/res/values-gd/strings.xml
@@ -51,10 +51,10 @@ Language: gd_GB
     <string name="my_site_btn_view_site">Seall an làrach agam</string>
     <string name="site_picker_title">Tagh làrach</string>
     <string name="my_site_header_publish">Foillsich</string>
-    <string name="my_site_header_look_and_feel">Coltas</string>
+    <string name="my_site_header_design">Coltas</string>
     <string name="my_site_btn_site_settings">Roghainnean</string>
-    <string name="my_site_btn_blog_posts">Puist bloga</string>
-    <string name="my_site_header_configuration">Rèiteachadh</string>
+    <string name="my_site_btn_posts">Puist bloga</string>
+    <string name="my_site_header_manage">Rèiteachadh</string>
     <string name="reader_label_new_posts_subtitle">Thoir gnogag gus an sealltainn</string>
     <string name="select_all">Tagh na h-uile</string>
     <string name="hide">Falaich</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -563,11 +563,11 @@ Language: gl_ES
     <string name="my_site_btn_view_site">Ver o sitio</string>
     <string name="my_site_btn_view_admin">Ir ao Panel</string>
     <string name="my_site_header_publish">Publicar</string>
-    <string name="my_site_header_look_and_feel">Aparencia</string>
+    <string name="my_site_header_design">Aparencia</string>
     <string name="my_site_btn_site_settings">Configuración</string>
-    <string name="my_site_btn_blog_posts">Artigos do blogue</string>
+    <string name="my_site_btn_posts">Artigos do blogue</string>
     <string name="reader_label_new_posts_subtitle">Pulsa para velos</string>
-    <string name="my_site_header_configuration">Configuración</string>
+    <string name="my_site_header_manage">Configuración</string>
     <string name="select_all">Seleccionar todo</string>
     <string name="hide">Ocultar</string>
     <string name="show">Mostrar</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -911,7 +911,7 @@ Language: he_IL
     <string name="plugin_byline">מאת %s</string>
     <string name="change_photo">שינוי התמונה</string>
     <string name="plugin_fetch_error">לא ניתן לטעון את התוספים</string>
-    <string name="my_site_btn_site_pages">עמודי האתר</string>
+    <string name="my_site_btn_pages">עמודי האתר</string>
     <string name="site_settings_tags_hint">ניהול התגיות באתר שלך</string>
     <string name="dlg_saving_tag">שומר</string>
     <string name="dlg_deleting_tag">מוחק</string>
@@ -1699,11 +1699,11 @@ Language: he_IL
     <string name="my_site_btn_view_site">הצגת אתר</string>
     <string name="my_site_btn_view_admin">הצגת מנהל מערכת</string>
     <string name="my_site_header_publish">פרסום</string>
-    <string name="my_site_header_look_and_feel">סגנון</string>
+    <string name="my_site_header_design">סגנון</string>
     <string name="my_site_btn_site_settings">הגדרות</string>
-    <string name="my_site_btn_blog_posts">פוסטים בבלוג</string>
+    <string name="my_site_btn_posts">פוסטים בבלוג</string>
     <string name="reader_label_new_posts_subtitle">יש ללחוץ כדי להציג</string>
-    <string name="my_site_header_configuration">הגדרות תצורה</string>
+    <string name="my_site_header_manage">הגדרות תצורה</string>
     <string name="select_all">בחר הכל</string>
     <string name="hide">הסתר</string>
     <string name="show">הצג</string>

--- a/WordPress/src/main/res/values-hi/strings.xml
+++ b/WordPress/src/main/res/values-hi/strings.xml
@@ -174,7 +174,7 @@ Language: hi_IN
     <string name="my_site_btn_view_site">साईट पर जाये</string>
     <string name="my_site_btn_switch_site">साइट स्विच करे</string>
     <string name="my_site_header_publish">प्रकाशित</string>
-    <string name="my_site_btn_blog_posts">ब्लॉग पोस्ट्स</string>
+    <string name="my_site_btn_posts">ब्लॉग पोस्ट्स</string>
     <string name="my_site_btn_site_settings">सेटिंग्स</string>
     <string name="show">दिखाएँ</string>
     <string name="hide">छुपाएँ</string>

--- a/WordPress/src/main/res/values-hr/strings.xml
+++ b/WordPress/src/main/res/values-hr/strings.xml
@@ -212,9 +212,9 @@ Language: hr
     <string name="my_site_btn_switch_site">Promjeni web-stranicu</string>
     <string name="my_site_btn_site_settings">Postavke</string>
     <string name="my_site_header_publish">Objavi</string>
-    <string name="my_site_btn_blog_posts">Blog objave</string>
-    <string name="my_site_header_look_and_feel">Izgled i dojam</string>
-    <string name="my_site_header_configuration">Konfiguracija</string>
+    <string name="my_site_btn_posts">Blog objave</string>
+    <string name="my_site_header_design">Izgled i dojam</string>
+    <string name="my_site_header_manage">Konfiguracija</string>
     <string name="reader_label_new_posts_subtitle">Pritisni za prikaz</string>
     <string name="show">Prikaži</string>
     <string name="hide">Sakrij</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -887,7 +887,7 @@ Language: id
     <string name="plugin_installed">Terpasang</string>
     <string name="plugin_installed_version">Versi %s telah diinstal</string>
     <string name="plugin_fetch_error">Tidak dapat memuat plugin</string>
-    <string name="my_site_btn_site_pages">Halaman Situs</string>
+    <string name="my_site_btn_pages">Halaman Situs</string>
     <string name="site_settings_tags_hint">Kelola tag situs Anda</string>
     <string name="dlg_saving_tag">Menyimpan</string>
     <string name="dlg_deleting_tag">Menghapus</string>
@@ -1664,11 +1664,11 @@ Language: id
     <string name="my_site_btn_view_site">Tampilkan Situs</string>
     <string name="my_site_btn_view_admin">Tampilkan Admin</string>
     <string name="my_site_header_publish">Terbitkan</string>
-    <string name="my_site_header_look_and_feel">Tampilan dan Nuansa</string>
+    <string name="my_site_header_design">Tampilan dan Nuansa</string>
     <string name="my_site_btn_site_settings">Pengaturan</string>
-    <string name="my_site_btn_blog_posts">Pos Blog</string>
+    <string name="my_site_btn_posts">Pos Blog</string>
     <string name="reader_label_new_posts_subtitle">Ketuk untuk menampilkannya</string>
-    <string name="my_site_header_configuration">Konfigurasi</string>
+    <string name="my_site_header_manage">Konfigurasi</string>
     <string name="select_all">Pilih semua</string>
     <string name="hide">Sembunyikan</string>
     <string name="show">Tampilkan</string>

--- a/WordPress/src/main/res/values-is/strings.xml
+++ b/WordPress/src/main/res/values-is/strings.xml
@@ -438,11 +438,11 @@ Language: is
     <string name="my_site_btn_view_site">Skoða vef</string>
     <string name="my_site_btn_view_admin">Skoða stjórnborð</string>
     <string name="my_site_header_publish">Birta</string>
-    <string name="my_site_header_look_and_feel">Útlit og áferð</string>
+    <string name="my_site_header_design">Útlit og áferð</string>
     <string name="my_site_btn_site_settings">Stillingar</string>
-    <string name="my_site_btn_blog_posts">Færslur</string>
+    <string name="my_site_btn_posts">Færslur</string>
     <string name="reader_label_new_posts_subtitle">Ýttu til þess að birta þær</string>
-    <string name="my_site_header_configuration">Stillingar</string>
+    <string name="my_site_header_manage">Stillingar</string>
     <string name="select_all">Velja allar</string>
     <string name="hide">Hylja</string>
     <string name="show">Sýna</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -932,7 +932,7 @@ Language: it
     <string name="plugin_byline">di %s</string>
     <string name="change_photo">Cambia foto</string>
     <string name="plugin_fetch_error">Impossibile caricare i plugin</string>
-    <string name="my_site_btn_site_pages">Pagine</string>
+    <string name="my_site_btn_pages">Pagine</string>
     <string name="site_settings_tags_hint">Gestisci i tag del tuo sito</string>
     <string name="dlg_saving_tag">Salvataggio</string>
     <string name="dlg_deleting_tag">Cancellazione</string>
@@ -1727,11 +1727,11 @@ Language: it
     <string name="my_site_btn_view_site">Visualizza il sito</string>
     <string name="my_site_btn_view_admin">Visualizza l\'amministrazione</string>
     <string name="my_site_header_publish">Pubblica</string>
-    <string name="my_site_header_look_and_feel">Aspetto</string>
+    <string name="my_site_header_design">Aspetto</string>
     <string name="my_site_btn_site_settings">Impostazioni</string>
-    <string name="my_site_btn_blog_posts">Articoli</string>
+    <string name="my_site_btn_posts">Articoli</string>
     <string name="reader_label_new_posts_subtitle">Tocca per visualizzarli</string>
-    <string name="my_site_header_configuration">Configurazione</string>
+    <string name="my_site_header_manage">Configurazione</string>
     <string name="select_all">Seleziona tutto</string>
     <string name="hide">Nascondi</string>
     <string name="show">Mostra</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -928,7 +928,7 @@ Language: ja_JP
     <string name="plugin_byline">作成者: %s</string>
     <string name="change_photo">写真を変更</string>
     <string name="plugin_fetch_error">プラグインを読み込めませんでした</string>
-    <string name="my_site_btn_site_pages">サイトページ</string>
+    <string name="my_site_btn_pages">サイトページ</string>
     <string name="site_settings_tags_hint">サイトのタグを管理</string>
     <string name="dlg_saving_tag">保存中</string>
     <string name="dlg_deleting_tag">削除中</string>
@@ -1722,11 +1722,11 @@ Language: ja_JP
     <string name="my_site_btn_view_site">サイトを表示</string>
     <string name="my_site_btn_view_admin">管理画面表示</string>
     <string name="my_site_header_publish">公開</string>
-    <string name="my_site_header_look_and_feel">外観</string>
+    <string name="my_site_header_design">外観</string>
     <string name="my_site_btn_site_settings">設定</string>
-    <string name="my_site_btn_blog_posts">ブログ投稿</string>
+    <string name="my_site_btn_posts">ブログ投稿</string>
     <string name="reader_label_new_posts_subtitle">タップして表示</string>
-    <string name="my_site_header_configuration">設定</string>
+    <string name="my_site_header_manage">設定</string>
     <string name="select_all">すべて選択</string>
     <string name="hide">隠す</string>
     <string name="show">表示</string>

--- a/WordPress/src/main/res/values-kmr/strings.xml
+++ b/WordPress/src/main/res/values-kmr/strings.xml
@@ -871,7 +871,7 @@ Language: ku_TR
     <string name="plugin_byline">ji aliye %s</string>
     <string name="change_photo">Wêne biguherîne</string>
     <string name="plugin_fetch_error">Pêvek nehatin barkirin</string>
-    <string name="my_site_btn_site_pages">Rûpelên Malperê</string>
+    <string name="my_site_btn_pages">Rûpelên Malperê</string>
     <string name="site_settings_tags_hint">Etîketên malpera xwe bi rê ve bibe</string>
     <string name="dlg_saving_tag">Tê tomarkirin</string>
     <string name="dlg_deleting_tag">Tê jêbirin</string>
@@ -1666,11 +1666,11 @@ Language: ku_TR
     <string name="my_site_btn_view_site">Malperê Bîbîne</string>
     <string name="my_site_btn_view_admin">Revebir Bibîne</string>
     <string name="my_site_header_publish">Biweşîne</string>
-    <string name="my_site_header_look_and_feel">Xuyanî û Şêwaz</string>
+    <string name="my_site_header_design">Xuyanî û Şêwaz</string>
     <string name="my_site_btn_site_settings">Sazkarî</string>
-    <string name="my_site_btn_blog_posts">Şandiyên Blogê</string>
+    <string name="my_site_btn_posts">Şandiyên Blogê</string>
     <string name="reader_label_new_posts_subtitle">Bo nîşandanê bitepîne</string>
-    <string name="my_site_header_configuration">Pevsazî</string>
+    <string name="my_site_header_manage">Pevsazî</string>
     <string name="select_all">Teva bijêre</string>
     <string name="hide">Veşêre</string>
     <string name="show">Nîşan bide</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -933,7 +933,7 @@ Language: ko_KR
     <string name="plugin_byline">제작자: %s</string>
     <string name="change_photo">사진 변경</string>
     <string name="plugin_fetch_error">플러그인을 로드할 수 없음</string>
-    <string name="my_site_btn_site_pages">사이트 페이지</string>
+    <string name="my_site_btn_pages">사이트 페이지</string>
     <string name="site_settings_tags_hint">사이트의 태그 관리</string>
     <string name="dlg_saving_tag">저장 중</string>
     <string name="dlg_deleting_tag">삭제 중</string>
@@ -1728,11 +1728,11 @@ Language: ko_KR
     <string name="my_site_btn_view_site">사이트 보기</string>
     <string name="my_site_btn_view_admin">관리자 보기</string>
     <string name="my_site_header_publish">게시</string>
-    <string name="my_site_header_look_and_feel">모양과 느낌</string>
+    <string name="my_site_header_design">모양과 느낌</string>
     <string name="my_site_btn_site_settings">설정</string>
-    <string name="my_site_btn_blog_posts">블로그 글</string>
+    <string name="my_site_btn_posts">블로그 글</string>
     <string name="reader_label_new_posts_subtitle">눌러서 표시</string>
-    <string name="my_site_header_configuration">설정</string>
+    <string name="my_site_header_manage">설정</string>
     <string name="select_all">모두 선택</string>
     <string name="hide">숨기기</string>
     <string name="show">표시</string>

--- a/WordPress/src/main/res/values-ms/strings.xml
+++ b/WordPress/src/main/res/values-ms/strings.xml
@@ -725,11 +725,11 @@ Language: ms
     <string name="my_site_btn_view_site">Lihat Laman</string>
     <string name="my_site_btn_view_admin">Lihat Pentadbir</string>
     <string name="my_site_header_publish">Terbit</string>
-    <string name="my_site_header_look_and_feel">Rupa dan Bentuk</string>
+    <string name="my_site_header_design">Rupa dan Bentuk</string>
     <string name="my_site_btn_site_settings">Tetapan</string>
-    <string name="my_site_btn_blog_posts">Kiriman Blog</string>
+    <string name="my_site_btn_posts">Kiriman Blog</string>
     <string name="reader_label_new_posts_subtitle">Tap untuk menunjukkannya</string>
-    <string name="my_site_header_configuration">Konfigurasi</string>
+    <string name="my_site_header_manage">Konfigurasi</string>
     <string name="select_all">Pilih semua</string>
     <string name="hide">Sembunyi</string>
     <string name="show">Tunjuk</string>

--- a/WordPress/src/main/res/values-nb/strings.xml
+++ b/WordPress/src/main/res/values-nb/strings.xml
@@ -905,7 +905,7 @@ Language: nb_NO
     <string name="plugin_byline">av %s</string>
     <string name="change_photo">Endre bilde</string>
     <string name="plugin_fetch_error">Kan ikke laste utvidelser</string>
-    <string name="my_site_btn_site_pages">Sider på nettstedet</string>
+    <string name="my_site_btn_pages">Sider på nettstedet</string>
     <string name="site_settings_tags_hint">Behandle stikkord på nettstedet</string>
     <string name="dlg_saving_tag">Lagrer</string>
     <string name="dlg_deleting_tag">Sletter</string>
@@ -1696,11 +1696,11 @@ Language: nb_NO
     <string name="my_site_btn_view_site">Vis nettsted</string>
     <string name="my_site_btn_view_admin">Vis admin-området</string>
     <string name="my_site_header_publish">Publiser</string>
-    <string name="my_site_header_look_and_feel">Se og kjenn</string>
+    <string name="my_site_header_design">Se og kjenn</string>
     <string name="my_site_btn_site_settings">Innstillinger</string>
-    <string name="my_site_btn_blog_posts">Blogginnlegg</string>
+    <string name="my_site_btn_posts">Blogginnlegg</string>
     <string name="reader_label_new_posts_subtitle">Trykk for å vise dem</string>
-    <string name="my_site_header_configuration">Oppsett</string>
+    <string name="my_site_header_manage">Oppsett</string>
     <string name="select_all">Velg alle</string>
     <string name="hide">Skjul</string>
     <string name="show">Vis</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -805,7 +805,7 @@ Language: nl
     <string name="plugin_byline">door %s</string>
     <string name="change_photo">Wijzig foto</string>
     <string name="plugin_fetch_error">Niet mogelijk om plugins te laden</string>
-    <string name="my_site_btn_site_pages">Site pagina\'s</string>
+    <string name="my_site_btn_pages">Site pagina\'s</string>
     <string name="site_settings_tags_hint">Beheer de tags van je site</string>
     <string name="dlg_saving_tag">Opslaan</string>
     <string name="dlg_deleting_tag">Verwijderen</string>
@@ -1594,11 +1594,11 @@ Language: nl
     <string name="my_site_btn_view_site">Bekijk site</string>
     <string name="my_site_btn_view_admin">Beheer bekijken</string>
     <string name="my_site_header_publish">Publiceren</string>
-    <string name="my_site_header_look_and_feel">Look and feel</string>
+    <string name="my_site_header_design">Look and feel</string>
     <string name="my_site_btn_site_settings">Instellingen</string>
-    <string name="my_site_btn_blog_posts">Blogberichten</string>
+    <string name="my_site_btn_posts">Blogberichten</string>
     <string name="reader_label_new_posts_subtitle">Tik om ze te tonen</string>
-    <string name="my_site_header_configuration">Configuratie</string>
+    <string name="my_site_header_manage">Configuratie</string>
     <string name="select_all">Alles selecteren</string>
     <string name="hide">Verbergen</string>
     <string name="show">Tonen</string>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -933,7 +933,7 @@ Language: pl
     <string name="plugin_byline">przez %s</string>
     <string name="change_photo">Zmień zdjęcie</string>
     <string name="plugin_fetch_error">Nie można było wczytać wtyczek</string>
-    <string name="my_site_btn_site_pages">Strony witryny</string>
+    <string name="my_site_btn_pages">Strony witryny</string>
     <string name="site_settings_tags_hint">Zarządzaj tagami swojej witryny</string>
     <string name="dlg_saving_tag">Zapisywanie</string>
     <string name="dlg_deleting_tag">Usuwanie</string>
@@ -1728,11 +1728,11 @@ Language: pl
     <string name="my_site_btn_view_site">Zobacz witrynę</string>
     <string name="my_site_btn_view_admin">Przejdź do kokpitu</string>
     <string name="my_site_header_publish">Opublikuj</string>
-    <string name="my_site_header_look_and_feel">Wygląd</string>
+    <string name="my_site_header_design">Wygląd</string>
     <string name="my_site_btn_site_settings">Ustawienia</string>
-    <string name="my_site_btn_blog_posts">Wpisy na blogu</string>
+    <string name="my_site_btn_posts">Wpisy na blogu</string>
     <string name="reader_label_new_posts_subtitle">Stuknij aby je pokazać</string>
-    <string name="my_site_header_configuration">Konfiguracja</string>
+    <string name="my_site_header_manage">Konfiguracja</string>
     <string name="select_all">Wybierz wszystko</string>
     <string name="hide">Ukryj</string>
     <string name="show">Pokaż</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -933,7 +933,7 @@ Language: pt_BR
     <string name="plugin_byline">por %s</string>
     <string name="change_photo">Alterar foto</string>
     <string name="plugin_fetch_error">Não foi possível carregar os plugins</string>
-    <string name="my_site_btn_site_pages">Páginas do site</string>
+    <string name="my_site_btn_pages">Páginas do site</string>
     <string name="site_settings_tags_hint">Gerenciar as tags do seu site</string>
     <string name="dlg_saving_tag">Salvando</string>
     <string name="dlg_deleting_tag">Excluindo</string>
@@ -1728,11 +1728,11 @@ Language: pt_BR
     <string name="my_site_btn_view_site">Ver site</string>
     <string name="my_site_btn_view_admin">Ver Painel</string>
     <string name="my_site_header_publish">Publicar</string>
-    <string name="my_site_header_look_and_feel">Aparência</string>
+    <string name="my_site_header_design">Aparência</string>
     <string name="my_site_btn_site_settings">Configurações</string>
-    <string name="my_site_btn_blog_posts">Posts do blog</string>
+    <string name="my_site_btn_posts">Posts do blog</string>
     <string name="reader_label_new_posts_subtitle">Toque para mostrar</string>
-    <string name="my_site_header_configuration">Configuração</string>
+    <string name="my_site_header_manage">Configuração</string>
     <string name="select_all">Selecionar todos</string>
     <string name="hide">Esconder</string>
     <string name="show">Mostrar</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -933,7 +933,7 @@ Language: ro
     <string name="plugin_byline">de %s</string>
     <string name="change_photo">Schimbă fotografia</string>
     <string name="plugin_fetch_error">Nu pot încărca module</string>
-    <string name="my_site_btn_site_pages">Pagini sit</string>
+    <string name="my_site_btn_pages">Pagini sit</string>
     <string name="site_settings_tags_hint">Administrează-ți etichetele sitului</string>
     <string name="dlg_saving_tag">Salvez</string>
     <string name="dlg_deleting_tag">Șterg</string>
@@ -1728,11 +1728,11 @@ Language: ro
     <string name="my_site_btn_view_site">Vezi sit</string>
     <string name="my_site_btn_view_admin">Vezi administrator</string>
     <string name="my_site_header_publish">Publicare</string>
-    <string name="my_site_header_look_and_feel">Aspect și afect</string>
+    <string name="my_site_header_design">Aspect și afect</string>
     <string name="my_site_btn_site_settings">Setări</string>
-    <string name="my_site_btn_blog_posts">Articole blog</string>
+    <string name="my_site_btn_posts">Articole blog</string>
     <string name="reader_label_new_posts_subtitle">Atinge pentru a le arăta</string>
-    <string name="my_site_header_configuration">Configurare</string>
+    <string name="my_site_header_manage">Configurare</string>
     <string name="select_all">Selectează tot</string>
     <string name="hide">Ascunde</string>
     <string name="show">Arată</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -933,7 +933,7 @@ Language: ru
     <string name="plugin_byline">от автора %s</string>
     <string name="change_photo">Изменить фото</string>
     <string name="plugin_fetch_error">Невозможно загрузить  плагины</string>
-    <string name="my_site_btn_site_pages">Страницы сайта</string>
+    <string name="my_site_btn_pages">Страницы сайта</string>
     <string name="site_settings_tags_hint">Управлять метками сайта</string>
     <string name="dlg_saving_tag">Сохранение</string>
     <string name="dlg_deleting_tag">Удаление</string>
@@ -1728,11 +1728,11 @@ Language: ru
     <string name="my_site_btn_view_site">Просмотреть веб-сайт</string>
     <string name="my_site_btn_view_admin">Перейти в консоль сайта</string>
     <string name="my_site_header_publish">Публикация</string>
-    <string name="my_site_header_look_and_feel">Внешний вид</string>
+    <string name="my_site_header_design">Внешний вид</string>
     <string name="my_site_btn_site_settings">Настройки</string>
-    <string name="my_site_btn_blog_posts">Записи в блоге</string>
+    <string name="my_site_btn_posts">Записи в блоге</string>
     <string name="reader_label_new_posts_subtitle">Нажмите, чтобы показать записи.</string>
-    <string name="my_site_header_configuration">Конфигурация</string>
+    <string name="my_site_header_manage">Конфигурация</string>
     <string name="select_all">Выделить все</string>
     <string name="hide">Скрыть</string>
     <string name="show">Показать</string>

--- a/WordPress/src/main/res/values-sk/strings.xml
+++ b/WordPress/src/main/res/values-sk/strings.xml
@@ -568,7 +568,7 @@ Language: sk
     <string name="plugin_byline">od %s</string>
     <string name="change_photo">Zmeňte fotku</string>
     <string name="plugin_fetch_error">Nepodarilo sa načítať pluginy</string>
-    <string name="my_site_btn_site_pages">Stránky webovej stránky</string>
+    <string name="my_site_btn_pages">Stránky webovej stránky</string>
     <string name="site_settings_tags_hint">Spravujte značky vašej webovej stránky</string>
     <string name="dlg_saving_tag">Ukladanie</string>
     <string name="dlg_deleting_tag">Mazanie</string>
@@ -1359,11 +1359,11 @@ Language: sk
     <string name="my_site_btn_view_site">Zobraziť webovú stránku</string>
     <string name="my_site_btn_view_admin">Zobraziť administráciu</string>
     <string name="my_site_header_publish">Zverejniť</string>
-    <string name="my_site_header_look_and_feel">Vzhľad</string>
+    <string name="my_site_header_design">Vzhľad</string>
     <string name="my_site_btn_site_settings">Nastavenia</string>
-    <string name="my_site_btn_blog_posts">Články blogu</string>
+    <string name="my_site_btn_posts">Články blogu</string>
     <string name="reader_label_new_posts_subtitle">Ťuknite k ich zobrazeniu</string>
-    <string name="my_site_header_configuration">Kanfigurácia</string>
+    <string name="my_site_header_manage">Kanfigurácia</string>
     <string name="select_all">Vybrať všetky</string>
     <string name="hide">Skryť</string>
     <string name="show">Zobraziť</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -931,7 +931,7 @@ Language: sq_AL
     <string name="plugin_byline">nga %s</string>
     <string name="change_photo">Ndryshoni foton</string>
     <string name="plugin_fetch_error">S’arrihet të ngarkohe shtojca</string>
-    <string name="my_site_btn_site_pages">Faqe Sajti</string>
+    <string name="my_site_btn_pages">Faqe Sajti</string>
     <string name="site_settings_tags_hint">Administroni etiketat e sajtit tuaj</string>
     <string name="dlg_saving_tag">Po ruhet</string>
     <string name="dlg_deleting_tag">Po fshihet</string>
@@ -1726,11 +1726,11 @@ Language: sq_AL
     <string name="my_site_btn_view_site">Shihni Sajtin</string>
     <string name="my_site_btn_view_admin">Shihni Përgjegjësin</string>
     <string name="my_site_header_publish">Botoje</string>
-    <string name="my_site_header_look_and_feel">Pamja dhe Ndjesitë</string>
+    <string name="my_site_header_design">Pamja dhe Ndjesitë</string>
     <string name="my_site_btn_site_settings">Rregullime</string>
-    <string name="my_site_btn_blog_posts">Postime Blogu</string>
+    <string name="my_site_btn_posts">Postime Blogu</string>
     <string name="reader_label_new_posts_subtitle">Prekeni që të shfaqen</string>
-    <string name="my_site_header_configuration">Formësim</string>
+    <string name="my_site_header_manage">Formësim</string>
     <string name="select_all">Përzgjidhe krejt</string>
     <string name="hide">Fshihe</string>
     <string name="show">Shfaqe</string>

--- a/WordPress/src/main/res/values-sr/strings.xml
+++ b/WordPress/src/main/res/values-sr/strings.xml
@@ -52,11 +52,11 @@ Language: sr_RS
     <string name="my_site_btn_view_site">Види веб место</string>
     <string name="site_picker_title">Одабери веб место</string>
     <string name="my_site_btn_view_admin">Види управљање</string>
-    <string name="my_site_header_look_and_feel">Изглед и осећај</string>
+    <string name="my_site_header_design">Изглед и осећај</string>
     <string name="my_site_header_publish">Објави</string>
-    <string name="my_site_btn_blog_posts">Чланци блога</string>
+    <string name="my_site_btn_posts">Чланци блога</string>
     <string name="my_site_btn_site_settings">Подешавања</string>
-    <string name="my_site_header_configuration">Поставка</string>
+    <string name="my_site_header_manage">Поставка</string>
     <string name="reader_label_new_posts_subtitle">Притисните да бисте их показали</string>
     <string name="deselect_all">Одбаци све</string>
     <string name="hide">Сакриј</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -933,7 +933,7 @@ Language: sv_SE
     <string name="plugin_byline">av %s</string>
     <string name="change_photo">Byt foto</string>
     <string name="plugin_fetch_error">Kan inte läsa in tillägg</string>
-    <string name="my_site_btn_site_pages">Webbplatssidor</string>
+    <string name="my_site_btn_pages">Webbplatssidor</string>
     <string name="site_settings_tags_hint">Hantera etiketterna för din webbplats</string>
     <string name="dlg_saving_tag">Sparar</string>
     <string name="dlg_deleting_tag">Raderar</string>
@@ -1728,11 +1728,11 @@ Language: sv_SE
     <string name="my_site_btn_view_site">Visa webbplats</string>
     <string name="my_site_btn_view_admin">Visa admin</string>
     <string name="my_site_header_publish">Publicera</string>
-    <string name="my_site_header_look_and_feel">Utseende och känsla</string>
+    <string name="my_site_header_design">Utseende och känsla</string>
     <string name="my_site_btn_site_settings">Inställningar </string>
-    <string name="my_site_btn_blog_posts">Blogginlägg</string>
+    <string name="my_site_btn_posts">Blogginlägg</string>
     <string name="reader_label_new_posts_subtitle">Knacka för att visa dem</string>
-    <string name="my_site_header_configuration">Konfiguration</string>
+    <string name="my_site_header_manage">Konfiguration</string>
     <string name="select_all">Välj alla</string>
     <string name="hide">Dölj</string>
     <string name="show">Visa</string>

--- a/WordPress/src/main/res/values-th/strings.xml
+++ b/WordPress/src/main/res/values-th/strings.xml
@@ -166,11 +166,11 @@ Language: th
     <string name="my_site_btn_view_site">ดูเว็บไซต์</string>
     <string name="my_site_btn_view_admin">ดูผู้ควบคุม</string>
     <string name="my_site_header_publish">เผยแพร่</string>
-    <string name="my_site_header_look_and_feel">หน้าตาและสัมผัส (Look and Feel)</string>
+    <string name="my_site_header_design">หน้าตาและสัมผัส (Look and Feel)</string>
     <string name="my_site_btn_site_settings">ตั้งค่า</string>
-    <string name="my_site_btn_blog_posts">เรื่องบล็อก</string>
+    <string name="my_site_btn_posts">เรื่องบล็อก</string>
     <string name="reader_label_new_posts_subtitle">แตะเพื่อแสดงมัน</string>
-    <string name="my_site_header_configuration">การปรับแต่ง</string>
+    <string name="my_site_header_manage">การปรับแต่ง</string>
     <string name="select_all">เลือกทั้งหมด</string>
     <string name="hide">ซ่อน</string>
     <string name="show">แสดง</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -933,7 +933,7 @@ Language: tr
     <string name="plugin_byline">%s tarafından</string>
     <string name="change_photo">Fotoğrafı değiştir</string>
     <string name="plugin_fetch_error">Eklentiler yüklenemedi</string>
-    <string name="my_site_btn_site_pages">Site sayfaları</string>
+    <string name="my_site_btn_pages">Site sayfaları</string>
     <string name="site_settings_tags_hint">Sitenizin etiketlerini yönetin</string>
     <string name="dlg_saving_tag">Kaydediliyor</string>
     <string name="dlg_deleting_tag">Siliniyor</string>
@@ -1728,11 +1728,11 @@ Language: tr
     <string name="my_site_btn_view_site">Siteyi göster</string>
     <string name="my_site_btn_view_admin">Yöneticiyi görüntüle</string>
     <string name="my_site_header_publish">Yayımla</string>
-    <string name="my_site_header_look_and_feel">Genel görünüm</string>
+    <string name="my_site_header_design">Genel görünüm</string>
     <string name="my_site_btn_site_settings">Ayarlar</string>
-    <string name="my_site_btn_blog_posts">Blog yazıları</string>
+    <string name="my_site_btn_posts">Blog yazıları</string>
     <string name="reader_label_new_posts_subtitle">Göstermek için dokunun</string>
-    <string name="my_site_header_configuration">Yapılandırma</string>
+    <string name="my_site_header_manage">Yapılandırma</string>
     <string name="select_all">Tümünü seç</string>
     <string name="hide">Gizle</string>
     <string name="show">Göster</string>

--- a/WordPress/src/main/res/values-vi/strings.xml
+++ b/WordPress/src/main/res/values-vi/strings.xml
@@ -377,11 +377,11 @@ Language: vi_VN
     <string name="my_site_btn_view_site">Xem Site</string>
     <string name="my_site_btn_view_admin">Xem Admin</string>
     <string name="my_site_header_publish">Xuất bản</string>
-    <string name="my_site_header_look_and_feel">Nhìn và Cảm nhận</string>
+    <string name="my_site_header_design">Nhìn và Cảm nhận</string>
     <string name="my_site_btn_site_settings">Thiết đặt</string>
-    <string name="my_site_btn_blog_posts">Bài viết Blog</string>
+    <string name="my_site_btn_posts">Bài viết Blog</string>
     <string name="reader_label_new_posts_subtitle">Chạm để hiện chúng</string>
-    <string name="my_site_header_configuration">Cấu hình</string>
+    <string name="my_site_header_manage">Cấu hình</string>
     <string name="select_all">Chọn tất cả</string>
     <string name="hide">Ẩn</string>
     <string name="show">Hiện</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -858,7 +858,7 @@ Language: zh_CN
     <string name="plugin_version">版本 %s</string>
     <string name="plugin_byline">作者：%s</string>
     <string name="change_photo">更改照片</string>
-    <string name="my_site_btn_site_pages">站点页面</string>
+    <string name="my_site_btn_pages">站点页面</string>
     <string name="site_settings_tags_hint">管理站点标签</string>
     <string name="dlg_saving_tag">正在保存</string>
     <string name="dlg_deleting_tag">正在删除</string>
@@ -1640,11 +1640,11 @@ Language: zh_CN
     <string name="my_site_btn_view_site">查看站点</string>
     <string name="my_site_btn_view_admin">查看管理员</string>
     <string name="my_site_header_publish">发布</string>
-    <string name="my_site_header_look_and_feel">外观</string>
+    <string name="my_site_header_design">外观</string>
     <string name="my_site_btn_site_settings">设置</string>
-    <string name="my_site_btn_blog_posts">博客文章</string>
+    <string name="my_site_btn_posts">博客文章</string>
     <string name="reader_label_new_posts_subtitle">轻点以显示文章</string>
-    <string name="my_site_header_configuration">配置</string>
+    <string name="my_site_header_manage">配置</string>
     <string name="select_all">选择全部</string>
     <string name="hide">隐藏</string>
     <string name="show">显示</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -905,7 +905,7 @@ Language: zh_TW
     <string name="plugin_byline">由 %s 提供</string>
     <string name="change_photo">變更照片</string>
     <string name="plugin_fetch_error">無法載入外掛程式</string>
-    <string name="my_site_btn_site_pages">網站頁面</string>
+    <string name="my_site_btn_pages">網站頁面</string>
     <string name="site_settings_tags_hint">管理你的網站標籤</string>
     <string name="dlg_saving_tag">儲存中</string>
     <string name="dlg_deleting_tag">正在刪除</string>
@@ -1682,11 +1682,11 @@ Language: zh_TW
     <string name="my_site_btn_view_site">檢視網站</string>
     <string name="my_site_btn_view_admin">檢視管理員</string>
     <string name="my_site_header_publish">發表</string>
-    <string name="my_site_header_look_and_feel">外觀和風格</string>
+    <string name="my_site_header_design">外觀和風格</string>
     <string name="my_site_btn_site_settings">設定</string>
-    <string name="my_site_btn_blog_posts">網誌文章</string>
+    <string name="my_site_btn_posts">網誌文章</string>
     <string name="reader_label_new_posts_subtitle">點選以顯示</string>
-    <string name="my_site_header_configuration">組態</string>
+    <string name="my_site_header_manage">組態</string>
     <string name="select_all">全部選取</string>
     <string name="hide">隱藏</string>
     <string name="show">顯示</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -905,7 +905,7 @@ Language: zh_TW
     <string name="plugin_byline">由 %s 提供</string>
     <string name="change_photo">變更照片</string>
     <string name="plugin_fetch_error">無法載入外掛程式</string>
-    <string name="my_site_btn_site_pages">網站頁面</string>
+    <string name="my_site_btn_pages">網站頁面</string>
     <string name="site_settings_tags_hint">管理你的網站標籤</string>
     <string name="dlg_saving_tag">儲存中</string>
     <string name="dlg_deleting_tag">正在刪除</string>
@@ -1682,11 +1682,11 @@ Language: zh_TW
     <string name="my_site_btn_view_site">檢視網站</string>
     <string name="my_site_btn_view_admin">檢視管理員</string>
     <string name="my_site_header_publish">發表</string>
-    <string name="my_site_header_look_and_feel">外觀和風格</string>
+    <string name="my_site_header_design">外觀和風格</string>
     <string name="my_site_btn_site_settings">設定</string>
-    <string name="my_site_btn_blog_posts">網誌文章</string>
+    <string name="my_site_btn_posts">網誌文章</string>
     <string name="reader_label_new_posts_subtitle">點選以顯示</string>
-    <string name="my_site_header_configuration">組態</string>
+    <string name="my_site_header_manage">組態</string>
     <string name="select_all">全部選取</string>
     <string name="hide">隱藏</string>
     <string name="show">顯示</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1742,11 +1742,11 @@
 
     <!--My Site-->
     <string name="my_site_header_external">External</string>
-    <string name="my_site_header_configuration">Configuration</string>
-    <string name="my_site_header_look_and_feel">Look and Feel</string>
-    <string name="my_site_header_publish">Publish</string>
-    <string name="my_site_btn_site_pages">Site Pages</string>
-    <string name="my_site_btn_blog_posts">Blog Posts</string>
+    <string name="my_site_header_manage">Manage</string>
+    <string name="my_site_header_design">Design</string>
+    <string name="my_site_header_publish">Site</string>
+    <string name="my_site_btn_pages">Pages</string>
+    <string name="my_site_btn_posts">Posts</string>
     <string name="my_site_btn_sharing">Sharing</string>
     <string name="my_site_btn_site_settings">Settings</string>
     <string name="my_site_btn_comments" translatable="false">@string/comments</string>


### PR DESCRIPTION
Fixes #10658 

To test:
1. Open My Site,
2. Check that the menus now show "Site", "Pages", "Posts", "Design", and "Manage", like on the  screenshot below:

![Screen Shot 2019-11-07 at 18 54 09](https://user-images.githubusercontent.com/266376/68387698-7b600f00-0191-11ea-81f6-f0ca8ccf6811.png)


PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

