### PR TITLE
Fix accessing gutenberg translations in release build

### DIFF
--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -72,6 +72,8 @@
 ###### React Native - end
 
 ###### Main resource class - begin
+-keepattributes InnerClasses
+
 -keep class org.wordpress.android.R
 -keep class org.wordpress.android.R$* {
     <fields>;

--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -70,3 +70,10 @@
 
 -dontwarn com.github.godness84.RNRecyclerViewList.**
 ###### React Native - end
+
+###### Main resource class - begin
+-keep class org.wordpress.android.R
+-keep class org.wordpress.android.R$* {
+    <fields>;
+}
+###### Main resource class - end

--- a/libs/editor/WordPressEditor/proguard-rules.pro
+++ b/libs/editor/WordPressEditor/proguard-rules.pro
@@ -15,3 +15,10 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+###### Main resource class - begin
+-keep class org.wordpress.android.R
+-keep class org.wordpress.android.R$* {
+    <fields>;
+}
+###### Main resource class - end

--- a/libs/editor/WordPressEditor/proguard-rules.pro
+++ b/libs/editor/WordPressEditor/proguard-rules.pro
@@ -15,10 +15,3 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
-
-###### Main resource class - begin
--keep class org.wordpress.android.R
--keep class org.wordpress.android.R$* {
-    <fields>;
-}
-###### Main resource class - end


### PR DESCRIPTION
This PR adds a rule to prevent proguard from obfuscating the main resource file so we can access its fields with reflection

Fixes (issue not created) gutenberg editor not receiving strings from parent app in release build

To test:
- Before applying this patch:
- `git checkout alpha-195`, `git submodule update --init --recursive`, `bundle exec fastlane build_beta skip_confirm:true`, `adb install build wpandroid-13.6-rc-2-universal.apk`
- Run the app on your device, set the language to spanish, open the block editor, add an image block then tap on the image block to show the menu, all items should be in english except the last one (bug)
-Remove the app from your device
- Checkout this branch and rebuild the app: `git checkout fix/resource-reflection-in-release`, `git submodule update --init --recursive`, `bundle exec fastlane build_beta skip_confirm:true`, `adb install build wpandroid-13.6-rc-2-universal.apk`
- Do the same test and make sure all the menu items are in spanish this time

PR submission checklist:

- [ ] I have considered adding unit tests where possible.

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

