### PR TITLE
Avoid reader tab refresh on config changes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -407,7 +407,7 @@ public class ReaderPostListFragment extends Fragment
 
             mViewModel.getReaderModeInfo().observe(getActivity(), readerModeInfo -> {
                 if (readerModeInfo != null) {
-                    changeReaderMode(readerModeInfo);
+                    changeReaderMode(readerModeInfo, true);
 
                     if (mBottomSheet != null) {
                         mBottomSheet.dismiss();
@@ -436,7 +436,21 @@ public class ReaderPostListFragment extends Fragment
         );
     }
 
-    private void changeReaderMode(ReaderModeInfo readerModeInfo) {
+    private void changeReaderMode(ReaderModeInfo readerModeInfo, boolean onlyOnChanges) {
+        boolean changesDetected = false;
+
+        if (onlyOnChanges) {
+            changesDetected = (readerModeInfo.getTag() != null
+                               && mCurrentTag != null
+                               && !readerModeInfo.getTag().equals(mCurrentTag))
+                              || (mPostListType != readerModeInfo.getListType())
+                              || (mCurrentBlogId != readerModeInfo.getBlogId())
+                              || (mCurrentFeedId != readerModeInfo.getFeedId())
+                              || (readerModeInfo.isFirstLoad());
+        }
+
+        if (onlyOnChanges && !changesDetected) return;
+
         if (readerModeInfo.getTag() != null) {
             mCurrentTag = readerModeInfo.getTag();
         }
@@ -1872,7 +1886,9 @@ public class ReaderPostListFragment extends Fragment
                         0,
                         0,
                         false,
-                        null)
+                        null,
+                        false),
+                        false
                 );
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderModeInfo.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderModeInfo.kt
@@ -10,5 +10,6 @@ data class ReaderModeInfo(
     val blogId: Long,
     val feedId: Long,
     val requestNewerPosts: Boolean,
-    val label: UiString?
+    val label: UiString?,
+    val isFirstLoad: Boolean
 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -59,6 +59,7 @@ class ReaderPostListViewModel @Inject constructor(
      */
     private var initialTag: ReaderTag? = null
     private var isStarted = false
+    private var isFirstLoad = true
 
     /**
      * Tag may be null for Blog previews for instance.
@@ -218,7 +219,8 @@ class ReaderPostListViewModel @Inject constructor(
                     0,
                     0,
                     requestNewerPosts,
-                    subfilterListItem.label
+                    subfilterListItem.label,
+                    isFirstLoad
             ))
             SubfilterListItem.ItemType.SITE -> {
                 val currentFeedId = (subfilterListItem as Site).blog.feedId
@@ -233,7 +235,8 @@ class ReaderPostListViewModel @Inject constructor(
                         currentBlogId,
                         currentFeedId,
                         requestNewerPosts,
-                        subfilterListItem.label
+                        subfilterListItem.label,
+                        isFirstLoad
                 ))
             }
             SubfilterListItem.ItemType.TAG -> _readerModeInfo.value = (ReaderModeInfo(
@@ -242,9 +245,11 @@ class ReaderPostListViewModel @Inject constructor(
                     0,
                     0,
                     requestNewerPosts,
-                    subfilterListItem.label
+                    subfilterListItem.label,
+                    isFirstLoad
             ))
         }
+        isFirstLoad = false
     }
 
     override fun onCleared() {


### PR DESCRIPTION
Fixes #10865 

## To test:
- open a reader tab
- rotate the device and check the page is not refreshed
- smoke test the reader as in previous IA project PRs

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

