### PR TITLE
Accessibility : Post Settings TalkBack Improvements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel
 import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
+import org.wordpress.android.util.AccessibilityUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import javax.inject.Inject
@@ -46,6 +47,9 @@ class EditPostPublishSettingsFragment : Fragment() {
         val publishNotificationContainer = rootView.findViewById<LinearLayout>(R.id.publish_notification_container)
         val addToCalendarContainer = rootView.findViewById<LinearLayout>(R.id.post_add_to_calendar_container)
         val addToCalendar = rootView.findViewById<TextView>(R.id.post_add_to_calendar)
+
+        AccessibilityUtils.disableHintAnnouncement(dateAndTime)
+        AccessibilityUtils.disableHintAnnouncement(publishNotification)
 
         dateAndTimeContainer.setOnClickListener { showPostDateSelectionDialog() }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -127,6 +127,7 @@ public class EditPostSettingsFragment extends Fragment {
     private TextView mCategoriesTagsHeaderTextView;
     private TextView mFeaturedImageHeaderTextView;
     private TextView mMoreOptionsHeaderTextView;
+    private TextView mPublishHeaderTextView;
     private ImageView mFeaturedImageView;
     private ImageView mLocalFeaturedImageView;
     private Button mFeaturedImageButton;
@@ -265,7 +266,8 @@ public class EditPostSettingsFragment extends Fragment {
         mCategoriesTagsHeaderTextView = rootView.findViewById(R.id.post_settings_categories_and_tags_header);
         mMoreOptionsHeaderTextView = rootView.findViewById(R.id.post_settings_more_options_header);
         mFeaturedImageHeaderTextView = rootView.findViewById(R.id.post_settings_featured_image_header);
-        
+        mPublishHeaderTextView = rootView.findViewById(R.id.post_settings_publish);
+
         mFeaturedImageView = rootView.findViewById(R.id.post_featured_image);
         mLocalFeaturedImageView = rootView.findViewById(R.id.post_featured_image_local);
         mFeaturedImageButton = rootView.findViewById(R.id.post_add_featured_image_button);
@@ -452,6 +454,7 @@ public class EditPostSettingsFragment extends Fragment {
         AccessibilityUtils.enableAccessibilityHeading(mCategoriesTagsHeaderTextView);
         AccessibilityUtils.enableAccessibilityHeading(mFeaturedImageHeaderTextView);
         AccessibilityUtils.enableAccessibilityHeading(mMoreOptionsHeaderTextView);
+        AccessibilityUtils.enableAccessibilityHeading(mPublishHeaderTextView);
     }
 
     private void retryFeaturedImageUpload(@NonNull SiteModel site, @NonNull PostImmutableModel post) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -71,6 +71,7 @@ import org.wordpress.android.ui.posts.PostSettingsListDialogFragment.DialogType;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface.SiteSettingsListener;
 import org.wordpress.android.ui.utils.UiHelpers;
+import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
@@ -123,6 +124,9 @@ public class EditPostSettingsFragment extends Fragment {
     private TextView mPostFormatTextView;
     private TextView mPasswordTextView;
     private TextView mPublishDateTextView;
+    private TextView mCategoriesTagsHeaderTextView;
+    private TextView mFeaturedImageHeaderTextView;
+    private TextView mMoreOptionsHeaderTextView;
     private ImageView mFeaturedImageView;
     private ImageView mLocalFeaturedImageView;
     private Button mFeaturedImageButton;
@@ -258,7 +262,10 @@ public class EditPostSettingsFragment extends Fragment {
         mPostFormatTextView = rootView.findViewById(R.id.post_format);
         mPasswordTextView = rootView.findViewById(R.id.post_password);
         mPublishDateTextView = rootView.findViewById(R.id.publish_date);
-
+        mCategoriesTagsHeaderTextView = rootView.findViewById(R.id.post_settings_categories_and_tags_header);
+        mMoreOptionsHeaderTextView = rootView.findViewById(R.id.post_settings_more_options_header);
+        mFeaturedImageHeaderTextView = rootView.findViewById(R.id.post_settings_featured_image_header);
+        
         mFeaturedImageView = rootView.findViewById(R.id.post_featured_image);
         mLocalFeaturedImageView = rootView.findViewById(R.id.post_featured_image_local);
         mFeaturedImageButton = rootView.findViewById(R.id.post_add_featured_image_button);
@@ -386,6 +393,9 @@ public class EditPostSettingsFragment extends Fragment {
             }
         });
 
+        setupSettingHintsForAccessibility();
+        applyAccessibilityHeadingToSettings();
+
         return rootView;
     }
 
@@ -426,6 +436,22 @@ public class EditPostSettingsFragment extends Fragment {
             default:
                 return false;
         }
+    }
+
+    private void setupSettingHintsForAccessibility() {
+        AccessibilityUtils.disableHintAnnouncement(mPublishDateTextView);
+        AccessibilityUtils.disableHintAnnouncement(mCategoriesTextView);
+        AccessibilityUtils.disableHintAnnouncement(mTagsTextView);
+        AccessibilityUtils.disableHintAnnouncement(mPasswordTextView);
+        AccessibilityUtils.disableHintAnnouncement(mSlugTextView);
+        AccessibilityUtils.disableHintAnnouncement(mExcerptTextView);
+        AccessibilityUtils.disableHintAnnouncement(mLocationTextView);
+    }
+
+    private void applyAccessibilityHeadingToSettings() {
+        AccessibilityUtils.enableAccessibilityHeading(mCategoriesTagsHeaderTextView);
+        AccessibilityUtils.enableAccessibilityHeading(mFeaturedImageHeaderTextView);
+        AccessibilityUtils.enableAccessibilityHeading(mMoreOptionsHeaderTextView);
     }
 
     private void retryFeaturedImageUpload(@NonNull SiteModel site, @NonNull PostImmutableModel post) {

--- a/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
@@ -12,7 +12,7 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <!--Status-->
+        <!--Publish-->
 
         <androidx.cardview.widget.CardView
             style="@style/PostSettingsCardView"
@@ -22,6 +22,10 @@
             <LinearLayout
                 style="@style/PostSettingsCardViewInnerLayout">
 
+                <TextView
+                    android:id="@+id/post_settings_publish"
+                    style="@style/PostSettingsSectionHeader"
+                    android:text="@string/post_settings_publish"/>
                 <LinearLayout
                     android:id="@+id/post_status_container"
                     style="@style/PostSettingsContainer">

--- a/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
@@ -81,6 +81,7 @@
                 style="@style/PostSettingsCardViewInnerLayout">
 
                 <TextView
+                    android:id="@+id/post_settings_categories_and_tags_header"
                     style="@style/PostSettingsSectionHeader"
                     android:text="@string/post_settings_categories_and_tags"/>
 
@@ -128,6 +129,7 @@
                 style="@style/PostSettingsCardViewInnerLayout">
 
                 <TextView
+                    android:id="@+id/post_settings_featured_image_header"
                     style="@style/PostSettingsSectionHeader"
                     android:text="@string/post_settings_featured_image"/>
 
@@ -245,6 +247,7 @@
                 style="@style/PostSettingsCardViewInnerLayout">
 
                 <TextView
+                    android:id="@+id/post_settings_more_options_header"
                     style="@style/PostSettingsSectionHeader"
                     android:text="@string/post_settings_more_options"/>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1238,6 +1238,7 @@
     <string name="post_settings">Post settings</string>
     <string name="post_settings_status">Status</string>
     <string name="post_settings_categories_and_tags">Categories &amp; Tags</string>
+    <string name="post_settings_publish">Publish</string>
     <string name="post_settings_more_options">More Options</string>
     <string name="post_settings_not_set">Not Set</string>
     <string name="post_settings_excerpt">Excerpt</string>

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AccessibilityUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AccessibilityUtils.java
@@ -45,6 +45,11 @@ public class AccessibilityUtils {
         });
     }
 
+    /**
+     * When the minsdk is 28 this can be replaced by adding android:accessibilityHeading="true" as a property to the
+     * view's xml declaration.
+     * @param view that will become a heading.
+     */
     public static void enableAccessibilityHeading(@NonNull View view) {
         setAccessibilityDelegateSafely(view, new AccessibilityDelegateCompat() {
             @Override public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AccessibilityUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AccessibilityUtils.java
@@ -12,6 +12,8 @@ import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
 
 import com.google.android.material.snackbar.Snackbar;
 
+import org.wordpress.android.util.AppLog.T;
+
 import static android.content.Context.ACCESSIBILITY_SERVICE;
 
 public class AccessibilityUtils {
@@ -35,7 +37,7 @@ public class AccessibilityUtils {
     }
 
     public static void disableHintAnnouncement(@NonNull TextView textView) {
-        ViewCompat.setAccessibilityDelegate(textView, new AccessibilityDelegateCompat() {
+        setAccessibilityDelegateSafely(textView, new AccessibilityDelegateCompat() {
             @Override public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
                 super.onInitializeAccessibilityNodeInfo(host, info);
                 info.setHintText(null);
@@ -44,11 +46,24 @@ public class AccessibilityUtils {
     }
 
     public static void enableAccessibilityHeading(@NonNull View view) {
-        ViewCompat.setAccessibilityDelegate(view, new AccessibilityDelegateCompat() {
+        setAccessibilityDelegateSafely(view, new AccessibilityDelegateCompat() {
             @Override public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
                 super.onInitializeAccessibilityNodeInfo(host, info);
                 info.setHeading(true);
             }
         });
+    }
+
+    public static void setAccessibilityDelegateSafely(View view,
+                                                      AccessibilityDelegateCompat accessibilityDelegateCompat) {
+        if (ViewCompat.hasAccessibilityDelegate(view)) {
+            final String errorMessage = "View already has an AccessibilityDelegate.";
+            if (PackageUtils.isDebugBuild()) {
+                throw new RuntimeException(errorMessage);
+            }
+            AppLog.e(T.UTILS, errorMessage);
+        } else {
+            ViewCompat.setAccessibilityDelegate(view, accessibilityDelegateCompat);
+        }
     }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AccessibilityUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AccessibilityUtils.java
@@ -1,7 +1,14 @@
 package org.wordpress.android.util;
 
 import android.content.Context;
+import android.view.View;
 import android.view.accessibility.AccessibilityManager;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.core.view.AccessibilityDelegateCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
 
 import com.google.android.material.snackbar.Snackbar;
 
@@ -25,5 +32,23 @@ public class AccessibilityUtils {
     public static int getSnackbarDuration(Context ctx, int defaultDuration) {
         return defaultDuration == Snackbar.LENGTH_INDEFINITE ? Snackbar.LENGTH_INDEFINITE
                 : isAccessibilityEnabled(ctx) ? SNACKBAR_WITH_ACTION_DURATION_IN_MILLIS : defaultDuration;
+    }
+
+    public static void disableHintAnnouncement(@NonNull TextView textView) {
+        ViewCompat.setAccessibilityDelegate(textView, new AccessibilityDelegateCompat() {
+            @Override public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
+                super.onInitializeAccessibilityNodeInfo(host, info);
+                info.setHintText(null);
+            }
+        });
+    }
+
+    public static void enableAccessibilityHeading(@NonNull View view) {
+        ViewCompat.setAccessibilityDelegate(view, new AccessibilityDelegateCompat() {
+            @Override public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
+                super.onInitializeAccessibilityNodeInfo(host, info);
+                info.setHeading(true);
+            }
+        });
     }
 }


### PR DESCRIPTION
Fixes #10895

This PR addresses several Settings that are represented as `TextViews` that had their `hints` being announced along with their `text` properties, which are identical. So now, the hint announcements are disabled, so the announcement is more concise. 

Another enhancement that was made was the addition of accessibility headings to several headings such as Categories & Tags, Featured Image, to name a few. Defining headings as "accessibility headings" allows the user to perform heading navigation and also to be informed of the headings during traversal. 

To test:

**Disabled hints**

1. Go to Post Settings. 
2. Select either Password, Categories or Location and only one property i.e text will be announced instead of the duplicate behavior before this change.
3. Navigate to Post Settings → Publish
4. Select Date & Time and Notifications and the hints aren't announced. 

**Accessibility headings**

1. Go to Post Settings. 
2. Select either Categories & Tags, Featured Image or More Options and you hear heading being announced. 
3. To verify the heading navigation simply swipe up until you reach the setting of "Headings". Then you can swipe left or right to cycle through the headings. For more details visit the [support documentation on navigation.
](https://support.google.com/accessibility/android/answer/6006598?hl=en)

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

#### Reviewing 

Only 1 reviewer is needed but anyone can review. 

