### PR TITLE
Reader PhotoViewer no longer crashes with null imgUrl

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPhotoView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPhotoView.java
@@ -190,7 +190,9 @@ public class ReaderPhotoView extends RelativeLayout {
             if (mIsInitialLayout) {
                 mIsInitialLayout = false;
                 AppLog.d(AppLog.T.READER, "reader photo > initial layout");
-                loadImage();
+                if (mLoResImageUrl != null && mHiResImageUrl != null) {
+                    loadImage();
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -142,24 +142,22 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
     fun loadWithResultListener(
         imageView: ImageView,
         imageType: ImageType,
-        imgUrl: String?,
+        imgUrl: String,
         scaleType: ScaleType = CENTER,
         thumbnailUrl: String? = null,
         requestListener: RequestListener<Drawable>
     ) {
         val context = imageView.context
         if (!context.isAvailable()) return
-        imgUrl?.let {
-            GlideApp.with(context)
-                    .load(it)
-                    .addFallback(imageType)
-                    .addPlaceholder(imageType)
-                    .addThumbnail(context, thumbnailUrl, requestListener)
-                    .applyScaleType(scaleType)
-                    .attachRequestListener(requestListener)
-                    .into(imageView)
-                    .clearOnDetach()
-        }
+        GlideApp.with(context)
+                .load(imgUrl)
+                .addFallback(imageType)
+                .addPlaceholder(imageType)
+                .addThumbnail(context, thumbnailUrl, requestListener)
+                .applyScaleType(scaleType)
+                .attachRequestListener(requestListener)
+                .into(imageView)
+                .clearOnDetach()
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -142,22 +142,24 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
     fun loadWithResultListener(
         imageView: ImageView,
         imageType: ImageType,
-        imgUrl: String,
+        imgUrl: String?,
         scaleType: ScaleType = CENTER,
         thumbnailUrl: String? = null,
         requestListener: RequestListener<Drawable>
     ) {
         val context = imageView.context
         if (!context.isAvailable()) return
-        GlideApp.with(context)
-                .load(imgUrl)
-                .addFallback(imageType)
-                .addPlaceholder(imageType)
-                .addThumbnail(context, thumbnailUrl, requestListener)
-                .applyScaleType(scaleType)
-                .attachRequestListener(requestListener)
-                .into(imageView)
-                .clearOnDetach()
+        imgUrl?.let {
+            GlideApp.with(context)
+                    .load(it)
+                    .addFallback(imageType)
+                    .addPlaceholder(imageType)
+                    .addThumbnail(context, thumbnailUrl, requestListener)
+                    .applyScaleType(scaleType)
+                    .attachRequestListener(requestListener)
+                    .into(imageView)
+                    .clearOnDetach()
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #10831

To test:
1. Simulate the `imgUrl` as being `null`.
2. Go to Reader. 
3. Click on an article.
4. Click on an image.
5. The app shouldn't crash. 

For further discussion, it just shows a loading spinner. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

