### PR TITLE
Refresh data on site change

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSect
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.MONTHS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.WEEKS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.YEARS
+import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider.SiteUpdateResult
 import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.widgets.WPSnackbar
@@ -138,8 +139,13 @@ class StatsFragment : DaggerFragment() {
             )
         })
 
-        viewModel.siteChanged.observe(this, Observer {
-            viewModel.onSiteChanged()
+        viewModel.siteChanged.observe(this, Observer { siteChangedEvent ->
+            siteChangedEvent?.applyIfNotHandled {
+                when(this) {
+                    is SiteUpdateResult.SiteConnected -> viewModel.onSiteChanged()
+                    is SiteUpdateResult.NotConnectedJetpackSite -> getActivity()?.finish()
+                }
+            }
         })
 
         viewModel.hideToolbar.observe(this, Observer { event ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -141,7 +141,7 @@ class StatsFragment : DaggerFragment() {
 
         viewModel.siteChanged.observe(this, Observer { siteChangedEvent ->
             siteChangedEvent?.applyIfNotHandled {
-                when(this) {
+                when (this) {
                     is SiteUpdateResult.SiteConnected -> viewModel.onSiteChanged()
                     is SiteUpdateResult.NotConnectedJetpackSite -> getActivity()?.finish()
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -175,7 +175,9 @@ class StatsViewModel
 
     fun onSiteChanged() {
         loadData {
-            listUseCases.values.forEach { it.onSiteChanged() }
+            listUseCases.values.forEach {
+                it.refreshData(true)
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -33,7 +33,6 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSect
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.MONTHS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.WEEKS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.YEARS
-import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseParam
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.utils.NewsCardHandler
 import org.wordpress.android.ui.stats.refresh.utils.SelectedSectionManager
@@ -176,7 +175,7 @@ class StatsViewModel
 
     fun onSiteChanged() {
         loadData {
-            listUseCases.values.forEach { it.onParamChanged(UseCaseParam.Site) }
+            listUseCases.values.forEach { it.onSiteChanged() }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
@@ -84,14 +84,6 @@ class BaseListUseCase(
         loadData(true, forced)
     }
 
-    suspend fun onSiteChanged() {
-        if (this.statsTypes.value.isNullOrEmpty()) {
-            refreshTypes()
-        } else {
-            onParamChanged(UseCaseParam.Site)
-        }
-    }
-
     private suspend fun onParamChanged(param: UseCaseParam) {
         statsTypes.value?.forEach { type ->
             useCases.find { it.type == type }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
@@ -84,7 +84,15 @@ class BaseListUseCase(
         loadData(true, forced)
     }
 
-    suspend fun onParamChanged(param: UseCaseParam) {
+    suspend fun onSiteChanged() {
+        if (this.statsTypes.value.isNullOrEmpty()) {
+            refreshTypes()
+        } else {
+            onParamChanged(UseCaseParam.Site)
+        }
+    }
+
+    private suspend fun onParamChanged(param: UseCaseParam) {
         statsTypes.value?.forEach { type ->
             useCases.find { it.type == type }
                     ?.let { block ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -148,33 +148,31 @@ class StatsListFragment : DaggerFragment() {
 
     private fun setupObservers(activity: FragmentActivity) {
         viewModel.uiModel.observe(this, Observer {
-            if (it != null) {
-                when (it) {
-                    is UiModel.Success -> {
-                        updateInsights(it.data)
+            when (it) {
+                is UiModel.Success -> {
+                    updateInsights(it.data)
+                }
+                is UiModel.Error, null -> {
+                    recyclerView.visibility = View.GONE
+                    statsErrorView.visibility = View.VISIBLE
+                    statsEmptyView.visibility = View.GONE
+                }
+                is UiModel.Empty -> {
+                    recyclerView.visibility = View.GONE
+                    statsEmptyView.visibility = View.VISIBLE
+                    statsErrorView.visibility = View.GONE
+                    statsEmptyView.title.setText(it.title)
+                    if (it.subtitle != null) {
+                        statsEmptyView.subtitle.setText(it.subtitle)
+                    } else {
+                        statsEmptyView.subtitle.text = ""
                     }
-                    is UiModel.Error -> {
-                        recyclerView.visibility = View.GONE
-                        statsErrorView.visibility = View.VISIBLE
-                        statsEmptyView.visibility = View.GONE
+                    if (it.image != null) {
+                        statsEmptyView.image.setImageResource(it.image)
+                    } else {
+                        statsEmptyView.image.setImageDrawable(null)
                     }
-                    is UiModel.Empty -> {
-                        recyclerView.visibility = View.GONE
-                        statsEmptyView.visibility = View.VISIBLE
-                        statsErrorView.visibility = View.GONE
-                        statsEmptyView.title.setText(it.title)
-                        if (it.subtitle != null) {
-                            statsEmptyView.subtitle.setText(it.subtitle)
-                        } else {
-                            statsEmptyView.subtitle.text = ""
-                        }
-                        if (it.image != null) {
-                            statsEmptyView.image.setImageResource(it.image)
-                        } else {
-                            statsEmptyView.image.setImageDrawable(null)
-                        }
-                        statsEmptyView.button.setVisible(it.showButton)
-                    }
+                    statsEmptyView.button.setVisible(it.showButton)
                 }
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
@@ -34,7 +34,7 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
     private val mainDispatcher: CoroutineDispatcher,
     private val backgroundDispatcher: CoroutineDispatcher,
     private val defaultUiState: UI_STATE,
-    private val fetchParams: List<UseCaseParam> = listOf(UseCaseParam.Site),
+    private val fetchParams: List<UseCaseParam> = listOf(),
     private val uiUpdateParams: List<UseCaseParam> = listOf()
 ) : CoroutineScope {
     override val coroutineContext: CoroutineContext
@@ -250,7 +250,7 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
         type: StatsType,
         mainDispatcher: CoroutineDispatcher,
         backgroundDispatcher: CoroutineDispatcher,
-        inputParams: List<UseCaseParam> = listOf(UseCaseParam.Site)
+        inputParams: List<UseCaseParam> = listOf()
     ) : BaseStatsUseCase<DOMAIN_MODEL, NotUsedUiState>(
             type,
             mainDispatcher,
@@ -281,7 +281,6 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
     }
 
     sealed class UseCaseParam {
-        object Site : UseCaseParam()
         data class SelectedDateParam(val statsSection: StatsSection) : UseCaseParam()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/GranularStatefulUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/GranularStatefulUseCase.kt
@@ -24,7 +24,7 @@ abstract class GranularStatefulUseCase<DOMAIN_MODEL, UI_STATE>(
         mainDispatcher,
         backgroundDispatcher,
         defaultUiState,
-        listOf(UseCaseParam.Site, UseCaseParam.SelectedDateParam(statsGranularity.toStatsSection()))
+        listOf(UseCaseParam.SelectedDateParam(statsGranularity.toStatsSection()))
 ) {
     abstract suspend fun loadCachedData(selectedDate: Date, site: SiteModel): DOMAIN_MODEL?
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/GranularStatelessUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/GranularStatelessUseCase.kt
@@ -22,7 +22,7 @@ abstract class GranularStatelessUseCase<DOMAIN_MODEL>(
         type,
         mainDispatcher,
         backgroundDispatcher,
-        listOf(UseCaseParam.Site, UseCaseParam.SelectedDateParam(statsGranularity.toStatsSection()))
+        listOf(UseCaseParam.SelectedDateParam(statsGranularity.toStatsSection()))
 ) {
     abstract suspend fun loadCachedData(selectedDate: Date, site: SiteModel): DOMAIN_MODEL?
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsSiteProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsSiteProvider.kt
@@ -87,7 +87,7 @@ class StatsSiteProvider
     }
 
     sealed class SiteUpdateResult {
-        object NotConnectedJetpackSite: SiteUpdateResult()
-        data class SiteConnected(val siteId: Long): SiteUpdateResult()
+        object NotConnectedJetpackSite : SiteUpdateResult()
+        data class SiteConnected(val siteId: Long) : SiteUpdateResult()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsSiteProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsSiteProvider.kt
@@ -5,10 +5,13 @@ import androidx.lifecycle.MutableLiveData
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.ui.prefs.AppPrefs
+import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider.SiteUpdateResult.NotConnectedJetpackSite
+import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider.SiteUpdateResult.SiteConnected
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -18,13 +21,15 @@ class StatsSiteProvider
 @Inject constructor(
     private val siteStore: SiteStore,
     private val selectedSite: SelectedSiteStorage,
-    dispatcher: Dispatcher
+    private val dispatcher: Dispatcher
 ) {
     var siteModel = SiteModel()
         private set
 
-    private val mutableSiteChanged = MutableLiveData<Event<Int>>()
-    val siteChanged: LiveData<Event<Int>> = mutableSiteChanged
+    private val mutableSiteChanged = MutableLiveData<Event<SiteUpdateResult>>()
+    val siteChanged: LiveData<Event<SiteUpdateResult>> = mutableSiteChanged
+    private val maxAttempts = 3
+    private var counter = 0
 
     init {
         reset()
@@ -36,9 +41,6 @@ class StatsSiteProvider
             val siteChanged = localSiteId != siteModel.id
             siteStore.getSiteByLocalId(localSiteId)?.let { site ->
                 siteModel = site
-            }
-            if (siteChanged) {
-                mutableSiteChanged.postValue(Event(localSiteId))
             }
             return siteChanged
         }
@@ -63,13 +65,29 @@ class StatsSiteProvider
             return
         }
         siteStore.getSiteByLocalId(siteModel.id)?.let { site ->
-            siteModel = site
-            mutableSiteChanged.value = Event(siteModel.id)
+            if (site.siteId != 0L) {
+                counter = 0
+                siteModel = site
+                mutableSiteChanged.value = Event(SiteConnected(site.siteId))
+            } else {
+                if (counter < maxAttempts) {
+                    dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(site))
+                    counter++
+                } else {
+                    counter = 0
+                    mutableSiteChanged.value = Event(NotConnectedJetpackSite)
+                }
+            }
         }
     }
 
     class SelectedSiteStorage {
         val currentLocalSiteId
             get() = AppPrefs.getSelectedSite()
+    }
+
+    sealed class SiteUpdateResult {
+        object NotConnectedJetpackSite: SiteUpdateResult()
+        data class SiteConnected(val siteId: Long): SiteUpdateResult()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsSiteProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsSiteProvider.kt
@@ -71,8 +71,8 @@ class StatsSiteProvider
                 mutableSiteChanged.value = Event(SiteConnected(site.siteId))
             } else {
                 if (counter < maxAttempts) {
-                    dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(site))
                     counter++
+                    dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(site))
                 } else {
                     counter = 0
                     mutableSiteChanged.value = Event(NotConnectedJetpackSite)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_PERIOD_WEEKS_
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_PERIOD_YEARS_ACCESSED
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.test
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DAYS
@@ -121,5 +122,12 @@ class StatsViewModelTest : BaseUnitTest() {
         _liveSelectedSection.value = DAYS
 
         assertThat(toolbarHasShadow).isFalse()
+    }
+
+    @Test
+    fun `propagates site change event to base list use case`() = test {
+        viewModel.onSiteChanged()
+
+        verify(baseListUseCase).refreshData(true)
     }
 }


### PR DESCRIPTION
Fixes #10767

When the Jetpack is installed and the user goes back to the stats screen, the app has to wait for the site to be loaded. Once the site is loaded, we were triggering the `onParamsChange` method which reloads all the cards. The problem was that without any site we couldn't load the card types (the types are related to the site) and we had no cards to reload. This PR fixes this issue. After the site is loaded we do a full stats refresh now. 
We no longer need the `UseCaseParam.Site` because instead of just updating the use cases we do a full refresh.

To test:
* Login with a self-hosted site without Jetpack
* Click on Stats
* Go through the Jetpack install/connect process
* Notice you're redirected back to the stats when the process is done
* The app shows either stats being loaded

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

