### PR TITLE
Do not trigger fragment change when the activity was already closed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -211,7 +211,7 @@ class WPMainNavigationView @JvmOverloads constructor(
                     .replace(R.id.fragment_container, fragment, getTagForPosition(position))
                     // This is used because the main activity sometimes crashes because it's trying to switch fragments
                     // after `onSaveInstanceState` was already called. This is the related issue
-                    // https://github.com/wordpress-mobile/WordPress-Android/pull/10853
+                    // https://github.com/wordpress-mobile/WordPress-Android/issues/10852
                     .commitAllowingStateLoss()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -209,6 +209,9 @@ class WPMainNavigationView @JvmOverloads constructor(
             fragmentManager
                     .beginTransaction()
                     .replace(R.id.fragment_container, fragment, getTagForPosition(position))
+                    // This is used because the main activity sometimes crashes because it's trying to switch fragments
+                    // after `onSaveInstanceState` was already called. This is the related issue
+                    // https://github.com/wordpress-mobile/WordPress-Android/pull/10853
                     .commitAllowingStateLoss()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -209,7 +209,7 @@ class WPMainNavigationView @JvmOverloads constructor(
             fragmentManager
                     .beginTransaction()
                     .replace(R.id.fragment_container, fragment, getTagForPosition(position))
-                    .commit()
+                    .commitAllowingStateLoss()
         }
     }
 


### PR DESCRIPTION
Fixes #10852

I've investigated this issue deeply but I couldn't find how it could be happening. It seems that the system gets the bottom nav click after `onSaveInstanceState` is called on the main activity. This shouldn't be possible. I think in this case it's safe to call `commitAllowingStateLoss` because we don't mind we lose the bottom nav position when the activity is being killed. It's better than crashing.

To test:
* Smoke test the bottom navigation

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

