### PR TITLE
Fixed NPE in LoginUsernamePasswordFragment

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -256,7 +256,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         super.onSaveInstanceState(outState);
 
         outState.putBoolean(KEY_LOGIN_FINISHED, mLoginFinished);
-        outState.putBoolean(KEY_LOGIN_FINISHED, mLoginStarted);
+        outState.putBoolean(KEY_LOGIN_STARTED, mLoginStarted);
         outState.putString(KEY_REQUESTED_USERNAME, mRequestedUsername);
         outState.putString(KEY_REQUESTED_PASSWORD, mRequestedPassword);
         outState.putIntegerArrayList(KEY_OLD_SITES_IDS, mOldSitesIDs);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -52,6 +52,7 @@ import dagger.android.support.AndroidSupportInjection;
 public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginListener> implements TextWatcher,
         OnEditorCommitListener {
     private static final String KEY_LOGIN_FINISHED = "KEY_LOGIN_FINISHED";
+    private static final String KEY_LOGIN_STARTED = "KEY_LOGIN_STARTED";
     private static final String KEY_REQUESTED_USERNAME = "KEY_REQUESTED_USERNAME";
     private static final String KEY_REQUESTED_PASSWORD = "KEY_REQUESTED_PASSWORD";
     private static final String KEY_OLD_SITES_IDS = "KEY_OLD_SITES_IDS";
@@ -74,6 +75,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
 
     private boolean mAuthFailed;
     private boolean mLoginFinished;
+    private boolean mLoginStarted;
 
     private String mRequestedUsername;
     private String mRequestedPassword;
@@ -229,6 +231,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
 
         if (savedInstanceState != null) {
             mLoginFinished = savedInstanceState.getBoolean(KEY_LOGIN_FINISHED);
+            mLoginStarted = savedInstanceState.getBoolean(KEY_LOGIN_STARTED);
 
             mRequestedUsername = savedInstanceState.getString(KEY_REQUESTED_USERNAME);
             mRequestedPassword = savedInstanceState.getString(KEY_REQUESTED_PASSWORD);
@@ -253,6 +256,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         super.onSaveInstanceState(outState);
 
         outState.putBoolean(KEY_LOGIN_FINISHED, mLoginFinished);
+        outState.putBoolean(KEY_LOGIN_FINISHED, mLoginStarted);
         outState.putString(KEY_REQUESTED_USERNAME, mRequestedUsername);
         outState.putString(KEY_REQUESTED_PASSWORD, mRequestedPassword);
         outState.putIntegerArrayList(KEY_OLD_SITES_IDS, mOldSitesIDs);
@@ -277,6 +281,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
             return;
         }
 
+        mLoginStarted = true;
         startProgress();
 
         mRequestedUsername = getCleanedUsername();
@@ -418,6 +423,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         }
 
         if (event.isError()) {
+            mLoginStarted = false;
             if (mRequestedUsername == null) {
                 // just bail since the operation was cancelled
                 return;
@@ -472,11 +478,12 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteChanged(OnSiteChanged event) {
-        if (!isAdded() || mLoginFinished) {
+        if (!isAdded() || mLoginFinished || !mLoginStarted) {
             return;
         }
 
         if (event.isError()) {
+            mLoginStarted = false;
             if (mRequestedUsername == null) {
                 // just bail since the operation was cancelled
                 return;


### PR DESCRIPTION
Fixes #10832 

After the user leaves `LoginUsernamePasswordFragment` for more than one hour and comes back, a global site refresh is triggered, which causes `onSiteChanged` in `LoginUsernamePasswordFragment` to propagate false "successful" login event, which causes a crash down the line.

To make the testing easier, change the throttle delay on-site refresh ([here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/WordPress.java#L133)) to something reasonable, like 10 seconds.

To test:
- Navigate to Site Picker and press the + icon to add new site.
- Chose "Add self-hosted site" option.
- In the Site address field input self-hosted site URL and press NEXT.
- While on the screen with login and password, press the home button and minimize the app.
- Wait 10 seconds (or whatever time you chouse for site fetch throttle.
- Navigate back to the app, and notice that it's not crashing.

Part 2:
- Input wrong login or password and press NEXT to produce an error.
- Press the home button and minimize the app.
- Navigate back to the app and input correct login credentials.
- Make sure you can login and the site is added.



PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

