### PR TITLE
Merge login lib changes from Woo and implement new interface methods

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -826,18 +826,21 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         return mFragmentInjector;
     }
 
-    @Override public void showHelpFindingConnectedEmail() {
+    @Override
+    public void showHelpFindingConnectedEmail() {
         // Not used in WordPress app
     }
 
-    @Override public void gotConnectedSiteInfo(
+    @Override
+    public void gotConnectedSiteInfo(
             @NonNull String siteAddress,
             @Nullable String redirectUrl,
             boolean hasJetpack) {
         // Not used in WordPress app
     }
 
-    @Override public void helpHandleDiscoveryError(
+    @Override
+    public void helpHandleDiscoveryError(
             String siteAddress,
             String endpointAddress,
             String username,
@@ -847,7 +850,8 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         // Not used in WordPress app
     }
 
-    @Override public void helpNoJetpackScreen(
+    @Override
+    public void helpNoJetpackScreen(
             String siteAddress,
             String endpointAddress,
             String username,
@@ -857,7 +861,8 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         // Not used in WordPress app
     }
 
-    @Override public void loginViaSiteCredentials(String inputSiteAddress) {
+    @Override
+    public void loginViaSiteCredentials(String inputSiteAddress) {
         // Not used in WordPress app
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -441,12 +441,12 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     // LoginListener implementation methods
 
     @Override
-    public void gotWpcomEmail(String email) {
+    public void gotWpcomEmail(String email, boolean verifyEmail) {
         initSmartLockIfNotFinished(false);
         if (getLoginMode() != LoginMode.WPCOM_LOGIN_DEEPLINK && getLoginMode() != LoginMode.SHARE_INTENT) {
             LoginMagicLinkRequestFragment loginMagicLinkRequestFragment = LoginMagicLinkRequestFragment.newInstance(
                     email, AuthEmailPayloadScheme.WORDPRESS, mIsJetpackConnect,
-                    mJetpackConnectSource != null ? mJetpackConnectSource.toString() : null);
+                    mJetpackConnectSource != null ? mJetpackConnectSource.toString() : null, verifyEmail);
             slideInFragment(loginMagicLinkRequestFragment, true, LoginMagicLinkRequestFragment.TAG);
         } else {
             LoginEmailPasswordFragment loginEmailPasswordFragment =
@@ -834,6 +834,30 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
             @NonNull String siteAddress,
             @Nullable String redirectUrl,
             boolean hasJetpack) {
+        // Not used in WordPress app
+    }
+
+    @Override public void helpHandleDiscoveryError(
+            String siteAddress,
+            String endpointAddress,
+            String username,
+            String password,
+            String userAvatarUrl,
+            int errorMessage) {
+        // Not used in WordPress app
+    }
+
+    @Override public void helpNoJetpackScreen(
+            String siteAddress,
+            String endpointAddress,
+            String username,
+            String password,
+            String userAvatarUrl,
+            Boolean checkJetpackAvailability) {
+        // Not used in WordPress app
+    }
+
+    @Override public void loginViaSiteCredentials(String inputSiteAddress) {
         // Not used in WordPress app
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2270,6 +2270,14 @@
     <string name="enter_wpcom_or_jetpack_site">Please enter a WordPress.com or Jetpack-connected self-hosted WordPress site</string>
     <string name="enter_wordpress_site">The website at this address is not a WordPress site. For us to connect to it, the site must have WordPress installed.</string>
     <string name="login_need_help_finding_connected_email">Need help finding the email you connected with?</string>
+    <string name="send_verification_email">Send verification email</string>
+    <string name="enter_credentials_for_site">Log in with your %1$s site credentials</string>
+    <string name="enter_site_credentials_instead">Log in with site credentials</string>
+    <string name="login_site_credentials_magic_link_label">Almost there! We just need to verify your Jetpack connected email address &lt;b>%1$s&lt;/b></string>
+    <string name="login_discovery_error_xmlrpc">We were unable to access the &lt;b>XMLRPC file&lt;/b> on your site. You will need to reach out to your host to resolve this.</string>
+    <string name="login_discovery_error_http_auth">We were unable to access your site because it requires &lt;b>HTTP Authentication&lt;/b>. You will need to reach out to your host to resolve this.</string>
+    <string name="login_discovery_error_ssl">We were unable to access your site because of a problem with the &lt;b>SSL Certificate&lt;/b>. You will need to reach out to your host to resolve this.</string>
+    <string name="login_discovery_error_generic">We were unable to access your site. You will need to reach out to your host to resolve this.</string>
     <!-- Screen titles -->
     <string name="email_address_login_title">Email address login</string>
     <string name="site_address_login_title">Site address login</string>

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -51,7 +51,7 @@ dependencies {
             exclude group: "org.wordpress", module: "utils"
         }
     } else {
-        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:9f07b031646dd3e6021d4b8e0a35647c9109ff27") {
+        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:1.5.1-beta-4") {
             exclude group: "com.android.support"
             exclude group: "org.wordpress", module: "utils"
         }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java
@@ -1,0 +1,77 @@
+package org.wordpress.android.login;
+
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
+import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder.DiscoveryError;
+import org.wordpress.android.fluxc.store.AccountStore.OnDiscoveryResponse;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.NetworkUtils;
+
+public abstract class LoginBaseDiscoveryFragment extends LoginBaseFormFragment<LoginListener> {
+    LoginBaseDiscoveryListener mLoginBaseDiscoveryListener;
+
+    public interface LoginBaseDiscoveryListener {
+        String getRequestedSiteAddress();
+        void handleWpComDiscoveryError(String failedEndpoint);
+        void handleDiscoverySuccess(String endpointAddress);
+        void handleDiscoveryError(DiscoveryError error, String failedEndpoint);
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        mLoginBaseDiscoveryListener = null;
+    }
+
+    void initiateDiscovery() {
+        if (!NetworkUtils.checkConnection(getActivity())) {
+            return;
+        }
+
+        // Start the discovery process
+        mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(
+                mLoginBaseDiscoveryListener.getRequestedSiteAddress()));
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onDiscoverySucceeded(OnDiscoveryResponse event) {
+        // hold the URL in a variable to use below otherwise it gets cleared up by endProgress
+        // bail if user canceled
+        String mRequestedSiteAddress = mLoginBaseDiscoveryListener.getRequestedSiteAddress();
+        if (mRequestedSiteAddress == null) {
+            return;
+        }
+
+        if (!isAdded()) {
+            return;
+        }
+
+        if (event.isError()) {
+            if (isInProgress()) {
+                endProgress();
+            }
+
+            mAnalyticsListener.trackLoginFailed(event.getClass().getSimpleName(),
+                    event.error.name(), event.error.toString());
+
+            AppLog.e(T.API, "onDiscoveryResponse has error: " + event.error.name()
+                            + " - " + event.error.toString());
+            handleDiscoveryError(event.error, event.failedEndpoint);
+            return;
+        }
+
+        AppLog.i(T.NUX, "Discovery succeeded, endpoint: " + event.xmlRpcEndpoint);
+        mLoginBaseDiscoveryListener.handleDiscoverySuccess(event.xmlRpcEndpoint);
+    }
+
+    private void handleDiscoveryError(DiscoveryError error, final String failedEndpoint) {
+        if (error == DiscoveryError.WORDPRESS_COM_SITE) {
+            mLoginBaseDiscoveryListener.handleWpComDiscoveryError(failedEndpoint);
+        } else {
+            mLoginBaseDiscoveryListener.handleDiscoveryError(error, failedEndpoint);
+        }
+    }
+}

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
@@ -237,6 +237,7 @@ public abstract class LoginBaseFormFragment<LoginListenerType> extends Fragment 
 
         if (mProgressDialog != null) {
             mProgressDialog.cancel();
+            mProgressDialog.setOnCancelListener(null);
             mProgressDialog = null;
         }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -18,11 +18,12 @@ public interface LoginListener {
     LoginMode getLoginMode();
 
     // Login Email input callbacks
-    void gotWpcomEmail(String email);
+    void gotWpcomEmail(String email, boolean verifyEmail);
     void loginViaSiteAddress();
     void loginViaSocialAccount(String email, String idToken, String service, boolean isPasswordRequired);
     void loggedInViaSocialAccount(ArrayList<Integer> oldSiteIds, boolean doLoginUpdate);
     void loginViaWpcomUsernameInstead();
+    void loginViaSiteCredentials(String inputSiteAddress);
     void helpEmailScreen(String email);
     void helpSocialEmailScreen(String email);
     void addGoogleLoginFragment();
@@ -59,6 +60,10 @@ public interface LoginListener {
                                     @NonNull String displayName, @Nullable Uri profilePicture);
     void loggedInViaUsernamePassword(ArrayList<Integer> oldSitesIds);
     void helpUsernamePassword(String url, String username, boolean isWpcom);
+    void helpNoJetpackScreen(String siteAddress, String endpointAddress, String username,
+                             String password, String userAvatarUrl, Boolean checkJetpackAvailability);
+    void helpHandleDiscoveryError(String siteAddress, String endpointAddress, String username,
+                                  String password, String userAvatarUrl, int errorMessage);
 
     // Login 2FA screen callbacks
     void help2FaScreen(String email);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressHelpDialogFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressHelpDialogFragment.java
@@ -38,6 +38,11 @@ public class LoginSiteAddressHelpDialogFragment extends DialogFragment {
         }
     }
 
+    @Override public void onDetach() {
+        super.onDetach();
+        mLoginListener = null;
+    }
+
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupEmailFragment.java
@@ -271,7 +271,7 @@ public class SignupEmailFragment extends LoginBaseFormFragment<LoginListener> im
                             } else {
                                 mAnalyticsListener.trackSignupEmailToLogin();
                                 mLoginListener.showSignupToLoginMessage();
-                                mLoginListener.gotWpcomEmail(event.value);
+                                mLoginListener.gotWpcomEmail(event.value, false);
                                 // Kill connections with FluxC and this fragment since the flow is changing to login.
                                 mDispatcher.unregister(this);
                                 getActivity().getSupportFragmentManager().beginTransaction().remove(this).commit();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/SiteUtils.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/SiteUtils.java
@@ -1,7 +1,10 @@
 package org.wordpress.android.login.util;
 
+import androidx.annotation.Nullable;
+
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.util.UrlUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,5 +18,20 @@ public class SiteUtils {
         }
 
         return siteIDs;
+    }
+
+    @Nullable
+    public static SiteModel getXMLRPCSiteByUrl(SiteStore siteStore, String url) {
+        List<SiteModel> selfhostedSites = siteStore.getSitesAccessedViaXMLRPC();
+        if (selfhostedSites != null && !selfhostedSites.isEmpty()) {
+            for (SiteModel siteModel : selfhostedSites) {
+                String storedSiteUrl = UrlUtils.removeScheme(siteModel.getUrl()).replace("/", "");
+                String incomingSiteUrl = UrlUtils.removeScheme(url).replace("/", "");
+                if (storedSiteUrl.equalsIgnoreCase(incomingSiteUrl)) {
+                    return siteModel;
+                }
+            }
+        }
+        return null;
     }
 }

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_username_password_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_username_password_screen.xml
@@ -11,6 +11,18 @@
     android:paddingEnd="@dimen/margin_extra_large"
     android:layout_marginBottom="@dimen/margin_extra_large">
 
+    <TextView
+        style="@style/LoginTheme.TextLabel"
+        android:id="@+id/label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:textAlignment="viewStart"
+        android:gravity="start"
+        android:visibility="gone"
+        android:layout_marginBottom="@dimen/margin_extra_large"
+        tools:text="@string/enter_credentials_for_site" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="verification_code">Verification code</string>
     <string name="invalid_verification_code">Invalid verification code</string>
     <string name="send_link">Send link</string>
+    <string name="send_verification_email">Send verification email</string>
     <string name="enter_your_password_instead">Enter your password instead</string>
     <string name="username">Username</string>
     <string name="password">Password</string>
@@ -16,10 +17,12 @@
     <string name="login_promo_text_jetpack">Manage your Jetpack-powered site on the go — you\'ve got WordPress in your pocket.</string>
     <string name="enter_email_wordpress_com">Log in to WordPress.com using an email address to manage all your WordPress sites.</string>
     <string name="enter_email_for_site">Log in with WordPress.com to connect to %1$s</string>
+    <string name="enter_credentials_for_site">Log in with your %1$s site credentials</string>
     <string name="next">Next</string>
     <string name="open_mail">Open mail</string>
     <string name="alternatively">Alternatively:</string>
     <string name="enter_site_address_instead">Log in by entering your site address.</string>
+    <string name="enter_site_credentials_instead">Log in with site credentials</string>
     <string name="enter_username_instead">Log in with your username.</string>
     <string name="enter_verification_code">Almost there! Please enter the verification code from your Authenticator app.</string>
     <string name="enter_verification_code_sms">We sent a text message to the phone number ending in %s. Please enter the verification code in the SMS.</string>
@@ -29,6 +32,7 @@
     <string name="email_not_registered_wpcom">Hmm, we can\'t find a WordPress.com account connected to this email address. Try the link below to log in using your site address.</string>
     <string name="password_incorrect">It looks like this password is incorrect. Please double check your information and try again.</string>
     <string name="login_magic_links_label">We\'ll email you a magic link that\'ll log you in instantly, no password needed. Hunt and peck no more!</string>
+    <string name="login_site_credentials_magic_link_label">Almost there! We just need to verify your Jetpack connected email address &lt;b>%1$s&lt;/b></string>
     <string name="login_magic_links_sent_label">Your magic link is on its way! Check your email on this device and tap the link in the email you received from WordPress.com.</string>
     <string name="login_magic_link_email_requesting">Requesting log-in email</string>
     <string name="magic_link_unavailable_error_message">Currently unavailable. Please enter your password</string>
@@ -99,6 +103,10 @@
     <string name="xmlrpc_endpoint_forbidden_error">Couldn\'t connect. We received a 403 error when trying to access your
         site XMLRPC endpoint. The app needs that in order to communicate with your site. Contact your host to solve
         this problem.</string>
+    <string name="login_discovery_error_xmlrpc">We were unable to access the &lt;b>XMLRPC file&lt;/b> on your site. You will need to reach out to your host to resolve this.</string>
+    <string name="login_discovery_error_http_auth">We were unable to access your site because it requires &lt;b>HTTP Authentication&lt;/b>. You will need to reach out to your host to resolve this.</string>
+    <string name="login_discovery_error_ssl">We were unable to access your site because of a problem with the &lt;b>SSL Certificate&lt;/b>. You will need to reach out to your host to resolve this.</string>
+    <string name="login_discovery_error_generic">We were unable to access your site. You will need to reach out to your host to resolve this.</string>
     <string name="enter_wpcom_or_jetpack_site">Please enter a WordPress.com or Jetpack-connected self-hosted WordPress site</string>
     <string name="enter_wordpress_site">The website at this address is not a WordPress site. For us to connect to it, the site must have WordPress installed.</string>
     <string name="error_generic_network">A network error occurred. Please check your connection and try again.</string>

--- a/libs/login/gradle/wrapper/gradle-wrapper.properties
+++ b/libs/login/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 24 12:48:58 EDT 2017
+#Fri Oct 18 14:55:25 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
This PR merges the `woocommerce-android` changes to the login library from this [PR](https://github.com/woocommerce/woocommerce-android/pull/1542). There were several new interface methods added existing classes:

#### LoginListener
+ `loginViaSiteCredentials`
+ `helpNoJetpackScreen`
+ `helpHandleDiscoveryError`

I've implemented these new interface methods in `LoginActivity` but there is no logic needed since none of them are currently being used in WPAndroid. 

#### Changes
+ The discovery process when validating a site address in `LoginSiteAddressFragment` is ported over to a new base fragment `LoginBaseDiscoveryFragment` so that it can be reused by multiple calling fragments. 
+ Modified existing method `gotWpcomEmail` to include a boolean flag `verifyEmail`. 

Full documentation around the changes to login library are documented in this [PR](https://github.com/woocommerce/woocommerce-android/pull/1542), but the **WPAndroid app should see no difference in the login experience.**

### Recommended Test Scenarios
- Verify login flow is unchanged from the current login flow of WPAndroid
- Verify the text in each of the login views is also unchanged
- Login with email
- Login by site url
- Login w/ Magic Link
- Login w/ Google

**Note: This PR is not ready for merge. [This PR](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/30) must first be merged, and then a new branch/PR will be submitted with the fresh changes ready for final review.**
