### PR TITLE
Accessibility : Posting Activity Stats Improvement

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -32,6 +32,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListAdapter
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TabsItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate
+import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnouncer
 import org.wordpress.android.ui.stats.refresh.utils.StatsNavigator
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.drawDateSelector
@@ -44,6 +45,7 @@ import javax.inject.Inject
 class StatsViewAllFragment : DaggerFragment() {
     @Inject lateinit var viewModelFactoryBuilder: StatsViewAllViewModelFactory.Builder
     @Inject lateinit var imageManager: ImageManager
+    @Inject lateinit var postingActivityBlockAnnouncer: PostingActivityBlockAnnouncer
     @Inject lateinit var navigator: StatsNavigator
     @Inject lateinit var statsSiteProvider: StatsSiteProvider
     private lateinit var viewModel: StatsViewAllViewModel
@@ -237,7 +239,7 @@ class StatsViewAllFragment : DaggerFragment() {
     private fun loadData(recyclerView: RecyclerView, data: List<BlockListItem>) {
         val adapter: BlockListAdapter
         if (recyclerView.adapter == null) {
-            adapter = BlockListAdapter(imageManager)
+            adapter = BlockListAdapter(imageManager, postingActivityBlockAnnouncer)
             recyclerView.adapter = adapter
         } else {
             adapter = recyclerView.adapter as BlockListAdapter

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsBlockAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsBlockAdapter.kt
@@ -16,8 +16,8 @@ import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnounce
 import org.wordpress.android.util.image.ImageManager
 
 class StatsBlockAdapter(
-    val imageManager: ImageManager, private val postingActivityBlockAnnouncer:
-    PostingActivityBlockAnnouncer
+    val imageManager: ImageManager,
+    private val postingActivityBlockAnnouncer: PostingActivityBlockAnnouncer
 ) : Adapter<BaseStatsViewHolder>() {
     private var items: List<StatsBlock> = listOf()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsBlockAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsBlockAdapter.kt
@@ -15,8 +15,10 @@ import org.wordpress.android.ui.stats.refresh.lists.viewholders.LoadingViewHolde
 import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnouncer
 import org.wordpress.android.util.image.ImageManager
 
-class StatsBlockAdapter(val imageManager: ImageManager, private val postingActivityBlockAnnouncer:
-PostingActivityBlockAnnouncer) : Adapter<BaseStatsViewHolder>() {
+class StatsBlockAdapter(
+    val imageManager: ImageManager, private val postingActivityBlockAnnouncer:
+    PostingActivityBlockAnnouncer
+) : Adapter<BaseStatsViewHolder>() {
     private var items: List<StatsBlock> = listOf()
 
     fun update(newItems: List<StatsBlock>) {
@@ -32,8 +34,12 @@ PostingActivityBlockAnnouncer) : Adapter<BaseStatsViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseStatsViewHolder {
         return when (values()[viewType]) {
-            SUCCESS, ERROR, EMPTY -> BlockListViewHolder(parent, imageManager,postingActivityBlockAnnouncer)
-            LOADING -> LoadingViewHolder(parent, imageManager,postingActivityBlockAnnouncer)
+            SUCCESS, ERROR, EMPTY -> BlockListViewHolder(
+                    parent,
+                    imageManager,
+                    postingActivityBlockAnnouncer
+            )
+            LOADING -> LoadingViewHolder(parent, imageManager, postingActivityBlockAnnouncer)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsBlockAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsBlockAdapter.kt
@@ -12,9 +12,11 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsBlock.Type.values
 import org.wordpress.android.ui.stats.refresh.lists.viewholders.BaseStatsViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.viewholders.BlockListViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.viewholders.LoadingViewHolder
+import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnouncer
 import org.wordpress.android.util.image.ImageManager
 
-class StatsBlockAdapter(val imageManager: ImageManager) : Adapter<BaseStatsViewHolder>() {
+class StatsBlockAdapter(val imageManager: ImageManager, private val postingActivityBlockAnnouncer:
+PostingActivityBlockAnnouncer) : Adapter<BaseStatsViewHolder>() {
     private var items: List<StatsBlock> = listOf()
 
     fun update(newItems: List<StatsBlock>) {
@@ -30,8 +32,8 @@ class StatsBlockAdapter(val imageManager: ImageManager) : Adapter<BaseStatsViewH
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseStatsViewHolder {
         return when (values()[viewType]) {
-            SUCCESS, ERROR, EMPTY -> BlockListViewHolder(parent, imageManager)
-            LOADING -> LoadingViewHolder(parent, imageManager)
+            SUCCESS, ERROR, EMPTY -> BlockListViewHolder(parent, imageManager,postingActivityBlockAnnouncer)
+            LOADING -> LoadingViewHolder(parent, imageManager,postingActivityBlockAnnouncer)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -33,7 +33,7 @@ import javax.inject.Inject
 class StatsListFragment : DaggerFragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var imageManager: ImageManager
-    @Inject lateinit var postingActivityBlockAnnouncer : PostingActivityBlockAnnouncer
+    @Inject lateinit var postingActivityBlockAnnouncer: PostingActivityBlockAnnouncer
     @Inject lateinit var statsDateFormatter: StatsDateFormatter
     @Inject lateinit var navigator: StatsNavigator
     private lateinit var viewModel: StatsListViewModel
@@ -223,7 +223,7 @@ class StatsListFragment : DaggerFragment() {
 
         val adapter: StatsBlockAdapter
         if (recyclerView.adapter == null) {
-            adapter = StatsBlockAdapter(imageManager,postingActivityBlockAnnouncer)
+            adapter = StatsBlockAdapter(imageManager, postingActivityBlockAnnouncer)
             recyclerView.adapter = adapter
         } else {
             adapter = recyclerView.adapter as StatsBlockAdapter

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel
 import org.wordpress.android.ui.stats.refresh.lists.detail.DetailListViewModel
+import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnouncer
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsNavigator
 import org.wordpress.android.ui.stats.refresh.utils.drawDateSelector
@@ -32,6 +33,7 @@ import javax.inject.Inject
 class StatsListFragment : DaggerFragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var imageManager: ImageManager
+    @Inject lateinit var postingActivityBlockAnnouncer : PostingActivityBlockAnnouncer
     @Inject lateinit var statsDateFormatter: StatsDateFormatter
     @Inject lateinit var navigator: StatsNavigator
     private lateinit var viewModel: StatsListViewModel
@@ -221,7 +223,7 @@ class StatsListFragment : DaggerFragment() {
 
         val adapter: StatsBlockAdapter
         if (recyclerView.adapter == null) {
-            adapter = StatsBlockAdapter(imageManager)
+            adapter = StatsBlockAdapter(imageManager,postingActivityBlockAnnouncer)
             recyclerView.adapter = adapter
         } else {
             adapter = recyclerView.adapter as StatsBlockAdapter

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
@@ -90,7 +90,7 @@ import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnounce
 import org.wordpress.android.util.image.ImageManager
 
 class BlockListAdapter(val imageManager: ImageManager,
-    var postingActivityBlockAnnouncer: PostingActivityBlockAnnouncer? = null)
+    var postingActivityBlockAnnouncer: PostingActivityBlockAnnouncer)
     : Adapter<BlockListItemViewHolder>() {
     private var items: List<BlockListItem> = listOf()
     fun update(newItems: List<BlockListItem>) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
@@ -86,9 +86,12 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.TagView
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.TextViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.TitleViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ValueViewHolder
+import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnouncer
 import org.wordpress.android.util.image.ImageManager
 
-class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockListItemViewHolder>() {
+class BlockListAdapter(val imageManager: ImageManager,
+    var postingActivityBlockAnnouncer: PostingActivityBlockAnnouncer? = null)
+    : Adapter<BlockListItemViewHolder>() {
     private var items: List<BlockListItem> = listOf()
     fun update(newItems: List<BlockListItem>) {
         val diffResult = DiffUtil.calculateDiff(
@@ -124,7 +127,7 @@ class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockListItemVi
             MAP -> MapViewHolder(parent)
             MAP_LEGEND -> MapLegendViewHolder(parent)
             VALUE_ITEM -> ValueViewHolder(parent)
-            ACTIVITY_ITEM -> ActivityViewHolder(parent)
+            ACTIVITY_ITEM -> ActivityViewHolder(parent,postingActivityBlockAnnouncer)
             REFERRED_ITEM -> ReferredItemViewHolder(parent)
             QUICK_SCAN_ITEM -> QuickScanItemViewHolder(parent)
             LINK_BUTTON -> LinkButtonViewHolder(parent)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
@@ -89,9 +89,10 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ValueVi
 import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnouncer
 import org.wordpress.android.util.image.ImageManager
 
-class BlockListAdapter(val imageManager: ImageManager,
-    var postingActivityBlockAnnouncer: PostingActivityBlockAnnouncer)
-    : Adapter<BlockListItemViewHolder>() {
+class BlockListAdapter(
+    val imageManager: ImageManager,
+    private var postingActivityBlockAnnouncer: PostingActivityBlockAnnouncer
+) : Adapter<BlockListItemViewHolder>() {
     private var items: List<BlockListItem> = listOf()
     fun update(newItems: List<BlockListItem>) {
         val diffResult = DiffUtil.calculateDiff(
@@ -127,7 +128,7 @@ class BlockListAdapter(val imageManager: ImageManager,
             MAP -> MapViewHolder(parent)
             MAP_LEGEND -> MapLegendViewHolder(parent)
             VALUE_ITEM -> ValueViewHolder(parent)
-            ACTIVITY_ITEM -> ActivityViewHolder(parent,postingActivityBlockAnnouncer)
+            ACTIVITY_ITEM -> ActivityViewHolder(parent, postingActivityBlockAnnouncer)
             REFERRED_ITEM -> ReferredItemViewHolder(parent)
             QUICK_SCAN_ITEM -> QuickScanItemViewHolder(parent)
             LINK_BUTTON -> LinkButtonViewHolder(parent)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -234,7 +234,7 @@ sealed class BlockListItem(val type: Type) {
 
     data class ActivityItem(val blocks: List<Block>) : BlockListItem(ACTIVITY_ITEM) {
         data class Block(val label: String, val boxes: List<BoxItem>)
-        data class BoxItem(val box: Box, val contentDescription: String)
+        data class BoxItem(val box: Box, val contentDescription: String? = null)
         enum class Box {
             INVISIBLE, VERY_LOW, LOW, MEDIUM, HIGH, VERY_HIGH
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -233,7 +233,8 @@ sealed class BlockListItem(val type: Type) {
     data class LoadingItem(val loadMore: () -> Unit, val isLoading: Boolean = false) : BlockListItem(LOADING_ITEM)
 
     data class ActivityItem(val blocks: List<Block>) : BlockListItem(ACTIVITY_ITEM) {
-        data class Block(val label: String, val boxes: List<Box>)
+        data class Block(val label: String, val boxes: List<BoxItem>)
+        data class BoxItem(val box: Box, val contentDescription: String)
         enum class Box {
             INVISIBLE, VERY_LOW, LOW, MEDIUM, HIGH, VERY_HIGH
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -233,7 +233,7 @@ sealed class BlockListItem(val type: Type) {
     data class LoadingItem(val loadMore: () -> Unit, val isLoading: Boolean = false) : BlockListItem(LOADING_ITEM)
 
     data class ActivityItem(val blocks: List<Block>) : BlockListItem(ACTIVITY_ITEM) {
-        data class Block(val label: String, val boxes: List<BoxItem>)
+        data class Block(val label: String, val boxItems: List<BoxItem>)
         data class BoxItem(val box: Box, val contentDescription: String? = null)
         enum class Box {
             INVISIBLE, VERY_LOW, LOW, MEDIUM, HIGH, VERY_HIGH

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PostingActivityMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PostingActivityMapper.kt
@@ -3,13 +3,13 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases
 import org.wordpress.android.fluxc.model.stats.insights.PostingActivityModel.Month
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Block
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.HIGH
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.INVISIBLE
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.LOW
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.MEDIUM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.VERY_HIGH
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.VERY_LOW
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.BoxItem
 import org.wordpress.android.util.LocaleManagerWrapper
 import java.util.Calendar
 import javax.inject.Inject
@@ -32,13 +32,14 @@ class PostingActivityMapper
             val firstDayOfWeek = Calendar.getInstance(localeManagerWrapper.getLocale())
             firstDayOfWeek.time = firstDayOfMonth.time
             firstDayOfWeek.set(Calendar.DAY_OF_WEEK, firstDayOfWeek.firstDayOfWeek)
-            val boxes = mutableListOf<Box>()
+            val boxes = mutableListOf<BoxItem>()
             while (firstDayOfWeek.before(firstDayOfMonth)) {
-                boxes.add(INVISIBLE)
+                boxes.add(BoxItem(INVISIBLE,""))
                 firstDayOfWeek.add(Calendar.DAY_OF_MONTH, 1)
             }
             for (day in month.days) {
                 boxes.add(
+                        BoxItem(
                         when {
                             day.value > veryHighLimit -> VERY_HIGH
                             day.value > highLimit -> HIGH
@@ -46,7 +47,7 @@ class PostingActivityMapper
                             day.value > LOW_LEVEL -> LOW
                             else -> VERY_LOW
                         }
-                )
+                ,""))
             }
             blocks.add(
                     Block(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PostingActivityMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PostingActivityMapper.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Activ
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.VERY_HIGH
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.VERY_LOW
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.BoxItem
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.util.LocaleManagerWrapper
 import java.util.Calendar
 import javax.inject.Inject
@@ -20,7 +21,8 @@ private const val MEDIUM_LEVEL = 0.25
 private const val LOW_LEVEL = 0
 
 class PostingActivityMapper
-@Inject constructor(private val localeManagerWrapper: LocaleManagerWrapper) {
+@Inject constructor(private val localeManagerWrapper: LocaleManagerWrapper,private val contentDescriptionHelper:
+ContentDescriptionHelper) {
     fun buildActivityItem(months: List<Month>, max: Int): ActivityItem {
         val blocks = mutableListOf<Block>()
         val veryHighLimit = (max * VERY_HIGH_LEVEL).toInt()
@@ -34,7 +36,7 @@ class PostingActivityMapper
             firstDayOfWeek.set(Calendar.DAY_OF_WEEK, firstDayOfWeek.firstDayOfWeek)
             val boxes = mutableListOf<BoxItem>()
             while (firstDayOfWeek.before(firstDayOfMonth)) {
-                boxes.add(BoxItem(INVISIBLE,""))
+                boxes.add(BoxItem(INVISIBLE))
                 firstDayOfWeek.add(Calendar.DAY_OF_MONTH, 1)
             }
             for (day in month.days) {
@@ -47,7 +49,11 @@ class PostingActivityMapper
                             day.value > LOW_LEVEL -> LOW
                             else -> VERY_LOW
                         }
-                ,""))
+                ,contentDescriptionHelper.buildContentDescription(firstDayOfMonth.getDisplayName(
+                                Calendar.MONTH,
+                                Calendar.SHORT,
+                                localeManagerWrapper.getLocale()
+                        ),day.key,day.value)))
             }
             blocks.add(
                     Block(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PostingActivityMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PostingActivityMapper.kt
@@ -21,8 +21,10 @@ private const val MEDIUM_LEVEL = 0.25
 private const val LOW_LEVEL = 0
 
 class PostingActivityMapper
-@Inject constructor(private val localeManagerWrapper: LocaleManagerWrapper,private val contentDescriptionHelper:
-ContentDescriptionHelper) {
+@Inject constructor(
+    private val localeManagerWrapper: LocaleManagerWrapper, private val contentDescriptionHelper:
+    ContentDescriptionHelper
+) {
     fun buildActivityItem(months: List<Month>, max: Int): ActivityItem {
         val blocks = mutableListOf<Block>()
         val veryHighLimit = (max * VERY_HIGH_LEVEL).toInt()
@@ -42,18 +44,22 @@ ContentDescriptionHelper) {
             for (day in month.days) {
                 boxes.add(
                         BoxItem(
-                        when {
-                            day.value > veryHighLimit -> VERY_HIGH
-                            day.value > highLimit -> HIGH
-                            day.value > mediumLimit -> MEDIUM
-                            day.value > LOW_LEVEL -> LOW
-                            else -> VERY_LOW
-                        }
-                ,contentDescriptionHelper.buildContentDescription(firstDayOfMonth.getDisplayName(
-                                Calendar.MONTH,
-                                Calendar.SHORT,
-                                localeManagerWrapper.getLocale()
-                        ),day.key,day.value)))
+                                when {
+                                    day.value > veryHighLimit -> VERY_HIGH
+                                    day.value > highLimit -> HIGH
+                                    day.value > mediumLimit -> MEDIUM
+                                    day.value > LOW_LEVEL -> LOW
+                                    else -> VERY_LOW
+                                }
+                                , contentDescriptionHelper.buildContentDescription(
+                                firstDayOfMonth.getDisplayName(
+                                        Calendar.MONTH,
+                                        Calendar.SHORT,
+                                        localeManagerWrapper.getLocale()
+                                ), day.key, day.value
+                        )
+                        )
+                )
             }
             blocks.add(
                     Block(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PostingActivityMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PostingActivityMapper.kt
@@ -22,8 +22,8 @@ private const val LOW_LEVEL = 0
 
 class PostingActivityMapper
 @Inject constructor(
-    private val localeManagerWrapper: LocaleManagerWrapper, private val contentDescriptionHelper:
-    ContentDescriptionHelper
+    private val localeManagerWrapper: LocaleManagerWrapper,
+    private val contentDescriptionHelper: ContentDescriptionHelper
 ) {
     fun buildActivityItem(months: List<Month>, max: Int): ActivityItem {
         val blocks = mutableListOf<Block>()
@@ -50,8 +50,7 @@ class PostingActivityMapper
                                     day.value > mediumLimit -> MEDIUM
                                     day.value > LOW_LEVEL -> LOW
                                     else -> VERY_LOW
-                                }
-                                , contentDescriptionHelper.buildContentDescription(
+                                }, contentDescriptionHelper.buildContentDescription(
                                 firstDayOfMonth.getDisplayName(
                                         Calendar.MONTH,
                                         Calendar.SHORT,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.BoxItem
 import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnouncer
 
 private const val SIZE_PADDING = 32
@@ -57,8 +57,7 @@ PostingActivityBlockAnnouncer?)
     }
 
     private fun setupBlocksForAccessibility(activityItem: ActivityItem) {
-        postingActivityBlockAnnouncer?.onBlocksInflated(firstBlock, secondBlock, thirdBlock)
-        postingActivityBlockAnnouncer?.onActivityItemBound(activityItem)
+        postingActivityBlockAnnouncer?.initialize(activityItem,firstBlock, secondBlock, thirdBlock)
     }
 
     private fun updateVisibility(
@@ -79,7 +78,7 @@ PostingActivityBlockAnnouncer?)
         }
     }
 
-    private fun drawBlock(recyclerView: RecyclerView, boxes: List<Box>) {
+    private fun drawBlock(recyclerView: RecyclerView, boxes: List<BoxItem>) {
         if (recyclerView.adapter == null) {
             recyclerView.adapter = MonthActivityAdapter()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
@@ -3,9 +3,7 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
 import android.graphics.Rect
 import android.view.View
 import android.view.ViewGroup
-import android.view.accessibility.AccessibilityEvent
 import android.widget.LinearLayout
-import androidx.core.view.AccessibilityDelegateCompat
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.stats_block_single_activity.view.*
@@ -17,16 +15,16 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.BoxItem
 import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnouncer
-import org.wordpress.android.util.AccessibilityUtils
 
 private const val SIZE_PADDING = 32
 private const val GAP = 8
 private const val BLOCK_WIDTH = 104
 private const val SPAN_COUNT = 7
 
-class ActivityViewHolder(val parent: ViewGroup, private var postingActivityBlockAnnouncer:
-PostingActivityBlockAnnouncer)
-    : BlockListItemViewHolder(
+class ActivityViewHolder(
+    val parent: ViewGroup, private var postingActivityBlockAnnouncer:
+    PostingActivityBlockAnnouncer
+) : BlockListItemViewHolder(
         parent,
         R.layout.stats_block_activity_item
 ) {
@@ -60,7 +58,7 @@ PostingActivityBlockAnnouncer)
     }
 
     private fun setupBlocksForAccessibility(activityItem: ActivityItem) {
-        postingActivityBlockAnnouncer.initialize(activityItem,firstBlock, secondBlock, thirdBlock)
+        postingActivityBlockAnnouncer.initialize(activityItem, firstBlock, secondBlock, thirdBlock)
     }
 
     private fun updateVisibility(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
@@ -35,14 +35,14 @@ class ActivityViewHolder(
     fun bind(
         item: ActivityItem
     ) {
-        drawBlock(firstBlock.activity, item.blocks[0].boxes)
+        drawBlock(firstBlock.activity, item.blocks[0].boxItems)
         firstBlock.label.text = item.blocks[0].label
         if (item.blocks.size > 1) {
-            drawBlock(secondBlock.activity, item.blocks[1].boxes)
+            drawBlock(secondBlock.activity, item.blocks[1].boxItems)
             secondBlock.label.text = item.blocks[1].label
         }
         if (item.blocks.size > 2) {
-            drawBlock(thirdBlock.activity, item.blocks[2].boxes)
+            drawBlock(thirdBlock.activity, item.blocks[2].boxItems)
             thirdBlock.label.text = item.blocks[2].label
         }
         val widthInDp = parent.width / parent.context.resources.displayMetrics.density

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
@@ -52,6 +52,21 @@ class ActivityViewHolder(val parent: ViewGroup,val postingActivityBlockAnnouncer
                 updateVisibility(item, parent.width / parent.context.resources.displayMetrics.density)
             }
         }
+        setupBlocksForAccessibility(item)
+    }
+
+    private fun setupBlocksForAccessibility(activityItem: ActivityItem) {
+        postingActivityBlockAnnouncer?.onBlockBinded(activityItem)
+
+        val blocks = listOf<View>(firstBlock, secondBlock, thirdBlock)
+
+        blocks.forEach {
+            it.setOnClickListener { view: View? ->
+                postingActivityBlockAnnouncer?.onBlockClicked(
+                        view
+                )
+            }
+        }
     }
 
     private fun updateVisibility(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
@@ -22,8 +22,8 @@ private const val BLOCK_WIDTH = 104
 private const val SPAN_COUNT = 7
 
 class ActivityViewHolder(
-    val parent: ViewGroup, private var postingActivityBlockAnnouncer:
-    PostingActivityBlockAnnouncer
+    val parent: ViewGroup,
+    private var postingActivityBlockAnnouncer: PostingActivityBlockAnnouncer
 ) : BlockListItemViewHolder(
         parent,
         R.layout.stats_block_activity_item

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
@@ -21,7 +21,8 @@ private const val GAP = 8
 private const val BLOCK_WIDTH = 104
 private const val SPAN_COUNT = 7
 
-class ActivityViewHolder(val parent: ViewGroup,val postingActivityBlockAnnouncer: PostingActivityBlockAnnouncer?)
+class ActivityViewHolder(val parent: ViewGroup, private val postingActivityBlockAnnouncer:
+PostingActivityBlockAnnouncer?)
     : BlockListItemViewHolder(
         parent,
         R.layout.stats_block_activity_item
@@ -56,17 +57,8 @@ class ActivityViewHolder(val parent: ViewGroup,val postingActivityBlockAnnouncer
     }
 
     private fun setupBlocksForAccessibility(activityItem: ActivityItem) {
-        postingActivityBlockAnnouncer?.onBlockBinded(activityItem)
-
-        val blocks = listOf<View>(firstBlock, secondBlock, thirdBlock)
-
-        blocks.forEach {
-            it.setOnClickListener { view: View? ->
-                postingActivityBlockAnnouncer?.onBlockClicked(
-                        view
-                )
-            }
-        }
+        postingActivityBlockAnnouncer?.onBlocksInflated(firstBlock, secondBlock, thirdBlock)
+        postingActivityBlockAnnouncer?.onActivityItemBound(activityItem)
     }
 
     private fun updateVisibility(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
@@ -3,7 +3,9 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
 import android.graphics.Rect
 import android.view.View
 import android.view.ViewGroup
+import android.view.accessibility.AccessibilityEvent
 import android.widget.LinearLayout
+import androidx.core.view.AccessibilityDelegateCompat
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.stats_block_single_activity.view.*
@@ -15,14 +17,15 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.BoxItem
 import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnouncer
+import org.wordpress.android.util.AccessibilityUtils
 
 private const val SIZE_PADDING = 32
 private const val GAP = 8
 private const val BLOCK_WIDTH = 104
 private const val SPAN_COUNT = 7
 
-class ActivityViewHolder(val parent: ViewGroup, private val postingActivityBlockAnnouncer:
-PostingActivityBlockAnnouncer?)
+class ActivityViewHolder(val parent: ViewGroup, private var postingActivityBlockAnnouncer:
+PostingActivityBlockAnnouncer)
     : BlockListItemViewHolder(
         parent,
         R.layout.stats_block_activity_item
@@ -57,7 +60,7 @@ PostingActivityBlockAnnouncer?)
     }
 
     private fun setupBlocksForAccessibility(activityItem: ActivityItem) {
-        postingActivityBlockAnnouncer?.initialize(activityItem,firstBlock, secondBlock, thirdBlock)
+        postingActivityBlockAnnouncer.initialize(activityItem,firstBlock, secondBlock, thirdBlock)
     }
 
     private fun updateVisibility(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
@@ -14,13 +14,15 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box
+import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnouncer
 
 private const val SIZE_PADDING = 32
 private const val GAP = 8
 private const val BLOCK_WIDTH = 104
 private const val SPAN_COUNT = 7
 
-class ActivityViewHolder(val parent: ViewGroup) : BlockListItemViewHolder(
+class ActivityViewHolder(val parent: ViewGroup,val postingActivityBlockAnnouncer: PostingActivityBlockAnnouncer?)
+    : BlockListItemViewHolder(
         parent,
         R.layout.stats_block_activity_item
 ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/DayViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/DayViewHolder.kt
@@ -5,13 +5,13 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import org.wordpress.android.R
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.HIGH
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.INVISIBLE
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.LOW
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.MEDIUM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.VERY_HIGH
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.VERY_LOW
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.BoxItem
 
 class DayViewHolder(parent: ViewGroup) : ViewHolder(
         LayoutInflater.from(parent.context).inflate(
@@ -20,8 +20,8 @@ class DayViewHolder(parent: ViewGroup) : ViewHolder(
                 false
         )
 ) {
-    fun bind(box: Box) {
-        val color = when (box) {
+    fun bind(box: BoxItem) {
+        val color = when (box.box) {
             INVISIBLE -> android.R.color.transparent
             VERY_LOW -> R.color.neutral_10
             LOW -> R.color.stats_activity_low

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/DayViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/DayViewHolder.kt
@@ -20,8 +20,8 @@ class DayViewHolder(parent: ViewGroup) : ViewHolder(
                 false
         )
 ) {
-    fun bind(box: BoxItem) {
-        val color = when (box.box) {
+    fun bind(boxItem: BoxItem) {
+        val color = when (boxItem.box) {
             INVISIBLE -> android.R.color.transparent
             VERY_LOW -> R.color.neutral_10
             LOW -> R.color.stats_activity_low

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MonthActivityAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MonthActivityAdapter.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView.Adapter
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.BoxItem
 
 class MonthActivityAdapter : Adapter<DayViewHolder>() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MonthActivityAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MonthActivityAdapter.kt
@@ -4,10 +4,11 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView.Adapter
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.BoxItem
 
 class MonthActivityAdapter : Adapter<DayViewHolder>() {
-    private var items: List<Box> = listOf()
-    fun update(newItems: List<Box>) {
+    private var items: List<BoxItem> = listOf()
+    fun update(newItems: List<BoxItem>) {
         val diffResult = DiffUtil.calculateDiff(BoxDiffCallback(items, newItems))
         items = newItems
 
@@ -30,8 +31,8 @@ class MonthActivityAdapter : Adapter<DayViewHolder>() {
     }
 
     private class BoxDiffCallback(
-        private val oldItems: List<Box>,
-        private val newItems: List<Box>
+        private val oldItems: List<BoxItem>,
+        private val newItems: List<BoxItem>
     ) : DiffUtil.Callback() {
         override fun areItemsTheSame(oldPosition: Int, newPosition: Int): Boolean {
             return oldItems[oldPosition] == newItems[newPosition]

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/BlockListViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/BlockListViewHolder.kt
@@ -11,7 +11,11 @@ import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnounce
 import org.wordpress.android.ui.stats.refresh.utils.WrappingLinearLayoutManager
 import org.wordpress.android.util.image.ImageManager
 
-open class BlockListViewHolder(parent: ViewGroup, val imageManager: ImageManager, val postingActivityBlockAnnouncer: PostingActivityBlockAnnouncer) : BaseStatsViewHolder(
+open class BlockListViewHolder(
+    parent: ViewGroup,
+    val imageManager: ImageManager,
+    private val postingActivityBlockAnnouncer: PostingActivityBlockAnnouncer
+) : BaseStatsViewHolder(
         parent,
         R.layout.stats_list_block
 ) {
@@ -20,7 +24,7 @@ open class BlockListViewHolder(parent: ViewGroup, val imageManager: ImageManager
         super.bind(statsType, items)
         list.isNestedScrollingEnabled = false
         if (list.adapter == null) {
-            val blockListAdapter = BlockListAdapter(imageManager,postingActivityBlockAnnouncer)
+            val blockListAdapter = BlockListAdapter(imageManager, postingActivityBlockAnnouncer)
             val layoutManager = WrappingLinearLayoutManager(
                     list.context,
                     LinearLayoutManager.VERTICAL,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/BlockListViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/BlockListViewHolder.kt
@@ -7,10 +7,11 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.StatsStore.StatsType
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListAdapter
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
+import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnouncer
 import org.wordpress.android.ui.stats.refresh.utils.WrappingLinearLayoutManager
 import org.wordpress.android.util.image.ImageManager
 
-open class BlockListViewHolder(parent: ViewGroup, val imageManager: ImageManager) : BaseStatsViewHolder(
+open class BlockListViewHolder(parent: ViewGroup, val imageManager: ImageManager, val postingActivityBlockAnnouncer: PostingActivityBlockAnnouncer) : BaseStatsViewHolder(
         parent,
         R.layout.stats_list_block
 ) {
@@ -19,7 +20,7 @@ open class BlockListViewHolder(parent: ViewGroup, val imageManager: ImageManager
         super.bind(statsType, items)
         list.isNestedScrollingEnabled = false
         if (list.adapter == null) {
-            val blockListAdapter = BlockListAdapter(imageManager)
+            val blockListAdapter = BlockListAdapter(imageManager,postingActivityBlockAnnouncer)
             val layoutManager = WrappingLinearLayoutManager(
                     list.context,
                     LinearLayoutManager.VERTICAL,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/LoadingViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/LoadingViewHolder.kt
@@ -10,8 +10,10 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnouncer
 import org.wordpress.android.util.image.ImageManager
 
-class LoadingViewHolder(parent: ViewGroup, val imageManager: ImageManager, private val postingActivityBlockAnnouncer:
-PostingActivityBlockAnnouncer) : BaseStatsViewHolder(
+class LoadingViewHolder(
+    parent: ViewGroup, val imageManager: ImageManager, private val postingActivityBlockAnnouncer:
+    PostingActivityBlockAnnouncer
+) : BaseStatsViewHolder(
         parent,
         R.layout.stats_loading_view
 ) {
@@ -21,7 +23,7 @@ PostingActivityBlockAnnouncer) : BaseStatsViewHolder(
         list.isNestedScrollingEnabled = false
         if (list.adapter == null) {
             list.layoutManager = LinearLayoutManager(list.context, RecyclerView.VERTICAL, false)
-            list.adapter = BlockListAdapter(imageManager,postingActivityBlockAnnouncer)
+            list.adapter = BlockListAdapter(imageManager, postingActivityBlockAnnouncer)
         }
         (list.adapter as BlockListAdapter).update(items)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/LoadingViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/LoadingViewHolder.kt
@@ -11,8 +11,8 @@ import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnounce
 import org.wordpress.android.util.image.ImageManager
 
 class LoadingViewHolder(
-    parent: ViewGroup, val imageManager: ImageManager, private val postingActivityBlockAnnouncer:
-    PostingActivityBlockAnnouncer
+    parent: ViewGroup, val imageManager: ImageManager,
+    private val postingActivityBlockAnnouncer: PostingActivityBlockAnnouncer
 ) : BaseStatsViewHolder(
         parent,
         R.layout.stats_loading_view

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/LoadingViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/LoadingViewHolder.kt
@@ -7,9 +7,11 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.StatsStore
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListAdapter
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
+import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnouncer
 import org.wordpress.android.util.image.ImageManager
 
-class LoadingViewHolder(parent: ViewGroup, val imageManager: ImageManager) : BaseStatsViewHolder(
+class LoadingViewHolder(parent: ViewGroup, val imageManager: ImageManager, private val postingActivityBlockAnnouncer:
+PostingActivityBlockAnnouncer) : BaseStatsViewHolder(
         parent,
         R.layout.stats_loading_view
 ) {
@@ -19,7 +21,7 @@ class LoadingViewHolder(parent: ViewGroup, val imageManager: ImageManager) : Bas
         list.isNestedScrollingEnabled = false
         if (list.adapter == null) {
             list.layoutManager = LinearLayoutManager(list.context, RecyclerView.VERTICAL, false)
-            list.adapter = BlockListAdapter(imageManager)
+            list.adapter = BlockListAdapter(imageManager,postingActivityBlockAnnouncer)
         }
         (list.adapter as BlockListAdapter).update(items)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/LoadingViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/LoadingViewHolder.kt
@@ -11,7 +11,8 @@ import org.wordpress.android.ui.stats.refresh.utils.PostingActivityBlockAnnounce
 import org.wordpress.android.util.image.ImageManager
 
 class LoadingViewHolder(
-    parent: ViewGroup, val imageManager: ImageManager,
+    parent: ViewGroup,
+    val imageManager: ImageManager,
     private val postingActivityBlockAnnouncer: PostingActivityBlockAnnouncer
 ) : BaseStatsViewHolder(
         parent,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
@@ -38,4 +38,22 @@ class ContentDescriptionHelper
             false -> "${resourceProvider.getString(keyLabel)}: $key"
         }
     }
+
+    fun buildContentDescription(month: String, days: Int, posts: Int): String {
+        return if (posts > 1) {
+            resourceProvider.getString(
+                    R.string.stats_posting_activity_description_plural,
+                    month,
+                    days,
+                    posts
+            )
+        } else {
+            resourceProvider.getString(
+                    R.string.stats_posting_activity_description,
+                    month,
+                    days,
+                    posts
+            )
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
@@ -72,6 +72,8 @@ class PostingActivityBlockAnnouncer
                 if (currentBoxIndex != boxes.size - 1) {
                     currentBoxIndex++
                 } else {
+                    view.announceForAccessibility(resourceProvider.getString(
+                            R.string.stats_posting_activity_end_description))
                     currentBoxIndex = 0
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.ui.stats.refresh.utils
+
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem
+import javax.inject.Inject
+
+class PostingActivityBlockAnnouncer
+@Inject constructor() {
+    private var activityItem: ActivityItem? = null
+    private var currentBoxIndex: Int? = null
+    private var currentBlockIndex: Int? = null
+
+    fun onBlockClicked() {
+
+    }
+
+    fun onBlockFocused() {
+
+    }
+
+    fun onBlockBinded(activityItem: ActivityItem) {
+
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
@@ -1,21 +1,63 @@
 package org.wordpress.android.ui.stats.refresh.utils
 
 import android.view.View
+import android.view.accessibility.AccessibilityEvent
+import androidx.core.view.AccessibilityDelegateCompat
+import androidx.core.view.accessibility.AccessibilityEventCompat.TYPE_VIEW_ACCESSIBILITY_FOCUSED
+import androidx.core.view.accessibility.AccessibilityEventCompat.TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED
+import androidx.core.view.accessibility.AccessibilityEventCompat.TYPE_VIEW_CONTEXT_CLICKED
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem
+import org.wordpress.android.util.AccessibilityUtils
 import javax.inject.Inject
 
 class PostingActivityBlockAnnouncer
 @Inject constructor() {
-    private var activityItem: ActivityItem? = null
-    private var currentBoxIndex: Int? = null
-    private var currentBlockIndex: Int? = null
-    private var blockViews:List<View>? = null 
+    private lateinit var activityItem: ActivityItem
+    private var currentBoxIndex: Int = 0
+    private var currentBlockIndex: Int = 0
+    private lateinit var blockViews: List<View>
 
-     fun onBlocksInflated(vararg blockViews:View) {
-         this.blockViews = blockViews.toList()
+    fun initialize(activityItem: ActivityItem, vararg blockViews: View) {
+        this.activityItem = activityItem
+        this.blockViews = blockViews.toList()
+
+        setupViewDelegate()
     }
 
-    fun onActivityItemBound(activityItem: ActivityItem) {
-        this.activityItem = activityItem
+    private fun setupViewDelegate() {
+        blockViews.forEach {
+            AccessibilityUtils.setAccessibilityDelegateSafely(
+                    it,
+                    object : AccessibilityDelegateCompat() {
+                        override fun onPopulateAccessibilityEvent(
+                            host: View?,
+                            event: AccessibilityEvent?
+                        ) {
+                            super.onPopulateAccessibilityEvent(host, event)
+                            when (event?.eventType) {
+                                TYPE_VIEW_ACCESSIBILITY_FOCUSED -> {
+                                    val view = blockViews.find { view -> view.id == host?.id }
+                                    currentBlockIndex = blockViews.indexOf(view)
+                                    currentBoxIndex = 0
+                                }
+
+                                TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED -> {
+                                    currentBlockIndex = 0
+                                    currentBoxIndex = 0
+                                }
+
+                                TYPE_VIEW_CONTEXT_CLICKED -> {
+                                    val box = activityItem.blocks[currentBlockIndex].boxes[currentBoxIndex]
+                                    host?.announceForAccessibility(box.contentDescription)
+                                    if (currentBoxIndex != activityItem.blocks.size - 1) {
+                                        currentBoxIndex++
+                                    } else {
+                                        currentBoxIndex = 0
+                                    }
+                                }
+                            }
+                        }
+                    })
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
@@ -34,12 +34,10 @@ class PostingActivityBlockAnnouncer
                             event: AccessibilityEvent?
                         ) {
                             super.onPopulateAccessibilityEvent(host, event)
-                            when (event?.eventType) {
-                                TYPE_VIEW_ACCESSIBILITY_FOCUSED -> {
-                                    val view = blockViews.find { view -> view.id == host?.id }
-                                    currentBlockIndex = blockViews.indexOf(view)
-                                    currentBoxIndex = 0
-                                }
+                            if (event?.eventType == TYPE_VIEW_ACCESSIBILITY_FOCUSED) {
+                                val view = blockViews.find { view -> view.id == host?.id }
+                                currentBlockIndex = blockViews.indexOf(view)
+                                currentBoxIndex = 0
                             }
                         }
                     })

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
@@ -3,7 +3,10 @@ package org.wordpress.android.ui.stats.refresh.utils
 import android.view.View
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED
+import android.view.accessibility.AccessibilityNodeInfo.ACTION_CLICK
 import androidx.core.view.AccessibilityDelegateCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
+import org.wordpress.android.R
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.INVISIBLE
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.VERY_LOW
@@ -39,6 +42,16 @@ class PostingActivityBlockAnnouncer
                                 currentBlockIndex = blockViews.indexOf(view)
                                 currentBoxIndex = 0
                             }
+                        }
+
+                        override fun onInitializeAccessibilityNodeInfo(
+                            host: View?,
+                            info: AccessibilityNodeInfoCompat?
+                        ) {
+                            super.onInitializeAccessibilityNodeInfo(host, info)
+                            info?.addAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat(
+                                    ACTION_CLICK, host?.context?.getString(
+                                    R.string.stats_posting_activity_action)))
                         }
                     })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
@@ -68,7 +68,7 @@ class PostingActivityBlockAnnouncer
 
                 // If a box has no stats then it's ignored.
                 while (boxItem.box == INVISIBLE || boxItem.box == VERY_LOW) {
-                    currentBoxIndex.inc()
+                    currentBoxIndex++
 
                     // If the end of the box list was reached then restart the index.
                     if (currentBoxIndex == boxItems.size - 1) {
@@ -100,7 +100,7 @@ class PostingActivityBlockAnnouncer
 
                 // If this isn't the last box then increase the index if not then announce that we reached the end.
                 if (currentBoxIndex != boxItems.size - 1) {
-                    currentBoxIndex.inc()
+                    currentBoxIndex++
                 } else {
                     view.announceForAccessibility(
                             resourceProvider.getString(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
@@ -11,10 +11,11 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Activ
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.INVISIBLE
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box.VERY_LOW
 import org.wordpress.android.util.AccessibilityUtils
+import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
 class PostingActivityBlockAnnouncer
-@Inject constructor() {
+@Inject constructor(private val resourceProvider: ResourceProvider) {
     private lateinit var activityItem: ActivityItem
     private var currentBoxIndex: Int = 0
     private var currentBlockIndex: Int = 0
@@ -50,7 +51,7 @@ class PostingActivityBlockAnnouncer
                         ) {
                             super.onInitializeAccessibilityNodeInfo(host, info)
                             info?.addAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat(
-                                    ACTION_CLICK, host?.context?.getString(
+                                    ACTION_CLICK, resourceProvider.getString(
                                     R.string.stats_posting_activity_action)))
                         }
                     })

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.utils
 
+import android.view.View
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem
 import javax.inject.Inject
 
@@ -9,7 +10,7 @@ class PostingActivityBlockAnnouncer
     private var currentBoxIndex: Int? = null
     private var currentBlockIndex: Int? = null
 
-    fun onBlockClicked() {
+     fun onBlockClicked(block:View?) {
 
     }
 
@@ -18,6 +19,6 @@ class PostingActivityBlockAnnouncer
     }
 
     fun onBlockBinded(activityItem: ActivityItem) {
-
+        this.activityItem = activityItem
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
@@ -9,16 +9,13 @@ class PostingActivityBlockAnnouncer
     private var activityItem: ActivityItem? = null
     private var currentBoxIndex: Int? = null
     private var currentBlockIndex: Int? = null
+    private var blockViews:List<View>? = null 
 
-     fun onBlockClicked(block:View?) {
-
+     fun onBlocksInflated(vararg blockViews:View) {
+         this.blockViews = blockViews.toList()
     }
 
-    fun onBlockFocused() {
-
-    }
-
-    fun onBlockBinded(activityItem: ActivityItem) {
+    fun onActivityItemBound(activityItem: ActivityItem) {
         this.activityItem = activityItem
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
@@ -63,7 +63,7 @@ class PostingActivityBlockAnnouncer
                     })
 
             blockView.setOnClickListener { view ->
-                val boxItems = activityItem.blocks[currentBlockIndex].boxes
+                val boxItems = activityItem.blocks[currentBlockIndex].boxItems
                 var boxItem = boxItems[currentBoxIndex]
 
                 // If a box has no stats then it's ignored.

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/PostingActivityBlockAnnouncer.kt
@@ -68,7 +68,7 @@ class PostingActivityBlockAnnouncer
 
                 // If a box has no stats then it's ignored.
                 while (boxItem.box == INVISIBLE || boxItem.box == VERY_LOW) {
-                    currentBoxIndex++
+                    currentBoxIndex.inc()
 
                     // If the end of the box list was reached then restart the index.
                     if (currentBoxIndex == boxItems.size - 1) {
@@ -85,6 +85,7 @@ class PostingActivityBlockAnnouncer
                                     )
                             )
                         }
+
                         currentBoxIndex = 0
                         return@setOnClickListener
                     }
@@ -99,7 +100,7 @@ class PostingActivityBlockAnnouncer
 
                 // If this isn't the last box then increase the index if not then announce that we reached the end.
                 if (currentBoxIndex != boxItems.size - 1) {
-                    currentBoxIndex++
+                    currentBoxIndex.inc()
                 } else {
                     view.announceForAccessibility(
                             resourceProvider.getString(

--- a/WordPress/src/main/res/layout/stats_block_activity_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_activity_item.xml
@@ -6,9 +6,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:animateLayoutChanges="true"
-    android:contentDescription="@string/stats_posting_activity_graph">
+    android:importantForAccessibility="no">
 
-    <include
+<include
         android:id="@+id/first_activity"
         layout="@layout/stats_block_single_activity"
         android:layout_width="0dp"

--- a/WordPress/src/main/res/layout/stats_block_single_activity.xml
+++ b/WordPress/src/main/res/layout/stats_block_single_activity.xml
@@ -5,7 +5,6 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:gravity="center_horizontal"
-    android:importantForAccessibility="no"
     android:orientation="vertical">
 
     <androidx.recyclerview.widget.RecyclerView
@@ -14,7 +13,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
         android:layout_marginTop="8dp"
-        android:importantForAccessibility="no"/>
+        />
 
     <TextView
         android:id="@+id/label"
@@ -22,6 +21,5 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
-        android:importantForAccessibility="no"
         tools:text="Jan"/>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/stats_block_single_activity.xml
+++ b/WordPress/src/main/res/layout/stats_block_single_activity.xml
@@ -5,15 +5,15 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:gravity="center_horizontal"
+    android:importantForAccessibility="yes"
     android:orientation="vertical">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/activity"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
         android:layout_marginTop="8dp"
-        />
+        android:layout_marginBottom="8dp" />
 
     <TextView
         android:id="@+id/label"
@@ -21,5 +21,5 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
-        tools:text="Jan"/>
+        tools:text="Jan" />
 </LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -882,7 +882,7 @@
     <string name="stats_list_item_description">%1$s: %2$s, %3$s: %4$s</string>
     <string name="stats_posting_activity_description">%1$s %2$d, %3$d post</string>
     <string name="stats_posting_activity_description_plural">%1$s %2$d, %3$d posts</string>
-    <string name="stats_posting_activity_action">navigate all stats for this period.</string>
+    <string name="stats_posting_activity_action">navigate all stats for this period</string>
     <string name="stats_posting_activity_empty_description">There are no stats in this period.</string>
     <string name="stats_posting_activity_end_description">You have heard all stats for this period.
         Tapping again will restart from the beginning.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -882,6 +882,7 @@
     <string name="stats_list_item_description">%1$s: %2$s, %3$s: %4$s</string>
     <string name="stats_posting_activity_description">%1$s %2$d, %3$d post</string>
     <string name="stats_posting_activity_description_plural">%1$s %2$d, %3$d posts</string>
+    <string name="stats_posting_activity_action">navigate all stats for this period.</string>
 
     <string name="stats_manage_your_stats">Manage Your Stats</string>
     <string name="stats_management_news_card_message">Choose what stats to see, and focus on the data you care most about. Tap %1$s at the bottom of Insights to customise your stats.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -883,6 +883,8 @@
     <string name="stats_posting_activity_description">%1$s %2$d, %3$d post</string>
     <string name="stats_posting_activity_description_plural">%1$s %2$d, %3$d posts</string>
     <string name="stats_posting_activity_action">navigate all stats for this period.</string>
+    <string name="stats_posting_activity_end_description">You have heard all stats for this period.
+        Tapping again will restart from the beginning.</string>
 
     <string name="stats_manage_your_stats">Manage Your Stats</string>
     <string name="stats_management_news_card_message">Choose what stats to see, and focus on the data you care most about. Tap %1$s at the bottom of Insights to customise your stats.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -880,6 +880,8 @@
     <string name="stats_item_collapsed">Item collapsed</string>
     <string name="stats_posting_activity_graph">Graph of posting activity.</string>
     <string name="stats_list_item_description">%1$s: %2$s, %3$s: %4$s</string>
+    <string name="stats_posting_activity_description">%1$s %2$d %3$d post</string>
+    <string name="stats_posting_activity_description_plural">%1$s %2$d %3$d posts</string>
 
     <string name="stats_manage_your_stats">Manage Your Stats</string>
     <string name="stats_management_news_card_message">Choose what stats to see, and focus on the data you care most about. Tap %1$s at the bottom of Insights to customise your stats.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -878,7 +878,6 @@
     <string name="stats_collapse_content_description">Collapse</string>
     <string name="stats_item_expanded">Item expanded</string>
     <string name="stats_item_collapsed">Item collapsed</string>
-    <string name="stats_posting_activity_graph">Graph of posting activity.</string>
     <string name="stats_list_item_description">%1$s: %2$s, %3$s: %4$s</string>
     <string name="stats_posting_activity_description">%1$s %2$d, %3$d post</string>
     <string name="stats_posting_activity_description_plural">%1$s %2$d, %3$d posts</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -880,8 +880,8 @@
     <string name="stats_item_collapsed">Item collapsed</string>
     <string name="stats_posting_activity_graph">Graph of posting activity.</string>
     <string name="stats_list_item_description">%1$s: %2$s, %3$s: %4$s</string>
-    <string name="stats_posting_activity_description">%1$s %2$d %3$d post</string>
-    <string name="stats_posting_activity_description_plural">%1$s %2$d %3$d posts</string>
+    <string name="stats_posting_activity_description">%1$s %2$d, %3$d post</string>
+    <string name="stats_posting_activity_description_plural">%1$s %2$d, %3$d posts</string>
 
     <string name="stats_manage_your_stats">Manage Your Stats</string>
     <string name="stats_management_news_card_message">Choose what stats to see, and focus on the data you care most about. Tap %1$s at the bottom of Insights to customise your stats.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -883,6 +883,7 @@
     <string name="stats_posting_activity_description">%1$s %2$d, %3$d post</string>
     <string name="stats_posting_activity_description_plural">%1$s %2$d, %3$d posts</string>
     <string name="stats_posting_activity_action">navigate all stats for this period.</string>
+    <string name="stats_posting_activity_empty_description">There are no stats in this period.</string>
     <string name="stats_posting_activity_end_description">You have heard all stats for this period.
         Tapping again will restart from the beginning.</string>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCaseTest.kt
@@ -84,7 +84,7 @@ class SearchTermsUseCaseTest : BaseUnitTest() {
                 )
         )
         whenever(contentDescriptionHelper.buildContentDescription(
-                any(),
+                any<Header>(),
                 any<Int>(),
                 any()
         )).thenReturn(contentDescription)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PostingActivityMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PostingActivityMapperTest.kt
@@ -43,18 +43,18 @@ class PostingActivityMapperTest : BaseUnitTest() {
         val result = mapper.buildActivityItem(listOf(Month(2018, Calendar.JULY, days)), max)
         assertThat(result.blocks).hasSize(1)
         result.blocks[0].let {
-            assertThat(it.boxes).hasSize(11)
-            assertThat(it.boxes[0].box).isEqualTo(Box.VERY_LOW)
-            assertThat(it.boxes[1].box).isEqualTo(Box.LOW)
-            assertThat(it.boxes[2].box).isEqualTo(Box.LOW)
-            assertThat(it.boxes[3].box).isEqualTo(Box.MEDIUM)
-            assertThat(it.boxes[4].box).isEqualTo(Box.MEDIUM)
-            assertThat(it.boxes[5].box).isEqualTo(Box.MEDIUM)
-            assertThat(it.boxes[6].box).isEqualTo(Box.HIGH)
-            assertThat(it.boxes[7].box).isEqualTo(Box.HIGH)
-            assertThat(it.boxes[8].box).isEqualTo(Box.VERY_HIGH)
-            assertThat(it.boxes[9].box).isEqualTo(Box.VERY_HIGH)
-            assertThat(it.boxes[10].box).isEqualTo(Box.VERY_HIGH)
+            assertThat(it.boxItems).hasSize(11)
+            assertThat(it.boxItems[0].box).isEqualTo(Box.VERY_LOW)
+            assertThat(it.boxItems[1].box).isEqualTo(Box.LOW)
+            assertThat(it.boxItems[2].box).isEqualTo(Box.LOW)
+            assertThat(it.boxItems[3].box).isEqualTo(Box.MEDIUM)
+            assertThat(it.boxItems[4].box).isEqualTo(Box.MEDIUM)
+            assertThat(it.boxItems[5].box).isEqualTo(Box.MEDIUM)
+            assertThat(it.boxItems[6].box).isEqualTo(Box.HIGH)
+            assertThat(it.boxItems[7].box).isEqualTo(Box.HIGH)
+            assertThat(it.boxItems[8].box).isEqualTo(Box.VERY_HIGH)
+            assertThat(it.boxItems[9].box).isEqualTo(Box.VERY_HIGH)
+            assertThat(it.boxItems[10].box).isEqualTo(Box.VERY_HIGH)
         }
     }
 
@@ -73,12 +73,12 @@ class PostingActivityMapperTest : BaseUnitTest() {
         assertThat(result.blocks).hasSize(1)
         val offset = 1
         result.blocks[0].let {
-            assertThat(it.boxes).hasSize(33)
+            assertThat(it.boxItems).hasSize(33)
             for (invisible in 0..offset) {
-                assertThat(it.boxes[invisible].box).isEqualTo(Box.INVISIBLE)
+                assertThat(it.boxItems[invisible].box).isEqualTo(Box.INVISIBLE)
             }
-            for (veryLow in (offset + 1) until it.boxes.size) {
-                assertThat(it.boxes[veryLow].box).isEqualTo(Box.VERY_LOW)
+            for (veryLow in (offset + 1) until it.boxItems.size) {
+                assertThat(it.boxItems[veryLow].box).isEqualTo(Box.VERY_LOW)
             }
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PostingActivityMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PostingActivityMapperTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -8,17 +9,27 @@ import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.stats.insights.PostingActivityModel.Month
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.util.LocaleManagerWrapper
 import java.util.Calendar
 import java.util.Locale
 
 class PostingActivityMapperTest : BaseUnitTest() {
     @Mock lateinit var localeManagerWrapper: LocaleManagerWrapper
+    @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
     private lateinit var mapper: PostingActivityMapper
+    private val contentDescription = "Oct 1, 1 post"
+
     @Before
     fun setUp() {
-        mapper = PostingActivityMapper(localeManagerWrapper)
+        mapper = PostingActivityMapper(localeManagerWrapper, contentDescriptionHelper)
         whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
+
+        whenever(contentDescriptionHelper.buildContentDescription(
+                any<String>(),
+                any(),
+                any()
+        )).thenReturn(contentDescription)
     }
 
     @Test
@@ -33,17 +44,17 @@ class PostingActivityMapperTest : BaseUnitTest() {
         assertThat(result.blocks).hasSize(1)
         result.blocks[0].let {
             assertThat(it.boxes).hasSize(11)
-            assertThat(it.boxes[0]).isEqualTo(Box.VERY_LOW)
-            assertThat(it.boxes[1]).isEqualTo(Box.LOW)
-            assertThat(it.boxes[2]).isEqualTo(Box.LOW)
-            assertThat(it.boxes[3]).isEqualTo(Box.MEDIUM)
-            assertThat(it.boxes[4]).isEqualTo(Box.MEDIUM)
-            assertThat(it.boxes[5]).isEqualTo(Box.MEDIUM)
-            assertThat(it.boxes[6]).isEqualTo(Box.HIGH)
-            assertThat(it.boxes[7]).isEqualTo(Box.HIGH)
-            assertThat(it.boxes[8]).isEqualTo(Box.VERY_HIGH)
-            assertThat(it.boxes[9]).isEqualTo(Box.VERY_HIGH)
-            assertThat(it.boxes[10]).isEqualTo(Box.VERY_HIGH)
+            assertThat(it.boxes[0].box).isEqualTo(Box.VERY_LOW)
+            assertThat(it.boxes[1].box).isEqualTo(Box.LOW)
+            assertThat(it.boxes[2].box).isEqualTo(Box.LOW)
+            assertThat(it.boxes[3].box).isEqualTo(Box.MEDIUM)
+            assertThat(it.boxes[4].box).isEqualTo(Box.MEDIUM)
+            assertThat(it.boxes[5].box).isEqualTo(Box.MEDIUM)
+            assertThat(it.boxes[6].box).isEqualTo(Box.HIGH)
+            assertThat(it.boxes[7].box).isEqualTo(Box.HIGH)
+            assertThat(it.boxes[8].box).isEqualTo(Box.VERY_HIGH)
+            assertThat(it.boxes[9].box).isEqualTo(Box.VERY_HIGH)
+            assertThat(it.boxes[10].box).isEqualTo(Box.VERY_HIGH)
         }
     }
 
@@ -64,10 +75,10 @@ class PostingActivityMapperTest : BaseUnitTest() {
         result.blocks[0].let {
             assertThat(it.boxes).hasSize(33)
             for (invisible in 0..offset) {
-                assertThat(it.boxes[invisible]).isEqualTo(Box.INVISIBLE)
+                assertThat(it.boxes[invisible].box).isEqualTo(Box.INVISIBLE)
             }
             for (veryLow in (offset + 1) until it.boxes.size) {
-                assertThat(it.boxes[veryLow]).isEqualTo(Box.VERY_LOW)
+                assertThat(it.boxes[veryLow].box).isEqualTo(Box.VERY_LOW)
             }
         }
     }


### PR DESCRIPTION
Fixes #10975 

## Findings
The Posting Stats was inaccessible when using TalkBack. This improvement makes it more accessible for visually impaired users who are navigating the stats functionality. 

## Solution
The solution was to loop through each `Box` that represents a day and announce the associated stats. This implementation is similar to [what was done on iOS.](https://github.com/wordpress-mobile/WordPress-iOS/pull/13123)  The `Boxes` didn't have a content description so refactoring was done to generate it based on the month, day and amount of posts. 

Before | After 
--------|-------
[Before Video ](https://drive.google.com/open?id=18ErO8-vpZxLuxucriVecOq218nEcmaSK) |   [After Video    ](https://drive.google.com/open?id=186KK4cugtT2PX-SzyCCeGM8ka3UyzPKR)

## Testing

1. Enable TalkBack. 
2. Navigate to the Stats page.
3. Ensure you are on the Insights Tab. 
4. Select each Month under "Posting Activity" and follow the instructions to hear the announcement. 


Tap To Hear Day Stats | Stat Announced 
--------|-------
<img src="https://user-images.githubusercontent.com/1509205/71115552-2fe14d80-21a0-11ea-8fd9-427a58b41d14.png" width="320">        |       <img src="https://user-images.githubusercontent.com/1509205/71115581-3f609680-21a0-11ea-8947-9a264a142cd2.png" width="320">




All Stats Announced | No Stats Available 
--------|-------
<img src="https://user-images.githubusercontent.com/1509205/71115354-bea19a80-219f-11ea-9193-8bcec2daeb6c.png" width="320">   |    <img src="https://user-images.githubusercontent.com/1509205/71115439-e2fd7700-219f-11ea-8c70-34569e4c7c2e.png" width="320">


## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 

