### PR TITLE
Main fab bottom sheet expanded in landscape

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainBottomSheetFragment.kt
@@ -5,11 +5,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import kotlinx.android.synthetic.main.add_content_bottom_sheet.*
 import org.wordpress.android.R
@@ -41,6 +44,19 @@ class MainBottomSheetFragment : BottomSheetDialogFragment() {
         viewModel.mainActions.observe(this, Observer {
             (dialog.create_actions_recycler_view.adapter as? AddContentAdapter)?.update(it ?: listOf())
         })
+
+        dialog.setOnShowListener { dialogInterface ->
+            val sheetDialog = dialogInterface as? BottomSheetDialog
+
+            val bottomSheet = sheetDialog?.findViewById<View>(
+                    com.google.android.material.R.id.design_bottom_sheet
+            ) as? FrameLayout
+
+            bottomSheet?.let {
+                val behavior = BottomSheetBehavior.from(it)
+                behavior.state = BottomSheetBehavior.STATE_EXPANDED
+            }
+        }
     }
 
     override fun onAttach(context: Context?) {


### PR DESCRIPTION
Fixes #11068 

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/47797566/72194864-d15e6680-340f-11ea-847f-3b8c5a5518ef.png) | ![image](https://user-images.githubusercontent.com/47797566/72194846-b855b580-340f-11ea-80aa-0726c70d65d4.png) |

## To test
- Compile and run zapha flavor
- Start WP app and put device in landscape
- Press the main FAB to open the bottom sheet and notice it is expanded
- Keep the bottom sheet opened and rotate the device in portrait; notice the bottom sheet stay expanded
- Keep the bottom sheet opened and rotate the device in landscape; notice the bottom sheet stay expanded
- Smoke test the FAB creating a post/page and switching between main pages of the app


PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

