### PR TITLE
IA reader nav: tabs order and naming

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -12,6 +12,7 @@ import java.util.regex.Pattern;
 
 public class ReaderTag implements Serializable, FilterCriteria {
     public static final String FOLLOWING_PATH = "/read/following";
+    public static final String LIKED_PATH = "/read/liked";
     public static final String DISCOVER_PATH = String.format(Locale.US, "read/sites/%d/posts",
             ReaderConstants.DISCOVER_SITE_ID);
 
@@ -76,7 +77,7 @@ public class ReaderTag implements Serializable, FilterCriteria {
         return StringUtils.notNullStr(mTagDisplayName);
     }
 
-    private void setTagDisplayName(String displayName) {
+    public void setTagDisplayName(String displayName) {
         this.mTagDisplayName = StringUtils.notNullStr(displayName);
     }
 
@@ -154,7 +155,7 @@ public class ReaderTag implements Serializable, FilterCriteria {
     }
 
     public boolean isPostsILike() {
-        return tagType == ReaderTagType.DEFAULT && getEndpoint().endsWith("/read/liked");
+        return tagType == ReaderTagType.DEFAULT && getEndpoint().endsWith(LIKED_PATH);
     }
 
     public boolean isFollowedSites() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -73,4 +73,9 @@ public class ReaderConstants {
     public static final String JSON_TAG_DISPLAY_NAME = "tag_display_name";
     public static final String JSON_TAG_SLUG = "slug";
     public static final String JSON_TAG_URL = "URL";
+
+    public static final String KEY_FOLLOWING = "following";
+    public static final String KEY_DISCOVER = "discover";
+    public static final String KEY_LIKES = "likes";
+    public static final String KEY_SAVED = "saved";
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -123,9 +123,11 @@ import org.wordpress.android.widgets.WPDialogSnackbar;
 import org.wordpress.android.widgets.WPSnackbar;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
@@ -2338,6 +2340,96 @@ public class ReaderPostListFragment extends Fragment
     private class LoadTagsTask extends AsyncTask<Void, Void, ReaderTagList> {
         private final FilteredRecyclerView.FilterCriteriaAsyncLoaderListener mFilterCriteriaLoaderListener;
 
+        private static final String KEY_FOLLOWING = "following";
+        private static final String KEY_DISCOVER = "discover";
+        private static final String KEY_LIKES = "likes";
+        private static final String KEY_SAVED = "saved";
+
+        private class TagInfo {
+            private ReaderTagType mTagType;
+            private String mEndPoint;
+
+            public boolean isDesiredTag(@NonNull ReaderTag tag) {
+                return tag.tagType == mTagType && (mEndPoint.isEmpty() || tag.getEndpoint().endsWith(mEndPoint));
+            }
+
+            TagInfo(ReaderTagType type, @Nullable String endPoint) {
+                mTagType = type;
+                mEndPoint = StringUtils.notNullStr(endPoint);
+            }
+        }
+        private Map<String, TagInfo> getDefaultTagInfo() {
+            // Note that the following is the desired order in the tabs
+            // (see usage in prependDefaults)
+            Map<String, TagInfo> defaultTagInfo = new LinkedHashMap<>();
+
+            defaultTagInfo.put(KEY_FOLLOWING, new TagInfo(ReaderTagType.DEFAULT, ReaderTag.FOLLOWING_PATH));
+            defaultTagInfo.put(KEY_DISCOVER, new TagInfo(ReaderTagType.DEFAULT, ReaderTag.DISCOVER_PATH));
+            defaultTagInfo.put(KEY_LIKES, new TagInfo(ReaderTagType.DEFAULT, ReaderTag.LIKED_PATH));
+            defaultTagInfo.put(KEY_SAVED, new TagInfo(ReaderTagType.BOOKMARKED, null));
+
+            return defaultTagInfo;
+        }
+
+        private boolean putIfAbsentDone(Map<String, ReaderTag> defaultTags, String key, ReaderTag tag) {
+            boolean insertionDone = false;
+
+            if (defaultTags.get(key) == null) {
+                defaultTags.put(key, tag);
+                insertionDone = true;
+            }
+
+            return insertionDone;
+        }
+        private void prependDefaults(
+                Map<String, ReaderTag> defaultTags,
+                ReaderTagList orderedTagList,
+                Map<String, TagInfo> defaultTagInfo
+        ) {
+            if (defaultTags.isEmpty()) return;
+
+            List<String> reverseOrderedKeys = new ArrayList<>(defaultTagInfo.keySet());
+            Collections.reverse(reverseOrderedKeys);
+
+            for (String key : reverseOrderedKeys) {
+                if (defaultTags.containsKey(key)) {
+                    ReaderTag tag = defaultTags.get(key);
+
+                    orderedTagList.add(0, tag);
+                }
+            }
+        }
+
+        private boolean defaultTagFoundAndAdded(Map<String, TagInfo> defaultTagInfos, ReaderTag tag, Map<String, ReaderTag> defaultTags) {
+            boolean foundAndAdded = false;
+
+            for (String key : defaultTagInfos.keySet()) {
+                if (defaultTagInfos.get(key).isDesiredTag(tag)) {
+                    if (putIfAbsentDone(defaultTags, key, tag)) {
+                        foundAndAdded = true;
+                    }
+                    break;
+                }
+            }
+
+            return foundAndAdded;
+        }
+
+        private ReaderTagList getOrderedTagsList(ReaderTagList tagList) {
+            Map<String, TagInfo> defaultTagInfos = getDefaultTagInfo();
+            ReaderTagList orderedTagList = new ReaderTagList();
+            Map<String, ReaderTag> defaultTags = new HashMap<>();
+
+            for (ReaderTag tag : tagList) {
+                if (defaultTagFoundAndAdded(defaultTagInfos, tag, defaultTags)) continue;
+
+                orderedTagList.add(tag);
+            }
+            prependDefaults(defaultTags, orderedTagList, defaultTagInfos);
+
+            return orderedTagList;
+        }
+
         LoadTagsTask(FilteredRecyclerView.FilterCriteriaAsyncLoaderListener listener) {
             mFilterCriteriaLoaderListener = listener;
         }
@@ -2348,7 +2440,9 @@ public class ReaderPostListFragment extends Fragment
             tagList.addAll(ReaderTagTable.getCustomListTags());
             tagList.addAll(ReaderTagTable.getFollowedTags());
             tagList.addAll(ReaderTagTable.getBookmarkTags());
-            return tagList;
+
+            return (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsMainReader)
+                    ? getOrderedTagsList(tagList) : tagList;
         }
 
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2400,7 +2400,11 @@ public class ReaderPostListFragment extends Fragment
             }
         }
 
-        private boolean defaultTagFoundAndAdded(Map<String, TagInfo> defaultTagInfos, ReaderTag tag, Map<String, ReaderTag> defaultTags) {
+        private boolean defaultTagFoundAndAdded(
+                Map<String, TagInfo> defaultTagInfos,
+                ReaderTag tag,
+                Map<String, ReaderTag> defaultTags
+        ) {
             boolean foundAndAdded = false;
 
             for (String key : defaultTagInfos.keySet()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -151,7 +151,7 @@ public class ReaderUpdateLogic {
                 // manually insert Bookmark tag, as server doesn't support bookmarking yet
                 serverTopics.add(
                         new ReaderTag(
-                                "", 
+                                "",
                                 BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE
                                 ? mContext.getString(R.string.reader_save_for_later_display_name) : "",
                                 mContext.getString(R.string.reader_save_for_later_title),

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -8,6 +8,7 @@ import com.wordpress.rest.RestRequest;
 
 import org.greenrobot.eventbus.EventBus;
 import org.json.JSONObject;
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.ReaderBlogTable;
@@ -116,6 +117,18 @@ public class ReaderUpdateLogic {
         WordPress.getRestClientUtilsV1_2().get("read/menu", params, null, listener, errorListener);
     }
 
+    private void updateServerTopicsDisplayName(ReaderTagList serverTopics) {
+        for (ReaderTag tag : serverTopics) {
+            if (tag.isFollowedSites()) {
+                tag.setTagDisplayName(mContext.getString(R.string.reader_following_display_name));
+            } else if (tag.isDiscover()) {
+                tag.setTagDisplayName(mContext.getString(R.string.reader_discover_display_name));
+            } else if (tag.isPostsILike()) {
+                tag.setTagDisplayName(mContext.getString(R.string.reader_my_likes_display_name));
+            }
+        }
+    }
+
     private void handleUpdateTagsResponse(final JSONObject jsonObject) {
         new Thread() {
             @Override
@@ -124,6 +137,11 @@ public class ReaderUpdateLogic {
                 // reader since user won't have any followed tags
                 ReaderTagList serverTopics = new ReaderTagList();
                 serverTopics.addAll(parseTags(jsonObject, "default", ReaderTagType.DEFAULT));
+
+                if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
+                    updateServerTopicsDisplayName(serverTopics);
+                }
+
                 if (!mAccountStore.hasAccessToken()) {
                     serverTopics.addAll(parseTags(jsonObject, "recommended", ReaderTagType.FOLLOWED));
                 } else {
@@ -131,9 +149,16 @@ public class ReaderUpdateLogic {
                 }
 
                 // manually insert Bookmark tag, as server doesn't support bookmarking yet
-                serverTopics.add(new ReaderTag("", "",
-                        mContext.getString(R.string.reader_save_for_later_title), "",
-                        ReaderTagType.BOOKMARKED));
+                serverTopics.add(
+                        new ReaderTag(
+                                "", 
+                                BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE
+                                ? mContext.getString(R.string.reader_save_for_later_display_name) : "",
+                                mContext.getString(R.string.reader_save_for_later_title),
+                                "",
+                                ReaderTagType.BOOKMARKED
+                        )
+                );
 
                 // parse topics from the response, detect whether they're different from local
                 ReaderTagList localTopics = new ReaderTagList();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/TagInfo.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/TagInfo.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.ui.reader.utils
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagType
 
-class TagInfo (
+class TagInfo(
     val tagType: ReaderTagType,
     private val endPoint: String
 ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/TagInfo.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/TagInfo.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.ui.reader.utils
+
+import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.models.ReaderTagType
+
+class TagInfo (
+    val tagType: ReaderTagType,
+    private val endPoint: String
+) {
+    fun isDesiredTag(tag: ReaderTag): Boolean {
+        return tag.tagType == tagType && (endPoint.isEmpty() || tag.endpoint.endsWith(endPoint))
+    }
+}

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1549,6 +1549,11 @@
       reader strings
     -->
     <string name="reader_save_for_later_title">Saved posts</string>
+    <string name="reader_save_for_later_display_name">Saved</string>
+    <string name="reader_discover_display_name">Discover</string>
+    <string name="reader_my_likes_display_name">Likes</string>
+    <string name="reader_following_display_name">Following</string>
+    
     <!-- timespan shown for posts/comments published within the past 60 seconds -->
     <string name="timespan_now">now</string>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
@@ -1,20 +1,14 @@
 package org.wordpress.android.ui.reader.utils
 
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagList
-import org.wordpress.android.models.ReaderTagType
 import org.wordpress.android.models.ReaderTagType.BOOKMARKED
 import org.wordpress.android.models.ReaderTagType.DEFAULT
 import org.wordpress.android.models.ReaderTagType.FOLLOWED
-import org.wordpress.android.ui.reader.ReaderConstants
-import java.util.Arrays
 
 @RunWith(MockitoJUnitRunner::class)
 class ReaderUtilsTest {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
@@ -1,0 +1,57 @@
+package org.wordpress.android.ui.reader.utils
+
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.models.ReaderTagList
+import org.wordpress.android.models.ReaderTagType
+import org.wordpress.android.models.ReaderTagType.BOOKMARKED
+import org.wordpress.android.models.ReaderTagType.DEFAULT
+import org.wordpress.android.models.ReaderTagType.FOLLOWED
+import org.wordpress.android.ui.reader.ReaderConstants
+import java.util.Arrays
+
+@RunWith(MockitoJUnitRunner::class)
+class ReaderUtilsTest {
+    private fun getShuffledTagList(): ReaderTagList {
+        val tagList = ReaderTagList()
+        tagList.addAll(listOf(
+                ReaderTag("", "", "", ReaderTag.LIKED_PATH, DEFAULT),
+                ReaderTag("", "", "", "https://genericendpoint2.com", FOLLOWED),
+                ReaderTag("", "", "", ReaderTag.DISCOVER_PATH, DEFAULT),
+                ReaderTag("", "", "", "https://genericendpoint4.com", DEFAULT),
+                ReaderTag("", "", "", "", BOOKMARKED),
+                ReaderTag("", "", "", ReaderTag.FOLLOWING_PATH, DEFAULT),
+                ReaderTag("", "", "", "https://genericendpoint7.com", DEFAULT)
+        ))
+
+        return tagList
+    }
+
+    private fun getExpectedTagList(): ReaderTagList {
+        val tagList = ReaderTagList()
+        tagList.addAll(listOf(
+                ReaderTag("", "", "", ReaderTag.FOLLOWING_PATH, DEFAULT),
+                ReaderTag("", "", "", ReaderTag.DISCOVER_PATH, DEFAULT),
+                ReaderTag("", "", "", ReaderTag.LIKED_PATH, DEFAULT),
+                ReaderTag("", "", "", "", BOOKMARKED),
+                ReaderTag("", "", "", "https://genericendpoint2.com", FOLLOWED),
+                ReaderTag("", "", "", "https://genericendpoint4.com", DEFAULT),
+                ReaderTag("", "", "", "https://genericendpoint7.com", DEFAULT)
+        ))
+
+        return tagList
+    }
+
+    @Test
+    fun `getOrderedTagsList return the desired ordered list`() {
+        val shuffledList = getShuffledTagList()
+        val orederList = ReaderUtils.getOrderedTagsList(shuffledList, ReaderUtils.getDefaultTagInfo())
+        assertThat(orederList).isEqualTo(getExpectedTagList())
+    }
+}


### PR DESCRIPTION
This PR is one of a set of PRs which aim to supersede the #10716 decomposing it in more manageable/testable/reviewable PRs (cc @osullivanchris ).

The current one is based and requires the #10782 

We have identified in the Reader 4 main tabs that we want to be in the following order and naming:

1. FOLLOWING
2. DISCOVER
3. LIKES
4. SAVED

This PR name the relevant tabs with the above naming and put them in front of eventual other tabs. Using string resources to account for i18n.

In the following an example

<p align="center">
  <img width="300" src="https://user-images.githubusercontent.com/47797566/68694504-9065e500-0579-11ea-8b68-fe4c64ebef20.png">
</p>
 
## To test

1. Open the reader and check that you get a list of item with correct names and order.
2. Select a tab, close/open the app and check you get the same correct tab selected.
3. Smoke test the reader as done in # 10782 test steps.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

