### PR TITLE
Analytics: Track phase 2 of the Gutenberg Rollout

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -114,7 +114,11 @@ public class SiteUtils {
                 }
             }
 
-            // Enable Gutenberg for all sites using a single network call
+            // Track and enable and  Gutenberg for all sites using a single network call. Ideally we would track this
+            // on the network response, but this would make this rollout even more complex.
+            // There might be some rare events when we register a site switched to Gutenberg which is actually
+            // still on Aztec.
+            trackGutenbergEnabledForNonGutenbergSites(siteStore);
             dispatcher.dispatch(SiteActionBuilder.newDesignateMobileEditorForAllSitesAction(
                     new DesignateMobileEditorForAllSitesPayload(SiteUtils.GB_EDITOR_NAME)));
 
@@ -133,6 +137,15 @@ public class SiteUtils {
         } else {
             dispatcher.dispatch(SiteActionBuilder.newDesignateMobileEditorForAllSitesAction(
                     new DesignateMobileEditorForAllSitesPayload(SiteUtils.AZTEC_EDITOR_NAME)));
+        }
+    }
+
+    private static void trackGutenbergEnabledForNonGutenbergSites(final SiteStore siteStore) {
+        for (SiteModel site : siteStore.getSites()) {
+            if (!TextUtils.equals(site.getMobileEditor(), GB_EDITOR_NAME)) {
+                AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_GUTENBERG_ENABLED, site,
+                        BlockEditorEnabledSource.ON_PROGRESSIVE_ROLLOUT_PHASE_1.asPropertyMap());
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -77,7 +77,12 @@ public class SiteUtils {
                     }
                 }
 
-                // Enable Gutenberg for all sites using a single network call
+                // Track and enable Gutenberg for all sites using a single network call. Ideally we would track this
+                // on the network response, but this would make this rollout even more complex.
+                // There might be some rare events when we register a site switched to Gutenberg which is actually
+                // still on Aztec.
+                trackGutenbergEnabledForNonGutenbergSites(siteStore,
+                        BlockEditorEnabledSource.ON_PROGRESSIVE_ROLLOUT_PHASE_2);
                 dispatcher.dispatch(SiteActionBuilder.newDesignateMobileEditorForAllSitesAction(
                         new DesignateMobileEditorForAllSitesPayload(SiteUtils.GB_EDITOR_NAME, false)));
 
@@ -118,7 +123,8 @@ public class SiteUtils {
             // on the network response, but this would make this rollout even more complex.
             // There might be some rare events when we register a site switched to Gutenberg which is actually
             // still on Aztec.
-            trackGutenbergEnabledForNonGutenbergSites(siteStore);
+            trackGutenbergEnabledForNonGutenbergSites(siteStore,
+                    BlockEditorEnabledSource.ON_PROGRESSIVE_ROLLOUT_PHASE_1);
             dispatcher.dispatch(SiteActionBuilder.newDesignateMobileEditorForAllSitesAction(
                     new DesignateMobileEditorForAllSitesPayload(SiteUtils.GB_EDITOR_NAME)));
 
@@ -140,11 +146,11 @@ public class SiteUtils {
         }
     }
 
-    private static void trackGutenbergEnabledForNonGutenbergSites(final SiteStore siteStore) {
+    private static void trackGutenbergEnabledForNonGutenbergSites(final SiteStore siteStore,
+                                                                  final BlockEditorEnabledSource source) {
         for (SiteModel site : siteStore.getSites()) {
             if (!TextUtils.equals(site.getMobileEditor(), GB_EDITOR_NAME)) {
-                AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_GUTENBERG_ENABLED, site,
-                        BlockEditorEnabledSource.ON_PROGRESSIVE_ROLLOUT_PHASE_1.asPropertyMap());
+                AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_GUTENBERG_ENABLED, site, source.asPropertyMap());
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -74,7 +74,8 @@ public class AnalyticsUtils {
         VIA_SITE_SETTINGS,
         ON_SITE_CREATION,
         ON_BLOCK_POST_OPENING,
-        ON_PROGRESSIVE_ROLLOUT;
+        ON_PROGRESSIVE_ROLLOUT_PHASE_1,
+        ON_PROGRESSIVE_ROLLOUT_PHASE_2;
 
         public Map<String, Object> asPropertyMap() {
             Map<String, Object> properties = new HashMap<>();


### PR DESCRIPTION
Second fix for wordpress-mobile/gutenberg-mobile#1718 - previous one was https://github.com/wordpress-mobile/WordPress-Android/pull/11045

Note: I merged `issue/1718-track-gutenberg-rollout` into this branch and added one more commit 25536d16e90327ca71258f78ba0665b817ea5211. `issue/1718-track-gutenberg-rollout` is targetting `release/13.9` and the release branch won't be merged into `develop` until the release next week. This branch targets `develop` because rollout phase 2 targets `develop`.

I double checked the property name `ON_PROGRESSIVE_ROLLOUT_PHASE_1` is the same in `13.9` and `develop`.
