### PR TITLE
Add @username suggestions to notification and reader full comment view.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -13,6 +13,7 @@ import org.wordpress.android.push.GCMMessageService;
 import org.wordpress.android.push.GCMRegistrationIntentService;
 import org.wordpress.android.push.NotificationsProcessingService;
 import org.wordpress.android.ui.AddQuickPressShortcutActivity;
+import org.wordpress.android.ui.CommentFullScreenDialogFragment;
 import org.wordpress.android.ui.DeepLinkingIntentReceiverActivity;
 import org.wordpress.android.ui.JetpackConnectionResultActivity;
 import org.wordpress.android.ui.JetpackRemoteInstallFragment;
@@ -235,6 +236,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(HelpActivity object);
 
     void inject(CommentDetailFragment object);
+
+    void inject(CommentFullScreenDialogFragment object);
 
     void inject(EditCommentActivity object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -322,7 +322,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
                             mEditReply.getText().toString(),
                             mEditReply.getSelectionStart(),
                             mEditReply.getSelectionEnd(),
-                            mSite
+                            mSite.getSiteId()
                                                        );
 
                     new Builder(requireContext())

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -321,7 +321,8 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
                     Bundle bundle = Companion.newBundle(
                             mEditReply.getText().toString(),
                             mEditReply.getSelectionStart(),
-                            mEditReply.getSelectionEnd()
+                            mEditReply.getSelectionEnd(),
+                            mSite
                                                        );
 
                     new Builder(requireContext())

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -42,6 +42,8 @@ import org.wordpress.android.datasets.ReaderCommentTable;
 import org.wordpress.android.datasets.ReaderPostTable;
 import org.wordpress.android.datasets.SuggestionTable;
 import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.models.ReaderComment;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.Suggestion;
@@ -117,7 +119,9 @@ public class ReaderCommentListActivity extends AppCompatActivity {
     private long mCommentId;
     private int mRestorePosition;
     private String mInterceptedUri;
+    private SiteModel mSite;
 
+    @Inject SiteStore mSiteStore;
     @Inject AccountStore mAccountStore;
     @Inject ViewModelProvider.Factory mViewModelFactory;
     private ReaderCommentListViewModel mViewModel;
@@ -256,6 +260,8 @@ public class ReaderCommentListActivity extends AppCompatActivity {
 
         AnalyticsUtils.trackWithReaderPostDetails(AnalyticsTracker.Stat.READER_ARTICLE_COMMENTS_OPENED, mPost);
 
+        mSite = mSiteStore.getSiteBySiteId(mBlogId);
+
         ImageView buttonExpand = findViewById(R.id.button_expand);
         buttonExpand.setOnClickListener(
             new OnClickListener() {
@@ -264,7 +270,8 @@ public class ReaderCommentListActivity extends AppCompatActivity {
                     Bundle bundle = CommentFullScreenDialogFragment.Companion
                             .newBundle(mEditComment.getText().toString(),
                                     mEditComment.getSelectionStart(),
-                                    mEditComment.getSelectionEnd());
+                                    mEditComment.getSelectionEnd(),
+                                    mSite);
 
                     new Builder(ReaderCommentListActivity.this)
                         .setTitle(R.string.comment)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -271,7 +271,8 @@ public class ReaderCommentListActivity extends AppCompatActivity {
                             .newBundle(mEditComment.getText().toString(),
                                     mEditComment.getSelectionStart(),
                                     mEditComment.getSelectionEnd(),
-                                    mSite);
+                                    mBlogId
+                            );
 
                     new Builder(ReaderCommentListActivity.this)
                         .setTitle(R.string.comment)

--- a/WordPress/src/main/res/layout/comment_dialog_fragment.xml
+++ b/WordPress/src/main/res/layout/comment_dialog_fragment.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <ScrollView
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:clipChildren="false"
     android:clipToPadding="false"
@@ -8,20 +9,33 @@
     android:layout_height="match_parent"
     android:layout_width="match_parent"
     android:padding="@dimen/margin_extra_large"
-    android:scrollbarStyle="outsideOverlay" >
+    android:scrollbarStyle="outsideOverlay">
 
-    <org.wordpress.android.widgets.SuggestionAutoCompleteText
-        android:id="@+id/edit_comment_expand"
-        android:background="@android:color/transparent"
-        android:gravity="start|top"
-        android:hint="@string/reader_hint_comment_on_post"
-        android:imeOptions="actionSend"
-        android:inputType="text|textCapSentences|textMultiLine"
-        android:layout_height="wrap_content"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:orientation="vertical"
         android:layout_width="match_parent"
-        android:textAlignment="viewStart"
-        android:textColorHint="@color/neutral_40"
-        android:textSize="@dimen/text_sz_large" >
-    </org.wordpress.android.widgets.SuggestionAutoCompleteText>
+        android:layout_height="wrap_content">
 
+        <org.wordpress.android.widgets.SuggestionAutoCompleteText
+            android:id="@+id/edit_comment_expand"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:gravity="start|top"
+            android:hint="@string/reader_hint_comment_on_post"
+            android:imeOptions="actionSend"
+            android:inputType="text|textCapSentences|textMultiLine"
+            android:textAlignment="viewStart"
+            android:textColorHint="@color/neutral_40"
+            android:textSize="@dimen/text_sz_large"
+            app:layout_constraintTop_toTopOf="parent"
+            android:dropDownAnchor="@+id/dummy_hidden_view" />
+
+        <View
+            android:id="@+id/dummy_hidden_view"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@android:color/transparent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>


### PR DESCRIPTION
Fixes #10328 

To test:

### On notification area
1. Go to Notifications tab.
2. Select Comments tab.
3. Find a comment to a site of yours that's on WordPress.com, tap it.
4. Tap Reply field.
5. Enter @ followed by username of site user or the commenter, assuming they're WordPress.com accounts.
6. Notice username suggestions are shown (this is already working prior to this PR, but just to check).
7. Delete text from Reply field.
8. Tap Expand action in Reply field.
9. Enter @ followed by username of site user or the commenter, assuming they're WordPress.com accounts. 
10. Notice username suggestions are now shown.

### On reader area
1. Go to Reader tab.
2. Find a WordPress.com site post, probably easiest if it's your own test site.
3. Tap the comment icon on that post.
4. Tap Reply field.
5. Enter @ followed by username of site user or the commenter, assuming they're WordPress.com accounts.
6. Notice username suggestions are shown (this is already working prior to this PR, but just to check).
7. Delete text from Reply field.
8. Tap Expand action in Reply field.
9. Enter @ followed by username of site user or the commenter, assuming they're WordPress.com accounts. 
10. Notice username suggestions are now shown.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

@shiki Question about that last checkbox above, is this change something that warrants being added to RELEASE-NOTES.txt?
