### PR TITLE
Download external media on Share intent received

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -188,6 +188,11 @@ public class MediaUtils {
         }
     }
 
+    /*
+     * Some media providers (eg. Google Photos) give us a limited access to media files just so we can copy them and
+     * then they revoke the access. Copying these files must be performed on the UI thread, otherwise the access might
+     * be revoked before the action completes. See https://github.com/wordpress-mobile/WordPress-Android/issues/5818
+     */
     public static Uri downloadExternalMedia(Context context, Uri imageUri) {
         if (context == null || imageUri == null) {
             return null;


### PR DESCRIPTION
Fixes #10575
This crash is probably triggered because the `content` system URIs are only available for a short time period after they are shared with our app. When the user has multiple sites we show a site selector first before we pass the URIs to the `MediaBrowserActivity` which downloads them. This PR changes this behaviour and saves the files directly when they are shared with the app. This should fix the crash. 

I've also found out there is a crash when you try to share a video with the app (tried on an emulator with the latest android). I think it's related to https://github.com/react-native-community/react-native-image-picker/issues/1139

To test:
* Try to share an image (from Google Photos) with the app
* On the site selector rotate the screen
* Select "Add to media library"
* Notice that the files are uploaded in the media library
 
To test 2:
* Try to share an image (from Google Photos) with the app
* Select "Add to new post"
* Notice that a post is created with the shared image

To test 3: 
* Try both scenarios with multiple images

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

