### PR TITLE
Posts: Show shortlink section in Post/Page Settings menu area.

### DIFF
--- a/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
@@ -66,6 +66,50 @@
                         style="@style/PostSettingsSubtitle"
                         android:hint="@string/post_settings_not_set"/>
                 </LinearLayout>
+
+                <View style="@style/PostSettingsDivider"/>
+
+                <LinearLayout
+                    android:id="@+id/post_shortlink_container"
+                    style="@style/PostSettingsContainer">
+
+                    <TextView
+                        style="@style/PostSettingsTitle"
+                        android:text="@string/post_settings_shortlink"/>
+
+                    <RelativeLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content">
+
+                        <TextView
+                            android:id="@+id/post_shortlink"
+                            style="@style/PostSettingsSubtitle"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_centerVertical="true"
+                            android:layout_toStartOf="@+id/shortlink_copy_url"
+                            android:ellipsize="end"
+                            android:singleLine="true" />
+
+                        <TextView
+                            android:id="@+id/shortlink_copy_url"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_alignParentEnd="true"
+                            android:layout_centerVertical="true"
+                            android:layout_marginEnd="1dp"
+                            android:background="@drawable/button_frame"
+                            android:paddingStart="@dimen/margin_extra_large"
+                            android:paddingTop="@dimen/margin_small"
+                            android:paddingEnd="@dimen/margin_extra_large"
+                            android:paddingBottom="@dimen/margin_small"
+                            android:text="@string/copy"
+                            android:textAllCaps="true"
+                            android:textColor="?attr/wpColorText"
+                            android:textSize="@dimen/text_sz_medium" />
+                    </RelativeLayout>
+
+                </LinearLayout>
             </LinearLayout>
         </androidx.cardview.widget.CardView>
 
@@ -141,7 +185,7 @@
                         android:text="@string/post_settings_set_featured_image"/>
 
                     <FrameLayout
-                            android:id="@+id/post_featured_image_container"
+                        android:id="@+id/post_featured_image_container"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content">
 
@@ -263,7 +307,7 @@
                 </LinearLayout>
 
                 <View android:id="@+id/post_format_bottom_separator"
-                      style="@style/PostSettingsDivider"/>
+                    style="@style/PostSettingsDivider"/>
 
                 <LinearLayout
                     android:id="@+id/post_slug_container"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1225,6 +1225,7 @@
     <!-- Post Settings -->
     <string name="post_settings">Post settings</string>
     <string name="post_settings_status">Status</string>
+    <string name="post_settings_shortlink">Shortlink</string>
     <string name="post_settings_categories_and_tags">Categories &amp; Tags</string>
     <string name="post_settings_more_options">More Options</string>
     <string name="post_settings_not_set">Not Set</string>


### PR DESCRIPTION
Fixes #9817 

This adds the option to see and copy a current post / page's automatically generated shortlinks:

<img width="383" alt="Screen Shot 2019-11-20 at 10 43 14" src="https://user-images.githubusercontent.com/266376/69207509-96178800-0b82-11ea-9fd0-8c755353f1dd.png">


To test:

1. Pick a WPCom site, edit a post, select Post Settings from the triple-dot menu on top right. Find the Shortlink field like on screenshot above. Ensure the shortlink and button next to it are shown.
2. Click the Copy button and ensure a toaster is shown saying "URL copied to clipboard".
3. Open a browser app and paste the URL, ensure it opens to the same post that's being edited.
4. Do step 1-3 above for a Page.
5. Do step 1-3 above for a Post on a Jetpack-connected site. The shortlink should show up and copying should work properly.
6. Do step 1-3 above for a Page on a Jetpack-connected site. The shortlink should show up and copying should work properly.
7. Do step 1 above for a Post on a regular .org, non-connected site. The shortlink area should not show up.
8. Do step 1 above for a Page on a Jetpack-connected site. The shortlink should not show up.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

### Etc's:

In Calypso, the shortlink section is placed under "Sharing", which I think makes sense because the URL is basically there for sharing purposes. In the app, I don't see specific section for sharing. So I decided to put it near the top where it seem to make the most sense to me. Happy to move it elsewhere if there's other design considerations I'm missing.
