### PR TITLE
Fix crash in QuickStart dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -653,6 +653,9 @@ public class MySiteFragment extends Fragment implements
     }
 
     private void updateQuickStartContainer() {
+        if (!isAdded()) {
+            return;
+        }
         if (QuickStartUtils.isQuickStartInProgress(mQuickStartStore)) {
             int site = AppPrefs.getSelectedSite();
 


### PR DESCRIPTION
Fixes #10844 

`updateQuickStartContainer` is sometimes called while the fragment isn't attached to an Activity.

Note: I've submitted a semi-related issue - https://github.com/wordpress-mobile/WordPress-Android/issues/10845.

To test - I'm not able to reproduce the crash. However, I'd suggest verifying quick start works as expected.
1. Create a new WordPress.com site
2. Enable QuickStart
3. Complete at least 2 tasks

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

