### PR TITLE
Enforcing feature flagging to use original code when off.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -185,7 +185,7 @@ public class WPMainActivity extends AppCompatActivity implements
     @Inject UploadActionUseCase mUploadActionUseCase;
     @Inject SystemNotificationsTracker mSystemNotificationsTracker;
     @Inject GCMMessageHandler mGCMMessageHandler;
-	@Inject ViewModelProvider.Factory mViewModelFactory;
+    @Inject ViewModelProvider.Factory mViewModelFactory;
 
     /*
      * fragments implement this if their contents can be scrolled, called when user

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -511,7 +511,7 @@ public class ReaderPostListFragment extends Fragment
             ReaderTag readerTag = AppPrefs.getReaderTag();
 
             if (discoverTag != null && discoverTag.equals(readerTag)) {
-                setCurrentTag(readerTag, true);
+                setCurrentTag(readerTag, BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE);
                 updateCurrentTag();
             } else if (discoverTag == null) {
                 AppLog.w(T.READER, "Discover tag not found; ReaderTagTable returned null");
@@ -855,7 +855,7 @@ public class ReaderPostListFragment extends Fragment
         // add a menu to the filtered recycler's toolbar
         if (mAccountStore.hasAccessToken() && (getPostListType() == ReaderPostListType.TAG_FOLLOWED
                                                || getPostListType() == ReaderPostListType.SEARCH_RESULTS
-                                               || mIsTopLevel)) {
+                                               || (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel))) {
             setupRecyclerToolbar();
         }
 
@@ -1897,7 +1897,7 @@ public class ReaderPostListFragment extends Fragment
 
         mCurrentTag = tag;
 
-        if (manageSubfilter) {
+        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && manageSubfilter) {
             if (mCurrentTag.isFollowedSites()) {
                 mViewModel.applySubfilter(mViewModel.getCurrentSubfilterValue(), false);
             } else {


### PR DESCRIPTION
This is a small PR that adds the check on the `INFORMATION_ARCHITECTURE_AVAILABLE` feature flag in 3 points in the code, to enforce execution of original code when the feature flag is off.

## To test:
We are going to re-test this deeper working on the feature branch targeted by this PR before to merge into develop, so should be enough to check the code and compare it with the develop original code. Check that in case when the feature flag is off the original code logic gets executed.

For convenience I put here below relevant screenshots that compare develop original (on the left) and the behavior we are willing to change (on the right).

![image](https://user-images.githubusercontent.com/47797566/69839195-ce8c2580-1256-11ea-914b-38451a50cc0c.png)

![image](https://user-images.githubusercontent.com/47797566/69839290-2f1b6280-1257-11ea-930e-c9c234de655b.png)

![image](https://user-images.githubusercontent.com/47797566/69839327-57a35c80-1257-11ea-8e98-8d6536b8d1e0.png)



PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

