### PR TITLE
Accessibility : Edit Post ViewPager no longer announces itself

### DIFF
--- a/WordPress/src/main/res/layout/new_edit_post_activity.xml
+++ b/WordPress/src/main/res/layout/new_edit_post_activity.xml
@@ -8,6 +8,7 @@
         android:id="@+id/pager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:importantForAccessibility="no"
         android:layout_above="@+id/photo_fragment_container"
         tools:context=".ui.posts.EditPostActivity"/>
 


### PR DESCRIPTION
The word "pager" is no longer announced when actions are taking place.

Fixes #10893

To test:
1. Go to the `EditPostActivity`. 
2.  When the `Title` Edit Box is selected it no longer says "in pager" at the end of it's announcement.
3.  When the keyboard's back button is pressed it no longer says "in pager" at the end of it's announcement. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

