### PR TITLE
Tooltip onboarding announcement for IA create FAB

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
@@ -66,7 +66,7 @@ class WPTooltipView @JvmOverloads constructor (
         inflate(getContext(), position.layout, this)
         val root = findViewById<LinearLayout>(R.id.root_view)
         val tvMessage = findViewById<TextView>(R.id.tooltip_message)
-        val arrow = findViewById<ImageView>(R.id.tooltip_arrow)
+        val arrow = findViewById<View>(R.id.tooltip_arrow)
 
         if (messageId > 0) {
             tvMessage.setText(messageId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
-import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.LayoutRes

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
@@ -1,0 +1,95 @@
+package org.wordpress.android.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.annotation.LayoutRes
+import androidx.core.view.ViewCompat
+import org.wordpress.android.R
+import org.wordpress.android.ui.WPTooltipView.TooltipPosition.ABOVE
+import org.wordpress.android.ui.WPTooltipView.TooltipPosition.BELOW
+import org.wordpress.android.ui.WPTooltipView.TooltipPosition.LEFT
+import org.wordpress.android.ui.WPTooltipView.TooltipPosition.RIGHT
+import org.wordpress.android.util.RtlUtils
+import java.lang.IllegalArgumentException
+import java.util.jar.Attributes
+
+/**
+ * Partially based on https://stackoverflow.com/a/42756576
+ *
+ * NOTE: this is a very basic implementation of a tooltip component
+ * mainly used to cover the need of onboarding/announcing in the IA Project main create FAB.
+ * More work/rework is needed to make it a full custom view tooltip component.
+ * A different and more dynamic approach that can be used is with PopupWindow taking care of behaviors like
+ * CoordinatorLayout behavior (as in this scenario with FAB and snackbars)
+ */
+
+class WPTooltipView @JvmOverloads constructor (
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : LinearLayout(context, attrs, defStyleAttr) {
+    var position = LEFT
+    var messageId = 0
+
+    init {
+        attrs?.also {
+            val a = context.theme.obtainStyledAttributes(
+                    attrs,
+                    R.styleable.WPTooltipView,
+                    0,
+                    0
+            )
+
+            try {
+                position = TooltipPosition.fromInt(a.getInt(R.styleable.WPTooltipView_wpTooltipPosition, 0))
+                messageId = a.getResourceId(R.styleable.WPTooltipView_wpTooltipMessage, 0)
+            } finally {
+                a.recycle()
+            }
+        }
+
+        inflate(getContext(), position.layout, this)
+        val tvMessage = findViewById<TextView>(R.id.tooltip_message)
+
+        if (RtlUtils.isRtl(context)) {
+            val arrow = findViewById<ImageView>(R.id.tooltip_arrow)
+            when (position) {
+                LEFT -> arrow.rotation = -90f
+                RIGHT -> arrow.rotation = 90f
+                ABOVE, BELOW -> {}
+            }
+        }
+
+        if (messageId > 0) {
+            tvMessage.setText(messageId)
+        }
+    }
+
+    enum class TooltipPosition(val value: Int, @LayoutRes val layout: Int) {
+        LEFT(0, R.layout.tooltip_left),
+        RIGHT(1, R.layout.tooltip_right),
+        ABOVE(2, R.layout.tooltip_above),
+        BELOW(3, R.layout.tooltip_below);
+
+        companion object {
+            fun fromInt(value: Int): TooltipPosition =
+                    values().firstOrNull() { it.value == value }
+                            ?: throw IllegalArgumentException("TooltipPosition wrong value $value")
+        }
+    }
+
+    fun show() {
+        this.postDelayed({
+            this.visibility = View.VISIBLE
+        }, 600)
+    }
+
+    fun hide() {
+        this.visibility = View.GONE
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
@@ -27,6 +27,8 @@ import java.lang.IllegalArgumentException
  * CoordinatorLayout behavior (as in this scenario with FAB and snackbars)
  */
 
+private const val HIDE_ANIMATION_DURATION = 50L
+
 class WPTooltipView @JvmOverloads constructor (
     context: Context,
     attrs: AttributeSet? = null,
@@ -130,7 +132,7 @@ class WPTooltipView @JvmOverloads constructor (
         this.apply {
             animate()
                     .alpha(0f)
-                    .setDuration(animationDuration.toLong())
+                    .setDuration(HIDE_ANIMATION_DURATION)
                     .setListener(object : AnimatorListenerAdapter() {
                         override fun onAnimationEnd(animation: Animator?) {
                             super.onAnimationEnd(animation)

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui
 
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
 import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
@@ -30,12 +32,13 @@ class WPTooltipView @JvmOverloads constructor (
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : LinearLayout(context, attrs, defStyleAttr) {
-    var position = LEFT
-    var messageId = 0
-    var arrowHorizontalOffsetFromEndResId = 0
-    var arrowHorizontalOffsetFromStartResId = 0
-    var arrowHorizontalOffsetFromEnd = -1
-    var arrowHorizontalOffsetFromStart = -1
+    private var position = LEFT
+    private var messageId = 0
+    private var arrowHorizontalOffsetFromEndResId = 0
+    private var arrowHorizontalOffsetFromStartResId = 0
+    private var arrowHorizontalOffsetFromEnd = -1
+    private var arrowHorizontalOffsetFromStart = -1
+    private var animationDuration: Int
 
     init {
         attrs?.also {
@@ -66,6 +69,7 @@ class WPTooltipView @JvmOverloads constructor (
         val root = findViewById<LinearLayout>(R.id.root_view)
         val tvMessage = findViewById<TextView>(R.id.tooltip_message)
         val arrow = findViewById<View>(R.id.tooltip_arrow)
+        animationDuration = resources.getInteger(android.R.integer.config_shortAnimTime)
 
         if (messageId > 0) {
             tvMessage.setText(messageId)
@@ -111,11 +115,28 @@ class WPTooltipView @JvmOverloads constructor (
 
     fun show() {
         this.postDelayed({
-            this.visibility = View.VISIBLE
-        }, 600)
+            this.apply {
+                alpha = 0f
+                visibility = View.VISIBLE
+                animate()
+                        .alpha(1f)
+                        .setDuration(animationDuration.toLong())
+                        .setListener(null)
+            }
+        }, 400)
     }
 
     fun hide() {
-        this.visibility = View.GONE
+        this.apply {
+            animate()
+                    .alpha(0f)
+                    .setDuration(animationDuration.toLong())
+                    .setListener(object : AnimatorListenerAdapter() {
+                        override fun onAnimationEnd(animation: Animator?) {
+                            super.onAnimationEnd(animation)
+                            visibility = View.GONE
+                        }
+                    })
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
@@ -3,12 +3,10 @@ package org.wordpress.android.ui
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
-import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.LayoutRes
-import androidx.core.view.ViewCompat
 import org.wordpress.android.R
 import org.wordpress.android.ui.WPTooltipView.TooltipPosition.ABOVE
 import org.wordpress.android.ui.WPTooltipView.TooltipPosition.BELOW
@@ -16,7 +14,6 @@ import org.wordpress.android.ui.WPTooltipView.TooltipPosition.LEFT
 import org.wordpress.android.ui.WPTooltipView.TooltipPosition.RIGHT
 import org.wordpress.android.util.RtlUtils
 import java.lang.IllegalArgumentException
-import java.util.jar.Attributes
 
 /**
  * Partially based on https://stackoverflow.com/a/42756576

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainFabUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainFabUiState.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.ui.main
 
-data class MainFabUiState (
+data class MainFabUiState(
     val isFabVisible: Boolean,
     val isFabTooltipVisible: Boolean
 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainFabUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainFabUiState.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.ui.main
+
+data class MainFabUiState (
+    val isFabVisible: Boolean,
+    val isFabTooltipVisible: Boolean
+)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -74,6 +74,7 @@ import org.wordpress.android.ui.JetpackConnectionWebViewActivity;
 import org.wordpress.android.ui.PagePostCreationSourcesDetail;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.ShortcutsNavigator;
+import org.wordpress.android.ui.WPTooltipView;
 import org.wordpress.android.ui.accounts.LoginActivity;
 import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
 import org.wordpress.android.ui.main.WPMainNavigationView.OnPageListener;
@@ -172,6 +173,7 @@ public class WPMainActivity extends AppCompatActivity implements
     private SiteModel mSelectedSite;
     private WPMainActivityViewModel mViewModel;
     private FloatingActionButton mFloatingActionButton;
+    private WPTooltipView mFabTooltip;
     private static final String MAIN_BOTTOM_SHEET_TAG = "MAIN_BOTTOM_SHEET_TAG";
 
     @Inject AccountStore mAccountStore;
@@ -386,16 +388,23 @@ public class WPMainActivity extends AppCompatActivity implements
 
     private void initViewModel() {
         mFloatingActionButton = findViewById(R.id.fab_button);
+        mFabTooltip = findViewById(R.id.fab_tooltip);
 
         mViewModel = ViewModelProviders.of(this, mViewModelFactory).get(WPMainActivityViewModel.class);
 
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
             // Setup Observers
-            mViewModel.getShowMainActionFab().observe(this, shouldShow -> {
-                if (shouldShow) {
+            mViewModel.getShowMainActionFab().observe(this, showUiState -> {
+                if (showUiState.isFabVisible()) {
                     mFloatingActionButton.show();
                 } else {
                     mFloatingActionButton.hide();
+                }
+
+                if (showUiState.isFabTooltipVisible()) {
+                    mFabTooltip.show();
+                } else {
+                    mFabTooltip.hide();
                 }
             });
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -394,14 +394,14 @@ public class WPMainActivity extends AppCompatActivity implements
 
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
             // Setup Observers
-            mViewModel.getShowMainActionFab().observe(this, showUiState -> {
-                if (showUiState.isFabVisible()) {
+            mViewModel.getFabUiState().observe(this, fabUiState -> {
+                if (fabUiState.isFabVisible()) {
                     mFloatingActionButton.show();
                 } else {
                     mFloatingActionButton.hide();
                 }
 
-                if (showUiState.isFabTooltipVisible()) {
+                if (fabUiState.isFabTooltipVisible()) {
                     mFabTooltip.show();
                 } else {
                     mFabTooltip.hide();

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -424,7 +424,7 @@ public class WPMainActivity extends AppCompatActivity implements
             });
 
             mFabTooltip.setOnClickListener(v -> {
-                mFabTooltip.hide();
+                mViewModel.onTooltipTapped();
             });
 
             mViewModel.isBottomSheetShowing().observe(this, event -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -395,16 +395,16 @@ public class WPMainActivity extends AppCompatActivity implements
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
             // Setup Observers
             mViewModel.getFabUiState().observe(this, fabUiState -> {
-                if (fabUiState.isFabVisible()) {
-                    mFloatingActionButton.show();
-                } else {
-                    mFloatingActionButton.hide();
-                }
-
                 if (fabUiState.isFabTooltipVisible()) {
                     mFabTooltip.show();
                 } else {
                     mFabTooltip.hide();
+                }
+
+                if (fabUiState.isFabVisible()) {
+                    mFloatingActionButton.show();
+                } else {
+                    mFloatingActionButton.hide();
                 }
             });
 
@@ -421,6 +421,10 @@ public class WPMainActivity extends AppCompatActivity implements
 
             mFloatingActionButton.setOnClickListener(v -> {
                 mViewModel.setIsBottomSheetShowing(true);
+            });
+
+            mFabTooltip.setOnClickListener(v -> {
+                mFabTooltip.hide();
             });
 
             mViewModel.isBottomSheetShowing().observe(this, event -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
@@ -877,7 +878,8 @@ public class AppPrefs {
     }
 
     public static boolean isMainFabTooltipDisabled() {
-        return getBoolean(UndeletablePrefKey.IS_MAIN_FAB_TOOLTIP_DISABLED, false);
+        return !BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE
+               || getBoolean(UndeletablePrefKey.IS_MAIN_FAB_TOOLTIP_DISABLED, false);
     }
 
     public static void setQuickStartMigrationDialogShown(Boolean shown) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -203,6 +203,9 @@ public class AppPrefs {
 
         // Used to indicate whether or not the the post-signup interstitial must be shown
         SHOULD_SHOW_POST_SIGNUP_INTERSTITIAL,
+
+        // used to indicate that we do not need to show the main FAB tooltip
+        IS_MAIN_FAB_TOOLTIP_DISABLED,
     }
 
     private static SharedPreferences prefs() {
@@ -867,6 +870,14 @@ public class AppPrefs {
 
     public static boolean isQuickStartDisabled() {
         return getBoolean(UndeletablePrefKey.IS_QUICK_START_DISABLED, false);
+    }
+
+    public static void setMainFabTooltipDisabled(Boolean disable) {
+        setBoolean(UndeletablePrefKey.IS_MAIN_FAB_TOOLTIP_DISABLED, disable);
+    }
+
+    public static boolean isMainFabTooltipDisabled() {
+        return getBoolean(UndeletablePrefKey.IS_MAIN_FAB_TOOLTIP_DISABLED, false);
     }
 
     public static void setQuickStartMigrationDialogShown(Boolean shown) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -111,7 +111,7 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun setMainFabTooltipDisabled(disable: Boolean) = AppPrefs.setMainFabTooltipDisabled(disable)
 
-    fun  isMainFabTooltipDisabled() = AppPrefs.isMainFabTooltipDisabled()
+    fun isMainFabTooltipDisabled() = AppPrefs.isMainFabTooltipDisabled()
 
     companion object {
         private const val LIGHT_MODE_ID = 0

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -109,6 +109,10 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun removeAppWidgetHasData(appWidgetId: Int) = AppPrefs.removeStatsWidgetHasData(appWidgetId)
 
+    fun setMainFabTooltipDisabled(disable: Boolean) = AppPrefs.setMainFabTooltipDisabled(disable)
+
+    fun  isMainFabTooltipDisabled() = AppPrefs.isMainFabTooltipDisabled()
+
     companion object {
         private const val LIGHT_MODE_ID = 0
         private const val DARK_MODE_ID = 1

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -37,7 +37,8 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
         if (isStarted) return
         isStarted = true
 
-        mainFabTooltipDisabled = !BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE || appPrefsWrapper.isMainFabTooltipDisabled()
+        mainFabTooltipDisabled = !BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE ||
+                appPrefsWrapper.isMainFabTooltipDisabled()
         setMainFabUiState(isFabVisible)
 
         loadMainActions()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.viewmodel.main
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.ui.main.MainActionListItem
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
@@ -19,8 +18,8 @@ import javax.inject.Inject
 class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: AppPrefsWrapper) : ViewModel() {
     private var isStarted = false
 
-    private val _showMainActionFab = MutableLiveData<MainFabUiState>()
-    val showMainActionFab: LiveData<MainFabUiState> = _showMainActionFab
+    private val _fabUiState = MutableLiveData<MainFabUiState>()
+    val fabUiState: LiveData<MainFabUiState> = _fabUiState
 
     private val _mainActions = MutableLiveData<List<MainActionListItem>>()
     val mainActions: LiveData<List<MainActionListItem>> = _mainActions
@@ -31,14 +30,10 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
     private val _isBottomSheetShowing = MutableLiveData<Event<Boolean>>()
     val isBottomSheetShowing: LiveData<Event<Boolean>> = _isBottomSheetShowing
 
-    private var mainFabTooltipDisabled = true
-
     fun start(isFabVisible: Boolean) {
         if (isStarted) return
         isStarted = true
 
-        mainFabTooltipDisabled = !BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE ||
-                appPrefsWrapper.isMainFabTooltipDisabled()
         setMainFabUiState(isFabVisible)
 
         loadMainActions()
@@ -69,11 +64,9 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
     }
 
     fun setIsBottomSheetShowing(showing: Boolean) {
-        if (!mainFabTooltipDisabled) {
-            mainFabTooltipDisabled = true
-            appPrefsWrapper.setMainFabTooltipDisabled(mainFabTooltipDisabled)
-            setMainFabUiState(true)
-        }
+        appPrefsWrapper.setMainFabTooltipDisabled(true)
+        setMainFabUiState(true)
+
         _isBottomSheetShowing.value = Event(showing)
     }
 
@@ -84,9 +77,9 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
     private fun setMainFabUiState(isFabVisible: Boolean) {
         val newState = MainFabUiState(
                         isFabVisible = isFabVisible,
-                        isFabTooltipVisible = if (mainFabTooltipDisabled) false else isFabVisible
+                        isFabTooltipVisible = if (appPrefsWrapper.isMainFabTooltipDisabled()) false else isFabVisible
         )
 
-        _showMainActionFab.value = newState
+        _fabUiState.value = newState
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -3,21 +3,24 @@ package org.wordpress.android.viewmodel.main
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.ui.main.MainActionListItem
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_PAGE
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
+import org.wordpress.android.ui.main.MainFabUiState
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 
-class WPMainActivityViewModel @Inject constructor() : ViewModel() {
+class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: AppPrefsWrapper) : ViewModel() {
     private var isStarted = false
 
-    private val _showMainActionFab = MutableLiveData<Boolean>()
-    val showMainActionFab: LiveData<Boolean> = _showMainActionFab
+    private val _showMainActionFab = MutableLiveData<MainFabUiState>()
+    val showMainActionFab: LiveData<MainFabUiState> = _showMainActionFab
 
     private val _mainActions = MutableLiveData<List<MainActionListItem>>()
     val mainActions: LiveData<List<MainActionListItem>> = _mainActions
@@ -28,11 +31,15 @@ class WPMainActivityViewModel @Inject constructor() : ViewModel() {
     private val _isBottomSheetShowing = MutableLiveData<Event<Boolean>>()
     val isBottomSheetShowing: LiveData<Event<Boolean>> = _isBottomSheetShowing
 
+    private var mainFabTooltipDisabled = true
+
     fun start(isFabVisible: Boolean) {
         if (isStarted) return
         isStarted = true
 
-        _showMainActionFab.value = isFabVisible
+        mainFabTooltipDisabled = !BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE || appPrefsWrapper.isMainFabTooltipDisabled()
+        setMainFabUiState(isFabVisible)
+
         loadMainActions()
     }
 
@@ -61,10 +68,24 @@ class WPMainActivityViewModel @Inject constructor() : ViewModel() {
     }
 
     fun setIsBottomSheetShowing(showing: Boolean) {
+        if (!mainFabTooltipDisabled) {
+            mainFabTooltipDisabled = true
+            appPrefsWrapper.setMainFabTooltipDisabled(mainFabTooltipDisabled)
+            setMainFabUiState(true)
+        }
         _isBottomSheetShowing.value = Event(showing)
     }
 
     fun onPageChanged(showFab: Boolean) {
-        _showMainActionFab.value = showFab
+        setMainFabUiState(showFab)
+    }
+
+    private fun setMainFabUiState(isFabVisible: Boolean) {
+        val newState = MainFabUiState(
+                        isFabVisible = isFabVisible,
+                        isFabTooltipVisible = if (mainFabTooltipDisabled) false else isFabVisible
+        )
+
+        _showMainActionFab.value = newState
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -74,6 +74,16 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
         setMainFabUiState(showFab)
     }
 
+    fun onTooltipTapped() {
+        val oldState = _fabUiState.value
+        oldState?.let {
+            _fabUiState.value = MainFabUiState(
+                    isFabVisible = it.isFabVisible,
+                    isFabTooltipVisible = false
+            )
+        }
+    }
+
     private fun setMainFabUiState(isFabVisible: Boolean) {
         val newState = MainFabUiState(
                         isFabVisible = isFabVisible,

--- a/WordPress/src/main/res/drawable/bg_tooltip.xml
+++ b/WordPress/src/main/res/drawable/bg_tooltip.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid
+        android:color="@color/background_snackbar">
+    </solid>
+</shape>

--- a/WordPress/src/main/res/drawable/bg_tooltip.xml
+++ b/WordPress/src/main/res/drawable/bg_tooltip.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<shape
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-
-    <solid
-        android:color="@color/background_snackbar">
-    </solid>
-</shape>

--- a/WordPress/src/main/res/drawable/tooltip_arrow.xml
+++ b/WordPress/src/main/res/drawable/tooltip_arrow.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item>
+        <rotate android:fromDegrees="45" android:toDegrees="45" android:pivotX="-40%" android:pivotY="87%" >
+            <shape android:shape="rectangle" >
+                <stroke android:color="@color/background_snackbar" android:width="10dp"/>
+                <solid android:color="@color/background_snackbar" />
+            </shape>
+        </rotate>
+    </item>
+</layer-list>

--- a/WordPress/src/main/res/drawable/tooltip_arrow.xml
+++ b/WordPress/src/main/res/drawable/tooltip_arrow.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:id="@android:id/background">
+        <shape>
+            <solid android:color="@color/transparent"/>
+        </shape>
+    </item>
     <item>
         <rotate android:fromDegrees="45" android:toDegrees="45" android:pivotX="-40%" android:pivotY="87%" >
             <shape android:shape="rectangle" >

--- a/WordPress/src/main/res/layout/main_activity.xml
+++ b/WordPress/src/main/res/layout/main_activity.xml
@@ -56,6 +56,20 @@
             app:menu="@menu/bottom_nav_main"/>
     </LinearLayout>
 
+    <org.wordpress.android.ui.WPTooltipView
+        android:id="@+id/fab_tooltip"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        app:wpTooltipPosition="left"
+        android:visibility="gone"
+        tools:visibility="visible"
+        app:wpTooltipMessage="@string/create_post_page_fab_tooltip"
+        android:layout_marginStart="@dimen/margin_medium"
+        android:layout_toStartOf="@+id/fab_button"
+        android:layout_alignTop="@+id/fab_button"
+        android:layout_alignBottom="@+id/fab_button"/>
+
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab_button"
         android:layout_width="wrap_content"
@@ -69,6 +83,5 @@
         android:contentDescription="@string/fab_create_desc"
         android:src="@drawable/ic_create_white_24dp"
         app:borderWidth="0dp"/>
-
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/main_activity.xml
+++ b/WordPress/src/main/res/layout/main_activity.xml
@@ -63,12 +63,11 @@
         app:wpTooltipPosition="above"
         android:visibility="gone"
         tools:visibility="visible"
-        android:background="@android:color/transparent"
         app:wpTooltipMessage="@string/create_post_page_fab_tooltip"
         app:wpArrowHorizontalOffsetFromEnd="@dimen/main_fab_tooltip_offset_end"
         android:layout_marginStart="@dimen/margin_medium"
         android:layout_alignParentEnd="true"
-        android:layout_marginEnd="@dimen/fab_margin"
+        android:layout_marginEnd="@dimen/margin_medium"
         android:layout_above="@+id/fab_button"/>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton

--- a/WordPress/src/main/res/layout/main_activity.xml
+++ b/WordPress/src/main/res/layout/main_activity.xml
@@ -60,15 +60,16 @@
         android:id="@+id/fab_tooltip"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        app:wpTooltipPosition="left"
+        app:wpTooltipPosition="above"
         android:visibility="gone"
         tools:visibility="visible"
+        android:background="@android:color/transparent"
         app:wpTooltipMessage="@string/create_post_page_fab_tooltip"
+        app:wpArrowHorizontalOffsetFromEnd="@dimen/main_fab_tooltip_offset_end"
         android:layout_marginStart="@dimen/margin_medium"
-        android:layout_toStartOf="@+id/fab_button"
-        android:layout_alignTop="@+id/fab_button"
-        android:layout_alignBottom="@+id/fab_button"/>
+        android:layout_alignParentEnd="true"
+        android:layout_marginEnd="@dimen/fab_margin"
+        android:layout_above="@+id/fab_button"/>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab_button"

--- a/WordPress/src/main/res/layout/tooltip_above.xml
+++ b/WordPress/src/main/res/layout/tooltip_above.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:gravity="center_horizontal">
+
+    <TextView
+        android:id="@+id/tooltip_message"
+        android:ellipsize="end"
+        android:minHeight="@dimen/snackbar_height_minimum"
+        android:background="@drawable/bg_tooltip"
+        android:gravity="center"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:maxLines="2"
+        android:textColor="@android:color/white"
+        android:textSize="@dimen/text_sz_medium"
+        android:layout_weight="1"
+        android:padding="@dimen/margin_medium"
+        tools:text="This is an example tooltip message"/>
+
+    <ImageView
+        android:id="@+id/tooltip_arrow"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_weight="1"
+        android:rotation="-180"
+        android:src="@drawable/tooltip_arrow"
+        android:contentDescription="@null" />
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/tooltip_above.xml
+++ b/WordPress/src/main/res/layout/tooltip_above.xml
@@ -1,33 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
+    android:id="@+id/root_view"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:gravity="center_horizontal">
+    android:gravity="center_horizontal"
+    android:orientation="vertical"
+    android:background="@android:color/transparent">
 
     <TextView
         android:id="@+id/tooltip_message"
-        android:ellipsize="end"
-        android:minHeight="@dimen/snackbar_height_minimum"
-        android:background="@drawable/bg_tooltip"
-        android:gravity="center"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:maxLines="2"
-        android:textColor="@android:color/white"
-        android:textSize="@dimen/text_sz_medium"
+        style="@style/TooltipTextView"
         android:layout_weight="1"
-        android:padding="@dimen/margin_medium"
-        tools:text="This is an example tooltip message"/>
+        tools:text="This is an example tooltip message" />
 
     <ImageView
         android:id="@+id/tooltip_arrow"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
+        style="@style/TooltipArrowView"
         android:layout_weight="1"
+        android:contentDescription="@null"
         android:rotation="-180"
-        android:src="@drawable/tooltip_arrow"
-        android:contentDescription="@null" />
+        android:src="@drawable/tooltip_arrow"/>
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/tooltip_above.xml
+++ b/WordPress/src/main/res/layout/tooltip_above.xml
@@ -2,11 +2,9 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_view"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
+    style="@style/TooltipContainer"
     android:gravity="center_horizontal"
-    android:orientation="vertical"
-    android:background="@android:color/transparent">
+    android:orientation="vertical">
 
     <TextView
         android:id="@+id/tooltip_message"
@@ -14,12 +12,12 @@
         android:layout_weight="1"
         tools:text="This is an example tooltip message" />
 
-    <ImageView
+    <View
         android:id="@+id/tooltip_arrow"
         style="@style/TooltipArrowView"
         android:layout_weight="1"
-        android:contentDescription="@null"
         android:rotation="-180"
-        android:src="@drawable/tooltip_arrow"/>
+        android:background="@drawable/tooltip_arrow"
+        android:contentDescription="@null"/>
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/tooltip_below.xml
+++ b/WordPress/src/main/res/layout/tooltip_below.xml
@@ -2,19 +2,17 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_view"
-    android:orientation="vertical"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
+    style="@style/TooltipContainer"
     android:gravity="center_horizontal"
-    android:background="@android:color/transparent">
+    android:orientation="vertical">
 
-    <ImageView
+    <View
         android:id="@+id/tooltip_arrow"
         style="@style/TooltipArrowView"
         android:layout_weight="1"
         android:rotation="0"
-        android:src="@drawable/tooltip_arrow"
-        android:contentDescription="@null" />
+        android:background="@drawable/tooltip_arrow"
+        android:contentDescription="@null"/>
 
     <TextView
         android:id="@+id/tooltip_message"

--- a/WordPress/src/main/res/layout/tooltip_below.xml
+++ b/WordPress/src/main/res/layout/tooltip_below.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_view"
     android:orientation="vertical"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:gravity="center_horizontal">
+    android:gravity="center_horizontal"
+    android:background="@android:color/transparent">
 
     <ImageView
         android:id="@+id/tooltip_arrow"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
+        style="@style/TooltipArrowView"
         android:layout_weight="1"
         android:rotation="0"
         android:src="@drawable/tooltip_arrow"
@@ -17,17 +18,8 @@
 
     <TextView
         android:id="@+id/tooltip_message"
-        android:ellipsize="end"
-        android:minHeight="@dimen/snackbar_height_minimum"
-        android:background="@drawable/bg_tooltip"
-        android:gravity="center"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:maxLines="2"
-        android:textColor="@android:color/white"
+        style="@style/TooltipTextView"
         android:layout_weight="1"
-        android:textSize="@dimen/text_sz_medium"
-        android:padding="@dimen/margin_medium"
         tools:text="This is an example tooltip message"/>
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/tooltip_below.xml
+++ b/WordPress/src/main/res/layout/tooltip_below.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:gravity="center_horizontal">
+
+    <ImageView
+        android:id="@+id/tooltip_arrow"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_weight="1"
+        android:rotation="0"
+        android:src="@drawable/tooltip_arrow"
+        android:contentDescription="@null" />
+
+    <TextView
+        android:id="@+id/tooltip_message"
+        android:ellipsize="end"
+        android:minHeight="@dimen/snackbar_height_minimum"
+        android:background="@drawable/bg_tooltip"
+        android:gravity="center"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:maxLines="2"
+        android:textColor="@android:color/white"
+        android:layout_weight="1"
+        android:textSize="@dimen/text_sz_medium"
+        android:padding="@dimen/margin_medium"
+        tools:text="This is an example tooltip message"/>
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/tooltip_left.xml
+++ b/WordPress/src/main/res/layout/tooltip_left.xml
@@ -2,11 +2,9 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_view"
-    android:orientation="horizontal"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
+    style="@style/TooltipContainer"
     android:gravity="center_vertical"
-    android:background="@android:color/transparent">
+    android:orientation="horizontal">
 
     <TextView
         android:id="@+id/tooltip_message"
@@ -14,12 +12,12 @@
         android:layout_weight="1"
         tools:text="This is an example tooltip message"/>
 
-    <ImageView
+    <View
         android:id="@+id/tooltip_arrow"
         style="@style/TooltipArrowView"
         android:layout_weight="1"
         android:rotation="90"
-        android:contentDescription="@null"
-        android:src="@drawable/tooltip_arrow"/>
+        android:background="@drawable/tooltip_arrow"
+        android:contentDescription="@null"/>
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/tooltip_left.xml
+++ b/WordPress/src/main/res/layout/tooltip_left.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="horizontal"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical">
+
+    <TextView
+        android:id="@+id/tooltip_message"
+        android:ellipsize="end"
+        android:minHeight="@dimen/snackbar_height_minimum"
+        android:background="@drawable/bg_tooltip"
+        android:gravity="center"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:maxLines="2"
+        android:textColor="@android:color/white"
+        android:textSize="@dimen/text_sz_medium"
+        android:layout_weight="1"
+        android:padding="@dimen/margin_medium"
+        tools:text="This is an example tooltip message"/>
+
+    <ImageView
+        android:id="@+id/tooltip_arrow"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_weight="1"
+        android:rotation="90"
+        android:src="@drawable/tooltip_arrow"
+        android:contentDescription="@null" />
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/tooltip_left.xml
+++ b/WordPress/src/main/res/layout/tooltip_left.xml
@@ -1,33 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_view"
     android:orientation="horizontal"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:gravity="center_vertical">
+    android:gravity="center_vertical"
+    android:background="@android:color/transparent">
 
     <TextView
         android:id="@+id/tooltip_message"
-        android:ellipsize="end"
-        android:minHeight="@dimen/snackbar_height_minimum"
-        android:background="@drawable/bg_tooltip"
-        android:gravity="center"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:maxLines="2"
-        android:textColor="@android:color/white"
-        android:textSize="@dimen/text_sz_medium"
+        style="@style/TooltipTextView"
         android:layout_weight="1"
-        android:padding="@dimen/margin_medium"
         tools:text="This is an example tooltip message"/>
 
     <ImageView
         android:id="@+id/tooltip_arrow"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
+        style="@style/TooltipArrowView"
         android:layout_weight="1"
         android:rotation="90"
-        android:src="@drawable/tooltip_arrow"
-        android:contentDescription="@null" />
+        android:contentDescription="@null"
+        android:src="@drawable/tooltip_arrow"/>
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/tooltip_right.xml
+++ b/WordPress/src/main/res/layout/tooltip_right.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="horizontal"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical">
+
+    <ImageView
+        android:id="@+id/tooltip_arrow"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_weight="1"
+        android:rotation="-90"
+        android:src="@drawable/tooltip_arrow"
+        android:contentDescription="@null" />
+
+    <TextView
+        android:id="@+id/tooltip_message"
+        android:ellipsize="end"
+        android:minHeight="@dimen/snackbar_height_minimum"
+        android:background="@drawable/bg_tooltip"
+        android:gravity="center"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:maxLines="2"
+        android:textColor="@android:color/white"
+        android:textSize="@dimen/text_sz_medium"
+        android:layout_weight="1"
+        android:padding="@dimen/margin_medium"
+        tools:text="This is an example tooltip message"/>
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/tooltip_right.xml
+++ b/WordPress/src/main/res/layout/tooltip_right.xml
@@ -2,18 +2,16 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_view"
-    android:orientation="horizontal"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
+    style="@style/TooltipContainer"
     android:gravity="center_vertical"
-    android:background="@android:color/transparent">
+    android:orientation="horizontal">
 
-    <ImageView
+    <View
         android:id="@+id/tooltip_arrow"
         style="@style/TooltipArrowView"
         android:layout_weight="1"
         android:rotation="-90"
-        android:src="@drawable/tooltip_arrow"
+        android:background="@drawable/tooltip_arrow"
         android:contentDescription="@null" />
 
     <TextView

--- a/WordPress/src/main/res/layout/tooltip_right.xml
+++ b/WordPress/src/main/res/layout/tooltip_right.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_view"
     android:orientation="horizontal"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:gravity="center_vertical">
+    android:gravity="center_vertical"
+    android:background="@android:color/transparent">
 
     <ImageView
         android:id="@+id/tooltip_arrow"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
+        style="@style/TooltipArrowView"
         android:layout_weight="1"
         android:rotation="-90"
         android:src="@drawable/tooltip_arrow"
@@ -17,17 +18,8 @@
 
     <TextView
         android:id="@+id/tooltip_message"
-        android:ellipsize="end"
-        android:minHeight="@dimen/snackbar_height_minimum"
-        android:background="@drawable/bg_tooltip"
-        android:gravity="center"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:maxLines="2"
-        android:textColor="@android:color/white"
-        android:textSize="@dimen/text_sz_medium"
+        style="@style/TooltipTextView"
         android:layout_weight="1"
-        android:padding="@dimen/margin_medium"
         tools:text="This is an example tooltip message"/>
 
 </LinearLayout>

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -161,6 +161,8 @@
             <enum name="below" value="3"/>
         </attr>
         <attr name="wpTooltipMessage" format="reference"/>
+        <attr name="wpArrowHorizontalOffsetFromEnd" format="dimension"/>
+        <attr name="wpArrowHorizontalOffsetFromStart" format="dimension"/>
     </declare-styleable>
 
     <!--

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -150,6 +150,20 @@
     </declare-styleable>
 
     <!--
+    WPTooltipView
+    -->
+    <declare-styleable name="WPTooltipView">
+        <!-- Position of the Tooltip -->
+        <attr name="wpTooltipPosition">
+            <enum name="left" value="0"/>
+            <enum name="right" value="1"/>
+            <enum name="above" value="2"/>
+            <enum name="below" value="3"/>
+        </attr>
+        <attr name="wpTooltipMessage" format="reference"/>
+    </declare-styleable>
+
+    <!--
         Actionable Empty View
     -->
     <declare-styleable name="ActionableEmptyView">

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -453,5 +453,8 @@
 
     <!--Main bottom sheet icon size -->
     <dimen name="main_bottom_sheet_list_row_icon_size">32dp</dimen>
+    <dimen name="main_fab_tooltip_offset_end">16dp</dimen>
+    <dimen name="main_fab_tooltip_elevation">6dp</dimen>
+    <dimen name="main_fab_tooltip_arrow_size">24dp</dimen>
 
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -453,8 +453,8 @@
 
     <!--Main bottom sheet icon size -->
     <dimen name="main_bottom_sheet_list_row_icon_size">32dp</dimen>
-    <dimen name="main_fab_tooltip_offset_end">16dp</dimen>
+    <dimen name="main_fab_tooltip_offset_end">20dp</dimen>
     <dimen name="main_fab_tooltip_elevation">6dp</dimen>
-    <dimen name="main_fab_tooltip_arrow_size">24dp</dimen>
+    <dimen name="main_fab_tooltip_arrow_size">16dp</dimen>
 
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2574,7 +2574,7 @@
     <string name="web_preview_default">Default</string>
     <string name="web_preview_desktop">Desktop</string>
 
-    <string name="create_post_page_fab_tooltip">Your new shortcut to create content</string>
+    <string name="create_post_page_fab_tooltip">Create a post or page</string>
 
     <!-- News Card -->
     <!-- When announcing a new feature, add new strings and make sure to update LocalNewsItem.kt -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2574,6 +2574,8 @@
     <string name="web_preview_default">Default</string>
     <string name="web_preview_desktop">Desktop</string>
 
+    <string name="create_post_page_fab_tooltip">Your new shortcut to create content</string>
+
     <!-- News Card -->
     <!-- When announcing a new feature, add new strings and make sure to update LocalNewsItem.kt -->
     <!-- Never reuse same keys for new announcements! The new value might not be translated before the release

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1101,6 +1101,14 @@
         <item name="android:layout_gravity">center_vertical</item>
     </style>
 
+    <style name="TooltipContainer">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:background">@android:color/transparent</item>
+        <item name="android:padding">@dimen/margin_medium</item>
+        <item name="android:clipToPadding">false</item>
+    </style>
+
     <style name="TooltipTextView">
         <item name="android:ellipsize">end</item>
         <item name="android:minHeight">@dimen/snackbar_height_minimum</item>
@@ -1111,12 +1119,13 @@
         <item name="android:maxLines">2</item>
         <item name="android:textColor">@color/neutral_5</item>
         <item name="android:textSize">@dimen/text_sz_medium</item>
-        <item name="android:padding">@dimen/margin_medium</item>
+        <item name="android:padding">@dimen/margin_extra_large</item>
         <item name="android:elevation">@dimen/main_fab_tooltip_elevation</item>
     </style>
 
     <style name="TooltipArrowView">
         <item name="android:layout_width">@dimen/main_fab_tooltip_arrow_size</item>
         <item name="android:layout_height">@dimen/main_fab_tooltip_arrow_size</item>
+        <item name="android:elevation">@dimen/main_fab_tooltip_elevation</item>
     </style>
 </resources>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1101,4 +1101,22 @@
         <item name="android:layout_gravity">center_vertical</item>
     </style>
 
+    <style name="TooltipTextView">
+        <item name="android:ellipsize">end</item>
+        <item name="android:minHeight">@dimen/snackbar_height_minimum</item>
+        <item name="android:background">@drawable/bg_snackbar</item>
+        <item name="android:gravity">center</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:maxLines">2</item>
+        <item name="android:textColor">@color/neutral_5</item>
+        <item name="android:textSize">@dimen/text_sz_medium</item>
+        <item name="android:padding">@dimen/margin_medium</item>
+        <item name="android:elevation">@dimen/main_fab_tooltip_elevation</item>
+    </style>
+
+    <style name="TooltipArrowView">
+        <item name="android:layout_width">@dimen/main_fab_tooltip_arrow_size</item>
+        <item name="android:layout_height">@dimen/main_fab_tooltip_arrow_size</item>
+    </style>
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -6,10 +6,12 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_PAGE
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 
 @RunWith(MockitoJUnitRunner::class)
 class WPMainActivityViewModelTest {
@@ -18,22 +20,25 @@ class WPMainActivityViewModelTest {
 
     private lateinit var viewModel: WPMainActivityViewModel
 
+    @Mock
+    private lateinit var appPrefsWrapper: AppPrefsWrapper
+
     @Before
     fun setUp() {
-        viewModel = WPMainActivityViewModel()
+        viewModel = WPMainActivityViewModel(appPrefsWrapper)
         viewModel.start(true)
     }
 
     @Test
     fun `fab visible when asked`() {
         viewModel.onPageChanged(true)
-        assertThat(viewModel.showMainActionFab.value).isEqualTo(true)
+        assertThat(viewModel.showMainActionFab.value?.isFabVisible).isEqualTo(true)
     }
 
     @Test
     fun `fab hidden when asked`() {
         viewModel.onPageChanged(false)
-        assertThat(viewModel.showMainActionFab.value).isEqualTo(false)
+        assertThat(viewModel.showMainActionFab.value?.isFabVisible).isEqualTo(false)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.viewmodel.main
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -25,6 +26,7 @@ class WPMainActivityViewModelTest {
 
     @Before
     fun setUp() {
+        whenever(appPrefsWrapper.isMainFabTooltipDisabled()).thenReturn(false)
         viewModel = WPMainActivityViewModel(appPrefsWrapper)
         viewModel.start(true)
     }
@@ -32,13 +34,25 @@ class WPMainActivityViewModelTest {
     @Test
     fun `fab visible when asked`() {
         viewModel.onPageChanged(true)
-        assertThat(viewModel.showMainActionFab.value?.isFabVisible).isEqualTo(true)
+        assertThat(viewModel.fabUiState.value?.isFabVisible).isEqualTo(true)
     }
 
     @Test
     fun `fab hidden when asked`() {
         viewModel.onPageChanged(false)
-        assertThat(viewModel.showMainActionFab.value?.isFabVisible).isEqualTo(false)
+        assertThat(viewModel.fabUiState.value?.isFabVisible).isEqualTo(false)
+    }
+
+    @Test
+    fun `fab tooltip visible when asked`() {
+        viewModel.onPageChanged(true)
+        assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(true)
+    }
+
+    @Test
+    fun `fab tooltip hidden when asked`() {
+        viewModel.onPageChanged(false)
+        assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
     }
 
     @Test


### PR DESCRIPTION
Fixes #11012

This PR adds an announcing tooltip for the create FAB in the My Site page.

The logic is the following:

- When this new app version is installed (or updated from previous older installation) the tooltip is shown near to the FAB

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/72091217-f5d31980-330f-11ea-8c89-a5bb4082a231.png>
</p>

- The tooltip is presented near the FAB until the user first tap on the FAB itself
- Once tapped on the FAB the tooltip is not shown any more and there is no way to have it back unless the app storage data is cleared or the user fully uninstall and reinstall the app

## Notes

- The tooltip work with RTL languages

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/72091155-d3410080-330f-11ea-812c-463b277483c1.png>
</p>

- Current implementation of `WPTooltipView` is pretty basic. Mainly to cover this specific scenario. More work/rework is needed to make it a full custom view tooltip component. I explored a bit also a more dynamic approach with the PopupWindow but messing around only with simple layouts seemed more convenient in this simple scenario. Also the placement and interactions (like the coordinator layout behavior with snackbars like in this case) comes at not cost in this way. (Nonetheless the PopupWindow approach can be something to further explore later and I have something basic working also there) 
- I used Chris original position and copy of the tooltip but we can change it (ping @osullivanchris)

## To test
Again all the feature is still behind feature flag so:

- First smock test with vanilla to check that no evident issues were introduced in the My Site and switching between pages in the `WPMainActivity`
- Compile zalpha flavor and check that you get the tooltip near the FAB
- Use the app without using the FAB (for example create a post from Blog Posts) and check that the tooltip is always presented when you come back to the My Site page
- Use the FAB and check that after that the tooltip is no more visualized. Also close and open the app to confirm.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

