### PR TITLE
Issue/10930 email address error is preserved on rotation

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -79,7 +79,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     private String mGoogleEmail;
     private String mRequestedEmail;
     private boolean mIsSocialLogin;
-    private boolean mIsValidEmail = true;
+    private boolean mIsValidEmail = false;
 
     protected WPLoginInputRow mEmailInput;
     protected boolean mHasDismissedEmailHints;
@@ -164,7 +164,6 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             public void onClick(View view) {
                 mAnalyticsListener.trackSocialButtonClick();
                 ActivityUtils.hideKeyboardForced(mEmailInput.getEditText());
-
 
                 if (NetworkUtils.checkConnection(getActivity())) {
                     if (isAdded()) {
@@ -282,7 +281,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             mLoginSiteUrl = args.getString(ARG_LOGIN_SITE_URL, "");
         }
     }
-    
+
     @Override
     public void onStart() {
         super.onStart();
@@ -291,7 +290,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
                 .enableAutoManage(getActivity(), GOOGLE_API_CLIENT_ID, LoginEmailFragment.this)
                 .addApi(Auth.CREDENTIALS_API)
                 .build();
-        validEmail();
+        showErrorIfEmailInvalid();
     }
 
     @Override
@@ -350,8 +349,8 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         }
     }
 
-    protected void validEmail() {
-        if (!mIsValidEmail) {
+    private void showErrorIfEmailInvalid() {
+        if (!mIsValidEmail && mEmailInput.getEditText().getText().length() > 0) {
             showEmailError(R.string.email_invalid);
         }
     }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -79,8 +79,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     private String mGoogleEmail;
     private String mRequestedEmail;
     private boolean mIsSocialLogin;
-    private boolean mIsValidEmail = true
-            ;
+    private boolean mIsValidEmail = true;
 
     protected WPLoginInputRow mEmailInput;
     protected boolean mHasDismissedEmailHints;
@@ -283,9 +282,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             mLoginSiteUrl = args.getString(ARG_LOGIN_SITE_URL, "");
         }
     }
-
-
-
+    
     @Override
     public void onStart() {
         super.onStart();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -79,7 +79,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     private String mGoogleEmail;
     private String mRequestedEmail;
     private boolean mIsSocialLogin;
-    private boolean mIsValidEmail = false;
+    private Boolean mIsValidEmail;
 
     protected WPLoginInputRow mEmailInput;
     protected boolean mHasDismissedEmailHints;
@@ -315,7 +315,12 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             mIsSocialLogin = savedInstanceState.getBoolean(KEY_IS_SOCIAL);
             mIsDisplayingEmailHints = savedInstanceState.getBoolean(KEY_IS_DISPLAYING_EMAIL_HINTS);
             mHasDismissedEmailHints = savedInstanceState.getBoolean(KEY_HAS_DISMISSED_EMAIL_HINTS);
-            mIsValidEmail = savedInstanceState.getBoolean(VALIDITY_EMAIL);
+            if (savedInstanceState.getBoolean(VALIDITY_EMAIL) || !(savedInstanceState
+                    .getBoolean(VALIDITY_EMAIL))) {
+                mIsValidEmail = savedInstanceState.getBoolean(VALIDITY_EMAIL);
+            } else {
+                mIsValidEmail = null;
+            }
         } else {
             mAnalyticsListener.trackEmailFormViewed();
         }
@@ -330,7 +335,9 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         outState.putBoolean(KEY_IS_SOCIAL, mIsSocialLogin);
         outState.putBoolean(KEY_IS_DISPLAYING_EMAIL_HINTS, mIsDisplayingEmailHints);
         outState.putBoolean(KEY_HAS_DISMISSED_EMAIL_HINTS, mHasDismissedEmailHints);
-        outState.putBoolean(VALIDITY_EMAIL, mIsValidEmail);
+        if (mIsValidEmail != null) {
+            outState.putBoolean(VALIDITY_EMAIL, mIsValidEmail);
+        }
     }
 
     protected void next(String email) {
@@ -350,7 +357,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     }
 
     private void showErrorIfEmailInvalid() {
-        if (!mIsValidEmail && mEmailInput.getEditText().getText().length() > 0) {
+        if (mIsValidEmail != null && !mIsValidEmail) {
             showEmailError(R.string.email_invalid);
         }
     }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -64,6 +64,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     private static final String KEY_IS_SOCIAL = "KEY_IS_SOCIAL";
     private static final String KEY_OLD_SITES_IDS = "KEY_OLD_SITES_IDS";
     private static final String KEY_REQUESTED_EMAIL = "KEY_REQUESTED_EMAIL";
+    private static final String VALIDITY_EMAIL = "VALIDITY_EMAIL";
     private static final String LOG_TAG = LoginEmailFragment.class.getSimpleName();
     private static final int GOOGLE_API_CLIENT_ID = 1002;
     private static final int EMAIL_CREDENTIALS_REQUEST_CODE = 25100;
@@ -78,6 +79,8 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     private String mGoogleEmail;
     private String mRequestedEmail;
     private boolean mIsSocialLogin;
+    private boolean mIsValidEmail = true
+            ;
 
     protected WPLoginInputRow mEmailInput;
     protected boolean mHasDismissedEmailHints;
@@ -162,6 +165,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             public void onClick(View view) {
                 mAnalyticsListener.trackSocialButtonClick();
                 ActivityUtils.hideKeyboardForced(mEmailInput.getEditText());
+
 
                 if (NetworkUtils.checkConnection(getActivity())) {
                     if (isAdded()) {
@@ -280,6 +284,8 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         }
     }
 
+
+
     @Override
     public void onStart() {
         super.onStart();
@@ -288,6 +294,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
                 .enableAutoManage(getActivity(), GOOGLE_API_CLIENT_ID, LoginEmailFragment.this)
                 .addApi(Auth.CREDENTIALS_API)
                 .build();
+        validEmail();
     }
 
     @Override
@@ -312,6 +319,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             mIsSocialLogin = savedInstanceState.getBoolean(KEY_IS_SOCIAL);
             mIsDisplayingEmailHints = savedInstanceState.getBoolean(KEY_IS_DISPLAYING_EMAIL_HINTS);
             mHasDismissedEmailHints = savedInstanceState.getBoolean(KEY_HAS_DISMISSED_EMAIL_HINTS);
+            mIsValidEmail = savedInstanceState.getBoolean(VALIDITY_EMAIL);
         } else {
             mAnalyticsListener.trackEmailFormViewed();
         }
@@ -326,6 +334,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         outState.putBoolean(KEY_IS_SOCIAL, mIsSocialLogin);
         outState.putBoolean(KEY_IS_DISPLAYING_EMAIL_HINTS, mIsDisplayingEmailHints);
         outState.putBoolean(KEY_HAS_DISMISSED_EMAIL_HINTS, mHasDismissedEmailHints);
+        outState.putBoolean(VALIDITY_EMAIL, mIsValidEmail);
     }
 
     protected void next(String email) {
@@ -334,10 +343,18 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         }
 
         if (isValidEmail(email)) {
+            mIsValidEmail = true;
             startProgress();
             mRequestedEmail = email;
             mDispatcher.dispatch(AccountActionBuilder.newIsAvailableEmailAction(email));
         } else {
+            mIsValidEmail = false;
+            showEmailError(R.string.email_invalid);
+        }
+    }
+
+    protected void validEmail() {
+        if (!mIsValidEmail) {
             showEmailError(R.string.email_invalid);
         }
     }


### PR DESCRIPTION
Fixes #10930 

Description: 
When rotate the device, the email error is preserved now.

Testing instructions: 

1. Press Log In
2. Enter Email address and press Next. An error message will be shown
3. Rotate the screen.

![test (1)](https://user-images.githubusercontent.com/28972973/71297509-5abad580-2349-11ea-903d-90cb6e17ff20.gif)

I also test it in an physical device. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

