### PR TITLE
Post-Signup Interstitial: Display interstitial screen

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
@@ -13,7 +13,6 @@ import static org.wordpress.android.BuildConfig.E2E_SIGNUP_DISPLAY_NAME;
 import static org.wordpress.android.BuildConfig.E2E_SIGNUP_EMAIL;
 import static org.wordpress.android.BuildConfig.E2E_SIGNUP_PASSWORD;
 import static org.wordpress.android.BuildConfig.E2E_SIGNUP_USERNAME;
-import static org.wordpress.android.TestUtils.clearDefaultSharedPreferences;
 
 public class SignUpTests extends BaseTest {
     @Rule
@@ -23,8 +22,6 @@ public class SignUpTests extends BaseTest {
     @Before
     public void setUp() {
         logoutIfNecessary();
-        // Clearing app preferences to ensure the post-signup interstitial is always shown
-        clearDefaultSharedPreferences(mAppContext);
     }
 
     @Test

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
@@ -13,6 +13,7 @@ import static org.wordpress.android.BuildConfig.E2E_SIGNUP_DISPLAY_NAME;
 import static org.wordpress.android.BuildConfig.E2E_SIGNUP_EMAIL;
 import static org.wordpress.android.BuildConfig.E2E_SIGNUP_PASSWORD;
 import static org.wordpress.android.BuildConfig.E2E_SIGNUP_USERNAME;
+import static org.wordpress.android.TestUtils.clearDefaultSharedPreferences;
 
 public class SignUpTests extends BaseTest {
     @Rule
@@ -22,6 +23,8 @@ public class SignUpTests extends BaseTest {
     @Before
     public void setUp() {
         logoutIfNecessary();
+        // Clearing app preferences to ensure the post-signup interstitial is always shown
+        clearDefaultSharedPreferences(mAppContext);
     }
 
     @Test
@@ -33,6 +36,7 @@ public class SignUpTests extends BaseTest {
                 E2E_SIGNUP_DISPLAY_NAME,
                 E2E_SIGNUP_USERNAME);
         signupFlow.enterPassword(E2E_SIGNUP_PASSWORD);
+        signupFlow.dismissInterstitial();
         signupFlow.confirmSignup();
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
@@ -58,13 +58,18 @@ public class SignupFlow {
         ViewInteraction passwordField = onView(allOf(withId(R.id.input), withHint("Password (optional)")));
         waitForElementToBeDisplayed(passwordField);
         populateTextField(passwordField, password);
+
+        // Click continue
+        clickOn(onView(withId(R.id.primary_button)));
+    }
+
+    public void dismissInterstitial() {
+        // Dismiss post-signup interstitial
+        clickOn(onView(withId(R.id.dismiss_button)));
     }
 
     public void confirmSignup() {
-        // Click continue
-        clickOn(onView(withId(R.id.primary_button)));
-
-        // Confirm login
+        // Confirm signup
         waitForElementToBeDisplayed(R.id.nav_me);
     }
 }

--- a/WordPress/src/debug/AndroidManifest.xml
+++ b/WordPress/src/debug/AndroidManifest.xml
@@ -8,13 +8,6 @@
         tools:replace="android:name,android:supportsRtl"
         android:name=".WordPressDebug"
         android:supportsRtl="true">
-        <!-- Temporarily adding this activity here, so we are able to launch it from adb -->
-        <activity
-            android:name=".ui.accounts.PostSignupInterstitialActivity"
-            android:label="@string/post_signup_interstitial_title"
-            android:theme="@style/LoginTheme"
-            android:exported="true"
-            />
     </application>
 
     <!--

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -124,6 +124,12 @@
             android:theme="@style/LoginTheme" />
 
         <activity
+            android:name=".ui.accounts.PostSignupInterstitialActivity"
+            android:label="@string/post_signup_interstitial_title"
+            android:theme="@style/LoginTheme"
+            />
+
+        <activity
             android:name=".ui.sitecreation.SiteCreationActivity"
             android:theme="@style/LoginTheme"
             android:windowSoftInputMode="adjustResize" />

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -23,6 +23,8 @@ import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.LoginActivity;
 import org.wordpress.android.ui.accounts.LoginEpilogueActivity;
 import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
+import org.wordpress.android.ui.accounts.PostSignupInterstitialActivity;
+import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueFragment;
 import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment;
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailFragment;
@@ -204,7 +206,11 @@ public interface AppComponent extends AndroidInjector<WordPress> {
 
     void inject(LoginMagicLinkInterceptActivity object);
 
+    void inject(SignupEpilogueActivity object);
+
     void inject(SignupEpilogueFragment object);
+
+    void inject(PostSignupInterstitialActivity object);
 
     void inject(SiteCreationActivity object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -30,6 +30,7 @@ import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.HelpActivity.Origin;
 import org.wordpress.android.ui.accounts.LoginActivity;
 import org.wordpress.android.ui.accounts.LoginEpilogueActivity;
+import org.wordpress.android.ui.accounts.PostSignupInterstitialActivity;
 import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailActivity;
 import org.wordpress.android.ui.activitylog.list.ActivityLogListActivity;
@@ -773,6 +774,14 @@ public class ActivityLauncher {
         intent.putExtra(SignupEpilogueActivity.EXTRA_SIGNUP_USERNAME, username);
         intent.putExtra(SignupEpilogueActivity.EXTRA_SIGNUP_IS_EMAIL, isEmail);
         activity.startActivityForResult(intent, RequestCodes.SHOW_SIGNUP_EPILOGUE_AND_RETURN);
+    }
+
+    public static void showPostSignupInterstitial(Context context) {
+        final Intent parentIntent = new Intent(context, WPMainActivity.class);
+        parentIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        parentIntent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+        final Intent intent = new Intent(context, PostSignupInterstitialActivity.class);
+        TaskStackBuilder.create(context).addNextIntent(parentIntent).addNextIntent(intent).startActivities();
     }
 
     public static void viewStatsSinglePostDetails(Context context, SiteModel site, PostModel post) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -58,6 +58,7 @@ import org.wordpress.android.ui.main.SitePickerActivity;
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter;
 import org.wordpress.android.ui.posts.BasicFragmentDialog;
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
 import org.wordpress.android.util.AppLog;
@@ -241,7 +242,11 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         switch (getLoginMode()) {
             case FULL:
             case WPCOM_LOGIN_ONLY:
-                ActivityLauncher.showMainActivityAndLoginEpilogue(this, oldSitesIds, doLoginUpdate);
+                if (!mSiteStore.hasSite() && AppPrefs.shouldShowPostSignupInterstitial()) {
+                    ActivityLauncher.showPostSignupInterstitial(this);
+                } else {
+                    ActivityLauncher.showMainActivityAndLoginEpilogue(this, oldSitesIds, doLoginUpdate);
+                }
                 setResult(Activity.RESULT_OK);
                 finish();
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -9,9 +9,11 @@ import androidx.fragment.app.FragmentTransaction;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueFragment;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueListener;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.LocaleManager;
 
 import java.util.ArrayList;
@@ -24,6 +26,7 @@ public class LoginEpilogueActivity extends AppCompatActivity implements LoginEpi
     public static final String ARG_OLD_SITES_IDS = "ARG_OLD_SITES_IDS";
 
     @Inject AccountStore mAccountStore;
+    @Inject SiteStore mSiteStore;
 
     @Override
     protected void attachBaseContext(Context newBase) {
@@ -67,7 +70,12 @@ public class LoginEpilogueActivity extends AppCompatActivity implements LoginEpi
 
     @Override
     public void onContinue() {
-        setResult(RESULT_OK);
+        if (mSiteStore.hasSite()) {
+            setResult(RESULT_OK);
+        } else if (AppPrefs.shouldShowPostSignupInterstitial()) {
+            ActivityLauncher.showPostSignupInterstitial(this);
+        }
+
         finish();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -9,11 +9,9 @@ import androidx.fragment.app.FragmentTransaction;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.store.AccountStore;
-import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueFragment;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueListener;
-import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.LocaleManager;
 
 import java.util.ArrayList;
@@ -26,7 +24,6 @@ public class LoginEpilogueActivity extends AppCompatActivity implements LoginEpi
     public static final String ARG_OLD_SITES_IDS = "ARG_OLD_SITES_IDS";
 
     @Inject AccountStore mAccountStore;
-    @Inject SiteStore mSiteStore;
 
     @Override
     protected void attachBaseContext(Context newBase) {
@@ -70,12 +67,7 @@ public class LoginEpilogueActivity extends AppCompatActivity implements LoginEpi
 
     @Override
     public void onContinue() {
-        if (mSiteStore.hasSite()) {
-            setResult(RESULT_OK);
-        } else if (AppPrefs.shouldShowPostSignupInterstitial()) {
-            ActivityLauncher.showPostSignupInterstitial(this);
-        }
-
+        setResult(RESULT_OK);
         finish();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/PostSignupInterstitialActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/PostSignupInterstitialActivity.kt
@@ -4,12 +4,21 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.android.synthetic.main.post_signup_interstitial_default.*
 import org.wordpress.android.R
+import org.wordpress.android.WordPress
 import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import javax.inject.Inject
 
 class PostSignupInterstitialActivity : AppCompatActivity() {
+    @Inject lateinit var appPrefsWrapper: AppPrefsWrapper
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        (application as WordPress).component().inject(this)
+
         setContentView(R.layout.post_signup_interstitial_activity)
+
+        appPrefsWrapper.shouldShowPostSignupInterstitial = false
 
         create_new_site_button.setOnClickListener {
             ActivityLauncher.newBlogForResult(this)

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignupEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignupEpilogueActivity.java
@@ -7,9 +7,15 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentTransaction;
 
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment;
 import org.wordpress.android.ui.accounts.signup.SignupEpilogueListener;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.LocaleManager;
+
+import javax.inject.Inject;
 
 public class SignupEpilogueActivity extends AppCompatActivity implements SignupEpilogueListener {
     public static final String EXTRA_SIGNUP_DISPLAY_NAME = "EXTRA_SIGNUP_DISPLAY_NAME";
@@ -20,6 +26,8 @@ public class SignupEpilogueActivity extends AppCompatActivity implements SignupE
     public static final String MAGIC_SIGNUP_PARAMETER = "new_user";
     public static final String MAGIC_SIGNUP_VALUE = "1";
 
+    @Inject SiteStore mSiteStore;
+
     @Override
     protected void attachBaseContext(Context newBase) {
         super.attachBaseContext(LocaleManager.setLocale(newBase));
@@ -28,6 +36,8 @@ public class SignupEpilogueActivity extends AppCompatActivity implements SignupE
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        ((WordPress) getApplication()).component().inject(this);
+
         setContentView(R.layout.signup_epilogue_activity);
 
         if (savedInstanceState == null) {
@@ -51,7 +61,12 @@ public class SignupEpilogueActivity extends AppCompatActivity implements SignupE
 
     @Override
     public void onContinue() {
-        setResult(RESULT_OK);
+        if (mSiteStore.hasSite()) {
+            setResult(RESULT_OK);
+        } else if (AppPrefs.shouldShowPostSignupInterstitial()) {
+            ActivityLauncher.showPostSignupInterstitial(this);
+        }
+
         finish();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignupEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignupEpilogueActivity.java
@@ -12,7 +12,6 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment;
 import org.wordpress.android.ui.accounts.signup.SignupEpilogueListener;
-import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.LocaleManager;
 
 import javax.inject.Inject;
@@ -61,12 +60,11 @@ public class SignupEpilogueActivity extends AppCompatActivity implements SignupE
 
     @Override
     public void onContinue() {
-        if (mSiteStore.hasSite()) {
-            setResult(RESULT_OK);
-        } else if (AppPrefs.shouldShowPostSignupInterstitial()) {
+        if (!mSiteStore.hasSite()) {
             ActivityLauncher.showPostSignupInterstitial(this);
         }
 
+        setResult(RESULT_OK);
         finish();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -199,7 +199,10 @@ public class AppPrefs {
         IS_GUTENBERG_INFORMATIVE_DIALOG_DISABLED,
 
         // indicates whether the system notifications are enabled for the app
-        SYSTEM_NOTIFICATIONS_ENABLED
+        SYSTEM_NOTIFICATIONS_ENABLED,
+
+        // Used to indicate whether or not the the post-signup interstitial must be shown
+        SHOULD_SHOW_POST_SIGNUP_INTERSTITIAL,
     }
 
     private static SharedPreferences prefs() {
@@ -987,6 +990,14 @@ public class AppPrefs {
 
     public static boolean getSystemNotificationsEnabled() {
         return getBoolean(UndeletablePrefKey.SYSTEM_NOTIFICATIONS_ENABLED, true);
+    }
+
+    public static void setShouldShowPostSignupInterstitial(boolean shouldShow) {
+        setBoolean(UndeletablePrefKey.SHOULD_SHOW_POST_SIGNUP_INTERSTITIAL, shouldShow);
+    }
+
+    public static boolean shouldShowPostSignupInterstitial() {
+        return getBoolean(UndeletablePrefKey.SHOULD_SHOW_POST_SIGNUP_INTERSTITIAL, true);
     }
 
     private static List<String> getPostWithHWAccelerationOff() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -50,6 +50,10 @@ class AppPrefsWrapper @Inject constructor() {
         get() = AppPrefs.getSystemNotificationsEnabled()
         set(value) = AppPrefs.setSystemNotificationsEnabled(value)
 
+    var shouldShowPostSignupInterstitial: Boolean
+        get() = AppPrefs.shouldShowPostSignupInterstitial()
+        set(shouldShow) = AppPrefs.setShouldShowPostSignupInterstitial(shouldShow)
+
     fun getAppWidgetSiteId(appWidgetId: Int) = AppPrefs.getStatsWidgetSelectedSiteId(appWidgetId)
     fun setAppWidgetSiteId(siteId: Long, appWidgetId: Int) = AppPrefs.setStatsWidgetSelectedSiteId(siteId, appWidgetId)
     fun removeAppWidgetSiteId(appWidgetId: Int) = AppPrefs.removeStatsWidgetSelectedSiteId(appWidgetId)

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v12_read_following_mine.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v12_read_following_mine.json
@@ -1,7 +1,7 @@
 {
     "request": {
         "method": "GET",
-        "urlPattern": "/rest/v1.2/read/following/mine.*"
+        "urlPattern": "/rest/v1.(1|2)/read/following/mine.*"
     },
     "response": {
         "status": 200,


### PR DESCRIPTION
Fixes #10969

For this PR, I have made the following changes:
- Created a new preference called `SHOULD_SHOW_POST_SIGNUP_INTERSTITIAL` to control whether the screen has already been shown or not.
  - Created a new `UndeletablePrefKey`, since we want the screen to be shown only once per install.
  - It has a default value of `true`, which is changed to `false` when the interstitial is created.
- Created a new method in the `ActivityLauncher` class to launch the interstitial activity.
  - It uses the `TaskStackBuilder` class and the `FLAG_ACTIVITY_CLEAR_TOP` to guarantee the interstitial activity will always be launched on top of `WPMainActivity`.
- Updated `LoginActivity` and `SignupEpilogueActivity` with a logic to check for the need to launch the interstitial activity.
  - Since we need to check if the user has sites, a `SiteStore` instance is now injected into those classes.
  - `LoginActivity` also checks for the newly created preference. 
  - Since this logic is pretty simple, I tried to avoid [early abstractions](https://en.wikipedia.org/wiki/Rule_of_three_(computer_programming)).
- Updated the UI tests for the signup flow, since it needed to account for the interstitial.

| Signup | Login |
|---|---|
| ![signup](https://user-images.githubusercontent.com/830056/71183394-b0fb1c00-2256-11ea-86bb-2dd009f31f5e.gif) | ![login](https://user-images.githubusercontent.com/830056/71184011-cb81c500-2257-11ea-845e-293008229d8e.gif) |

## To test

#### 1. Signup
1. Clear app data.
2. On the initial screen, tap _**Sign up for WordPress.com**_ and _**Sign up with email**_.
3. Enter an email address _that is not associated_ with a WordPress.com account.
4. Complete the signup flow.
5. Confirm that the post-signup interstitial screen is shown.

#### 2. Login (account without sites)
1. Clear app data.
2. On the initial screen, tap _**Log in**._
3. Enter an email address that is associated with an account _that doesn't have any sites_.
4. Complete the login flow.
5. Confirm that the login epilogue screen is **not** shown.
6. Confirm that the post-signup interstitial screen is shown instead.

#### 3. Login (account with sites)
1. Clear app data.
2. On the initial screen, tap _**Log in**_.
3. Enter an email address that is associated with an account _that has at least one site_.
4. Complete the login flow.
5. Confirm that the post-signup interstitial screen  is **not** shown.
6. Confirm that the login epilogue screen is shown instead.

#### 4. Once per app install
1. Complete test 2 and sign out.
2. Repeat test 2 _without clearing the app data_.
3. Confirm that the post-signup interstitial screen is **not** shown.

#### 5. Site creation and site connection flows
1. Complete test 1 or 2.
2. On the post-signup interstitial screen, tap either **Create WordPress.com Site** or **Add Self-Hosted Site**.
3. Complete the flow.
4. Confirm that the main screen is shown.

## Notes
- `LoginEpilogueActivity` seems to not only be shown at the end of the login flow itself, but also in [other flows](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java#L248-L254) related to Jetpack and reauthentication.
  - Because of that, I initially thought of an edge case where I would need to make sure an already authenticated user with no sites wouldn't see the interstitial screen from one of these flows.
  - After a bit of investigation, this seems like it wouldn't be needed. The Jetpack flow seems to only happen when the user already has a site and the interstitial screen doesn't seem to be out of place for the reauthentication flow.
- I’m assuming the only behavior I need to guarantee upon completion (successfully or not) of either the site creation or site connection flow is that the user will be redirected to `WPMainActivity`.
- I haven't felt the need to implement a ViewModel for this screen yet. I might do that after we start tracking the screen events as we may need some unit tests then.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.