### PR TITLE
Update rest_v11_me_settings_post mock with the correct display and username values

### DIFF
--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_settings_post.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_settings_post.json
@@ -6,7 +6,9 @@
     "response": {
         "status": 200,
         "jsonBody": {
-            "password": ""
+            "password": "",
+            "user_login": "e2eflowsignuptestingmobile",
+            "display_name": "Eeflowsignuptestingmobile"
         },
         "headers": {
             "Content-Type": "application/json",


### PR DESCRIPTION
Fixes #10924

The test was simplified when it was written originally. We're now expecting the username or display name to be updated in the account store.

To test, make sure the test in `SignUpTests` pass.

