### PR TITLE
issue/9985 catching IllegalStateException.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/service/InstallationReferrerServiceLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/service/InstallationReferrerServiceLogic.java
@@ -86,6 +86,7 @@ public class InstallationReferrerServiceLogic {
                             mReferrerClient.endConnection();
                         } catch (RemoteException | IllegalStateException e) {
                             e.printStackTrace();
+                            CrashLoggingUtils.logException(e, T.UTILS);
                             AppLog.e(T.UTILS, "installation referrer: " + e.getClass().getSimpleName() + " occurred");
                         }
                         break;

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/service/InstallationReferrerServiceLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/service/InstallationReferrerServiceLogic.java
@@ -84,9 +84,9 @@ public class InstallationReferrerServiceLogic {
                                     response.getReferrerClickTimestampSeconds());
                             AnalyticsTracker.track(AnalyticsTracker.Stat.INSTALLATION_REFERRER_OBTAINED, properties);
                             mReferrerClient.endConnection();
-                        } catch (RemoteException e) {
+                        } catch (RemoteException | IllegalStateException e) {
                             e.printStackTrace();
-                            AppLog.i(T.UTILS, "installation referrer: RemoteException occurred");
+                            AppLog.e(T.UTILS, "installation referrer: " + e.getClass().getSimpleName() + " occurred");
                         }
                         break;
                     case InstallReferrerResponse.FEATURE_NOT_SUPPORTED:


### PR DESCRIPTION
Fixes #9985

I was only able to reproduce this issues once, on an emulator with Pixel 2 on API 29. After tests on other platforms, I came back to the original emulator, and stopped getting it.

It happens inside `InstallReferrerClient`, and we don't know what causes it. Since it's not a critical component of the app (we just retrieve Play Store referrer for analytics) but it causes crashes, I think it's appropriate to deal with it by catching exceptions.

Install Referrer Client also causes some other issues, like [this](https://github.com/wordpress-mobile/WordPress-Android/issues/10532), and I found out that some issues dealing with is were assigned to Google team. I hope that they will be resolved on their side.

To test:
There is nothing really to test unless you can reproduce issue reliably.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

