### PR TITLE
Stop hiding data when there is no connection

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -128,6 +128,7 @@ public class AppPrefs {
         STATS_WIDGET_SELECTED_SITE_ID,
         STATS_WIDGET_COLOR_MODE,
         STATS_WIDGET_DATA_TYPE,
+        STATS_WIDGET_HAS_DATA,
 
         // Keep the local_blog_id + local_post_id values that have HW Acc. turned off
         AZTEC_EDITOR_DISABLE_HW_ACC_KEYS,
@@ -948,20 +949,36 @@ public class AppPrefs {
         return DeletablePrefKey.STATS_WIDGET_COLOR_MODE.name() + appWidgetId;
     }
 
-    public static void setStatsWidgetDatatTypeId(int dataTypeId, int appWidgetId) {
-        prefs().edit().putInt(getDatatTypeIdWidgetKey(appWidgetId), dataTypeId).apply();
+    public static void setStatsWidgetDataTypeId(int dataTypeId, int appWidgetId) {
+        prefs().edit().putInt(getDataTypeIdWidgetKey(appWidgetId), dataTypeId).apply();
     }
 
-    public static int getStatsWidgetDatatTypeId(int appWidgetId) {
-        return prefs().getInt(getDatatTypeIdWidgetKey(appWidgetId), -1);
+    public static int getStatsWidgetDataTypeId(int appWidgetId) {
+        return prefs().getInt(getDataTypeIdWidgetKey(appWidgetId), -1);
     }
 
-    public static void removeStatsWidgetDatatTypeId(int appWidgetId) {
-        prefs().edit().remove(getDatatTypeIdWidgetKey(appWidgetId)).apply();
+    public static void removeStatsWidgetDataTypeId(int appWidgetId) {
+        prefs().edit().remove(getDataTypeIdWidgetKey(appWidgetId)).apply();
     }
 
-    @NonNull private static String getDatatTypeIdWidgetKey(int appWidgetId) {
+    @NonNull private static String getDataTypeIdWidgetKey(int appWidgetId) {
         return DeletablePrefKey.STATS_WIDGET_DATA_TYPE.name() + appWidgetId;
+    }
+
+    public static void setStatsWidgetHasData(boolean hasData, int appWidgetId) {
+        prefs().edit().putBoolean(getHasDataWidgetKey(appWidgetId), hasData).apply();
+    }
+
+    public static boolean getStatsWidgetHasData(int appWidgetId) {
+        return prefs().getBoolean(getHasDataWidgetKey(appWidgetId), false);
+    }
+
+    public static void removeStatsWidgetHasData(int appWidgetId) {
+        prefs().edit().remove(getHasDataWidgetKey(appWidgetId)).apply();
+    }
+
+    @NonNull private static String getHasDataWidgetKey(int appWidgetId) {
+        return DeletablePrefKey.STATS_WIDGET_HAS_DATA.name() + appWidgetId;
     }
 
     public static void setSystemNotificationsEnabled(boolean enabled) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -73,7 +73,7 @@ class AppPrefsWrapper @Inject constructor() {
     fun removeAppWidgetColorModeId(appWidgetId: Int) = AppPrefs.removeStatsWidgetColorModeId(appWidgetId)
 
     fun getAppWidgetDataType(appWidgetId: Int): DataType? {
-        return when (AppPrefs.getStatsWidgetDatatTypeId(appWidgetId)) {
+        return when (AppPrefs.getStatsWidgetDataTypeId(appWidgetId)) {
             VIEWS_TYPE_ID -> VIEWS
             VISITORS_TYPE_ID -> VISITORS
             COMMENTS_TYPE_ID -> COMMENTS
@@ -89,10 +89,20 @@ class AppPrefsWrapper @Inject constructor() {
             COMMENTS -> COMMENTS_TYPE_ID
             LIKES -> LIKES_TYPE_ID
         }
-        AppPrefs.setStatsWidgetDatatTypeId(dataTypeId, appWidgetId)
+        AppPrefs.setStatsWidgetDataTypeId(dataTypeId, appWidgetId)
     }
 
-    fun removeAppWidgetDataTypeModeId(appWidgetId: Int) = AppPrefs.removeStatsWidgetDatatTypeId(appWidgetId)
+    fun removeAppWidgetDataTypeModeId(appWidgetId: Int) = AppPrefs.removeStatsWidgetDataTypeId(appWidgetId)
+
+    fun hasAppWidgetData(appWidgetId: Int): Boolean {
+        return AppPrefs.getStatsWidgetHasData(appWidgetId)
+    }
+
+    fun setAppWidgetHasData(hasData: Boolean, appWidgetId: Int) {
+        AppPrefs.setStatsWidgetHasData(hasData, appWidgetId)
+    }
+
+    fun removeAppWidgetHasData(appWidgetId: Int) = AppPrefs.removeStatsWidgetHasData(appWidgetId)
 
     companion object {
         private const val LIGHT_MODE_ID = 0

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetBlockListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetBlockListViewModel.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.stats.InsightsAllTimeModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.AllTimeInsightsStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetBlockListProvider.BlockItemUiModel
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetBlockListProvider.WidgetBlockListViewModel
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
@@ -19,7 +20,8 @@ class AllTimeWidgetBlockListViewModel
     private val siteStore: SiteStore,
     private val allTimeStore: AllTimeInsightsStore,
     private val resourceProvider: ResourceProvider,
-    private val allTimeWidgetUpdater: AllTimeWidgetUpdater
+    private val allTimeWidgetUpdater: AllTimeWidgetUpdater,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) : WidgetBlockListViewModel {
     private var siteId: Int? = null
     private var colorMode: Color = Color.LIGHT
@@ -44,6 +46,9 @@ class AllTimeWidgetBlockListViewModel
                     if (uiModels != data) {
                         mutableData.clear()
                         mutableData.addAll(uiModels)
+                        appWidgetId?.let {
+                            appPrefsWrapper.setAppWidgetHasData(true, it)
+                        }
                     }
                 }
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetListViewModel.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.stats.InsightsAllTimeModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.AllTimeInsightsStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.utils.ONE_THOUSAND
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
@@ -16,7 +17,8 @@ class AllTimeWidgetListViewModel
 @Inject constructor(
     private val siteStore: SiteStore,
     private val allTimeStore: AllTimeInsightsStore,
-    private val resourceProvider: ResourceProvider
+    private val resourceProvider: ResourceProvider,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) {
     private var siteId: Int? = null
     private var colorMode: Color = Color.LIGHT
@@ -41,6 +43,9 @@ class AllTimeWidgetListViewModel
                     if (uiModels != data) {
                         mutableData.clear()
                         mutableData.addAll(uiModels)
+                        appWidgetId?.let {
+                            appPrefsWrapper.setAppWidgetHasData(true, it)
+                        }
                     }
                 }
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetUpdater.kt
@@ -47,6 +47,7 @@ class AllTimeWidgetUpdater
         val hasToken = accountStore.hasAccessToken()
         val views = RemoteViews(context.packageName, widgetUtils.getLayout(colorMode))
         views.setTextViewText(R.id.widget_title, resourceProvider.getString(R.string.stats_insights_all_time_stats))
+        val widgetHasData = appPrefsWrapper.hasAppWidgetData(appWidgetId)
         if (networkAvailable && siteModel != null && hasToken) {
             widgetUtils.setSiteIcon(siteModel, context, views, appWidgetId)
             siteModel.let {
@@ -65,7 +66,7 @@ class AllTimeWidgetUpdater
                     ALL_TIME_VIEWS,
                     isWideView
             )
-        } else {
+        } else if (!widgetHasData || !hasToken || siteModel == null) {
             widgetUtils.showError(
                     widgetManager,
                     views,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetBlockListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetBlockListViewModel.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.stats.VisitsModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.TodayInsightsStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetBlockListProvider.BlockItemUiModel
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetBlockListProvider.WidgetBlockListViewModel
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
@@ -19,7 +20,8 @@ class TodayWidgetBlockListViewModel
     private val siteStore: SiteStore,
     private val todayInsightsStore: TodayInsightsStore,
     private val resourceProvider: ResourceProvider,
-    private val todayWidgetUpdater: TodayWidgetUpdater
+    private val todayWidgetUpdater: TodayWidgetUpdater,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) : WidgetBlockListViewModel {
     private var siteId: Int? = null
     private var colorMode: Color = Color.LIGHT
@@ -48,6 +50,9 @@ class TodayWidgetBlockListViewModel
                     if (uiModels != data) {
                         mutableData.clear()
                         mutableData.addAll(uiModels)
+                        appWidgetId?.let {
+                            appPrefsWrapper.setAppWidgetHasData(true, it)
+                        }
                     }
                 }
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetListViewModel.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.stats.VisitsModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.TodayInsightsStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.utils.ONE_THOUSAND
 import org.wordpress.android.ui.stats.refresh.utils.toFormattedString
@@ -16,7 +17,8 @@ class TodayWidgetListViewModel
 @Inject constructor(
     private val siteStore: SiteStore,
     private val todayInsightsStore: TodayInsightsStore,
-    private val resourceProvider: ResourceProvider
+    private val resourceProvider: ResourceProvider,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) {
     private var siteId: Int? = null
     private var colorMode: Color = Color.LIGHT
@@ -30,17 +32,20 @@ class TodayWidgetListViewModel
     }
 
     fun onDataSetChanged(onError: (appWidgetId: Int) -> Unit) {
-        siteId?.apply {
-            val site = siteStore.getSiteByLocalId(this)
+        siteId?.let { nonNullSiteId ->
+            val site = siteStore.getSiteByLocalId(nonNullSiteId)
             if (site != null) {
                 runBlocking {
                     todayInsightsStore.fetchTodayInsights(site)
                 }
                 todayInsightsStore.getTodayInsights(site)?.let { visitsAndViewsModel ->
-                    val uiModels = buildListItemUiModel(visitsAndViewsModel, this)
+                    val uiModels = buildListItemUiModel(visitsAndViewsModel, nonNullSiteId)
                     if (uiModels != data) {
                         mutableData.clear()
                         mutableData.addAll(uiModels)
+                        appWidgetId?.let {
+                            appPrefsWrapper.setAppWidgetHasData(true, it)
+                        }
                     }
                 }
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
@@ -47,6 +47,7 @@ class TodayWidgetUpdater
         val views = RemoteViews(context.packageName, widgetUtils.getLayout(colorMode))
         views.setTextViewText(R.id.widget_title, resourceProvider.getString(R.string.stats_insights_today_stats))
         val hasAccessToken = accountStore.hasAccessToken()
+        val widgetHasData = appPrefsWrapper.hasAppWidgetData(appWidgetId)
         if (networkAvailable && hasAccessToken && siteModel != null) {
             widgetUtils.setSiteIcon(siteModel, context, views, appWidgetId)
             siteModel.let {
@@ -65,7 +66,7 @@ class TodayWidgetUpdater
                     TODAY_VIEWS,
                     isWideView
             )
-        } else {
+        } else if (!widgetHasData || !hasAccessToken || siteModel == null) {
             widgetUtils.showError(
                     widgetManager,
                     views,
@@ -85,5 +86,7 @@ class TodayWidgetUpdater
         analyticsTrackerWrapper.trackWithWidgetType(AnalyticsTracker.Stat.STATS_WIDGET_REMOVED, TODAY_VIEWS)
         appPrefsWrapper.removeAppWidgetColorModeId(appWidgetId)
         appPrefsWrapper.removeAppWidgetSiteId(appWidgetId)
+        appPrefsWrapper.removeAppWidgetDataTypeModeId(appWidgetId)
+        appPrefsWrapper.removeAppWidgetHasData(appWidgetId)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetListViewModel.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel.PeriodDa
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem.State.NEGATIVE
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem.State.NEUTRAL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem.State.POSITIVE
@@ -29,7 +30,8 @@ class ViewsWidgetListViewModel
     private val visitsAndViewsStore: VisitsAndViewsStore,
     private val overviewMapper: OverviewMapper,
     private val resourceProvider: ResourceProvider,
-    private val statsDateFormatter: StatsDateFormatter
+    private val statsDateFormatter: StatsDateFormatter,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) {
     private var siteId: Int? = null
     private var colorMode: Color = Color.LIGHT
@@ -63,6 +65,9 @@ class ViewsWidgetListViewModel
                 if (uiModels != data) {
                     mutableData.clear()
                     mutableData.addAll(uiModels)
+                    appWidgetId?.let {
+                        appPrefsWrapper.setAppWidgetHasData(true, it)
+                    }
                 }
             } else {
                 appWidgetId?.let { nonNullAppWidgetId ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetUpdater.kt
@@ -46,6 +46,7 @@ class ViewsWidgetUpdater
         views.setTextViewText(R.id.widget_title, resourceProvider.getString(R.string.stats_views))
         widgetUtils.setSiteIcon(siteModel, context, views, appWidgetId)
         val hasAccessToken = accountStore.hasAccessToken()
+        val widgetHasData = appPrefsWrapper.hasAppWidgetData(appWidgetId)
         if (networkAvailable && hasAccessToken && siteModel != null) {
             siteModel.let {
                 views.setOnClickPendingIntent(
@@ -63,7 +64,7 @@ class ViewsWidgetUpdater
                     WEEK_VIEWS,
                     isWideView
             )
-        } else {
+        } else if (!widgetHasData || !hasAccessToken || siteModel == null) {
             widgetUtils.showError(
                     widgetManager,
                     views,

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetBlockListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetBlockListViewModelTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.InsightsAllTimeModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.AllTimeInsightsStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetBlockListProvider.BlockItemUiModel
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -30,13 +31,20 @@ class AllTimeWidgetBlockListViewModelTest {
     @Mock private lateinit var site: SiteModel
     @Mock private lateinit var context: Context
     @Mock private lateinit var allTimeWidgetUpdater: AllTimeWidgetUpdater
+    @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
     private lateinit var viewModel: AllTimeWidgetBlockListViewModel
     private val siteId: Int = 15
     private val appWidgetId: Int = 1
     private val color = Color.LIGHT
     @Before
     fun setUp() {
-        viewModel = AllTimeWidgetBlockListViewModel(siteStore, allTimeStore, resourceProvider, allTimeWidgetUpdater)
+        viewModel = AllTimeWidgetBlockListViewModel(
+                siteStore,
+                allTimeStore,
+                resourceProvider,
+                allTimeWidgetUpdater,
+                appPrefsWrapper
+        )
         viewModel.start(siteId, color, appWidgetId)
     }
 
@@ -71,6 +79,7 @@ class AllTimeWidgetBlockListViewModelTest {
         Assertions.assertThat(viewModel.data).hasSize(2)
         assertListItem(viewModel.data[0], viewsKey, views, visitorsKey, visitors)
         assertListItem(viewModel.data[1], postsKey, posts, bestKey, viewsBestDayTotal)
+        verify(appPrefsWrapper).setAppWidgetHasData(true, appWidgetId)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/AllTimeWidgetListViewModelTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.widget.alltime
 
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -12,6 +13,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.InsightsAllTimeModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.AllTimeInsightsStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.AllTimeWidgetListViewModel.AllTimeItemUiModel
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -21,6 +23,7 @@ class AllTimeWidgetListViewModelTest {
     @Mock private lateinit var siteStore: SiteStore
     @Mock private lateinit var allTimeStore: AllTimeInsightsStore
     @Mock private lateinit var resourceProvider: ResourceProvider
+    @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
     @Mock private lateinit var site: SiteModel
     private lateinit var viewModel: AllTimeWidgetListViewModel
     private val siteId: Int = 15
@@ -28,7 +31,7 @@ class AllTimeWidgetListViewModelTest {
     private val color = Color.LIGHT
     @Before
     fun setUp() {
-        viewModel = AllTimeWidgetListViewModel(siteStore, allTimeStore, resourceProvider)
+        viewModel = AllTimeWidgetListViewModel(siteStore, allTimeStore, resourceProvider, appPrefsWrapper)
         viewModel.start(siteId, color, appWidgetId)
     }
 
@@ -66,6 +69,7 @@ class AllTimeWidgetListViewModelTest {
         assertListItem(viewModel.data[1], visitorsKey, visitors)
         assertListItem(viewModel.data[2], postsKey, posts)
         assertListItem(viewModel.data[3], bestKey, viewsBestDayTotal)
+        verify(appPrefsWrapper).setAppWidgetHasData(true, appWidgetId)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetBlockListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetBlockListViewModelTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.VisitsModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.TodayInsightsStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetBlockListProvider.BlockItemUiModel
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -29,6 +30,7 @@ class TodayWidgetBlockListViewModelTest {
     @Mock private lateinit var resourceProvider: ResourceProvider
     @Mock private lateinit var site: SiteModel
     @Mock private lateinit var context: Context
+    @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
     @Mock private lateinit var todayWidgetUpdater: TodayWidgetUpdater
     private lateinit var viewModel: TodayWidgetBlockListViewModel
     private val siteId: Int = 15
@@ -36,7 +38,13 @@ class TodayWidgetBlockListViewModelTest {
     private val color = Color.LIGHT
     @Before
     fun setUp() {
-        viewModel = TodayWidgetBlockListViewModel(siteStore, store, resourceProvider, todayWidgetUpdater)
+        viewModel = TodayWidgetBlockListViewModel(
+                siteStore,
+                store,
+                resourceProvider,
+                todayWidgetUpdater,
+                appPrefsWrapper
+        )
         viewModel.start(siteId, color, appWidgetId)
     }
 
@@ -64,6 +72,7 @@ class TodayWidgetBlockListViewModelTest {
         Assertions.assertThat(viewModel.data).hasSize(2)
         assertListItem(viewModel.data[0], viewsKey, views, visitorsKey, visitors)
         assertListItem(viewModel.data[1], likesKey, likes, commentsKey, comments)
+        verify(appPrefsWrapper).setAppWidgetHasData(true, appWidgetId)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetListViewModelTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.widget.today
 
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -12,6 +13,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.VisitsModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.TodayInsightsStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.lists.widget.today.TodayWidgetListViewModel.TodayItemUiModel
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -21,6 +23,7 @@ class TodayWidgetListViewModelTest {
     @Mock private lateinit var siteStore: SiteStore
     @Mock private lateinit var store: TodayInsightsStore
     @Mock private lateinit var resourceProvider: ResourceProvider
+    @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
     @Mock private lateinit var site: SiteModel
     private lateinit var viewModel: TodayWidgetListViewModel
     private val siteId: Int = 15
@@ -28,7 +31,7 @@ class TodayWidgetListViewModelTest {
     private val color = Color.LIGHT
     @Before
     fun setUp() {
-        viewModel = TodayWidgetListViewModel(siteStore, store, resourceProvider)
+        viewModel = TodayWidgetListViewModel(siteStore, store, resourceProvider, appPrefsWrapper)
         viewModel.start(siteId, color, appWidgetId)
     }
 
@@ -58,6 +61,7 @@ class TodayWidgetListViewModelTest {
         assertListItem(viewModel.data[1], visitorsKey, visitors)
         assertListItem(viewModel.data[2], likesKey, likes)
         assertListItem(viewModel.data[3], commentsKey, comments)
+        verify(appPrefsWrapper).setAppWidgetHasData(true, appWidgetId)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetListViewModelTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.stats.refresh.lists.widget.views
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.isNull
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -18,6 +19,7 @@ import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel.PeriodDa
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem.State.NEGATIVE
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem.State.NEUTRAL
@@ -35,6 +37,7 @@ class ViewsWidgetListViewModelTest {
     @Mock private lateinit var overviewMapper: OverviewMapper
     @Mock private lateinit var resourceProvider: ResourceProvider
     @Mock private lateinit var statsDateFormatter: StatsDateFormatter
+    @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
     @Mock private lateinit var site: SiteModel
     private lateinit var viewModel: ViewsWidgetListViewModel
     private val siteId: Int = 15
@@ -48,7 +51,8 @@ class ViewsWidgetListViewModelTest {
                 visitsAndViewsStore,
                 overviewMapper,
                 resourceProvider,
-                statsDateFormatter
+                statsDateFormatter,
+                appPrefsWrapper
         )
     }
 
@@ -125,6 +129,7 @@ class ViewsWidgetListViewModelTest {
             assertThat(data[2].isNegativeChangeVisible).isFalse()
             assertThat(data[2].change).isEqualTo(change)
         }
+        verify(appPrefsWrapper).setAppWidgetHasData(true, appWidgetId)
     }
 
     @Test


### PR DESCRIPTION
Fixes #10836

The idea behind this change is to not allow the `error` state of no connection to override the actual data shown. The widget refreshes the data periodically and I think there might actually be a fake no-connection response. I couldn't actually reproduce this error. 

Once you have a widget data, we save a flag into the shared prefs for the given widget and never replace the data with the error (if the user still has the access token). 

To test:
* Try to add/remove/change Today widget for various sites
* Lock the phone
* Check that it does not hide the data when you come back

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

