### PR TITLE
IA Reader Navigation: adding subfiltering

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -26,6 +26,8 @@ public class ReaderTag implements Serializable, FilterCriteria {
     private String mTagTitle; // title, used for default tags
     private String mEndpoint; // endpoint for updating posts with this tag
 
+    private boolean mIsDefaultTag;
+
     public final ReaderTagType tagType;
 
     public ReaderTag(String slug,
@@ -33,6 +35,15 @@ public class ReaderTag implements Serializable, FilterCriteria {
                      String title,
                      String endpoint,
                      ReaderTagType tagType) {
+        this(slug, displayName, title, endpoint, tagType, false);
+    }
+
+    public ReaderTag(String slug,
+                     String displayName,
+                     String title,
+                     String endpoint,
+                     ReaderTagType tagType,
+                     boolean isDefaultTag) {
         // we need a slug since it's used to uniquely ID the tag (including setting it as the
         // primary key in the tag table)
         if (TextUtils.isEmpty(slug)) {
@@ -51,6 +62,7 @@ public class ReaderTag implements Serializable, FilterCriteria {
         setTagTitle(title);
         setEndpoint(endpoint);
         this.tagType = tagType;
+        mIsDefaultTag = isDefaultTag;
     }
 
     public String getEndpoint() {
@@ -160,6 +172,10 @@ public class ReaderTag implements Serializable, FilterCriteria {
 
     public boolean isFollowedSites() {
         return tagType == ReaderTagType.DEFAULT && getEndpoint().endsWith(FOLLOWING_PATH);
+    }
+
+    public boolean isDefaultTag() {
+        return tagType == ReaderTagType.DEFAULT && mIsDefaultTag;
     }
 
     public boolean isBookmarked() {

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -116,6 +116,7 @@ import org.wordpress.android.ui.reader.ReaderCommentListActivity;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
 import org.wordpress.android.ui.reader.ReaderPostListFragment;
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity;
+import org.wordpress.android.ui.reader.SubfilterBottomSheetFragment;
 import org.wordpress.android.ui.reader.adapters.ReaderBlogAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderCommentAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderPostAdapter;
@@ -474,6 +475,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(PublishNotificationReceiver object);
 
     void inject(MainBottomSheetFragment object);
+
+    void inject(SubfilterBottomSheetFragment object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -120,13 +120,10 @@ public class FilteredRecyclerView extends RelativeLayout {
     }
 
     public boolean isValidFilter(FilterCriteria filter) {
-        if (filter == null) return false;
-
-        if (mFilterCriteriaOptions == null || mFilterCriteriaOptions.isEmpty()) return false;
-
-        if (mFilterCriteriaOptions.contains(filter)) return true;
-
-        return false;
+        return filter != null
+               && mFilterCriteriaOptions != null
+               && !mFilterCriteriaOptions.isEmpty()
+               && mFilterCriteriaOptions.contains(filter);
     }
 
     public void setFilterListener(FilterListener filterListener) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -120,6 +120,16 @@ public class FilteredRecyclerView extends RelativeLayout {
         return mCurrentFilter;
     }
 
+    public boolean isValidFilter(FilterCriteria filter) {
+        if (filter == null) return false;
+
+        if (mFilterCriteriaOptions == null || mFilterCriteriaOptions.isEmpty()) return false;
+
+        if (mFilterCriteriaOptions.contains(filter)) return true;
+
+        return false;
+    }
+
     public void setFilterListener(FilterListener filterListener) {
         mFilterListener = filterListener;
         setup(false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -396,7 +396,7 @@ public class ReaderPostListFragment extends Fragment
                         mCurrentTag,
                         BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel,
                         mRecyclerView
-                )) {
+                ) || ReaderUtils.isDefaultTag(mCurrentTag)) {
                   mViewModel.applySubfilter(subfilterListItem, true);
                 }
             });
@@ -427,11 +427,11 @@ public class ReaderPostListFragment extends Fragment
 
         mViewModel.start(
                 mCurrentTag,
-                ReaderUtils.isFollowing(
+                (ReaderUtils.isFollowing(
                         mCurrentTag,
                         BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel,
                         mRecyclerView
-                )
+                ) || ReaderUtils.isDefaultTag(mCurrentTag))
                 && BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel
         );
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -394,7 +394,11 @@ public class ReaderPostListFragment extends Fragment
 
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel) {
             mViewModel.getCurrentSubFilter().observe(getActivity(), subfilterListItem -> {
-                if (ReaderUtils.isFollowing(mCurrentTag, mIsTopLevel, mRecyclerView)) {
+                if (ReaderUtils.isFollowing(
+                        mCurrentTag,
+                        BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel,
+                        mRecyclerView
+                )) {
                     setCurrentSubfilter(subfilterListItem, true);
                 }
             });
@@ -406,7 +410,11 @@ public class ReaderPostListFragment extends Fragment
 
         mViewModel.start(
                 mCurrentTag,
-                ReaderUtils.isFollowing(mCurrentTag, mIsTopLevel, mRecyclerView)
+                ReaderUtils.isFollowing(
+                        mCurrentTag,
+                        BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel,
+                        mRecyclerView
+                )
                 && BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel
         );
     }
@@ -811,7 +819,11 @@ public class ReaderPostListFragment extends Fragment
                 if (hasCurrentTag()) {
                     ReaderTag tag = getCurrentTag();
 
-                    if (ReaderUtils.isValidTagForSharedPrefs(tag, mIsTopLevel, mRecyclerView)) {
+                    if (ReaderUtils.isValidTagForSharedPrefs(
+                            tag,
+                            BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel,
+                            mRecyclerView)
+                    ) {
                         return tag;
                     } else {
                         return ReaderUtils.getDefaultTag();
@@ -994,7 +1006,11 @@ public class ReaderPostListFragment extends Fragment
 
 
                 if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel) {
-                    if (ReaderUtils.isFollowing(mCurrentTag, mIsTopLevel, mRecyclerView)) {
+                    if (ReaderUtils.isFollowing(
+                            mCurrentTag,
+                            BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel,
+                            mRecyclerView)
+                    ) {
                         setCurrentSubfilter(mViewModel.getCurrentSubfilterValue(), false);
                     } else {
                         // return to the followed tag that was showing prior to searching
@@ -1415,7 +1431,11 @@ public class ReaderPostListFragment extends Fragment
 
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel) {
             totalMargin += getActivity().getResources().getDimensionPixelSize(R.dimen.tab_height);
-            if (ReaderUtils.isFollowing(mCurrentTag, mIsTopLevel, mRecyclerView)) {
+            if (ReaderUtils.isFollowing(
+                    mCurrentTag,
+                    BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel,
+                    mRecyclerView)
+            ) {
                 totalMargin += mSubFilterComponent.getHeight();
             }
         }
@@ -1899,7 +1919,11 @@ public class ReaderPostListFragment extends Fragment
         switch (getPostListType()) {
             case TAG_FOLLOWED:
                 // remember this as the current tag if viewing followed tag
-                if (ReaderUtils.isValidTagForSharedPrefs(tag, mIsTopLevel, mRecyclerView)) {
+                if (ReaderUtils.isValidTagForSharedPrefs(
+                        tag,
+                        BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel,
+                        mRecyclerView)
+                ) {
                     AppPrefs.setReaderTag(tag);
                 }
                 break;
@@ -1915,7 +1939,10 @@ public class ReaderPostListFragment extends Fragment
         }
 
         getPostAdapter().setCurrentTag(mCurrentTag);
-        mViewModel.setSubfiltersVisibility(ReaderUtils.isFollowing(mCurrentTag, mIsTopLevel, mRecyclerView));
+        mViewModel.setSubfiltersVisibility(BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && ReaderUtils.isFollowing(
+                mCurrentTag,
+                BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel,
+                mRecyclerView));
         hideNewPostsBar();
         showLoadingProgress(false);
         updateCurrentTagIfTime();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1890,14 +1890,9 @@ public class ReaderPostListFragment extends Fragment
 
     private boolean isValidTagForSharedPrefs(ReaderTag tag) {
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsMainReader) {
-            if ((mRecyclerView != null && mRecyclerView.isValidFilter(tag))
-                ||
-                (tag.isFollowedSites() || tag.isDiscover() || tag.isPostsILike() || tag.isBookmarked())
-            ) {
-                return true;
-            } else {
-                return false;
-            }
+            return (mRecyclerView != null && mRecyclerView.isValidFilter(tag))
+                   ||
+                   (tag.isFollowedSites() || tag.isDiscover() || tag.isPostsILike() || tag.isBookmarked());
         } else {
             return true;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
@@ -62,11 +62,11 @@ class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
         (requireActivity().applicationContext as WordPress).component().inject(this)
     }
 
-   @Subscribe(threadMode = ThreadMode.MAIN)
-   fun onEventMainThread(event: ReaderEvents.FollowedTagsChanged) {
-       AppLog.d(T.READER, "Subfilter bottom sheet > followed tags changed")
-       viewModel.loadSubFilters()
-   }
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onEventMainThread(event: ReaderEvents.FollowedTagsChanged) {
+        AppLog.d(T.READER, "Subfilter bottom sheet > followed tags changed")
+        viewModel.loadSubFilters()
+    }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: ReaderEvents.FollowedBlogsChanged) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
@@ -1,0 +1,55 @@
+package org.wordpress.android.ui.reader
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProviders
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import kotlinx.android.synthetic.main.subfilter_list.*
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.ui.reader.subfilter.adapters.SubfilterListAdapter
+import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel
+import org.wordpress.android.ui.utils.UiHelpers
+import javax.inject.Inject
+
+class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var viewModel: ReaderPostListViewModel
+    @Inject lateinit var uiHelpers: UiHelpers
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.subfilter_list, container)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val recyclerView = view.findViewById<RecyclerView>(R.id.filter_recycler_view)
+        recyclerView.layoutManager = LinearLayoutManager(requireActivity())
+        recyclerView.adapter = SubfilterListAdapter(uiHelpers)
+
+        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory).get(ReaderPostListViewModel::class.java)
+
+        viewModel.subFilters.observe(this, Observer {
+            (dialog.filter_recycler_view.adapter as? SubfilterListAdapter)?.update(it ?: listOf())
+        })
+
+        viewModel.loadSubFilters()
+    }
+
+    override fun onAttach(context: Context?) {
+        super.onAttach(context)
+        (requireActivity().applicationContext as WordPress).component().inject(this)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
@@ -12,11 +12,20 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import kotlinx.android.synthetic.main.subfilter_list.*
+import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask
+import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter
 import org.wordpress.android.ui.reader.subfilter.adapters.SubfilterListAdapter
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.NetworkUtils
+import java.util.EnumSet
 import javax.inject.Inject
 
 class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
@@ -44,12 +53,52 @@ class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
         viewModel.subFilters.observe(this, Observer {
             (dialog.filter_recycler_view.adapter as? SubfilterListAdapter)?.update(it ?: listOf())
         })
-
         viewModel.loadSubFilters()
+        performUpdate()
     }
 
     override fun onAttach(context: Context?) {
         super.onAttach(context)
         (requireActivity().applicationContext as WordPress).component().inject(this)
+    }
+
+   @Subscribe(threadMode = ThreadMode.MAIN)
+   fun onEventMainThread(event: ReaderEvents.FollowedTagsChanged) {
+       AppLog.d(T.READER, "Subfilter bottom sheet > followed tags changed")
+       viewModel.loadSubFilters()
+   }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onEventMainThread(event: ReaderEvents.FollowedBlogsChanged) {
+        AppLog.d(T.READER, "Subfilter bottom sheet > followed blogs changed")
+        viewModel.loadSubFilters()
+    }
+
+    private fun performUpdate() {
+        performUpdate(
+                EnumSet.of(
+                        UpdateTask.TAGS,
+                        UpdateTask.FOLLOWED_BLOGS/*,
+                        UpdateTask.RECOMMENDED_BLOGS*/
+                )
+        )
+    }
+
+    private fun performUpdate(tasks: EnumSet<UpdateTask>) {
+        if (!NetworkUtils.isNetworkAvailable(activity)) {
+            return
+        }
+
+        ReaderUpdateServiceStarter.startService(activity, tasks)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        EventBus.getDefault().register(this)
+    }
+
+    override fun onStop() {
+        EventBus.getDefault().unregister(this)
+        super.onStop()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -122,6 +122,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     private static final int NEWS_CARD_POSITION = 0;
 
+    private boolean mIsMainReader = false;
+
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
 
@@ -680,7 +682,12 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     // ********************************************************************************************
 
-    public ReaderPostAdapter(Context context, ReaderPostListType postListType, ImageManager imageManager) {
+    public ReaderPostAdapter(
+            Context context,
+            ReaderPostListType postListType,
+            ImageManager imageManager,
+            boolean isMainReader
+    ) {
         super();
         ((WordPress) context.getApplicationContext()).component().inject(this);
         this.mImageManager = imageManager;
@@ -689,6 +696,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         mAvatarSzSmall = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_small);
         mMarginLarge = context.getResources().getDimensionPixelSize(R.dimen.margin_large);
         mIsLoggedOutReader = !mAccountStore.hasAccessToken();
+        mIsMainReader = isMainReader;
 
         int displayWidth = DisplayUtils.getDisplayPixelWidth(context);
         int cardMargin = context.getResources().getDimensionPixelSize(R.dimen.reader_card_margin);
@@ -703,11 +711,11 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     private boolean hasSiteHeader() {
-        return isDiscover() || getPostListType() == ReaderTypes.ReaderPostListType.BLOG_PREVIEW;
+        return !mIsMainReader && (isDiscover() || getPostListType() == ReaderTypes.ReaderPostListType.BLOG_PREVIEW);
     }
 
     private boolean hasTagHeader() {
-        return mCurrentTag != null && mCurrentTag.isTagTopic() && !isEmpty();
+        return !mIsMainReader && (mCurrentTag != null && mCurrentTag.isTagTopic() && !isEmpty());
     }
 
     private boolean isDiscover() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -137,6 +137,27 @@ public class ReaderUpdateLogic {
         return updateDone;
     }
 
+    private boolean downgradeFromIAFeatureFlagDetected() {
+        boolean downgradeDetected = false;
+
+        ReaderTagList savedTags = ReaderTagTable.getBookmarkTags();
+
+        if (savedTags != null && savedTags.size() == 1) {
+            ReaderTag savedTag = savedTags.get(0);
+
+            if (savedTag != null) {
+                String tagNameBefore = savedTag.getTagDisplayName();
+
+                if (!BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE
+                    && tagNameBefore.equals(mContext.getString(R.string.reader_save_for_later_display_name))) {
+                    downgradeDetected = true;
+                }
+            }
+        }
+
+        return downgradeDetected;
+    }
+
     private void handleUpdateTagsResponse(final JSONObject jsonObject) {
         new Thread() {
             @Override
@@ -159,16 +180,19 @@ public class ReaderUpdateLogic {
                 }
 
                 // manually insert Bookmark tag, as server doesn't support bookmarking yet
+                // and check if we are going to change it to trigger UI update in case of downgrade
                 serverTopics.add(
                         new ReaderTag(
                                 "",
                                 BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE
-                                ? mContext.getString(R.string.reader_save_for_later_display_name) : "",
+                                        ? mContext.getString(R.string.reader_save_for_later_display_name) : "",
                                 mContext.getString(R.string.reader_save_for_later_title),
                                 "",
                                 ReaderTagType.BOOKMARKED
                         )
                 );
+
+                boolean downgradeFromIAFeatureFlagDetected = downgradeFromIAFeatureFlagDetected();
 
                 // parse topics from the response, detect whether they're different from local
                 ReaderTagList localTopics = new ReaderTagList();
@@ -177,8 +201,14 @@ public class ReaderUpdateLogic {
                 localTopics.addAll(ReaderTagTable.getBookmarkTags());
                 localTopics.addAll(ReaderTagTable.getCustomListTags());
 
-                if (!localTopics.isSameList(serverTopics) || displayNameUpdateWasNeeded) {
-                    AppLog.d(AppLog.T.READER, "reader service > followed topics changed");
+                if (
+                        !localTopics.isSameList(serverTopics)
+                        || displayNameUpdateWasNeeded
+                        || downgradeFromIAFeatureFlagDetected
+                ) {
+                    AppLog.d(AppLog.T.READER, "reader service > followed topics changed "
+                                              + "updatedDisplaYNames [" + displayNameUpdateWasNeeded
+                                              + "] donwgradeDetected [" + downgradeFromIAFeatureFlagDetected + "]");
                     // if any local topics have been removed from the server, make sure to delete
                     // them locally (including their posts)
                     deleteTags(localTopics.getDeletions(serverTopics));

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterListItem.kt
@@ -1,0 +1,48 @@
+package org.wordpress.android.ui.reader.subfilter
+
+import org.wordpress.android.models.ReaderBlog
+import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.DIVIDER
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.SECTION_TITLE
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.SITE
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.SITE_ALL
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.TAG
+import org.wordpress.android.ui.utils.UiString
+
+sealed class SubfilterListItem(val type: ItemType) {
+    open var isSelected: Boolean = false
+    open val onClickAction: ((filter: SubfilterListItem) -> Unit)? = null
+    open val label: UiString? = null
+
+    enum class ItemType {
+        SECTION_TITLE,
+        SITE_ALL,
+        SITE,
+        DIVIDER,
+        TAG
+    }
+
+    data class SectionTitle(override val label: UiString) : SubfilterListItem(SECTION_TITLE)
+
+    object Divider : SubfilterListItem(DIVIDER)
+
+    data class SiteAll(
+        override val label: UiString,
+        override var isSelected: Boolean = false,
+        override val onClickAction: (filter: SubfilterListItem) -> Unit
+    ) : SubfilterListItem(SITE_ALL)
+
+    data class Site(
+        override val label: UiString,
+        override var isSelected: Boolean = false,
+        override val onClickAction: (filter: SubfilterListItem) -> Unit,
+        val blog: ReaderBlog
+    ) : SubfilterListItem(SITE)
+
+    data class Tag(
+        override val label: UiString,
+        override var isSelected: Boolean = false,
+        override val onClickAction: (filter: SubfilterListItem) -> Unit,
+        val tag: ReaderTag
+    ) : SubfilterListItem(TAG)
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/adapters/SubfilterListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/adapters/SubfilterListAdapter.kt
@@ -1,0 +1,65 @@
+package org.wordpress.android.ui.reader.subfilter.adapters
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView.Adapter
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.DIVIDER
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.SECTION_TITLE
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.SITE
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.SITE_ALL
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.TAG
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.SectionTitle
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Site
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.SiteAll
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Tag
+import org.wordpress.android.ui.reader.subfilter.viewholders.DividerViewHolder
+import org.wordpress.android.ui.reader.subfilter.viewholders.SectionTitleViewHolder
+import org.wordpress.android.ui.reader.subfilter.viewholders.SiteAllViewHolder
+import org.wordpress.android.ui.reader.subfilter.viewholders.SiteViewHolder
+import org.wordpress.android.ui.reader.subfilter.viewholders.SubFilterDiffCallback
+import org.wordpress.android.ui.reader.subfilter.viewholders.SubfilterListItemViewHolder
+import org.wordpress.android.ui.reader.subfilter.viewholders.TagViewHolder
+import org.wordpress.android.ui.utils.UiHelpers
+
+class SubfilterListAdapter(val uiHelpers: UiHelpers) : Adapter<SubfilterListItemViewHolder>() {
+    private var items: List<SubfilterListItem> = listOf()
+    fun update(newItems: List<SubfilterListItem>) {
+        val diffResult = DiffUtil.calculateDiff(
+                SubFilterDiffCallback(
+                        items,
+                        newItems
+                )
+        )
+        items = newItems
+        diffResult.dispatchUpdatesTo(this)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: SubfilterListItemViewHolder, position: Int) {
+        val item = items[position]
+        when (holder) {
+            is SectionTitleViewHolder -> holder.bind(item as SectionTitle, uiHelpers)
+            is SiteViewHolder -> holder.bind(item as Site, uiHelpers)
+            is SiteAllViewHolder -> holder.bind(item as SiteAll, uiHelpers)
+            is TagViewHolder -> holder.bind(item as Tag, uiHelpers)
+            is DividerViewHolder -> {}
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SubfilterListItemViewHolder {
+        return when (ItemType.values()[viewType]) {
+            SECTION_TITLE -> SectionTitleViewHolder(parent)
+            SITE -> SiteViewHolder(parent)
+            SITE_ALL -> SiteAllViewHolder(parent)
+            DIVIDER -> DividerViewHolder(parent)
+            TAG -> TagViewHolder(parent)
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return items[position].type.ordinal
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/DividerViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/DividerViewHolder.kt
@@ -1,0 +1,8 @@
+package org.wordpress.android.ui.reader.subfilter.viewholders
+
+import android.view.ViewGroup
+import org.wordpress.android.R
+
+class DividerViewHolder(
+    parent: ViewGroup
+) : SubfilterListItemViewHolder(parent, R.layout.subfilter_divider_item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SectionTitleViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SectionTitleViewHolder.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.ui.reader.subfilter.viewholders
+
+import android.view.ViewGroup
+import android.widget.TextView
+import org.wordpress.android.R
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.SectionTitle
+import org.wordpress.android.ui.utils.UiHelpers
+
+class SectionTitleViewHolder(
+    parent: ViewGroup
+) : SubfilterListItemViewHolder(parent, R.layout.subfilter_section_title) {
+    private val sectionTitle = itemView.findViewById<TextView>(R.id.section_title)
+
+    fun bind(sectionTitle: SectionTitle, uiHelpers: UiHelpers) {
+        super.bind(sectionTitle, uiHelpers)
+        this.sectionTitle.text = uiHelpers.getTextOfUiString(parent.context, sectionTitle.label)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SiteAllViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SiteAllViewHolder.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.ui.reader.subfilter.viewholders
+
+import android.view.ViewGroup
+import android.widget.TextView
+import org.wordpress.android.R
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.SiteAll
+import org.wordpress.android.ui.utils.UiHelpers
+
+class SiteAllViewHolder(
+    parent: ViewGroup
+) : SubfilterListItemViewHolder(parent, R.layout.subfilter_list_item) {
+    private val itemTitle = itemView.findViewById<TextView>(R.id.item_title)
+
+    fun bind(site: SiteAll, uiHelpers: UiHelpers) {
+        super.bind(site, uiHelpers)
+        this.itemTitle.text = uiHelpers.getTextOfUiString(parent.context, site.label)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SiteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SiteViewHolder.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.ui.reader.subfilter.viewholders
+
+import android.view.ViewGroup
+import android.widget.TextView
+import org.wordpress.android.R
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Site
+import org.wordpress.android.ui.utils.UiHelpers
+
+class SiteViewHolder(
+    parent: ViewGroup
+) : SubfilterListItemViewHolder(parent, R.layout.subfilter_list_item) {
+    private val itemTitle = itemView.findViewById<TextView>(R.id.item_title)
+
+    fun bind(site: Site, uiHelpers: UiHelpers) {
+        super.bind(site, uiHelpers)
+        this.itemTitle.text = uiHelpers.getTextOfUiString(parent.context, site.label)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubFilterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubFilterDiffCallback.kt
@@ -1,0 +1,42 @@
+package org.wordpress.android.ui.reader.subfilter.viewholders
+
+import androidx.recyclerview.widget.DiffUtil.Callback
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.DIVIDER
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.SECTION_TITLE
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.SITE
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.SITE_ALL
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.TAG
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Site
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Tag
+
+class SubFilterDiffCallback(
+    private val oldList: List<SubfilterListItem>,
+    private val newList: List<SubfilterListItem>
+) : Callback() {
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        val newItem = newList[newItemPosition]
+        val oldItem = oldList[oldItemPosition]
+
+        return if (oldItem.type == newItem.type) {
+            when (oldItem.type) {
+                SECTION_TITLE -> oldItem.label == newItem.label
+                SITE -> (oldItem as Site).blog.isSameAs((newItem as Site).blog)
+                TAG -> (oldItem as Tag).tag == (newItem as Tag).tag
+                SITE_ALL,
+                DIVIDER -> true
+            }
+        } else {
+            false
+        }
+    }
+
+    override fun getOldListSize(): Int = oldList.size
+
+    override fun getNewListSize(): Int = newList.size
+
+    override fun areContentsTheSame(
+        oldItemPosition: Int,
+        newItemPosition: Int
+    ): Boolean = oldList[oldItemPosition].isSelected == newList[newItemPosition].isSelected
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubfilterListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubfilterListItemViewHolder.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.LayoutRes
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import org.wordpress.android.R
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem
@@ -23,8 +24,7 @@ open class SubfilterListItemViewHolder(
         val itemText: TextView? = this.itemView.findViewById(R.id.item_title)
         itemText?.let {
             if (filter.isSelected) {
-                @Suppress("DEPRECATION")
-                it.setTextColor(parent.resources.getColor(R.color.primary))
+                it.setTextColor(ContextCompat.getColor(parent.context, R.color.primary))
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubfilterListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubfilterListItemViewHolder.kt
@@ -1,0 +1,35 @@
+package org.wordpress.android.ui.reader.subfilter.viewholders
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.annotation.LayoutRes
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import org.wordpress.android.R
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem
+import org.wordpress.android.ui.utils.UiHelpers
+
+open class SubfilterListItemViewHolder(
+    internal val parent: ViewGroup,
+    @LayoutRes layout: Int
+) : ViewHolder(LayoutInflater.from(parent.context).inflate(layout, parent, false)) {
+    open fun bind(filter: SubfilterListItem, uiHelpers: UiHelpers) {
+        val selectedTick: ImageView? = this.itemView.findViewById(R.id.item_selected)
+        selectedTick?.let {
+            it.visibility = if (filter.isSelected) View.VISIBLE else View.GONE
+        }
+        val itemText: TextView? = this.itemView.findViewById(R.id.item_title)
+        itemText?.let {
+            if (filter.isSelected) {
+                @Suppress("DEPRECATION")
+                it.setTextColor(parent.resources.getColor(R.color.primary))
+            }
+        }
+
+        this.itemView.setOnClickListener {
+            filter.onClickAction?.invoke(filter)
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/TagViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/TagViewHolder.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.ui.reader.subfilter.viewholders
+
+import android.view.ViewGroup
+import android.widget.TextView
+import org.wordpress.android.R
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Tag
+import org.wordpress.android.ui.utils.UiHelpers
+
+class TagViewHolder(
+    parent: ViewGroup
+) : SubfilterListItemViewHolder(parent, R.layout.subfilter_list_item) {
+    private val itemTitle = itemView.findViewById<TextView>(R.id.item_title)
+
+    fun bind(tag: Tag, uiHelpers: UiHelpers) {
+        super.bind(tag, uiHelpers)
+        this.itemTitle.text = uiHelpers.getTextOfUiString(parent.context, tag.label)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -322,13 +322,13 @@ public class ReaderUtils {
             boolean isTopLevelReader,
             FilteredRecyclerView recyclerView
     ) {
-        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && isTopLevelReader) {
+        if (isTopLevelReader) {
             if (currentTag != null
                 &&
                 (currentTag.isDiscover() || currentTag.isPostsILike() || currentTag.isBookmarked())) {
                 return false;
             } else if (recyclerView != null && recyclerView.getCurrentFilter() == null) {
-                // we are initializing now: return true to gt the subfiltering first init
+                // we are initializing now: return true to get the subfiltering first init
                 return currentTag != null && currentTag.isFollowedSites();
             } else if (recyclerView != null && recyclerView.getCurrentFilter() instanceof ReaderTag) {
                 ReaderTag filter = (ReaderTag) recyclerView.getCurrentFilter();
@@ -346,7 +346,7 @@ public class ReaderUtils {
             boolean isTopLevelReader,
             FilteredRecyclerView recyclerView
     ) {
-        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && isTopLevelReader) {
+        if (isTopLevelReader) {
             return (recyclerView != null && recyclerView.isValidFilter(tag))
                    ||
                    (tag.isFollowedSites() || tag.isDiscover() || tag.isPostsILike() || tag.isBookmarked());

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -8,7 +8,6 @@ import android.view.View;
 import androidx.annotation.NonNull;
 
 import org.apache.commons.text.StringEscapeUtils;
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.datasets.ReaderCommentTable;
 import org.wordpress.android.datasets.ReaderPostTable;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -31,8 +31,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
 public class ReaderUtils {
     public static String getResizedImageUrl(final String imageUrl, int width, int height, boolean isPrivate) {
         return getResizedImageUrl(imageUrl, width, height, isPrivate, PhotonUtils.Quality.MEDIUM);
@@ -207,18 +205,33 @@ public class ReaderUtils {
      * (so we can also get its title & endpoint), returns a new tag if that fails
      */
     public static ReaderTag getTagFromTagName(String tagName, ReaderTagType tagType) {
+        return getTagFromTagName(tagName, tagType, false);
+    }
+
+    public static ReaderTag getTagFromTagName(String tagName, ReaderTagType tagType, boolean isDefaultTag) {
         ReaderTag tag = ReaderTagTable.getTag(tagName, tagType);
         if (tag != null) {
             return tag;
         } else {
-            return createTagFromTagName(tagName, tagType);
+            return createTagFromTagName(tagName, tagType, isDefaultTag);
         }
     }
 
     public static ReaderTag createTagFromTagName(String tagName, ReaderTagType tagType) {
+        return createTagFromTagName(tagName, tagType, false);
+    }
+
+    public static ReaderTag createTagFromTagName(String tagName, ReaderTagType tagType, boolean isDefaultTag) {
         String tagSlug = sanitizeWithDashes(tagName).toLowerCase(Locale.ROOT);
         String tagDisplayName = tagType == ReaderTagType.DEFAULT ? tagName : tagSlug;
-        return new ReaderTag(tagSlug, tagDisplayName, tagName, null, tagType);
+        return new ReaderTag(
+                tagSlug,
+                tagDisplayName,
+                tagName,
+                null,
+                tagType,
+                isDefaultTag
+        );
     }
 
     /*
@@ -228,7 +241,7 @@ public class ReaderUtils {
     public static ReaderTag getDefaultTag() {
         ReaderTag defaultTag = getTagFromEndpoint(ReaderTag.TAG_ENDPOINT_DEFAULT);
         if (defaultTag == null) {
-            defaultTag = getTagFromTagName(ReaderTag.TAG_TITLE_DEFAULT, ReaderTagType.DEFAULT);
+            defaultTag = getTagFromTagName(ReaderTag.TAG_TITLE_DEFAULT, ReaderTagType.DEFAULT, true);
         }
         return defaultTag;
     }
@@ -359,7 +372,6 @@ public class ReaderUtils {
                 if (isFollowing(tag, isTopLevelReader, recyclerView)) {
                     validTag = ReaderUtils.getDefaultTag();
 
-                    ReaderUtils.getDefaultTag();
                     // it's possible the default tag won't exist if the user just changed the app's
                     // language, in which case default to the first tag in the table
                     if (!ReaderTagTable.tagExists(tag)) {
@@ -370,5 +382,9 @@ public class ReaderUtils {
         }
 
         return validTag;
+    }
+
+    public static boolean isDefaultTag(ReaderTag tag) {
+        return tag != null && tag.isDefaultTag();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 public class ReaderUtils {
     public static String getResizedImageUrl(final String imageUrl, int width, int height, boolean isPrivate) {
         return getResizedImageUrl(imageUrl, width, height, isPrivate, PhotonUtils.Quality.MEDIUM);
@@ -340,17 +342,33 @@ public class ReaderUtils {
         }
     }
 
-    public static boolean isValidTagForSharedPrefs(
+    public static ReaderTag getValidTagForSharedPrefs(
             ReaderTag tag,
             boolean isTopLevelReader,
             FilteredRecyclerView recyclerView
     ) {
+        ReaderTag validTag = tag;
+
         if (isTopLevelReader) {
-            return (recyclerView != null && recyclerView.isValidFilter(tag))
-                   ||
-                   (tag.isFollowedSites() || tag.isDiscover() || tag.isPostsILike() || tag.isBookmarked());
-        } else {
-            return true;
+            if (tag.isDiscover() || tag.isPostsILike() || tag.isBookmarked()
+                    ||
+                (recyclerView != null && recyclerView.isValidFilter(tag))
+            ) {
+                validTag = tag;
+            } else {
+                if (isFollowing(tag, isTopLevelReader, recyclerView)) {
+                    validTag = ReaderUtils.getDefaultTag();
+
+                    ReaderUtils.getDefaultTag();
+                    // it's possible the default tag won't exist if the user just changed the app's
+                    // language, in which case default to the first tag in the table
+                    if (!ReaderTagTable.tagExists(tag)) {
+                        validTag = ReaderTagTable.getFirstTag();
+                    }
+                }
+            }
         }
+
+        return validTag;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -343,10 +343,14 @@ public class ReaderUtils {
                 return false;
             } else if (recyclerView != null && recyclerView.getCurrentFilter() == null) {
                 // we are initializing now: return true to get the subfiltering first init
-                return currentTag != null && currentTag.isFollowedSites();
+                return currentTag != null
+                       && (currentTag.isFollowedSites() || currentTag.tagType == ReaderTagType.FOLLOWED);
             } else if (recyclerView != null && recyclerView.getCurrentFilter() instanceof ReaderTag) {
-                ReaderTag filter = (ReaderTag) recyclerView.getCurrentFilter();
-                return filter.isFollowedSites();
+                if (recyclerView.isValidFilter(currentTag)) {
+                    return currentTag.isFollowedSites();
+                } else {
+                    return true;
+                }
             } else {
                 return false;
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/CurrentTagInfo.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/CurrentTagInfo.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.ui.reader.viewmodels
+
+import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
+import org.wordpress.android.ui.utils.UiString
+
+data class CurrentTagInfo(
+    val tag: ReaderTag?,
+    val listType: ReaderPostListType,
+    val blogId: Long,
+    val feedId: Long,
+    val requestNewerPosts: Boolean,
+    val label: UiString?
+)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderModeInfo.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderModeInfo.kt
@@ -4,7 +4,7 @@ import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
 import org.wordpress.android.ui.utils.UiString
 
-data class CurrentTagInfo(
+data class ReaderModeInfo(
     val tag: ReaderTag?,
     val listType: ReaderPostListType,
     val blogId: Long,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -85,9 +85,6 @@ class ReaderPostListViewModel @Inject constructor(
                 _newsItemSourceMediator.value = null
             }
         }
-
-        _shouldShowSubFilters.postValue((tag?.let { !it.isDiscover && !it.isPostsILike && !it.isBookmarked })
-                ?: false)
     }
 
     fun onNewsCardDismissed(item: NewsItem) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -57,7 +57,7 @@ class ReaderPostListViewModel @Inject constructor(
     /**
      * Tag may be null for Blog previews for instance.
      */
-    fun start(tag: ReaderTag?) {
+    fun start(tag: ReaderTag?, shouldShowSubfilter: Boolean) {
         if (isStarted) {
             return
         }
@@ -66,6 +66,7 @@ class ReaderPostListViewModel @Inject constructor(
             newsManager.pull()
 
             _currentSubFilter.value = getCurrentSubfilterValue()
+            _shouldShowSubFilters.value = shouldShowSubfilter
         }
         isStarted = true
     }
@@ -165,17 +166,7 @@ class ReaderPostListViewModel @Inject constructor(
             it
         })
 
-        when (filter) {
-            is SectionTitle,
-            Divider -> {
-                // nop
-            }
-            is SiteAll,
-            is Site,
-            is Tag -> {
-                _currentSubFilter.postValue(filter)
-            }
-        }
+        _currentSubFilter.postValue(filter)
     }
 
     fun setSubfiltersVisibility(show: Boolean) = _shouldShowSubFilters.postValue(show)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -2,25 +2,51 @@ package org.wordpress.android.ui.reader.viewmodels
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.launch
+import org.wordpress.android.R
+import org.wordpress.android.datasets.ReaderBlogTable
+import org.wordpress.android.datasets.ReaderTagTable
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.news.NewsItem
+import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.news.NewsManager
 import org.wordpress.android.ui.news.NewsTracker
 import org.wordpress.android.ui.news.NewsTracker.NewsCardOrigin.READER
 import org.wordpress.android.ui.news.NewsTrackerHelper
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Divider
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.SectionTitle
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Site
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.SiteAll
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Tag
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
+import javax.inject.Named
 
 class ReaderPostListViewModel @Inject constructor(
     private val newsManager: NewsManager,
     private val newsTracker: NewsTracker,
-    private val newsTrackerHelper: NewsTrackerHelper
-) : ViewModel() {
+    private val newsTrackerHelper: NewsTrackerHelper,
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+) : ScopedViewModel(bgDispatcher) {
     private val newsItemSource = newsManager.newsItemSource()
     private val _newsItemSourceMediator = MediatorLiveData<NewsItem>()
 
     private val onTagChanged: Observer<NewsItem?> = Observer { _newsItemSourceMediator.value = it }
+
+    private val _subFilters = MutableLiveData<List<SubfilterListItem>>()
+    val subFilters: LiveData<List<SubfilterListItem>> = _subFilters
+
+    private val _currentSubFilter = MutableLiveData<SubfilterListItem>()
+    val currentSubFilter: LiveData<SubfilterListItem> = _currentSubFilter
+
+    private val _shouldShowSubFilters = MutableLiveData<Boolean>()
+    val shouldShowSubFilters: LiveData<Boolean> = _shouldShowSubFilters
 
     /**
      * First tag for which the card was shown.
@@ -38,6 +64,8 @@ class ReaderPostListViewModel @Inject constructor(
         tag?.let {
             onTagChanged(tag)
             newsManager.pull()
+
+            _currentSubFilter.value = getCurrentSubfilterValue()
         }
         isStarted = true
     }
@@ -57,6 +85,9 @@ class ReaderPostListViewModel @Inject constructor(
                 _newsItemSourceMediator.value = null
             }
         }
+
+        _shouldShowSubFilters.postValue((tag?.let { !it.isDiscover && !it.isPostsILike && !it.isBookmarked })
+                ?: false)
     }
 
     fun onNewsCardDismissed(item: NewsItem) {
@@ -78,6 +109,104 @@ class ReaderPostListViewModel @Inject constructor(
 
     fun onNewsCardExtendedInfoRequested(item: NewsItem) {
         newsTracker.trackNewsCardExtendedInfoRequested(READER, item.version)
+    }
+
+    fun loadSubFilters() {
+        launch {
+            val filterList = ArrayList<SubfilterListItem>()
+
+            filterList.add(SectionTitle(UiStringRes(R.string.reader_filter_sites_title)))
+            filterList.add(
+                    SiteAll(
+                        label = UiStringRes(R.string.reader_filter_all_sites),
+                        onClickAction = ::onSubfilterClicked,
+                        isSelected = (getCurrentSubfilterValue() is SiteAll)
+                    )
+            )
+
+            // Filtering Discover out
+            val followedBlogs = ReaderBlogTable.getFollowedBlogs().let { blogList ->
+                blogList.filter { blog ->
+                    !(blog.url.startsWith("https://discover.wordpress.com"))
+                }
+            }
+
+            for (blog in followedBlogs) {
+                filterList.add(Site(
+                        label = if (blog.name.isNotEmpty()) UiStringText(blog.name) else UiStringRes(
+                            R.string.reader_untitled_post),
+                        onClickAction = ::onSubfilterClicked,
+                        blog = blog,
+                        isSelected = (getCurrentSubfilterValue() is Site) &&
+                                (getCurrentSubfilterValue() as Site).blog.name == blog.name
+                ))
+            }
+
+            filterList.add(Divider)
+
+            filterList.add(SectionTitle(UiStringRes(R.string.reader_filter_tags_title)))
+
+            val tags = ReaderTagTable.getFollowedTags()
+
+            for (tag in tags) {
+                filterList.add(Tag(
+                        label = UiStringText(tag.tagTitle),
+                        onClickAction = ::onSubfilterClicked,
+                        tag = tag,
+                        isSelected = (getCurrentSubfilterValue() is Tag) &&
+                                (getCurrentSubfilterValue() as Tag).tag.tagTitle == tag.tagTitle
+                ))
+            }
+
+            _subFilters.postValue(filterList)
+        }
+    }
+
+    private fun onSubfilterClicked(filter: SubfilterListItem) {
+        _subFilters.postValue(_subFilters.value?.map {
+            it.isSelected = filter == it
+            it
+        })
+
+        when (filter) {
+            is SectionTitle,
+            Divider -> {
+                // nop
+            }
+            is SiteAll,
+            is Site,
+            is Tag -> {
+                _currentSubFilter.postValue(filter)
+            }
+        }
+    }
+
+    fun setSubfiltersVisibility(show: Boolean) = _shouldShowSubFilters.postValue(show)
+
+    fun getCurrentSubfilterValue(): SubfilterListItem {
+        return _currentSubFilter.value ?: SiteAll(
+                label = UiStringRes(R.string.reader_filter_all_sites),
+                onClickAction = ::onSubfilterClicked,
+                isSelected = true)
+    }
+
+    fun setSubfilterFromTag(tag: ReaderTag) {
+        _currentSubFilter.postValue(
+                Tag(
+                    label = UiStringText(tag.tagTitle),
+                    onClickAction = ::onSubfilterClicked,
+                    tag = tag,
+                    isSelected = true
+                ))
+    }
+
+    fun setDefaultSubfilter() {
+        _currentSubFilter.postValue(
+                SiteAll(
+                        label = UiStringRes(R.string.reader_filter_all_sites),
+                        onClickAction = ::onSubfilterClicked,
+                        isSelected = true
+                ))
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -51,8 +51,8 @@ class ReaderPostListViewModel @Inject constructor(
     private val _shouldShowSubFilters = MutableLiveData<Boolean>()
     val shouldShowSubFilters: LiveData<Boolean> = _shouldShowSubFilters
 
-    private val _currentTagInfo = SingleLiveEvent<CurrentTagInfo>()
-    val currentTagInfo: LiveData<CurrentTagInfo> = _currentTagInfo
+    private val _readerModeInfo = SingleLiveEvent<ReaderModeInfo>()
+    val readerModeInfo: LiveData<ReaderModeInfo> = _readerModeInfo
 
     /**
      * First tag for which the card was shown.
@@ -203,7 +203,7 @@ class ReaderPostListViewModel @Inject constructor(
                 ))
     }
 
-    fun setCurrentSubfilter(
+    fun applySubfilter(
         subfilterListItem: SubfilterListItem,
         requestNewerPosts: Boolean
     ) {
@@ -212,7 +212,7 @@ class ReaderPostListViewModel @Inject constructor(
             SubfilterListItem.ItemType.DIVIDER -> {
                 // nop
             }
-            SubfilterListItem.ItemType.SITE_ALL -> _currentTagInfo.value = (CurrentTagInfo(
+            SubfilterListItem.ItemType.SITE_ALL -> _readerModeInfo.value = (ReaderModeInfo(
                     ReaderUtils.getDefaultTag(),
                     ReaderPostListType.TAG_FOLLOWED,
                     0,
@@ -227,7 +227,7 @@ class ReaderPostListViewModel @Inject constructor(
                 else
                     subfilterListItem.blog.blogId
 
-                _currentTagInfo.value = (CurrentTagInfo(
+                _readerModeInfo.value = (ReaderModeInfo(
                         null,
                         ReaderPostListType.BLOG_PREVIEW,
                         currentBlogId,
@@ -236,7 +236,7 @@ class ReaderPostListViewModel @Inject constructor(
                         subfilterListItem.label
                 ))
             }
-            SubfilterListItem.ItemType.TAG -> _currentTagInfo.value = (CurrentTagInfo(
+            SubfilterListItem.ItemType.TAG -> _readerModeInfo.value = (ReaderModeInfo(
                     (subfilterListItem as Tag).tag,
                     ReaderPostListType.TAG_FOLLOWED,
                     0,

--- a/WordPress/src/main/res/drawable/ic_done_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_done_white_24dp.xml
@@ -1,0 +1,11 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9,16.2L4.8,12l-1.4,1.4L9,19 21,7l-1.4,-1.4L9,16.2z"/>
+</vector>

--- a/WordPress/src/main/res/drawable/ic_filter_list_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_filter_list_white_24dp.xml
@@ -1,0 +1,11 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10,18h4v-2h-4v2zM3,6v2h18L21,6L3,6zM6,13h12v-2L6,11v2z"/>
+</vector>

--- a/WordPress/src/main/res/layout/subfilter_component.xml
+++ b/WordPress/src/main/res/layout/subfilter_component.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/one_line_list_item_height"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@android:color/white"
+    android:elevation="@dimen/appbar_elevation">
+
+    <ImageButton
+        android:id="@+id/filter_list_button"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:background="?selectableItemBackgroundBorderless"
+        android:contentDescription="@null"
+        android:paddingStart="@dimen/margin_extra_large"
+        android:paddingEnd="@dimen/margin_extra_large"
+        android:src="@drawable/ic_filter_list_white_24dp"
+        android:tint="@color/neutral_70"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/selected_filter_name"
+        style="@style/SiteTagFilteredTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_medium"
+        android:layout_marginEnd="@dimen/margin_medium"
+        android:ellipsize="end"
+        android:singleLine="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/view"
+        app:layout_constraintStart_toEndOf="@+id/filter_list_button"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="@string/reader_filter_all_sites" />
+
+    <View
+        android:id="@+id/view"
+        android:layout_width="@dimen/list_divider_height"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="@dimen/margin_medium"
+        android:layout_marginTop="@dimen/margin_medium"
+        android:background="@color/divider"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/filter_settings_button"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageButton
+        android:id="@+id/filter_settings_button"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:background="?selectableItemBackgroundBorderless"
+        android:contentDescription="@null"
+        android:paddingStart="@dimen/margin_extra_large"
+        android:paddingEnd="@dimen/margin_extra_large"
+        android:src="@drawable/ic_cog_white_24dp"
+        android:tint="@color/neutral_70"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/subfilter_component.xml
+++ b/WordPress/src/main/res/layout/subfilter_component.xml
@@ -7,34 +7,46 @@
     android:background="@android:color/white"
     android:elevation="@dimen/appbar_elevation">
 
-    <ImageButton
-        android:id="@+id/filter_list_button"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:id="@+id/filter_selection"
+        android:layout_width="0dp"
         android:layout_height="match_parent"
         android:background="?selectableItemBackgroundBorderless"
-        android:contentDescription="@null"
         android:paddingStart="@dimen/margin_extra_large"
         android:paddingEnd="@dimen/margin_extra_large"
-        android:src="@drawable/ic_filter_list_white_24dp"
-        android:tint="@color/neutral_70"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-        android:id="@+id/selected_filter_name"
-        style="@style/SiteTagFilteredTitle"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_medium"
-        android:layout_marginEnd="@dimen/margin_medium"
-        android:ellipsize="end"
-        android:singleLine="true"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/view"
-        app:layout_constraintStart_toEndOf="@+id/filter_list_button"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="@string/reader_filter_all_sites" />
+        app:layout_constraintEnd_toStartOf="@+id/view">
+
+        <ImageView
+            android:id="@+id/filter_list_button"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_filter_list_white_24dp"
+            android:tint="@color/neutral_70"
+            android:background="@null"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/selected_filter_name"
+            style="@style/SiteTagFilteredTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_medium"
+            android:layout_marginEnd="@dimen/margin_medium"
+            android:ellipsize="end"
+            android:singleLine="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/filter_list_button"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="@string/reader_filter_all_sites" />
+
+    </LinearLayout>
 
     <View
         android:id="@+id/view"
@@ -47,7 +59,7 @@
         app:layout_constraintEnd_toStartOf="@+id/filter_settings_button"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <ImageButton
+    <ImageView
         android:id="@+id/filter_settings_button"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"

--- a/WordPress/src/main/res/layout/subfilter_divider_item.xml
+++ b/WordPress/src/main/res/layout/subfilter_divider_item.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    style="@style/SubfilterDividerItem">
+
+    <View
+        style="@style/SubfilterDivider"
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:visibility="visible"/>
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/subfilter_list.xml
+++ b/WordPress/src/main/res/layout/subfilter_list.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:animateLayoutChanges="true">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/filter_recycler_view"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:clipToPadding="false"
+        android:descendantFocusability="beforeDescendants"
+        android:scrollbars="vertical"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:layout_marginBottom="@dimen/margin_extra_large"/>
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/subfilter_list_item.xml
+++ b/WordPress/src/main/res/layout/subfilter_list_item.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/SubfilterSiteTagItem"
+    android:layout_width="match_parent"
+    android:orientation="horizontal">
+
+    <TextView
+        android:id="@+id/item_title"
+        style="@style/SiteTagFilteredTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/item_selected"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="@string/unknown" />
+
+    <ImageView
+        android:id="@+id/item_selected"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_done_white_24dp"
+        android:tint="@color/primary"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:visibility="gone"
+        tools:visibility="visible"
+        android:contentDescription="@null" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/subfilter_section_title.xml
+++ b/WordPress/src/main/res/layout/subfilter_section_title.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    style="@style/SubfilterSectionItem">
+
+    <TextView
+        android:id="@+id/section_title"
+        style="@style/SubfilterSectionTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        tools:text="@string/unknown"/>
+
+</LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1209,6 +1209,9 @@
 
     <!-- reader -->
     <string name="reader">Reader</string>
+    <string name="reader_filter_all_sites">All sites</string>
+    <string name="reader_filter_sites_title">Sites</string>
+    <string name="reader_filter_tags_title">Tags</string>
 
     <!-- editor -->
     <string name="editor_post_saved_online">Post saved online</string>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1066,5 +1066,39 @@
     <style name="MainBottomSheetRowTextView" parent="MySiteListRowTextView">
         <item name="android:layout_gravity">center_vertical</item>
     </style>
+    
+    <!-- Reader styles -->
+    <style name="SubfilterSectionItem">
+        <item name="android:layout_height">@dimen/one_line_list_item_height</item>
+        <item name="android:paddingStart">@dimen/content_margin_site_row_start</item>
+    </style>
+
+    <style name="SubfilterSectionTitle" parent="TextAppearance.AppCompat.Body2">
+        <item name="android:textColor">@color/neutral_30</item>
+        <item name="android:textSize">@dimen/text_sz_small</item>
+    </style>
+
+    <style name="SubfilterSiteTagItem">
+        <item name="android:layout_height">@dimen/one_line_list_item_height</item>
+        <item name="android:paddingStart">@dimen/content_margin_site_row_start</item>
+        <item name="android:paddingEnd">@dimen/content_margin_site_row_start</item>
+        <item name="android:background">?attr/selectableItemBackground</item>
+    </style>
+
+    <style name="SiteTagFilteredTitle" parent="MySiteListRowTextView">
+        <item name="android:layout_gravity">center_vertical</item>
+    </style>
+
+    <style name="SubfilterDividerItem">
+        <item name="android:layout_height">@dimen/one_line_list_item_height</item>
+    </style>
+
+    <style name="SubfilterDivider">
+        <item name="android:layout_height">@dimen/list_divider_height</item>
+        <item name="android:layout_marginStart">@dimen/margin_medium</item>
+        <item name="android:layout_marginEnd">@dimen/margin_medium</item>
+        <item name="android:background">@color/neutral_30</item>
+        <item name="android:layout_gravity">center_vertical</item>
+    </style>
 
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
@@ -1,8 +1,6 @@
 package org.wordpress.android.ui.reader.utils
 
 import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
@@ -67,6 +67,7 @@ class ReaderUtilsTest {
     fun `isFollowing is based on FilteredRecyclerView when is top level reader`() {
         whenever(currentTag.isFollowedSites).thenReturn(true)
         whenever(filteredRecyclerView.currentFilter).thenReturn(currentTag)
+        whenever(filteredRecyclerView.isValidFilter(currentTag)).thenReturn(true)
         var result = ReaderUtils.isFollowing(currentTag, true, filteredRecyclerView)
         assertThat(result).isEqualTo(true)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
@@ -1,17 +1,27 @@
 package org.wordpress.android.ui.reader.utils
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.models.ReaderTagType.BOOKMARKED
+import org.wordpress.android.models.ReaderTagType.CUSTOM_LIST
 import org.wordpress.android.models.ReaderTagType.DEFAULT
 import org.wordpress.android.models.ReaderTagType.FOLLOWED
+import org.wordpress.android.ui.FilteredRecyclerView
 
 @RunWith(MockitoJUnitRunner::class)
 class ReaderUtilsTest {
+    @Mock lateinit var currentTag: ReaderTag
+    @Mock lateinit var filteredRecyclerView: FilteredRecyclerView
+
     private fun getShuffledTagList(): ReaderTagList {
         val tagList = ReaderTagList()
         tagList.addAll(listOf(
@@ -47,5 +57,45 @@ class ReaderUtilsTest {
         val shuffledList = getShuffledTagList()
         val orederList = ReaderUtils.getOrderedTagsList(shuffledList, ReaderUtils.getDefaultTagInfo())
         assertThat(orederList).isEqualTo(getExpectedTagList())
+    }
+
+    @Test
+    fun `isFollowing is based on currentTag status if is not top level reader`() {
+        whenever(currentTag.isFollowedSites).thenReturn(true)
+        assertThat(ReaderUtils.isFollowing(currentTag, false, null)).isEqualTo(true)
+        whenever(currentTag.isFollowedSites).thenReturn(false)
+        assertThat(ReaderUtils.isFollowing(currentTag, false, null)).isEqualTo(false)
+    }
+
+    @Test
+    fun `isFollowing is based on FilteredRecyclerView when is top level reader`() {
+        whenever(currentTag.isFollowedSites).thenReturn(true)
+        whenever(filteredRecyclerView.currentFilter).thenReturn(currentTag)
+        var result = ReaderUtils.isFollowing(currentTag, true, filteredRecyclerView)
+        assertThat(result).isEqualTo(true)
+
+        whenever(currentTag.isFollowedSites).thenReturn(false)
+        whenever(filteredRecyclerView.currentFilter).thenReturn(currentTag)
+        result = ReaderUtils.isFollowing(currentTag, true, filteredRecyclerView)
+        assertThat(result).isEqualTo(false)
+    }
+
+    @Test
+    fun `isValidTagForSharedPrefs is based on isValidFilter when is top level reader`() {
+        whenever(filteredRecyclerView.isValidFilter(any())).thenReturn(true)
+        assertThat(
+                ReaderUtils.isValidTagForSharedPrefs(
+                        ReaderTag("", "", "", "", CUSTOM_LIST),
+                        true,
+                        filteredRecyclerView)
+        ).isEqualTo(true)
+
+        whenever(filteredRecyclerView.isValidFilter(any())).thenReturn(false)
+        assertThat(
+                ReaderUtils.isValidTagForSharedPrefs(
+                        ReaderTag("", "", "", "", CUSTOM_LIST),
+                        true,
+                        filteredRecyclerView)
+        ).isEqualTo(false)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.reader.utils
 
-import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -10,7 +9,6 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.models.ReaderTagType.BOOKMARKED
-import org.wordpress.android.models.ReaderTagType.CUSTOM_LIST
 import org.wordpress.android.models.ReaderTagType.DEFAULT
 import org.wordpress.android.models.ReaderTagType.FOLLOWED
 import org.wordpress.android.ui.FilteredRecyclerView
@@ -76,24 +74,5 @@ class ReaderUtilsTest {
         whenever(filteredRecyclerView.currentFilter).thenReturn(currentTag)
         result = ReaderUtils.isFollowing(currentTag, true, filteredRecyclerView)
         assertThat(result).isEqualTo(false)
-    }
-
-    @Test
-    fun `isValidTagForSharedPrefs is based on isValidFilter when is top level reader`() {
-        whenever(filteredRecyclerView.isValidFilter(any())).thenReturn(true)
-        assertThat(
-                ReaderUtils.isValidTagForSharedPrefs(
-                        ReaderTag("", "", "", "", CUSTOM_LIST),
-                        true,
-                        filteredRecyclerView)
-        ).isEqualTo(true)
-
-        whenever(filteredRecyclerView.isValidFilter(any())).thenReturn(false)
-        assertThat(
-                ReaderUtils.isValidTagForSharedPrefs(
-                        ReaderTag("", "", "", "", CUSTOM_LIST),
-                        true,
-                        filteredRecyclerView)
-        ).isEqualTo(false)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -61,13 +61,13 @@ class ReaderPostListViewModelTest {
 
     @Test
     fun verifyPullInvokedInOnStart() {
-        viewModel.start(initialTag)
+        viewModel.start(initialTag, false)
         verify(newsManager).pull(false)
     }
 
     @Test
     fun verifyViewModelPropagatesNewsItems() {
-        viewModel.start(initialTag)
+        viewModel.start(initialTag, false)
         liveData.postValue(item)
         liveData.postValue(null)
         liveData.postValue(item)
@@ -86,7 +86,7 @@ class ReaderPostListViewModelTest {
 
     @Test
     fun emitNullOnInitialTagChanged() {
-        viewModel.start(otherTag)
+        viewModel.start(otherTag, false)
         // propagates the item since the card hasn't been shown yet
         liveData.postValue(item)
         viewModel.onTagChanged(initialTag)
@@ -101,7 +101,7 @@ class ReaderPostListViewModelTest {
 
     @Test
     fun verifyNewsItemAvailableOnlyForFirstTagForWhichCardWasShown() {
-        viewModel.start(otherTag)
+        viewModel.start(otherTag, false)
         // propagate the item since the card hasn't been shown yet
         liveData.postValue(item)
         viewModel.onTagChanged(initialTag)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -9,20 +9,28 @@ import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.models.ReaderTagType.BOOKMARKED
 import org.wordpress.android.models.news.NewsItem
 import org.wordpress.android.ui.news.NewsManager
 import org.wordpress.android.ui.news.NewsTracker
 import org.wordpress.android.ui.news.NewsTracker.NewsCardOrigin.READER
 import org.wordpress.android.ui.news.NewsTrackerHelper
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.SiteAll
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Tag
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel
 
+@InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class ReaderPostListViewModelTest {
     @Rule
@@ -46,7 +54,7 @@ class ReaderPostListViewModelTest {
     @Before
     fun setUp() {
         whenever(newsManager.newsItemSource()).thenReturn(liveData)
-        viewModel = ReaderPostListViewModel(newsManager, newsTracker, newsTrackerHelper)
+        viewModel = ReaderPostListViewModel(newsManager, newsTracker, newsTrackerHelper, TEST_DISPATCHER)
         val observable = viewModel.getNewsDataSource()
         observable.observeForever(observer)
     }
@@ -142,5 +150,41 @@ class ReaderPostListViewModelTest {
     fun verifyViewModelPropagatesExtendedInfoRequestedToNewsTracker() {
         viewModel.onNewsCardExtendedInfoRequested(item)
         verify(newsTracker).trackNewsCardExtendedInfoRequested(argThat { this == READER }, any())
+    }
+
+    @Test
+    fun verifySubfilterVisibility() {
+        viewModel.setSubfiltersVisibility(true)
+        assertThat(viewModel.shouldShowSubFilters.value).isEqualTo(true)
+
+        viewModel.setSubfiltersVisibility(false)
+        assertThat(viewModel.shouldShowSubFilters.value).isEqualTo(false)
+    }
+
+    @Test
+    fun getCurrentSubfilterReturnsDefaultAtStart() {
+        assertThat(viewModel.getCurrentSubfilterValue()).isInstanceOf(SiteAll::class.java)
+    }
+
+    @Test
+    fun verifySetSubfilterFromTag() {
+        val tag = ReaderTag("", "", "", "", BOOKMARKED)
+        var item: SubfilterListItem? = null
+        viewModel.setSubfilterFromTag(tag)
+
+        viewModel.currentSubFilter.observeForever { item = it }
+
+        assertThat((item as Tag).tag).isEqualTo(tag)
+    }
+
+    @Test
+    fun verifySetDefaultSubfilter() {
+        val tag = ReaderTag("", "", "", "", BOOKMARKED)
+        var item: SubfilterListItem? = null
+        viewModel.setDefaultSubfilter()
+
+        viewModel.currentSubFilter.observeForever { item = it }
+
+        assertThat(item).isInstanceOf(SiteAll::class.java)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -179,7 +179,6 @@ class ReaderPostListViewModelTest {
 
     @Test
     fun verifySetDefaultSubfilter() {
-        val tag = ReaderTag("", "", "", "", BOOKMARKED)
         var item: SubfilterListItem? = null
         viewModel.setDefaultSubfilter()
 


### PR DESCRIPTION
This PR is one of a set of PRs which aim to supersede the #10716 decomposing it in more manageable/testable/reviewable PRs (cc @osullivanchris ).

The current one is based and requires the #10783 

Visually we have added a subfiltering component that should be available only in the `FOLLOWING` tab. Below you can see the subfiltering component

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/68861160-413fc180-06eb-11ea-86fc-b796db7eb87b.png>
</p>

Below what you get tapping on each of the above

| Tag/Site selector  | Settings selector |
|---|---|
|![image](https://user-images.githubusercontent.com/47797566/68861257-7ea44f00-06eb-11ea-99a4-4b2fc0e484b6.png)|![image](https://user-images.githubusercontent.com/47797566/68861308-97146980-06eb-11ea-822e-2261c4cee14a.png)|

## Notes
- Feature flag is again active only in zalpha flavor. Important goal is to make the feature flag have no impact in code base when disabled (vanilla flavor)! So I appreciate a special eye on the code in this direction :)
- The settings screen is not changed, only the botton from which to access to it was moved to the subfilter bar
- Similarly to the bottom sheet for the create post/pages in my site, also this one is pretty basic. There is some design work ongoing in the direction of creating a standard component we can use for the Bottom Sheet paradigm
- Could not find a better way to filter out the Discover from the followed sites in the bottom sheet than filter on the URL (better suggestions accepted :) )
- Left for now (tracking it in a separate issue) a different behavior that was already present but less impacting with the previous IA. When adding a new tag in settings and coming back to the reader, the new added tag is selected and posts shown. This does not happen when adding a followed site from settings
- Release notes will be updated when releasing in develop removing the feature flag

## To test
### With the vanilla flavor
- Use the Vanilla flavor and smoke test to check the original behavior didn't changed (doing same steps with same user account in parallel on emulator/device with last release and this one would be great)
- Check the behavior of My Site > Comments and My Site > People did not change
- Check the behavior of Reader nested navigation did not change

### With the zalpha flavor
- Check that you have only the FOLLOWING, DISCOVER, LIKES and SAVED tabs in the reader (NOTE: you will also get AUTOMATTIC tab as last tab in case you login with an Automattic account)
- Check that the subfilter bar is only available when you are in the FOLLOWING tab
- Try to open the settings and try to add/remove a TAG , when coming back in the reader you should get that one selected or the Following selected if you removed the tag yo were looking at
- Try to open the settings and try to follow/unfollow a site, when coming back to the reader you should get the same page where you were before
- Select a site from Discover tab, you should get a list of post from that site in a new activity. Come back from it and you should get the reader stay in the same tab you left before
- smoke test the search icon
- Smoke test the reader in general (move between tabs, use the subfilter to select different sources, open posts from the reader, follow/unfollow tags/sites etc...)

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

