### PR TITLE
Accessibility : TalkBack EmptyView announcement fix

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
@@ -137,6 +137,13 @@ class ActionableEmptyView : LinearLayout {
         layout.layoutParams = params
     }
 
+    /**
+     * Announces the empty view when the empty state occur. Due to the formatting of subtitle text in certain
+     * circumstances TalkBack isn't able to properly make it's announcement so in cases like these the content
+     * description is dynamically added before doing so. Since the appropriate measure is to rely on the TextView's
+     * text as the content for announcement the content description of the subtitle is cleared so that the subtitle
+     * text can be default.
+     */
     fun announceEmptyStateForAccessibility() {
         val subTitle = if (!TextUtils.isEmpty(subtitle.contentDescription)) {
             subtitle.contentDescription
@@ -145,5 +152,7 @@ class ActionableEmptyView : LinearLayout {
         }
 
         announceForAccessibility("${title.text}.$subTitle")
+
+        subtitle.contentDescription = null
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
@@ -138,11 +138,9 @@ class ActionableEmptyView : LinearLayout {
     }
 
     /**
-     * Announces the empty view when the empty state occur. Due to the formatting of subtitle text in certain
+     * Announces the empty view when the empty state occurs. Due to the formatting of subtitle text in certain
      * circumstances TalkBack isn't able to properly make it's announcement so in cases like these the content
-     * description is dynamically added before doing so. Since the appropriate measure is to rely on the TextView's
-     * text as the content for announcement the content description of the subtitle is cleared so that the subtitle
-     * text can be default.
+     * description is dynamically added before doing so.
      */
     fun announceEmptyStateForAccessibility() {
         val subTitle = if (!TextUtils.isEmpty(subtitle.contentDescription)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
@@ -152,7 +152,9 @@ class ActionableEmptyView : LinearLayout {
         }
 
         announceForAccessibility("${title.text}.$subTitle")
+    }
 
+    fun resetSubTitleContentDescription() {
         subtitle.contentDescription = null
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
@@ -153,8 +153,4 @@ class ActionableEmptyView : LinearLayout {
 
         announceForAccessibility("${title.text}.$subTitle")
     }
-
-    fun resetSubTitleContentDescription() {
-        subtitle.contentDescription = null
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1434,7 +1434,7 @@ public class ReaderPostListFragment extends Fragment
         int heightToolbar = getActivity().getResources().getDimensionPixelSize(R.dimen.toolbar_height);
         int heightTabs = getActivity().getResources().getDimensionPixelSize(R.dimen.tab_height);
         mActionableEmptyView.updateLayoutForSearch(false, getEmptyViewTopMargin());
-        mActionableEmptyView.resetSubTitleContentDescription();
+        mActionableEmptyView.subtitle.setContentDescription(null);
         boolean isSearching = false;
         String title;
         String description = null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1434,6 +1434,7 @@ public class ReaderPostListFragment extends Fragment
         int heightToolbar = getActivity().getResources().getDimensionPixelSize(R.dimen.toolbar_height);
         int heightTabs = getActivity().getResources().getDimensionPixelSize(R.dimen.tab_height);
         mActionableEmptyView.updateLayoutForSearch(false, getEmptyViewTopMargin());
+        mActionableEmptyView.resetSubTitleContentDescription();
         boolean isSearching = false;
         String title;
         String description = null;


### PR DESCRIPTION
Fixes issue when the content description of the TextView remains set so the actual TextView text isn't being read.

Fixes #10907

What caused this issue was that when announcing the empty view the default behavior is to utilize the text of the `TextViews` but there's is a case where an icon is being injected in the string that's being set to a `TextView`.
https://github.com/wordpress-mobile/WordPress-Android/blob/caeaf58e0137b56b7c27fbc5913107dfcbbf422c/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java#L1517
 so TalkBack is reading the symbols that represent the icon in the string so the content description was leveraged to set a text that TalkBack truly understands. But this wasn't being cleared so it was being used as the default content description being supplied for announcement for every empty state. The solution is a bit hacky but it's the easiest way to address the issue since adding icons to the Text of the `TextView` made it inaccessible in the first place.

To test:

1. Navigate to Reader → Followed Sites
2. Tap on Search
3. Enter a very long text that should have no results
4. Turn on TackBack
5. Hover on the empty list

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

