### PR TITLE
Disable long tap to remove Jetpack sites

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 14.1
 -----
+* Disable the option to remove a Jetpack site from site picker
  
 14.0
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -523,7 +523,7 @@ public class SitePickerActivity extends AppCompatActivity
         if (site == null) {
             return false;
         }
-        if (site.isWPCom()) {
+        if (site.isUsingWpComRestApi()) {
             if (mActionMode != null) {
                 return false;
             }


### PR DESCRIPTION
This PR disables the option to remove a Jetpack or Atomic site with a long press. (as requested in mobile requests p2) These sites should behave the same way as WordPress.com sites do.

**To test:**
* Go to site picker
* Tap and hold a Jetpack or Atomic site
* Verify that the "Remove Site" dialog is not shown and instead you are able to show/hide REST api sites.

Here is my test: https://cloudup.com/cFZHsbMYLUN (before) https://cloudup.com/cRMktoUSIbK (after) In both options I am tapping on the atomic site. (tap is not visible)

**PR submission checklist:**
- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

