### PR TITLE
IA reader self hosted enhancements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -69,7 +69,7 @@ public class ReaderTag implements Serializable, FilterCriteria {
         return StringUtils.notNullStr(mEndpoint);
     }
 
-    private void setEndpoint(String endpoint) {
+    public void setEndpoint(String endpoint) {
         this.mEndpoint = StringUtils.notNullStr(endpoint);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -101,7 +101,7 @@ public class FilteredRecyclerView extends RelativeLayout {
         mCurrentFilter = filter;
 
         if (mUseTabsForFiltering) {
-            int position = mFilteredPagerAdapter.getItemPosition(filter);
+            int position = filter == null ? -1 : mFilteredPagerAdapter.getItemPosition(filter);
             if (position > -1 && position != mViewPager.getCurrentItem()) {
                 mViewPager.setCurrentItem(position);
             } else if (position > -1 && position == mViewPager.getCurrentItem()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
@@ -19,13 +19,11 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask
-import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter
 import org.wordpress.android.ui.reader.subfilter.adapters.SubfilterListAdapter
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import org.wordpress.android.util.NetworkUtils
 import java.util.EnumSet
 import javax.inject.Inject
 
@@ -55,7 +53,13 @@ class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
             (dialog.filter_recycler_view.adapter as? SubfilterListAdapter)?.update(it ?: listOf())
         })
         viewModel.loadSubFilters()
-        performUpdate()
+        viewModel.performUpdate(
+                context,
+                EnumSet.of(
+                        UpdateTask.TAGS,
+                        UpdateTask.FOLLOWED_BLOGS/*,
+                        UpdateTask.RECOMMENDED_BLOGS*/)
+        )
     }
 
     override fun onAttach(context: Context?) {
@@ -78,24 +82,6 @@ class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
     fun onEventMainThread(event: ReaderEvents.FollowedBlogsChanged) {
         AppLog.d(T.READER, "Subfilter bottom sheet > followed blogs changed")
         viewModel.loadSubFilters()
-    }
-
-    private fun performUpdate() {
-        performUpdate(
-                EnumSet.of(
-                        UpdateTask.TAGS,
-                        UpdateTask.FOLLOWED_BLOGS/*,
-                        UpdateTask.RECOMMENDED_BLOGS*/
-                )
-        )
-    }
-
-    private fun performUpdate(tasks: EnumSet<UpdateTask>) {
-        if (!NetworkUtils.isNetworkAvailable(activity)) {
-            return
-        }
-
-        ReaderUpdateServiceStarter.startService(activity, tasks)
     }
 
     override fun onStart() {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1220,6 +1220,7 @@
     <!-- reader -->
     <string name="reader">Reader</string>
     <string name="reader_filter_all_sites">All sites</string>
+    <string name="reader_filter_select_filter">Select Filter</string>
     <string name="reader_filter_sites_title">Sites</string>
     <string name="reader_filter_tags_title">Tags</string>
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -18,6 +18,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagType.BOOKMARKED
 import org.wordpress.android.models.news.NewsItem
@@ -47,6 +48,7 @@ class ReaderPostListViewModelTest {
     @Mock private lateinit var otherTag: ReaderTag
     @Mock private lateinit var newsTracker: NewsTracker
     @Mock private lateinit var newsTrackerHelper: NewsTrackerHelper
+    @Mock private lateinit var accountStore: AccountStore
 
     private lateinit var viewModel: ReaderPostListViewModel
     private val liveData = MutableLiveData<NewsItem>()
@@ -54,7 +56,7 @@ class ReaderPostListViewModelTest {
     @Before
     fun setUp() {
         whenever(newsManager.newsItemSource()).thenReturn(liveData)
-        viewModel = ReaderPostListViewModel(newsManager, newsTracker, newsTrackerHelper, TEST_DISPATCHER)
+        viewModel = ReaderPostListViewModel(newsManager, newsTracker, newsTrackerHelper, accountStore, TEST_DISPATCHER)
         val observable = viewModel.getNewsDataSource()
         observable.observeForever(observer)
     }


### PR DESCRIPTION
This PR aims to bring some bug fix/improvements to the IA modified reader in logged out WP.com but with self-hosted sites user. 

In more details it does the following:

1. Fix a crash that can happen if a WP.com user with self-hosted sites signs out
2. Create a dummy in memory Following Tag to be used to show the default tags for self-hosted users
3. Introduce an auto update step in the reader in case a user changed is detected

cc @osullivanchris 

## To test
### Case 1 - crash fix
- Log in with a WP.com account and also add a pure self-hosted site (no jetpack)
- Log out from WP.com account, you are still kept in the app since you have at least one self-hosted site added
- Check that the app does not crash and you can access all the 3 main pages of the app (My site, Reader, Notifications

### Case 2 - Reader for self-hosted site user
- Verify you are logged out from WP.com account and you have added a pure self-hosted site
- Go to reader and check you have a condition similar to the following (the 3 Tabs and subfilter in Following with "Select Filter" text and bottom sheet with default proposed tags only)
<p align="center">
  <img width="300" src="https://user-images.githubusercontent.com/47797566/71131522-3a7a0200-21f5-11ea-8a03-ec806372d31f.png">
</p>

- Smoke test the reader

### Case 3 - Auto update in case of user changed detected
- Log in with a WP.com account and also add a pure self-hosted site
- Go to the Reader and check the list of posts is automatically loaded and you get a condition similar to the following
<p align="center">
  <img width="300" src="https://user-images.githubusercontent.com/47797566/71131798-fe936c80-21f5-11ea-9d7e-efb8e38a1392.png">
</p>

- Smoke test the reader
- Log out from WP.com 
- Go to the Reader and check the list of posts is automatically loaded and you get a condition similar to the following
<p align="center">
  <img width="300" src="https://user-images.githubusercontent.com/47797566/71131750-de63ad80-21f5-11ea-90a0-91b474d2e6f9.png">
</p>

- Smoke test the reader

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

