### PR TITLE
Fix NPE in SiteSettingsFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1018,8 +1018,8 @@ public class SiteSettingsFragment extends PreferenceFragment
     }
 
     private void setupJetpackSearch() {
-        boolean isJetpackBusiness =
-                mSite.isJetpackConnected() && mSite.getPlanId() == PlansConstants.JETPACK_BUSINESS_PLAN_ID;
+        boolean isJetpackBusiness = mSite != null && mSite.isJetpackConnected()
+                                    && mSite.getPlanId() == PlansConstants.JETPACK_BUSINESS_PLAN_ID;
         if (isJetpackBusiness || mSiteSettings.getJetpackSearchSupported()) {
             mImprovedSearch
                     .setChecked(mSiteSettings.isImprovedSearchEnabled() || mSiteSettings.getJetpackSearchEnabled());


### PR DESCRIPTION
Fixes #10774

I think this happens when the Jetpack is disconnected and the site is set to null in SiteSetting (and site settings are updated). In this case I think in this case it's fine to assume that `mSite.isJetpackConnected() && mSite.getPlanId() == PlansConstants.JETPACK_BUSINESS_PLAN_ID` is false and we don't want to show Jetpack settings. 

To test:
* I don't think there is a way to test this.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

