### PR TITLE
Add react-native-linear-gradient library

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,8 @@ include ':WordPressMocks'
 project(':WordPressMocks').projectDir = new File(rootProject.projectDir, properties.getOrDefault('wp.wordpress_mocks_path', 'libs/mocks') + '/WordPressMocks')
 
 if (properties.getOrDefault('wp.BUILD_GUTENBERG_FROM_SOURCE', false).toBoolean()) {
+    include ':react-native-linear-gradient'
+    project(':react-native-linear-gradient').projectDir = new File(rootProject.projectDir, 'libs/gutenberg-mobile/node_modules/react-native-linear-gradient/android')
     include ':react-native-svg'
     project(':react-native-svg').projectDir = new File(rootProject.projectDir, 'libs/gutenberg-mobile/node_modules/react-native-svg/android')
     include ':react-native-aztec'


### PR DESCRIPTION
Fixes #

Ref to gb-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1616
Ref to gutenberg: https://github.com/WordPress/gutenberg/pull/18823

This PR introduces 1st iteration of mobile `Button` block component.

To achieve gradient background color on mobile `react-native-linear-gradient` comes in handy.

The first iteration includes:
* Rendering `Button` with:
	* gradient background color ✅ 
	* custom background color chosen from picker ✅ 
	* custom text color chosen from picker ✅ 
* Options to change border radius, add link, open url in new tab ✅ 
* Expanding and shrinking `RichText` ✅ 
* Notification for missing color settings functionality ✅ 

To test:

**-> Gradient**
* open draft post on web
* add Button
* choose the gradient background color
* save post
* open draft post on mobile
* check if a gradient is correct

Screenshot /  gifs:

**ANDROID**

regular | linear gradient
--- | ---
![Screenshot 2019-12-02 at 10 35 50](https://user-images.githubusercontent.com/22746080/69949086-1928ce80-14f1-11ea-96b7-87305d9664eb.png) | ![Screenshot 2019-12-02 at 10 45 54](https://user-images.githubusercontent.com/22746080/69949089-1a59fb80-14f1-11ea-8848-3ec61349ae79.png)


PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

