### PR TITLE
[Gutenberg] hotfix crash which occurs after deleting image or page break block

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * Block editor: Media & Text block alignment options
 * Block editor: Images clickable for fullscreen preview
 * Fixed time displayed on Post Conflict Detected and Unpublished Revision dialogs
+* Block editor: Fix issue when removing image/page break block crashes the app
  
 13.6
 -----


### PR DESCRIPTION
Fixes: 

`gutenberg-mobile` https://github.com/wordpress-mobile/gutenberg-mobile/pull/1582

**To test:**

Follow instructions on gb-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1582#issue-341454458

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

