### PR TITLE
Fix npe in UploadService

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -232,8 +232,10 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
     }
 
     private MediaModel getNextMediaToUpload() {
-        if (!sPendingUploads.isEmpty()) {
-            return sPendingUploads.remove(0);
+        synchronized (sPendingUploads) {
+            if (!sPendingUploads.isEmpty()) {
+                return sPendingUploads.remove(0);
+            }
         }
         return null;
     }
@@ -244,8 +246,10 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
                 return;
             }
 
-            // no match found in queue
-            sPendingUploads.add(media);
+            synchronized (sPendingUploads) {
+                // no match found in queue
+                sPendingUploads.add(media);
+            }
         }
     }
 
@@ -391,13 +395,15 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
             }
         }
 
-        for (MediaModel queuedMedia : sPendingUploads) {
-            AppLog.i(T.MEDIA, "MediaUploadHandler > Attempting to add media with path " + mediaModel.getFilePath()
-                              + " and site id " + mediaModel.getLocalSiteId() + ". Comparing with " + queuedMedia
-                                      .getFilePath()
-                              + ", " + queuedMedia.getLocalSiteId());
-            if (isSameMediaFileQueuedForThisPost(queuedMedia, mediaModel)) {
-                return true;
+        synchronized (sPendingUploads) {
+            for (MediaModel queuedMedia : sPendingUploads) {
+                AppLog.i(T.MEDIA, "MediaUploadHandler > Attempting to add media with path " + mediaModel.getFilePath()
+                                  + " and site id " + mediaModel.getLocalSiteId() + ". Comparing with " + queuedMedia
+                                          .getFilePath()
+                                  + ", " + queuedMedia.getLocalSiteId());
+                if (isSameMediaFileQueuedForThisPost(queuedMedia, mediaModel)) {
+                    return true;
+                }
             }
         }
         return false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -575,7 +575,7 @@ public class UploadService extends Service {
         uploadingOrQueuedMedia.addAll(queuedMedia);
 
         for (final MediaModel media : uploadingOrQueuedMedia) {
-            if (media != null && !UploadService.isPendingOrInProgressMediaUpload(media)) {
+            if (!UploadService.isPendingOrInProgressMediaUpload(media)) {
                 // it is NOT being uploaded or queued in the actual UploadService, mark it failed
                 media.setUploadState(MediaUploadState.FAILED);
                 dispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -575,7 +575,7 @@ public class UploadService extends Service {
         uploadingOrQueuedMedia.addAll(queuedMedia);
 
         for (final MediaModel media : uploadingOrQueuedMedia) {
-            if (!UploadService.isPendingOrInProgressMediaUpload(media)) {
+            if (media != null && !UploadService.isPendingOrInProgressMediaUpload(media)) {
                 // it is NOT being uploaded or queued in the actual UploadService, mark it failed
                 media.setUploadState(MediaUploadState.FAILED);
                 dispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));


### PR DESCRIPTION
Fixes #11104
The app crashes on NPE in UploadService.

To test:
- I wasn't able to reproduce this issue.

Updated on 01/29:
1. Open Media section for a site
2. Click + for upload
3. Click Choose photo from device
4. Long press an image, and select several images
5. Click "OPEN" to being upload
6. Confirm images are uploaded

--------------------------------
1. Create a post with Aztec
2. Add multiple images from the local storage
3. Make sure all the images are correctly uploaded

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

