### PR TITLE
Site Creation Domain Selection Layout Fix

### DIFF
--- a/WordPress/src/main/res/layout/site_creation_domains_item.xml
+++ b/WordPress/src/main/res/layout/site_creation_domains_item.xml
@@ -24,9 +24,10 @@
         android:textAlignment="viewStart"
         android:textColor="@color/neutral_80"
         android:textSize="@dimen/text_sz_large"
-        app:layout_constraintBottom_toBottomOf="@+id/domain_suggestion"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/domain_suggestion"
         tools:ignore="RtlSymmetry" />
 
     <TextView
@@ -39,9 +40,10 @@
         android:textAlignment="viewStart"
         android:textColor="@color/neutral_80"
         android:textSize="@dimen/text_sz_large"
-        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/domain_suggestion_radio_button"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/domain_unavailability"
         tools:text="johndoe.wordpress.com" />
     <TextView
         android:id="@+id/domain_unavailability"
@@ -52,7 +54,8 @@
         android:textColor="@color/gray_40"
         android:textSize="@dimen/text_sz_medium"
         android:visibility="visible"
-        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@+id/domain_suggestion"
-        app:layout_constraintTop_toBottomOf="@+id/domain_suggestion" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/domain_suggestion"
+        app:layout_constraintBottom_toBottomOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/site_creation_domains_item.xml
+++ b/WordPress/src/main/res/layout/site_creation_domains_item.xml
@@ -24,6 +24,7 @@
         android:textAlignment="viewStart"
         android:textColor="@color/neutral_80"
         android:textSize="@dimen/text_sz_large"
+        app:layout_constraintBottom_toBottomOf="@+id/domain_suggestion"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:ignore="RtlSymmetry" />
@@ -37,20 +38,21 @@
         android:paddingBottom="@dimen/margin_medium"
         android:textAlignment="viewStart"
         android:textColor="@color/neutral_80"
-        tools:text="johndoe.wordpress.com"
         android:textSize="@dimen/text_sz_large"
-        app:layout_constraintBottom_toBottomOf="@+id/domain_suggestion_radio_button"
-        app:layout_constraintStart_toEndOf="@+id/domain_suggestion_radio_button" />
-
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/domain_suggestion_radio_button"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="johndoe.wordpress.com" />
     <TextView
         android:id="@+id/domain_unavailability"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:paddingBottom="@dimen/margin_medium"
         android:textAlignment="viewStart"
         android:textColor="@color/gray_40"
         android:textSize="@dimen/text_sz_medium"
         android:visibility="visible"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@+id/domain_suggestion"
         app:layout_constraintTop_toBottomOf="@+id/domain_suggestion" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #11008

## Findings
The layout was broken due to constraints that weren't optimized for really long text. 

## Solution
I optimized the constraints of the views within the layout. 

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/1509205/71362067-04c17a00-2563-11ea-9ef3-727b0eebda8f.png" width="320">        |       <img src="https://user-images.githubusercontent.com/1509205/71362076-0be88800-2563-11ea-92a6-e9ab98ba59dc.png" width="320">



## Testing
1. My Site
2. Switch Site
3. Plus sign button
4. Create WordPress.com site
5. Choose a type
6. Skip
7. Skip
8. Type a long domain name into the search box

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
