### PR TITLE
Accessibility : Safe Accessibility Delegate usage

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNestedScrollView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNestedScrollView.java
@@ -8,10 +8,11 @@ import android.view.accessibility.AccessibilityEvent;
 import android.widget.ScrollView;
 
 import androidx.core.view.AccessibilityDelegateCompat;
-import androidx.core.view.ViewCompat;
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
 import androidx.core.view.accessibility.AccessibilityRecordCompat;
 import androidx.core.widget.NestedScrollView;
+
+import org.wordpress.android.util.AccessibilityUtils;
 
 
 /**
@@ -40,7 +41,7 @@ public class WPNestedScrollView extends NestedScrollView {
 
     public WPNestedScrollView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        ViewCompat.setAccessibilityDelegate(this, ACCESSIBILITY_DELEGATE);
+        AccessibilityUtils.setAccessibilityDelegateSafely(this, ACCESSIBILITY_DELEGATE);
     }
 
 


### PR DESCRIPTION
Fixes #10964

## Findings
When improving accessibility a contributor may set a delegate on a view and not know that another delegate exists.

## Solution
`AccessibilityUtils` has a method that provides a safe way for setting delegates. It should always be utilized so functionality is never overwritten and other contributors can see its usage and follow suit. 

## Testing
The easiest way to test this would be to attempt to set a delegate on a view that already has a delegate using the function. In debug mode, it would cause a crash. 

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 

