### PR TITLE
Fix search resume behavior.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -521,6 +521,9 @@ public class ReaderPostListFragment extends Fragment
                 mLastTappedSiteSearchResult = null;
             }
 
+            if (getPostListType() == ReaderPostListType.SEARCH_RESULTS) {
+                return;
+            }
             ReaderTag discoverTag = ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH);
             ReaderTag readerTag = AppPrefs.getReaderTag();
 


### PR DESCRIPTION
# Fixes 
#11055 

This fixes this issue. The problem was on the search resume behavior. The original and fixed versions can be seen in the links below.
### The issue
The discovery was being loaded when the user was on the search after resuming.
I suppose that this wasn't the expected behavior. Also if the user would do a search, "pause" the app and then resume, the discovery would come up.. If the user would "pause" and resume again the discovery results would "erase" the search results. 

This issues can be seen below.
Also I leave the links to the videos <a href="https://www.dropbox.com/s/0acw1c1q5cqj18k/fix-search-behave.mp4?dl=0" target="_blank"> Original</a> and  <a href="https://www.dropbox.com/s/0acw1c1q5cqj18k/fix-search-behave.mp4?dl=0=0" target="_blank"> Fixed</a>
# Screens

### Original
![original-search-behave](https://user-images.githubusercontent.com/57217107/72515376-150e0180-3850-11ea-8bb0-44cb76354ff7.gif)

### Fixed
![fix-search-behave](https://user-images.githubusercontent.com/57217107/72515375-14756b00-3850-11ea-96b8-ab341d0e0f96.gif)


PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

