### PR TITLE
Removed hint that notification settings moved

### DIFF
--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -210,17 +210,6 @@
 
             <View style="@style/MeListSectionDividerView"/>
 
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_large"
-                android:layout_marginEnd="@dimen/content_margin"
-                android:layout_marginStart="@dimen/content_margin"
-                android:layout_marginTop="@dimen/margin_extra_large"
-                android:text="@string/notification_settings_moved_notices"
-                android:textColor="@color/gray_50"
-                android:textSize="@dimen/text_sz_small" />
-
         </LinearLayout>
     </ScrollView>
 </LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1801,7 +1801,6 @@
     <string name="me_btn_login_logout">Login/Logout</string>
     <string name="me_connect_to_wordpress_com">Log in to WordPress.com</string>
     <string name="me_disconnect_from_wordpress_com">Log out of WordPress.com</string>
-    <string name="notification_settings_moved_notices">Notification Settings can now be found in the Notifications tab.</string>
 
     <!--TabBar Accessibility Labels-->
     <string name="tabbar_accessibility_label_my_site">My Site. View your site and manage it, including stats.</string>


### PR DESCRIPTION
Hint has been out there for quite some time, and it's time to remove it :)

To test:
- Navigate to Me screen, and make sure there is no hint at the bottom.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

