### PR TITLE
Accessibility : Free Photo Library Crash Fix

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
@@ -635,21 +635,19 @@ public class StockMediaPickerActivity extends AppCompatActivity implements Searc
         }
 
         private void addImageSelectedToAccessibilityFocusedEvent(ImageView imageView, int position) {
-            if (!ViewCompat.hasAccessibilityDelegate(imageView)) {
-                AccessibilityUtils.addPopulateAccessibilityEventFocusedListener(imageView, event -> {
-                    if (isValidPosition(position)) {
-                        if (isItemSelected(position)) {
-                            final String imageSelectedText = imageView.getContext().getString(
-                                    R.string.photo_picker_image_selected);
-                            if (!imageView.getContentDescription().toString().contains(imageSelectedText)) {
-                                imageView.setContentDescription(
-                                        imageView.getContentDescription() + " "
-                                        + imageSelectedText);
-                            }
+            AccessibilityUtils.addPopulateAccessibilityEventFocusedListener(imageView, event -> {
+                if (isValidPosition(position)) {
+                    if (isItemSelected(position)) {
+                        final String imageSelectedText = imageView.getContext().getString(
+                                R.string.photo_picker_image_selected);
+                        if (!imageView.getContentDescription().toString().contains(imageSelectedText)) {
+                            imageView.setContentDescription(
+                                    imageView.getContentDescription() + " "
+                                    + imageSelectedText);
                         }
                     }
-                });
-            }
+                }
+            });
         }
 
         boolean isValidPosition(int position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
@@ -22,6 +22,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.view.ViewCompat;
 import androidx.fragment.app.FragmentManager;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -634,19 +635,21 @@ public class StockMediaPickerActivity extends AppCompatActivity implements Searc
         }
 
         private void addImageSelectedToAccessibilityFocusedEvent(ImageView imageView, int position) {
-            AccessibilityUtils.addPopulateAccessibilityEventFocusedListener(imageView, event -> {
-                if (isValidPosition(position)) {
-                    if (isItemSelected(position)) {
-                        final String imageSelectedText = imageView.getContext().getString(
-                                R.string.photo_picker_image_selected);
-                        if (!imageView.getContentDescription().toString().contains(imageSelectedText)) {
-                            imageView.setContentDescription(
-                                    imageView.getContentDescription() + " "
-                                    + imageSelectedText);
+            if (!ViewCompat.hasAccessibilityDelegate(imageView)) {
+                AccessibilityUtils.addPopulateAccessibilityEventFocusedListener(imageView, event -> {
+                    if (isValidPosition(position)) {
+                        if (isItemSelected(position)) {
+                            final String imageSelectedText = imageView.getContext().getString(
+                                    R.string.photo_picker_image_selected);
+                            if (!imageView.getContentDescription().toString().contains(imageSelectedText)) {
+                                imageView.setContentDescription(
+                                        imageView.getContentDescription() + " "
+                                        + imageSelectedText);
+                            }
                         }
                     }
-                }
-            });
+                });
+            }
         }
 
         boolean isValidPosition(int position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
@@ -22,7 +22,6 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
-import androidx.core.view.ViewCompat;
 import androidx.fragment.app.FragmentManager;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;

--- a/WordPress/src/main/res/layout/media_picker_thumbnail.xml
+++ b/WordPress/src/main/res/layout/media_picker_thumbnail.xml
@@ -22,6 +22,7 @@
         android:layout_marginStart="@dimen/margin_medium"
         android:background="@drawable/photo_picker_circle_selector"
         android:elevation="4dp"
+        android:importantForAccessibility="no"
         android:gravity="center"
         android:includeFontPadding="false"
         android:textColor="@android:color/white"

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AccessibilityUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AccessibilityUtils.java
@@ -60,7 +60,7 @@ public class AccessibilityUtils {
     public static void addPopulateAccessibilityEventFocusedListener(@NonNull final View target,
                                                                     @NonNull final AccessibilityEventListener
                                                                             listener) {
-        setAccessibilityDelegateSafely(target, new AccessibilityDelegateCompat() {
+        ViewCompat.setAccessibilityDelegate(target, new AccessibilityDelegateCompat() {
             @Override public void onPopulateAccessibilityEvent(View host, AccessibilityEvent event) {
                 if (event.getEventType() == TYPE_VIEW_ACCESSIBILITY_FOCUSED) {
                     listener.onResult(event);


### PR DESCRIPTION
Fixes #11041

To test:

1. Create a new post
2. Add a new image
3. Select "Choose from Free Photo Library"
4. Type "cat" into the search box
5. Select an image and notice the app doesn't crash.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

