### PR TITLE
Accessibility : Sign Up - Terms of Service Announcement Fix

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupBottomSheetDialog.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupBottomSheetDialog.java
@@ -54,6 +54,7 @@ public class SignupBottomSheetDialog extends WPBottomSheetDialog {
         });
 
         setContentView(layout);
+        setTitle(R.string.signup_title);
 
         // Set peek height to full height of view to avoid signup buttons being off screen when
         // bottom sheet is shown with small screen height (e.g. landscape orientation).

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="signup_magic_link_error_button_positive">Retry</string>
     <string name="signup_magic_link_message">We sent you a magic signup link! Check your email on this device, and tap the link in the email to finish signing up.</string>
     <string name="signup_magic_link_progress">Sending email</string>
+    <string name="signup_title">Sign up for WordPress</string>
     <string name="signup_terms_of_service_text">By signing up, you agree to our %1$sTerms of Service%2$s.</string>
     <string name="signup_with_email_button">Sign Up with Email</string>
     <string name="signup_with_google_button">Sign Up with Google</string>


### PR DESCRIPTION
Fixes #10510

To test:

1. Go to Settings > Accessibility > TalkBack and turn on "Use service".
2. In the WordPress app, go to the log in screen.
3. Double tap the "Sign up for WordPress.com" button.
4. You will hear "Sign Up For WordPress" as the first announcement. 

This fix solves the issue partially because when the device goes to sleep and wakes up it still does the announcement of the terms of service text twice. Nonetheless, we have stopped the initial double announcement so it's worth merging this in until another solution is found. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

