### PR TITLE
Move ReattachUploadMedia to a usecase

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -685,6 +685,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private void reattachUploadingMediaForAztec() {
         if (mEditorMediaUploadListener != null) {
             mEditorMedia.reattachUploadingMediaForAztec(
+                    mEditPostRepository,
                     mEditorFragment instanceof AztecEditorFragment,
                     mEditorMediaUploadListener
             );

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -683,37 +683,11 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private void reattachUploadingMediaForAztec() {
-        if (mEditorFragment instanceof AztecEditorFragment && mEditorMediaUploadListener != null) {
-            // UploadService.getPendingMediaForPost will be populated only when the user exits the editor
-            // But if the user doesn't exit the editor and sends the app to the background, a reattachment
-            // for the media within this Post is needed as soon as the app comes back to foreground,
-            // so we get the list of progressing media for this Post from the UploadService
-            Set<MediaModel> uploadingMediaInPost = mEditPostRepository.getPendingMediaForPost();
-            List<MediaModel> allUploadingMediaInPost = new ArrayList<>(uploadingMediaInPost);
-            // add them to the array only if they are not in there yet
-            for (MediaModel media1 : mEditPostRepository.getPendingOrInProgressMediaUploadsForPost()) {
-                boolean found = false;
-                for (MediaModel media2 : uploadingMediaInPost) {
-                    if (media1.getId() == media2.getId()) {
-                        // if it exists, just break the loop and check for the next one
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found) {
-                    // we haven't found it before, so let's add it to the list.
-                    allUploadingMediaInPost.add(media1);
-                }
-            }
-
-            // now do proper re-attachment of upload progress on each media item
-            for (MediaModel media : allUploadingMediaInPost) {
-                if (media != null) {
-                    mEditorMediaUploadListener.onMediaUploadReattached(String.valueOf(media.getId()),
-                            UploadService.getUploadProgressForMedia(media));
-                }
-            }
+        if (mEditorMediaUploadListener != null) {
+            mEditorMedia.reattachUploadingMediaForAztec(
+                    mEditorFragment instanceof AztecEditorFragment,
+                    mEditorMediaUploadListener
+            );
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
@@ -245,11 +245,12 @@ class EditorMedia @Inject constructor(
         isAztec: Boolean,
         editorMediaUploadListener: EditorMediaUploadListener
     ) {
-        reattachUploadingMediaUseCase.reattachUploadingMediaForAztec(
-                editPostRepository,
-                isAztec,
-                editorMediaUploadListener
-        )
+        if (isAztec) {
+            reattachUploadingMediaUseCase.reattachUploadingMediaForAztec(
+                    editPostRepository,
+                    editorMediaUploadListener
+            )
+        }
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.EditPostActivity.AfterSavePostListener
+import org.wordpress.android.ui.posts.EditPostRepository
 import org.wordpress.android.ui.posts.ProgressDialogUiState
 import org.wordpress.android.ui.posts.ProgressDialogUiState.HiddenProgressDialog
 import org.wordpress.android.ui.posts.ProgressDialogUiState.VisibleProgressDialog
@@ -240,10 +241,12 @@ class EditorMedia @Inject constructor(
     }
 
     fun reattachUploadingMediaForAztec(
+        editPostRepository: EditPostRepository,
         isAztec: Boolean,
         editorMediaUploadListener: EditorMediaUploadListener
     ) {
         reattachUploadingMediaUseCase.reattachUploadingMediaForAztec(
+                editPostRepository,
                 isAztec,
                 editorMediaUploadListener
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.runBlocking
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.editor.EditorMediaUploadListener
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.model.MediaModel
@@ -61,6 +62,7 @@ class EditorMedia @Inject constructor(
     private val retryFailedMediaUploadUseCase: RetryFailedMediaUploadUseCase,
     private val cleanUpMediaToPostAssociationUseCase: CleanUpMediaToPostAssociationUseCase,
     private val removeMediaUseCase: RemoveMediaUseCase,
+    private val reattachUploadingMediaUseCase: ReattachUploadingMediaUseCase,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
 ) : CoroutineScope {
     // region Fields
@@ -235,6 +237,16 @@ class EditorMedia @Inject constructor(
             cleanUpMediaToPostAssociationUseCase
                     .purgeMediaToPostAssociationsIfNotInPostAnymore(editorMediaListener.getImmutablePost())
         }
+    }
+
+    fun reattachUploadingMediaForAztec(
+        isAztec: Boolean,
+        editorMediaUploadListener: EditorMediaUploadListener
+    ) {
+        reattachUploadingMediaUseCase.reattachUploadingMediaForAztec(
+                isAztec,
+                editorMediaUploadListener
+        )
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/ReattachUploadingMediaUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/ReattachUploadingMediaUseCase.kt
@@ -11,31 +11,28 @@ class ReattachUploadingMediaUseCase @Inject constructor(
 ) {
     fun reattachUploadingMediaForAztec(
         editPostRepository: EditPostRepository,
-        isAztec: Boolean,
         editorMediaUploadListener: EditorMediaUploadListener
     ) {
-        if (isAztec) {
-            // UploadService.getPendingMediaForPost will be populated only when the user exits the editor
-            // But if the user doesn't exit the editor and sends the app to the background, a reattachment
-            // for the media within this Post is needed as soon as the app comes back to foreground,
-            // so we get the list of progressing media for this Post from the UploadService
-            val uploadingMediaInPost = editPostRepository.getPendingMediaForPost()
-            val allUploadingMediaInPost = ArrayList<MediaModel>(uploadingMediaInPost)
+        // UploadService.getPendingMediaForPost will be populated only when the user exits the editor
+        // But if the user doesn't exit the editor and sends the app to the background, a reattachment
+        // for the media within this Post is needed as soon as the app comes back to foreground,
+        // so we get the list of progressing media for this Post from the UploadService
+        val uploadingMediaInPost = editPostRepository.getPendingMediaForPost()
+        val allUploadingMediaInPost = ArrayList<MediaModel>(uploadingMediaInPost)
 
-            editPostRepository.getPendingOrInProgressMediaUploadsForPost().forEach { media1 ->
-                // add them to the array only if they are not in there yet
-                if (uploadingMediaInPost.none { media2 -> media1.id == media2.id }) {
-                    allUploadingMediaInPost.add(media1)
-                }
+        editPostRepository.getPendingOrInProgressMediaUploadsForPost().forEach { media1 ->
+            // add them to the array only if they are not in there yet
+            if (uploadingMediaInPost.none { media2 -> media1.id == media2.id }) {
+                allUploadingMediaInPost.add(media1)
             }
+        }
 
-            // now do proper re-attachment of upload progress on each media item
-            allUploadingMediaInPost.forEach { mediaModel ->
-                editorMediaUploadListener.onMediaUploadReattached(
-                        mediaModel.id.toString(),
-                        uploadServiceFacade.getUploadProgressForMedia(mediaModel)
-                )
-            }
+        // now do proper re-attachment of upload progress on each media item
+        allUploadingMediaInPost.forEach { mediaModel ->
+            editorMediaUploadListener.onMediaUploadReattached(
+                    mediaModel.id.toString(),
+                    uploadServiceFacade.getUploadProgressForMedia(mediaModel)
+            )
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/ReattachUploadingMediaUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/ReattachUploadingMediaUseCase.kt
@@ -7,10 +7,10 @@ import org.wordpress.android.ui.uploads.UploadServiceFacade
 import javax.inject.Inject
 
 class ReattachUploadingMediaUseCase @Inject constructor(
-    private val editPostRepository: EditPostRepository,
     private val uploadServiceFacade: UploadServiceFacade
 ) {
     fun reattachUploadingMediaForAztec(
+        editPostRepository: EditPostRepository,
         isAztec: Boolean,
         editorMediaUploadListener: EditorMediaUploadListener
     ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/ReattachUploadingMediaUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/ReattachUploadingMediaUseCase.kt
@@ -1,0 +1,41 @@
+package org.wordpress.android.ui.posts.editor.media
+
+import org.wordpress.android.editor.EditorMediaUploadListener
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.uploads.UploadServiceFacade
+import javax.inject.Inject
+
+class ReattachUploadingMediaUseCase @Inject constructor(
+    private val editPostRepository: EditPostRepository,
+    private val uploadServiceFacade: UploadServiceFacade
+) {
+    fun reattachUploadingMediaForAztec(
+        isAztec: Boolean,
+        editorMediaUploadListener: EditorMediaUploadListener
+    ) {
+        if (isAztec) {
+            // UploadService.getPendingMediaForPost will be populated only when the user exits the editor
+            // But if the user doesn't exit the editor and sends the app to the background, a reattachment
+            // for the media within this Post is needed as soon as the app comes back to foreground,
+            // so we get the list of progressing media for this Post from the UploadService
+            val uploadingMediaInPost = editPostRepository.getPendingMediaForPost()
+            val allUploadingMediaInPost = ArrayList<MediaModel>(uploadingMediaInPost)
+
+            editPostRepository.getPendingOrInProgressMediaUploadsForPost().forEach { media1 ->
+                // add them to the array only if they are not in there yet
+                if (uploadingMediaInPost.none { media2 -> media1.id == media2.id }) {
+                    allUploadingMediaInPost.add(media1)
+                }
+            }
+
+            // now do proper re-attachment of upload progress on each media item
+            allUploadingMediaInPost.forEach { mediaModel ->
+                editorMediaUploadListener.onMediaUploadReattached(
+                        mediaModel.id.toString(),
+                        uploadServiceFacade.getUploadProgressForMedia(mediaModel)
+                )
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
@@ -44,4 +44,7 @@ class UploadServiceFacade @Inject constructor(private val appContext: Context) {
 
     fun isPendingOrInProgressMediaUpload(mediaModel: MediaModel): Boolean =
             UploadService.isPendingOrInProgressMediaUpload(mediaModel)
+
+    fun getUploadProgressForMedia(mediaModel: MediaModel): Float =
+            UploadService.getUploadProgressForMedia(mediaModel)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
@@ -346,7 +346,7 @@ class EditorMediaTest : BaseUnitTest() {
     }
 
     @Test
-    fun `reattachUploadingMedia is called when isAztec is true`() {
+    fun `reattachUploadingMedia is called for Aztec editor`() {
         // Arrange
         val reattachUploadingMediaUseCase = mock<ReattachUploadingMediaUseCase>()
         // Act
@@ -357,7 +357,7 @@ class EditorMediaTest : BaseUnitTest() {
     }
 
     @Test
-    fun `reattachUploadingMedia is NOT called when isAztec is false`() {
+    fun `reattachUploadingMedia is NOT called for other editors`() {
         // Arrange
         val reattachUploadingMediaUseCase = mock<ReattachUploadingMediaUseCase>()
         // Act

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
@@ -345,6 +345,28 @@ class EditorMediaTest : BaseUnitTest() {
         verify(retryFailedMediaUploadUseCase).retryFailedMediaAsync(anyOrNull(), eq(expectedIds))
     }
 
+    @Test
+    fun `reattachUploadingMedia is called when isAztec is true`() {
+        // Arrange
+        val reattachUploadingMediaUseCase = mock<ReattachUploadingMediaUseCase>()
+        // Act
+        createEditorMedia(reattachUploadingMediaUseCase = reattachUploadingMediaUseCase)
+                .reattachUploadingMediaForAztec(mock(), true, mock())
+        // Assert
+        verify(reattachUploadingMediaUseCase).reattachUploadingMediaForAztec(anyOrNull(), anyOrNull())
+    }
+
+    @Test
+    fun `reattachUploadingMedia is NOT called when isAztec is false`() {
+        // Arrange
+        val reattachUploadingMediaUseCase = mock<ReattachUploadingMediaUseCase>()
+        // Act
+        createEditorMedia(reattachUploadingMediaUseCase = reattachUploadingMediaUseCase)
+                .reattachUploadingMediaForAztec(mock(), false, mock())
+        // Assert
+        verify(reattachUploadingMediaUseCase, never()).reattachUploadingMediaForAztec(anyOrNull(), anyOrNull())
+    }
+
     private companion object Fixtures {
         private val VIDEO_URI = mock<Uri>()
         private val IMAGE_URI = mock<Uri>()

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
@@ -363,7 +363,8 @@ class EditorMediaTest : BaseUnitTest() {
             siteModel: SiteModel = mock(),
             editorMediaListener: EditorMediaListener = mock(),
             removeMediaUseCase: RemoveMediaUseCase = mock(),
-            cleanUpMediaToPostAssociationUseCase: CleanUpMediaToPostAssociationUseCase = mock()
+            cleanUpMediaToPostAssociationUseCase: CleanUpMediaToPostAssociationUseCase = mock(),
+            reattachUploadingMediaUseCase: ReattachUploadingMediaUseCase = mock()
         ): EditorMedia {
             val editorMedia = EditorMedia(
                     updateMediaModelUseCase,
@@ -376,6 +377,7 @@ class EditorMediaTest : BaseUnitTest() {
                     retryFailedMediaUploadUseCase,
                     cleanUpMediaToPostAssociationUseCase,
                     removeMediaUseCase,
+                    reattachUploadingMediaUseCase,
                     TEST_DISPATCHER
             )
             editorMedia.start(siteModel, editorMediaListener)

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/ReattachUploadingMediaUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/ReattachUploadingMediaUseCaseTest.kt
@@ -25,7 +25,7 @@ class ReattachUploadingMediaUseCaseTest {
 
     @Before
     fun setUp() {
-        useCase = ReattachUploadingMediaUseCase(editPostRepository, uploadServiceFacade)
+        useCase = ReattachUploadingMediaUseCase(uploadServiceFacade)
     }
 
     @Test
@@ -37,7 +37,7 @@ class ReattachUploadingMediaUseCaseTest {
                 .thenReturn(listOf(mediaModel2))
 
         // Act
-        useCase.reattachUploadingMediaForAztec(true, editorMediaUploadListener)
+        useCase.reattachUploadingMediaForAztec(editPostRepository, editorMediaUploadListener)
 
         // Assert
         verify(editorMediaUploadListener).onMediaUploadReattached(mediaModel1.id.toString(), 0f)
@@ -53,7 +53,7 @@ class ReattachUploadingMediaUseCaseTest {
                 .thenReturn(listOf(mediaModel1, mediaModel2))
 
         // Act
-        useCase.reattachUploadingMediaForAztec(true, editorMediaUploadListener)
+        useCase.reattachUploadingMediaForAztec(editPostRepository, editorMediaUploadListener)
 
         // Assert
         verify(editorMediaUploadListener, times(1)).onMediaUploadReattached(mediaModel1.id.toString(), 0f)
@@ -72,7 +72,7 @@ class ReattachUploadingMediaUseCaseTest {
         whenever(uploadServiceFacade.getUploadProgressForMedia(mediaModel1)).thenReturn(progress)
 
         // Act
-        useCase.reattachUploadingMediaForAztec(true, editorMediaUploadListener)
+        useCase.reattachUploadingMediaForAztec(editPostRepository, editorMediaUploadListener)
 
         // Assert
         verify(editorMediaUploadListener, times(1)).onMediaUploadReattached(mediaModel1.id.toString(), progress)

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/ReattachUploadingMediaUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/ReattachUploadingMediaUseCaseTest.kt
@@ -1,0 +1,80 @@
+package org.wordpress.android.ui.posts.editor.media
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.editor.EditorMediaUploadListener
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.uploads.UploadServiceFacade
+
+@RunWith(MockitoJUnitRunner::class)
+class ReattachUploadingMediaUseCaseTest {
+    private lateinit var useCase: ReattachUploadingMediaUseCase
+    private val editPostRepository: EditPostRepository = mock()
+    private val uploadServiceFacade: UploadServiceFacade = mock()
+    private val editorMediaUploadListener: EditorMediaUploadListener = mock()
+
+    private val mediaModel1 = MediaModel().apply { id = 1 }
+    private val mediaModel2 = MediaModel().apply { id = 2 }
+
+    @Before
+    fun setUp() {
+        useCase = ReattachUploadingMediaUseCase(editPostRepository, uploadServiceFacade)
+    }
+
+    @Test
+    fun `Media from both db and uploadHandler get reattached`() {
+        // Arrange
+        whenever(editPostRepository.getPendingMediaForPost())
+                .thenReturn(setOf(mediaModel1))
+        whenever(editPostRepository.getPendingOrInProgressMediaUploadsForPost())
+                .thenReturn(listOf(mediaModel2))
+
+        // Act
+        useCase.reattachUploadingMediaForAztec(true, editorMediaUploadListener)
+
+        // Assert
+        verify(editorMediaUploadListener).onMediaUploadReattached(mediaModel1.id.toString(), 0f)
+        verify(editorMediaUploadListener).onMediaUploadReattached(mediaModel2.id.toString(), 0f)
+    }
+
+    @Test
+    fun `Media from db and uploadHandler are merged using union strategy`() {
+        // Arrange
+        whenever(editPostRepository.getPendingMediaForPost())
+                .thenReturn(setOf(mediaModel1))
+        whenever(editPostRepository.getPendingOrInProgressMediaUploadsForPost())
+                .thenReturn(listOf(mediaModel1, mediaModel2))
+
+        // Act
+        useCase.reattachUploadingMediaForAztec(true, editorMediaUploadListener)
+
+        // Assert
+        verify(editorMediaUploadListener, times(1)).onMediaUploadReattached(mediaModel1.id.toString(), 0f)
+        verify(editorMediaUploadListener, times(1)).onMediaUploadReattached(mediaModel2.id.toString(), 0f)
+    }
+
+    @Test
+    fun `Upload progress is propagated to EditorMediaUploadListener`() {
+        // Arrange
+        whenever(editPostRepository.getPendingMediaForPost())
+                .thenReturn(setOf(mediaModel1))
+        whenever(editPostRepository.getPendingOrInProgressMediaUploadsForPost())
+                .thenReturn(listOf())
+
+        val progress = 15.4f
+        whenever(uploadServiceFacade.getUploadProgressForMedia(mediaModel1)).thenReturn(progress)
+
+        // Act
+        useCase.reattachUploadingMediaForAztec(true, editorMediaUploadListener)
+
+        // Assert
+        verify(editorMediaUploadListener, times(1)).onMediaUploadReattached(mediaModel1.id.toString(), progress)
+    }
+}


### PR DESCRIPTION
Moves `reattachUploadingMediaForAztec` to a usecase.

To test:
1. Create a new draft in Aztec
2. Attach an image (You might need to slow down the internet connection)
3. Rotate your device before the upload completes
4. Make sure `uploadServiceFacade.getUploadProgressForMedia(..)` gets invoked (Eg. put breakpoint/log [here](https://github.com/wordpress-mobile/WordPress-Android/blob/2223b16c80727424d79fde464c06f759031f39f5/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/ReattachUploadingMediaUseCase.kt#L32))
-------------------
1. Run the same test, just add multiple images in step 2 and make sure the method gets called for all of them.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

