### PR TITLE
Issue/10859 bottom sheet not dismissed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -19,6 +19,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.RemoteInput;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.lifecycle.ViewModelProviders;
@@ -169,7 +170,6 @@ public class WPMainActivity extends AppCompatActivity implements
     private SiteModel mSelectedSite;
     private WPMainActivityViewModel mViewModel;
     private FloatingActionButton mFloatingActionButton;
-    private MainBottomSheetFragment mMainBottomSheetFragment;
     private static final String MAIN_BOTTOM_SHEET_TAG = "MAIN_BOTTOM_SHEET_TAG";
 
     @Inject AccountStore mAccountStore;
@@ -404,16 +404,26 @@ public class WPMainActivity extends AppCompatActivity implements
                         handleNewPageAction(PagePostCreationSourcesDetail.PAGE_FROM_MY_SITE);
                         break;
                 }
-
-                if (mMainBottomSheetFragment != null) {
-                    mMainBottomSheetFragment.dismiss();
-                    mMainBottomSheetFragment = null;
-                }
             });
 
             mFloatingActionButton.setOnClickListener(v -> {
-                mMainBottomSheetFragment = new MainBottomSheetFragment();
-                mMainBottomSheetFragment.show(getSupportFragmentManager(), MAIN_BOTTOM_SHEET_TAG);
+                MainBottomSheetFragment bottomSheet = new MainBottomSheetFragment();
+                bottomSheet.show(getSupportFragmentManager(), MAIN_BOTTOM_SHEET_TAG);
+                mViewModel.setIsBottomSheetShowing(true);
+            });
+
+            mViewModel.isBottomSheetShowing().observe(this, isShowing -> {
+                if (!isShowing) {
+                    FragmentManager fm = getSupportFragmentManager();
+                    if (fm != null) {
+                        MainBottomSheetFragment bottomSheet =
+                                (MainBottomSheetFragment) fm.findFragmentByTag(MAIN_BOTTOM_SHEET_TAG);
+
+                        if (bottomSheet != null) {
+                            bottomSheet.dismiss();
+                        }
+                    }
+                }
             });
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -407,21 +407,19 @@ public class WPMainActivity extends AppCompatActivity implements
             });
 
             mFloatingActionButton.setOnClickListener(v -> {
-                MainBottomSheetFragment bottomSheet = new MainBottomSheetFragment();
-                bottomSheet.show(getSupportFragmentManager(), MAIN_BOTTOM_SHEET_TAG);
                 mViewModel.setIsBottomSheetShowing(true);
             });
 
             mViewModel.isBottomSheetShowing().observe(this, isShowing -> {
-                if (!isShowing) {
-                    FragmentManager fm = getSupportFragmentManager();
-                    if (fm != null) {
-                        MainBottomSheetFragment bottomSheet =
-                                (MainBottomSheetFragment) fm.findFragmentByTag(MAIN_BOTTOM_SHEET_TAG);
-
-                        if (bottomSheet != null) {
-                            bottomSheet.dismiss();
-                        }
+                FragmentManager fm = getSupportFragmentManager();
+                if (fm != null) {
+                    MainBottomSheetFragment bottomSheet =
+                            (MainBottomSheetFragment) fm.findFragmentByTag(MAIN_BOTTOM_SHEET_TAG);
+                    if (isShowing && bottomSheet == null) {
+                        bottomSheet = new MainBottomSheetFragment();
+                        bottomSheet.show(getSupportFragmentManager(), MAIN_BOTTOM_SHEET_TAG);
+                    } else if (!isShowing && bottomSheet != null) {
+                        bottomSheet.dismiss();
                     }
                 }
             });

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -40,7 +40,6 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -34,11 +34,13 @@ import androidx.appcompat.widget.SearchView;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener;
@@ -170,7 +172,6 @@ public class ReaderPostListFragment extends Fragment
     private ImageView mSettingsButton;
     private View mSubFiltersListButton;
     private TextView mSubFilterTitle;
-    private SubfilterBottomSheetFragment mBottomSheet;
 
     private boolean mIsTopLevel = false;
     private static final String SUBFILTER_BOTTOM_SHEET_TAG = "SUBFILTER_BOTTOM_SHEET_TAG";
@@ -373,6 +374,7 @@ public class ReaderPostListFragment extends Fragment
             if (savedInstanceState.containsKey(ReaderConstants.ARG_IS_TOP_LEVEL)) {
                 mIsTopLevel = savedInstanceState.getBoolean(ReaderConstants.ARG_IS_TOP_LEVEL);
             }
+
             mRestorePosition = savedInstanceState.getInt(ReaderConstants.KEY_RESTORE_POSITION);
             mSiteSearchRestorePosition = savedInstanceState.getInt(ReaderConstants.KEY_SITE_SEARCH_RESTORE_POSITION);
             mWasPaused = savedInstanceState.getBoolean(ReaderConstants.KEY_WAS_PAUSED);
@@ -409,10 +411,6 @@ public class ReaderPostListFragment extends Fragment
                 if (readerModeInfo != null) {
                     changeReaderMode(readerModeInfo);
 
-                    if (mBottomSheet != null) {
-                        mBottomSheet.dismiss();
-                        mBottomSheet = null;
-                    }
                     if (readerModeInfo.getLabel() != null) {
                         mSubFilterTitle.setText(
                                 mUiHelpers.getTextOfUiString(
@@ -420,6 +418,20 @@ public class ReaderPostListFragment extends Fragment
                                         readerModeInfo.getLabel()
                                 )
                         );
+                    }
+                }
+            });
+
+            mViewModel.isBottomSheetShowing().observe(getActivity(), isShowing -> {
+                if (!isShowing) {
+                    FragmentManager fm = getFragmentManager();
+                    if (fm != null) {
+                        SubfilterBottomSheetFragment bottomSheet =
+                                (SubfilterBottomSheetFragment) fm.findFragmentByTag(SUBFILTER_BOTTOM_SHEET_TAG);
+
+                        if (bottomSheet != null) {
+                            bottomSheet.dismiss();
+                        }
                     }
                 }
             });
@@ -868,8 +880,9 @@ public class ReaderPostListFragment extends Fragment
 
             mSubFiltersListButton = mSubFilterComponent.findViewById(R.id.filter_selection);
             mSubFiltersListButton.setOnClickListener(v -> {
-                mBottomSheet = new SubfilterBottomSheetFragment();
-                mBottomSheet.show(getFragmentManager(), SUBFILTER_BOTTOM_SHEET_TAG);
+                BottomSheetDialogFragment bottomSheet = new SubfilterBottomSheetFragment();
+                bottomSheet.show(getFragmentManager(), SUBFILTER_BOTTOM_SHEET_TAG);
+                mViewModel.setIsBottomSheetShowing(true);
             });
 
             mSubFilterTitle = mSubFilterComponent.findViewById(R.id.selected_filter_name);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -423,15 +423,15 @@ public class ReaderPostListFragment extends Fragment
             });
 
             mViewModel.isBottomSheetShowing().observe(getActivity(), isShowing -> {
-                if (!isShowing) {
-                    FragmentManager fm = getFragmentManager();
-                    if (fm != null) {
-                        SubfilterBottomSheetFragment bottomSheet =
-                                (SubfilterBottomSheetFragment) fm.findFragmentByTag(SUBFILTER_BOTTOM_SHEET_TAG);
-
-                        if (bottomSheet != null) {
-                            bottomSheet.dismiss();
-                        }
+                FragmentManager fm = getFragmentManager();
+                if (fm != null) {
+                    SubfilterBottomSheetFragment bottomSheet =
+                            (SubfilterBottomSheetFragment) fm.findFragmentByTag(SUBFILTER_BOTTOM_SHEET_TAG);
+                    if (isShowing && bottomSheet == null) {
+                        bottomSheet = new SubfilterBottomSheetFragment();
+                        bottomSheet.show(getFragmentManager(), SUBFILTER_BOTTOM_SHEET_TAG);
+                    } else if (!isShowing && bottomSheet != null) {
+                        bottomSheet.dismiss();
                     }
                 }
             });
@@ -880,8 +880,6 @@ public class ReaderPostListFragment extends Fragment
 
             mSubFiltersListButton = mSubFilterComponent.findViewById(R.id.filter_selection);
             mSubFiltersListButton.setOnClickListener(v -> {
-                BottomSheetDialogFragment bottomSheet = new SubfilterBottomSheetFragment();
-                bottomSheet.show(getFragmentManager(), SUBFILTER_BOTTOM_SHEET_TAG);
                 mViewModel.setIsBottomSheetShowing(true);
             });
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterListItem.kt
@@ -14,6 +14,22 @@ sealed class SubfilterListItem(val type: ItemType) {
     open val onClickAction: ((filter: SubfilterListItem) -> Unit)? = null
     open val label: UiString? = null
 
+    fun isSameItem(otherItem: SubfilterListItem?): Boolean {
+        if (otherItem == null) return false
+
+        return if (type == otherItem.type) {
+            when (type) {
+                SECTION_TITLE -> label == otherItem.label
+                SITE -> (this as Site).blog.isSameAs((otherItem as Site).blog)
+                TAG -> (this as Tag).tag == (otherItem as Tag).tag
+                SITE_ALL,
+                DIVIDER -> true
+            }
+        } else {
+            false
+        }
+    }
+
     enum class ItemType {
         SECTION_TITLE,
         SITE_ALL,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -54,6 +54,9 @@ class ReaderPostListViewModel @Inject constructor(
     private val _readerModeInfo = SingleLiveEvent<ReaderModeInfo>()
     val readerModeInfo: LiveData<ReaderModeInfo> = _readerModeInfo
 
+    private val _isBottomSheetShowing = MutableLiveData<Boolean>()
+    val isBottomSheetShowing: LiveData<Boolean> = _isBottomSheetShowing
+
     /**
      * First tag for which the card was shown.
      */
@@ -167,8 +170,10 @@ class ReaderPostListViewModel @Inject constructor(
     }
 
     private fun onSubfilterClicked(filter: SubfilterListItem) {
+        _isBottomSheetShowing.postValue(false)
+
         _subFilters.postValue(_subFilters.value?.map {
-            it.isSelected = filter == it
+            it.isSelected = it.isSameItem(filter)
             it
         })
 
@@ -201,6 +206,10 @@ class ReaderPostListViewModel @Inject constructor(
                         onClickAction = ::onSubfilterClicked,
                         isSelected = true
                 ))
+    }
+
+    fun setIsBottomSheetShowing(showing: Boolean) {
+        _isBottomSheetShowing.value = showing
     }
 
     fun applySubfilter(

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -24,6 +24,9 @@ class WPMainActivityViewModel @Inject constructor() : ViewModel() {
     private val _createAction = SingleLiveEvent<ActionType>()
     val createAction: LiveData<ActionType> = _createAction
 
+    private val _isBottomSheetShowing = MutableLiveData<Boolean>()
+    val isBottomSheetShowing: LiveData<Boolean> = _isBottomSheetShowing
+
     fun start(isFabVisible: Boolean) {
         if (isStarted) return
         isStarted = true
@@ -52,7 +55,12 @@ class WPMainActivityViewModel @Inject constructor() : ViewModel() {
     }
 
     private fun onCreateActionClicked(actionType: ActionType) {
+        _isBottomSheetShowing.postValue(false)
         _createAction.postValue(actionType)
+    }
+
+    fun setIsBottomSheetShowing(showing: Boolean) {
+        _isBottomSheetShowing.value = showing
     }
 
     fun onPageChanged(showFab: Boolean) {


### PR DESCRIPTION
Fixes #10859 

We fixed the issue both for the bottom sheet in reader and in main activity (create fab bottom sheet).

While debugging it I also actually noticed that in the onSubfilterClicked, the equality to compute the it.filtered was not super correct in cases when the filter is not the same object you have in the collection so added an equality function to the SubfilterListItem (since the PR is small I included it here, I know it's not super clean hope its fine enough 😅) 

## To test:
- follow steps in #10859 with the reader bottom sheet
- also check that the selected item in the bottom sheet is always the desired one
- repeat the #10859 steps for the create fab

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

