### PR TITLE
Replace recursion with inline logic to fix stack overflow

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -862,6 +862,7 @@
     <string name="stats_data_not_recorded_for_period">File download stats were not recorded before June 28th 2019.</string>
 
     <!-- Number suffixes -->
+    <string name="negative_prefix">-%s</string>
     <string name="suffix_1_000">%sk</string>
     <string name="suffix_1_000_000">%sM</string>
     <string name="suffix_1_000_000_000">%sB</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtilsTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.utils
 
 import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -28,17 +27,17 @@ class StatsUtilsTest {
     fun setUp() {
         statsUtils = StatsUtils(resourceProvider, localeManagerWrapper)
         whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
-        whenever(resourceProvider.getString(eq(R.string.suffix_1_000), any())).then { invocation ->
-            invocation.arguments[1] as String + suffixThousand
-        }
-        whenever(resourceProvider.getString(eq(R.string.suffix_1_000_000), any())).then { invocation ->
-            invocation.arguments[1] as String + suffixMillion
-        }
-        whenever(resourceProvider.getString(eq(R.string.suffix_1_000_000_000), any())).then { invocation ->
-            invocation.arguments[1] as String + suffixBillion
-        }
-        whenever(resourceProvider.getString(eq(R.string.suffix_1_000_000_000_000), any())).then { invocation ->
-            invocation.arguments[1] as String + suffixTrillion
+        whenever(resourceProvider.getString(any(), any())).then {
+            val resourceId = it.getArgument<Int>(0)
+            val value = it.getArgument<String>(1)
+            when(resourceId) {
+                R.string.negative_prefix -> "-$value"
+                R.string.suffix_1_000 -> value + suffixThousand
+                R.string.suffix_1_000_000 -> value + suffixMillion
+                R.string.suffix_1_000_000_000 -> value + suffixBillion
+                R.string.suffix_1_000_000_000_000 -> value + suffixTrillion
+                else -> value
+            }
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtilsTest.kt
@@ -30,7 +30,7 @@ class StatsUtilsTest {
         whenever(resourceProvider.getString(any(), any())).then {
             val resourceId = it.getArgument<Int>(0)
             val value = it.getArgument<String>(1)
-            when(resourceId) {
+            when (resourceId) {
                 R.string.negative_prefix -> "-$value"
                 R.string.suffix_1_000 -> value + suffixThousand
                 R.string.suffix_1_000_000 -> value + suffixMillion


### PR DESCRIPTION
Fixes #11034 
I can't explain how this stack overflow happens. For some reason `-this` on a long doesn't change the value to be negative. However, I've removed even the option of this overflow by replacing the recursive function with a simpler approach where I update a variable instead. The functionality remains unchanged. I would trust tests to check whether everything works as expected.

To test:
* Smoke tests stats on a site with huge number of values. The numbers should still be correctly shortened/negated.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

