### PR TITLE
Set focus on search view in site picker action bar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -455,6 +455,7 @@ public class SitePickerActivity extends AppCompatActivity
     private void setupSearchView() {
         mSearchView = (SearchView) mMenuSearch.getActionView();
         mSearchView.setIconifiedByDefault(false);
+        mSearchView.setIconified(false);
         mSearchView.setOnQueryTextListener(this);
 
         mMenuSearch.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {


### PR DESCRIPTION
Fixes #9690

### Testing instructions

1. Select **SWITCH SITE** from **My site** tab.
2. Select search icon in the **Choose site** screen action bar (ensure there are at least 2 sites for the search icon to appear).
3. Note that Search field is focussed and keyboard is shown.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/1405144/71336407-05f7a480-256d-11ea-85b2-cd5bf1ca454b.gif)

### Review
Only one developer is required to review these changes, but anyone can perform the review.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
