### PR TITLE
Fix crash in UploadStarter on Samsung devices with Android 5

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,7 +10,6 @@
 * Block editor: Images clickable for fullscreen preview
 * Fixed time displayed on Post Conflict Detected and Unpublished Revision dialogs
 * Block editor: Fix issue when removing image/page break block crashes the app
-* Removed support for Giphy
 * Fixed a crash on Samsung devices running Android 5 (Lollipop)
  
 13.6

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,8 @@
 * Block editor: Images clickable for fullscreen preview
 * Fixed time displayed on Post Conflict Detected and Unpublished Revision dialogs
 * Block editor: Fix issue when removing image/page break block crashes the app
+* Removed support for Giphy
+* Fixed a crash on Samsung devices running Android 5 (Lollipop)
  
 13.6
 -----


### PR DESCRIPTION
This has the same contents as #10877. The difference is this one is targeting `release/13.7`. 

## Testing 

Please do the same testing steps in #10877.

 
## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
