### PR TITLE
Issue/10930 login email errmsg not preserved

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <AndroidXmlCodeStyleSettings>
+      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
+    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />
@@ -83,6 +86,7 @@
               <match>
                 <AND>
                   <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -93,6 +97,7 @@
               <match>
                 <AND>
                   <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -104,6 +109,7 @@
               <match>
                 <AND>
                   <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
@@ -114,6 +120,7 @@
               <match>
                 <AND>
                   <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
@@ -124,6 +131,7 @@
               <match>
                 <AND>
                   <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -134,6 +142,7 @@
               <match>
                 <AND>
                   <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -144,6 +153,7 @@
               <match>
                 <AND>
                   <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -154,53 +164,12 @@
             <rule>
               <match>
                 <AND>
-                  <NAME>.*:layout_width</NAME>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:layout_height</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:layout_.*</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:width</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:height</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
             </rule>
           </section>
           <section>
@@ -208,17 +177,7 @@
               <match>
                 <AND>
                   <NAME>.*</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>.*</XML_NAMESPACE>
                 </AND>
               </match>

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java
@@ -33,6 +33,7 @@ public abstract class LoginBaseDiscoveryFragment extends LoginBaseFormFragment<L
         // Start the discovery process
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(
                 mLoginBaseDiscoveryListener.getRequestedSiteAddress()));
+
     }
 
     @SuppressWarnings("unused")

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java
@@ -33,7 +33,6 @@ public abstract class LoginBaseDiscoveryFragment extends LoginBaseFormFragment<L
         // Start the discovery process
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(
                 mLoginBaseDiscoveryListener.getRequestedSiteAddress()));
-
     }
 
     @SuppressWarnings("unused")

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -64,10 +64,12 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     private static final String KEY_IS_SOCIAL = "KEY_IS_SOCIAL";
     private static final String KEY_OLD_SITES_IDS = "KEY_OLD_SITES_IDS";
     private static final String KEY_REQUESTED_EMAIL = "KEY_REQUESTED_EMAIL";
+    private static final String KEY_EMAIL_ERROR_MSG = "KEY_EMAIL_ERROR_MSG";
     private static final String LOG_TAG = LoginEmailFragment.class.getSimpleName();
     private static final int GOOGLE_API_CLIENT_ID = 1002;
     private static final int EMAIL_CREDENTIALS_REQUEST_CODE = 25100;
 
+    private static final String ARG_HIDE_LOGIN_BY_SITE_OPTION = "ARG_HIDE_LOGIN_BY_SITE_OPTION";
     private static final String ARG_LOGIN_SITE_URL = "ARG_LOGIN_SITE_URL";
 
     public static final String TAG = "login_email_fragment_tag";
@@ -77,6 +79,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     private GoogleApiClient mGoogleApiClient;
     private String mGoogleEmail;
     private String mRequestedEmail;
+    private String mErrmsg;
     private boolean mIsSocialLogin;
 
     protected WPLoginInputRow mEmailInput;
@@ -84,7 +87,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     protected boolean mIsDisplayingEmailHints;
     protected String mLoginSiteUrl;
 
-    public static LoginEmailFragment newInstance(String url) {
+    public static LoginEmailFragment newInstance(Boolean hideLoginWithSiteOption, String url) {
         LoginEmailFragment fragment = new LoginEmailFragment();
         Bundle args = new Bundle();
         args.putString(ARG_LOGIN_SITE_URL, url);
@@ -283,6 +286,10 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     @Override
     public void onStart() {
         super.onStart();
+        if (mErrmsg != null) {
+            mEmailInput.setError(mErrmsg);
+        }
+
         mGoogleApiClient = new GoogleApiClient.Builder(getActivity())
                 .addConnectionCallbacks(LoginEmailFragment.this)
                 .enableAutoManage(getActivity(), GOOGLE_API_CLIENT_ID, LoginEmailFragment.this)
@@ -312,6 +319,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             mIsSocialLogin = savedInstanceState.getBoolean(KEY_IS_SOCIAL);
             mIsDisplayingEmailHints = savedInstanceState.getBoolean(KEY_IS_DISPLAYING_EMAIL_HINTS);
             mHasDismissedEmailHints = savedInstanceState.getBoolean(KEY_HAS_DISMISSED_EMAIL_HINTS);
+            mErrmsg = savedInstanceState.getString(KEY_EMAIL_ERROR_MSG);
         } else {
             mAnalyticsListener.trackEmailFormViewed();
         }
@@ -326,6 +334,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         outState.putBoolean(KEY_IS_SOCIAL, mIsSocialLogin);
         outState.putBoolean(KEY_IS_DISPLAYING_EMAIL_HINTS, mIsDisplayingEmailHints);
         outState.putBoolean(KEY_HAS_DISMISSED_EMAIL_HINTS, mHasDismissedEmailHints);
+        outState.putString(KEY_EMAIL_ERROR_MSG, mEmailInput.getError());
     }
 
     protected void next(String email) {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -47,12 +47,14 @@ import dagger.android.support.AndroidSupportInjection;
 public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment implements TextWatcher,
         OnEditorCommitListener, LoginBaseDiscoveryFragment.LoginBaseDiscoveryListener {
     private static final String KEY_REQUESTED_SITE_ADDRESS = "KEY_REQUESTED_SITE_ADDRESS";
+    private static final String KEY_EMAIL_ERROR_MSG = "KEY_EMAIL_ERROR_MSG";
 
     public static final String TAG = "login_site_address_fragment_tag";
 
     private WPLoginInputRow mSiteAddressInput;
 
     private String mRequestedSiteAddress;
+    private String mErrmsg;
 
     private LoginSiteAddressValidator mLoginSiteAddressValidator;
 
@@ -88,6 +90,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
         // important for accessibility - talkback
         getActivity().setTitle(R.string.site_address_login_title);
         mSiteAddressInput = rootView.findViewById(R.id.login_site_address_row);
+
         if (BuildConfig.DEBUG) {
             mSiteAddressInput.getEditText().setText(BuildConfig.DEBUG_WPCOM_WEBSITE_URL);
         }
@@ -135,6 +138,9 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
         if (savedInstanceState != null) {
             mRequestedSiteAddress = savedInstanceState.getString(KEY_REQUESTED_SITE_ADDRESS);
+            mErrmsg = savedInstanceState.getString(KEY_EMAIL_ERROR_MSG);
+            if (mErrmsg != null)
+                mSiteAddressInput.setError(mErrmsg);
         } else {
             mAnalyticsListener.trackUrlFormViewed();
         }
@@ -162,6 +168,16 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
         super.onSaveInstanceState(outState);
 
         outState.putString(KEY_REQUESTED_SITE_ADDRESS, mRequestedSiteAddress);
+        outState.putString(KEY_EMAIL_ERROR_MSG, mSiteAddressInput.getError());
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        if (mErrmsg != null) {
+            mSiteAddressInput.setError(mErrmsg);
+        }
+        return;
     }
 
     @Override public void onDestroyView() {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -139,8 +139,9 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
         if (savedInstanceState != null) {
             mRequestedSiteAddress = savedInstanceState.getString(KEY_REQUESTED_SITE_ADDRESS);
             mErrmsg = savedInstanceState.getString(KEY_EMAIL_ERROR_MSG);
-            if (mErrmsg != null)
+            if (mErrmsg != null) {
                 mSiteAddressInput.setError(mErrmsg);
+            }
         } else {
             mAnalyticsListener.trackUrlFormViewed();
         }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java
@@ -33,6 +33,7 @@ import org.wordpress.android.login.R;
  */
 public class WPLoginInputRow extends RelativeLayout {
     private static final String KEY_SUPER_STATE = "wplogin_input_row_super_state";
+    private String mErrMsg;
 
     public interface OnEditorCommitListener {
         void onEditorCommit();
@@ -207,10 +208,16 @@ public class WPLoginInputRow extends RelativeLayout {
 
     public void setError(@Nullable final CharSequence error) {
         mTextInputLayout.setError(error);
+        if (error != null) mErrMsg = error.toString();
         if (error == null) {
             mTextInputLayout.setErrorEnabled(false);
         }
     }
+
+    public String getError() {
+        return mErrMsg;
+    }
+
 
     private static class SavedState extends BaseSavedState {
         private Parcelable mEditTextState;


### PR DESCRIPTION


Fixes # 10930
There was a bug that the email format error or email unregistered error disappeared when we rotated the screen.

To test:

- Try login with an email with bad format, press Next, and rotate the screen. The error message should remain.

- Try login with an email unregistered, press Next, rotate the screen. The error message should remain.

![demo](https://user-images.githubusercontent.com/39059254/70524631-e496c180-1b45-11ea-86a9-8fe87774c8a6.gif)
