### PR TITLE
Track gutenberg_enabled event during rollout

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -81,10 +81,10 @@ public class SiteUtils {
                 }
             }
 
-            // Enable Gutenberg for all sites using a single network call
+            // Enable and track Gutenberg for all sites using a single network call
+            trackGutenbergEnabledForNonGutenbergSites(siteStore);
             dispatcher.dispatch(SiteActionBuilder.newDesignateMobileEditorForAllSitesAction(
                     new DesignateMobileEditorForAllSitesPayload(SiteUtils.GB_EDITOR_NAME)));
-            trackGutenbergEnabledForNonGutenbergSites(siteStore);
 
             // After enabling Gutenberg on these sites, we consider the user entered the rollout group
             AppPrefs.setUserInGutenbergRolloutGroup();

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -84,6 +84,7 @@ public class SiteUtils {
             // Enable Gutenberg for all sites using a single network call
             dispatcher.dispatch(SiteActionBuilder.newDesignateMobileEditorForAllSitesAction(
                     new DesignateMobileEditorForAllSitesPayload(SiteUtils.GB_EDITOR_NAME)));
+            trackGutenbergEnabledForNonGutenbergSites(siteStore);
 
             // After enabling Gutenberg on these sites, we consider the user entered the rollout group
             AppPrefs.setUserInGutenbergRolloutGroup();
@@ -100,6 +101,15 @@ public class SiteUtils {
         } else {
             dispatcher.dispatch(SiteActionBuilder.newDesignateMobileEditorForAllSitesAction(
                     new DesignateMobileEditorForAllSitesPayload(SiteUtils.AZTEC_EDITOR_NAME)));
+        }
+    }
+
+    private static void trackGutenbergEnabledForNonGutenbergSites(final SiteStore siteStore) {
+        for (SiteModel site : siteStore.getSites()) {
+            if (!TextUtils.equals(site.getMobileEditor(), GB_EDITOR_NAME)) {
+                AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_GUTENBERG_ENABLED, site,
+                        BlockEditorEnabledSource.ON_PROGRESSIVE_ROLLOUT_PHASE_1.asPropertyMap());
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -81,7 +81,10 @@ public class SiteUtils {
                 }
             }
 
-            // Enable and track Gutenberg for all sites using a single network call
+            // Track and enable and  Gutenberg for all sites using a single network call. Ideally we would track this
+            // on the network response, but this would make this rollout even more complex.
+            // There might be some rare events when we register a site switched to Gutenberg which is actually
+            // still on Aztec.
             trackGutenbergEnabledForNonGutenbergSites(siteStore);
             dispatcher.dispatch(SiteActionBuilder.newDesignateMobileEditorForAllSitesAction(
                     new DesignateMobileEditorForAllSitesPayload(SiteUtils.GB_EDITOR_NAME)));

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -74,7 +74,8 @@ public class AnalyticsUtils {
         VIA_SITE_SETTINGS,
         ON_SITE_CREATION,
         ON_BLOCK_POST_OPENING,
-        ON_PROGRESSIVE_ROLLOUT;
+        ON_PROGRESSIVE_ROLLOUT_PHASE_1,
+        ON_PROGRESSIVE_ROLLOUT_PHASE_2;
 
         public Map<String, Object> asPropertyMap() {
             Map<String, Object> properties = new HashMap<>();


### PR DESCRIPTION
Part fix for https://github.com/wordpress-mobile/gutenberg-mobile/issues/1718
There is another upcoming PR for `develop` but I'm waiting for https://github.com/wordpress-mobile/WordPress-Android/pull/11029 to be merged before opening it (code is ready here: https://github.com/wordpress-mobile/WordPress-Android/tree/issue/1718-track-gutenberg-rollout-v2)

Known issue: it's tracked when the network request is initiated, not when we get the response.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

