### PR TITLE
Fix post-signup interstitial for login with magic link

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -9,9 +9,11 @@ import androidx.fragment.app.FragmentTransaction;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueFragment;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueListener;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.LocaleManager;
 
 import java.util.ArrayList;
@@ -24,6 +26,7 @@ public class LoginEpilogueActivity extends AppCompatActivity implements LoginEpi
     public static final String ARG_OLD_SITES_IDS = "ARG_OLD_SITES_IDS";
 
     @Inject AccountStore mAccountStore;
+    @Inject SiteStore mSiteStore;
 
     @Override
     protected void attachBaseContext(Context newBase) {
@@ -67,6 +70,10 @@ public class LoginEpilogueActivity extends AppCompatActivity implements LoginEpi
 
     @Override
     public void onContinue() {
+        if (!mSiteStore.hasSite() && AppPrefs.shouldShowPostSignupInterstitial()) {
+            ActivityLauncher.showPostSignupInterstitial(this);
+        }
+
         setResult(RESULT_OK);
         finish();
     }


### PR DESCRIPTION
Fixes #11019 

To test:
1. Clear app data.
2. On the initial screen, tap _**Log in**._
3. Enter an email address that is associated with an account _that doesn't have any sites_.
4. Complete the login flow using a magic link.
5. On the login epilogue screen, tap **Continue**.
6. Confirm that the post-signup interstitial screen is shown.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

