### PR TITLE
Accessibility : Aztec Media Touch Targets

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
@@ -10,6 +10,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import androidx.appcompat.widget.AppCompatButton
 import org.wordpress.android.R
+import org.wordpress.android.util.expandTouchTargetArea
 import org.wordpress.android.widgets.WPTextView
 
 /**
@@ -56,6 +57,7 @@ class ActionableEmptyView : LinearLayout {
         image = layout.findViewById(R.id.image)
         title = layout.findViewById(R.id.title)
         subtitle = layout.findViewById(R.id.subtitle)
+        subtitle.expandTouchTargetArea(R.dimen.actionable_subtitle_extra_padding,true)
         button = layout.findViewById(R.id.button)
         bottomImage = layout.findViewById(R.id.bottom_image)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
@@ -57,7 +57,7 @@ class ActionableEmptyView : LinearLayout {
         image = layout.findViewById(R.id.image)
         title = layout.findViewById(R.id.title)
         subtitle = layout.findViewById(R.id.subtitle)
-        subtitle.expandTouchTargetArea(R.dimen.actionable_subtitle_extra_padding,true)
+        subtitle.expandTouchTargetArea(R.dimen.actionable_subtitle_extra_padding, true)
         button = layout.findViewById(R.id.button)
         bottomImage = layout.findViewById(R.id.bottom_image)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -302,6 +302,8 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
 
             mVideoOverlayContainer = view.findViewById(R.id.frame_video_overlay);
             mSelectionCountContainer = view.findViewById(R.id.frame_selection_count);
+            ViewUtilsKt.expandTouchTargetArea(mSelectionCountContainer, R.dimen.media_picker_selection_extra_padding,
+                    false);
 
             // make the progress bar white
             mProgressUpload.getIndeterminateDrawable().setColorFilter(Color.WHITE, PorterDuff.Mode.MULTIPLY);

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -174,6 +174,8 @@
     <dimen name="reader_remove_button_extra_padding">12dp</dimen>
     <dimen name="reader_more_image_extra_padding">12dp</dimen>
     <dimen name="reader_follow_button_extra_padding">32dp</dimen>
+    <dimen name="media_picker_selection_extra_padding">8dp</dimen>
+    <dimen name="actionable_subtitle_extra_padding">23dp</dimen>
 
     <dimen name="empty_list_title_text_size">24sp</dimen>
     <dimen name="empty_list_title_side_margin">32dp</dimen>


### PR DESCRIPTION
Fixes #10905

## Findings
These controls didn't have enough padding around them to make them adhere to the touch target sizing constraints as described by the Material Design spec. 

## Solution
To utilize a touch delegate to expand the touch targets without making any UI changes. 

## Testing
1. New post. 
2. Go to the classic editor. 
3. Go to free photo picker and ensure that clicking on the subtitle text with the photo provider takes you to the web. 
4. Go to WordPress Media Picker and click an item. 

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
