### PR TITLE
Fix confirmation message on syncing scheduled post changes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -77,8 +77,11 @@ class PostActionHandler(
             BUTTON_MOVE_TO_DRAFT -> {
                 moveTrashedPostToDraft(post)
             }
-            BUTTON_SYNC, BUTTON_PUBLISH -> {
+            BUTTON_PUBLISH -> {
                 postListDialogHelper.showPublishConfirmationDialog(post)
+            }
+            BUTTON_SYNC -> {
+                postListDialogHelper.showSyncScheduledPostConfirmationDialog(post)
             }
             BUTTON_SUBMIT -> publishPost(post.id)
             BUTTON_VIEW -> triggerPostListAction.invoke(ViewPost(site, post))

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
@@ -15,6 +15,7 @@ private const val CONFIRM_PUBLISH_POST_DIALOG_TAG = "CONFIRM_PUBLISH_POST_DIALOG
 private const val CONFIRM_TRASH_POST_WITH_LOCAL_CHANGES_DIALOG_TAG = "CONFIRM_TRASH_POST_WITH_LOCAL_CHANGES_DIALOG_TAG"
 private const val CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG = "CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG"
 private const val CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG = "CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG"
+private const val CONFIRM_SYNC_SCHEDULED_POST_DIALOG_TAG = "CONFIRM_SYNC_SCHEDULED_POST_DIALOG_TAG"
 
 /**
  * This is a temporary class to make the PostListViewModel more manageable. Please feel free to refactor it any way
@@ -31,6 +32,7 @@ class PostListDialogHelper(
     private var localPostIdForTrashPostWithLocalChangesDialog: Int? = null
     private var localPostIdForConflictResolutionDialog: Int? = null
     private var localPostIdForAutosaveRevisionResolutionDialog: Int? = null
+    private var localPostIdForScheduledPostSyncDialog: Int? = null
 
     fun showDeletePostConfirmationDialog(post: PostModel) {
         // We need network connection to delete a remote post, but not a local draft
@@ -61,6 +63,22 @@ class PostListDialogHelper(
                 negativeButton = UiStringRes(R.string.cancel)
         )
         localPostIdForPublishDialog = post.id
+        showDialog.invoke(dialogHolder)
+    }
+
+    fun showSyncScheduledPostConfirmationDialog(post: PostModel) {
+        if (localPostIdForScheduledPostSyncDialog != null) {
+            // We can only handle one sync post dialog at once
+            return
+        }
+        val dialogHolder = DialogHolder(
+                tag = CONFIRM_SYNC_SCHEDULED_POST_DIALOG_TAG,
+                title = UiStringRes(R.string.dialog_confirm_scheduled_post_sync_title),
+                message = UiStringRes(R.string.dialog_confirm_scheduled_post_sync_message),
+                positiveButton = UiStringRes(R.string.dialog_confirm_scheduled_post_sync_yes),
+                negativeButton = UiStringRes(R.string.cancel)
+        )
+        localPostIdForScheduledPostSyncDialog = post.id
         showDialog.invoke(dialogHolder)
     }
 
@@ -121,6 +139,10 @@ class PostListDialogHelper(
                 localPostIdForPublishDialog = null
                 publishPost(it)
             }
+            CONFIRM_SYNC_SCHEDULED_POST_DIALOG_TAG -> localPostIdForScheduledPostSyncDialog?.let {
+                localPostIdForScheduledPostSyncDialog = null
+                publishPost(it)
+            }
             CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG -> localPostIdForConflictResolutionDialog?.let {
                 localPostIdForConflictResolutionDialog = null
                 // here load version from remote
@@ -148,6 +170,7 @@ class PostListDialogHelper(
         when (instanceTag) {
             CONFIRM_DELETE_POST_DIALOG_TAG -> localPostIdForDeleteDialog = null
             CONFIRM_PUBLISH_POST_DIALOG_TAG -> localPostIdForPublishDialog = null
+            CONFIRM_SYNC_SCHEDULED_POST_DIALOG_TAG -> localPostIdForScheduledPostSyncDialog = null
             CONFIRM_TRASH_POST_WITH_LOCAL_CHANGES_DIALOG_TAG -> localPostIdForTrashPostWithLocalChangesDialog = null
             CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG -> localPostIdForConflictResolutionDialog?.let {
                 updateConflictedPostWithLocalVersion(it)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -340,6 +340,11 @@
     <string name="dialog_confirm_update_yes">Update now</string>
     <string name="dialog_confirm_delete_permanently_post">Are you sure you\'d like to permanently delete this post?</string>
 
+    <!-- scheduled post sync confirmation dialog -->
+    <string name="dialog_confirm_scheduled_post_sync_title">Ready to Sync?</string>
+    <string name="dialog_confirm_scheduled_post_sync_message">This post will be synced immediately.</string>
+    <string name="dialog_confirm_scheduled_post_sync_yes">Sync now</string>
+
     <!-- post version sync conflict dialog -->
     <string name="dialog_confirm_load_remote_post_title">Resolve sync conflict</string>
     <string name="dialog_confirm_load_remote_post_body">This post has two versions that are in conflict. Select the version you would like to discard.\n\n</string>


### PR DESCRIPTION
Fixes #10464
Created a separate flow for publish and sync actions for better readability.

### To test:

1. Schedule a post
2. Turn on airplane mode
3. Make changes to the post
4. Press back
5. Go to the Scheduled tab
6. Turn off airplane mode
7. Click on "Sync"
8. Notice a confirmation message that corresponds with the sync status

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/1405144/71343875-1a489b00-2587-11ea-87de-07d94f289039.gif)

PR submission checklist:

- [X] I have considered adding unit tests where possible.

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

