### PR TITLE
Allow user to change display name and password at the same time during signup

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -521,9 +521,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     }
 
     protected boolean changedUsername() {
-        final String savedUsername = mAccount.getAccount().getUserName();
-        final String initialUsername = getArguments().getString(ARG_USERNAME);
-        return !TextUtils.equals(!TextUtils.isEmpty(savedUsername) ? savedUsername : initialUsername, mUsername);
+        return !TextUtils.equals(mAccount.getAccount().getUserName(), mUsername);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -475,7 +475,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                    && !TextUtils.isEmpty(mAccountStore.getAccount().getEmail())) {
             endProgress();
             populateViews();
-        } else if (event.causeOfChange == AccountAction.PUSH_SETTINGS && mSignupEpilogueListener != null) {
+        } else if (event.causeOfChange == AccountAction.PUSH_SETTINGS) {
             mHasMadeUpdates = true;
 
             if (mIsUpdatingDisplayName) {
@@ -503,7 +503,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                             + event.error.type + " - " + event.error.message);
             endProgress();
             showErrorDialog(getString(R.string.signup_epilogue_error_generic));
-        } else if (mSignupEpilogueListener != null) {
+        } else {
             mHasMadeUpdates = true;
             AnalyticsTracker.track(mIsEmailSignup
                     ? AnalyticsTracker.Stat.SIGNUP_EMAIL_EPILOGUE_UPDATE_USERNAME_SUCCEEDED

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -703,32 +703,44 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     protected void updateAccountOrContinue() {
         if (changedDisplayName()) {
             startProgress(false);
-            PushAccountSettingsPayload payload = new PushAccountSettingsPayload();
-            payload.params = new HashMap<>();
-            payload.params.put("display_name", mDisplayName);
-
-            if (changedPassword()) {
-                payload.params.put("password", mInputPassword.getEditText().getText().toString());
-            }
-
-            mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
+            updateDisplayName();
         } else if (changedPassword()) {
             startProgress(false);
-            PushAccountSettingsPayload payload = new PushAccountSettingsPayload();
-            payload.params = new HashMap<>();
-            payload.params.put("password", mInputPassword.getEditText().getText().toString());
-            mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
+            updatePassword();
         } else if (changedUsername()) {
             startProgress(false);
-            PushUsernamePayload payload = new PushUsernamePayload(
-                    mUsername, AccountUsernameActionType.KEEP_OLD_SITE_AND_ADDRESS);
-            mDispatcher.dispatch(AccountActionBuilder.newPushUsernameAction(payload));
+            updateUsername();
         } else if (mSignupEpilogueListener != null) {
             AnalyticsTracker.track(mIsEmailSignup
                     ? AnalyticsTracker.Stat.SIGNUP_EMAIL_EPILOGUE_UNCHANGED
                     : AnalyticsTracker.Stat.SIGNUP_SOCIAL_EPILOGUE_UNCHANGED);
             mSignupEpilogueListener.onContinue();
         }
+    }
+
+    private void updateDisplayName() {
+        PushAccountSettingsPayload payload = new PushAccountSettingsPayload();
+        payload.params = new HashMap<>();
+        payload.params.put("display_name", mDisplayName);
+
+        if (changedPassword()) {
+            payload.params.put("password", mInputPassword.getEditText().getText().toString());
+        }
+
+        mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
+    }
+
+    private void updatePassword() {
+        PushAccountSettingsPayload payload = new PushAccountSettingsPayload();
+        payload.params = new HashMap<>();
+        payload.params.put("password", mInputPassword.getEditText().getText().toString());
+        mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
+    }
+
+    private void updateUsername() {
+        PushUsernamePayload payload = new PushUsernamePayload(
+                mUsername, AccountUsernameActionType.KEEP_OLD_SITE_AND_ADDRESS);
+        mDispatcher.dispatch(AccountActionBuilder.newPushUsernameAction(payload));
     }
 
     private class DownloadAvatarAndUploadGravatarThread extends Thread {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -119,6 +119,11 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     private static final String KEY_IS_AVATAR_ADDED = "KEY_IS_AVATAR_ADDED";
     private static final String KEY_PHOTO_URL = "KEY_PHOTO_URL";
     private static final String KEY_USERNAME = "KEY_USERNAME";
+    private static final String KEY_IS_UPDATING_DISPLAY_NAME = "KEY_IS_UPDATING_DISPLAY_NAME";
+    private static final String KEY_IS_UPDATING_PASSWORD = "KEY_IS_UPDATING_PASSWORD";
+    private static final String KEY_HAS_UPDATED_DISPLAY_NAME = "KEY_HAS_UPDATED_DISPLAY_NAME";
+    private static final String KEY_HAS_UPDATED_USERNAME = "KEY_HAS_UPDATED_USERNAME";
+    private static final String KEY_HAS_UPDATED_PASSWORD = "KEY_HAS_UPDATED_PASSWORD";
 
     public static final String TAG = "signup_epilogue_fragment_tag";
 
@@ -312,6 +317,12 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                 mHeaderAvatarAdd.setVisibility(mIsAvatarAdded ? View.GONE : View.VISIBLE);
             }
             mImageManager.loadIntoCircle(mHeaderAvatar, ImageType.AVATAR_WITHOUT_BACKGROUND, mPhotoUrl);
+
+            mIsUpdatingDisplayName = savedInstanceState.getBoolean(KEY_IS_UPDATING_DISPLAY_NAME);
+            mIsUpdatingPassword = savedInstanceState.getBoolean(KEY_IS_UPDATING_PASSWORD);
+            mHasUpdatedDisplayName = savedInstanceState.getBoolean(KEY_HAS_UPDATED_DISPLAY_NAME);
+            mHasUpdatedUsername = savedInstanceState.getBoolean(KEY_HAS_UPDATED_USERNAME);
+            mHasUpdatedPassword = savedInstanceState.getBoolean(KEY_HAS_UPDATED_PASSWORD);
         }
     }
 
@@ -414,6 +425,11 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
         outState.putString(KEY_EMAIL_ADDRESS, mEmailAddress);
         outState.putString(KEY_USERNAME, mUsername);
         outState.putBoolean(KEY_IS_AVATAR_ADDED, mIsAvatarAdded);
+        outState.putBoolean(KEY_IS_UPDATING_DISPLAY_NAME, mIsUpdatingDisplayName);
+        outState.putBoolean(KEY_IS_UPDATING_PASSWORD, mIsUpdatingPassword);
+        outState.putBoolean(KEY_HAS_UPDATED_DISPLAY_NAME, mHasUpdatedDisplayName);
+        outState.putBoolean(KEY_HAS_UPDATED_USERNAME, mHasUpdatedUsername);
+        outState.putBoolean(KEY_HAS_UPDATED_PASSWORD, mHasUpdatedPassword);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -286,9 +286,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                 // Start progress and wait for account to be fetched before populating views when
                 // email does not exist in account store.
                 if (TextUtils.isEmpty(mAccountStore.getAccount().getEmail())) {
-                    if (!isInProgress()) {
-                        startProgress(false);
-                    }
+                    startProgress(false);
                 } else {
                     // Skip progress and populate views when email does exist in account store.
                     populateViews();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -513,10 +513,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     }
 
     protected boolean changedDisplayName() {
-        final String savedDisplayName = mAccount.getAccount().getDisplayName();
-        final String initialDisplayName = getArguments().getString(ARG_DISPLAY_NAME);
-        return !TextUtils.equals(!TextUtils.isEmpty(savedDisplayName)
-                ? savedDisplayName : initialDisplayName, mDisplayName);
+        return !TextUtils.equals(mAccount.getAccount().getDisplayName(), mDisplayName);
     }
 
     protected boolean changedPassword() {


### PR DESCRIPTION
Fixes #10835 

**The problem:** it's impossible for the user to change their display name and password at the same time during email signup. When trying to do so, the user gets a dialog stating that "The password setting cannot be changed at the same time as any other setting".

**The cause:** this is an API limitation (thank you @hypest for confirming this) that the current implementation doesn't take into consideration when it tries to update the display name and password [with a single network call](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java#L710-L712).

**The solution:** updating each account field (display name, username and password) separately – each with their own network call.

The main target of this PR was the `SignupEpilogueFragment` class, where I added some extra logic to manage the chain of updates. I suggest looking into the [`updateAccountOrContinue()`](https://github.com/renanferrari/WordPress-Android/blob/51485bbbc08b02d658bb0d5aeabb8823730937e4/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java#L739-L760) method, which is where most of this logic happens. 

I also tried to keep in mind scenarios where it would be necessary to recover from failures that occurred in the middle of the chain. Even though I wasn't able to test this as much as I wanted, the order in which the updates occur (username -> display name -> password) were thought of with this in mind and I've also added some extra functionality that would allow for a more consistent behavior in those cases, which were the main reasons for the changes you can see [here](https://github.com/renanferrari/WordPress-Android/blob/51485bbbc08b02d658bb0d5aeabb8823730937e4/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java#L515-L530) and [here](https://github.com/renanferrari/WordPress-Android/blob/51485bbbc08b02d658bb0d5aeabb8823730937e4/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java#L728-L737). Let me know if I need to go into more detail about this.

To test
---

1. Make sure you have OAuth credentials with user creation capabilities.
2. If you have logged in to the app, sign out.
3. On the initial screen, tap **Sign up for WordPress.com**.
4. Tap **Sign up with email**.
5. Enter an email address that is not associated with a WordPress.com account.
6. On the next screen, tap **Open mail**.
7. On the signup email sent to the address used in step 5, tap **Sign up to WordPress.com**.
8. On the epilogue screen, fill in the _Display Name_ and _Password_ fields and tap **Continue**.
9. Confirm that **no error dialog appeared** and that the values were **correctly updated**.

Notes
---

1. For this PR, I did the minimum necessary to ensure the expected behavior and because of that, the proposed implementation here is extremely simple and tries to make good use of existing structures in the current code. However, this part of the signup flow seems to be a good candidate for further refactoring. As an example, I believe that the readability and testability of the `SignupEpilogueFragment` class could greatly benefit from the separation of responsibilities that a ViewModel could bring.

2. While working on this PR, I found another existing bug where the username, display name, and password fields don't seem to retain their values after configuration changes (screen rotation, for example). In an attempt to maintain the focus of this PR, I haven't looked into this problem any further. Let me know if I should open a specific issue for it.

---

**PR submission checklist:**

- [x] I have considered adding unit tests where possible.

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

