### PR TITLE
Enable Spacer block in production

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.18.0
+------
+* Block editor: New Spacer block available
+
 13.7
 -----
 * Block editor: Include block title in Unsupported block's UI

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,4 @@
-1.18.0
+13.8
 ------
 * Block editor: New Spacer block available
 


### PR DESCRIPTION
Updates Gutenberg so the `Spacer` block is available in production.

`Gutenberg`->  https://github.com/WordPress/gutenberg/pull/18605

To test:
- Run the app without metro running
- Start a new post
- Select the `Spacer` block
  - Change the height of the `Spacer`
  - Move the block between other ones and check it works correctly
  - Remove the block
  - Add one again
- Save as draft
- Open your draft and check the Spacer block is shown correctly

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

