### PR TITLE
Bump Gutenberg progressive rollout phase 1 from 30 to 100%

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class SiteUtils {
     public static final String GB_EDITOR_NAME = "gutenberg";
     public static final String AZTEC_EDITOR_NAME = "aztec";
-    private static final int GB_ROLLOUT_PERCENTAGE = 30;
+    private static final int GB_ROLLOUT_PERCENTAGE = 100;
 
     /**
      * Migrate the old app-wide editor preference value to per-site setting. wpcom sites will make a network call


### PR DESCRIPTION
Bump Gutenberg progressive rollout phase 1 from 30 to 100%

Note: this targets the current release branch (13.9)