### PR TITLE
Add tests for RemoveMediaUseCase

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/RemoveMediaUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/RemoveMediaUseCase.kt
@@ -7,9 +7,9 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.modules.BG_THREAD
-import org.wordpress.android.ui.uploads.UploadService
-import org.wordpress.android.util.MediaUtils
-import org.wordpress.android.util.StringUtils
+import org.wordpress.android.ui.uploads.UploadServiceFacade
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.MediaUtilsWrapper
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
@@ -17,20 +17,26 @@ import javax.inject.Named
 class RemoveMediaUseCase @Inject constructor(
     private val mediaStore: MediaStore,
     private val dispatcher: Dispatcher,
+    private val mediaUtils: MediaUtilsWrapper,
+    private val uploadService: UploadServiceFacade,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) {
     suspend fun removeMediaIfNotUploading(mediaIds: List<String>) = withContext(bgDispatcher) {
         for (mediaId in mediaIds) {
             if (!TextUtils.isEmpty(mediaId)) {
                 // make sure the MediaModel exists
-                val mediaModel = mediaStore.getMediaWithLocalId(StringUtils.stringToInt(mediaId))
-                        ?: continue
+                val mediaModel = try {
+                    mediaStore.getMediaWithLocalId(Integer.valueOf(mediaId)) ?: continue
+                } catch (e: NumberFormatException) {
+                    AppLog.e(AppLog.T.MEDIA, "Invalid media id: $mediaId")
+                    continue
+                }
 
                 // also make sure it's not being uploaded anywhere else (maybe on some other Post,
                 // simultaneously)
                 if (mediaModel.uploadState != null &&
-                        MediaUtils.isLocalFile(mediaModel.uploadState.toLowerCase(Locale.ROOT)) &&
-                        !UploadService.isPendingOrInProgressMediaUpload(mediaModel)) {
+                        mediaUtils.isLocalFile(mediaModel.uploadState.toLowerCase(Locale.ROOT)) &&
+                        !uploadService.isPendingOrInProgressMediaUpload(mediaModel)) {
                     dispatcher.dispatch(MediaActionBuilder.newRemoveMediaAction(mediaModel))
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
@@ -41,4 +41,7 @@ class UploadServiceFacade @Inject constructor(private val appContext: Context) {
     fun uploadMediaFromEditor(mediaList: ArrayList<MediaModel>) {
         UploadService.uploadMediaFromEditor(appContext, mediaList)
     }
+
+    fun isPendingOrInProgressMediaUpload(mediaModel: MediaModel): Boolean =
+            UploadService.isPendingOrInProgressMediaUpload(mediaModel)
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
@@ -45,4 +45,6 @@ class MediaUtilsWrapper @Inject constructor(private val appContext: Context) {
 
     fun getVideoThumbnail(videoPath: String): String? =
             EditorMediaUtils.getVideoThumbnail(appContext, videoPath)
+
+    fun isLocalFile(uploadState: String): Boolean = MediaUtils.isLocalFile(uploadState)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/RemoveMediaUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/RemoveMediaUseCaseTest.kt
@@ -1,0 +1,97 @@
+package org.wordpress.android.ui.posts.editor.media
+
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.store.MediaStore
+import org.wordpress.android.test
+import org.wordpress.android.ui.uploads.UploadServiceFacade
+import org.wordpress.android.util.MediaUtilsWrapper
+
+private const val DUMMY_MEDIA_ID = "1"
+
+@InternalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class RemoveMediaUseCaseTest {
+    private lateinit var removeMediaUseCase: RemoveMediaUseCase
+    private val mediaStore: MediaStore = mock()
+    private val dispatcher: Dispatcher = mock()
+    private val mediaUtilsWrapper: MediaUtilsWrapper = mock()
+    private val uploadServiceFacade: UploadServiceFacade = mock()
+
+    @Before
+    fun setUp() {
+        removeMediaUseCase = RemoveMediaUseCase(
+                mediaStore,
+                dispatcher,
+                mediaUtilsWrapper,
+                uploadServiceFacade,
+                TEST_DISPATCHER
+        )
+        whenever(mediaStore.getMediaWithLocalId(anyInt())).thenReturn(MediaModel().apply {
+            uploadState = "non-empty-state"
+        })
+        whenever(mediaUtilsWrapper.isLocalFile(anyString())).thenReturn(true)
+        whenever(uploadServiceFacade.isPendingOrInProgressMediaUpload(anyOrNull())).thenReturn(false)
+    }
+
+    @Test
+    fun `Media is removed  when it's not uploading and is local file`() = test {
+        // Arrange
+        val mediaIds = listOf(DUMMY_MEDIA_ID)
+        // Act
+        removeMediaUseCase.removeMediaIfNotUploading(mediaIds = mediaIds)
+        // Assert
+        verify(dispatcher, times(1)).dispatch(any<Action<MediaModel>>())
+    }
+
+    @Test
+    fun `Media is NOT removed  when it's being uploaded`() = test {
+        // Arrange
+        val mediaIds = listOf(DUMMY_MEDIA_ID)
+        whenever(uploadServiceFacade.isPendingOrInProgressMediaUpload(anyOrNull())).thenReturn(true)
+        // Act
+        removeMediaUseCase.removeMediaIfNotUploading(mediaIds = mediaIds)
+        // Assert
+        verify(dispatcher, never()).dispatch(any<Action<MediaModel>>())
+    }
+
+    @Test
+    fun `Media is NOT removed  when it's not a local file`() = test {
+        // Arrange
+        val mediaIds = listOf(DUMMY_MEDIA_ID)
+        whenever(mediaUtilsWrapper.isLocalFile(anyString())).thenReturn(false)
+        // Act
+        removeMediaUseCase.removeMediaIfNotUploading(mediaIds = mediaIds)
+        // Assert
+        verify(dispatcher, never()).dispatch(any<Action<MediaModel>>())
+    }
+
+    @Test
+    fun `Media is skipped when it's not found in media store`() = test {
+        // Arrange
+        val mediaIds = listOf(DUMMY_MEDIA_ID)
+        whenever(mediaStore.getMediaWithLocalId(anyInt())).thenReturn(null)
+        // Act
+        removeMediaUseCase.removeMediaIfNotUploading(mediaIds = mediaIds)
+        // Assert
+        verify(dispatcher, never()).dispatch(any<Action<MediaModel>>())
+        verify(uploadServiceFacade, never()).isPendingOrInProgressMediaUpload(anyOrNull())
+        verify(mediaUtilsWrapper, never()).isLocalFile(anyOrNull())
+    }
+}


### PR DESCRIPTION
Adds basic tests for RemoveMediaUseCase.

To test:
1. Create a post
2. Turn on airplane mode
3. Add an image
4. Remove the image
5. Press back and make sure `removeMediaIfNotUploading` is invoked and the media is removed (using a breakpoint)

Note: My AS keeps freezing when I try to stop the app on the breakpoint, I'm not sure why.
It seems the logic is run only with Aztec, is this expected?

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

