### PR TITLE
Navigation Bar shadowed by bottom sheet

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainBottomSheetFragment.kt
@@ -24,6 +24,11 @@ class MainBottomSheetFragment : BottomSheetDialogFragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: WPMainActivityViewModel
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setStyle(STYLE_NORMAL, R.style.LoginTheme_BottomSheetDialogStyle)
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/WordPress/src/main/res/layout/add_content_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout/add_content_bottom_sheet.xml
@@ -4,7 +4,8 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:animateLayoutChanges="true">
+    android:animateLayoutChanges="true"
+    android:fitsSystemWindows="true">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/create_actions_recycler_view"

--- a/WordPress/src/main/res/values-v27/styles.xml
+++ b/WordPress/src/main/res/values-v27/styles.xml
@@ -4,4 +4,11 @@
         <item name="android:navigationBarColor">@android:color/white</item>
         <item name="android:windowLightNavigationBar">true</item>
     </style>
+
+    <style name="LoginTheme.BottomSheetDialogStyle" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">?android:attr/colorBackground</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="bottomSheetStyle">@style/Widget.Design.BottomSheet.Modal</item>
+    </style>
 </resources>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1128,4 +1128,11 @@
         <item name="android:layout_height">@dimen/main_fab_tooltip_arrow_size</item>
         <item name="android:elevation">@dimen/main_fab_tooltip_elevation</item>
     </style>
+
+    <style name="LoginTheme.BottomSheetDialogStyle" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="bottomSheetStyle">@style/Widget.Design.BottomSheet.Modal</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Fixes #11018 

This PR is based on the solution elaborated in #11051 (credits to @ashiagr , @theck13 and @malinajirka to having come to this 🙇‍♂️).

In the following the relevant screenshots (FYI cc @osullivanchris ).

| API Level/Device type | Portrait | Landscape |
|---|---|---|
| API 26/Phone | ![image](https://user-images.githubusercontent.com/47797566/72515521-56061600-3850-11ea-896c-a5191411c0ee.png) | ![image](https://user-images.githubusercontent.com/47797566/72515538-60c0ab00-3850-11ea-9332-df4c226a4e4b.png) |
| API 26/Tablet | ![image](https://user-images.githubusercontent.com/47797566/72515680-99608480-3850-11ea-9ff5-4710aac8babb.png) | ![image](https://user-images.githubusercontent.com/47797566/72515706-a4b3b000-3850-11ea-8332-e00a1cbba8a2.png) |
| API 28/Phone| ![image](https://user-images.githubusercontent.com/47797566/72515798-d298f480-3850-11ea-97b0-445c63a3d921.png) | ![image](https://user-images.githubusercontent.com/47797566/72515843-e6dcf180-3850-11ea-9207-2d9f17cc061d.png) |
| API 28/Tablet | ![image](https://user-images.githubusercontent.com/47797566/72515899-096f0a80-3851-11ea-98b8-564b112f1549.png) | ![image](https://user-images.githubusercontent.com/47797566/72515920-12f87280-3851-11ea-9155-7501f709dfb0.png) |
| API 29/Phone | ![image](https://user-images.githubusercontent.com/47797566/72516005-3cb19980-3851-11ea-881c-06e2a74e644c.png) | ![image](https://user-images.githubusercontent.com/47797566/72516035-4b984c00-3851-11ea-9b18-edbc22748a5b.png) |
| API 29/Tablet | ![image](https://user-images.githubusercontent.com/47797566/72516107-6e2a6500-3851-11ea-8e21-b1046d3c9686.png) | ![image](https://user-images.githubusercontent.com/47797566/72516129-771b3680-3851-11ea-90dd-86f059917149.png) |





 


## To test
- Use an emulator for each of the above API level
- Open the bottom sheet tapping on the FAB
- Check that the system navigation bar is not shadowed both in portrait and landscape 

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

