### PR TITLE
Do not refresh site details when view not initialized

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -974,7 +974,7 @@ public class MySiteFragment extends Fragment implements
     }
 
     private void refreshSelectedSiteDetails(SiteModel site) {
-        if (!isAdded()) {
+        if (!isAdded() || getView() == null) {
             return;
         }
 


### PR DESCRIPTION
Fixes #10854

OnSiteChanged is probably called before `onCreateView` is triggered and that causes the views to not be initialized. I've added a check to see if the `fragment.getView()` is not null before we continue with the event processing. This should fix this crash. 

To test:
* I don't know how to reproduce this crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

