### PR TITLE
Replace use of release-checks.sh with Fastlane actions from release-toolkit

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -332,7 +332,7 @@ android.buildTypes.all { buildType ->
     }
 
     // Print warning message if example Google services file is used.
-    if ((new File('WordPress/google-services.json').text) == (new File('WordPress/google-services.json-example').text)) {
+    if ((file('google-services.json').text) == (file('google-services.json-example').text)) {
         println("WARNING: You're using the example google-services.json file. Google login will fail.")
     }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -171,8 +171,22 @@ ENV["HAS_ALPHA_VERSION"]="true"
     android_finalize_prechecks(options)
     hotfix = android_current_branch_is_hotfix
     android_update_metadata(options) unless hotfix
-    android_bump_version_final_release() unless hotfix
+
+    # Run release checks
+    project_folder = Dir.pwd + "/.."
+    android_check_new_languages_glotpress(verbose: false,
+        glotpress_status_url: "http://translate.wordpress.org/projects/apps/android/dev",
+        language_file: project_folder + "/tools/exported-language-codes.csv") unless hotfix
+    android_check_en_strings(verbose: false,
+        res_dir: project_folder + "/WordPress/src/main/res/",
+        project_dir: project_folder) unless hotfix
+    UI.message("alpha_version: #{android_get_alpha_version()}") unless hotfix
     version = android_get_release_version() unless hotfix
+    UI.message("release_version: #{version}") unless hotfix
+    android_check_devices(require_device: true) unless hotfix
+    gradle(task: "connectedVanillaDebugAndroidTest") unless hotfix
+
+    android_bump_version_final_release() unless hotfix
     download_metadata_strings(version: version["name"], build_number: version["code"]) unless hotfix
     android_tag_build(tag_alpha: false)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -173,13 +173,9 @@ ENV["HAS_ALPHA_VERSION"]="true"
     android_update_metadata(options) unless hotfix
 
     # Run release checks
-    project_folder = Dir.pwd + "/.."
-    android_check_new_languages_glotpress(verbose: false,
-        glotpress_status_url: "http://translate.wordpress.org/projects/apps/android/dev",
-        language_file: project_folder + "/tools/exported-language-codes.csv") unless hotfix
-    android_check_en_strings(verbose: false,
-        res_dir: project_folder + "/WordPress/src/main/res/",
-        project_dir: project_folder) unless hotfix
+    android_check_new_languages_glotpress(glotpress_status_url: "http://translate.wordpress.org/projects/apps/android/dev",
+        language_file: "tools/exported-language-codes.csv") unless hotfix
+    android_check_en_strings(ensure_git_status_clean: false, res_dir: "WordPress/src/main/res/") unless hotfix
     UI.message("alpha_version: #{android_get_alpha_version()}") unless hotfix
     version = android_get_release_version() unless hotfix
     UI.message("release_version: #{version}") unless hotfix


### PR DESCRIPTION
Addresses #10699 

### Description
This pull request contains two changes:
- added to the `finalize_release` lane the release check Fastlane actions from my fork's [`release-toolkit` feature branch](https://github.com/ravenstewart/release-toolkit/tree/feature/add-release-checks)
- a fix for a line in build.gradle that was causing other_action.gradle to fail in [`android_check_en_strings`](https://github.com/ravenstewart/release-toolkit/blob/feature/add-release-checks/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_check_en_strings.rb) due to the working directory is set when running an action in a custom action

I chose to add the release check actions to the `finalize_release` lane right after the `android_update_metadata` action because the `android_update_metadata` action used to run [`release-checks.sh`](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/tools/release-checks.sh) at the end.  (I removed this line from the `android_update_metadata` action in the `release-toolkit`)

`release-checks.sh` previously performed the following actions:
- checkNewLanguages
- checkENStrings
- printVersion

The following actions were intended but commented out:
- checkDeviceToTest
- runConnectedTests

I added the following Fastlane actions from the `release-toolkit` to the `finalize_release` lane:
- [`android_check_new_languages_glotpress`](https://github.com/ravenstewart/release-toolkit/blob/feature/add-release-checks/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_check_new_languages_glotpress.rb)
- [`android_check_en_strings`](https://github.com/ravenstewart/release-toolkit/blob/feature/add-release-checks/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_check_en_strings.rb)
- print results of [`android_get_alpha_version`](https://github.com/ravenstewart/release-toolkit/blob/feature/add-release-checks/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_alpha_version.rb)
- print results of [`android_get_release_version`](https://github.com/ravenstewart/release-toolkit/blob/feature/add-release-checks/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_release_version.rb)
- [`android_check_devices`](https://github.com/ravenstewart/release-toolkit/blob/feature/add-release-checks/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_check_devices.rb)`(require_device: true)`
- [`gradle`](https://docs.fastlane.tools/actions/gradle/)`(task: "connectedVanillaDebugAndroidTest")`

I chose the `connectedVanillaDebugAndroidTest` gradle task for replacing the runConnectedTests step in `release-toolkit.sh` because it was the closest to what I felt the original intent was.  To run connected tests on available devices using the flavor of the build to be released.

### To Test:
1. modify the location for the gem `fastlane-plugin-wpmreleasetoolkit` in the Fastlane [`Pluginfile`](https://github.com/ravenstewart/WordPress-Android/blob/issue/10699-migrate-release-checks/fastlane/Pluginfile) to use my fork's [`release-toolkit` feature branch](https://github.com/ravenstewart/release-toolkit/tree/feature/add-release-checks)
2. either run the `finalize_release` lane or an individual action from the list

**Note:**
- The `android_check_en_strings` action will fail if your git status is not clean unless the `ensure_git_status_clean` parameter is set to false. You will need to do this during testing since the `Pluginfile` will be modified.
- The `connectedVanillaDebugAndroidTest` is currently failing one of its tests (`wPScreenshotTest` - `expectation wasn't satisfied quickly enough`), because of this the gradle action step to run connected tests in the lane will fail.



