### PR TITLE
Replace date locally changed with UTC

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -14,7 +14,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.ContextThemeWrapper;
 import android.view.DragEvent;
 import android.view.Menu;
@@ -125,10 +124,10 @@ import org.wordpress.android.ui.posts.editor.EditorTracker;
 import org.wordpress.android.ui.posts.editor.PostLoadingState;
 import org.wordpress.android.ui.posts.editor.PrimaryEditorAction;
 import org.wordpress.android.ui.posts.editor.SecondaryEditorAction;
+import org.wordpress.android.ui.posts.reactnative.ReactNativeRequestHandler;
 import org.wordpress.android.ui.posts.editor.media.EditorMedia;
 import org.wordpress.android.ui.posts.editor.media.EditorMedia.AddExistingMediaSource;
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener;
-import org.wordpress.android.ui.posts.reactnative.ReactNativeRequestHandler;
 import org.wordpress.android.ui.posts.services.AztecImageLoader;
 import org.wordpress.android.ui.posts.services.AztecVideoLoader;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -442,7 +441,6 @@ public class EditPostActivity extends AppCompatActivity implements
 
                 if (mEditPostRepository.hasPost()) {
                     if (extras.getBoolean(EXTRA_LOAD_AUTO_SAVE_REVISION)) {
-                        Log.d("vojta", "org.wordpress.android.ui.posts.EditPostActivity.onCreate");
                         mEditPostRepository.updateInTransaction(postModel -> {
                             postModel.setTitle(
                                     TextUtils.isEmpty(postModel.getAutoSaveTitle()) ? postModel
@@ -653,7 +651,6 @@ public class EditPostActivity extends AppCompatActivity implements
         if (!useAztec || UploadService.hasPendingOrInProgressMediaUploadsForPost(mEditPostRepository.getPost())) {
             return;
         }
-        Log.d("vojta", "org.wordpress.android.ui.posts.EditPostActivity.resetUploadingMediaToFailedIfPostHasNotMediaInProgressOrQueued");
         mEditPostRepository.updateInTransaction(postModel -> {
             String oldContent = postModel.getContent();
             if (!AztecEditorFragment.hasMediaItemsMarkedUploading(EditPostActivity.this, oldContent)
@@ -1765,7 +1762,6 @@ public class EditPostActivity extends AppCompatActivity implements
     private void loadRevision() {
         updatePostLoadingAndDialogState(PostLoadingState.LOADING_REVISION);
         mEditPostRepository.saveForUndo();
-        Log.d("vojta", "EditPostActivity.loadRevision");
         mEditPostRepository.updateInTransaction(postModel -> {
             postModel.setTitle(Objects.requireNonNull(mRevision.getPostTitle()));
             postModel.setContent(Objects.requireNonNull(mRevision.getPostContent()));
@@ -1842,7 +1838,6 @@ public class EditPostActivity extends AppCompatActivity implements
         // text 2. better not to call `updatePostObject()` from the UI thread due to weird thread blocking behavior
         // on API 16 (and 21) with the visual editor.
         new Thread(() -> {
-            Log.d("vojta", "EditPostActivity.uploadPost");
             mEditPostRepository.updateInTransaction(postModel -> {
                 boolean isFirstTimePublish = isFirstTimePublish(publishPost);
                 if (publishPost) {
@@ -2203,7 +2198,6 @@ public class EditPostActivity extends AppCompatActivity implements
         final String text = intent.getStringExtra(Intent.EXTRA_TEXT);
         final String title = intent.getStringExtra(Intent.EXTRA_SUBJECT);
         if (text != null) {
-            Log.d("vojta", "EditPostActivity.setPostContentFromShareAction");
             mEditPostRepository.updateInTransaction(postModel -> {
                 if (title != null) {
                     mEditorFragment.setTitle(title);
@@ -2249,7 +2243,6 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private void setFeaturedImageId(final long mediaId) {
-        Log.d("vojta", "EditPostActivity.setFeaturedImageId");
         mEditPostRepository.updateInTransaction(postModel -> {
             postModel.setFeaturedImageId(mediaId);
             postModel.setIsLocallyChanged(true);
@@ -2814,7 +2807,6 @@ public class EditPostActivity extends AppCompatActivity implements
             if (mediaList != null && !mediaList.isEmpty()) {
                 shouldFinishInit = false;
                 mViewModel.setMediaInsertedOnCreation(true);
-                Log.d("vojta", "Adding existing media to editor async from EPA");
                 mEditorMedia.addExistingMediaToEditorAsync(mediaList, AddExistingMediaSource.WP_MEDIA_LIBRARY);
                 // TODO we save the post in `addExistingMediaToEditor` but we don't have access to AfterSavePostListener
                 updateAndSavePostAsync(this::onEditorFinalTouchesBeforeShowing);
@@ -3065,7 +3057,6 @@ public class EditPostActivity extends AppCompatActivity implements
     // EditorMediaListener
     @Override
     public void appendMediaFiles(@NotNull Map<String, ? extends MediaFile> mediaFiles) {
-        Log.d("vojta", "Appending media files: " + mediaFiles);
         mEditorFragment.appendMediaFiles((Map<String, MediaFile>) mediaFiles);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -14,6 +14,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.ContextThemeWrapper;
 import android.view.DragEvent;
 import android.view.Menu;
@@ -124,10 +125,10 @@ import org.wordpress.android.ui.posts.editor.EditorTracker;
 import org.wordpress.android.ui.posts.editor.PostLoadingState;
 import org.wordpress.android.ui.posts.editor.PrimaryEditorAction;
 import org.wordpress.android.ui.posts.editor.SecondaryEditorAction;
-import org.wordpress.android.ui.posts.reactnative.ReactNativeRequestHandler;
 import org.wordpress.android.ui.posts.editor.media.EditorMedia;
 import org.wordpress.android.ui.posts.editor.media.EditorMedia.AddExistingMediaSource;
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener;
+import org.wordpress.android.ui.posts.reactnative.ReactNativeRequestHandler;
 import org.wordpress.android.ui.posts.services.AztecImageLoader;
 import org.wordpress.android.ui.posts.services.AztecVideoLoader;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -441,6 +442,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
                 if (mEditPostRepository.hasPost()) {
                     if (extras.getBoolean(EXTRA_LOAD_AUTO_SAVE_REVISION)) {
+                        Log.d("vojta", "org.wordpress.android.ui.posts.EditPostActivity.onCreate");
                         mEditPostRepository.updateInTransaction(postModel -> {
                             postModel.setTitle(
                                     TextUtils.isEmpty(postModel.getAutoSaveTitle()) ? postModel
@@ -651,6 +653,7 @@ public class EditPostActivity extends AppCompatActivity implements
         if (!useAztec || UploadService.hasPendingOrInProgressMediaUploadsForPost(mEditPostRepository.getPost())) {
             return;
         }
+        Log.d("vojta", "org.wordpress.android.ui.posts.EditPostActivity.resetUploadingMediaToFailedIfPostHasNotMediaInProgressOrQueued");
         mEditPostRepository.updateInTransaction(postModel -> {
             String oldContent = postModel.getContent();
             if (!AztecEditorFragment.hasMediaItemsMarkedUploading(EditPostActivity.this, oldContent)
@@ -668,8 +671,8 @@ public class EditPostActivity extends AppCompatActivity implements
                 if (!postModel.isLocalDraft()) {
                     postModel.setIsLocallyChanged(true);
                 }
-                postModel
-                        .setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
+                postModel.setDateLocallyChanged(
+                        DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
                 return true;
             }
             return false;
@@ -1763,12 +1766,14 @@ public class EditPostActivity extends AppCompatActivity implements
     private void loadRevision() {
         updatePostLoadingAndDialogState(PostLoadingState.LOADING_REVISION);
         mEditPostRepository.saveForUndo();
+        Log.d("vojta", "EditPostActivity.loadRevision");
         mEditPostRepository.updateInTransaction(postModel -> {
             postModel.setTitle(Objects.requireNonNull(mRevision.getPostTitle()));
             postModel.setContent(Objects.requireNonNull(mRevision.getPostContent()));
             postModel.setIsLocallyChanged(true);
-            postModel
-                    .setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
+            postModel.setDateLocallyChanged(
+                    DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000)
+            );
             return true;
         });
         refreshEditorContent();
@@ -1840,6 +1845,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // text 2. better not to call `updatePostObject()` from the UI thread due to weird thread blocking behavior
         // on API 16 (and 21) with the visual editor.
         new Thread(() -> {
+            Log.d("vojta", "EditPostActivity.uploadPost");
             mEditPostRepository.updateInTransaction(postModel -> {
                 boolean isFirstTimePublish = isFirstTimePublish(publishPost);
                 if (publishPost) {
@@ -2200,6 +2206,7 @@ public class EditPostActivity extends AppCompatActivity implements
         final String text = intent.getStringExtra(Intent.EXTRA_TEXT);
         final String title = intent.getStringExtra(Intent.EXTRA_SUBJECT);
         if (text != null) {
+            Log.d("vojta", "EditPostActivity.setPostContentFromShareAction");
             mEditPostRepository.updateInTransaction(postModel -> {
                 if (title != null) {
                     mEditorFragment.setTitle(title);
@@ -2212,8 +2219,8 @@ public class EditPostActivity extends AppCompatActivity implements
                 // update PostModel
                 postModel.setContent(updatedContent);
                 mEditPostRepository.updatePublishDateIfShouldBePublishedImmediately(postModel);
-                postModel
-                        .setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
+                postModel.setDateLocallyChanged(
+                        DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
                 return true;
             });
         }
@@ -2245,6 +2252,7 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private void setFeaturedImageId(final long mediaId) {
+        Log.d("vojta", "EditPostActivity.setFeaturedImageId");
         mEditPostRepository.updateInTransaction(postModel -> {
             postModel.setFeaturedImageId(mediaId);
             postModel.setIsLocallyChanged(true);
@@ -2809,6 +2817,7 @@ public class EditPostActivity extends AppCompatActivity implements
             if (mediaList != null && !mediaList.isEmpty()) {
                 shouldFinishInit = false;
                 mViewModel.setMediaInsertedOnCreation(true);
+                Log.d("vojta", "Adding existing media to editor async from EPA");
                 mEditorMedia.addExistingMediaToEditorAsync(mediaList, AddExistingMediaSource.WP_MEDIA_LIBRARY);
                 // TODO we save the post in `addExistingMediaToEditor` but we don't have access to AfterSavePostListener
                 updateAndSavePostAsync(this::onEditorFinalTouchesBeforeShowing);
@@ -3059,6 +3068,7 @@ public class EditPostActivity extends AppCompatActivity implements
     // EditorMediaListener
     @Override
     public void appendMediaFiles(@NotNull Map<String, ? extends MediaFile> mediaFiles) {
+        Log.d("vojta", "Appending media files: " + mediaFiles);
         mEditorFragment.appendMediaFiles((Map<String, MediaFile>) mediaFiles);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -145,7 +145,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.AutolinkUtils;
 import org.wordpress.android.util.CrashLoggingUtils;
-import org.wordpress.android.util.DateTimeUtils;
+import org.wordpress.android.util.DateTimeUtilsWrapper;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.ListUtils;
 import org.wordpress.android.util.LocaleManager;
@@ -177,7 +177,6 @@ import org.wordpress.aztec.util.AztecLog;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -323,6 +322,7 @@ public class EditPostActivity extends AppCompatActivity implements
     @Inject PostUtilsWrapper mPostUtils;
     @Inject EditorTracker mEditorTracker;
     @Inject UploadUtilsWrapper mUploadUtilsWrapper;
+    @Inject DateTimeUtilsWrapper mDateTimeUtils;
     @Inject ViewModelProvider.Factory mViewModelFactory;
 
     private EditPostViewModel mViewModel;
@@ -671,8 +671,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 if (!postModel.isLocalDraft()) {
                     postModel.setIsLocallyChanged(true);
                 }
-                postModel.setDateLocallyChanged(
-                        DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
+                postModel.setDateLocallyChanged(mDateTimeUtils.currentTimeInIso8601UTC());
                 return true;
             }
             return false;
@@ -1771,9 +1770,7 @@ public class EditPostActivity extends AppCompatActivity implements
             postModel.setTitle(Objects.requireNonNull(mRevision.getPostTitle()));
             postModel.setContent(Objects.requireNonNull(mRevision.getPostContent()));
             postModel.setIsLocallyChanged(true);
-            postModel.setDateLocallyChanged(
-                    DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000)
-            );
+            postModel.setDateLocallyChanged(mDateTimeUtils.currentTimeInIso8601UTC());
             return true;
         });
         refreshEditorContent();
@@ -1853,7 +1850,7 @@ public class EditPostActivity extends AppCompatActivity implements
                     // otherwise we'd have an incorrect value
                     // also re-set the published date in case it was SCHEDULED and they want to publish NOW
                     if (postModel.getStatus().equals(PostStatus.SCHEDULED.toString())) {
-                        postModel.setDateCreated(DateTimeUtils.iso8601FromDate(new Date()));
+                        postModel.setDateCreated(mDateTimeUtils.currentTimeInIso8601UTC());
                     }
                     postModel.setStatus(PostStatus.PUBLISHED.toString());
                     mPostEditorAnalyticsSession.setOutcome(Outcome.PUBLISH);
@@ -2220,7 +2217,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 postModel.setContent(updatedContent);
                 mEditPostRepository.updatePublishDateIfShouldBePublishedImmediately(postModel);
                 postModel.setDateLocallyChanged(
-                        DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
+                        mDateTimeUtils.currentTimeInIso8601UTC());
                 return true;
             });
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostViewModel.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.posts
 
 import android.content.Context
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
@@ -110,11 +109,8 @@ class EditPostViewModel
         doFinishActivity: Boolean
     ) {
         launch(bgDispatcher) {
-            Log.d("vojta", "savePostLocally")
             if (editPostRepository.postHasEdits()) {
-                Log.d("vojta", "Post has edits")
                 editPostRepository.updateInTransaction { postModel ->
-                    Log.d("vojta", "Updating post in transaction")
                     // Changes have been made - save the post and ask for the post list to refresh
                     // We consider this being "manual save", it will replace some Android "spans" by an html
                     // or a shortcode replacement (for instance for images and galleries)
@@ -163,7 +159,6 @@ class EditPostViewModel
             }
             if (doFinishActivity) {
                 withContext(mainDispatcher) {
-                    Log.d("vojta", "Save action invoked")
                     _onFinish.value = Event(Unit)
                 }
             }
@@ -176,9 +171,7 @@ class EditPostViewModel
         showAztecEditor: Boolean,
         editPostRepository: EditPostRepository
     ) {
-        Log.d("vojta", "updatePostLocallyChangedOnStatusOrMediaChange")
         if (editedPost == null) {
-            Log.d("vojta", "post is null")
             return
         }
         val contentChanged: Boolean
@@ -196,10 +189,6 @@ class EditPostViewModel
                 editedPost.status
         )
         if (!editedPost.isLocalDraft && (contentChanged || statusChanged)) {
-            Log.d(
-                    "vojta",
-                    "really updating post: ${!editedPost.isLocalDraft && (contentChanged || statusChanged)}"
-            )
             editedPost.setIsLocallyChanged(true)
             editedPost.setDateLocallyChanged(dateTimeUtils.currentTimeInIso8601UTC())
         }
@@ -212,10 +201,8 @@ class EditPostViewModel
         getUpdatedTitleAndContent: ((currentContent: String) -> UpdateFromEditor),
         onSaveAction: (() -> Unit)? = null
     ) {
-        Log.d("vojta", "updateAndSavePostAsync")
         launch {
             val postUpdated = withContext(bgDispatcher) {
-                Log.d("vojta", "Starting post update on the background")
                 (updatePostObject(
                         context,
                         showAztecEditor,
@@ -224,20 +211,17 @@ class EditPostViewModel
                 ) is Success)
                         .also { success ->
                             if (success) {
-                                Log.d("vojta", "Is success so saving to the DB")
                                 savePostToDb(context, postRepository, showAztecEditor)
                             }
                         }
             }
             if (postUpdated) {
-                Log.d("vojta", "Save action invoked")
                 onSaveAction?.invoke()
             }
         }
     }
 
     fun savePostWithDelay() {
-        Log.d("vojta", "Saving post with delay")
         saveJob?.cancel()
         saveJob = launch {
             if (debounceCounter < MAX_UNSAVED_POSTS) {
@@ -258,9 +242,7 @@ class EditPostViewModel
         postRepository: EditPostRepository,
         showAztecEditor: Boolean
     ) {
-        Log.d("vojta", "Saving post to DB")
         if (postRepository.postHasChangesFromDb()) {
-            Log.d("vojta", "Post has changes so really saving")
             postRepository.saveDbSnapshot()
             dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(postRepository.getEditablePost()))
 
@@ -280,7 +262,6 @@ class EditPostViewModel
         postRepository: EditPostRepository,
         getUpdatedTitleAndContent: ((currentContent: String) -> UpdateFromEditor)
     ): UpdateResult {
-        Log.d("vojta", "updatePostObject")
         if (!postRepository.hasPost()) {
             AppLog.e(AppLog.T.POSTS, "Attempted to save an invalid Post.")
             return Error
@@ -305,7 +286,6 @@ class EditPostViewModel
                         postModel.setDateLocallyChanged(dateTimeUtils.currentTimeInIso8601UTC())
                     }
 
-                    Log.d("vojta", "updatePostObject: success - $postTitleOrContentChanged")
                     Success(postTitleOrContentChanged)
                 }
                 is UpdateFromEditor.Failed -> Error
@@ -324,7 +304,6 @@ class EditPostViewModel
         title: String,
         content: String
     ): Boolean {
-        Log.d("vojta", "updatePostContentNewEditor")
         if (editedPost == null) {
             return false
         }
@@ -354,7 +333,6 @@ class EditPostViewModel
             editedPost.setDateLocallyChanged(dateTimeUtils.currentTimeInIso8601UTC())
         }
 
-        Log.d("vojta", "updatePostContentNewEditor - ${titleChanged || contentChanged}")
         return titleChanged || contentChanged
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostViewModel.kt
@@ -201,8 +201,7 @@ class EditPostViewModel
                     "really updating post: ${!editedPost.isLocalDraft && (contentChanged || statusChanged)}"
             )
             editedPost.setIsLocallyChanged(true)
-            val currentTime = localeManagerWrapper.getCurrentCalendar()
-            editedPost.setDateLocallyChanged(dateTimeUtils.iso8601UTCFromCalendar(currentTime))
+            editedPost.setDateLocallyChanged(dateTimeUtils.currentTimeInIso8601UTC())
         }
     }
 
@@ -303,11 +302,7 @@ class EditPostViewModel
                         postRepository.updatePublishDateIfShouldBePublishedImmediately(
                                 postModel
                         )
-                        val currentTime = localeManagerWrapper.getCurrentCalendar()
-                        postModel
-                                .setDateLocallyChanged(
-                                        dateTimeUtils.iso8601UTCFromCalendar(currentTime)
-                                )
+                        postModel.setDateLocallyChanged(dateTimeUtils.currentTimeInIso8601UTC())
                     }
 
                     Log.d("vojta", "updatePostObject: success - $postTitleOrContentChanged")
@@ -356,9 +351,7 @@ class EditPostViewModel
 
         if (!editedPost.isLocalDraft && (titleChanged || contentChanged || statusChanged)) {
             editedPost.setIsLocallyChanged(true)
-            val currentTime = localeManagerWrapper.getCurrentCalendar()
-            editedPost
-                    .setDateLocallyChanged(dateTimeUtils.iso8601UTCFromCalendar(currentTime))
+            editedPost.setDateLocallyChanged(dateTimeUtils.currentTimeInIso8601UTC())
         }
 
         Log.d("vojta", "updatePostContentNewEditor - ${titleChanged || contentChanged}")

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -546,7 +546,7 @@ public class PostUtils {
 
     public static void preparePostForPublish(PostModel post, SiteModel site) {
         PostUtils.updatePublishDateIfShouldBePublishedImmediately(post);
-        post.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
+        post.setDateLocallyChanged(DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
 
         // We need to update the post status and mark the post as locally changed. If we didn't mark it as locally
         // changed the UploadStarter wouldn't upload the post if the only change the user did was clicking on Publish

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddExistingMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddExistingMediaToPostUseCase.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.posts.editor.media
 
+import android.util.Log
 import dagger.Reusable
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.editor.EditorTracker
@@ -24,9 +25,11 @@ class AddExistingMediaToPostUseCase @Inject constructor(
         getMediaModelUseCase
                 .loadMediaByRemoteId(site, mediaIdList)
                 .onEach { media ->
+                    Log.d("vojta", "On each loaded media: $media")
                     editorTracker.trackAddMediaEvent(site, source, media.isVideo)
                 }
                 .let {
+                    Log.d("vojta", "Adding media to editor $it")
                     appendMediaToEditorUseCase.addMediaToEditor(editorMediaListener, it)
                     editorMediaListener.syncPostObjectWithUiAndSaveIt()
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddExistingMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddExistingMediaToPostUseCase.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.posts.editor.media
 
-import android.util.Log
 import dagger.Reusable
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.editor.EditorTracker
@@ -25,11 +24,9 @@ class AddExistingMediaToPostUseCase @Inject constructor(
         getMediaModelUseCase
                 .loadMediaByRemoteId(site, mediaIdList)
                 .onEach { media ->
-                    Log.d("vojta", "On each loaded media: $media")
                     editorTracker.trackAddMediaEvent(site, source, media.isVideo)
                 }
                 .let {
-                    Log.d("vojta", "Adding media to editor $it")
                     appendMediaToEditorUseCase.addMediaToEditor(editorMediaListener, it)
                     editorMediaListener.syncPostObjectWithUiAndSaveIt()
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -588,7 +588,7 @@ public class UploadService extends Service {
             boolean changesConfirmed = post.contentHashcode() == post.getChangesConfirmedContentHashcode();
             post.setFeaturedImageId(remoteMediaId);
             post.setIsLocallyChanged(true);
-            post.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
+            post.setDateLocallyChanged(DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
             if (changesConfirmed) {
                 /*
                  * We are replacing local featured image with a remote version. We need to make sure
@@ -611,7 +611,7 @@ public class UploadService extends Service {
             if (!post.isLocalDraft()) {
                 post.setIsLocallyChanged(true);
             }
-            post.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
+            post.setDateLocallyChanged(DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
             if (changesConfirmed) {
                 /*
                  * We are replacing image local path with a url. We need to make sure to retain the confirmation
@@ -635,7 +635,7 @@ public class UploadService extends Service {
             if (!post.isLocalDraft()) {
                 post.setIsLocallyChanged(true);
             }
-            post.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
+            post.setDateLocallyChanged(DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
             if (changesConfirmed) {
                 /*
                  * We are updating media upload status, but we don't make any undesired changes to the post. We need to

--- a/WordPress/src/main/java/org/wordpress/android/util/DateTimeUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/DateTimeUtilsWrapper.kt
@@ -5,6 +5,6 @@ import javax.inject.Inject
 
 class DateTimeUtilsWrapper
 @Inject constructor() {
-    fun iso8601FromCalendar(calendar: Calendar) =
-            DateTimeUtils.iso8601FromTimestamp(calendar.timeInMillis / 1000)
+    fun iso8601UTCFromCalendar(calendar: Calendar): String =
+            DateTimeUtils.iso8601UTCFromTimestamp(calendar.timeInMillis / 1000)
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/DateTimeUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/DateTimeUtilsWrapper.kt
@@ -4,7 +4,7 @@ import java.util.Calendar
 import javax.inject.Inject
 
 class DateTimeUtilsWrapper
-@Inject constructor() {
-    fun iso8601UTCFromCalendar(calendar: Calendar): String =
-            DateTimeUtils.iso8601UTCFromTimestamp(calendar.timeInMillis / 1000)
+@Inject constructor(private val localeManagerWrapper: LocaleManagerWrapper) {
+    fun currentTimeInIso8601UTC(): String =
+            DateTimeUtils.iso8601UTCFromTimestamp(localeManagerWrapper.getCurrentCalendar().timeInMillis / 1000)
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/DateTimeUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/DateTimeUtilsWrapper.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.util
 
-import java.util.Calendar
 import javax.inject.Inject
 
 class DateTimeUtilsWrapper

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostViewModelTest.kt
@@ -594,6 +594,6 @@ class EditPostViewModelTest : BaseUnitTest() {
         now.set(2019, 10, 10, 10, 10, 0)
         now.timeZone = TimeZone.getTimeZone("UTC")
         whenever(localeManagerWrapper.getCurrentCalendar()).thenReturn(now)
-        whenever(dateTimeUtils.iso8601FromCalendar(now)).thenReturn(currentTime)
+        whenever(dateTimeUtils.currentTimeInIso8601UTC()).thenReturn(currentTime)
     }
 }


### PR DESCRIPTION
There was a bug that caused date locally changed to be in 2 formats, one ending with `+0000` and the other one with `+00:00`. This makes `equals` always fail and causes unnecessary saves to the database even when there was no actual change.  

To test:
* Try saving posts and check with debug that the save to DB is not called when there is no change

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

