### PR TITLE
Move onMediaDeleted logic into EditorMedia

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -69,7 +69,6 @@ import org.wordpress.android.editor.ImageSettingsDialogFragment;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
-import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.model.AccountModel;
 import org.wordpress.android.fluxc.model.CauseOfOnPostChanged;
@@ -2544,31 +2543,8 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override
     public void onMediaDeleted(String localMediaId) {
         if (!TextUtils.isEmpty(localMediaId)) {
-            if (mShowAztecEditor && !mShowGutenbergEditor) {
-                setDeletedMediaIdOnUploadService(localMediaId);
-                // passing false here as we need to keep the media item in case the user wants to undo
-                mEditorMedia.cancelMediaUploadAsync(StringUtils.stringToInt(localMediaId), false);
-            } else if (mShowGutenbergEditor) {
-                MediaModel mediaModel = mMediaStore.getMediaWithLocalId(StringUtils.stringToInt(localMediaId));
-                if (mediaModel == null) {
-                    return;
-                }
-
-                setDeletedMediaIdOnUploadService(localMediaId);
-
-                // also make sure it's not being uploaded anywhere else (maybe on some other Post,
-                // simultaneously)
-                if (mediaModel.getUploadState() != null
-                    && MediaUtils.isLocalFile(mediaModel.getUploadState().toLowerCase(Locale.ROOT))
-                    && !UploadService.isPendingOrInProgressMediaUpload(mediaModel)) {
-                    mDispatcher.dispatch(MediaActionBuilder.newRemoveMediaAction(mediaModel));
-                }
-            }
+            mEditorMedia.onMediaDeleted(mShowAztecEditor, mShowGutenbergEditor, localMediaId);
         }
-    }
-
-    private void setDeletedMediaIdOnUploadService(String localMediaId) {
-        mEditorMedia.removeMediaItem(localMediaId);
     }
 
     @Override
@@ -2596,7 +2572,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
             if (!found) {
                 if (mEditorFragment instanceof AztecEditorFragment) {
-                    mEditorMedia.removeMediaItem(mediaId);
+                    mEditorMedia.updateDeletedMediaItemIds(mediaId);
                     ((AztecEditorFragment) mEditorFragment).setMediaToFailed(mediaId);
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
@@ -33,6 +33,7 @@ import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.StringUtils
 import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.util.helpers.MediaFile
 import org.wordpress.android.viewmodel.Event
@@ -250,7 +251,7 @@ class EditorMedia @Inject constructor(
         }
     }
 
-    fun removeMediaItem(localMediaId: String) {
+    fun updateDeletedMediaItemIds(localMediaId: String) {
         deletedMediaItemIds.add(localMediaId)
         UploadService.setDeletedMediaItemIds(deletedMediaItemIds)
     }
@@ -259,6 +260,22 @@ class EditorMedia @Inject constructor(
 
     fun cancelAddMediaToEditorActions() {
         job.cancel()
+    }
+
+    fun onMediaDeleted(
+        showAztecEditor: Boolean,
+        showGutenbergEditor: Boolean,
+        localMediaId: String
+    ) {
+        updateDeletedMediaItemIds(localMediaId)
+        if (showAztecEditor && !showGutenbergEditor) {
+            // passing false here as we need to keep the media item in case the user wants to undo
+            cancelMediaUploadAsync(StringUtils.stringToInt(localMediaId), false)
+        } else {
+            launch {
+                removeMediaUseCase.removeMediaIfNotUploading(listOf(localMediaId))
+            }
+        }
     }
 
     enum class AddExistingMediaSource {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/10689
Refactor and move OnMediaDeleted logic to EditorMedia.

To test:
1. Create a post in Aztec
2. Add an image and delete it before the upload completes -> make sure the upload gets canceled (in other words make sure the upload notification disappears)

I'm not sure why we don't call `cancelMediaUploadAsync` with `delete = true` in gutenberg instead of calling `removeMediaUseCase.removeMediaIfNotUploading` so I decided adding tests doesn't make sense (yet).

PR submission checklist:

- [x] I have considered adding unit tests where possible. 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

