### PR TITLE
Update Construct Site

### DIFF
--- a/WordPress/src/main/res/drawable/img_illustration_construct_site_190dp.xml
+++ b/WordPress/src/main/res/drawable/img_illustration_construct_site_190dp.xml
@@ -1,234 +1,220 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="190dp"
+<?xml version="1.0" encoding="utf-8"?>
+
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:height="142dp"
-    android:viewportWidth="190"
-    android:viewportHeight="142">
+    android:width="190dp"
+    android:viewportHeight="142.0"
+    android:viewportWidth="190.0">
+
     <path
         android:fillColor="@color/blue_5"
-        android:pathData="M34.739,127.758V31.7h137.585v96.058H69.326z" />
-    <path
-        android:pathData="M106.474,105.575v2.5h-2.5"
-        android:strokeWidth="2"
-        android:strokeColor="@android:color/white"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
-    <path
-        android:pathData="M99.364,108.075H55.566"
-        android:strokeWidth="2"
-        android:strokeColor="@android:color/white"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
-    <path
-        android:pathData="M53.26,108.075h-2.5v-2.5"
-        android:strokeWidth="2"
-        android:strokeColor="@android:color/white"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
-    <path
-        android:pathData="M50.76,100.308V60.805"
-        android:strokeWidth="2"
-        android:strokeColor="@android:color/white"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
-    <path
-        android:pathData="M50.76,58.171v-2.5h2.5"
-        android:strokeWidth="2"
-        android:strokeColor="@android:color/white"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
-    <path
-        android:pathData="M57.87,55.671h43.799"
-        android:strokeWidth="2"
-        android:strokeColor="@android:color/white"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
-    <path
-        android:pathData="M103.974,55.671h2.5v2.5"
-        android:strokeWidth="2"
-        android:strokeColor="@android:color/white"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
-    <path
-        android:pathData="M106.474,63.438v39.502"
-        android:strokeWidth="2"
-        android:strokeColor="@android:color/white"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
+        android:pathData="M34.7,127.8V31.7h137.6v96.1h-103H34.7z">
+    </path>
+
     <path
         android:fillColor="@android:color/white"
-        android:pathData="M103.177,81.402H59.46v-9.947h51.915v1.749a8.198,8.198 0,0 1,-8.198 8.198" />
-    <path
-        android:fillColor="@color/gray_10"
-        android:pathData="M0.371,98.963c2.901,-0.275 5.803,-0.334 8.705,-0.402l8.704,-0.064c5.803,0.06 11.607,0.026 17.41,0.366 0.07,0.004 0.124,0.097 0.121,0.207 -0.002,0.105 -0.056,0.189 -0.122,0.193 -5.802,0.34 -11.606,0.305 -17.409,0.366l-8.704,-0.064c-2.902,-0.07 -5.804,-0.127 -8.705,-0.402 -0.035,-0.004 -0.062,-0.051 -0.06,-0.106 0.002,-0.052 0.028,-0.091 0.06,-0.094" />
+        android:pathData="M100.4,108.1c0,-0.6 -0.4,-1 -1,-1h-4.6c-0.6,0 -1,0.4 -1,1s0.4,1 1,1h4.6C100,109.1 100.4,108.7 100.4,108.1zM91.2,108.1c0,-0.6 -0.4,-1 -1,-1h-4.6c-0.6,0 -1,0.4 -1,1s0.4,1 1,1h4.6C90.7,109.1 91.2,108.7 91.2,108.1zM82,108.1c0,-0.6 -0.4,-1 -1,-1h-4.6c-0.6,0 -1,0.4 -1,1s0.4,1 1,1H81C81.5,109.1 82,108.7 82,108.1zM72.7,108.1c0,-0.6 -0.4,-1 -1,-1h-4.6c-0.6,0 -1,0.4 -1,1s0.4,1 1,1h4.6C72.3,109.1 72.7,108.7 72.7,108.1zM63.5,108.1c0,-0.6 -0.4,-1 -1,-1h-4.6c-0.6,0 -1,0.4 -1,1s0.4,1 1,1h4.6C63.1,109.1 63.5,108.7 63.5,108.1zM54.3,108.1c0,-0.6 -0.4,-1 -1,-1h-1.5v-1.5c0,-0.6 -0.4,-1 -1,-1s-1,0.4 -1,1v2.5c0,0.6 0.4,1 1,1h2.5C53.9,109.1 54.3,108.7 54.3,108.1z">
+    </path>
+
     <path
         android:fillColor="@android:color/white"
-        android:pathData="M179.627,74.732h-41.955V41.125h36.119a5.836,5.836 0,0 1,5.836 5.836v27.77z" />
+        android:pathData="M51.8,100.3V95c0,-0.6 -0.4,-1 -1,-1s-1,0.4 -1,1v5.3c0,0.6 0.4,1 1,1S51.8,100.9 51.8,100.3zM51.8,89.8v-5.3c0,-0.6 -0.4,-1 -1,-1s-1,0.4 -1,1v5.3c0,0.6 0.4,1 1,1S51.8,90.3 51.8,89.8zM51.8,79.2V74c0,-0.6 -0.4,-1 -1,-1s-1,0.4 -1,1v5.3c0,0.6 0.4,1 1,1S51.8,79.8 51.8,79.2zM51.8,68.7v-5.3c0,-0.6 -0.4,-1 -1,-1s-1,0.4 -1,1v5.3c0,0.6 0.4,1 1,1S51.8,69.3 51.8,68.7zM51.8,58.2v-1.5h1.5c0.6,0 1,-0.4 1,-1s-0.4,-1 -1,-1h-2.5c-0.6,0 -1,0.4 -1,1v2.5c0,0.6 0.4,1 1,1S51.8,58.8 51.8,58.2z">
+    </path>
+
     <path
-        android:pathData="M179.627,72.232v2.5h-2.5"
-        android:strokeWidth="2"
-        android:strokeColor="@color/gray_10"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
+        android:fillColor="@android:color/white"
+        android:pathData="M100.4,55.7c0,-0.6 -0.4,-1 -1,-1h-4.6c-0.6,0 -1,0.4 -1,1s0.4,1 1,1h4.6C100,56.7 100.4,56.3 100.4,55.7zM91.2,55.7c0,-0.6 -0.4,-1 -1,-1h-4.6c-0.6,0 -1,0.4 -1,1s0.4,1 1,1h4.6C90.7,56.7 91.2,56.3 91.2,55.7zM82,55.7c0,-0.6 -0.4,-1 -1,-1h-4.6c-0.6,0 -1,0.4 -1,1s0.4,1 1,1H81C81.5,56.7 82,56.3 82,55.7zM72.7,55.7c0,-0.6 -0.4,-1 -1,-1h-4.6c-0.6,0 -1,0.4 -1,1s0.4,1 1,1h4.6C72.3,56.7 72.7,56.3 72.7,55.7zM63.5,55.7c0,-0.6 -0.4,-1 -1,-1h-4.6c-0.6,0 -1,0.4 -1,1s0.4,1 1,1h4.6C63.1,56.7 63.5,56.3 63.5,55.7zM107.5,58.2v-2.5c0,-0.6 -0.4,-1 -1,-1H104c-0.6,0 -1,0.4 -1,1s0.4,1 1,1h1.5v1.5c0,0.6 0.4,1 1,1S107.5,58.8 107.5,58.2z">
+    </path>
+
     <path
-        android:pathData="M171.847,74.732h-29.036"
-        android:strokeWidth="2"
-        android:strokeColor="@color/gray_10"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
+        android:fillColor="@android:color/white"
+        android:pathData="M106.5,109.1H104c-0.6,0 -1,-0.4 -1,-1s0.4,-1 1,-1h1.5v-1.5c0,-0.6 0.4,-1 1,-1s1,0.4 1,1v2.5C107.5,108.7 107.1,109.1 106.5,109.1zM107.5,100.3V95c0,-0.6 -0.4,-1 -1,-1s-1,0.4 -1,1v5.3c0,0.6 0.4,1 1,1S107.5,100.8 107.5,100.3zM107.5,89.7v-5.3c0,-0.6 -0.4,-1 -1,-1s-1,0.4 -1,1v5.3c0,0.6 0.4,1 1,1S107.5,90.3 107.5,89.7zM107.5,79.2v-5.3c0,-0.6 -0.4,-1 -1,-1s-1,0.4 -1,1v5.3c0,0.6 0.4,1 1,1S107.5,79.8 107.5,79.2zM107.5,68.7v-5.3c0,-0.6 -0.4,-1 -1,-1s-1,0.4 -1,1v5.3c0,0.6 0.4,1 1,1S107.5,69.2 107.5,68.7z">
+    </path>
+
     <path
-        android:pathData="M140.171,74.732h-2.5v-2.5"
-        android:strokeWidth="2"
-        android:strokeColor="@color/gray_10"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
+        android:fillColor="@android:color/white"
+        android:pathData="M103.2,81.4H59.5v-9.9h51.9v1.7C111.4,77.7 107.7,81.4 103.2,81.4">
+    </path>
+
     <path
-        android:pathData="M137.671,66.51V46.485"
-        android:strokeWidth="2"
-        android:strokeColor="@color/gray_10"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
+        android:fillColor="@color/gray_10"
+        android:pathData="M0.4,99c2.9,-0.3 5.8,-0.3 8.7,-0.4l8.7,-0.1c5.8,0.1 11.6,0 17.4,0.4c0.1,0 0.1,0.1 0.1,0.2s-0.1,0.2 -0.1,0.2c-5.8,0.3 -11.6,0.3 -17.4,0.4l-8.7,-0.1c-2.9,-0.1 -5.8,-0.1 -8.7,-0.4C0.3,99.2 0.3,99.1 0.4,99C0.3,99 0.3,99 0.4,99">
+    </path>
+
     <path
-        android:pathData="M137.671,43.624v-2.5h2.5"
-        android:strokeWidth="2"
-        android:strokeColor="@color/gray_10"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
+        android:fillColor="@android:color/white"
+        android:pathData="M179.6,74.7h-42V41.1h36.1c3.2,0 5.8,2.6 5.8,5.8L179.6,74.7L179.6,74.7z">
+    </path>
+
     <path
-        android:pathData="M145.405,41.124h28.385a5.836,5.836 0,0 1,5.836 5.836v22.654"
-        android:strokeWidth="2"
-        android:strokeColor="@color/gray_10"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
+        android:fillColor="@color/gray_10"
+        android:pathData="M172.8,74.7c0,-0.6 -0.4,-1 -1,-1h-5.3c-0.6,0 -1,0.4 -1,1s0.4,1 1,1h5.3C172.4,75.7 172.8,75.3 172.8,74.7zM162.2,74.7c0,-0.6 -0.4,-1 -1,-1H156c-0.6,0 -1,0.4 -1,1s0.4,1 1,1h5.3C161.8,75.7 162.2,75.3 162.2,74.7zM151.7,74.7c0,-0.6 -0.4,-1 -1,-1h-5.3c-0.6,0 -1,0.4 -1,1s0.4,1 1,1h5.3C151.2,75.7 151.7,75.3 151.7,74.7zM141.2,74.7c0,-0.6 -0.4,-1 -1,-1h-1.5v-1.5c0,-0.6 -0.4,-1 -1,-1s-1,0.4 -1,1v2.5c0,0.6 0.4,1 1,1h2.5C140.8,75.7 141.2,75.3 141.2,74.7zM138.7,66.5v-5.7c0,-0.6 -0.4,-1 -1,-1s-1,0.4 -1,1v5.7c0,0.6 0.4,1 1,1S138.7,67.1 138.7,66.5zM138.7,55.1v-5.7c0,-0.6 -0.4,-1 -1,-1s-1,0.4 -1,1v5.7c0,0.6 0.4,1 1,1S138.7,55.6 138.7,55.1zM138.7,43.6v-1.5h1.5c0.6,0 1,-0.4 1,-1s-0.4,-1 -1,-1h-2.5c-0.6,0 -1,0.4 -1,1v2.5c0,0.6 0.4,1 1,1S138.7,44.2 138.7,43.6z">
+    </path>
+
     <path
-        android:pathData="M137.482,41.285l1.948,1.567"
-        android:strokeWidth="2"
-        android:strokeColor="@color/gray_10"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
+        android:fillColor="@color/gray_10"
+        android:pathData="M179.6,75.7h-2.5c-0.6,0-1,-0.4-1,-1s0.4,-1 1,-1h1.5v-1.5c0,-0.6 0.4,-1 1,-1s1,0.4 1,1v2.5C180.6,75.3 180.2,75.7 179.6,75.7zM180.6,67v-5.2c0,-0.6-0.4,-1-1,-1s-1,0.4-1,1V67c0,0.6 0.4,1 1,1S180.6,67.5 180.6,67zM180.6,56.5v-5.2c0,-0.6 -0.4,-1-1,-1s-1,0.4-1,1v5.2c0,0.6 0.4,1 1,1S180.6,57 180.6,56.5zM179.7,47c0.5,-0.1 0.9,-0.6 0.8,-1.1c-0.3,-2.1-1.5,-3.8-3.4,-4.9c-0.5,-0.3 -1.1,-0.1-1.4,0.4c-0.3,0.5-0.1,1.1 0.4,1.4c1.3,0.7 2.2,2 2.4,3.4c0.1,0.5 0.5,0.9 1,0.9C179.6,47 179.6,47 179.7,47zM172.6,41.1c0,-0.6-0.4,-1-1,-1h-5.2c-0.6,0-1,0.4-1,1s0.4,1 1,1h5.2C172.1,42.1 172.6,41.7 172.6,41.1zM162.1,41.1c0,-0.6-0.4,-1-1,-1h-5.2c-0.6,0-1,0.4-1,1s0.4,1 1,1h5.2C161.7,42.1 162.1,41.7 162.1,41.1zM151.6,41.1c0,-0.6-0.4,-1-1,-1h-5.2c-0.6,0-1,0.4-1,1s0.4,1 1,1h5.2C151.2,42.1 151.6,41.7 151.6,41.1z">
+    </path>
+
     <path
-        android:pathData="M143.553,46.17l30.925,24.89"
-        android:strokeWidth="2"
-        android:strokeColor="@color/gray_10"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
+        android:fillColor="@color/gray_10"
+        android:pathData="M140,43.9c-0.2,0 -0.5,-0.1 -0.6,-0.2l-1.9,-1.6c-0.4,-0.4 -0.5,-1 -0.1,-1.4s1,-0.5 1.4,-0.1l1.9,1.6c0.4,0.4 0.5,1 0.1,1.4C140.6,43.8 140.3,43.9 140,43.9zM156.6,57.2c-0.2,0 -0.4,-0.1 -0.6,-0.2l-4.1,-3.3c-0.4,-0.3 -0.5,-1 -0.2,-1.4s1,-0.5 1.4,-0.2l4.1,3.3c0.4,0.3 0.5,1 0.2,1.4C157.1,57 156.9,57.2 156.6,57.2zM148.3,50.5c-0.2,0 -0.4,-0.1 -0.6,-0.2l-4.1,-3.3c-0.4,-0.3 -0.5,-1 -0.2,-1.4s1,-0.5 1.4,-0.2l4.1,3.3c0.4,0.3 0.5,1 0.2,1.4C148.9,50.4 148.6,50.5 148.3,50.5z">
+    </path>
+
     <path
-        android:pathData="M176.54,72.718l1.947,1.567"
-        android:strokeWidth="2"
-        android:strokeColor="@color/gray_10"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
+        android:fillColor="@color/gray_10"
+        android:pathData="M173,70.4c-0.2,0 -0.4,-0.1 -0.6,-0.2l-4.1,-3.3c-0.4,-0.3 -0.5,-1 -0.2,-1.4s1,-0.5 1.4,-0.2l4.1,3.3c0.4,0.3 0.5,1 0.2,1.4C173.6,70.3 173.3,70.4 173,70.4zM164.8,63.8c-0.2,0 -0.4,-0.1 -0.6,-0.2l-4.1,-3.3c-0.4,-0.3 -0.5,-1 -0.2,-1.4s1,-0.5 1.4,-0.2l4.1,3.3c0.4,0.3 0.5,1 0.2,1.4C165.4,63.7 165.1,63.8 164.8,63.8zM179.1,75.3c-0.2,0 -0.4,-0.1 -0.6,-0.2l-2,-1.6c-0.4,-0.3 -0.5,-1 -0.2,-1.4s1,-0.5 1.4,-0.2l2,1.6c0.4,0.3 0.5,1 0.2,1.4C179.7,75.2 179.4,75.3 179.1,75.3z">
+    </path>
+
     <path
         android:fillColor="@color/blue_40"
-        android:pathData="M160.319,118.727h-39.684V90.84a6.973,6.973 0,0 1,6.974 -6.973h32.71v34.859z" />
+        android:pathData="M160.3,118.7h-39.7V90.8c0,-3.9 3.1,-7 7,-7h32.7V118.7z">
+    </path>
+
     <path
         android:fillColor="@color/blue_10"
-        android:pathData="M83.703,99.798H59.46V89.85h32.441V91.6a8.198,8.198 0,0 1,-8.198 8.198" />
+        android:pathData="M83.7,99.8H59.5v-9.9h32.4v1.7C91.9,96.1 88.2,99.8 83.7,99.8">
+    </path>
+
     <path
         android:fillColor="@color/gray_10"
-        android:pathData="M189.588,99.162c-1.626,0.262 -3.252,0.356 -4.878,0.404a155.57,155.57 0,0 1,-4.878 0.063c-3.252,-0.06 -6.504,-0.026 -9.757,-0.367a0.202,0.202 0,0 1,-0.179 -0.22,0.202 0.202,0 0,1 0.18,-0.18c3.252,-0.34 6.504,-0.304 9.756,-0.365 1.626,-0.008 3.252,0.02 4.878,0.061 1.626,0.048 3.252,0.142 4.878,0.404a0.1,0.1 0,0 1,0.084 0.117,0.102 0.102,0 0,1 -0.084,0.084" />
+        android:pathData="M189.6,99.2c-1.6,0.3 -3.3,0.4 -4.9,0.4c-1.6,0 -3.3,0.1 -4.9,0.1c-3.3,-0.1 -6.5,0 -9.8,-0.4c-0.1,0 -0.2,-0.1 -0.2,-0.2s0.1,-0.2 0.2,-0.2c3.3,-0.3 6.5,-0.3 9.8,-0.4c1.6,0 3.3,0 4.9,0.1c1.6,0 3.3,0.1 4.9,0.4C189.6,99 189.7,99 189.6,99.2C189.7,99.1 189.6,99.2 189.6,99.2">
+    </path>
+
     <path
         android:fillColor="@color/gray_10"
-        android:pathData="M182.553,138.05c-0.275,-3.25 -0.333,-6.498 -0.402,-9.747l-0.064,-9.747c0.061,-6.497 0.026,-12.995 0.366,-19.493a0.2,0.2 0,0 1,0.21 -0.19c0.103,0.006 0.184,0.089 0.19,0.19 0.34,6.498 0.305,12.996 0.366,19.493l-0.063,9.747c-0.069,3.249 -0.127,6.498 -0.403,9.747a0.103,0.103 0,0 1,-0.109 0.092,0.102 0.102,0 0,1 -0.09,-0.092" />
-    <path
-        android:pathData="M19.868,45.808c0.774,-0.015 1.132,-0.121 1.906,-0.379 3.184,-1.066 4.72,-3.817 4.597,-6.913 -0.035,-0.876 1.483,-1.466 1.182,-2.368 -0.391,-1.168 -2.466,-1.087 -3.517,-3.331 -1.178,-2.517 -4.295,-3.16 -7.213,-2.184a7.801,7.801 0,0 0,-4.922 9.873"
-        android:strokeWidth="1"
-        android:strokeColor="@color/blue_70"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
-    <path
-        android:fillColor="@color/blue_40"
-        android:pathData="M19.02,36.055c1.136,2.842 0.852,7.579 -2.085,8.715 -2.937,1.138 -5.035,-4.263 -5.035,-4.263l7.12,-4.452z" />
+        android:pathData="M182.6,138c-0.3,-3.2 -0.3,-6.5 -0.4,-9.7l-0.1,-9.7c0.1,-6.5 0,-13 0.4,-19.5c0,-0.1 0.1,-0.2 0.2,-0.2c0.1,0 0.2,0.1 0.2,0.2c0.3,6.5 0.3,13 0.4,19.5l-0.1,9.7c-0.1,3.2 -0.1,6.5 -0.4,9.7C182.7,138.1 182.7,138.1 182.6,138C182.6,138.1 182.6,138.1 182.6,138">
+    </path>
+
     <path
         android:fillColor="@color/blue_70"
-        android:pathData="M10.81,77.31c-2.559,19.752 -0.41,61.958 -0.41,61.958h9.661l0.853,-35.385" />
-    <path
-        android:pathData="M10.81,77.31c-2.559,19.752 -0.41,61.958 -0.41,61.958h9.661l0.853,-35.385"
-        android:strokeWidth=".735"
-        android:strokeColor="@color/blue_70" />
-    <path
-        android:fillColor="@color/blue_70"
-        android:pathData="M10.398,138.273c2.937,0.095 11.84,0.663 13.167,1.137 1.326,0.473 1.42,0.662 -0.19,1.04 -1.61,0.38 -12.977,0 -12.977,0v-2.177z" />
-    <path
-        android:fillColor="@android:color/transparent"
-        android:pathData="M10.398,138.273c2.937,0.095 11.84,0.663 13.167,1.137 1.326,0.473 1.42,0.662 -0.19,1.04 -1.61,0.38 -12.977,0 -12.977,0v-2.177z"
-        android:strokeWidth=".735"
-        android:strokeColor="@color/blue_70" />
+        android:pathData="M25,140c0,0.4 -0.5,0.6 -1.5,0.8c-0.6,0.1 -2.2,0.2 -4.2,0.2c-3.7,0 -8.6,-0.2 -8.9,-0.2H10v-1.4c0,-0.7 -2.2,-42.5 0.4,-62.1l0.7,0.1c0,0.2 -0.1,0.5 -0.1,0.7l9.9,25.9l0,0h0.4l-0.9,34.7c1.5,0.1 2.7,0.3 3.2,0.4C24.5,139.4 25,139.6 25,140z">
+    </path>
+
     <path
         android:fillColor="@color/blue_40"
-        android:pathData="M26.598,76.884s1.057,14.97 1.563,30.41c0.424,12.911 -1.125,26.537 -0.995,31.973H16.651c0.142,-31.547 -6.127,-44.62 -5.842,-61.957" />
+        android:pathData="M29.7,141c-1.6,0.4 -13,0 -13,0v-1.7c0.1,-31.5 -6.1,-44.6 -5.8,-62l15.7,-0.4c0,0 1.1,15 1.6,30.4c0.4,12.7 -1.1,26.1 -1,31.7c1.3,0.1 2.3,0.3 2.7,0.4C31.2,139.9 31.3,140.6 29.7,141z">
+    </path>
+
     <path
         android:fillColor="@color/blue_40"
-        android:pathData="M10.031,55.502c-1.156,10.817 0.778,21.808 0.778,21.808l15.931,-0.426 -0.237,-9.759 -3.695,-1.988 4.5,-8.716 -2.984,-3.127 -4.529,-4.678c-4.659,-1.085 -9.256,2.13 -9.764,6.886" />
+        android:pathData="M10,55.5c-1.2,10.8 0.8,21.8 0.8,21.8l15.9,-0.4l-0.2,-9.8l-3.7,-2l4.5,-8.7l-3,-3.1l-4.5,-4.7C15.1,47.5 10.5,50.7 10,55.5">
+    </path>
+
     <path
         android:fillColor="@color/blue_10"
-        android:pathData="M21.34,64.379l0.71,51.726h6.68l-0.995,-48.6z" />
-    <path
-        android:pathData="M19.493,62.248c6.252,5.4 12.363,6.962 14.92,4.83 3.82,-3.186 -2.96,-15.779 -3.41,-17.62 -1.563,-6.395 -5.115,-6.393 -5.968,-5.682 -0.853,0.71 0.853,4.688 0.853,4.688l1.563,8.526"
-        android:strokeWidth="1"
-        android:strokeColor="@color/blue_70"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
-    <path
-        android:pathData="M23.756,53.579l5.827,5.543"
-        android:strokeWidth="1"
-        android:strokeColor="@color/blue_70"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
-    <path
-        android:fillColor="@color/blue_40"
-        android:pathData="M16.651,138.273c2.937,0.095 11.84,0.663 13.167,1.137 1.326,0.473 1.42,1.23 -0.19,1.61 -1.61,0.379 -12.977,0 -12.977,0v-2.747z" />
-    <path
-        android:pathData="M21.204,45.998l-0.86,2.607 -0.661,-2.7z"
-        android:strokeWidth="1"
-        android:strokeColor="@color/blue_70"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
-    <path
-        android:pathData="M24.04,76.602c-4.832,2.131 -14.21,0.995 -14.21,0.995"
-        android:strokeWidth="1"
-        android:strokeColor="@color/blue_10"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
-    <path
-        android:pathData="M29.535,90.999c-1.586,0.291 -3.515,0.187 -5.428,-0.098"
-        android:strokeWidth="1"
-        android:strokeColor="@android:color/white"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
-    <path
-        android:pathData="M16.238,48.872c2.514,-0.853 -2.938,-3.75 -3.265,-1.804 -0.327,1.947 1.12,2.533 3.265,1.804zM17.361,48.463s3.126,0.427 4.69,1.99M11.393,41.217l15.63,-10.657"
-        android:strokeWidth="1"
-        android:strokeColor="@color/blue_10"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
-    <path
-        android:pathData="M24.465,40.981c0.696,0.061 1.276,-0.169 1.276,-0.169"
-        android:strokeWidth="1"
-        android:strokeColor="@color/blue_70"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
+        android:pathData="M21.3,64.4l0.8,51.7h6.6l-1,-48.6L21.3,64.4z">
+    </path>
+
     <path
         android:fillColor="@color/blue_70"
-        android:pathData="M23.79,37.709a0.448,0.448 0,0 1,-0.52 -0.36l-0.136,-0.743a0.446,0.446 0,1 1,0.879 -0.161l0.136,0.743a0.447,0.447 0,0 1,-0.358 0.52" />
+        android:pathData="M31.4,68.4c-3.3,0 -7.9,-2.1 -12.3,-5.9c-0.2,-0.2 -0.2,-0.5 -0.1,-0.7c0.2,-0.2 0.5,-0.2 0.7,-0.1c6.5,5.6 12.2,6.6 14.2,4.8c2.7,-2.3 -0.9,-10.6 -2.6,-14.6c-0.5,-1.2 -0.9,-2.1 -1,-2.5c-1,-4 -2.7,-5.2 -3.6,-5.5c-0.8,-0.3 -1.4,-0.1 -1.6,0.1c-0.3,0.3 0.2,2.3 1,4.1v0.1l1.6,8.5c0.1,0.3 -0.1,0.5 -0.4,0.6s-0.5,-0.1 -0.6,-0.4l-1.6,-8.4c-0.6,-1.3 -1.8,-4.4 -0.7,-5.2c0.4,-0.3 1.4,-0.6 2.5,-0.2c1.1,0.4 3.2,1.7 4.3,6.2c0.1,0.3 0.5,1.3 0.9,2.3c2,4.5 5.6,13 2.3,15.8C33.9,68.1 32.8,68.4 31.4,68.4z">
+    </path>
+
     <path
-        android:pathData="M31.47,14.581l-0.004,-0.202V9.195A8.195,8.195 0,0 1,39.66 1h121.242a8.195,8.195 0,0 1,8.195 8.195v7.927"
-        android:strokeWidth="2"
-        android:strokeColor="@color/gray_10"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
+        android:fillColor="@color/blue_70"
+        android:pathData="M29.6,59.6c-0.1,0 -0.2,0 -0.3,-0.1L23.5,54c-0.2,-0.2 -0.2,-0.5 0,-0.7s0.5,-0.2 0.7,0l5.8,5.5c0.2,0.2 0.2,0.5 0,0.7C29.9,59.5 29.7,59.6 29.6,59.6z">
+    </path>
+
     <path
-        android:pathData="M31.687,22.166l-0.07,-2.499"
-        android:strokeWidth="2"
-        android:strokeColor="@color/gray_10"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
+        android:fillColor="@color/blue_70"
+        android:pathData="M20.3,49.1L20.3,49.1c-0.3,0 -0.4,-0.2 -0.5,-0.4L19.2,46c0,-0.2 0,-0.3 0.1,-0.4c0.1,-0.1 0.3,-0.2 0.4,-0.2l1.5,0.1c0.2,0 0.3,0.1 0.4,0.2c0.1,0.1 0.1,0.3 0.1,0.4l-0.9,2.6C20.7,49 20.5,49.1 20.3,49.1zM20.3,46.4l0.1,0.3l0.1,-0.3H20.3z">
+    </path>
+
+    <path
+        android:fillColor="@color/blue_10"
+        android:pathData="M15.3,78.4c-3,0 -5.4,-0.3 -5.6,-0.3c-0.3,0 -0.5,-0.3 -0.4,-0.6c0,-0.3 0.3,-0.5 0.6,-0.4c0.1,0 9.3,1.1 13.9,-1c0.3,-0.1 0.5,0 0.7,0.3c0.1,0.3 0,0.5 -0.3,0.7C21.8,78.1 18.3,78.4 15.3,78.4z">
+    </path>
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M28.2,90.7v1c-0.3,0 -0.6,0 -0.8,0c-1,0 -2.1,-0.1 -3.3,-0.3c-0.3,0 -0.5,-0.3 -0.4,-0.6c0,-0.3 0.3,-0.5 0.6,-0.4C25.7,90.6 27,90.7 28.2,90.7z">
+    </path>
+
+    <path
+        android:fillColor="@color/blue_10"
+        android:pathData="M14.7,49.7c-0.7,0 -1.2,-0.2 -1.6,-0.5c-0.4,-0.3 -0.8,-1 -0.6,-2.1c0.1,-0.7 0.7,-1.1 1.6,-1.1c1.3,0 3.2,1.1 3.4,2.1c0,0.3 0,1 -1,1.3l0,0C15.7,49.6 15.2,49.7 14.7,49.7zM16.2,48.9L16.2,48.9L16.2,48.9zM13.9,46.9c-0.3,0 -0.5,0.1 -0.5,0.3c-0.1,0.6 0,1 0.3,1.2c0.4,0.4 1.3,0.4 2.4,0c0.2,-0.1 0.3,-0.2 0.3,-0.2c0,-0.2 -0.9,-1.1 -2.1,-1.3C14.2,46.9 14,46.9 13.9,46.9z">
+    </path>
+
+    <path
+        android:fillColor="@color/blue_40"
+        android:pathData="M19,36.1c1.1,2.8 0.9,7.6 -2.1,8.7c-2.9,1.1 -5,-4.3 -5,-4.3L19,36.1z">
+    </path>
+
+    <path
+        android:fillColor="@color/blue_70"
+        android:pathData="M19.9,46.3c-0.3,0 -0.5,-0.2 -0.5,-0.5s0.2,-0.5 0.5,-0.5c0.7,0 0.9,-0.1 1.7,-0.4c2.8,-1 4.4,-3.3 4.3,-6.4c0,-0.6 0.4,-1.1 0.8,-1.5c0.3,-0.4 0.5,-0.6 0.5,-0.8c-0.1,-0.3 -0.5,-0.5 -1,-0.8c-0.8,-0.4 -1.8,-1 -2.5,-2.4c-1,-2.1 -3.7,-2.9 -6.6,-1.9c-1.9,0.6 -3.4,1.9 -4.2,3.7c-0.9,1.7 -1,3.7 -0.4,5.6c0.1,0.3 -0.1,0.5 -0.3,0.6c-0.3,0.1 -0.5,-0.1 -0.6,-0.3c-0.7,-2.1 -0.6,-4.4 0.4,-6.3c1,-2 2.7,-3.5 4.8,-4.2c3.4,-1.2 6.6,-0.1 7.8,2.5c0.5,1.1 1.3,1.6 2,2c0.6,0.4 1.3,0.7 1.5,1.4c0.3,0.8 -0.3,1.4 -0.7,1.8c-0.2,0.3 -0.5,0.6 -0.5,0.8c0.1,3.5 -1.7,6.3 -4.9,7.4C21.2,46.2 20.8,46.3 19.9,46.3z">
+    </path>
+
+    <path
+        android:fillColor="@color/blue_10"
+        android:pathData="M22.1,51c-0.1,0 -0.3,0 -0.4,-0.1c-1.5,-1.5 -4.4,-1.9 -4.4,-1.9c-0.3,0 -0.5,-0.3 -0.4,-0.6c0,-0.3 0.3,-0.5 0.6,-0.4c0.1,0 3.3,0.4 5,2.1c0.2,0.2 0.2,0.5 0,0.7C22.4,51 22.2,51 22.1,51z">
+    </path>
+
+    <path
+        android:fillColor="@color/blue_10"
+        android:pathData="M11.4,41.7c-0.2,0 -0.3,-0.1 -0.4,-0.2c-0.2,-0.2 -0.1,-0.5 0.1,-0.7l15.6,-10.6c0.2,-0.2 0.5,-0.1 0.7,0.1s0.1,0.5 -0.1,0.7L11.7,41.6C11.6,41.7 11.5,41.7 11.4,41.7z">
+    </path>
+
+    <path
+        android:fillColor="@color/blue_70"
+        android:pathData="M24.8,41.5c-0.1,0 -0.2,0 -0.4,0c-0.3,0 -0.5,-0.3 -0.4,-0.6c0,-0.3 0.3,-0.5 0.6,-0.4c0.5,0.1 1,-0.2 1,-0.2c0.2,-0.1 0.5,0 0.7,0.2c0.1,0.2 0,0.5 -0.2,0.7C26,41.3 25.5,41.5 24.8,41.5z">
+    </path>
+
+    <path
+        android:fillColor="@color/blue_70"
+        android:pathData="M23.8,37.7L23.8,37.7c-0.2,0 -0.5,-0.1 -0.5,-0.4l-0.1,-0.7c0,-0.2 0.1,-0.5 0.4,-0.5c0.2,0 0.5,0.1 0.5,0.4l0.1,0.7C24.2,37.4 24,37.7 23.8,37.7">
+    </path>
+
     <path
         android:fillColor="@color/gray_10"
-        android:pathData="M48.733,11.583a2.05,2.05 0,1 1,-4.099 0,2.05 2.05,0 0,1 4.099,0M59.473,11.583a2.049,2.049 0,1 1,-4.099 0,2.05 2.05,0 0,1 4.1,0M70.214,11.583a2.049,2.049 0,1 1,-4.098 0,2.049 2.049,0 0,1 4.098,0M175.937,23.417c-12.609,0.759 -25.218,0.753 -37.828,0.796l-37.828,0.135 -37.827,-0.135c-12.61,-0.043 -25.219,-0.036 -37.829,-0.796v-0.5c12.61,-0.76 25.22,-0.753 37.83,-0.796l37.826,-0.135 37.828,0.135c12.61,0.043 25.22,0.037 37.828,0.796v0.5z" />
+        android:pathData="M48.7,11.6c0,1.1 -0.9,2 -2.1,2s-2,-0.9 -2,-2s0.9,-2 2,-2S48.7,10.5 48.7,11.6M59.5,11.6c0,1.1 -0.9,2 -2,2s-2.1,-0.9 -2.1,-2s0.9,-2 2.1,-2C58.6,9.5 59.5,10.5 59.5,11.6M70.2,11.6c0,1.1 -0.9,2 -2.1,2c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2C69.3,9.5 70.2,10.5 70.2,11.6">
+    </path>
+
     <path
-        android:pathData="M169.098,19.666v2.5"
-        android:strokeWidth="2"
-        android:strokeColor="@color/gray_10"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
+        android:fillColor="@color/gray_10"
+        android:pathData="M175.9,23.4c-12.6,0.8 -25.2,0.8 -37.8,0.8l-37.8,0.1l-37.8,-0.1c-12.6,0 -25.2,0 -37.8,-0.8v-0.5c12.6,-0.8 25.2,-0.8 37.8,-0.8l37.8,-0.1l37.8,0.1c12.6,0 25.2,0 37.8,0.8V23.4z">
+    </path>
+
+    <path
+        android:fillColor="@color/gray_10"
+        android:pathData="M31.5,15.6c-0.6,0 -1,-0.4 -1,-1V9.5c0,-0.6 0.4,-1 1,-1c0.6,0 1,0.4 1,1v5.1C32.5,15.2 32.1,15.6 31.5,15.6z">
+    </path>
+
+    <path
+        android:fillColor="@color/gray_10"
+        android:pathData="M32.9,5.7c-0.2,0 -0.4,-0.1 -0.6,-0.2c-0.5,-0.3 -0.6,-0.9 -0.3,-1.4c1.1,-1.6 2.6,-2.8 4.4,-3.5c0.5,-0.2 1.1,0.1 1.3,0.6s-0.1,1.1 -0.6,1.3C35.7,3 34.5,4 33.7,5.2C33.5,5.5 33.2,5.7 32.9,5.7z">
+    </path>
+
+    <path
+        android:fillColor="@color/gray_10"
+        android:pathData="M128.3,2h-5.1c-0.6,0 -1,-0.4 -1,-1s0.4,-1 1,-1h5.1c0.6,0 1,0.4 1,1S128.8,2 128.3,2zM118.1,2H113c-0.6,0 -1,-0.4 -1,-1s0.4,-1 1,-1h5.1c0.6,0 1,0.4 1,1S118.7,2 118.1,2zM107.9,2h-5.1c-0.6,0 -1,-0.4 -1,-1s0.4,-1 1,-1h5.1c0.6,0 1,0.4 1,1S108.5,2 107.9,2zM97.7,2h-5.1c-0.6,0 -1,-0.4 -1,-1s0.4,-1 1,-1h5.1c0.6,0 1,0.4 1,1S98.3,2 97.7,2zM87.6,2h-5.1c-0.6,0 -1,-0.4 -1,-1s0.4,-1 1,-1h5.1c0.6,0 1,0.4 1,1S88.1,2 87.6,2zM77.4,2h-5.1c-0.6,0 -1,-0.4 -1,-1s0.4,-1 1,-1h5.1c0.6,0 1,0.4 1,1S77.9,2 77.4,2z">
+    </path>
+
+    <path
+        android:fillColor="@color/gray_10"
+        android:pathData="M67.2,2h-5.1c-0.6,0 -1,-0.4 -1,-1s0.4,-1 1,-1h5.1c0.6,0 1,0.4 1,1S67.8,2 67.2,2z">
+    </path>
+
+    <path
+        android:fillColor="@color/gray_10"
+        android:pathData="M57,2h-5c-0.6,0 -1,-0.4 -1,-1s0.4,-1 1,-1h5c0.6,0 1,0.4 1,1S57.6,2 57,2z">
+    </path>
+
+    <path
+        android:fillColor="@color/gray_10"
+        android:pathData="M46.9,2h-5.1c-0.6,0 -1,-0.4 -1,-1s0.4,-1 1,-1h5.1c0.6,0 1,0.4 1,1S47.4,2 46.9,2z">
+    </path>
+
+    <path
+        android:fillColor="@color/gray_10"
+        android:pathData="M31.7,23.2c-0.5,0 -1,-0.4 -1,-1l-0.1,-2.5c0,-0.6 0.4,-1 1,-1s1,0.4 1,1l0.1,2.5C32.7,22.7 32.3,23.2 31.7,23.2L31.7,23.2z">
+    </path>
+
+    <path
+        android:fillColor="@color/gray_10"
+        android:pathData="M169.1,15.6c-0.6,0 -1,-0.4 -1,-1V9.5c0,-0.6 0.4,-1 1,-1s1,0.4 1,1v5.1C170.1,15.1 169.7,15.6 169.1,15.6zM167.7,5.7c-0.3,0 -0.6,-0.2 -0.8,-0.4c-0.8,-1.2 -2,-2.2 -3.4,-2.8c-0.5,-0.2 -0.8,-0.8 -0.6,-1.3s0.8,-0.8 1.3,-0.6c1.8,0.7 3.3,1.9 4.4,3.5c0.3,0.5 0.2,1.1 -0.3,1.4C168.1,5.6 167.9,5.7 167.7,5.7zM158.8,2h-5.1c-0.6,0 -1,-0.4 -1,-1s0.4,-1 1,-1h5.1c0.6,0 1,0.4 1,1S159.4,2 158.8,2zM148.6,2h-5.1c-0.6,0 -1,-0.4 -1,-1s0.4,-1 1,-1h5.1c0.6,0 1,0.4 1,1S149.2,2 148.6,2zM138.5,2h-5.1c-0.6,0 -1,-0.4 -1,-1s0.4,-1 1,-1h5.1c0.6,0 1,0.4 1,1S139,2 138.5,2zM169.1,23.2c-0.6,0 -1,-0.4 -1,-1v-2.5c0,-0.6 0.4,-1 1,-1s1,0.4 1,1v2.5C170.1,22.8 169.7,23.2 169.1,23.2z">
+    </path>
+
 </vector>


### PR DESCRIPTION
### Fix
Update the paths, attributes,  and code style of the `img_illustration_construct_site_190dp.xml` file to show the correct illustration, mimic other vector files, and optimize paths for better performance.  See the screenshots below for illustration.

![update_construct_site_portrait](https://user-images.githubusercontent.com/3827611/70954268-b9224400-2029-11ea-9cb7-00ecb573d76a.png)

![update_construct_site_landscape](https://user-images.githubusercontent.com/3827611/70954272-baec0780-2029-11ea-92bd-43775a0e1f37.png)

### Test
There are two ways to get to the post-signup interstitial screen; use an `adb` command or go through the signup flow.
#### ADB Command
1. Launch `wasabi` build variant of app.
2. Enter following command via terminal.
```
adb shell am start -n org.wordpress.android.beta/org.wordpress.android.ui.accounts.PostSignupInterstitialActivity
```
3. Notice illustration as shown above.
4. Rotate device into landscape orientation.
5. Notice illustration as shown above.

#### Signup Flow
0. Clear app data.
1. Tap ***Sign Up for WordPress.com*** button.
2. Tap ***Sign Up with Email*** button.
3. Enter email address not associated with WordPress.com account in ***Email Address*** field.
4. Tap ***Next*** button.
5. Notice magic link screen.
6. Go to email app on device.
7. Tap ***Sign up to WordPress.com*** magic link button.
8. Notice signup epilogue screen is shown on device.
9. Tap ***Continue*** button.
10. Notice illustration as shown above.
11. Rotate device into landscape orientation.
12. Notice illustration as shown above.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.