### PR TITLE
Replace EditorMediaPostData with PostImmutableModel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -121,7 +121,6 @@ import org.wordpress.android.ui.posts.editor.SecondaryEditorAction;
 import org.wordpress.android.ui.posts.editor.media.EditorMedia;
 import org.wordpress.android.ui.posts.editor.media.EditorMedia.AddExistingMediaSource;
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener;
-import org.wordpress.android.ui.posts.editor.media.EditorMediaPostData;
 import org.wordpress.android.ui.posts.services.AztecImageLoader;
 import org.wordpress.android.ui.posts.services.AztecVideoLoader;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -3334,9 +3333,8 @@ public class EditPostActivity extends AppCompatActivity implements
         mEditorFragment.appendMediaFile(mediaFile, imageUrl, mImageLoader);
     }
 
-    @Override
-    public @NonNull EditorMediaPostData editorMediaPostData() {
-        return new EditorMediaPostData(mEditPostRepository.getId(), mEditPostRepository.getRemotePostId());
+    @NotNull @Override public PostImmutableModel getImmutablePost() {
+        return Objects.requireNonNull(mEditPostRepository.getPost());
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
@@ -85,7 +85,7 @@ class AddLocalMediaToPostUseCase @Inject constructor(
         mediaModels.forEach {
             updateMediaModelUseCase.updateMediaModel(
                     it,
-                    editorMediaListener.editorMediaPostData(),
+                    editorMediaListener.getImmutablePost(),
                     QUEUED
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState
+import org.wordpress.android.fluxc.model.PostImmutableModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.MediaStore.CancelMediaPayload
@@ -41,16 +42,11 @@ import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
-data class EditorMediaPostData(
-    val localPostId: Int,
-    val remotePostId: Long
-)
-
 interface EditorMediaListener {
     fun appendMediaFile(mediaFile: MediaFile, imageUrl: String)
     fun syncPostObjectWithUiAndSaveIt(listener: AfterSavePostListener? = null)
     fun advertiseImageOptimization(listener: () -> Unit)
-    fun editorMediaPostData(): EditorMediaPostData
+    fun getImmutablePost(): PostImmutableModel
 }
 
 class EditorMedia @Inject constructor(
@@ -215,7 +211,7 @@ class EditorMedia @Inject constructor(
                     ?.let {
                         updateMediaModelUseCase.updateMediaModel(
                                 it,
-                                editorMediaListener.editorMediaPostData(),
+                                editorMediaListener.getImmutablePost(),
                                 mediaUploadState
                         )
                         it

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/RetryFailedMediaUploadUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/RetryFailedMediaUploadUseCase.kt
@@ -22,7 +22,7 @@ class RetryFailedMediaUploadUseCase @Inject constructor(
                 .map { media ->
                     updateMediaModelUseCase.updateMediaModel(
                             media,
-                            editorMediaListener.editorMediaPostData(),
+                            editorMediaListener.getImmutablePost(),
                             QUEUED
                     )
                     media

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/UpdateMediaModelUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/UpdateMediaModelUseCase.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState
+import org.wordpress.android.fluxc.model.PostImmutableModel
 import javax.inject.Inject
 
 /**
@@ -15,11 +16,11 @@ import javax.inject.Inject
 class UpdateMediaModelUseCase @Inject constructor(private val dispatcher: Dispatcher) {
     fun updateMediaModel(
         media: MediaModel,
-        postData: EditorMediaPostData,
+        postData: PostImmutableModel,
         initialUploadState: MediaUploadState
     ) {
         media.postId = postData.remotePostId
-        media.localPostId = postData.localPostId
+        media.localPostId = postData.id
         media.setUploadState(initialUploadState)
         dispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media))
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/UpdateMediaModelUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/UpdateMediaModelUseCaseTest.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.action.MediaAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState
+import org.wordpress.android.fluxc.model.PostImmutableModel
 
 @RunWith(MockitoJUnitRunner::class)
 class UpdateMediaModelUseCaseTest {
@@ -80,9 +81,9 @@ class UpdateMediaModelUseCaseTest {
         }
 
         fun createPostData(localId: Int = LOCAL_ID, remoteId: Long = REMOTE_ID) =
-                mock<EditorMediaPostData> {
+                mock<PostImmutableModel> {
                     on { remotePostId }.thenReturn(remoteId)
-                    on { localPostId }.thenReturn(localId)
+                    on { id }.thenReturn(localId)
                 }
 
         fun createMediaModel(uploadState: MediaUploadState = MediaUploadState.QUEUED) =


### PR DESCRIPTION
Replaces EditorMediaPostData with PostImmutableModel.

To test:
- Add a media to editor

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

