### PR TITLE
Set gutenbergEnabled to false if all sites use Aztec

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -9,6 +9,7 @@ import android.text.TextUtils;
 import android.webkit.MimeTypeMap;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -37,6 +38,7 @@ import org.wordpress.android.util.VideoUtils;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -118,14 +120,21 @@ public class AnalyticsUtils {
         metadata.setNumBlogs(siteStore.getSitesCount());
         metadata.setUsername(accountStore.getAccount().getUserName());
         metadata.setEmail(accountStore.getAccount().getEmail());
-        for (SiteModel currentSite : siteStore.getSites()) {
-            if (SiteUtils.GB_EDITOR_NAME.equals(currentSite.getMobileEditor())) {
-                metadata.setGutenbergEnabled(true);
-                break;
-            }
+        if (siteStore.hasSite()) {
+            metadata.setGutenbergEnabled(isGutenbergEnabledOnAnySite(siteStore.getSites()));
         }
 
         AnalyticsTracker.refreshMetadata(metadata);
+    }
+
+    @VisibleForTesting
+    protected static boolean isGutenbergEnabledOnAnySite(List<SiteModel> sites) {
+        for (SiteModel currentSite : sites) {
+            if (SiteUtils.GB_EDITOR_NAME.equals(currentSite.getMobileEditor())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/WordPress/src/test/java/org/wordpress/android/util/analytics/AnalyticsUtilsTest.java
+++ b/WordPress/src/test/java/org/wordpress/android/util/analytics/AnalyticsUtilsTest.java
@@ -1,0 +1,54 @@
+package org.wordpress.android.util.analytics;
+
+import org.junit.Test;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.util.SiteUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.wordpress.android.util.analytics.AnalyticsUtils.isGutenbergEnabledOnAnySite;
+
+public class AnalyticsUtilsTest {
+    @Test
+    public void isGutenbergEnabledOnAnySite_no_sites() {
+        assertFalse(isGutenbergEnabledOnAnySite(siteList()));
+    }
+
+    @Test
+    public void isGutenbergEnabledOnAnySite_single_gutenberg_site() {
+        List<SiteModel> sites = siteList(false, true, false);
+        assertTrue(isGutenbergEnabledOnAnySite(sites));
+    }
+
+    @Test
+    public void isGutenbergEnabledOnAnySite_multiple_gutenberg_sites() {
+        List<SiteModel> sites = siteList(true, false, true, false);
+        assertTrue(isGutenbergEnabledOnAnySite(sites));
+    }
+
+    @Test
+    public void isGutenbergEnabledOnAnySite_no_gutenberg_sites() {
+        List<SiteModel> sites = siteList(false, false);
+        assertFalse(isGutenbergEnabledOnAnySite(sites));
+    }
+
+    private List<SiteModel> siteList(boolean... isGutenbergEnabledList) {
+        List<SiteModel> sites = new ArrayList<>();
+        for (boolean isEnabled : isGutenbergEnabledList) {
+            sites.add(mockSite(isEnabled));
+        }
+        return sites;
+    }
+
+    private SiteModel mockSite(boolean isGutenbergEnabled) {
+        String enabledString = isGutenbergEnabled ? SiteUtils.GB_EDITOR_NAME : "";
+        SiteModel mockSite = mock(SiteModel.class);
+        when(mockSite.getMobileEditor()).thenReturn(enabledString);
+        return mockSite;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1714

This fixes an issue that began occurring with the `user_info_gutenberg_enabled` boolean property to our analytics events. In particular, we switched from sending `false` if a user was only using Aztec to sending `null`. iOS did not make this change and continued sending `false` in that scenario (as did Android until recently). This PR fixes fixes that by setting the `gutenbergEnabled` metadata to be false if all of a user's sites use Aztec.

### Background

This issue occurs because we made a change in July to check to see whether the `gutenbergEnabled` metadata has been set and only set that property on analytics events [if it has been set](https://github.com/wordpress-mobile/WordPress-Android/pull/10300/files#diff-b746b023ad22dfe67f64acc153c207deR527-R531). At the same time, we also made a change to only update the metadata's `gutenbergEnabled` property to be `true` [if _at least one_ of the user's sites were using gutenberg](https://github.com/wordpress-mobile/WordPress-Android/pull/10300/files#diff-1f0db6b056d7a64bd9a2584db14f7006R119-R122). **We do not do anything, however, if none of the user's sites use gutenberg.** As a result, the `gutenbergEnabled` metadata property remained unset, and a `null` value was sent if the user used Aztec on all their sites.

With the changes in this PR, we now only send `null` if the user has no sites. Otherwise we send `true` if any of the user's sites use gutenberg (this behavior is unchanged) and we send `false` if all the user's sites use Aztec (before this change, this would have been sent as `null`). This should reverse the "swap" that occurred between `null` and `false` values in August 2019.

![Screen Shot 2020-01-08 at 2 05 43 PM](https://user-images.githubusercontent.com/4656348/72007904-abbf3a80-3220-11ea-9432-8a40e6f11ea2.png)

### To test

#### Scenario 1: No Sites
1. Log into an account with no sites
2. Verify that the `user_info_gutenberg_enabled` property on the analytics events is set to `null`

#### Scenario 2: All sites using Aztec
1. Log into an account where all the associated sites use the Aztec editor
2. Verify that the `user_info_gutenberg_enabled` property on the analytics events is set to `false`

#### Scenario 3: At least one site using Gutenberg
1. Log into an account with at least one site using the gutenberg editor (i.e., log into the account used in test scenario 2, and change one site to use gutenberg by default).
2. Verify that the `user_info_gutenberg_enabled` property on the analytics events is set to `false`

#### PR submission checklist

- [X] I have considered adding unit tests where possible.

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

