### PR TITLE
Bump Gutenberg progressive rollout from 5 to 10%

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class SiteUtils {
     public static final String GB_EDITOR_NAME = "gutenberg";
     public static final String AZTEC_EDITOR_NAME = "aztec";
-    private static final int GB_ROLLOUT_PERCENTAGE = 5;
+    private static final int GB_ROLLOUT_PERCENTAGE = 10;
 
     /**
      * Migrate the old app-wide editor preference value to per-site setting. wpcom sites will make a network call


### PR DESCRIPTION
Bump Gutenberg progressive rollout from 5 to 10%.

cc @hypest - small bump to align with our plans.