### PR TITLE
IA reader nav: adding tabs filtering

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -67,6 +67,7 @@ android {
         testInstrumentationRunner 'org.wordpress.android.WordPressTestRunner'
 
         buildConfigField "boolean", "OFFER_GUTENBERG", "true"
+        buildConfigField "boolean", "INFORMATION_ARCHITECTURE_AVAILABLE", "false"
     }
 
     // Gutenberg's dependency - react-native-video is using
@@ -86,7 +87,6 @@ android {
                 versionName "13.6-rc-1"
             }
             versionCode 790
-            buildConfigField "boolean", "INFORMATION_ARCHITECTURE_AVAILABLE", "false"
         }
 
         zalpha { // alpha version - enable experimental features
@@ -99,7 +99,6 @@ android {
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
             applicationId "org.wordpress.android.beta"
             dimension "buildType"
-            buildConfigField "boolean", "INFORMATION_ARCHITECTURE_AVAILABLE", "false"
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredPagerAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredPagerAdapter.kt
@@ -1,0 +1,82 @@
+package org.wordpress.android.ui
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager.widget.PagerAdapter
+import org.wordpress.android.models.FilterCriteria
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+
+class FilteredPagerAdapter(
+    private val mRecyclerView: RecyclerView,
+    private var mFilterCriteria: List<FilterCriteria>
+) : PagerAdapter() {
+    fun datasetChanged(filterCriteriaOptions: List<FilterCriteria>): Boolean {
+        var isChanged = false
+
+        if (mFilterCriteria.size != filterCriteriaOptions.size) {
+            isChanged = true
+        } else {
+            for (index in mFilterCriteria.indices) {
+                if (mFilterCriteria[index] != filterCriteriaOptions[index]) {
+                    isChanged = true
+                    break
+                }
+            }
+        }
+
+        return isChanged
+    }
+
+    fun updateFilters(filterCriteriaOptions: List<FilterCriteria>) {
+            mFilterCriteria = filterCriteriaOptions
+            notifyDataSetChanged()
+    }
+
+    fun getFilterAtPosition(position: Int): FilterCriteria {
+        return mFilterCriteria[position]
+    }
+
+    override fun getItemPosition(`object`: Any): Int {
+        mFilterCriteria?.let {
+            for (i in mFilterCriteria.indices) {
+                val criteria = mFilterCriteria[i]
+                if (criteria != null && criteria == `object`) {
+                    return i
+                }
+            }
+        }
+        return -1
+    }
+
+    override fun getCount(): Int {
+        return mFilterCriteria.size
+    }
+
+    override fun isViewFromObject(view: View, `object`: Any): Boolean {
+        return view === `object`
+    }
+
+    override fun getPageTitle(position: Int): CharSequence? {
+        return mFilterCriteria!![position].label
+    }
+
+    override fun instantiateItem(container: ViewGroup, position: Int): Any {
+        if (mRecyclerView != null && mRecyclerView.parent !== container) {
+            container.addView(mRecyclerView)
+        } else {
+            AppLog.d(
+                    T.READER,
+                    "FilteredPagerAdapter - Calling instantiateItem at $position without adding the view."
+            )
+        }
+
+        // Return the page
+        return mRecyclerView
+    }
+
+    override fun destroyItem(container: ViewGroup, position: Int, `object`: Any) {
+        container.removeView(`object` as View)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -24,7 +24,6 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.core.view.ViewCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 import androidx.viewpager.widget.ViewPager.OnPageChangeListener;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -307,7 +307,10 @@ public class FilteredRecyclerView extends RelativeLayout {
                     }
                 });
             } else {
-                mFilteredPagerAdapter.updateFiltersIfNeeded(mFilterCriteriaOptions);
+                if (mFilteredPagerAdapter.datasetChanged(mFilterCriteriaOptions)) {
+                    mSelectingRememberedFilterOnCreate = true;
+                    mFilteredPagerAdapter.updateFilters(mFilterCriteriaOptions);
+                }
             }
         } else {
             mSpinnerAdapter = new SpinnerAdapter(getContext(),
@@ -606,95 +609,6 @@ public class FilteredRecyclerView extends RelativeLayout {
 
         View child = mRecyclerView.getLayoutManager().getChildAt(0);
         return (child != null && mRecyclerView.getLayoutManager().getPosition(child) == 0);
-    }
-
-    class FilteredPagerAdapter extends PagerAdapter {
-        private RecyclerView mRecyclerView;
-        private List<FilterCriteria> mFilterCriteria;
-
-        FilteredPagerAdapter(RecyclerView recyclerView, List<FilterCriteria> filterCriteria) {
-            mRecyclerView = recyclerView;
-            mFilterCriteria = filterCriteria;
-        }
-
-
-        private boolean datasetChanged(List<FilterCriteria> filterCriteriaOptions) {
-            boolean isChanged = false;
-
-            if (mFilterCriteria.size() != filterCriteriaOptions.size()) {
-                isChanged = true;
-            } else {
-                for (int index = 0; index < mFilterCriteria.size(); index++) {
-                    if (!mFilterCriteria.get(index).equals(filterCriteriaOptions.get(index))) {
-                        isChanged = true;
-                        break;
-                    }
-                }
-            }
-
-            return isChanged;
-        }
-
-        public void updateFiltersIfNeeded(List<FilterCriteria> filterCriteriaOptions) {
-            if (datasetChanged(filterCriteriaOptions)) {
-                mFilterCriteria = filterCriteriaOptions;
-                mSelectingRememberedFilterOnCreate = true;
-                notifyDataSetChanged();
-            }
-        }
-
-        public FilterCriteria getFilterAtPosition(int position) {
-            return mFilterCriteria.get(position);
-        }
-
-        @Override
-        public int getItemPosition(@NonNull Object object) {
-            if (mFilterCriteria != null) {
-                for (int i = 0; i < mFilterCriteria.size(); i++) {
-                    FilterCriteria criteria = mFilterCriteria.get(i);
-                    if (criteria != null && criteria.equals(object)) {
-                        return i;
-                    }
-                }
-            }
-            return -1;
-        }
-
-        @Override
-        public int getCount() {
-            return mFilterCriteria.size();
-        }
-
-        @Override
-        public boolean isViewFromObject(@NonNull View view, @NonNull Object object) {
-            return view == object;
-        }
-
-        @Override
-        @Nullable
-        public CharSequence getPageTitle(int position) {
-            return mFilterCriteria.get(position).getLabel();
-        }
-
-        @Override
-        public Object instantiateItem(@NonNull ViewGroup container, int position) {
-            if (mRecyclerView != null && mRecyclerView.getParent() != container) {
-                container.addView(mRecyclerView);
-            } else {
-                AppLog.d(
-                        mTAG,
-                        "FilteredPagerAdapter - Calling instantiateItem at " + position + " without adding the view."
-                );
-            }
-
-            // Return the page
-            return mRecyclerView;
-        }
-
-        @Override
-        public void destroyItem(@NonNull ViewGroup container, int position, Object object) {
-            container.removeView((View) object);
-        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -647,8 +647,9 @@ public class FilteredRecyclerView extends RelativeLayout {
             return mFilterCriteria.get(position);
         }
 
-        @Override public int getItemPosition(@NonNull Object object) {
-            if (object != null && mFilterCriteria != null) {
+        @Override
+        public int getItemPosition(@NonNull Object object) {
+            if (mFilterCriteria != null) {
                 for (int i = 0; i < mFilterCriteria.size(); i++) {
                     FilterCriteria criteria = mFilterCriteria.get(i);
                     if (criteria != null && criteria.equals(object)) {
@@ -659,15 +660,19 @@ public class FilteredRecyclerView extends RelativeLayout {
             return -1;
         }
 
-        @Override public int getCount() {
+        @Override
+        public int getCount() {
             return mFilterCriteria.size();
         }
 
-        @Override public boolean isViewFromObject(@NonNull View view, @NonNull Object object) {
+        @Override
+        public boolean isViewFromObject(@NonNull View view, @NonNull Object object) {
             return view == object;
         }
 
-        @Nullable @Override public CharSequence getPageTitle(int position) {
+        @Override
+        @Nullable
+        public CharSequence getPageTitle(int position) {
             return mFilterCriteria.get(position).getLabel();
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -19,13 +19,19 @@ import androidx.annotation.LayoutRes;
 import androidx.annotation.MenuRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.view.ViewCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.viewpager.widget.PagerAdapter;
+import androidx.viewpager.widget.ViewPager;
+import androidx.viewpager.widget.ViewPager.OnPageChangeListener;
 
 import com.google.android.material.appbar.AppBarLayout;
+import com.google.android.material.tabs.TabLayout;
 
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.models.FilterCriteria;
 import org.wordpress.android.util.AppLog;
@@ -46,6 +52,11 @@ public class FilteredRecyclerView extends RelativeLayout {
     private SwipeToRefreshHelper mSwipeToRefreshHelper;
     private Spinner mSpinner;
     private boolean mSelectingRememberedFilterOnCreate = false;
+
+    private TabLayout mTabLayout;
+    private ViewPager mViewPager;
+    private FilteredPagerAdapter mFilteredPagerAdapter;
+    private boolean mUseTabsForFiltering = false;
 
     private RecyclerView mRecyclerView;
     private TextView mEmptyView;
@@ -89,9 +100,17 @@ public class FilteredRecyclerView extends RelativeLayout {
 
     public void setCurrentFilter(FilterCriteria filter) {
         mCurrentFilter = filter;
-        int position = mSpinnerAdapter.getIndexOfCriteria(filter);
-        if (position > -1 && position != mSpinner.getSelectedItemPosition()) {
-            mSpinner.setSelection(position);
+
+        if (mUseTabsForFiltering) {
+            int position = mFilteredPagerAdapter.getItemPosition(filter);
+            if (position > -1 && position != mViewPager.getCurrentItem()) {
+                mViewPager.setCurrentItem(position, false);
+            }
+        } else {
+            int position = mSpinnerAdapter.getIndexOfCriteria(filter);
+            if (position > -1 && position != mSpinner.getSelectedItemPosition()) {
+                mSpinner.setSelection(position);
+            }
         }
     }
 
@@ -139,6 +158,13 @@ public class FilteredRecyclerView extends RelativeLayout {
                 mSpinnerItemView = a.getResourceId(R.styleable.FilteredRecyclerView_wpSpinnerItemView, 0);
                 mSpinnerDropDownItemView = a.getResourceId(
                         R.styleable.FilteredRecyclerView_wpSpinnerDropDownItemView, 0);
+
+                mUseTabsForFiltering = a.getBoolean(
+                        R.styleable.FilteredRecyclerView_wpUseTabsForFiltering, false);
+
+                // TODO: once the feature flag is removed delete this row and use the
+                // app:wpUseTabsForFiltering="true|false" in reader_fragment_post_cards.xml
+                if (!BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) mUseTabsForFiltering = false;
             } finally {
                 a.recycle();
             }
@@ -192,6 +218,19 @@ public class FilteredRecyclerView extends RelativeLayout {
         if (mSpinner == null) {
             mSpinner = findViewById(R.id.filter_spinner);
         }
+
+        mViewPager = findViewById(R.id.pager);
+        mTabLayout = findViewById(R.id.tab_layout);
+
+        if (mUseTabsForFiltering) {
+            mViewPager.setVisibility(View.VISIBLE);
+            mTabLayout.setVisibility(View.VISIBLE);
+            mSpinner.setVisibility(View.GONE);
+        } else {
+            mViewPager.setVisibility(View.GONE);
+            mTabLayout.setVisibility(View.GONE);
+            mSpinner.setVisibility(View.VISIBLE);
+        }
     }
 
     private void setup(boolean refresh) {
@@ -206,54 +245,82 @@ public class FilteredRecyclerView extends RelativeLayout {
                     if (criteriaList != null) {
                         mFilterCriteriaOptions = new ArrayList<>();
                         mFilterCriteriaOptions.addAll(criteriaList);
-                        initSpinnerAdapter();
+                        initFilterAdapter();
                         setCurrentFilter(mFilterListener.onRecallSelection());
                     }
                 }
             }, refresh);
         } else {
-            initSpinnerAdapter();
+            initFilterAdapter();
             setCurrentFilter(mFilterListener.onRecallSelection());
         }
     }
 
-    private void initSpinnerAdapter() {
-        mSpinnerAdapter = new SpinnerAdapter(getContext(),
-                mFilterCriteriaOptions, mSpinnerItemView, mSpinnerDropDownItemView);
+    private void manageFilterSelection(int position) {
+        if (mSelectingRememberedFilterOnCreate) {
+            mSelectingRememberedFilterOnCreate = false;
+            return;
+        }
 
-        mSelectingRememberedFilterOnCreate = true;
-        mSpinner.setAdapter(mSpinnerAdapter);
-        mSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                if (mSelectingRememberedFilterOnCreate) {
-                    mSelectingRememberedFilterOnCreate = false;
-                    return;
+        FilterCriteria selectedCriteria;
+        if (mUseTabsForFiltering) {
+            selectedCriteria = mFilteredPagerAdapter.getFilterAtPosition(position);
+        } else {
+            selectedCriteria = (FilterCriteria) mSpinnerAdapter.getItem(position);
+        }
+
+        if (mCurrentFilter == selectedCriteria) {
+            AppLog.d(mTAG, "The selected STATUS is already active: "
+                           + selectedCriteria.getLabel());
+            return;
+        }
+
+        AppLog.d(mTAG, "NEW STATUS : " + selectedCriteria.getLabel());
+        setCurrentFilter(selectedCriteria);
+        if (mFilterListener != null) {
+            mFilterListener.onFilterSelected(position, selectedCriteria);
+            setRefreshing(true);
+            mFilterListener.onLoadData(false);
+        }
+    }
+
+    private void initFilterAdapter() {
+        if (mUseTabsForFiltering) {
+            mFilteredPagerAdapter = new FilteredPagerAdapter(getContext(), mRecyclerView, mFilterCriteriaOptions);
+
+            mSelectingRememberedFilterOnCreate = true;
+
+            mViewPager.setAdapter(mFilteredPagerAdapter);
+            mTabLayout.setupWithViewPager(mViewPager);
+            mViewPager.addOnPageChangeListener(new OnPageChangeListener() {
+                @Override public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
                 }
 
-                FilterCriteria selectedCriteria =
-                        (FilterCriteria) mSpinnerAdapter.getItem(position);
-
-                if (mCurrentFilter == selectedCriteria) {
-                    AppLog.d(mTAG, "The selected STATUS is already active: "
-                            + selectedCriteria.getLabel());
-                    return;
+                @Override public void onPageSelected(int position) {
+                    manageFilterSelection(position);
                 }
 
-                AppLog.d(mTAG, "NEW STATUS : " + selectedCriteria.getLabel());
-                setCurrentFilter(selectedCriteria);
-                if (mFilterListener != null) {
-                    mFilterListener.onFilterSelected(position, selectedCriteria);
-                    setRefreshing(true);
-                    mFilterListener.onLoadData(false);
+                @Override public void onPageScrollStateChanged(int state) {
                 }
-            }
+            });
+        } else {
+            mSpinnerAdapter = new SpinnerAdapter(getContext(),
+                    mFilterCriteriaOptions, mSpinnerItemView, mSpinnerDropDownItemView);
 
-            @Override
-            public void onNothingSelected(AdapterView<?> parent) {
-                // nop
-            }
-        });
+            mSelectingRememberedFilterOnCreate = true;
+            mSpinner.setAdapter(mSpinnerAdapter);
+            mSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+                @Override
+                public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                    manageFilterSelection(position);
+                }
+
+                @Override
+                public void onNothingSelected(AdapterView<?> parent) {
+                    // nop
+                }
+            });
+        }
     }
 
     private boolean hasAdapter() {
@@ -316,6 +383,10 @@ public class FilteredRecyclerView extends RelativeLayout {
         return mToolbar.getMenu();
     }
 
+    public void setTabLayoutVisibility(boolean mustShow) {
+        mTabLayout.setVisibility((mustShow && mUseTabsForFiltering) ? View.VISIBLE : View.GONE);
+    }
+
     public void setToolbarBackgroundColor(int color) {
         mToolbar.setBackgroundColor(color);
     }
@@ -341,6 +412,11 @@ public class FilteredRecyclerView extends RelativeLayout {
     public void setToolbarLeftAndRightPadding(int paddingLeft, int paddingRight) {
         ViewCompat.setPaddingRelative(mToolbar, paddingLeft, mToolbar.getPaddingTop(), paddingRight,
                                       mToolbar.getPaddingBottom());
+    }
+
+    public void setToolbarTitle(@StringRes int title, int startMargin) {
+        mToolbar.setTitle(title);
+        mToolbar.setTitleMarginStart(startMargin);
     }
 
     public void setToolbarScrollFlags(int flags) {
@@ -526,6 +602,66 @@ public class FilteredRecyclerView extends RelativeLayout {
         return (child != null && mRecyclerView.getLayoutManager().getPosition(child) == 0);
     }
 
+    class FilteredPagerAdapter extends PagerAdapter {
+        Context mContext;
+        RecyclerView mRecyclerView;
+        List<FilterCriteria> mFilterCriteria;
+
+        FilteredPagerAdapter(Context context, RecyclerView recyclerView, List<FilterCriteria> filterCriteria) {
+            mContext = context;
+            mRecyclerView = recyclerView;
+            mFilterCriteria = filterCriteria;
+        }
+
+
+        public FilterCriteria getFilterAtPosition(int position) {
+            return mFilterCriteria.get(position);
+        }
+
+        @Override public int getItemPosition(@NonNull Object object) {
+            if (object != null && mFilterCriteria != null) {
+                for (int i = 0; i < mFilterCriteria.size(); i++) {
+                    FilterCriteria criteria = mFilterCriteria.get(i);
+                    if (criteria != null && criteria.equals(object)) {
+                        return i;
+                    }
+                }
+            }
+            return -1;
+        }
+
+        @Override public int getCount() {
+            return mFilterCriteria.size();
+        }
+
+        @Override public boolean isViewFromObject(@NonNull View view, @NonNull Object object) {
+            return view == object;
+        }
+
+        @Nullable @Override public CharSequence getPageTitle(int position) {
+            return mFilterCriteria.get(position).getLabel();
+        }
+
+        @Override
+        public Object instantiateItem(@NonNull ViewGroup container, int position) {
+            if (mRecyclerView != null && mRecyclerView.getParent() != container) {
+                container.addView(mRecyclerView);
+            } else {
+                AppLog.d(
+                        mTAG,
+                        "FilteredPagerAdapter - Calling instantiateItem at " + position + " without adding the view."
+                );
+            }
+
+            // Return the page
+            return mRecyclerView;
+        }
+
+        @Override
+        public void destroyItem(@NonNull ViewGroup container, int position, Object object) {
+            container.removeView((View) object);
+        }
+    }
 
     /**
      * implement this interface to use FilterRecyclerView

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -104,7 +104,7 @@ public class FilteredRecyclerView extends RelativeLayout {
         if (mUseTabsForFiltering) {
             int position = mFilteredPagerAdapter.getItemPosition(filter);
             if (position > -1 && position != mViewPager.getCurrentItem()) {
-                mViewPager.setCurrentItem(position, false);
+                mViewPager.setCurrentItem(position);
             }
         } else {
             int position = mSpinnerAdapter.getIndexOfCriteria(filter);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -183,7 +183,7 @@ public class WPMainActivity extends AppCompatActivity implements
     @Inject QuickStartStore mQuickStartStore;
     @Inject UploadActionUseCase mUploadActionUseCase;
     @Inject SystemNotificationsTracker mSystemNotificationsTracker;
-	@Inject ViewModelProvider.Factory mViewModelFactory;
+    @Inject ViewModelProvider.Factory mViewModelFactory;
 
     /*
      * fragments implement this if their contents can be scrolled, called when user

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -354,7 +354,7 @@ class WPMainNavigationView @JvmOverloads constructor(
         private fun createFragment(position: Int): Fragment? {
             val fragment: Fragment = when (pages().getOrNull(position)) {
                 MY_SITE -> MySiteFragment.newInstance()
-                READER -> ReaderPostListFragment.newInstance()
+                READER -> ReaderPostListFragment.newInstance(true)
                 ME -> MeFragment.newInstance()
                 NOTIFS -> NotificationsListFragment.newInstance()
                 else -> return null

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -47,6 +47,7 @@ public class ReaderConstants {
     static final String ARG_IS_RELATED_POST = "is_related_post";
     static final String ARG_SEARCH_QUERY = "search_query";
     static final String ARG_VIDEO_URL = "video_url";
+    static final String ARG_IS_MAIN_READER = "is_main_reader";
 
     static final String KEY_POST_SLUGS_RESOLUTION_UNDERWAY = "post_slugs_resolution_underway";
     static final String KEY_ALREADY_UPDATED = "already_updated";

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -47,7 +47,7 @@ public class ReaderConstants {
     static final String ARG_IS_RELATED_POST = "is_related_post";
     static final String ARG_SEARCH_QUERY = "search_query";
     static final String ARG_VIDEO_URL = "video_url";
-    static final String ARG_IS_MAIN_READER = "is_main_reader";
+    static final String ARG_IS_TOP_LEVEL = "is_top_level";
 
     static final String KEY_POST_SLUGS_RESOLUTION_UNDERWAY = "post_slugs_resolution_underway";
     static final String KEY_ALREADY_UPDATED = "already_updated";

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -162,7 +162,7 @@ public class ReaderPostListFragment extends Fragment
     private MenuItem mSettingsMenuItem;
     private MenuItem mSearchMenuItem;
 
-    private boolean mIsMainReader = false;
+    private boolean mIsTopLevel = false;
     private BottomNavController mBottomNavController;
 
     private ReaderTag mCurrentTag;
@@ -237,12 +237,12 @@ public class ReaderPostListFragment extends Fragment
         }
     }
 
-    public static ReaderPostListFragment newInstance(boolean isMainReader) {
+    public static ReaderPostListFragment newInstance(boolean isTopLevel) {
         ReaderTag tag = AppPrefs.getReaderTag();
         if (tag == null) {
             tag = ReaderUtils.getDefaultTag();
         }
-        return newInstanceForTag(tag, ReaderPostListType.TAG_FOLLOWED, isMainReader);
+        return newInstanceForTag(tag, ReaderPostListType.TAG_FOLLOWED, isTopLevel);
     }
 
     /*
@@ -252,13 +252,13 @@ public class ReaderPostListFragment extends Fragment
         return newInstanceForTag(tag, listType, false);
     }
 
-    static ReaderPostListFragment newInstanceForTag(ReaderTag tag, ReaderPostListType listType, boolean isMainReader) {
+    static ReaderPostListFragment newInstanceForTag(ReaderTag tag, ReaderPostListType listType, boolean isTopLevel) {
         AppLog.d(T.READER, "reader post list > newInstance (tag)");
 
         Bundle args = new Bundle();
         args.putSerializable(ReaderConstants.ARG_TAG, tag);
         args.putSerializable(ReaderConstants.ARG_POST_LIST_TYPE, listType);
-        args.putBoolean(ReaderConstants.ARG_IS_MAIN_READER, isMainReader);
+        args.putBoolean(ReaderConstants.ARG_IS_TOP_LEVEL, isTopLevel);
 
         ReaderPostListFragment fragment = new ReaderPostListFragment();
         fragment.setArguments(args);
@@ -317,8 +317,8 @@ public class ReaderPostListFragment extends Fragment
                 mPostListType = (ReaderPostListType) args.getSerializable(ReaderConstants.ARG_POST_LIST_TYPE);
             }
 
-            if (args.containsKey(ReaderConstants.ARG_IS_MAIN_READER)) {
-                mIsMainReader = args.getBoolean(ReaderConstants.ARG_IS_MAIN_READER);
+            if (args.containsKey(ReaderConstants.ARG_IS_TOP_LEVEL)) {
+                mIsTopLevel = args.getBoolean(ReaderConstants.ARG_IS_TOP_LEVEL);
             }
 
             mCurrentBlogId = args.getLong(ReaderConstants.ARG_BLOG_ID);
@@ -357,8 +357,8 @@ public class ReaderPostListFragment extends Fragment
             if (getPostListType() == ReaderPostListType.TAG_PREVIEW) {
                 mTagPreviewHistory.restoreInstance(savedInstanceState);
             }
-            if (savedInstanceState.containsKey(ReaderConstants.ARG_IS_MAIN_READER)) {
-                mIsMainReader = savedInstanceState.getBoolean(ReaderConstants.ARG_IS_MAIN_READER);
+            if (savedInstanceState.containsKey(ReaderConstants.ARG_IS_TOP_LEVEL)) {
+                mIsTopLevel = savedInstanceState.getBoolean(ReaderConstants.ARG_IS_TOP_LEVEL);
             }
             mRestorePosition = savedInstanceState.getInt(ReaderConstants.KEY_RESTORE_POSITION);
             mSiteSearchRestorePosition = savedInstanceState.getInt(ReaderConstants.KEY_SITE_SEARCH_RESTORE_POSITION);
@@ -600,7 +600,7 @@ public class ReaderPostListFragment extends Fragment
         outState.putBoolean(ReaderConstants.KEY_IS_REFRESHING, mRecyclerView.isRefreshing());
         outState.putInt(ReaderConstants.KEY_RESTORE_POSITION, getCurrentPosition());
         outState.putSerializable(ReaderConstants.ARG_POST_LIST_TYPE, getPostListType());
-        outState.putBoolean(ReaderConstants.ARG_IS_MAIN_READER, mIsMainReader);
+        outState.putBoolean(ReaderConstants.ARG_IS_TOP_LEVEL, mIsTopLevel);
         outState.putParcelable(QuickStartEvent.KEY, mQuickStartEvent);
 
         if (isSearchTabsShowing()) {
@@ -727,7 +727,7 @@ public class ReaderPostListFragment extends Fragment
         mRecyclerView.setToolbarSpinnerTextColor(ContextCompat.getColor(context, android.R.color.white));
         mRecyclerView.setToolbarSpinnerDrawable(R.drawable.ic_dropdown_primary_30_24dp);
 
-        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsMainReader) {
+        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel) {
             mRecyclerView.setToolbarTitle(
                     R.string.reader_screen_title,
                     getResources().getDimensionPixelSize(R.dimen.margin_extra_large)
@@ -843,7 +843,7 @@ public class ReaderPostListFragment extends Fragment
                 // return to the followed tag that was showing prior to searching
                 resetPostAdapter(ReaderPostListType.TAG_FOLLOWED);
 
-                if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsMainReader) {
+                if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel) {
                     mRecyclerView.setTabLayoutVisibility(true);
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -46,6 +46,7 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.jetbrains.annotations.NotNull;
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -161,6 +162,7 @@ public class ReaderPostListFragment extends Fragment
     private MenuItem mSettingsMenuItem;
     private MenuItem mSearchMenuItem;
 
+    private boolean mIsMainReader = false;
     private BottomNavController mBottomNavController;
 
     private ReaderTag mCurrentTag;
@@ -235,23 +237,28 @@ public class ReaderPostListFragment extends Fragment
         }
     }
 
-    public static ReaderPostListFragment newInstance() {
+    public static ReaderPostListFragment newInstance(boolean isMainReader) {
         ReaderTag tag = AppPrefs.getReaderTag();
         if (tag == null) {
             tag = ReaderUtils.getDefaultTag();
         }
-        return newInstanceForTag(tag, ReaderPostListType.TAG_FOLLOWED);
+        return newInstanceForTag(tag, ReaderPostListType.TAG_FOLLOWED, isMainReader);
     }
 
     /*
      * show posts with a specific tag (either TAG_FOLLOWED or TAG_PREVIEW)
      */
     static ReaderPostListFragment newInstanceForTag(ReaderTag tag, ReaderPostListType listType) {
+        return newInstanceForTag(tag, listType, false);
+    }
+
+    static ReaderPostListFragment newInstanceForTag(ReaderTag tag, ReaderPostListType listType, boolean isMainReader) {
         AppLog.d(T.READER, "reader post list > newInstance (tag)");
 
         Bundle args = new Bundle();
         args.putSerializable(ReaderConstants.ARG_TAG, tag);
         args.putSerializable(ReaderConstants.ARG_POST_LIST_TYPE, listType);
+        args.putBoolean(ReaderConstants.ARG_IS_MAIN_READER, isMainReader);
 
         ReaderPostListFragment fragment = new ReaderPostListFragment();
         fragment.setArguments(args);
@@ -310,6 +317,10 @@ public class ReaderPostListFragment extends Fragment
                 mPostListType = (ReaderPostListType) args.getSerializable(ReaderConstants.ARG_POST_LIST_TYPE);
             }
 
+            if (args.containsKey(ReaderConstants.ARG_IS_MAIN_READER)) {
+                mIsMainReader = args.getBoolean(ReaderConstants.ARG_IS_MAIN_READER);
+            }
+
             mCurrentBlogId = args.getLong(ReaderConstants.ARG_BLOG_ID);
             mCurrentFeedId = args.getLong(ReaderConstants.ARG_FEED_ID);
             mCurrentSearchQuery = args.getString(ReaderConstants.ARG_SEARCH_QUERY);
@@ -345,6 +356,9 @@ public class ReaderPostListFragment extends Fragment
             }
             if (getPostListType() == ReaderPostListType.TAG_PREVIEW) {
                 mTagPreviewHistory.restoreInstance(savedInstanceState);
+            }
+            if (savedInstanceState.containsKey(ReaderConstants.ARG_IS_MAIN_READER)) {
+                mIsMainReader = savedInstanceState.getBoolean(ReaderConstants.ARG_IS_MAIN_READER);
             }
             mRestorePosition = savedInstanceState.getInt(ReaderConstants.KEY_RESTORE_POSITION);
             mSiteSearchRestorePosition = savedInstanceState.getInt(ReaderConstants.KEY_SITE_SEARCH_RESTORE_POSITION);
@@ -586,6 +600,7 @@ public class ReaderPostListFragment extends Fragment
         outState.putBoolean(ReaderConstants.KEY_IS_REFRESHING, mRecyclerView.isRefreshing());
         outState.putInt(ReaderConstants.KEY_RESTORE_POSITION, getCurrentPosition());
         outState.putSerializable(ReaderConstants.ARG_POST_LIST_TYPE, getPostListType());
+        outState.putBoolean(ReaderConstants.ARG_IS_MAIN_READER, mIsMainReader);
         outState.putParcelable(QuickStartEvent.KEY, mQuickStartEvent);
 
         if (isSearchTabsShowing()) {
@@ -711,9 +726,17 @@ public class ReaderPostListFragment extends Fragment
         mRecyclerView.setToolbarBackgroundColor(ContextCompat.getColor(context, R.color.primary));
         mRecyclerView.setToolbarSpinnerTextColor(ContextCompat.getColor(context, android.R.color.white));
         mRecyclerView.setToolbarSpinnerDrawable(R.drawable.ic_dropdown_primary_30_24dp);
-        mRecyclerView.setToolbarLeftAndRightPadding(
-                getResources().getDimensionPixelSize(R.dimen.margin_medium),
-                getResources().getDimensionPixelSize(R.dimen.margin_extra_large));
+
+        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsMainReader) {
+            mRecyclerView.setToolbarTitle(
+                    R.string.reader_screen_title,
+                    getResources().getDimensionPixelSize(R.dimen.margin_extra_large)
+            );
+        } else {
+            mRecyclerView.setToolbarLeftAndRightPadding(
+                    getResources().getDimensionPixelSize(R.dimen.margin_medium),
+                    getResources().getDimensionPixelSize(R.dimen.margin_extra_large));
+        }
 
         // add a menu to the filtered recycler's toolbar
         if (mAccountStore.hasAccessToken() && (getPostListType() == ReaderPostListType.TAG_FOLLOWED
@@ -790,6 +813,7 @@ public class ReaderPostListFragment extends Fragment
                 resetPostAdapter(ReaderPostListType.SEARCH_RESULTS);
                 showSearchMessage();
                 mSettingsMenuItem.setVisible(false);
+                mRecyclerView.setTabLayoutVisibility(false);
 
                 // hide the bottom navigation when search is active
                 if (mBottomNavController != null) {
@@ -818,6 +842,10 @@ public class ReaderPostListFragment extends Fragment
 
                 // return to the followed tag that was showing prior to searching
                 resetPostAdapter(ReaderPostListType.TAG_FOLLOWED);
+
+                if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsMainReader) {
+                    mRecyclerView.setTabLayoutVisibility(true);
+                }
 
                 return true;
             }

--- a/WordPress/src/main/res/layout/filtered_list_component.xml
+++ b/WordPress/src/main/res/layout/filtered_list_component.xml
@@ -30,6 +30,22 @@
 
         </androidx.appcompat.widget.Toolbar>
 
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tab_layout"
+            android:background="@color/primary"
+            android:layout_gravity="start"
+            android:layout_height="@dimen/tab_height"
+            android:layout_width="match_parent"
+            app:tabGravity="fill"
+            app:tabIndicatorColor="@android:color/white"
+            app:tabIndicatorAnimationDuration="0"
+            app:tabMode="scrollable"
+            app:tabSelectedTextColor="@android:color/white"
+            app:tabTextColor="@android:color/white"
+            app:theme="@style/Base.Widget.Design.TabLayout"
+            android:visibility="gone"
+            tools:visibility="visible"/>
+
     </com.google.android.material.appbar.AppBarLayout>
 
     <RelativeLayout
@@ -48,8 +64,12 @@
                 android:layout_height="match_parent"
                 android:scrollbars="vertical"/>
 
-        </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
+            <androidx.viewpager.widget.ViewPager
+                android:id="@+id/pager"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"/>
 
+        </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/empty_view"

--- a/WordPress/src/main/res/layout/filtered_list_component.xml
+++ b/WordPress/src/main/res/layout/filtered_list_component.xml
@@ -38,7 +38,6 @@
             android:layout_width="match_parent"
             app:tabGravity="fill"
             app:tabIndicatorColor="@android:color/white"
-            app:tabIndicatorAnimationDuration="0"
             app:tabMode="scrollable"
             app:tabSelectedTextColor="@android:color/white"
             app:tabTextColor="@android:color/white"

--- a/WordPress/src/main/res/layout/reader_fragment_post_cards.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_cards.xml
@@ -11,7 +11,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:wpSpinnerItemView="@layout/toolbar_main_spinner_item"
-        app:wpToolbarDisableScrollGestures="true"/>
+        app:wpToolbarDisableScrollGestures="true"
+        app:wpUseTabsForFiltering="true"/>
 
     <include
         android:id="@+id/empty_custom_view"

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -145,6 +145,8 @@
 
         <!-- Optional: Default is false. Locks the toolbar and prevents scroll to hide/reveal functionality -->
         <attr name="wpToolbarDisableScrollGestures" format="boolean"/>
+        <!-- Optional: Default to false. Activate filtering by Tabs instead of Spinner -->
+        <attr name="wpUseTabsForFiltering" format="boolean"/>
     </declare-styleable>
 
     <!--


### PR DESCRIPTION
This PR is one of a set of PR which aims to supersede the #10716 decomposing it in more manageable/testable/reviewable PRs (cc @osullivanchris ).

The current one adds to the FilteredRecyclerView component (currently used in the ReaderPostsListFragment but also in CommentsListFragment and PeopleListFragment) the capability to filter by Tabs in addition to the already present filter by Spinner. In the following a before and after comparison for the Reader.

| Spinner Filtering  | Tab Filtering |
|---|---|
|![image](https://user-images.githubusercontent.com/47797566/68679469-373d8780-0560-11ea-9ad3-92cb1f41cd92.png)|![image](https://user-images.githubusercontent.com/47797566/68679683-a2875980-0560-11ea-84f9-817afbf34f73.png)|

As a result you should get as tabs all the items that were in the spinner and selecting them you should get the relevant list populated as it was selected from the spinner.

Searching and Settings should work as before.

## Notes
- Not adding Release Notes changes since we are still behind feature flagging.
- Current implementation of the tabs with view pager is not using FragmentPagerAdapter/FragmentStatePagerAdapter but a simple PagerAdapter. Fragment sliding will be eventually addressed in future steps.

## To test
Would be good to have both standard and this PR version running (emulator/real device for example) using the same user account so to make behavior comparison easier while doing the following steps.

1. Open the Reader and check you have same items in Spinner/Tabs
2. Select the single items and check the listed content is the same
3. Use the search and check it behaves as expected
4. Access to settings and Subscribe/Unsubscribe to Tags and Sites and check that when you come back to the reader the items are added/removed correctly
5. Select a Tag/Site then close the app and open it again. The reader should be presented with the last selected Tag/Site.
6. Smoke test the reader in general (open posts from the reader, follow/unfollow tags/sites etc...)
7. Smoke test the other parts in which the FilteredRecyclerView is used (namely My Site > Comments and My Site > People)

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

