### PR TITLE
QuickStart review for ia changes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -615,7 +615,13 @@ public class MySiteFragment extends Fragment implements
     }
 
     private void viewPosts() {
-        ActivityLauncher.viewCurrentBlogPosts(getActivity(), getSelectedSite());
+        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) requestNextStepOfActiveQuickStartTask();
+        SiteModel selectedSite = getSelectedSite();
+        if (selectedSite != null) {
+            ActivityLauncher.viewCurrentBlogPosts(requireActivity(), selectedSite);
+        } else {
+            ToastUtils.showToast(getActivity(), R.string.site_cannot_be_loaded);
+        }
     }
 
     private void viewPages() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -759,7 +759,8 @@ public class WPMainActivity extends AppCompatActivity implements
             return;
         }
 
-        if (getSelectedSite() != null && getMySiteFragment() != null) {
+        if (getSelectedSite() != null && getMySiteFragment() != null
+            && !BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
             if (getMySiteFragment().isQuickStartTaskActive(QuickStartTask.PUBLISH_POST)) {
                 // PUBLISH_POST task requires special Quick Start notice logic, so we set the flag here
                 AppPrefs.setQuickStartNoticeRequired(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -509,8 +509,10 @@ public class EditPostActivity extends AppCompatActivity implements
         mEditorMedia.start(mSite, this);
         startObserving();
 
-        QuickStartUtils.completeTaskAndRemindNextOne(mQuickStartStore, QuickStartTask.PUBLISH_POST,
-                mDispatcher, mSite, this);
+        if (!BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
+            QuickStartUtils.completeTaskAndRemindNextOne(mQuickStartStore, QuickStartTask.PUBLISH_POST,
+                    mDispatcher, mSite, this);
+        }
 
         if (mHasSetPostContent = mEditorFragment != null) {
             mEditorFragment.setImageLoader(mImageLoader);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -25,10 +25,16 @@ import androidx.viewpager.widget.ViewPager.OnPageChangeListener
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout
+import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.QuickStartStore
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.ActivityId
 import org.wordpress.android.ui.ActivityLauncher
@@ -39,6 +45,7 @@ import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogOnDismissBy
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface
 import org.wordpress.android.ui.posts.PostListType.SEARCH
 import org.wordpress.android.ui.posts.adapters.AuthorSelectionAdapter
+import org.wordpress.android.ui.quickstart.QuickStartEvent
 import org.wordpress.android.ui.uploads.UploadActionUseCase
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper
 import org.wordpress.android.ui.utils.UiHelpers
@@ -46,9 +53,11 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.LocaleManager
+import org.wordpress.android.util.QuickStartUtils
 import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.SnackbarItem
 import org.wordpress.android.util.redirectContextClickToLongPressListener
+import org.wordpress.android.widgets.WPDialogSnackbar
 import javax.inject.Inject
 
 const val EXTRA_TARGET_POST_LOCAL_ID = "targetPostLocalId"
@@ -68,6 +77,7 @@ class PostsListActivity : AppCompatActivity(),
     @Inject internal lateinit var uploadActionUseCase: UploadActionUseCase
     @Inject internal lateinit var snackbarSequencer: SnackbarSequencer
     @Inject internal lateinit var uploadUtilsWrapper: UploadUtilsWrapper
+    @Inject internal lateinit var quickStartStore: QuickStartStore
 
     private lateinit var site: SiteModel
     private lateinit var viewModel: PostListMainViewModel
@@ -83,6 +93,8 @@ class PostsListActivity : AppCompatActivity(),
     private lateinit var fab: FloatingActionButton
     private lateinit var searchActionButton: MenuItem
     private lateinit var toggleViewLayoutMenuItem: MenuItem
+
+    private var quickStartEvent: QuickStartEvent? = null
 
     private var restorePreviousSearch = false
 
@@ -144,6 +156,8 @@ class PostsListActivity : AppCompatActivity(),
         setupContent()
         initViewModel(initPreviewState)
         loadIntentData(intent)
+
+        quickStartEvent = savedInstanceState?.getParcelable(QuickStartEvent.KEY)
     }
 
     private fun setupActionBar() {
@@ -227,6 +241,15 @@ class PostsListActivity : AppCompatActivity(),
 
         viewModel.postListAction.observe(this, Observer { postListAction ->
             postListAction?.let { action ->
+                QuickStartUtils.completeTaskAndRemindNextOne(
+                        quickStartStore,
+                        QuickStartTask.PUBLISH_POST,
+                        dispatcher,
+                        site,
+                        quickStartEvent,
+                        this@PostsListActivity
+                )
+
                 handlePostListAction(
                         this@PostsListActivity,
                         action,
@@ -469,5 +492,43 @@ class PostsListActivity : AppCompatActivity(),
 
     private fun updateMenuTitle(title: UiString, menuItem: MenuItem): MenuItem? {
         return menuItem.setTitle(uiHelpers.getTextOfUiString(this@PostsListActivity, title))
+    }
+
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
+    @SuppressWarnings("unused")
+    fun onEvent(event: QuickStartEvent) {
+        val view = findViewById<View>(R.id.coordinator)
+
+        if (!BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE || view == null) {
+            return
+        }
+
+        EventBus.getDefault().removeStickyEvent(event)
+        quickStartEvent = event
+
+        if (quickStartEvent?.task == QuickStartTask.PUBLISH_POST) {
+            view.post {
+                val title = QuickStartUtils.stylizeQuickStartPrompt(
+                        this,
+                        R.string.quick_start_dialog_create_new_post_message_short_posts,
+                        R.drawable.ic_create_white_24dp
+                )
+
+                WPDialogSnackbar.make(
+                        view, title,
+                        resources.getInteger(R.integer.quick_start_snackbar_duration_ms)
+                ).show()
+            }
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        EventBus.getDefault().register(this)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        EventBus.getDefault().unregister(this)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartMySitePrompts.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartMySitePrompts.kt
@@ -45,8 +45,14 @@ enum class QuickStartMySitePrompts constructor(
     PUBLISH_POST_TUTORIAL(
             QuickStartTask.PUBLISH_POST,
             if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) R.id.my_site_scroll_view_root else R.id.root_view_main,
-            if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) R.id.row_blog_posts else R.id.bottom_nav_new_post_button,
-            if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) R.string.quick_start_dialog_create_new_post_message_short else R.string.quick_start_dialog_publish_post_message_short,
+            if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE)
+                R.id.row_blog_posts
+            else
+                R.id.bottom_nav_new_post_button,
+            if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE)
+                R.string.quick_start_dialog_create_new_post_message_short
+            else
+                R.string.quick_start_dialog_publish_post_message_short,
             if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) -1 else R.drawable.ic_create_white_24dp
     ),
     FOLLOW_SITES_TUTORIAL(
@@ -98,7 +104,8 @@ enum class QuickStartMySitePrompts constructor(
 
         @JvmStatic
         fun isTargetingBottomNavBar(task: QuickStartTask): Boolean {
-            return task == QuickStartTask.FOLLOW_SITE || (!BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && task == QuickStartTask.PUBLISH_POST)
+            return task == QuickStartTask.FOLLOW_SITE ||
+                    (!BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && task == QuickStartTask.PUBLISH_POST)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartMySitePrompts.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartMySitePrompts.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.quickstart
 
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 
@@ -43,10 +44,10 @@ enum class QuickStartMySitePrompts constructor(
     ),
     PUBLISH_POST_TUTORIAL(
             QuickStartTask.PUBLISH_POST,
-            R.id.root_view_main,
-            R.id.bottom_nav_new_post_button,
-            R.string.quick_start_dialog_publish_post_message_short,
-            R.drawable.ic_create_white_24dp
+            if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) R.id.my_site_scroll_view_root else R.id.root_view_main,
+            if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) R.id.row_blog_posts else R.id.bottom_nav_new_post_button,
+            if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) R.string.quick_start_dialog_create_new_post_message_short else R.string.quick_start_dialog_publish_post_message_short,
+            if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) -1 else R.drawable.ic_create_white_24dp
     ),
     FOLLOW_SITES_TUTORIAL(
             QuickStartTask.FOLLOW_SITE,
@@ -97,7 +98,7 @@ enum class QuickStartMySitePrompts constructor(
 
         @JvmStatic
         fun isTargetingBottomNavBar(task: QuickStartTask): Boolean {
-            return task == QuickStartTask.FOLLOW_SITE || task == QuickStartTask.PUBLISH_POST
+            return task == QuickStartTask.FOLLOW_SITE || (!BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && task == QuickStartTask.PUBLISH_POST)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTaskDetails.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTaskDetails.java
@@ -42,7 +42,8 @@ public enum QuickStartTaskDetails {
             QuickStartTask.PUBLISH_POST,
             R.string.quick_start_list_publish_post_title,
             R.string.quick_start_list_publish_post_subtitle,
-            BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE ? R.drawable.ic_posts_white_24dp : R.drawable.ic_create_white_24dp
+            BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE
+                    ? R.drawable.ic_posts_white_24dp : R.drawable.ic_create_white_24dp
     ),
     FOLLOW_SITES_TUTORIAL(
             QuickStartTask.FOLLOW_SITE,

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTaskDetails.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTaskDetails.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.quickstart;
 
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask;
 
@@ -41,7 +42,7 @@ public enum QuickStartTaskDetails {
             QuickStartTask.PUBLISH_POST,
             R.string.quick_start_list_publish_post_title,
             R.string.quick_start_list_publish_post_subtitle,
-            R.drawable.ic_create_white_24dp
+            BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE ? R.drawable.ic_posts_white_24dp : R.drawable.ic_create_white_24dp
     ),
     FOLLOW_SITES_TUTORIAL(
             QuickStartTask.FOLLOW_SITE,

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -437,28 +437,22 @@
                 </LinearLayout>
 
                 <!--Blog Posts-->
-                <FrameLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent">
+                <LinearLayout
+                    android:id="@+id/row_blog_posts"
+                    style="@style/MySiteListRowLayout">
 
-                    <LinearLayout
-                        android:id="@+id/row_blog_posts"
-                        style="@style/MySiteListRowLayout">
+                    <ImageView
+                        android:id="@+id/my_site_blog_posts_icon"
+                        style="@style/MySiteListRowIcon"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_posts_white_24dp"/>
 
-                        <ImageView
-                            android:id="@+id/my_site_blog_posts_icon"
-                            style="@style/MySiteListRowIcon"
-                            android:importantForAccessibility="no"
-                            android:src="@drawable/ic_posts_white_24dp"/>
+                    <org.wordpress.android.widgets.WPTextView
+                        android:id="@+id/my_site_blog_posts_text_view"
+                        style="@style/MySiteListRowTextView"
+                        android:text="@string/my_site_btn_blog_posts"/>
 
-                        <org.wordpress.android.widgets.WPTextView
-                            android:id="@+id/my_site_blog_posts_text_view"
-                            style="@style/MySiteListRowTextView"
-                            android:text="@string/my_site_btn_blog_posts"/>
-
-                    </LinearLayout>
-
-                </FrameLayout>
+                </LinearLayout>
 
                 <!--Media-->
                 <LinearLayout

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2500,6 +2500,8 @@
     <string name="quick_start_dialog_check_stats_message_short" tools:ignore="UnusedResources">Tap %1$s Stats %2$s to see how your site is performing.</string>
     <string name="quick_start_dialog_create_new_page_message_short" tools:ignore="UnusedResources">Tap %1$s Site Pages %2$s to continue.</string>
     <string name="quick_start_dialog_create_new_page_message_short_pages">Tap %1$s Add Page %2$s to create a new page.</string>
+    <string name="quick_start_dialog_create_new_post_message_short" tools:ignore="UnusedResources">Tap %1$s Blog Posts %2$s to continue.</string>
+    <string name="quick_start_dialog_create_new_post_message_short_posts">Tap %1$s Add Post %2$s to create a new post.</string>
     <string name="quick_start_dialog_explore_plans_message_short" tools:ignore="UnusedResources">Tap %1$s Plan %2$s to see your current plan and other available plans</string>
     <string name="quick_start_dialog_upload_icon_message">Your visitors will see your icon in their browser. Add a custom icon for a polished, pro look.</string>
     <string name="quick_start_dialog_upload_icon_title">Upload a site icon</string>


### PR DESCRIPTION
Fixes #11011 

With the modifications for the IA project we made some layout changes. In the IA project we removed the add post button in the main navigation bottom bar. As a result of this, the majority of the QuickStart tutorials are still ok, but the `PUBLISH_POST_TUTORIAL` that was targeting the removed bottom button is no more ok as it is.

Our working hypothesis is to align the `PUBLISH_POST_TUTORIAL` to the `CREATE_NEW_PAGE` behavior. That is targeting the `row_blog_posts` in the My Site list of sections (in analogy to the `row_pages` targeted by the `CREATE_NEW_PAGE` tutorial). We are thinking to not move the `PUBLISH_POST_TUTORIAL` to the FAB (and in this case possibly also the `CREATE_NEW_PAGE` should be moved there) also because the new added IA FAB in the My Site page will be announced by an onboarding tooltip woking on the #11012 issue. (cc @osullivanchris to review this rationale)

## Notes
Working on this PR we also noticed the following:
- In the `my_site_fragment.xml` the post row is the only one inside a FrameLayout. Based on the following commit comment

> adf72e53fea9caf5df4fe413c4484d8145bd4ef0 -> Switching to FrameLayout so blinking animation works on API 16

I think it was due to this [lines of code](https://github.com/wordpress-mobile/WordPress-Android/blob/adf72e53fea9caf5df4fe413c4484d8145bd4ef0/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java#L286) that AFAIU are no more used (so we are removing the FrameLayout)

- AFAIU currently the Publish Post tutorial is usually not triggered since it is marked as completed by the EditPostActivity when doing the Create Page tutorial; we are moving this completion logic for Posts into the `MySiteFragment > viewPosts` function

- With the presence of the FAB, it could be possible that in some screen resolution configuration the focus point is not fully visible (see the image below for the VIew Site step). It seems still good enough, but maybe we could reconsider the horizontal placement of the focus point in this or another PR (cc @osullivanchris )

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/71814862-00768000-307e-11ea-85ec-e955aac54897.png>
</p>

## To test
The modifications are still all behind the `INFORMATION_ARCHITECTURE_AVAILABLE` feature flag.

Note that to have access to the QuickStart tutorials you need to create a new site (you can do it from the Switch Site on the My Site page). Once done this when coming back to the My Site page you will be prompted if you want to use the QuickStart tutorial to getting started; Accept and you will have access to the tutorials

| Accept dialog | Next Steps tutorials |
|---|---|
| ![image](https://user-images.githubusercontent.com/47797566/71814267-26028a00-307c-11ea-8dd9-04a2378f4ed1.png) | ![image](https://user-images.githubusercontent.com/47797566/71814354-6c57e900-307c-11ea-86a1-4191234f01ba.png) |


- with `vanilla` flavor go through the tutorials and check that nothing changed for the QuickStart
- with the `zalpha` go through the tutorials and check that nothing changed for the QuickStart except the Publish Post for which check the next step
- for the Publish Post you need to get a similar behavior as for the create page tutorial but targeting the blog posts row in My Site. Also some minor changes in the copy of the snackbars are made to account for the Posts (not Pages) scenario naming. Note that in zalpha you are prompted for the create post tutorial since it is not marked as completed while doing the create page tutorial.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

