### PR TITLE
Issue/10634 material pages list

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -225,12 +225,12 @@
             android:label="" />
         <activity
             android:name=".ui.pages.PagesActivity"
-            android:theme="@style/Calypso.NoActionBar"
+            android:theme="@style/WordPress.NoActionBar"
             android:launchMode="singleTop"
             android:label="@string/my_site_btn_site_pages" />
         <activity
             android:name=".ui.pages.PageParentActivity"
-            android:theme="@style/Calypso.NoActionBar"
+            android:theme="@style/WordPress.NoActionBar"
             android:label="@string/set_parent" />
         <activity
             android:name=".ui.posts.SelectCategoriesActivity"

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
@@ -11,7 +11,6 @@ import android.widget.PopupMenu
 import android.widget.RadioButton
 import android.widget.TextView
 import androidx.annotation.LayoutRes
-import androidx.core.widget.CompoundButtonCompat
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
 import org.wordpress.android.ui.ActionableEmptyView
@@ -20,11 +19,11 @@ import org.wordpress.android.ui.pages.PageItem.Empty
 import org.wordpress.android.ui.pages.PageItem.Page
 import org.wordpress.android.ui.pages.PageItem.ParentPage
 import org.wordpress.android.ui.reader.utils.ReaderUtils
-import org.wordpress.android.util.currentLocale
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.ImageUtils
 import org.wordpress.android.util.capitalizeWithLocaleWithoutLint
+import org.wordpress.android.util.currentLocale
 import org.wordpress.android.util.getDrawableFromAttribute
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType
@@ -163,10 +162,6 @@ sealed class PageItemViewHolder(internal val parent: ViewGroup, @LayoutRes layou
                 radioButton.setOnClickListener {
                     onParentSelected(pageItem)
                 }
-
-                @Suppress("DEPRECATION")
-                CompoundButtonCompat.setButtonTintList(radioButton,
-                        radioButton.resources.getColorStateList(R.color.primary_40_gray_20_gray_40_selector))
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentActivity.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.pages
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import kotlinx.android.synthetic.main.toolbar.*
+import kotlinx.android.synthetic.main.toolbar_main.*
 import org.wordpress.android.R
 
 class PageParentActivity : AppCompatActivity() {
@@ -11,7 +11,7 @@ class PageParentActivity : AppCompatActivity() {
 
         setContentView(R.layout.pages_parent_activity)
 
-        setSupportActionBar(toolbar)
+        setSupportActionBar(toolbar_main)
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/res/layout/actionable_empty_view.xml
+++ b/WordPress/src/main/res/layout/actionable_empty_view.xml
@@ -1,68 +1,69 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<merge
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_height="match_parent"
-    android:layout_width="match_parent" >
+    xmlns:tool="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <androidx.core.widget.NestedScrollView
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent" >
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
         <LinearLayout
-            android:importantForAccessibility="yes"
-            android:layout_height="wrap_content"
             android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:gravity="center"
-            android:orientation="vertical" >
+            android:orientation="vertical">
 
             <ImageView
                 android:id="@+id/image"
-                android:adjustViewBounds="true"
-                android:importantForAccessibility="no"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_extra_large"
-                android:layout_marginTop="@dimen/margin_extra_large"
                 android:layout_width="wrap_content"
-                android:visibility="gone" >
-            </ImageView>
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_extra_large"
+                android:layout_marginBottom="@dimen/margin_extra_large"
+                android:adjustViewBounds="true"
+                android:contentDescription="@string/content_description_person_reading_device_notification"
+                android:visibility="gone"
+                tool:src="@drawable/img_illustration_empty_results_216dp"
+                tool:visibility="visible" />
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/title"
-                android:layout_height="wrap_content"
+                style="@style/ActionableEmptyStateTitle"
                 android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 app:fixWidowWords="true"
-                style="@style/ActionableEmptyStateTitle" >
-            </org.wordpress.android.widgets.WPTextView>
+                tool:text="Title" />
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/subtitle"
-                android:layout_height="wrap_content"
+                style="@style/ActionableEmptyStateSubtitle"
                 android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:visibility="gone"
                 app:fixWidowWords="true"
-                style="@style/ActionableEmptyStateSubtitle" >
-            </org.wordpress.android.widgets.WPTextView>
+                tool:text="Subtitle"
+                tool:visibility="visible" />
 
-            <androidx.appcompat.widget.AppCompatButton
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/button"
+                style="@style/ActionableEmptyStateButton"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/margin_extra_large"
-                android:layout_width="wrap_content"
-                android:theme="@style/ActionableEmptyStateButton"
-                android:visibility="gone" >
-            </androidx.appcompat.widget.AppCompatButton>
+                android:visibility="gone"
+                tool:text="Button"
+                tool:visibility="visible" />
 
             <ImageView
                 android:id="@+id/bottom_image"
-                android:adjustViewBounds="true"
-                android:contentDescription="@string/content_description_person_reading_device_notification"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_extra_large"
-                android:layout_width="wrap_content"
-                android:visibility="gone" >
-            </ImageView>
+                android:adjustViewBounds="true"
+                android:contentDescription="@string/content_description_person_reading_device_notification"
+                android:visibility="gone" />
 
         </LinearLayout>
 

--- a/WordPress/src/main/res/layout/page_divider_item.xml
+++ b/WordPress/src/main/res/layout/page_divider_item.xml
@@ -10,8 +10,8 @@
         android:layout_height="match_parent"
         android:gravity="center_vertical"
         android:layout_marginStart="@dimen/page_item_horizontal_padding"
-        android:textColor="?attr/wpColorTextSubtle"
-        android:textSize="14sp"
+        android:textAppearance="?attr/textAppearanceSubtitle2"
+        android:textColor="?attr/wpColorOnSurfaceMedium"
         tools:text="First part of pages" />
 
 </FrameLayout>

--- a/WordPress/src/main/res/layout/page_empty_item.xml
+++ b/WordPress/src/main/res/layout/page_empty_item.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <org.wordpress.android.ui.ActionableEmptyView
         android:id="@+id/actionable_empty_view"
-        android:background="@color/background_default"
-        android:layout_height="match_parent"
         android:layout_width="match_parent"
+        android:layout_height="match_parent"
         app:aevButton="@string/pages_empty_list_button"
         app:aevImage="@drawable/img_illustration_pages_104dp"
         app:aevTitle="@string/empty_list_default" />

--- a/WordPress/src/main/res/layout/page_list_item.xml
+++ b/WordPress/src/main/res/layout/page_list_item.xml
@@ -1,89 +1,98 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/page_item"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@android:color/white">
+    android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/page_layout"
+    <FrameLayout
+        android:id="@+id/page_item"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/two_line_list_item_height"
-        android:background="?attr/selectableItemBackground">
-
-        <ImageButton
-            android:id="@+id/page_more"
-            android:layout_width="56dp"
-            android:layout_height="0dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@string/show_more_desc"
-            android:paddingEnd="@dimen/page_item_horizontal_padding"
-            android:paddingStart="@dimen/page_item_horizontal_padding"
-            android:src="@drawable/ic_ellipsis_vertical_white_24dp"
-            android:tint="@color/neutral_50"
-            android:visibility="visible"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <ImageView
-            android:id="@+id/featured_image"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:contentDescription="@string/featured_image_desc"
-            app:layout_constraintBottom_toBottomOf="@id/constraintLayout2"
-            app:layout_constraintEnd_toStartOf="@id/page_more"
-            app:layout_constraintStart_toEndOf="@id/constraintLayout2"
-            app:layout_constraintTop_toTopOf="@id/constraintLayout2"
-            tools:srcCompat="@tools:sample/avatars"/>
+        android:layout_height="wrap_content">
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/constraintLayout2"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:layout_marginStart="@dimen/page_item_horizontal_padding"
-            android:orientation="vertical"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/featured_image"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            android:id="@+id/page_layout"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/two_line_list_item_height"
+            android:background="?attr/selectableItemBackground">
 
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/page_title"
-                style="@style/PageListItemTextStyle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="First pag ds ds sddsdsds ds ds dsdse adsd"/>
+            <ImageButton
+                android:id="@+id/page_more"
+                android:layout_width="56dp"
+                android:layout_height="0dp"
+                android:alpha="@dimen/material_emphasis_medium"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/show_more_desc"
+                android:paddingStart="@dimen/page_item_horizontal_padding"
+                android:paddingEnd="@dimen/page_item_horizontal_padding"
+                android:src="@drawable/ic_ellipsis_vertical_white_24dp"
+                android:tint="?attr/colorOnSurface"
+                android:visibility="visible"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/time_posted"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="3dp"
-                android:textColor="?attr/wpColorTextSubtle"
-                android:textSize="14sp"
-                app:layout_constraintStart_toStartOf="@id/page_title"
-                app:layout_constraintTop_toBottomOf="@+id/page_title"
-                tools:text="2 days ago"/>
+            <ImageView
+                android:id="@+id/featured_image"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:contentDescription="@string/featured_image_desc"
+                app:layout_constraintBottom_toBottomOf="@id/constraintLayout2"
+                app:layout_constraintEnd_toStartOf="@id/page_more"
+                app:layout_constraintStart_toEndOf="@id/constraintLayout2"
+                app:layout_constraintTop_toTopOf="@id/constraintLayout2"
+                tools:srcCompat="@tools:sample/avatars" />
 
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/labels"
-                android:layout_width="wrap_content"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/constraintLayout2"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="3dp"
-                android:textColor="?attr/wpColorTextSubtle"
-                android:textSize="14sp"
-                app:layout_constraintStart_toEndOf="@+id/time_posted"
-                app:layout_constraintTop_toBottomOf="@+id/page_title"
-                tools:text="Local Draft"/>
+                android:layout_marginStart="@dimen/page_item_horizontal_padding"
+                android:layout_marginEnd="8dp"
+                android:orientation="vertical"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/featured_image"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <org.wordpress.android.widgets.WPTextView
+                    android:id="@+id/page_title"
+                    style="@style/PageListItemTextStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="First pag ds ds sddsdsds ds ds dsdse adsd" />
+
+                <org.wordpress.android.widgets.WPTextView
+                    android:id="@+id/time_posted"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="3dp"
+                    android:textAppearance="?attr/textAppearanceCaption"
+                    app:layout_constraintStart_toStartOf="@id/page_title"
+                    app:layout_constraintTop_toBottomOf="@+id/page_title"
+                    tools:text="2 days ago" />
+
+                <org.wordpress.android.widgets.WPTextView
+                    android:id="@+id/labels"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="3dp"
+                    android:textAppearance="?attr/textAppearanceCaption"
+                    app:layout_constraintStart_toEndOf="@+id/time_posted"
+                    app:layout_constraintTop_toBottomOf="@+id/page_title"
+                    tools:text="Local Draft" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </FrameLayout>
 
-</FrameLayout>
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="?android:attr/listDivider" />
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/page_parent_list_item.xml
+++ b/WordPress/src/main/res/layout/page_parent_list_item.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/page_item"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/one_line_list_item_height"
-    android:background="@android:color/white">
+    android:layout_height="@dimen/one_line_list_item_height">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -22,18 +20,18 @@
             android:layout_marginEnd="@dimen/page_item_horizontal_padding"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            tools:text="First page"/>
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="First page" />
 
-        <RadioButton
+        <com.google.android.material.radiobutton.MaterialRadioButton
             android:id="@+id/radio_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/page_parent_radio_button_offset"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/WordPress/src/main/res/layout/page_parent_top_level_item.xml
+++ b/WordPress/src/main/res/layout/page_parent_top_level_item.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/page_item"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/one_line_list_item_height"
-    android:background="@android:color/white">
+    android:layout_height="@dimen/one_line_list_item_height">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -22,18 +20,18 @@
             android:layout_marginEnd="@dimen/page_item_horizontal_padding"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            tools:text="First page"/>
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="First page" />
 
-        <RadioButton
+        <com.google.android.material.radiobutton.MaterialRadioButton
             android:id="@+id/radio_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/page_parent_radio_button_offset"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/WordPress/src/main/res/layout/pages_fragment.xml
+++ b/WordPress/src/main/res/layout/pages_fragment.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/constraintLayout"
     android:layout_width="match_parent"
@@ -21,7 +20,7 @@
             <androidx.viewpager.widget.ViewPager
                 android:id="@+id/pagesPager"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"/>
+                android:layout_height="match_parent" />
 
         </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
@@ -30,8 +29,8 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:visibility="gone"
-            app:layout_constraintTop_toBottomOf="@id/toolbar"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"
+            app:layout_constraintTop_toBottomOf="@id/toolbar" />
 
         <com.google.android.material.appbar.AppBarLayout
             android:layout_width="match_parent"
@@ -39,29 +38,23 @@
             android:animateLayoutChanges="true"
             android:fitsSystemWindows="true">
 
-            <androidx.appcompat.widget.Toolbar
+            <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
                 app:layout_collapseMode="pin"
                 app:layout_scrollFlags="scroll|exitUntilCollapsed"
                 app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-                app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" >
-            </androidx.appcompat.widget.Toolbar>
+                app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
 
             <com.google.android.material.tabs.TabLayout
                 android:id="@+id/tabLayout"
                 android:layout_width="match_parent"
                 android:layout_height="48dp"
                 android:layout_gravity="start"
-                android:background="@color/primary"
                 app:tabContentStart="72dp"
                 app:tabGravity="fill"
-                app:tabIndicatorColor="@android:color/white"
-                app:tabMode="scrollable"
-                app:tabSelectedTextColor="@android:color/white"
-                app:tabTextColor="@android:color/white"
-                app:theme="@style/Base.Widget.Design.TabLayout"/>
+                app:tabMode="scrollable" />
 
         </com.google.android.material.appbar.AppBarLayout>
 
@@ -70,12 +63,12 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end|bottom"
+            android:layout_marginEnd="@dimen/fab_margin"
             android:layout_marginBottom="@dimen/fab_margin"
-            android:src="@drawable/ic_create_white_24dp"
             android:contentDescription="@string/fab_create_desc"
-            app:borderWidth="0dp"
+            android:src="@drawable/ic_create_white_24dp"
             android:visibility="gone"
-            android:layout_marginEnd="@dimen/fab_margin"/>
+            app:borderWidth="0dp" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/WordPress/src/main/res/layout/pages_list_fragment.xml
+++ b/WordPress/src/main/res/layout/pages_list_fragment.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/WordPress/src/main/res/layout/pages_parent_activity.xml
+++ b/WordPress/src/main/res/layout/pages_parent_activity.xml
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <include
-        android:id="@+id/toolbar"
-        layout="@layout/toolbar" />
+    <include layout="@layout/toolbar_main" />
 
     <fragment
         android:id="@+id/fragment_container"
         android:name="org.wordpress.android.ui.pages.PageParentFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent" />
 
 </LinearLayout>

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -14,12 +14,18 @@
         <item name="colorOnBackground">@android:color/white</item>
         <item name="colorOnSurface">@android:color/white</item>
         <item name="colorOnError">@android:color/black</item>
+        <item name="colorControlActivated">?attr/colorPrimary</item>
 
         <item name="wpColorText">@android:color/white</item>
         <item name="wpColorTextSubtle">@color/neutral_50</item>
         <item name="wpColorError">@color/error_50</item>
         <item name="wpColorWarningDark">@color/warning_50</item>
         <item name="wpColorAppBar">?attr/colorSurface</item>
+        <item name="wpColorOnSurfaceMedium">@color/material_on_surface_emphasis_medium</item>
+
+        <item name="floatingActionButtonStyle">@style/WordPress.FloatingActionButton</item>
+        <item name="tabStyle">@style/WordPress.TabLayout</item>
+        <item name="android:popupMenuStyle">@style/Widget.MaterialComponents.PopupMenu.Dark</item>
 
         <item name="actionOverflowMenuStyle">
             @style/Widget.MaterialComponents.PopupMenu.Overflow.Dark
@@ -71,6 +77,15 @@
 
     <style name="WordPress.AppBarLayout" parent="Widget.MaterialComponents.AppBarLayout.Surface">
         <item name="android:elevation">@dimen/appbar_elevation</item>
+    </style>
+
+    <style name="WordPress.TabLayout" parent="Widget.MaterialComponents.TabLayout">
+        <item name="android:elevation">0dp</item>
+    </style>
+
+    <style name="WordPress.FloatingActionButton" parent="Widget.MaterialComponents.FloatingActionButton">
+        <item name="android:backgroundTint">@color/pink_50</item>
+        <item name="tint">?attr/colorOnSurface</item>
     </style>
 
 </resources>

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -84,8 +84,13 @@
     </style>
 
     <style name="WordPress.FloatingActionButton" parent="Widget.MaterialComponents.FloatingActionButton">
-        <item name="android:backgroundTint">@color/pink_50</item>
+        <item name="android:backgroundTint">?attr/colorSecondaryVariant</item>
         <item name="tint">?attr/colorOnSurface</item>
+    </style>
+
+       <style name="WordPress.Button.Primary" parent="Widget.MaterialComponents.Button">
+        <item name="backgroundTint">?attr/colorSecondaryVariant</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
     </style>
 
 </resources>

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -8,7 +8,8 @@
     <attr name="wpColorTextSubtle" format="reference|color" />
     <attr name="wpColorError" format="reference|color" />
     <attr name="wpColorAppBar" format="reference|color" />
-  
+    <attr name="wpColorOnSurfaceMedium" format="reference|color" />
+
     <attr name="wpColorWarningDark" format="reference|color" />
 
     <!-- SummaryEditTextPreference attributes -->

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -29,12 +29,13 @@
         <item name="wpColorError">@color/error</item>
         <item name="wpColorWarningDark">@color/warning_50</item>
         <item name="wpColorAppBar">@color/primary</item>
+        <item name="wpColorOnSurfaceMedium">@color/material_on_surface_emphasis_medium</item>
 
+        <item name="android:popupMenuStyle">@style/Widget.MaterialComponents.PopupMenu</item>
         <item name="actionOverflowMenuStyle">
             @style/Widget.MaterialComponents.PopupMenu.Overflow
         </item>
 
-        <item name="android:popupMenuStyle">@style/PopupMenu.WordPress</item>
         <item name="android:dropDownListViewStyle">@style/DropDownListView.Light.WordPress</item>
         <item name="android:actionDropDownStyle">@style/DropDownNav.WordPress</item>
         <item name="android:actionModeCloseButtonStyle">@style/ActionButton.CloseMode.WordPress</item>
@@ -165,9 +166,10 @@
         <item name="android:textColorSecondary">?attr/colorOnPrimarySurface</item>
     </style>
 
-    <style name="WordPress.TabLayout" parent="Widget.MaterialComponents.TabLayout">
-        <item name="android:background">@color/primary_50</item>
+    <style name="WordPress.TabLayout" parent="Widget.MaterialComponents.TabLayout.Colored">
+        <item name="android:background">?attr/wpColorAppBar</item>
         <item name="android:elevation">@dimen/appbar_elevation</item>
+        <item name="android:textColor">@color/white</item>
     </style>
 
     <style name="WordPress.AppBarLayout" parent="Widget.MaterialComponents.AppBarLayout.Primary">
@@ -256,9 +258,8 @@
         <item name="android:textColor">?attr/wpColorText</item>
     </style>
 
-    <style name="WordPress.Button.Primary" parent="Widget.AppCompat.Button.Colored">
-        <item name="colorButtonNormal">@color/accent</item>
-        <item name="android:textColor">@android:color/white</item>
+    <style name="WordPress.Button.Primary" parent="Widget.MaterialComponents.Button">
+        <item name="backgroundTint">?attr/colorSecondary</item>
     </style>
 
     <style name="WordPress.Button.Secondary" parent="Widget.AppCompat.Button.Borderless.Colored">
@@ -852,14 +853,13 @@
         <item name="android:layout_marginStart">@dimen/actionable_empty_view_text_margin_horizontal</item>
         <item name="android:maxWidth">@dimen/actionable_empty_view_text_maximum_width</item>
         <item name="android:textAlignment">center</item>
-        <item name="android:textColor">?attr/wpColorTextSubtle</item>
-        <item name="android:textSize">@dimen/text_sz_extra_large</item>
+        <item name="android:textColor">?attr/wpColorOnSurfaceMedium</item>
+        <item name="android:textAppearance">@dimen/text_sz_extra_large</item>
     </style>
 
     <style name="ActionableEmptyStateSubtitle" parent="@style/ActionableEmptyStateTitle">
         <item name="android:layout_marginBottom">@dimen/margin_extra_large</item>
-        <item name="android:textColor">?attr/wpColorText</item>
-        <item name="android:textSize">@dimen/text_sz_large</item>
+        <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
     </style>
 
     <style name="ActionableEmptyStateButton" parent="WordPress.Button.Primary">
@@ -875,8 +875,7 @@
     </style>
 
     <style name="PageListTopLevelItemTextStyle">
-        <item name="android:textSize">@dimen/text_sz_large</item>
-        <item name="android:textColor">?attr/wpColorText</item>
+        <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
         <item name="android:maxLines">1</item>
         <item name="android:textStyle">bold</item>
         <item name="android:ellipsize">end</item>
@@ -1100,7 +1099,7 @@
         <item name="android:textSize">@dimen/text_sz_larger</item>
         <item name="android:gravity">start|center_vertical</item>
     </style>
-    
+
     <!-- Main actions styles -->
     <style name="MainBottomSheetRowIcon" parent="MySiteListRowIcon">
         <item name="android:layout_height">@dimen/main_bottom_sheet_list_row_icon_size</item>
@@ -1109,7 +1108,7 @@
     <style name="MainBottomSheetRowTextView" parent="MySiteListRowTextView">
         <item name="android:layout_gravity">center_vertical</item>
     </style>
-    
+
     <!-- Reader styles -->
     <style name="SubfilterSectionItem">
         <item name="android:layout_height">@dimen/one_line_list_item_height</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -847,19 +847,20 @@
         <item name="android:background">@color/neutral_10</item>
     </style>
 
-    <style name="ActionableEmptyStateTitle" parent="TextAppearance.AppCompat">
+    <style name="ActionableEmptyStateTitle">
         <item name="android:layout_marginBottom">@dimen/margin_medium</item>
         <item name="android:layout_marginEnd">@dimen/actionable_empty_view_text_margin_horizontal</item>
         <item name="android:layout_marginStart">@dimen/actionable_empty_view_text_margin_horizontal</item>
         <item name="android:maxWidth">@dimen/actionable_empty_view_text_maximum_width</item>
         <item name="android:textAlignment">center</item>
         <item name="android:textColor">?attr/wpColorOnSurfaceMedium</item>
-        <item name="android:textAppearance">@dimen/text_sz_extra_large</item>
+        <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
+        <item name="android:textSize">@dimen/text_sz_extra_large</item>
     </style>
 
     <style name="ActionableEmptyStateSubtitle" parent="@style/ActionableEmptyStateTitle">
         <item name="android:layout_marginBottom">@dimen/margin_extra_large</item>
-        <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
+         <item name="android:textSize">@dimen/text_sz_large</item>
     </style>
 
     <style name="ActionableEmptyStateButton" parent="WordPress.Button.Primary">


### PR DESCRIPTION
Fixes #10634 

This PR moves Pages screen to Material Theme and adds Dark Theme support. Changes are cosmetic.

At the time, not all screens have Dark Theme support, so the layout will look broken at most of the places.

![comparison](https://user-images.githubusercontent.com/728822/70108296-cdb01680-15fd-11ea-89f6-2cfb612f7513.png) 

To test:
- Navigate to Pages screen and make sure it looks as expected in both light and dark themes. The theme can be changed from App Settings.

This PR requires one designer and one developer to review it.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

