### PR TITLE
Update post object from a background thread using coroutines

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -810,6 +810,7 @@ public class EditPostActivity extends AppCompatActivity implements
         if (mReactNativeRequestHandler != null) {
             mReactNativeRequestHandler.destroy();
         }
+        mEditPostRepository.destroy();
 
         super.onDestroy();
     }
@@ -2480,16 +2481,18 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private void setFeaturedImageId(final long mediaId) {
-        mEditPostRepository.updateInTransaction(postModel -> {
+        mEditPostRepository.updateAndForget(postModel -> {
             postModel.setFeaturedImageId(mediaId);
             postModel.setIsLocallyChanged(true);
             return true;
+        }, success -> {
+            savePostAsync(() -> EditPostActivity.this.runOnUiThread(() -> {
+                if (mEditPostSettingsFragment != null) {
+                    mEditPostSettingsFragment.updateFeaturedImage(mediaId);
+                }
+            }));
+            return null;
         });
-        savePostAsync(() -> EditPostActivity.this.runOnUiThread(() -> {
-            if (mEditPostSettingsFragment != null) {
-                mEditPostSettingsFragment.updateFeaturedImage(mediaId);
-            }
-        }));
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
@@ -110,7 +110,7 @@ class EditPostPublishSettingsViewModel
     }
 
     fun updatePost(updatedDate: Calendar, postRepository: EditPostRepository?) {
-        postRepository?.updateInTransaction { postModel ->
+        postRepository?.updateAndForget({ postModel ->
             val dateCreated = DateTimeUtils.iso8601FromDate(updatedDate.time)
             postModel.setDateCreated(dateCreated)
             val initialPostStatus = postRepository.status
@@ -135,11 +135,13 @@ class EditPostPublishSettingsViewModel
             }
             postModel.setStatus(finalPostStatus.toString())
             _onPostStatusChanged.value = finalPostStatus
-            val scheduledTime = postSchedulingNotificationStore.getSchedulingReminderPeriod(postRepository.id)
+            val scheduledTime = postSchedulingNotificationStore.getSchedulingReminderPeriod(
+                    postRepository.id
+            )
             updateNotifications(postRepository, scheduledTime)
             updateUiModel(postRepository = postRepository)
             true
-        }
+        })
     }
 
     fun updateUiModel(postRepository: EditPostRepository?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostRepository.kt
@@ -32,7 +32,7 @@ class EditPostRepository
     private val localeManagerWrapper: LocaleManagerWrapper,
     private val postStore: PostStore,
     private val postUtils: PostUtilsWrapper
-): CoroutineScope {
+) : CoroutineScope {
     private var job: Job = Job()
 
     override val coroutineContext: CoroutineContext

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -662,10 +662,12 @@ public class EditPostSettingsFragment extends Fragment {
     private void updateExcerpt(String excerpt) {
         EditPostRepository editPostRepository = getEditPostRepository();
         if (editPostRepository != null) {
-            editPostRepository.updateInTransaction(postModel -> {
+            editPostRepository.updateAndForget(postModel -> {
                 postModel.setExcerpt(excerpt);
-                mExcerptTextView.setText(excerpt);
                 return true;
+            }, success -> {
+                mExcerptTextView.setText(excerpt);
+                return null;
             });
         }
     }
@@ -673,10 +675,12 @@ public class EditPostSettingsFragment extends Fragment {
     private void updateSlug(String slug) {
         EditPostRepository editPostRepository = getEditPostRepository();
         if (editPostRepository != null) {
-            editPostRepository.updateInTransaction(postModel -> {
+            editPostRepository.updateAndForget(postModel -> {
                 postModel.setSlug(slug);
-                mSlugTextView.setText(slug);
                 return true;
+            }, success -> {
+                mSlugTextView.setText(slug);
+                return null;
             });
         }
     }
@@ -684,10 +688,12 @@ public class EditPostSettingsFragment extends Fragment {
     private void updatePassword(String password) {
         EditPostRepository editPostRepository = getEditPostRepository();
         if (editPostRepository != null) {
-            editPostRepository.updateInTransaction(postModel -> {
+            editPostRepository.updateAndForget(postModel -> {
                 postModel.setPassword(password);
-                mPasswordTextView.setText(password);
                 return true;
+            }, success -> {
+                mPasswordTextView.setText(password);
+                return null;
             });
         }
     }
@@ -698,10 +704,12 @@ public class EditPostSettingsFragment extends Fragment {
         }
         EditPostRepository editPostRepository = getEditPostRepository();
         if (editPostRepository != null) {
-            editPostRepository.updateInTransaction(postModel -> {
+            editPostRepository.updateAndForget(postModel -> {
                 postModel.setCategoryIdList(categoryList);
-                updateCategoriesTextView();
                 return true;
+            }, success -> {
+                updateCategoriesTextView();
+                return null;
             });
         }
     }
@@ -709,11 +717,13 @@ public class EditPostSettingsFragment extends Fragment {
     public void updatePostStatus(PostStatus postStatus) {
         EditPostRepository editPostRepository = getEditPostRepository();
         if (editPostRepository != null) {
-            editPostRepository.updateInTransaction(postModel -> {
+            editPostRepository.updateAndForget(postModel -> {
                 postModel.setStatus(postStatus.toString());
+                return true;
+            }, success -> {
                 updatePostStatusRelatedViews();
                 updateSaveButton();
-                return true;
+                return null;
             });
         }
     }
@@ -721,10 +731,12 @@ public class EditPostSettingsFragment extends Fragment {
     private void updatePostFormat(String postFormat) {
         EditPostRepository editPostRepository = getEditPostRepository();
         if (editPostRepository != null) {
-            editPostRepository.updateInTransaction(postModel -> {
+            editPostRepository.updateAndForget(postModel -> {
                 postModel.setPostFormat(postFormat);
-                updatePostFormatTextView();
                 return true;
+            }, success -> {
+                updatePostFormatTextView();
+                return null;
             });
         }
     }
@@ -751,15 +763,17 @@ public class EditPostSettingsFragment extends Fragment {
         if (postRepository == null) {
             return;
         }
-        postRepository.updateInTransaction(postModel -> {
+        postRepository.updateAndForget(postModel -> {
             if (!TextUtils.isEmpty(selectedTags)) {
                 String tags = selectedTags.replace("\n", " ");
                 postModel.setTagNameList(Arrays.asList(TextUtils.split(tags, ",")));
             } else {
                 postModel.setTagNameList(new ArrayList<>());
             }
-            updateTagsTextView();
             return true;
+        }, success -> {
+            updateTagsTextView();
+            return null;
         });
     }
 
@@ -902,10 +916,12 @@ public class EditPostSettingsFragment extends Fragment {
         if (postRepository == null) {
             return;
         }
-        postRepository.updateInTransaction(postModel -> {
+        postRepository.updateAndForget(postModel -> {
             postModel.setFeaturedImageId(featuredImageId);
-            updateFeaturedImageView();
             return true;
+        }, success -> {
+            updateFeaturedImageView();
+            return null;
         });
     }
 
@@ -1069,17 +1085,24 @@ public class EditPostSettingsFragment extends Fragment {
         if (postRepository == null) {
             return;
         }
-        postRepository.updateInTransaction(postModel -> {
+        postRepository.updateAndForget(postModel -> {
             if (place == null) {
                 postModel.clearLocation();
+                return false;
+            } else {
+                mPostLocation = new PostLocation(place.getLatLng().latitude, place.getLatLng().longitude);
+                postModel.setLocation(mPostLocation);
+                return true;
+            }
+        }, success -> {
+            if (success) {
+                mLocationTextView.setText(place.getAddress());
+            } else {
                 mLocationTextView.setText("");
                 mPostLocation = null;
-                return false;
             }
-            mPostLocation = new PostLocation(place.getLatLng().latitude, place.getLatLng().longitude);
-            postModel.setLocation(mPostLocation);
-            mLocationTextView.setText(place.getAddress());
-            return true;
+            updateFeaturedImageView();
+            return null;
         });
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.posts
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
@@ -172,7 +173,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
 
         viewModel.updatePost(futureDate, editPostRepository)
 
-        verify(editPostRepository).updateInTransaction(actionCaptor.capture())
+        verify(editPostRepository).updateAndForget(actionCaptor.capture(), isNull())
         val post = PostModel()
         actionCaptor.firstValue.invoke(post)
 
@@ -205,7 +206,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
 
         viewModel.updatePost(currentCalendar, editPostRepository)
 
-        verify(editPostRepository).updateInTransaction(actionCaptor.capture())
+        verify(editPostRepository).updateAndForget(actionCaptor.capture(), isNull())
         val post = PostModel()
         actionCaptor.firstValue.invoke(post)
 
@@ -248,7 +249,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
 
         viewModel.updatePost(currentCalendar, editPostRepository)
 
-        verify(editPostRepository).updateInTransaction(actionCaptor.capture())
+        verify(editPostRepository).updateAndForget(actionCaptor.capture(), isNull())
         val post = PostModel()
         actionCaptor.firstValue.invoke(post)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostRepositoryTest.kt
@@ -1,12 +1,14 @@
 package org.wordpress.android.ui.posts
 
 import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.post.PostLocation
@@ -24,9 +26,10 @@ class EditPostRepositoryTest {
     @Mock lateinit var postStore: PostStore
     @Mock lateinit var postUtils: PostUtilsWrapper
     private lateinit var editPostRepository: EditPostRepository
+    @InternalCoroutinesApi
     @Before
     fun setUp() {
-        editPostRepository = EditPostRepository(localeManager, postStore, postUtils)
+        editPostRepository = EditPostRepository(TEST_DISPATCHER, TEST_DISPATCHER, localeManager, postStore, postUtils)
     }
 
     @Test


### PR DESCRIPTION
There is a deadlock happening in the `EditPostActivity` which is causes by the post settings fragment calling `updateInTransaction` at the same time as the `EditPostActivity`. The main reason is that the aztec fragment method `getContent` jumps on the main thread and blocks it. There is a race condition, however, it happens quite often. I've added a new method called `updateAndForget` which calls the `updateInTransaction` asynchronously with a callback. This ensures that we call the `updateInTransaction` always from a background thread and should be called whenever we don't need the result of the `updateInTransaction` method (which is the case of the post being updated from post settings). 

The `updateAndForget` method doesn't block the current thread.

To test:
* Go to media
* Add a photo with +
* Choose "Take a photo"
* Wait until the photo gets uploaded
* Click on the success snackbar button to create a new post
* The post gets created with the image and the app doesn't freeze

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

