### PR TITLE
Fix crash on access to non-initialized lateinit property

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -558,10 +558,10 @@ public class ActivityLauncher {
         fragment.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 
-    public static void viewHistoryDetailForResult(Activity activity, Revision revision, ArrayList<Revision> revisions) {
+    public static void viewHistoryDetailForResult(Activity activity, Revision revision, List<Revision> revisions) {
         Intent intent = new Intent(activity, HistoryDetailActivity.class);
         intent.putExtra(HistoryDetailContainerFragment.EXTRA_REVISION, revision);
-        intent.putParcelableArrayListExtra(HistoryDetailContainerFragment.EXTRA_REVISIONS, revisions);
+        intent.putParcelableArrayListExtra(HistoryDetailContainerFragment.EXTRA_REVISIONS, new ArrayList<>(revisions));
         activity.startActivityForResult(intent, RequestCodes.HISTORY_DETAIL);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1754,7 +1754,7 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void onHistoryItemClicked(@NonNull Revision revision, @NonNull ArrayList<Revision> revisions) {
+    public void onHistoryItemClicked(@NonNull Revision revision, @NonNull List<Revision> revisions) {
         AnalyticsTracker.track(Stat.REVISIONS_DETAIL_VIEWED_FROM_LIST);
         mRevision = revision;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -45,7 +45,7 @@ class HistoryListFragment : Fragment() {
     }
 
     interface HistoryItemClickInterface {
-        fun onHistoryItemClicked(revision: Revision, revisions: ArrayList<Revision>)
+        fun onHistoryItemClicked(revision: Revision, revisions: List<Revision>)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -147,9 +147,12 @@ class HistoryListFragment : Fragment() {
             }
         })
 
-        viewModel.showDialog.observe(this, Observer {
-            if (it is Revision && activity is HistoryItemClickInterface) {
-                (activity as HistoryItemClickInterface).onHistoryItemClicked(it, viewModel.revisionsList)
+        viewModel.showDialog.observe(this, Observer { showDialogItem ->
+            if (showDialogItem.historyListItem is Revision && activity is HistoryItemClickInterface) {
+                (activity as HistoryItemClickInterface).onHistoryItemClicked(
+                        showDialogItem.historyListItem,
+                        showDialogItem.revisionsList
+                )
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.posts
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -64,6 +65,13 @@ class HistoryListFragment : Fragment() {
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(HistoryViewModel::class.java)
     }
 
+    override fun onAttach(context: Context?) {
+        super.onAttach(context)
+        check(activity is HistoryItemClickInterface) {
+            "Parent activity has to implement HistoryItemClickInterface"
+        }
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -120,35 +128,37 @@ class HistoryListFragment : Fragment() {
         })
 
         viewModel.listStatus.observe(this, Observer { listStatus ->
-            if (isAdded && view != null) {
-                swipeToRefreshHelper.isRefreshing = listStatus == HistoryListStatus.FETCHING
-            }
-            when (listStatus) {
-                HistoryListStatus.DONE -> {
-                    updatePostOrPageEmptyView()
+            listStatus?.let {
+                if (isAdded && view != null) {
+                    swipeToRefreshHelper.isRefreshing = listStatus == HistoryListStatus.FETCHING
                 }
-                HistoryListStatus.FETCHING -> {
-                    actionable_empty_view.title.setText(R.string.history_fetching_revisions)
-                    actionable_empty_view.subtitle.visibility = View.GONE
-                    actionable_empty_view.button.visibility = View.GONE
-                }
-                HistoryListStatus.NO_NETWORK -> {
-                    actionable_empty_view.title.setText(R.string.no_network_title)
-                    actionable_empty_view.subtitle.setText(R.string.no_network_message)
-                    actionable_empty_view.subtitle.visibility = View.VISIBLE
-                    actionable_empty_view.button.visibility = View.VISIBLE
-                }
-                HistoryListStatus.ERROR -> {
-                    actionable_empty_view.title.setText(R.string.no_network_title)
-                    actionable_empty_view.subtitle.setText(R.string.error_generic_network)
-                    actionable_empty_view.subtitle.visibility = View.VISIBLE
-                    actionable_empty_view.button.visibility = View.VISIBLE
+                when (listStatus) {
+                    HistoryListStatus.DONE -> {
+                        updatePostOrPageEmptyView()
+                    }
+                    HistoryListStatus.FETCHING -> {
+                        actionable_empty_view.title.setText(R.string.history_fetching_revisions)
+                        actionable_empty_view.subtitle.visibility = View.GONE
+                        actionable_empty_view.button.visibility = View.GONE
+                    }
+                    HistoryListStatus.NO_NETWORK -> {
+                        actionable_empty_view.title.setText(R.string.no_network_title)
+                        actionable_empty_view.subtitle.setText(R.string.no_network_message)
+                        actionable_empty_view.subtitle.visibility = View.VISIBLE
+                        actionable_empty_view.button.visibility = View.VISIBLE
+                    }
+                    HistoryListStatus.ERROR -> {
+                        actionable_empty_view.title.setText(R.string.no_network_title)
+                        actionable_empty_view.subtitle.setText(R.string.error_generic_network)
+                        actionable_empty_view.subtitle.visibility = View.VISIBLE
+                        actionable_empty_view.button.visibility = View.VISIBLE
+                    }
                 }
             }
         })
 
         viewModel.showDialog.observe(this, Observer { showDialogItem ->
-            if (showDialogItem.historyListItem is Revision && activity is HistoryItemClickInterface) {
+            if (showDialogItem != null && showDialogItem.historyListItem is Revision) {
                 (activity as HistoryItemClickInterface).onHistoryItemClicked(
                         showDialogItem.historyListItem,
                         showDialogItem.revisionsList


### PR DESCRIPTION
This fixes part of this issue #10019
It's a crash in the HistoryViewModel where an non-initialized lateinit property is accessed. The crash is linked from the original issue: crash: https://sentry.io/share/issue/7d4c3139eb874b45a4b27b0dd3ef97c1/

To test:
* Test that the Post/History works as expected
* Try to rotate the device
* The data is not refreshed
* Try to switch offline/online
* The data is refreshed on going back online

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

