### PR TITLE
Fix crash when reading from ReaderPost JSON

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -233,15 +233,17 @@ public class ReaderPost {
 
         for (int i = 0; i < jsonMetadata.length(); i++) {
             JSONObject jsonMetaItem = jsonMetadata.optJSONObject(i);
-            String metaKey = jsonMetaItem.optString("key");
-            if (!TextUtils.isEmpty(metaKey) && metaKey.equals("xpost_origin")) {
-                String value = jsonMetaItem.optString("value");
-                if (!TextUtils.isEmpty(value) && value.contains(":")) {
-                    String[] valuePair = value.split(":");
-                    if (valuePair.length == 2) {
-                        post.xpostBlogId = StringUtils.stringToLong(valuePair[0]);
-                        post.xpostPostId = StringUtils.stringToLong(valuePair[1]);
-                        return;
+            if (jsonMetaItem != null) {
+                String metaKey = jsonMetaItem.optString("key");
+                if (!TextUtils.isEmpty(metaKey) && metaKey.equals("xpost_origin")) {
+                    String value = jsonMetaItem.optString("value");
+                    if (!TextUtils.isEmpty(value) && value.contains(":")) {
+                        String[] valuePair = value.split(":");
+                        if (valuePair.length == 2) {
+                            post.xpostBlogId = StringUtils.stringToLong(valuePair[0]);
+                            post.xpostPostId = StringUtils.stringToLong(valuePair[1]);
+                            return;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes #10573

This PR adds a non-null check when reading data from JSON in `ReaderPost`.

To test:
* I don't know how to reproduce this issue but the check should be straightforward

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

