### PR TITLE
Search view width fix.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -457,6 +457,7 @@ public class SitePickerActivity extends AppCompatActivity
         mSearchView.setIconifiedByDefault(false);
         mSearchView.setIconified(false);
         mSearchView.setOnQueryTextListener(this);
+        mSearchView.setMaxWidth(Integer.MAX_VALUE);
 
         mMenuSearch.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -527,6 +527,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
         mSearchView = (SearchView) mSearchMenuItem.getActionView();
         mSearchView.setOnQueryTextListener(this);
+        mSearchView.setMaxWidth(Integer.MAX_VALUE);
 
         // open search bar if we were searching for something before
         if (!TextUtils.isEmpty(mQuery) && mMediaGridFragment != null && mMediaGridFragment.isVisible()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -249,6 +249,7 @@ public class PluginBrowserActivity extends AppCompatActivity
 
         mSearchMenuItem = menu.findItem(R.id.menu_search);
         mSearchView = (SearchView) mSearchMenuItem.getActionView();
+        mSearchView.setMaxWidth(Integer.MAX_VALUE);
 
         PluginListFragment currentFragment = getCurrentFragment();
         if (currentFragment != null && currentFragment.getListType() == PluginListType.SEARCH) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -210,6 +210,7 @@ public class SiteSettingsTagListActivity extends AppCompatActivity
         mSearchMenuItem.setOnActionExpandListener(this);
         mSearchView = (SearchView) mSearchMenuItem.getActionView();
         mSearchView.setOnQueryTextListener(this);
+        mSearchView.setMaxWidth(Integer.MAX_VALUE);
 
         // open search bar if we were searching for something before
         if (mIsSearching) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
@@ -176,6 +176,7 @@ public class ReaderBlogFragment extends Fragment
 
         MenuItem searchMenu = menu.findItem(R.id.menu_search);
         SearchView searchView = (SearchView) searchMenu.getActionView();
+        searchView.setMaxWidth(Integer.MAX_VALUE);
         searchView.setQueryHint(getString(R.string.reader_hint_search_followed_sites));
 
         searchMenu.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -242,6 +242,7 @@ public class ThemeBrowserFragment extends Fragment
         mSearchMenuItem = menu.findItem(R.id.menu_search);
         mSearchView = (SearchView) mSearchMenuItem.getActionView();
         mSearchView.setOnQueryTextListener(this);
+        mSearchView.setMaxWidth(Integer.MAX_VALUE);
 
         if (!TextUtils.isEmpty(mLastSearch)) {
             mSearchMenuItem.expandActionView();


### PR DESCRIPTION
Fixes #11043
This fixes the above issue of the search view not expanding the whole bar width. From the screenshot of the issue I'm not sure if this fix should be applied somewhere else in the project as I'm not sure if this is the same place. Anyway I detected this behavior in the ReaderBlogFragment where I made the change.

## Screenshots Before->After fix
 <img src="https://user-images.githubusercontent.com/57217107/71927856-bb923c80-3196-11ea-9533-db9e380960db.png" width="300"> <img src="https://user-images.githubusercontent.com/57217107/71927855-bb923c80-3196-11ea-94c4-1168e50b11b6.png" width="300">



To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

