### PR TITLE
Accessibility : Sign Up/Login TalkBack Improvements

### DIFF
--- a/WordPress/src/main/res/layout/login_signup_screen.xml
+++ b/WordPress/src/main/res/layout/login_signup_screen.xml
@@ -8,6 +8,7 @@
         android:id="@+id/intros_pager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:contentDescription="@string/login_promo_viewpager_content_description"
         android:layout_above="@+id/bottom_buttons"
         android:clipToPadding="false"/>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2229,6 +2229,7 @@
     <!-- If any of these appear unused, be sure to check the same string in the login library -
     it may be used there and keeping it here is required for translation. -->
     <string name="log_in">Log In</string>
+    <string name="login_promo_viewpager_content_description">Introduction</string>
     <string name="login_promo_text_onthego">Publish from the park. Blog from the bus. Comment from the café. WordPress goes where you go.</string>
     <string name="login_promo_text_realtime">Watch readers from around the world read and interact with your site — in realtime.</string>
     <string name="login_promo_text_anytime">Catch up with your favorite sites and join the conversation anywhere, any time.</string>


### PR DESCRIPTION
Fixes #10896

Add a content description of "Introduction" to the `ViewPager` that's utilized on the Sign-Up screen. 
The rationale for doing this is that when the app is loaded for the first time this is the first view that gains focus and it doesn't really relate much. It goes straight into reading the details of each slide. 
Another option would be to include an announcement saying "Welcome to WordPress" in some way on this page but I wasn't sure if doing that is good placement so feedback on this is welcome. 

<img src="https://user-images.githubusercontent.com/1509205/70410029-ab623280-1a1b-11ea-9b00-52b180ac57a0.png" width="320">

To test:

1. Start the app in a logged-out state with TalkBack enabled. 
2. Select the first slide and it should be announced as "Introduction, Multi-Page View" 

## Copy Review Request

Hi! 👋 Please see https://github.com/wordpress-mobile/WordPress-Android/pull/10922#issuecomment-564152754. 

## PR submission checklist:

- [ ] I have considered adding unit tests where possible.

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
