### PR TITLE
Fix module with the Main dispatcher is missing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-    ext.kotlin_version = '1.3.11'
-    ext.kotlin_coroutines_version = '1.1.0'
+    ext.kotlin_version = '1.3.61'
+    ext.kotlin_coroutines_version = '1.3.3'
     ext.androidx_work_version = "2.0.1"
 
     repositories {


### PR DESCRIPTION
Fixes #11086 

##### Issue was reproducible on Pixel3a, Android 10, WPAndroid 14.0
### Steps to reproduce
- Select **Posts** from **My SIte** tab
- App crashes with logs
```
IllegalStateException: Module with the Main dispatcher is missing. Add dependency providing the Main dispatcher, e.g. 'kotlinx-coroutines-android'
```

As [kotlin-coroutines](https://github.com/Kotlin/kotlinx.coroutines) and kotlin versions were updated, we should do an ad hoc testing if the app functions properly with these versions.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

