### PR TITLE
Accessibility : Aztec UI Improvements 

### DIFF
--- a/libs/editor/WordPressEditor/src/main/res/values/colors.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/colors.xml
@@ -19,7 +19,7 @@
     <color name="code_background">@color/wp_grey_light</color>
     <color name="hint_text">@color/wp_grey_darken_10</color>
     <color name="link">@color/wp_blue_medium</color>
-    <color name="quote">@color/wp_grey_darken_10</color>
+    <color name="quote">@color/wp_grey</color>
     <color name="quote_background">@color/wp_grey_lighten_30</color>
     <color name="text">@color/wp_grey_darken_30</color>
 

--- a/libs/editor/WordPressEditor/src/main/res/values/colors.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/colors.xml
@@ -17,9 +17,9 @@
     <color name="bullet">@color/wp_grey_darken_30</color>
     <color name="code">@color/text</color>
     <color name="code_background">@color/wp_grey_light</color>
-    <color name="hint_text">@color/wp_grey</color>
+    <color name="hint_text">@color/wp_grey_darken_10</color>
     <color name="link">@color/wp_blue_medium</color>
-    <color name="quote">@color/wp_grey</color>
+    <color name="quote">@color/wp_grey_darken_10</color>
     <color name="quote_background">@color/wp_grey_lighten_30</color>
     <color name="text">@color/wp_grey_darken_30</color>
 


### PR DESCRIPTION
Fixes #10906

## Findings

Title and Aztec content views weren't meeting the contrast guidelines for accessibility. i.e the contrast ratio derived from the foreground and background wasn't high enough to pass the mark that makes the control's color accessible. The only point to note here, is that this change makes it obvious that the hint colors in Gutenberg are different from Aztec when doing the switch.

## Solution
Changed the hint color of the views to one that makes the contrast ratio higher. 

## Testing
1. New post. 
2. Switch to the classic editor. 
3. You will see the controls as shown below. 

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/1509205/71564967-16c97e00-2a77-11ea-8372-04791708408a.png" width="320">        | <img src="https://user-images.githubusercontent.com/1509205/71564969-1fba4f80-2a77-11ea-84e7-3353ba5c7454.png" width="320">

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
