### PR TITLE
Accessibility : Notification Improvements 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -19,7 +19,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.widget.EditText;
 
-import androidx.annotation.ColorRes;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.content.ContextCompat;
@@ -192,7 +191,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         mSearchMenuItem = menu.findItem(R.id.menu_notifications_settings_search);
         mSearchView = (SearchView) mSearchMenuItem.getActionView();
         mSearchView.setQueryHint(getString(R.string.search_sites));
-        setSearchViewHintColor(R.color.wordpress_blue_10);
+        setSearchViewHintColor();
         mBlogsCategory = (PreferenceCategory) findPreference(
                 getString(R.string.pref_notification_blogs));
         mFollowedBlogsCategory = (PreferenceCategory) findPreference(
@@ -244,10 +243,10 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         }
     }
 
-    private void setSearchViewHintColor(@ColorRes int colorRes) {
-        if (mSearchView != null) {
+    private void setSearchViewHintColor() {
+        if (mSearchView != null && getActivity() != null) {
             ((EditText) mSearchView.findViewById(androidx.appcompat.R.id.search_src_text))
-                    .setHintTextColor(ContextCompat.getColor(getActivity(), colorRes));
+                    .setHintTextColor(ContextCompat.getColor(getActivity(), R.color.wordpress_blue_10));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -246,7 +246,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
     private void setSearchViewHintColor() {
         if (mSearchView != null && getActivity() != null) {
             ((EditText) mSearchView.findViewById(androidx.appcompat.R.id.search_src_text))
-                    .setHintTextColor(ContextCompat.getColor(getActivity(), R.color.wordpress_blue_10));
+                    .setHintTextColor(ContextCompat.getColor(getActivity(), R.color.wordpress_blue_5));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -17,9 +17,12 @@ import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.widget.EditText;
 
+import androidx.annotation.ColorRes;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SearchView;
+import androidx.core.content.ContextCompat;
 
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
@@ -189,6 +192,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         mSearchMenuItem = menu.findItem(R.id.menu_notifications_settings_search);
         mSearchView = (SearchView) mSearchMenuItem.getActionView();
         mSearchView.setQueryHint(getString(R.string.search_sites));
+        setSearchViewHintColor(R.color.wordpress_blue_10);
         mBlogsCategory = (PreferenceCategory) findPreference(
                 getString(R.string.pref_notification_blogs));
         mFollowedBlogsCategory = (PreferenceCategory) findPreference(
@@ -237,6 +241,13 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         if (!TextUtils.isEmpty(mRestoredQuery)) {
             mSearchMenuItem.expandActionView();
             mSearchView.setQuery(mRestoredQuery, true);
+        }
+    }
+
+    private void setSearchViewHintColor(@ColorRes int colorRes) {
+        if (mSearchView != null) {
+            ((EditText) mSearchView.findViewById(androidx.appcompat.R.id.search_src_text))
+                    .setHintTextColor(ContextCompat.getColor(getActivity(), colorRes));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -19,6 +19,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.widget.EditText;
 
+import androidx.annotation.ColorRes;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.content.ContextCompat;
@@ -191,7 +192,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         mSearchMenuItem = menu.findItem(R.id.menu_notifications_settings_search);
         mSearchView = (SearchView) mSearchMenuItem.getActionView();
         mSearchView.setQueryHint(getString(R.string.search_sites));
-        setSearchViewHintColor();
+        setSearchViewHintColor(mSearchView, R.color.wordpress_blue_5);
         mBlogsCategory = (PreferenceCategory) findPreference(
                 getString(R.string.pref_notification_blogs));
         mFollowedBlogsCategory = (PreferenceCategory) findPreference(
@@ -243,10 +244,11 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         }
     }
 
-    private void setSearchViewHintColor() {
-        if (mSearchView != null && getActivity() != null) {
-            ((EditText) mSearchView.findViewById(androidx.appcompat.R.id.search_src_text))
-                    .setHintTextColor(ContextCompat.getColor(getActivity(), R.color.wordpress_blue_5));
+    private static void setSearchViewHintColor(@NonNull SearchView searchView, @ColorRes int colorResId) {
+        final Context context = searchView.getContext();
+        if (context != null) {
+            ((EditText) searchView.findViewById(androidx.appcompat.R.id.search_src_text))
+                    .setHintTextColor(ContextCompat.getColor(context, colorResId));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/PrefMasterSwitchToolbarView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/PrefMasterSwitchToolbarView.kt
@@ -100,12 +100,14 @@ class PrefMasterSwitchToolbarView @JvmOverloads constructor(
                     R.styleable.PrefMasterSwitchToolbarView, 0, 0
             )
             try {
+                titleContentDescription = typedArray
+                        .getString(R.styleable.PrefMasterSwitchToolbarView_masterContentDescription)
+
                 val titleOn = typedArray.getString(R.styleable.PrefMasterSwitchToolbarView_masterTitleOn)
                 val titleOff = typedArray.getString(R.styleable.PrefMasterSwitchToolbarView_masterTitleOff)
                 val hintOn = typedArray.getString(R.styleable.PrefMasterSwitchToolbarView_masterHintOn)
                 val hintOff = typedArray.getString(R.styleable.PrefMasterSwitchToolbarView_masterHintOff)
-                titleContentDescription = typedArray
-                        .getString(R.styleable.PrefMasterSwitchToolbarView_masterContentDescription)
+
                 val contentInsetStart = resources.getDimensionPixelSize(
                         typedArray.getResourceId(
                                 R.styleable.PrefMasterSwitchToolbarView_masterContentInsetStart,
@@ -149,7 +151,7 @@ class PrefMasterSwitchToolbarView @JvmOverloads constructor(
     }
 
     @Suppress("MemberVisibilityCanBePrivate")
-    fun setToolbarTitleContentDescription() {
+    fun updateToolbarSwitchForAccessibility() {
         titleContentDescription?.let {
             for (i in 0 until toolbarSwitch.childCount) {
                 if (toolbarSwitch.getChildAt(i) is TextView) {
@@ -194,7 +196,7 @@ class PrefMasterSwitchToolbarView @JvmOverloads constructor(
         setChecked(checkMaster)
         setToolbarTitle(checkMaster)
         toolbarSwitch.visibility = View.VISIBLE
-        setToolbarTitleContentDescription()
+        updateToolbarSwitchForAccessibility()
     }
 
     @Suppress("MemberVisibilityCanBePrivate")

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/PrefMasterSwitchToolbarView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/PrefMasterSwitchToolbarView.kt
@@ -66,6 +66,7 @@ class PrefMasterSwitchToolbarView @JvmOverloads constructor(
     private var titleOff: String? = null
     private var titleOn: String? = null
     private var viewStyle: PrefMasterSwitchToolbarViewStyle? = null
+    private var titleContentDescription: String? = null
 
     val isMasterChecked: Boolean
         get() = masterSwitch.isChecked
@@ -103,7 +104,7 @@ class PrefMasterSwitchToolbarView @JvmOverloads constructor(
                 val titleOff = typedArray.getString(R.styleable.PrefMasterSwitchToolbarView_masterTitleOff)
                 val hintOn = typedArray.getString(R.styleable.PrefMasterSwitchToolbarView_masterHintOn)
                 val hintOff = typedArray.getString(R.styleable.PrefMasterSwitchToolbarView_masterHintOff)
-                val titleContentDescription = typedArray
+                titleContentDescription = typedArray
                         .getString(R.styleable.PrefMasterSwitchToolbarView_masterContentDescription)
                 val contentInsetStart = resources.getDimensionPixelSize(
                         typedArray.getResourceId(
@@ -127,7 +128,6 @@ class PrefMasterSwitchToolbarView @JvmOverloads constructor(
                 setTitleOff(titleOff)
                 setHintOn(hintOn)
                 setHintOff(hintOff)
-                setToolbarTitleContentDescription(titleContentDescription)
                 setContentOffset(contentInsetStart)
                 setMasterOffsetEnd(masterOffsetEnd)
 
@@ -149,7 +149,7 @@ class PrefMasterSwitchToolbarView @JvmOverloads constructor(
     }
 
     @Suppress("MemberVisibilityCanBePrivate")
-    fun setToolbarTitleContentDescription(titleContentDescription: String?) {
+    fun setToolbarTitleContentDescription() {
         titleContentDescription?.let {
             for (i in 0 until toolbarSwitch.childCount) {
                 if (toolbarSwitch.getChildAt(i) is TextView) {
@@ -194,6 +194,7 @@ class PrefMasterSwitchToolbarView @JvmOverloads constructor(
         setChecked(checkMaster)
         setToolbarTitle(checkMaster)
         toolbarSwitch.visibility = View.VISIBLE
+        setToolbarTitleContentDescription()
     }
 
     @Suppress("MemberVisibilityCanBePrivate")

--- a/WordPress/src/main/res/layout/followed_sites_dialog.xml
+++ b/WordPress/src/main/res/layout/followed_sites_dialog.xml
@@ -44,7 +44,7 @@
             android:paddingBottom="@dimen/margin_large"
             android:paddingTop="@dimen/margin_large"
             android:text="@string/notification_settings_followed_dialog_notification_posts_description"
-            android:textColor="@color/neutral_40"
+            android:textColor="@color/neutral_50"
             android:textSize="@dimen/text_sz_medium" >
         </org.wordpress.android.widgets.WPTextView>
 

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -59,7 +59,7 @@
                 android:layout_marginStart="@dimen/notifications_note_icon_margin"
                 android:layout_marginTop="@dimen/notifications_note_icon_margin"
                 android:background="@drawable/bg_oval_primary_40_stroke_notification_unread"
-                android:contentDescription="@string/icon"
+                android:importantForAccessibility="no"
                 android:gravity="center"
                 android:padding="4dp" />
 

--- a/WordPress/src/main/res/layout/notifications_settings_switch.xml
+++ b/WordPress/src/main/res/layout/notifications_settings_switch.xml
@@ -9,6 +9,7 @@
         android:id="@+id/row_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:minHeight="@dimen/min_touch_target_sz"
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:paddingBottom="@dimen/margin_medium"


### PR DESCRIPTION
Fixes #10735 #10736

Some of the issues described in the above issue were ignored due to further analysis that deemed them not being necessary for resolution. Most notably, some of the accessibility prompts for the Accessibility Scanner were for items that don't need to have to have larger touch targets as they were easy enough to select for announcement and they wouldn't be clickable. eg. some of the header text.

## Main

#### TalkBack Audit

<img src="https://user-images.githubusercontent.com/1509205/68186446-01454580-ff59-11e9-84ea-bef480d04c5a.png" alt="Screenshot_20191104-191209" width="300" />

- [x]  The icon(s) in the list item shouldn't be read since the are profile pictures and the notification content has the name of the person. 

## Settings

#### Accessibility Scanner Audit
<img src="https://user-images.githubusercontent.com/1509205/68187586-e1fbe780-ff5b-11e9-893b-5a8b5be28542.png" alt="screenshot_WordPress_ 0,490 1440,622 _4294967305_2019-11-04-19_47_31" width="300" />

**Main Area** - Your Sites- `org.wordpress.android:id/header_text` - Text contrast

- [x] The item's text contrast ratio is 1.98. This ratio is based on an estimated foreground color of #B2B2B2 and an estimated background color of #F6F7F7. Consider increasing this item's text contrast ratio to 3.00 or greater.

 **Followed Sites - Notification Dialog** - 
<img src="https://user-images.githubusercontent.com/1509205/68187707-31daae80-ff5c-11e9-8523-48f5c87ac5b4.png" alt="screenshot_WordPress_2019-11-04-19_49_15" width="300" />

- [x] New posts - Description - Text contrast
`org.wordpress.android:id/notifications_new_posts_description`

The item's text contrast ratio is 4.20. This ratio is based on an estimated foreground color of `#787C82` and an estimated background color of `#FFFFFF`. Consider using a contrast ratio greater than 4.50 for small text, or 3.00 for large text.

 **Your Sites - Notification Screen** 
	
- [x] * Notification Setting Pop up Dialog -  org.wordpress.android:id/row_containerTouch target
	
This item's height is 44dp. Consider making the height of this touch target 48dp or larger.

**Notification Search** 

Before | After 
--------|-------
![Before](https://user-images.githubusercontent.com/1509205/68889800-7855a900-06d2-11ea-8bbc-2d12b53ef5b6.png)        |      ![2019-10-02 13 33 28](https://user-images.githubusercontent.com/1509205/68889700-45131a00-06d2-11ea-93f7-ed0094b932e4.png)

- [x] Search Text - `org.wordpress.android:id/search_src_text` - Text contrast
	
The item's text contrast ratio is 2.95. This ratio is based on an estimated foreground color of #80B0C4 and an estimated background color of #006088. Consider increasing this item's text contrast ratio to 3.00 or greater.

#### TalkBack Audit

##### Notifications On Switch 

- [x] The message being read wasn't descriptive. It read "On, On Switch". It should read "Notifications, On Switch" 

Before | After 
--------|-------
![Before](https://user-images.githubusercontent.com/1509205/68971051-845a6d00-079d-11ea-93db-13e67bfb6de2.png)        |      ![after_switch](https://user-images.githubusercontent.com/1509205/68971050-845a6d00-079d-11ea-9479-80768c93e399.png)

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

