### PR TITLE
Fix for crash in Context cast

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/image/getters/WPCustomImageGetter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/getters/WPCustomImageGetter.kt
@@ -35,7 +35,7 @@ class WPCustomImageGetter(
     @Inject lateinit var imageManager: ImageManager
 
     init {
-        (WordPress.getContext() as WordPress).component().inject(this)
+        (WordPress.getContext().applicationContext as WordPress).component().inject(this)
         clear(textView)
         // store the WPCustomImageGetter into the textView's tag, so we can cancel any pending/ongoing requests when the
         // TextView is reused.


### PR DESCRIPTION
Fixes #10776 

When changing the app's language, the `Context` kept and returned by `WordPress.getContext()`  is no longer a `WordPress` instance but rather it's superclass instance (Context).

```
    /**
     * Update locale of the static context when language is changed.
     */
    public static void updateContextLocale() {
        mContext = LocaleManager.setLocale(mContext);
    }

```

I've checked to make sure there were no other places where we were calling `WordPress.getContext()` assuming we'd be able to cast to `Application`, and didn't find anything weird.

Checked other similar places and this is what I could find:

**MediaGridAdapter.java:**
`        ((WordPress) WordPress.getContext().getApplicationContext()).component().inject(this);
`

**MediaUploadHandler.java**
`        ((WordPress) WordPress.getContext().getApplicationContext()).component().inject(this);
`

**PostUploadHandler.java**
`        ((WordPress) WordPress.getContext().getApplicationContext()).component().inject(this);
`

**WpWebViewClient.java**
`        ((WordPress) WordPress.getContext().getApplicationContext()).component().inject(this);
`

**WPCustomImageGetter.kt (this one is the failing one)**
`        (WordPress.getContext() as WordPress).component().inject(this)
`

The last one is the only place where it crashes, and seems to me like a problem of getting the `Context` (but _not_ the `ApplicationContext`)  then casting it `as WordPress`.

This issue was probably a glitch from translating Java to Kotlin I guess? Given what was happening is that we were trying to cast  `Context` to `WordPress` (which is an `Application`).

This PR fixes this assumption by making the explicit call to `applicationContext`, and fixes the issue.

To test:

0. you'll need to have a comment notification with at least one image in your Notifications tab. For this, you could have someone else make a comment on a Post you're an author of, on a Blog you're an admin of, adding an image within the comment.
1. open the app
2. go to Me -> App Settings
3. Change language
4. Go to Notifications
5. try to open a Notification that shows an image in it (such as a comment where you were mentioned that has an embedded image)
6. the app shouldn't crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

