### PR TITLE
Fixes time in unpublished revision and conflicted post dialogs

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 13.7
 -----
+* Fixed time displayed on Post Conflict Detected and Unpublished Revision dialogs
  
 13.6
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -43,7 +43,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -479,10 +478,12 @@ public class PostUtils {
     public static String getConflictedPostCustomStringForDialog(PostModel post) {
         Context context = WordPress.getContext();
         String firstPart = context.getString(R.string.dialog_confirm_load_remote_post_body);
+        String lastModified =
+                TextUtils.isEmpty(post.getDateLocallyChanged()) ? post.getLastModified() : post.getDateLocallyChanged();
         String secondPart =
                 String.format(context.getString(R.string.dialog_confirm_load_remote_post_body_2),
                         getFormattedDateForLastModified(
-                                context, DateTimeUtils.timestampFromIso8601Millis(post.getLastModified())),
+                                context, DateTimeUtils.timestampFromIso8601Millis(lastModified)),
                         getFormattedDateForLastModified(
                                 context, DateTimeUtils.timestampFromIso8601Millis(post.getRemoteLastModified())));
         return firstPart + secondPart;
@@ -516,10 +517,8 @@ public class PostUtils {
                 DateFormat.SHORT,
                 LocaleManager.getSafeLocale(context));
 
-
-        // The timezone on the website is at GMT
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-        timeFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+        dateFormat.setTimeZone(Calendar.getInstance().getTimeZone());
+        timeFormat.setTimeZone(Calendar.getInstance().getTimeZone());
 
         return dateFormat.format(date) + " @ " + timeFormat.format(date);
     }


### PR DESCRIPTION
Fixes #10786 

Fixes two issues
1. Both unpublished revision(autosave) dialog and conflicted post dialogs were displaying dates in wrong timezone.
2. Conflicted post dialog was using incorrect local date - it was using `post.getLastModified()`. However, AFAIK when we modify post locally we update `dateLocallyChanged` not the `lastModified` date.

The code contained `// The timezone on the website is at GMT` this comment so it seems we were setting the GMT on purpose. However, I can't think of a reason why we'd want to display the time in GMT. Wdyt?

To test:
1. Turn on airplane mode
2. Open a published post
3. Modify it's title
4. Leave the editor
5. Open the same post on the web, change its title and publish the changes
6. Turn off airplane mode
7. Pull-to-refresh
8. Notice the Version conflict label
9. Click on the post and make sure the times are in the correct timezone. Also make sure the "Local saved on" corresponds to the date you actually saved the post in step 3.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


