### PR TITLE
Remove all item decorations to fix post list items spacing issues

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -94,13 +94,15 @@ class PostListFragment : Fragment() {
 
         mainViewModel.viewLayoutType.observe(this, Observer { optionaLayoutType ->
             optionaLayoutType?.let { layoutType ->
+                recyclerView?.let {
+                    uiHelpers.removeAllItemDecorationsInRecyclerView(it)
+                }
+
                 when (layoutType) {
                     STANDARD -> {
-                        recyclerView?.removeItemDecoration(itemDecorationCompactLayout)
                         recyclerView?.addItemDecoration(itemDecorationStandardLayout)
                     }
                     COMPACT -> {
-                        recyclerView?.removeItemDecoration(itemDecorationStandardLayout)
                         recyclerView?.addItemDecoration(itemDecorationCompactLayout)
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -94,9 +94,8 @@ class PostListFragment : Fragment() {
 
         mainViewModel.viewLayoutType.observe(this, Observer { optionaLayoutType ->
             optionaLayoutType?.let { layoutType ->
-                recyclerView?.let {
-                    uiHelpers.removeAllItemDecorationsInRecyclerView(it)
-                }
+                recyclerView?.removeItemDecoration(itemDecorationCompactLayout)
+                recyclerView?.removeItemDecoration(itemDecorationStandardLayout)
 
                 when (layoutType) {
                     STANDARD -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
 import android.graphics.Point
+import androidx.recyclerview.widget.RecyclerView
 
 class UiHelpers @Inject constructor() {
     fun getPxOfUiDimen(context: Context, uiDimen: UiDimen): Int =
@@ -55,6 +56,12 @@ class UiHelpers @Inject constructor() {
         updateVisibility(imageView, resId != null)
         resId?.let {
             imageView.setImageResource(resId)
+        }
+    }
+
+    fun removeAllItemDecorationsInRecyclerView(recyclerView: RecyclerView) {
+        while (recyclerView.itemDecorationCount > 0) {
+            recyclerView.removeItemDecorationAt(0)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
 import android.graphics.Point
-import androidx.recyclerview.widget.RecyclerView
 
 class UiHelpers @Inject constructor() {
     fun getPxOfUiDimen(context: Context, uiDimen: UiDimen): Int =
@@ -56,12 +55,6 @@ class UiHelpers @Inject constructor() {
         updateVisibility(imageView, resId != null)
         resId?.let {
             imageView.setImageResource(resId)
-        }
-    }
-
-    fun removeAllItemDecorationsInRecyclerView(recyclerView: RecyclerView) {
-        while (recyclerView.itemDecorationCount > 0) {
-            recyclerView.removeItemDecorationAt(0)
         }
     }
 


### PR DESCRIPTION
Fixes #10993 

### To test:

Go to a site

- Go to Blog Posts view, note the size of the margins on the list items
- Tap the search icon in the app bar
- Tap/gesture back to Blog Posts
- Note margins between the posts remain the same

![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/1405144/71713032-eba3ad80-2e2d-11ea-9d3b-398d7843f2e8.gif)

PR submission checklist:

- [X] I have considered adding unit tests where possible.

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

