### PR TITLE
Add non-null check for activity in Gutenberg fragment

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -26,6 +26,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.util.Consumer;
+import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.LiveData;
@@ -378,10 +379,12 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     private ArrayList<MediaOption> initOtherMediaImageOptions() {
         ArrayList<MediaOption> otherMediaOptions = new ArrayList<>();
+        FragmentActivity activity = getActivity();
 
-        boolean supportStockPhotos = getArguments().getBoolean(ARG_SUPPORT_STOCK_PHOTOS);
-        if (supportStockPhotos) {
-            String packageName = getActivity().getApplication().getPackageName();
+        Bundle arguments = getArguments();
+        boolean supportStockPhotos = arguments != null && arguments.getBoolean(ARG_SUPPORT_STOCK_PHOTOS);
+        if (supportStockPhotos && activity != null) {
+            String packageName = activity.getApplication().getPackageName();
             int stockMediaResourceId = getResources().getIdentifier("photo_picker_stock_media", "string", packageName);
 
             otherMediaOptions.add(new MediaOption(MEDIA_SOURCE_STOCK_MEDIA, getString(stockMediaResourceId)));

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -383,11 +383,16 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
         Bundle arguments = getArguments();
         boolean supportStockPhotos = arguments != null && arguments.getBoolean(ARG_SUPPORT_STOCK_PHOTOS);
-        if (supportStockPhotos && activity != null) {
-            String packageName = activity.getApplication().getPackageName();
-            int stockMediaResourceId = getResources().getIdentifier("photo_picker_stock_media", "string", packageName);
+        if (activity != null) {
+            if (supportStockPhotos) {
+                String packageName = activity.getApplication().getPackageName();
+                int stockMediaResourceId =
+                        getResources().getIdentifier("photo_picker_stock_media", "string", packageName);
 
-            otherMediaOptions.add(new MediaOption(MEDIA_SOURCE_STOCK_MEDIA, getString(stockMediaResourceId)));
+                otherMediaOptions.add(new MediaOption(MEDIA_SOURCE_STOCK_MEDIA, getString(stockMediaResourceId)));
+            }
+        } else {
+            AppLog.e(T.EDITOR, "Failed to initialize other media options because the activity is null");
         }
 
         return otherMediaOptions;


### PR DESCRIPTION
Fixes #10829

This PR adds a non-null check for activity to the `onGetOtherMediaImageOptions` callback from Gutenberg. 

To test:
* I don't know how to reproduce this issue but the fix should be straightforward

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

