### PR TITLE
Fix navigation bar color in webviews

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -151,7 +151,8 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
         if (VERSION.SDK_INT >= VERSION_CODES.M) {
             Window window = getWindow();
             window.setStatusBarColor(getColor(R.color.white));
-            window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+            window.getDecorView().setSystemUiVisibility(
+                    window.getDecorView().getSystemUiVisibility() | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
         }
     }
 


### PR DESCRIPTION
Fixes Navigation Bar Buttons color on api >=27.


![nav-bar](https://user-images.githubusercontent.com/2261188/68577840-2530eb80-0471-11ea-9bb5-4187544deb7c.jpg)

To test - Api 27 < should still look the same. Api >= 27 should have light Navigation Bar + grey navigation bar buttons.
1. My Site
2. View your site
3. Notice the color of the navigation bar + the navigation bar buttons.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


cc @jkmassel I'm targeting 13.6 since this bug was found during the freeze. I'll leave the final decision whether we want to include it in 13.6 or 13.7 to you.
