### PR TITLE
Accessibility : Reader - Decorative Icons Announcement Fix

### DIFF
--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -181,7 +181,7 @@
                 android:layout_gravity="center_vertical"
                 android:layout_marginEnd="@dimen/margin_large"
                 android:src="@drawable/bg_rectangle_neutral_10_user_32dp"
-                android:contentDescription="@string/reader_blavatar_desc"
+                android:importantForAccessibility="no"
                 style="@style/ReaderImageView.Avatar.Small" >
             </ImageView>
 

--- a/WordPress/src/main/res/layout/reader_cardview_xpost.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_xpost.xml
@@ -33,7 +33,7 @@
                 android:layout_width="@dimen/blavatar_sz"
                 android:layout_height="@dimen/blavatar_sz"
                 android:layout_gravity="top|start"
-                android:contentDescription="@string/reader_blavatar_desc"
+                android:importantForAccessibility="no"
                 android:src="@drawable/bg_rectangle_neutral_10_globe_32dp" />
 
             <ImageView
@@ -41,7 +41,7 @@
                 style="@style/ReaderImageView.Avatar.Small"
                 android:layout_gravity="bottom|end"
                 android:layout_marginTop="14dp"
-                android:contentDescription="@string/reader_avatar_desc"
+                android:importantForAccessibility="no"
                 android:src="@drawable/bg_rectangle_neutral_10_user_32dp"
                 android:layout_marginStart="14dp"/>
         </FrameLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2436,7 +2436,6 @@
     <string name="navigate_up_desc">navigate up</string>
     <string name="fab_add_tag_desc">Create Tag</string>
     <string name="fab_create_desc">create</string>
-    <string name="reader_blavatar_desc">site icon</string>
     <string name="reader_avatar_desc">profile picture</string>
     <string name="reader_gallery_images_desc">image gallery</string>
     <string name="quick_start_completed_tasks_header_chevron_expand_desc">expand</string>


### PR DESCRIPTION
Fixes #11091 

## Findings
Several decorative icons inside Reader were being announced. 

## Solution
Remove their `contentDescriptions` and set `android:importantForAccessibility="no"`

## Testing
1. Enable TalkBack.
2. Go to Reader and then Discover.
3. Hover "Originally posted by `{author name}`" & "Visit `{site name}`"
4. Hear the announcement.

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/1509205/72487037-b195bc80-37da-11ea-986c-15d5158b6cde.png" width="320">    | <img src="https://user-images.githubusercontent.com/1509205/72488172-2caca200-37de-11ea-80d5-ccf647c6ad13.png" width="320">

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/1509205/72488085-ef481480-37dd-11ea-8f7f-b4fac8524a8f.png" width="320">   |  <img src="https://user-images.githubusercontent.com/1509205/72488084-ef481480-37dd-11ea-96d5-22ebead175ce.png" width="320">


## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
