### PR TITLE
[WIP] Accessibility : Reader Settings Improvements

### DIFF
--- a/WordPress/src/main/res/layout/reader_activity_subs.xml
+++ b/WordPress/src/main/res/layout/reader_activity_subs.xml
@@ -54,10 +54,10 @@
         <EditText
             android:textSize="@dimen/text_sz_medium"
             android:textAlignment="viewStart"
-            android:gravity="start"
             android:id="@+id/edit_add"
             style="@style/ReaderEditText.Topic"
             android:layout_width="0dp"
+            android:minHeight="@dimen/min_touch_target_sz"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:hint="@string/reader_hint_add_tag_or_url" />
@@ -67,8 +67,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:background="?android:selectableItemBackground"
-            android:padding="@dimen/margin_small"
             android:contentDescription="@string/add"
+            android:minHeight="@dimen/min_touch_target_sz"
+            android:minWidth="@dimen/min_touch_target_sz"
             android:src="@drawable/ic_reader_follow_white_24dp"
             android:tint="@color/primary_40" />
 

--- a/WordPress/src/main/res/layout/reader_listitem_tag.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_tag.xml
@@ -32,6 +32,8 @@
         android:id="@+id/btn_remove"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:minHeight="@dimen/min_touch_target_sz"
+        android:minWidth="@dimen/min_touch_target_sz"
         android:layout_gravity="center_vertical"
         android:background="?android:selectableItemBackground"
         android:padding="@dimen/margin_small"

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -62,7 +62,7 @@
     <!-- EditTexts -->
     <style name="ReaderEditText" parent="android:Widget.EditText">
         <item name="android:textSize">@dimen/text_sz_large</item>
-        <item name="android:textColorHint">@color/neutral_40</item>
+        <item name="android:textColorHint">@color/neutral_50</item>
     </style>
     <style name="ReaderEditText.Topic" parent="ReaderEditText">
         <item name="android:background">@android:color/transparent</item>


### PR DESCRIPTION
Fixes #10731 

**Work in progress. Don't merge.** 

Below are the improvements that were made on the reader settings.

###### Accessibility Scanner Audit


#### To Test

To verify this works all these improvements were made you can simply run the Accessibility Scanner on the screen and the issues below won't be shown. Another means of verification is simply running the app to see the changes are shown below. 

<img src="https://user-images.githubusercontent.com/1509205/68079747-d5389180-fdab-11e9-9c2e-879189447169.png" width="400" alt="settings" />	
	
- [x] Remove Button `org.wordpress.android:id/btn_remove` - Touch target
	
	This item's size is 32dp x 32dp. Consider making this touch target 48dp wide and 48dp high or larger.
	
- [x] Add URL or Tag EditText org.wordpress.android:id/edit_add - Touch target

	This item's height is 38dp. Consider making the height of this touch target 48dp or larger.
	
- [x] Add Button org.wordpress.android:id/btn_add - Touch target

	This item's size is 32dp x 32dp. Consider making this touch target 48dp wide and 48dp high or larger.
	
- [x] Add URL or Tag EditText `org.wordpress.android:id/edit_add` - Text contrast

	The item's text contrast ratio is 4.20. This ratio is based on an estimated foreground color of `#787C82` and an estimated background color of `#FFFFFF`. Consider using a contrast ratio greater than 4.50 for small text, or 3.00 for large text.
		
### Contains tabs: 
 
### Followed Sites Tab
    	
###### Talkback Audit 

#### To Test

Enable TalkBack and put the app in the states described below. 
    	
* Search  
<img src="https://user-images.githubusercontent.com/1509205/68091812-5b4ee980-fe39-11e9-8bca-e893b2ff0d21.png" alt="Screenshot_20191102-200643" width="400" />

- [x] Search input doesn't tell when no results have been returned. Return results after waiting for at least 4 - 5 seconds to ensure query was properly entered. 	
	
- [ ] When search returns results the user won't know if results are actually present. The app should announce that two items actually exist. (It actually announces this the first time the user selects an item in the list.)


PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

