### PR TITLE
Fix issues in upload service

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -975,7 +975,7 @@ public class UploadService extends Service {
         for (PostModel postModel : mUploadStore.getAllRegisteredPosts()) {
             if (PostUtils.isPostCurrentlyBeingEdited(postModel)) {
                 // don't touch a Post that is being currently open in the Editor.
-                break;
+                continue;
             }
 
             if (!UploadService.hasPendingOrInProgressMediaUploadsForPost(postModel)) {
@@ -1002,7 +1002,8 @@ public class UploadService extends Service {
                                 new PostEvents.PostUploadCanceled(postModel));
                     } else {
                         // Do not re-enqueue a post that has already failed
-                        if (isError != null && isError && mUploadStore.isFailedPost(post)) {
+                        if (post.getId() == updatedPost.getId() && isError != null && isError && mUploadStore
+                                .isFailedPost(post)) {
                             continue;
                         }
                         // TODO Should do some extra validation here

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -1002,7 +1002,7 @@ public class UploadService extends Service {
                                 new PostEvents.PostUploadCanceled(postModel));
                     } else {
                         // Do not re-enqueue a post that has already failed
-                        if (post.getId() == updatedPost.getId() && isError != null && isError && mUploadStore
+                        if (isError != null && isError && post.getId() == updatedPost.getId() && mUploadStore
                                 .isFailedPost(post)) {
                             continue;
                         }


### PR DESCRIPTION
I noticed two "obvious" issues in the UploadService while browsing the code. I don't have any steps for reproducing a bug, but I thought we should better fix them.

Fix 1 -> we had `break` instead of `continue` when we encountered a post which is currently being edited while iterating over all registered posts. I believe we want to skip just the post which is being edited not all the remaining posts.
Fix 2 -> We don't want to re-enqueue a post which has already failed. However, we were skipping all registered posts if the `post` passed as parameter has failed. I've added a check that the post we are about to skip is actually the post that has failed.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

