### PR TITLE
Bump FluxC to version 1.5.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.5.7'
+    fluxCVersion = '1.5.8'
 }
 
 // Onboarding and dev env setup tasks

--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.5.4'
+    fluxCVersion = '1.5.7'
 }
 
 // Onboarding and dev env setup tasks
@@ -114,7 +114,7 @@ task checkBundler(type:Exec) {
     doFirst {
         println "Check Bundler"
     }
-    
+
     workingDir = './'
     executable "sh"
     args "-c", "if ! type 'bundle' > /dev/null; then gem install bundler; fi"
@@ -132,7 +132,7 @@ task checkBundle(type:Exec, dependsOn:checkBundler) {
     doFirst {
         println "Check Bundle"
     }
-    
+
     workingDir = './'
     executable "sh"
     args "-c", "bundle check --path=\${BUNDLE_PATH:-vendor/bundle} > /dev/null || bundle install --jobs=3 --retry=3 --path=\${BUNDLE_PATH:-vendor/bundle}"
@@ -150,7 +150,7 @@ task applyCredentials(type:Exec, dependsOn:checkBundle) {
     doFirst {
         println "Apply credentials for this branch"
     }
-    
+
     workingDir = './'
     executable "sh"
     args "-c", "FASTLANE_SKIP_UPDATE_CHECK=1 FASTLANE_ENV_PRINTER=1 bundle exec fastlane run configure_apply force:true"
@@ -164,11 +164,11 @@ task applyCredentials(type:Exec, dependsOn:checkBundle) {
     }
 }
 
-tasks.register("prodDeps") { 
+tasks.register("prodDeps") {
     group = 'Onboarding'
     description = 'Install dependencies for production builds'
     dependsOn applyCredentials
-    doLast { 
+    doLast {
         println("Done")
     }
 }


### PR DESCRIPTION
Fixes #11030 and fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1728

There are no behavioral changes in FluxC from 1.5.4 to 1.5.8 according to the [release notes](https://github.com/wordpress-mobile/WordPress-FluxC-Android/releases). And a recent fix in 1.5.7 will fix this 2 issues mentioned earlier.