### PR TITLE
Closing leaking categories cursor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
@@ -49,20 +49,25 @@ public final class SiteSettingsTable {
     public static SparseArrayCompat<CategoryModel> getAllCategories() {
         String sqlCommand = sqlSelectAllCategories() + ";";
         Cursor cursor = WordPress.wpDB.getDatabase().rawQuery(sqlCommand, null);
+        try {
+            if (cursor == null || !cursor.moveToFirst() || cursor.getCount() == 0) {
+                return null;
+            }
 
-        if (cursor == null || !cursor.moveToFirst() || cursor.getCount() == 0) {
-            return null;
+            SparseArrayCompat<CategoryModel> models = new SparseArrayCompat<>();
+            for (int i = 0; i < cursor.getCount(); ++i) {
+                CategoryModel model = new CategoryModel();
+                model.deserializeFromDatabase(cursor);
+                models.put(model.id, model);
+                cursor.moveToNext();
+            }
+
+            return models;
+        } finally {
+            if (cursor != null && !cursor.isClosed()) {
+                cursor.close();
+            }
         }
-
-        SparseArrayCompat<CategoryModel> models = new SparseArrayCompat<>();
-        for (int i = 0; i < cursor.getCount(); ++i) {
-            CategoryModel model = new CategoryModel();
-            model.deserializeFromDatabase(cursor);
-            models.put(model.id, model);
-            cursor.moveToNext();
-        }
-
-        return models;
     }
 
     public static Cursor getCategory(long id) {


### PR DESCRIPTION
This PR closes cursor responsible for retrieving post categories. We cache categories really often but never close the cursor.

To test:
- Just for a sanity check, navigate to site settings and make sure Categories are there.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

