### PR TITLE
Ignore unrelated theme change events in ThemeBrowserActivity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -37,6 +37,7 @@ import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.themes.ThemeBrowserFragment.ThemeBrowserFragmentCallback;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.CrashLoggingUtils;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
@@ -215,6 +216,10 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteThemesChanged(OnSiteThemesChanged event) {
+        if (event.site.getId() != mSite.getId()) {
+            // ignore this event as it's not related to the currently selected site
+            return;
+        }
         if (event.origin == ThemeAction.FETCH_INSTALLED_THEMES) {
             // always unset refreshing status to remove progress indicator
             if (mThemeBrowserFragment != null) {
@@ -239,6 +244,10 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onCurrentThemeFetched(OnCurrentThemeFetched event) {
+        if (event.site.getId() != mSite.getId()) {
+            // ignore this event as it's not related to the currently selected site
+            return;
+        }
         if (event.isError()) {
             AppLog.e(T.THEMES, "Error fetching current theme: " + event.error.message);
             ToastUtils.showToast(this, R.string.theme_fetch_failed, ToastUtils.Duration.SHORT);
@@ -261,6 +270,10 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onThemeInstalled(OnThemeInstalled event) {
+        if (event.site.getId() != mSite.getId()) {
+            // ignore this event as it's not related to the currently selected site
+            return;
+        }
         if (event.isError()) {
             AppLog.e(T.THEMES, "Error installing theme: " + event.error.message);
         } else {
@@ -272,6 +285,10 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onThemeActivated(OnThemeActivated event) {
+        if (event.site.getId() != mSite.getId()) {
+            // ignore this event as it's not related to the currently selected site
+            return;
+        }
         if (event.isError()) {
             AppLog.e(T.THEMES, "Error activating theme: " + event.error.message);
             ToastUtils.showToast(this, R.string.theme_activation_error, ToastUtils.Duration.SHORT);
@@ -279,6 +296,11 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
             AppLog.d(T.THEMES, "Theme activation successful! New theme: " + event.theme.getName());
 
             mCurrentTheme = mThemeStore.getActiveThemeForSite(event.site);
+            if (mCurrentTheme == null) {
+                CrashLoggingUtils.log("NOT A CRASH: OnThemeActivated event is ignored as `getActiveThemeForSite` "
+                                      + "returned null.");
+                return;
+            }
             updateCurrentThemeView();
 
             Map<String, Object> themeProperties = new HashMap<>();


### PR DESCRIPTION
Fixes https://sentry.io/organizations/a8c/issues/1021450053/?project=1438088&query=is%3Aunresolved+release%3Aorg.wordpress.android-13.6&statsPeriod=90d

The Sentry ticket contains a bunch of unrelated issues -> don't close it.

To test:
Test updating/reverting a theme on some of your sites. Make sure that when it's activated it appears as the first item in the list + you can see it on your site.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

