### PR TITLE
Replace lock with logging to fix deadlock when opening the editor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -354,7 +354,7 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         // Create a new post
-        mEditPostRepository.setInTransaction(() -> {
+        mEditPostRepository.set(() -> {
             PostModel post = mPostStore.instantiatePostModel(mSite, mIsPage, null, null);
             post.setStatus(PostStatus.DRAFT.toString());
             return post;
@@ -442,7 +442,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
                 if (mEditPostRepository.hasPost()) {
                     if (extras.getBoolean(EXTRA_LOAD_AUTO_SAVE_REVISION)) {
-                        mEditPostRepository.updateInTransaction(postModel -> {
+                        mEditPostRepository.update(postModel -> {
                             postModel.setTitle(
                                     TextUtils.isEmpty(postModel.getAutoSaveTitle()) ? postModel
                                             .getTitle()
@@ -608,7 +608,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private void initializePostObject() {
         if (mEditPostRepository.hasPost()) {
             mEditPostRepository.saveSnapshot();
-            mEditPostRepository.replaceInTransaction(UploadService::updatePostWithCurrentlyCompletedUploads);
+            mEditPostRepository.replace(UploadService::updatePostWithCurrentlyCompletedUploads);
             if (mShowAztecEditor) {
                 try {
                     mMediaMarkedUploadingOnStartIds = AztecEditorFragment
@@ -683,7 +683,7 @@ public class EditPostActivity extends AppCompatActivity implements
         if (!useAztec || UploadService.hasPendingOrInProgressMediaUploadsForPost(mEditPostRepository.getPost())) {
             return;
         }
-        mEditPostRepository.updateInTransaction(postModel -> {
+        mEditPostRepository.update(postModel -> {
             String oldContent = postModel.getContent();
             if (!AztecEditorFragment.hasMediaItemsMarkedUploading(EditPostActivity.this, oldContent)
                 // we need to make sure items marked failed are still failed or not as well
@@ -1611,7 +1611,7 @@ public class EditPostActivity extends AppCompatActivity implements
             AppLog.e(AppLog.T.POSTS, "Attempted to save an invalid Post.");
             return false;
         }
-        return mEditPostRepository.updateInTransaction(postModel -> {
+        return mEditPostRepository.update(postModel -> {
             try {
                 boolean postTitleOrContentChanged =
                         updatePostContentNewEditor(postModel, isAutosave, (String) mEditorFragment.getTitle(),
@@ -1821,7 +1821,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private void loadRevision() {
         updatePostLoadingAndDialogState(PostLoadingState.LOADING_REVISION);
         mEditPostRepository.saveForUndo();
-        mEditPostRepository.updateInTransaction(postModel -> {
+        mEditPostRepository.update(postModel -> {
             postModel.setTitle(Objects.requireNonNull(mRevision.getPostTitle()));
             postModel.setContent(Objects.requireNonNull(mRevision.getPostContent()));
             postModel.setIsLocallyChanged(true);
@@ -1907,7 +1907,7 @@ public class EditPostActivity extends AppCompatActivity implements
         @Override
         protected Boolean doInBackground(Void... params) {
             if (mEditPostRepository.postHasEdits()) {
-                mEditPostRepository.updateInTransaction(postModel -> {
+                mEditPostRepository.update(postModel -> {
                     // Changes have been made - save the post and ask for the post list to refresh
                     // We consider this being "manual save", it will replace some Android "spans" by an html
                     // or a shortcode replacement (for instance for images and galleries)
@@ -2010,7 +2010,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // text 2. better not to call `updatePostObject()` from the UI thread due to weird thread blocking behavior
         // on API 16 (and 21) with the visual editor.
         new Thread(() -> {
-            mEditPostRepository.updateInTransaction(postModel -> {
+            mEditPostRepository.update(postModel -> {
                 boolean isFirstTimePublish = isFirstTimePublish(publishPost);
                 if (publishPost) {
                     // now set status to PUBLISHED - only do this AFTER we have run the isFirstTimePublish() check,
@@ -2382,7 +2382,7 @@ public class EditPostActivity extends AppCompatActivity implements
         final String text = intent.getStringExtra(Intent.EXTRA_TEXT);
         final String title = intent.getStringExtra(Intent.EXTRA_SUBJECT);
         if (text != null) {
-            mEditPostRepository.updateInTransaction(postModel -> {
+            mEditPostRepository.update(postModel -> {
                 if (title != null) {
                     mEditorFragment.setTitle(title);
                     postModel.setTitle(title);
@@ -2480,7 +2480,7 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private void setFeaturedImageId(final long mediaId) {
-        mEditPostRepository.updateInTransaction(postModel -> {
+        mEditPostRepository.update(postModel -> {
             postModel.setFeaturedImageId(mediaId);
             postModel.setIsLocallyChanged(true);
             return true;
@@ -3158,7 +3158,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 AppLog.e(T.POSTS, "REMOTE_AUTO_SAVE_POST failed: " + event.error.type + " - " + event.error.message);
             }
             mEditPostRepository.loadPostByLocalPostId(mEditPostRepository.getId());
-            mEditPostRepository.replaceInTransaction(postModel -> handleRemoteAutoSave(event.isError(), postModel));
+            mEditPostRepository.replace(postModel -> handleRemoteAutoSave(event.isError(), postModel));
         }
     }
 
@@ -3219,13 +3219,13 @@ public class EditPostActivity extends AppCompatActivity implements
                 mUploadUtilsWrapper.onPostUploadedSnackbarHandler(this, snackbarAttachView, event.isError(), post,
                         event.isError() ? event.error.message : null, getSite());
                 if (!event.isError()) {
-                    mEditPostRepository.setInTransaction(() -> {
+                    mEditPostRepository.set(() -> {
                         updateOnSuccessfulUpload();
                         return post;
                     });
                 }
             } else {
-                mEditPostRepository.setInTransaction(() -> handleRemoteAutoSave(event.isError(), post));
+                mEditPostRepository.set(() -> handleRemoteAutoSave(event.isError(), post));
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
@@ -110,7 +110,7 @@ class EditPostPublishSettingsViewModel
     }
 
     fun updatePost(updatedDate: Calendar, postRepository: EditPostRepository?) {
-        postRepository?.updateInTransaction { postModel ->
+        postRepository?.update { postModel ->
             val dateCreated = DateTimeUtils.iso8601FromDate(updatedDate.time)
             postModel.setDateCreated(dateCreated)
             val initialPostStatus = postRepository.status

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostRepository.kt
@@ -10,11 +10,13 @@ import org.wordpress.android.fluxc.model.post.PostStatus.DRAFT
 import org.wordpress.android.fluxc.model.post.PostStatus.fromPost
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.ui.uploads.UploadService
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.CrashLoggingUtils
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.LocaleManagerWrapper
-import java.util.concurrent.locks.ReentrantReadWriteLock
+import java.util.Arrays
 import javax.inject.Inject
-import kotlin.concurrent.write
 
 class EditPostRepository
 @Inject constructor(
@@ -72,18 +74,37 @@ class EditPostRepository
     val dateLocallyChanged: String
         get() = post!!.dateLocallyChanged
 
-    private val lock = ReentrantReadWriteLock()
+    private var locked = false
 
-    fun updateInTransaction(action: (PostModel) -> Boolean) = lock.write {
-        action(post!!)
+    fun update(action: (PostModel) -> Boolean): Boolean {
+        reportTransactionState(true)
+        val result = action(post!!)
+        reportTransactionState(false)
+        return result
     }
 
-    fun replaceInTransaction(action: (PostModel) -> PostModel) = lock.write {
+    fun replace(action: (PostModel) -> PostModel) {
+        reportTransactionState(true)
         this.post = action(post!!)
+        reportTransactionState(false)
     }
 
-    fun setInTransaction(action: () -> PostModel) = lock.write {
+    fun set(action: () -> PostModel) {
+        reportTransactionState(true)
         this.post = action()
+        reportTransactionState(false)
+    }
+
+    @Synchronized
+    private fun reportTransactionState(lock: Boolean) {
+        if (lock && locked) {
+            val message = "EditPostRepository: Transaction is writing on a locked thread ${Arrays.toString(
+                    Thread.currentThread().stackTrace
+            )}"
+            AppLog.e(T.EDITOR, message)
+            CrashLoggingUtils.log(message)
+        }
+        locked = lock
     }
 
     fun hasLocation() = post!!.hasLocation()
@@ -132,7 +153,9 @@ class EditPostRepository
     fun updateStatusFromSnapshot(post: PostModel) {
         // the user has just tapped on "PUBLISH" on an empty post, make sure to set the status back to the
         // original post's status as we could not proceed with the action
+        reportTransactionState(true)
         post.setStatus(postSnapshotWhenEditorOpened?.status ?: DRAFT.toString())
+        reportTransactionState(false)
     }
 
     fun hasStatusChanged(postStatus: String?): Boolean {
@@ -142,21 +165,21 @@ class EditPostRepository
     fun postHasEdits() = postUtils.postHasEdits(postSnapshotWhenEditorOpened, post!!)
 
     fun updateStatus(status: PostStatus) {
-        updateInTransaction {
+        update {
             it.setStatus(status.toString())
             true
         }
     }
 
     fun loadPostByLocalPostId(postId: Int) {
-        lock.write {
-            post = postStore.getPostByLocalPostId(postId)
-        }
+        reportTransactionState(true)
+        post = postStore.getPostByLocalPostId(postId)
+        reportTransactionState(false)
     }
 
     fun loadPostByRemotePostId(remotePostId: Long, site: SiteModel) {
-        lock.write {
-            post = postStore.getPostByRemotePostId(remotePostId, site)
-        }
+        reportTransactionState(true)
+        post = postStore.getPostByRemotePostId(remotePostId, site)
+        reportTransactionState(false)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -662,7 +662,7 @@ public class EditPostSettingsFragment extends Fragment {
     private void updateExcerpt(String excerpt) {
         EditPostRepository editPostRepository = getEditPostRepository();
         if (editPostRepository != null) {
-            editPostRepository.updateInTransaction(postModel -> {
+            editPostRepository.update(postModel -> {
                 postModel.setExcerpt(excerpt);
                 mExcerptTextView.setText(excerpt);
                 return true;
@@ -673,7 +673,7 @@ public class EditPostSettingsFragment extends Fragment {
     private void updateSlug(String slug) {
         EditPostRepository editPostRepository = getEditPostRepository();
         if (editPostRepository != null) {
-            editPostRepository.updateInTransaction(postModel -> {
+            editPostRepository.update(postModel -> {
                 postModel.setSlug(slug);
                 mSlugTextView.setText(slug);
                 return true;
@@ -684,7 +684,7 @@ public class EditPostSettingsFragment extends Fragment {
     private void updatePassword(String password) {
         EditPostRepository editPostRepository = getEditPostRepository();
         if (editPostRepository != null) {
-            editPostRepository.updateInTransaction(postModel -> {
+            editPostRepository.update(postModel -> {
                 postModel.setPassword(password);
                 mPasswordTextView.setText(password);
                 return true;
@@ -698,7 +698,7 @@ public class EditPostSettingsFragment extends Fragment {
         }
         EditPostRepository editPostRepository = getEditPostRepository();
         if (editPostRepository != null) {
-            editPostRepository.updateInTransaction(postModel -> {
+            editPostRepository.update(postModel -> {
                 postModel.setCategoryIdList(categoryList);
                 updateCategoriesTextView();
                 return true;
@@ -709,7 +709,7 @@ public class EditPostSettingsFragment extends Fragment {
     public void updatePostStatus(PostStatus postStatus) {
         EditPostRepository editPostRepository = getEditPostRepository();
         if (editPostRepository != null) {
-            editPostRepository.updateInTransaction(postModel -> {
+            editPostRepository.update(postModel -> {
                 postModel.setStatus(postStatus.toString());
                 updatePostStatusRelatedViews();
                 updateSaveButton();
@@ -721,7 +721,7 @@ public class EditPostSettingsFragment extends Fragment {
     private void updatePostFormat(String postFormat) {
         EditPostRepository editPostRepository = getEditPostRepository();
         if (editPostRepository != null) {
-            editPostRepository.updateInTransaction(postModel -> {
+            editPostRepository.update(postModel -> {
                 postModel.setPostFormat(postFormat);
                 updatePostFormatTextView();
                 return true;
@@ -751,7 +751,7 @@ public class EditPostSettingsFragment extends Fragment {
         if (postRepository == null) {
             return;
         }
-        postRepository.updateInTransaction(postModel -> {
+        postRepository.update(postModel -> {
             if (!TextUtils.isEmpty(selectedTags)) {
                 String tags = selectedTags.replace("\n", " ");
                 postModel.setTagNameList(Arrays.asList(TextUtils.split(tags, ",")));
@@ -902,7 +902,7 @@ public class EditPostSettingsFragment extends Fragment {
         if (postRepository == null) {
             return;
         }
-        postRepository.updateInTransaction(postModel -> {
+        postRepository.update(postModel -> {
             postModel.setFeaturedImageId(featuredImageId);
             updateFeaturedImageView();
             return true;
@@ -1069,7 +1069,7 @@ public class EditPostSettingsFragment extends Fragment {
         if (postRepository == null) {
             return;
         }
-        postRepository.updateInTransaction(postModel -> {
+        postRepository.update(postModel -> {
             if (place == null) {
                 postModel.clearLocation();
                 mLocationTextView.setText("");

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
@@ -172,7 +172,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
 
         viewModel.updatePost(futureDate, editPostRepository)
 
-        verify(editPostRepository).updateInTransaction(actionCaptor.capture())
+        verify(editPostRepository).update(actionCaptor.capture())
         val post = PostModel()
         actionCaptor.firstValue.invoke(post)
 
@@ -205,7 +205,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
 
         viewModel.updatePost(currentCalendar, editPostRepository)
 
-        verify(editPostRepository).updateInTransaction(actionCaptor.capture())
+        verify(editPostRepository).update(actionCaptor.capture())
         val post = PostModel()
         actionCaptor.firstValue.invoke(post)
 
@@ -248,7 +248,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
 
         viewModel.updatePost(currentCalendar, editPostRepository)
 
-        verify(editPostRepository).updateInTransaction(actionCaptor.capture())
+        verify(editPostRepository).update(actionCaptor.capture())
         val post = PostModel()
         actionCaptor.firstValue.invoke(post)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostRepositoryTest.kt
@@ -33,7 +33,7 @@ class EditPostRepositoryTest {
     fun `reads post correctly`() {
         val post = PostModel()
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()).isEqualTo(post)
         assertThat(editPostRepository.hasPost()).isTrue()
@@ -53,7 +53,7 @@ class EditPostRepositoryTest {
     fun `reads post for undo correctly`() {
         val post = PostModel()
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         editPostRepository.saveForUndo()
 
@@ -66,7 +66,7 @@ class EditPostRepositoryTest {
         val id = 10
         post.setId(id)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.id).isEqualTo(id)
         assertThat(editPostRepository.id).isEqualTo(id)
@@ -78,7 +78,7 @@ class EditPostRepositoryTest {
         val localSiteId = 10
         post.setLocalSiteId(localSiteId)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.localSiteId).isEqualTo(localSiteId)
         assertThat(editPostRepository.localSiteId).isEqualTo(localSiteId)
@@ -90,7 +90,7 @@ class EditPostRepositoryTest {
         val remotePostId = 10L
         post.setRemotePostId(remotePostId)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.remotePostId).isEqualTo(remotePostId)
         assertThat(editPostRepository.remotePostId).isEqualTo(remotePostId)
@@ -102,7 +102,7 @@ class EditPostRepositoryTest {
         val title = "title"
         post.setTitle(title)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.title).isEqualTo(title)
         assertThat(editPostRepository.title).isEqualTo(title)
@@ -114,7 +114,7 @@ class EditPostRepositoryTest {
         val autoSaveTitle = "autoSaveTitle"
         post.setAutoSaveTitle(autoSaveTitle)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.autoSaveTitle).isEqualTo(autoSaveTitle)
         assertThat(editPostRepository.autoSaveTitle).isEqualTo(autoSaveTitle)
@@ -126,7 +126,7 @@ class EditPostRepositoryTest {
         val content = "content"
         post.setContent(content)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.content).isEqualTo(content)
         assertThat(editPostRepository.content).isEqualTo(content)
@@ -138,7 +138,7 @@ class EditPostRepositoryTest {
         val autoSaveContent = "autoSaveContent"
         post.setAutoSaveContent(autoSaveContent)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.autoSaveContent).isEqualTo(autoSaveContent)
         assertThat(editPostRepository.autoSaveContent).isEqualTo(autoSaveContent)
@@ -150,7 +150,7 @@ class EditPostRepositoryTest {
         val excerpt = "excerpt"
         post.setExcerpt(excerpt)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.excerpt).isEqualTo(excerpt)
         assertThat(editPostRepository.excerpt).isEqualTo(excerpt)
@@ -162,7 +162,7 @@ class EditPostRepositoryTest {
         val autoSaveExcerpt = "autoSaveExcerpt"
         post.setAutoSaveExcerpt(autoSaveExcerpt)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.autoSaveExcerpt).isEqualTo(autoSaveExcerpt)
         assertThat(editPostRepository.autoSaveExcerpt).isEqualTo(autoSaveExcerpt)
@@ -174,7 +174,7 @@ class EditPostRepositoryTest {
         val password = "password"
         post.setPassword(password)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.password).isEqualTo(password)
         assertThat(editPostRepository.password).isEqualTo(password)
@@ -186,7 +186,7 @@ class EditPostRepositoryTest {
         val status = DRAFT
         post.setStatus(status.toString())
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.status).isEqualTo(status.toString())
         assertThat(editPostRepository.status).isEqualTo(status)
@@ -198,7 +198,7 @@ class EditPostRepositoryTest {
         val isPage = true
         post.setIsPage(isPage)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.isPage).isEqualTo(isPage)
         assertThat(editPostRepository.isPage).isEqualTo(isPage)
@@ -210,7 +210,7 @@ class EditPostRepositoryTest {
         val isLocalDraft = true
         post.setIsLocalDraft(isLocalDraft)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.isLocalDraft).isEqualTo(isLocalDraft)
         assertThat(editPostRepository.isLocalDraft).isEqualTo(isLocalDraft)
@@ -222,7 +222,7 @@ class EditPostRepositoryTest {
         val isLocallyChanged = true
         post.setIsLocallyChanged(isLocallyChanged)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.isLocallyChanged).isEqualTo(isLocallyChanged)
         assertThat(editPostRepository.isLocallyChanged).isEqualTo(isLocallyChanged)
@@ -234,7 +234,7 @@ class EditPostRepositoryTest {
         val featuredImageId = 10L
         post.setFeaturedImageId(featuredImageId)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.featuredImageId).isEqualTo(featuredImageId)
         assertThat(editPostRepository.featuredImageId).isEqualTo(featuredImageId)
@@ -246,7 +246,7 @@ class EditPostRepositoryTest {
         val dateCreated = "2019-05-05T14:33:20+0000"
         post.setDateCreated(dateCreated)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.dateCreated).isEqualTo(dateCreated)
         assertThat(editPostRepository.dateCreated).isEqualTo(dateCreated)
@@ -258,7 +258,7 @@ class EditPostRepositoryTest {
         val changesConfirmedContentHashcode = 10
         post.setChangesConfirmedContentHashcode(changesConfirmedContentHashcode)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.changesConfirmedContentHashcode).isEqualTo(
                 changesConfirmedContentHashcode
@@ -274,7 +274,7 @@ class EditPostRepositoryTest {
         val postFormat = "format"
         post.setPostFormat(postFormat)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.postFormat).isEqualTo(postFormat)
         assertThat(editPostRepository.postFormat).isEqualTo(postFormat)
@@ -286,7 +286,7 @@ class EditPostRepositoryTest {
         val slug = "slug"
         post.setSlug(slug)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.slug).isEqualTo(slug)
         assertThat(editPostRepository.slug).isEqualTo(slug)
@@ -298,7 +298,7 @@ class EditPostRepositoryTest {
         val link = "link"
         post.setLink(link)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.link).isEqualTo(link)
         assertThat(editPostRepository.link).isEqualTo(link)
@@ -310,7 +310,7 @@ class EditPostRepositoryTest {
         val location = PostLocation(20.0, 30.0)
         post.setLocation(location)
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         assertThat(editPostRepository.getPost()!!.location).isEqualTo(location)
         assertThat(editPostRepository.location).isEqualTo(location)
@@ -330,7 +330,7 @@ class EditPostRepositoryTest {
 
         post.setStatus(DRAFT.toString())
         post.setDateCreated(dateCreated)
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
         whenever(postUtils.shouldPublishImmediately(DRAFT, dateCreated)).thenReturn(true)
 
         editPostRepository.updatePublishDateIfShouldBePublishedImmediately(post)
@@ -349,7 +349,7 @@ class EditPostRepositoryTest {
 
         post.setStatus(PUBLISHED.toString())
         post.setDateCreated(dateCreated)
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
         whenever(postUtils.shouldPublishImmediately(PUBLISHED, dateCreated)).thenReturn(false)
 
         editPostRepository.updatePublishDateIfShouldBePublishedImmediately(post)
@@ -362,7 +362,7 @@ class EditPostRepositoryTest {
     fun `is not publishable when isPublishable(post) is false`() {
         val post = PostModel()
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         whenever(postUtils.isPublishable(post)).thenReturn(false)
 
@@ -373,7 +373,7 @@ class EditPostRepositoryTest {
     fun `is publishable when isPublishable(post) is true`() {
         val post = PostModel()
 
-        editPostRepository.setInTransaction { post }
+        editPostRepository.set { post }
 
         whenever(postUtils.isPublishable(post)).thenReturn(true)
 
@@ -389,13 +389,13 @@ class EditPostRepositoryTest {
         val secondPostId = 2
         secondPost.setId(secondPostId)
 
-        editPostRepository.setInTransaction { firstPost }
+        editPostRepository.set { firstPost }
 
         assertThat(editPostRepository.getPost()).isEqualTo(firstPost)
 
         editPostRepository.saveForUndo()
 
-        editPostRepository.setInTransaction { secondPost }
+        editPostRepository.set { secondPost }
 
         assertThat(editPostRepository.getPost()).isEqualTo(secondPost)
 
@@ -410,7 +410,7 @@ class EditPostRepositoryTest {
         val firstPostId = 1
         firstPost.setId(firstPostId)
 
-        editPostRepository.setInTransaction { firstPost }
+        editPostRepository.set { firstPost }
 
         assertThat(editPostRepository.getPost()).isEqualTo(firstPost)
 
@@ -428,7 +428,7 @@ class EditPostRepositoryTest {
         val secondPostId = 2
         secondPost.setId(secondPostId)
 
-        editPostRepository.setInTransaction { firstPost }
+        editPostRepository.set { firstPost }
 
         assertThat(editPostRepository.getPost()).isEqualTo(firstPost)
 
@@ -436,7 +436,7 @@ class EditPostRepositoryTest {
 
         assertThat(editPostRepository.isSnapshotDifferent()).isFalse()
 
-        editPostRepository.setInTransaction { secondPost }
+        editPostRepository.set { secondPost }
 
         assertThat(editPostRepository.isSnapshotDifferent()).isTrue()
     }
@@ -450,11 +450,11 @@ class EditPostRepositoryTest {
         val secondPostStatus = PENDING
         secondPost.setStatus(secondPostStatus.toString())
 
-        editPostRepository.setInTransaction { firstPost }
+        editPostRepository.set { firstPost }
 
         editPostRepository.saveSnapshot()
 
-        editPostRepository.setInTransaction { secondPost }
+        editPostRepository.set { secondPost }
 
         assertThat(editPostRepository.status).isEqualTo(PENDING)
 


### PR DESCRIPTION
There is a deadlock happening in the `EditPostActivity` which is causes by the post settings fragment calling `updateInTransaction` at the same time as the `EditPostActivity`. The main reason is that the aztec fragment method `getContent` jumps on the main thread and blocks it. There is a race condition, however, it happens quite often. I've removed the `lock` and replaced it with logging. This way we can actually investigate if the issue causes any problems before we implement a more strict solution.

cc @jkmassel this requires a hotfix

To test:
* Go to media
* Add a photo with +
* Choose "Take a photo"
* Wait until the photo gets uploaded
* Click on the success snackbar button to create a new post
* The post gets created with the image and the app doesn't freeze

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

