### PR TITLE
Accessibility : Bar Chart Improvements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsMapper.kt
@@ -96,7 +96,7 @@ class PostDayViewsMapper
         }
         val result = mutableListOf<BlockListItem>()
 
-        val contentDescriptions = statsUtils.getEntryContentDescriptions(
+        val contentDescriptions = statsUtils.getBarChartEntryContentDescriptions(
                 R.string.stats_views,
                 chartItems
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsMapper.kt
@@ -95,12 +95,19 @@ class PostDayViewsMapper
             )
         }
         val result = mutableListOf<BlockListItem>()
+
+        val contentDescriptions = statsUtils.getEntryContentDescriptions(
+                R.string.stats_views,
+                chartItems
+        )
+
         result.add(
                 BarChartItem(
                         chartItems,
                         selectedItem = selectedDay,
                         onBarSelected = onBarSelected,
-                        onBarChartDrawn = onBarChartDrawn
+                        onBarChartDrawn = onBarChartDrawn,
+                        entryContentDescriptions = contentDescriptions
                 )
         )
         return result

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
@@ -5,7 +5,6 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView.Adapter
 import org.wordpress.android.ui.stats.refresh.BlockDiffCallback
 import org.wordpress.android.ui.stats.refresh.BlockDiffCallback.BlockListPayload.EXPAND_CHANGED
-import org.wordpress.android.ui.stats.refresh.BlockDiffCallback.BlockListPayload.SELECTED_BAR_CHANGED
 import org.wordpress.android.ui.stats.refresh.BlockDiffCallback.BlockListPayload.TAB_CHANGED
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarChartItem
@@ -151,7 +150,7 @@ class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockListItemVi
             is TextViewHolder -> holder.bind(item as Text)
             is FourColumnsViewHolder -> holder.bind(item as Columns, payloads)
             is LinkViewHolder -> holder.bind(item as Link)
-            is BarChartViewHolder -> holder.bind(item as BarChartItem, payloads.contains(SELECTED_BAR_CHANGED))
+            is BarChartViewHolder -> holder.bind(item as BarChartItem)
             is ChartLegendViewHolder -> holder.bind(item as ChartLegend)
             is TabsViewHolder -> holder.bind(item as TabsItem, payloads.contains(TAB_CHANGED))
             is InformationViewHolder -> holder.bind(item as Information)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -193,7 +193,8 @@ sealed class BlockListItem(val type: Type) {
         val overlappingEntries: List<Bar>? = null,
         val selectedItem: String? = null,
         val onBarSelected: ((period: String?) -> Unit)? = null,
-        val onBarChartDrawn: ((visibleBarCount: Int) -> Unit)? = null
+        val onBarChartDrawn: ((visibleBarCount: Int) -> Unit)? = null,
+        val entryContentDescriptions: List<String>
     ) : BlockListItem(BAR_CHART) {
         data class Bar(val label: String, val id: String, val value: Int)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
@@ -225,7 +225,7 @@ class OverviewMapper
             null
         }
 
-        val contentDescriptions = statsUtils.getEntryContentDescriptions(
+        val contentDescriptions = statsUtils.getBarChartEntryContentDescriptions(
                 entryType,
                 chartItems,
                 overlappingType,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
@@ -12,6 +12,10 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Colum
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Columns.Column
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem.State
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.OverviewMapper.SelectedType.Comments
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.OverviewMapper.SelectedType.Likes
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.OverviewMapper.SelectedType.Views
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.OverviewMapper.SelectedType.Visitors
 import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.MILLION
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
@@ -32,6 +36,17 @@ class OverviewMapper
             R.string.stats_likes,
             R.string.stats_comments
     )
+
+    enum class SelectedType(val value: Int) {
+        Views(0),
+        Visitors(1),
+        Likes(2),
+        Comments(3);
+
+        companion object {
+            fun valueOf(value: Int): SelectedType? = values().find { it.value == value }
+        }
+    }
 
     fun buildTitle(
         selectedItem: PeriodData,
@@ -99,11 +114,11 @@ class OverviewMapper
     private fun PeriodData.getValue(
         selectedPosition: Int
     ): Long? {
-        return when (selectedPosition) {
-            0 -> this.views
-            1 -> this.visitors
-            2 -> this.likes
-            3 -> this.comments
+        return when (SelectedType.valueOf(selectedPosition)) {
+            Views -> this.views
+            Visitors -> this.visitors
+            Likes -> this.likes
+            Comments -> this.comments
             else -> null
         }
     }
@@ -166,11 +181,11 @@ class OverviewMapper
         selectedItemPeriod: String
     ): List<BlockListItem> {
         val chartItems = dates.map {
-            val value = when (selectedType) {
-                0 -> it.views
-                1 -> it.visitors
-                2 -> it.likes
-                3 -> it.comments
+            val value = when (SelectedType.valueOf(selectedType)) {
+                Views -> it.views
+                Visitors -> it.visitors
+                Likes -> it.likes
+                Comments -> it.comments
                 else -> 0L
             }
             Bar(
@@ -197,10 +212,10 @@ class OverviewMapper
             result.add(ChartLegend(R.string.stats_visitors))
         }
 
-        val entryType = when (selectedType) {
-            1 -> R.string.stats_visitors
-            2 -> R.string.stats_likes
-            3 -> R.string.stats_comments
+        val entryType = when (SelectedType.valueOf(selectedType)) {
+            Visitors -> R.string.stats_visitors
+            Likes -> R.string.stats_likes
+            Comments -> R.string.stats_comments
             else -> R.string.stats_views
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
@@ -198,11 +198,10 @@ class OverviewMapper
         }
 
         val entryType = when (selectedType) {
-            0 -> R.string.stats_views
             1 -> R.string.stats_visitors
             2 -> R.string.stats_likes
             3 -> R.string.stats_comments
-            else -> -1
+            else -> R.string.stats_views
         }
 
         val overlappingType = if (shouldShowVisitors) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
@@ -202,7 +202,7 @@ class OverviewMapper
             1 -> R.string.stats_visitors
             2 -> R.string.stats_likes
             3 -> R.string.stats_comments
-            else -> 0
+            else -> -1
         }
 
         val overlappingType = if (shouldShowVisitors) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/OverviewMapper.kt
@@ -196,13 +196,36 @@ class OverviewMapper
         if (shouldShowVisitors) {
             result.add(ChartLegend(R.string.stats_visitors))
         }
+
+        val entryType = when (selectedType) {
+            0 -> R.string.stats_views
+            1 -> R.string.stats_visitors
+            2 -> R.string.stats_likes
+            3 -> R.string.stats_comments
+            else -> 0
+        }
+
+        val overlappingType = if (shouldShowVisitors) {
+            R.string.stats_visitors
+        } else {
+            null
+        }
+
+        val contentDescriptions = statsUtils.getEntryContentDescriptions(
+                entryType,
+                chartItems,
+                overlappingType,
+                overlappingItems
+        )
+
         result.add(
                 BarChartItem(
                         chartItems,
                         overlappingEntries = overlappingItems,
                         selectedItem = selectedItemPeriod,
                         onBarSelected = onBarSelected,
-                        onBarChartDrawn = onBarChartDrawn
+                        onBarChartDrawn = onBarChartDrawn,
+                        entryContentDescriptions = contentDescriptions
                 )
         )
         return result

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryMapper.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Text
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Text.Clickable
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.LatestPostSummaryUseCase.LinkClickParams
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
+import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
@@ -17,7 +18,8 @@ class LatestPostSummaryMapper
 @Inject constructor(
     private val statsUtilsWrapper: StatsUtilsWrapper,
     private val resourceProvider: ResourceProvider,
-    private val statsDateFormatter: StatsDateFormatter
+    private val statsDateFormatter: StatsDateFormatter,
+    private val statsUtils: StatsUtils
 ) {
     fun buildMessageItem(
         model: InsightsLatestPostModel?,
@@ -62,6 +64,11 @@ class LatestPostSummaryMapper
     fun buildBarChartItem(dayViews: List<Pair<String, Int>>): BarChartItem {
         val barEntries = dayViews.subList(Math.max(0, dayViews.size - 30), dayViews.size)
                 .map { pair -> BarChartItem.Bar(statsDateFormatter.printDate(pair.first), pair.first, pair.second) }
-        return BarChartItem(barEntries)
+
+        val contentDescriptions = statsUtils.getEntryContentDescriptions(
+                R.string.stats_views,
+                barEntries)
+
+        return BarChartItem(barEntries,entryContentDescriptions = contentDescriptions)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryMapper.kt
@@ -69,6 +69,6 @@ class LatestPostSummaryMapper
                 R.string.stats_views,
                 barEntries)
 
-        return BarChartItem(barEntries,entryContentDescriptions = contentDescriptions)
+        return BarChartItem(barEntries, entryContentDescriptions = contentDescriptions)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryMapper.kt
@@ -65,7 +65,7 @@ class LatestPostSummaryMapper
         val barEntries = dayViews.subList(Math.max(0, dayViews.size - 30), dayViews.size)
                 .map { pair -> BarChartItem.Bar(statsDateFormatter.printDate(pair.first), pair.first, pair.second) }
 
-        val contentDescriptions = statsUtils.getEntryContentDescriptions(
+        val contentDescriptions = statsUtils.getBarChartEntryContentDescriptions(
                 R.string.stats_views,
                 barEntries)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -62,8 +62,7 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
                         chart,
                         contentDescriptions = item.entryContentDescriptions,
                         hasOverlappingEntries = item.overlappingEntries != null,
-                        accessibilityEvent = accessibilityEvent,
-                        dataSet = chart.data.dataSets.first()
+                        accessibilityEvent = accessibilityEvent
                 )
 
                 ViewCompat.setAccessibilityDelegate(chart, accessibilityHelper)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -62,7 +62,8 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
                         chart,
                         contentDescriptions = item.entryContentDescriptions,
                         hasOverlappingEntries = item.overlappingEntries != null,
-                        accessibilityEvent = accessibilityEvent
+                        accessibilityEvent = accessibilityEvent,
+                        dataSet = chart.data.dataSets.first()
                 )
 
                 ViewCompat.setAccessibilityDelegate(chart, accessibilityHelper)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -10,12 +10,10 @@ import com.github.mikephil.charting.components.Description
 import com.github.mikephil.charting.data.BarData
 import com.github.mikephil.charting.data.BarDataSet
 import com.github.mikephil.charting.data.BarEntry
-import com.github.mikephil.charting.data.DataSet
 import com.github.mikephil.charting.data.Entry
 import com.github.mikephil.charting.highlight.Highlight
 import com.github.mikephil.charting.interfaces.datasets.IBarDataSet
 import com.github.mikephil.charting.listener.OnChartValueSelectedListener
-import com.github.mikephil.charting.listener.OnDrawListener
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -9,10 +9,12 @@ import com.github.mikephil.charting.components.Description
 import com.github.mikephil.charting.data.BarData
 import com.github.mikephil.charting.data.BarDataSet
 import com.github.mikephil.charting.data.BarEntry
+import com.github.mikephil.charting.data.DataSet
 import com.github.mikephil.charting.data.Entry
 import com.github.mikephil.charting.highlight.Highlight
 import com.github.mikephil.charting.interfaces.datasets.IBarDataSet
 import com.github.mikephil.charting.listener.OnChartValueSelectedListener
+import com.github.mikephil.charting.listener.OnDrawListener
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
@@ -20,6 +22,7 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarChartItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarChartItem.Bar
+import org.wordpress.android.ui.stats.refresh.utils.BarChartAccessibilityHelper
 import org.wordpress.android.ui.stats.refresh.utils.LargeValueFormatter
 import org.wordpress.android.util.DisplayUtils
 
@@ -42,6 +45,20 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         GlobalScope.launch(Dispatchers.Main) {
             delay(50)
             chart.draw(item, labelStart, labelEnd)
+            chart.setOnDrawListener(object : OnDrawListener {
+                override fun onEntryMoved(entry: Entry?) {
+                }
+
+                override fun onEntryAdded(entry: Entry?) {
+                }
+
+                override fun onDrawFinished(dataSet: DataSet<*>?) {
+                    BarChartAccessibilityHelper(
+                            barChart = chart, dataSet = dataSet as BarDataSet,
+                            contentDescriptions = item.entryContentDescriptions
+                    )
+                }
+            })
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -47,10 +47,6 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             delay(50)
             chart.draw(item, labelStart, labelEnd)
             chart.post {
-                if (item.entryContentDescriptions.isEmpty()) {
-                    return@post
-                }
-
                 accessibilityHelper = BarChartAccessibilityHelper(
                         chart,
                         contentDescriptions = item.entryContentDescriptions,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarChartItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarChartItem.Bar
 import org.wordpress.android.ui.stats.refresh.utils.BarChartAccessibilityHelper
+import org.wordpress.android.ui.stats.refresh.utils.BarChartAccessibilityHelper.BarChartAccessibilityEvent
 import org.wordpress.android.ui.stats.refresh.utils.LargeValueFormatter
 import org.wordpress.android.util.DisplayUtils
 
@@ -52,6 +53,16 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
                         chart,
                         contentDescriptions = item.entryContentDescriptions
                 )
+
+                accessibilityHelper.accessibilityEvent = object : BarChartAccessibilityEvent {
+                    override fun onHighlight(index: Int) {
+                        chart.highlightColumn(index, true)
+                        val entry = chart.data.dataSets.first().getEntryForIndex(index)
+                        val value = entry?.data as? String
+                        item.onBarSelected?.invoke(value)
+                    }
+                }
+
                 ViewCompat.setAccessibilityDelegate(chart, accessibilityHelper)
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -47,6 +47,10 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             delay(50)
             chart.draw(item, labelStart, labelEnd)
             chart.post {
+                if (item.entryContentDescriptions.isEmpty()) {
+                    return@post
+                }
+
                 accessibilityHelper = BarChartAccessibilityHelper(
                         chart,
                         contentDescriptions = item.entryContentDescriptions,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
 import com.github.mikephil.charting.charts.BarChart
 import com.github.mikephil.charting.components.Description
 import com.github.mikephil.charting.data.BarData
@@ -36,6 +37,7 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
     private val chart = itemView.findViewById<BarChart>(R.id.chart)
     private val labelStart = itemView.findViewById<TextView>(R.id.label_start)
     private val labelEnd = itemView.findViewById<TextView>(R.id.label_end)
+    private lateinit var accessibilityHelper: BarChartAccessibilityHelper
 
     fun bind(
         item: BarChartItem,
@@ -45,20 +47,13 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         GlobalScope.launch(Dispatchers.Main) {
             delay(50)
             chart.draw(item, labelStart, labelEnd)
-            chart.setOnDrawListener(object : OnDrawListener {
-                override fun onEntryMoved(entry: Entry?) {
-                }
-
-                override fun onEntryAdded(entry: Entry?) {
-                }
-
-                override fun onDrawFinished(dataSet: DataSet<*>?) {
-                    BarChartAccessibilityHelper(
-                            barChart = chart, dataSet = dataSet as BarDataSet,
-                            contentDescriptions = item.entryContentDescriptions
-                    )
-                }
-            })
+            chart.post {
+                accessibilityHelper = BarChartAccessibilityHelper(
+                        chart,
+                        contentDescriptions = item.entryContentDescriptions
+                )
+                ViewCompat.setAccessibilityDelegate(chart, accessibilityHelper)
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -47,13 +47,7 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             delay(50)
             chart.draw(item, labelStart, labelEnd)
             chart.post {
-                accessibilityHelper = BarChartAccessibilityHelper(
-                        chart,
-                        contentDescriptions = item.entryContentDescriptions,
-                        hasOverlappingEntries = item.overlappingEntries != null
-                )
-
-                accessibilityHelper.accessibilityEvent = object : BarChartAccessibilityEvent {
+                val accessibilityEvent = object : BarChartAccessibilityEvent {
                     override fun onHighlight(index: Int, hasOverlappingEntries: Boolean) {
                         chart.highlightColumn(index, hasOverlappingEntries)
                         val entry = chart.data.dataSets.first().getEntryForIndex(index)
@@ -63,6 +57,13 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
                         }
                     }
                 }
+
+                accessibilityHelper = BarChartAccessibilityHelper(
+                        chart,
+                        contentDescriptions = item.entryContentDescriptions,
+                        hasOverlappingEntries = item.overlappingEntries != null,
+                        accessibilityEvent = accessibilityEvent
+                )
 
                 ViewCompat.setAccessibilityDelegate(chart, accessibilityHelper)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -51,12 +51,13 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             chart.post {
                 accessibilityHelper = BarChartAccessibilityHelper(
                         chart,
-                        contentDescriptions = item.entryContentDescriptions
+                        contentDescriptions = item.entryContentDescriptions,
+                        hasOverlappingEntries = item.overlappingEntries != null
                 )
 
                 accessibilityHelper.accessibilityEvent = object : BarChartAccessibilityEvent {
-                    override fun onHighlight(index: Int) {
-                        chart.highlightColumn(index, true)
+                    override fun onHighlight(index: Int, hasOverlappingEntries: Boolean) {
+                        chart.highlightColumn(index, hasOverlappingEntries)
                         val entry = chart.data.dataSets.first().getEntryForIndex(index)
                         val value = entry?.data as? String
                         item.onBarSelected?.invoke(value)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -58,7 +58,9 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
                         chart.highlightColumn(index, hasOverlappingEntries)
                         val entry = chart.data.dataSets.first().getEntryForIndex(index)
                         val value = entry?.data as? String
-                        item.onBarSelected?.invoke(value)
+                        value?.let {
+                            item.onBarSelected?.invoke(it)
+                        }
                     }
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -48,10 +48,13 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             chart.draw(item, labelStart, labelEnd)
             chart.post {
                 val accessibilityEvent = object : BarChartAccessibilityEvent {
-                    override fun onHighlight(index: Int, hasOverlappingEntries: Boolean) {
+                    override fun onHighlight(
+                        entry: BarEntry,
+                        index: Int,
+                        hasOverlappingEntries: Boolean
+                    ) {
                         chart.highlightColumn(index, hasOverlappingEntries)
-                        val entry = chart.data.dataSets.first().getEntryForIndex(index)
-                        val value = entry?.data as? String
+                        val value = entry.data as? String
                         value?.let {
                             item.onBarSelected?.invoke(it)
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
@@ -16,19 +16,15 @@ class BarChartAccessibilityHelper(
     private val barChart: BarChart,
     private val contentDescriptions: List<String>
 ) : ExploreByTouchHelper(barChart) {
-    private val dataSet =barChart.data.dataSets.first()
+    interface BarChartAccessibilityEvent {
+        fun onHighlight(index: Int)
+    }
+
+    private val dataSet = barChart.data.dataSets.first()
+    var accessibilityEvent: BarChartAccessibilityEvent? = null
+
     init {
         barChart.setOnHoverListener { _, event -> dispatchHoverEvent(event) }
-        barChart.setOnChartValueSelectedListener(object : OnChartValueSelectedListener {
-            override fun onNothingSelected() {
-            }
-
-            override fun onValueSelected(entry: Entry?, highlight: Highlight?) {
-                highlight?.let {
-                    invalidateVirtualView(it.dataIndex)
-                }
-            }
-        })
     }
 
     override fun getVirtualViewAt(x: Float, y: Float): Int {
@@ -57,7 +53,7 @@ class BarChartAccessibilityHelper(
     ): Boolean {
         when (action) {
             AccessibilityNodeInfoCompat.ACTION_CLICK -> {
-                invalidateVirtualView(virtualViewId)
+                accessibilityEvent?.onHighlight(virtualViewId)
                 return true
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
@@ -6,18 +6,15 @@ import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat
 import androidx.customview.widget.ExploreByTouchHelper
 import com.github.mikephil.charting.charts.BarChart
-import com.github.mikephil.charting.data.BarDataSet
 import com.github.mikephil.charting.data.BarEntry
-import com.github.mikephil.charting.data.Entry
-import com.github.mikephil.charting.highlight.Highlight
-import com.github.mikephil.charting.listener.OnChartValueSelectedListener
 
 class BarChartAccessibilityHelper(
     private val barChart: BarChart,
-    private val contentDescriptions: List<String>
+    private val contentDescriptions: List<String>,
+    private val hasOverlappingEntries: Boolean
 ) : ExploreByTouchHelper(barChart) {
     interface BarChartAccessibilityEvent {
-        fun onHighlight(index: Int)
+        fun onHighlight(index: Int, hasOverlappingEntries: Boolean)
     }
 
     private val dataSet = barChart.data.dataSets.first()
@@ -53,7 +50,7 @@ class BarChartAccessibilityHelper(
     ): Boolean {
         when (action) {
             AccessibilityNodeInfoCompat.ACTION_CLICK -> {
-                accessibilityEvent?.onHighlight(virtualViewId)
+                accessibilityEvent?.onHighlight(virtualViewId, hasOverlappingEntries)
                 return true
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
@@ -11,20 +11,17 @@ import com.github.mikephil.charting.interfaces.datasets.IBarDataSet
 
 class BarChartAccessibilityHelper(
     private val barChart: BarChart,
-    contentDescriptions: List<String>,
-    private val hasOverlappingEntries: Boolean,
+    private val contentDescriptions: List<String>,
     private val accessibilityEvent: BarChartAccessibilityEvent
 ) : ExploreByTouchHelper(barChart) {
     private val dataSet: IBarDataSet = barChart.data.dataSets.first()
-    private val cutContentDescriptions: List<String>
 
     interface BarChartAccessibilityEvent {
-        fun onHighlight(entry: BarEntry, index: Int, hasOverlappingEntries: Boolean)
+        fun onHighlight(entry: BarEntry, index: Int)
     }
 
     init {
         barChart.setOnHoverListener { _, event -> dispatchHoverEvent(event) }
-        cutContentDescriptions = contentDescriptions.take(dataSet.entryCount)
     }
 
     override fun getVirtualViewAt(x: Float, y: Float): Int {
@@ -54,7 +51,7 @@ class BarChartAccessibilityHelper(
         when (action) {
             AccessibilityNodeInfoCompat.ACTION_CLICK -> {
                 val entry = dataSet.getEntryForIndex(virtualViewId)
-                accessibilityEvent.onHighlight(entry, virtualViewId, hasOverlappingEntries)
+                accessibilityEvent.onHighlight(entry, virtualViewId)
                 return true
             }
         }
@@ -66,7 +63,7 @@ class BarChartAccessibilityHelper(
         virtualViewId: Int,
         node: AccessibilityNodeInfoCompat
     ) {
-        node.contentDescription = cutContentDescriptions[virtualViewId]
+        node.contentDescription = contentDescriptions[virtualViewId]
 
         barChart.highlighted?.let { highlights ->
             highlights.forEach { highlight ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
@@ -1,0 +1,90 @@
+package org.wordpress.android.ui.stats.refresh.utils
+
+import android.graphics.Rect
+import android.os.Bundle
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat
+import androidx.customview.widget.ExploreByTouchHelper
+import com.github.mikephil.charting.charts.BarChart
+import com.github.mikephil.charting.data.BarDataSet
+import com.github.mikephil.charting.data.BarEntry
+import com.github.mikephil.charting.data.Entry
+import com.github.mikephil.charting.highlight.Highlight
+import com.github.mikephil.charting.listener.OnChartValueSelectedListener
+
+class BarChartAccessibilityHelper(
+    private val barChart: BarChart,
+    private val dataSet: BarDataSet,
+    private val contentDescriptions: List<String>
+) : ExploreByTouchHelper(barChart) {
+
+    init {
+        barChart.setOnHoverListener { _, event -> dispatchHoverEvent(event) }
+        barChart.setOnChartValueSelectedListener(object : OnChartValueSelectedListener {
+            override fun onNothingSelected() {
+            }
+
+            override fun onValueSelected(entry: Entry?, highlight: Highlight?) {
+                highlight?.let {
+                    invalidateVirtualView(it.dataIndex)
+                }
+            }
+        })
+    }
+
+    override fun getVirtualViewAt(x: Float, y: Float): Int {
+        val entry = barChart.getEntryByTouchPoint(x, y)
+
+        return when {
+            entry != null -> {
+                dataSet.getEntryIndex(entry as BarEntry?)
+            }
+            else -> {
+                INVALID_ID
+            }
+        }
+    }
+
+    override fun getVisibleVirtualViews(virtualViewIds: MutableList<Int>?) {
+        for (i in 0..dataSet.entryCount) {
+            virtualViewIds?.add(i)
+        }
+    }
+
+    override fun onPerformActionForVirtualView(
+        virtualViewId: Int,
+        action: Int,
+        arguments: Bundle?
+    ): Boolean {
+        when (action) {
+            AccessibilityNodeInfoCompat.ACTION_CLICK -> {
+                invalidateVirtualView(virtualViewId)
+                return true
+            }
+        }
+
+        return false
+    }
+
+    override fun onPopulateNodeForVirtualView(
+        virtualViewId: Int,
+        node: AccessibilityNodeInfoCompat
+    ) {
+        node.contentDescription = contentDescriptions[virtualViewId]
+
+        barChart.highlighted?.let { highlights ->
+            highlights.forEach { highlight ->
+                if (highlight.dataIndex == virtualViewId) {
+                    node.isSelected = true
+                }
+            }
+        }
+
+        node.addAction(AccessibilityActionCompat.ACTION_CLICK)
+        val entryRectF = barChart.getBarBounds(dataSet.getEntryForIndex(virtualViewId))
+        val entryRect = Rect()
+        entryRectF.round(entryRect)
+
+        node.setBoundsInParent(entryRect)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
@@ -14,7 +14,7 @@ class BarChartAccessibilityHelper(
     private val contentDescriptions: List<String>,
     private val hasOverlappingEntries: Boolean,
     private val accessibilityEvent: BarChartAccessibilityEvent,
-    private val dataSet:IBarDataSet
+    private val dataSet:IBarDataSet = barChart.data.dataSets.first()
 ) : ExploreByTouchHelper(barChart) {
     interface BarChartAccessibilityEvent {
         fun onHighlight(index: Int, hasOverlappingEntries: Boolean)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
@@ -45,7 +45,7 @@ class BarChartAccessibilityHelper(
     }
 
     override fun getVisibleVirtualViews(virtualViewIds: MutableList<Int>?) {
-        for (i in 0..dataSet.entryCount) {
+        for (i in 0 until dataSet.entryCount) {
             virtualViewIds?.add(i)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
@@ -14,7 +14,7 @@ class BarChartAccessibilityHelper(
     private val contentDescriptions: List<String>,
     private val hasOverlappingEntries: Boolean,
     private val accessibilityEvent: BarChartAccessibilityEvent,
-    private val dataSet:IBarDataSet = barChart.data.dataSets.first()
+    private val dataSet: IBarDataSet = barChart.data.dataSets.first()
 ) : ExploreByTouchHelper(barChart) {
     interface BarChartAccessibilityEvent {
         fun onHighlight(index: Int, hasOverlappingEntries: Boolean)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
@@ -11,17 +11,20 @@ import com.github.mikephil.charting.interfaces.datasets.IBarDataSet
 
 class BarChartAccessibilityHelper(
     private val barChart: BarChart,
-    private val contentDescriptions: List<String>,
+    contentDescriptions: List<String>,
     private val hasOverlappingEntries: Boolean,
     private val accessibilityEvent: BarChartAccessibilityEvent,
     private val dataSet: IBarDataSet = barChart.data.dataSets.first()
 ) : ExploreByTouchHelper(barChart) {
+    private val cutContentDescriptions:List<String>
+
     interface BarChartAccessibilityEvent {
         fun onHighlight(index: Int, hasOverlappingEntries: Boolean)
     }
 
     init {
         barChart.setOnHoverListener { _, event -> dispatchHoverEvent(event) }
+        cutContentDescriptions = contentDescriptions.take(dataSet.entryCount)
     }
 
     override fun getVirtualViewAt(x: Float, y: Float): Int {
@@ -62,7 +65,7 @@ class BarChartAccessibilityHelper(
         virtualViewId: Int,
         node: AccessibilityNodeInfoCompat
     ) {
-        node.contentDescription = contentDescriptions[virtualViewId]
+        node.contentDescription = cutContentDescriptions[virtualViewId]
 
         barChart.highlighted?.let { highlights ->
             highlights.forEach { highlight ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
@@ -13,13 +13,13 @@ class BarChartAccessibilityHelper(
     private val barChart: BarChart,
     contentDescriptions: List<String>,
     private val hasOverlappingEntries: Boolean,
-    private val accessibilityEvent: BarChartAccessibilityEvent,
-    private val dataSet: IBarDataSet = barChart.data.dataSets.first()
+    private val accessibilityEvent: BarChartAccessibilityEvent
 ) : ExploreByTouchHelper(barChart) {
+    private val dataSet: IBarDataSet = barChart.data.dataSets.first()
     private val cutContentDescriptions:List<String>
 
     interface BarChartAccessibilityEvent {
-        fun onHighlight(index: Int, hasOverlappingEntries: Boolean)
+        fun onHighlight(entry: BarEntry, index: Int, hasOverlappingEntries: Boolean)
     }
 
     init {
@@ -53,7 +53,8 @@ class BarChartAccessibilityHelper(
     ): Boolean {
         when (action) {
             AccessibilityNodeInfoCompat.ACTION_CLICK -> {
-                accessibilityEvent.onHighlight(virtualViewId, hasOverlappingEntries)
+                val entry = dataSet.getEntryForIndex(virtualViewId)
+                accessibilityEvent.onHighlight(entry, virtualViewId, hasOverlappingEntries)
                 return true
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
@@ -14,10 +14,9 @@ import com.github.mikephil.charting.listener.OnChartValueSelectedListener
 
 class BarChartAccessibilityHelper(
     private val barChart: BarChart,
-    private val dataSet: BarDataSet,
     private val contentDescriptions: List<String>
 ) : ExploreByTouchHelper(barChart) {
-
+    private val dataSet =barChart.data.dataSets.first()
     init {
         barChart.setOnHoverListener { _, event -> dispatchHoverEvent(event) }
         barChart.setOnChartValueSelectedListener(object : OnChartValueSelectedListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
@@ -11,14 +11,14 @@ import com.github.mikephil.charting.data.BarEntry
 class BarChartAccessibilityHelper(
     private val barChart: BarChart,
     private val contentDescriptions: List<String>,
-    private val hasOverlappingEntries: Boolean
+    private val hasOverlappingEntries: Boolean,
+    private val accessibilityEvent: BarChartAccessibilityEvent
 ) : ExploreByTouchHelper(barChart) {
     interface BarChartAccessibilityEvent {
         fun onHighlight(index: Int, hasOverlappingEntries: Boolean)
     }
 
     private val dataSet = barChart.data.dataSets.first()
-    var accessibilityEvent: BarChartAccessibilityEvent? = null
 
     init {
         barChart.setOnHoverListener { _, event -> dispatchHoverEvent(event) }
@@ -50,7 +50,7 @@ class BarChartAccessibilityHelper(
     ): Boolean {
         when (action) {
             AccessibilityNodeInfoCompat.ACTION_CLICK -> {
-                accessibilityEvent?.onHighlight(virtualViewId, hasOverlappingEntries)
+                accessibilityEvent.onHighlight(virtualViewId, hasOverlappingEntries)
                 return true
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
@@ -7,18 +7,18 @@ import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.Accessibilit
 import androidx.customview.widget.ExploreByTouchHelper
 import com.github.mikephil.charting.charts.BarChart
 import com.github.mikephil.charting.data.BarEntry
+import com.github.mikephil.charting.interfaces.datasets.IBarDataSet
 
 class BarChartAccessibilityHelper(
     private val barChart: BarChart,
     private val contentDescriptions: List<String>,
     private val hasOverlappingEntries: Boolean,
-    private val accessibilityEvent: BarChartAccessibilityEvent
+    private val accessibilityEvent: BarChartAccessibilityEvent,
+    private val dataSet:IBarDataSet
 ) : ExploreByTouchHelper(barChart) {
     interface BarChartAccessibilityEvent {
         fun onHighlight(index: Int, hasOverlappingEntries: Boolean)
     }
-
-    private val dataSet = barChart.data.dataSets.first()
 
     init {
         barChart.setOnHoverListener { _, event -> dispatchHoverEvent(event) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
@@ -16,7 +16,7 @@ class BarChartAccessibilityHelper(
     private val accessibilityEvent: BarChartAccessibilityEvent
 ) : ExploreByTouchHelper(barChart) {
     private val dataSet: IBarDataSet = barChart.data.dataSets.first()
-    private val cutContentDescriptions:List<String>
+    private val cutContentDescriptions: List<String>
 
     interface BarChartAccessibilityEvent {
         fun onHighlight(entry: BarEntry, index: Int, hasOverlappingEntries: Boolean)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
@@ -143,6 +143,10 @@ class StatsUtils
     ): List<String> {
         val contentDescriptions = mutableListOf<String>()
 
+        if (entryType == -1) {
+            return contentDescriptions
+        }
+
         entries.forEachIndexed { index, bar ->
             var contentDescription = resourceProvider.getString(
                     R.string.stats_bar_chart_accessibility_entry,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
@@ -135,7 +135,7 @@ class StatsUtils
         }
     }
 
-    fun getEntryContentDescriptions(
+    fun getBarChartEntryContentDescriptions(
         @StringRes entryType: Int,
         entries: List<Bar>,
         @StringRes overlappingEntryType: Int? = null,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
@@ -136,7 +136,9 @@ class StatsUtils
     }
 
     fun getEntryContentDescriptions(
-        @StringRes entryType: Int, entries: List<Bar>, @StringRes overlappingEntryType: Int? = null,
+        @StringRes entryType: Int,
+        entries: List<Bar>,
+        @StringRes overlappingEntryType: Int? = null,
         overlappingEntries: List<Bar>? = null
     ): List<String> {
         val contentDescriptions = mutableListOf<String>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.ui.stats.refresh.utils
 
+import androidx.annotation.StringRes
 import org.wordpress.android.R
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarChartItem.Bar
 import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.text.DecimalFormat
@@ -131,6 +133,35 @@ class StatsUtils
         } else {
             number
         }
+    }
+
+    fun getEntryContentDescriptions(
+        @StringRes entryType: Int, entries: List<Bar>, @StringRes overlappingEntryType: Int?,
+        overlappingEntries: List<Bar>? = null
+    ): List<String> {
+        val contentDescriptions = mutableListOf<String>()
+
+        entries.forEachIndexed { index, bar ->
+            var contentDescription = resourceProvider.getString(
+                    R.string.stats_bar_chart_accessibility_entry,
+                    bar.label,
+                    bar.value,
+                    resourceProvider.getString(entryType)
+            )
+
+            overlappingEntries?.getOrNull(index)?.let { overlappingBar ->
+                overlappingEntryType?.let {
+                    contentDescription += resourceProvider.getString(
+                            R.string.stats_bar_chart_accessibility_overlapping_entry,
+                            overlappingBar.value,
+                            resourceProvider.getString(overlappingEntryType)
+                    )
+                }
+            }
+
+            contentDescriptions.add(contentDescription)
+        }
+        return contentDescriptions
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
@@ -136,7 +136,7 @@ class StatsUtils
     }
 
     fun getEntryContentDescriptions(
-        @StringRes entryType: Int, entries: List<Bar>, @StringRes overlappingEntryType: Int?,
+        @StringRes entryType: Int, entries: List<Bar>, @StringRes overlappingEntryType: Int? = null,
         overlappingEntries: List<Bar>? = null
     ): List<String> {
         val contentDescriptions = mutableListOf<String>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
@@ -142,7 +142,6 @@ class StatsUtils
         overlappingEntries: List<Bar>? = null
     ): List<String> {
         val contentDescriptions = mutableListOf<String>()
-        
         entries.forEachIndexed { index, bar ->
             var contentDescription = resourceProvider.getString(
                     R.string.stats_bar_chart_accessibility_entry,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
@@ -142,11 +142,7 @@ class StatsUtils
         overlappingEntries: List<Bar>? = null
     ): List<String> {
         val contentDescriptions = mutableListOf<String>()
-
-        if (entryType == -1) {
-            return contentDescriptions
-        }
-
+        
         entries.forEachIndexed { index, bar ->
             var contentDescription = resourceProvider.getString(
                     R.string.stats_bar_chart_accessibility_entry,

--- a/WordPress/src/main/res/layout/stats_block_bar_chart_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_bar_chart_item.xml
@@ -5,7 +5,7 @@
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:layout_marginBottom="24dp"
-              android:contentDescription="@string/stats_bar_chart_content_description"
+              android:importantForAccessibility="no"
               android:orientation="vertical"
               android:paddingEnd="@dimen/margin_extra_large"
               android:paddingStart="@dimen/margin_key">

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -887,7 +887,7 @@
     <string name="stats_posting_activity_graph">Graph of posting activity.</string>
     <string name="stats_list_item_description">%1$s: %2$s, %3$s: %4$s</string>
     <string name="stats_bar_chart_accessibility_entry">%1$s, %2$d %3$s</string>
-    <string name="stats_bar_chart_accessibility_overlapping_entry">&amp; %1$d %2$s</string>
+    <string name="stats_bar_chart_accessibility_overlapping_entry">&#160; &amp; %1$d %2$s</string>
 
     <string name="stats_manage_your_stats">Manage Your Stats</string>
     <string name="stats_management_news_card_message">Choose what stats to see, and focus on the data you care most about. Tap %1$s at the bottom of Insights to customise your stats.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -877,7 +877,6 @@
 
     <!-- Stats accessibility strings -->
     <string name="stats_loading_card">Loading selected card data</string>
-    <string name="stats_bar_chart_content_description">Graph of site views.</string>
     <string name="stats_overview_content_description">%1$s %2$s for period: %3$s, change from previous period - %4$s</string>
     <string name="stats_graph_updated">Graph updated.</string>
     <string name="stats_expand_content_description">Expand</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -886,6 +886,8 @@
     <string name="stats_item_collapsed">Item collapsed</string>
     <string name="stats_posting_activity_graph">Graph of posting activity.</string>
     <string name="stats_list_item_description">%1$s: %2$s, %3$s: %4$s</string>
+    <string name="stats_bar_chart_accessibility_entry">%1$s, %2$d %3$s</string>
+    <string name="stats_bar_chart_accessibility_overlapping_entry">&amp; %1$d %2$s</string>
 
     <string name="stats_manage_your_stats">Manage Your Stats</string>
     <string name="stats_management_news_card_message">Choose what stats to see, and focus on the data you care most about. Tap %1$s at the bottom of Insights to customise your stats.</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryMapperTest.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.stats.InsightsLatestPostModel
 import org.wordpress.android.ui.stats.StatsUtilsWrapper
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
+import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Date
 
@@ -19,6 +20,7 @@ import java.util.Date
 class LatestPostSummaryMapperTest {
     @Mock lateinit var resourceProvider: ResourceProvider
     @Mock lateinit var statsUtilsWrapper: StatsUtilsWrapper
+    @Mock lateinit var statsUtils: StatsUtils
     @Mock lateinit var statsDateFormatter: StatsDateFormatter
     private lateinit var mapper: LatestPostSummaryMapper
     private val date = Date(10)
@@ -31,7 +33,8 @@ class LatestPostSummaryMapperTest {
         mapper = LatestPostSummaryMapper(
                 statsUtilsWrapper,
                 resourceProvider,
-                statsDateFormatter
+                statsDateFormatter,
+                statsUtils
         )
     }
 


### PR DESCRIPTION
Fixes #10987

## Findings
The bar chart component wasn't accessible so this improvement seeks to make it easier for visually impaired users to navigate its contents. 

## Solution

`ExploreByTouchHelper` was utilized to make the bars within the chart selectable which would then trigger the announcement of a bar's content description. 

Before | After 
--------|-------
[Before Video ](https://drive.google.com/file/d/19dDnYoiueb1S5NTwNTH8POlAQvb65-vH/view?usp=sharing) |   [After Video    ](https://drive.google.com/file/d/19m6iZKmCrKoBehhI0k3YAVGDHlpxbloB/view?usp=sharing)

## Testing
1. Turn on TalkBack
2. Open Stats → Days
3. Slide finger over each bar to hear the content description. 
4. Open other tabs and the bar chart will update. 
5. Tap to make a bar highlighted and the stats will be updated as well. 

Days - Visitors | Days - Visitors (Bar Selected) 
--------|-------
<img src="https://user-images.githubusercontent.com/1509205/72017432-a91a1080-3233-11ea-97c8-267512e9b987.png" width="320">        |   <img src="https://user-images.githubusercontent.com/1509205/72017433-a91a1080-3233-11ea-9993-0f027a03b766.png" width="320">

Days - Views | Days - Views (Bar Selected) 
--------|-------
  <img src="https://user-images.githubusercontent.com/1509205/72017434-a91a1080-3233-11ea-8bbb-6081de51a6ab.png" width="320">      | <img src="https://user-images.githubusercontent.com/1509205/72017435-a91a1080-3233-11ea-90b0-2262d7859dd9.png" width="320">

Days - Likes | Week - Views 
--------|-------
<img src="https://user-images.githubusercontent.com/1509205/72017437-a9b2a700-3233-11ea-94b4-4279497fa3f1.png" width="320">        |       <img src="https://user-images.githubusercontent.com/1509205/72017438-a9b2a700-3233-11ea-9d61-79bd4965ef85.png" width="320">

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 