### PR TITLE
Bump Stetho version from 1.5.0 to 1.5.1

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -288,8 +288,8 @@ dependencies {
     implementation 'org.slf4j:slf4j-nop:1.7.25'
 
     // Debug
-    debugImplementation 'com.facebook.stetho:stetho:1.5.0'
-    debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.5.0'
+    debugImplementation 'com.facebook.stetho:stetho:1.5.1'
+    debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.5.1'
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"


### PR DESCRIPTION
Stetho's view hierarchy keeps crashing on Android 9+. It's a known bug, which has been fixed in v1.5.1.

More info https://github.com/facebook/stetho/pull/622 and https://github.com/facebook/stetho/issues/633#issuecomment-473776323

To test:
1. Run the app on Android 9+
2. Open Stetho on Elements tab
3. Start diving into the hierarchy and notice the app doesn't crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

