### PR TITLE
Gutenberg and Aztec update - add content watcher to aztec

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     ext {
-        aztecVersion = 'v1.3.36'
+        aztecVersion = 'v1.3.37'
     }
 
     dependencies {


### PR DESCRIPTION
This PR updates Aztec (both the built in editor and gutenberg which uses Aztec internally). The only change in Aztec is introduction of a content watcher which notifies clients about all changes to the content - including changes to spans.

Aztec PR - https://github.com/wordpress-mobile/AztecEditor-Android/pull/887
Gutenberg-mobile PR - https://github.com/wordpress-mobile/gutenberg-mobile/pull/1710

To test:
- The content watcher isn't being used yet, so just smoke test gutenberg and aztec editors -> eg. add some text + an image to the content.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

