### PR TITLE
Zendesk: Fix ticket language id for "he", "id", "yi".

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -37,7 +37,6 @@ import zendesk.support.UiConfig
 import zendesk.support.guide.HelpCenterActivity
 import zendesk.support.request.RequestActivity
 import zendesk.support.requestlist.RequestListActivity
-import java.util.Locale
 import java.util.Timer
 import kotlin.concurrent.schedule
 

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.support
 import android.content.Context
 import android.net.ConnectivityManager
 import android.telephony.TelephonyManager
-import android.util.Log
 import androidx.preference.PreferenceManager
 import com.zendesk.logger.Logger
 import com.zendesk.service.ErrorResponse

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.support
 import android.content.Context
 import android.net.ConnectivityManager
 import android.telephony.TelephonyManager
+import android.util.Log
 import androidx.preference.PreferenceManager
 import com.zendesk.logger.Logger
 import com.zendesk.service.ErrorResponse
@@ -21,6 +22,7 @@ import org.wordpress.android.util.currentLocale
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.DeviceUtils
+import org.wordpress.android.util.LanguageUtils
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.PackageUtils
 import org.wordpress.android.util.SiteUtils
@@ -365,6 +367,7 @@ private fun buildZendeskCustomFields(
     } else {
         "not_selected"
     }
+
     return listOf(
             CustomField(TicketFieldIds.appVersion, PackageUtils.getVersionName(context)),
             CustomField(TicketFieldIds.blogList, getCombinedLogInformationOfSites(allSites)),
@@ -372,7 +375,7 @@ private fun buildZendeskCustomFields(
             CustomField(TicketFieldIds.deviceFreeSpace, DeviceUtils.getTotalAvailableMemorySize()),
             CustomField(TicketFieldIds.logs, AppLog.toPlainText(context)),
             CustomField(TicketFieldIds.networkInformation, getNetworkInformation(context)),
-            CustomField(TicketFieldIds.appLanguage, Locale.getDefault().language),
+            CustomField(TicketFieldIds.appLanguage, LanguageUtils.getPatchedCurrentDeviceLanguage(context)),
             CustomField(TicketFieldIds.sourcePlatform, ZendeskConstants.sourcePlatform)
     )
 }


### PR DESCRIPTION
Fixes #10742

To test:

Ideally this should be tested by filling the actual contact form using the app while set to use Indonesian language, then see if it gets tagged properly with "id" instead of "in" inside Zendesk. However, I haven't figured out how to set up the Zendesk auth setting properly to allow actual contact submission in my emulator, so I am not able to test it that way so far. Still trying to find more info about it.

I can confirm thru logging that the `LanguageUtils.getPatchedCurrentDeviceLanguage(context))`  function call will then output `id` properly instead of `in`, though. 


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

