### PR TITLE
Changing lifecycle owner to be the fragment instead of the activity.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -392,7 +392,7 @@ public class ReaderPostListFragment extends Fragment
                                        .get(ReaderPostListViewModel.class);
 
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel) {
-            mViewModel.getCurrentSubFilter().observe(getActivity(), subfilterListItem -> {
+            mViewModel.getCurrentSubFilter().observe(this, subfilterListItem -> {
                 if (ReaderUtils.isFollowing(
                         mCurrentTag,
                         BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel,
@@ -402,11 +402,11 @@ public class ReaderPostListFragment extends Fragment
                 }
             });
 
-            mViewModel.getShouldShowSubFilters().observe(getActivity(), show -> {
+            mViewModel.getShouldShowSubFilters().observe(this, show -> {
                 mSubFilterComponent.setVisibility(show ? View.VISIBLE : View.GONE);
             });
 
-            mViewModel.getReaderModeInfo().observe(getActivity(), readerModeInfo -> {
+            mViewModel.getReaderModeInfo().observe(this, readerModeInfo -> {
                 if (readerModeInfo != null) {
                     changeReaderMode(readerModeInfo, true);
 
@@ -421,7 +421,7 @@ public class ReaderPostListFragment extends Fragment
                 }
             });
 
-            mViewModel.isBottomSheetShowing().observe(getActivity(), event -> {
+            mViewModel.isBottomSheetShowing().observe(this, event -> {
                 event.applyIfNotHandled(isShowing -> {
                     FragmentManager fm = getFragmentManager();
                     if (fm != null) {


### PR DESCRIPTION
Fixes #10948 

This issue is related to the zalpha-199 and zalpha-200 versions. (pinging @jkmassel , the code affects the logic under feature flag so I think can make sense to release as hotfix in 13.8 for alpha testers. @planarvoid let me know wdyt also, thanks)

We were able to reproduce the issue (see below for the steps). Not fully sure on the why, but what happens is that the observer lifecycle owner in the fragment is the getActivity() context and it can happen that the observer stays active even with a not valid activity to which currently the fragment is attached. We changed the lifecycle owner to be the Fragment instead of the Activity (that probably is also more correct).

## To reproduce (before applying the current PR)
- In an emulator (or a usb connected device to check logcat logs) open the reader so it is the last screen used in the app
- Close the app
- Force a notification for example making a new post in a site you follow
- Tap on the notification to open the new post
- The app does not open and in logcat you can see the following

```
NullPointerException: Attempt to invoke virtual method 'android.content.Context android.content.Context.getApplicationContext()' on a null object reference
    at org.wordpress.android.ui.reader.adapters.ReaderPostAdapter.<init>(ReaderPostAdapter.java:697)
    at org.wordpress.android.ui.reader.ReaderPostListFragment.getPostAdapter(ReaderPostListFragment.java:1809)
    at org.wordpress.android.ui.reader.ReaderPostListFragment.resetPostAdapter(ReaderPostListFragment.java:628)
    at org.wordpress.android.ui.reader.ReaderPostListFragment.changeReaderMode(ReaderPostListFragment.java:476)
    at org.wordpress.android.ui.reader.ReaderPostListFragment.lambda$onActivityCreated$2$ReaderPostListFragment(ReaderPostListFragment.java:411)
...
```
## To test
- Follow the above step and check the post opens in the app and no crash log in logcat
- smoke test the reader


PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.