### PR TITLE
Updated Aztec version to v1.3.35

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -207,8 +207,8 @@ dependencies {
         exclude group: 'com.squareup.okhttp3'
     }
 
-    implementation 'com.github.bumptech.glide:glide:4.9.0'
-    kapt 'com.github.bumptech.glide:compiler:4.9.0'
+    implementation 'com.github.bumptech.glide:glide:4.10.0'
+    kapt 'com.github.bumptech.glide:compiler:4.10.0'
     implementation 'com.github.bumptech.glide:volley-integration:4.6.1@aar'
 
     testImplementation 'junit:junit:4.12'

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     ext {
-        aztecVersion = 'v1.3.34'
+        aztecVersion = 'v1.3.35'
     }
 
     dependencies {

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -57,8 +57,8 @@ dependencies {
         }
     }
 
-    implementation 'com.github.bumptech.glide:glide:4.9.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.9.0'
+    implementation 'com.github.bumptech.glide:glide:4.10.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.10.0'
 
     // Dagger
     implementation 'com.google.dagger:dagger:2.22.1'


### PR DESCRIPTION
Fixes #
The latest Aztec version includes Glide version update to 4.10.0. To keep the Glide version in sync across repositories, I also updated the Glide version to 4.10.0.

To test:
- Smoke test the app to verify that images/videos are displayed correctly. 
- Adding images/videos to Aztec Editor works correctly.

### Notes:
- This PR should not be merged till the Aztec version is updated in `gutenberg-mobile` repository.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

