### PR TITLE
Create FAB tooltip announce improvements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -430,7 +430,6 @@ public class WPMainActivity extends AppCompatActivity implements
 
         ViewUtilsKt.redirectContextClickToLongPressListener(mFloatingActionButton);
 
-
         mFabTooltip.setOnClickListener(v -> {
             mViewModel.onTooltipTapped();
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -423,7 +423,7 @@ public class WPMainActivity extends AppCompatActivity implements
             if (v.isHapticFeedbackEnabled()) {
                 v.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
             }
-
+            mViewModel.onFabLongPressed();
             Toast.makeText(v.getContext(), R.string.create_post_page_fab_tooltip, Toast.LENGTH_SHORT).show();
             return true;
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -10,9 +10,11 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.text.TextUtils;
+import android.view.HapticFeedbackConstants;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -114,6 +116,7 @@ import org.wordpress.android.util.QuickStartUtils;
 import org.wordpress.android.util.ShortcutUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.ViewUtilsKt;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.service.InstallationReferrerServiceStarter;
@@ -415,6 +418,18 @@ public class WPMainActivity extends AppCompatActivity implements
         mFloatingActionButton.setOnClickListener(v -> {
             mViewModel.setIsBottomSheetShowing(true);
         });
+
+        mFloatingActionButton.setOnLongClickListener(v -> {
+            if (v.isHapticFeedbackEnabled()) {
+                v.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
+            }
+
+            Toast.makeText(v.getContext(), R.string.create_post_page_fab_tooltip, Toast.LENGTH_SHORT).show();
+            return true;
+        });
+
+        ViewUtilsKt.redirectContextClickToLongPressListener(mFloatingActionButton);
+
 
         mFabTooltip.setOnClickListener(v -> {
             mViewModel.onTooltipTapped();

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -82,6 +82,8 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
     }
 
     fun onTooltipTapped() {
+        appPrefsWrapper.setMainFabTooltipDisabled(true)
+
         val oldState = _fabUiState.value
         oldState?.let {
             _fabUiState.value = MainFabUiState(

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -70,6 +70,18 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
         _createAction.postValue(actionType)
     }
 
+    private fun disableTooltip() {
+        appPrefsWrapper.setMainFabTooltipDisabled(true)
+
+        val oldState = _fabUiState.value
+        oldState?.let {
+            _fabUiState.value = MainFabUiState(
+                    isFabVisible = it.isFabVisible,
+                    isFabTooltipVisible = false
+            )
+        }
+    }
+
     fun setIsBottomSheetShowing(showing: Boolean) {
         appPrefsWrapper.setMainFabTooltipDisabled(true)
         setMainFabUiState(true)
@@ -82,15 +94,11 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
     }
 
     fun onTooltipTapped() {
-        appPrefsWrapper.setMainFabTooltipDisabled(true)
+        disableTooltip()
+    }
 
-        val oldState = _fabUiState.value
-        oldState?.let {
-            _fabUiState.value = MainFabUiState(
-                    isFabVisible = it.isFabVisible,
-                    isFabTooltipVisible = false
-            )
-        }
+    fun onFabLongPressed() {
+        disableTooltip()
     }
 
     private fun setMainFabUiState(isFabVisible: Boolean) {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.viewmodel.main
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -52,6 +53,21 @@ class WPMainActivityViewModelTest {
     @Test
     fun `fab tooltip hidden when asked`() {
         viewModel.onPageChanged(false)
+        assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
+    }
+
+    @Test
+    fun `fab tooltip disabled when tapped`() {
+        viewModel.onTooltipTapped()
+        verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
+        assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
+    }
+
+    @Test
+    fun `fab tooltip disabled when bottom sheet opened`() {
+        whenever(appPrefsWrapper.isMainFabTooltipDisabled()).thenReturn(true)
+        viewModel.setIsBottomSheetShowing(true)
+        verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
         assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -72,6 +72,13 @@ class WPMainActivityViewModelTest {
     }
 
     @Test
+    fun `fab tooltip disabled when fab long pressed`() {
+        viewModel.onFabLongPressed()
+        verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
+        assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
+    }
+
+    @Test
     fun `bottom sheet action is new post when new post is tapped`() {
         val action = viewModel.mainActions.value?.first { it.actionType == CREATE_NEW_POST } as CreateAction
         assertThat(action).isNotNull


### PR DESCRIPTION
Fixes #11088

| ![image](https://user-images.githubusercontent.com/47797566/72477465-df393080-37ef-11ea-8537-012a94fae952.png) | ![image](https://user-images.githubusercontent.com/47797566/72477448-d5afc880-37ef-11ea-839b-18a90a12ce86.png) |
|---|---|


## To test
### Test Case 1: FAB still dismisses the Tooltip forever
- Check that the tooltip is shown above the FAB (if not, clear the storage of the app and open it again)
- Tap on the FAB anche check the tooltip is dismissed
- Go to Reader, come back to My Site and check the FAB is shown but the tooltip is not shown any more
- Close and open the app again and check the FAB is shown but the tooltip is not shown any more

### Test Case 2: tooltip is dismissed forever on tap
- Clear the storage of the app, open the app again and check the tooltip is shown
- Tap on the tooltip and check it is dismissed
- Go to Reader, come back to My Site and check the FAB is shown but the tooltip is not shown any more
- Close and open the app again and check the FAB is shown but the tooltip is not shown any more

### Test Case 3: tooltip is dismissed forever on long press and we show a toast
- Clear the storage of the app, open the app again and check the tooltip is shown
- Long-press the fab anche check that a toast is shown with the message `Create a post or page`. Also the tooltip is dismissed
- Go to Reader, come back to My Site and check the FAB is shown but the tooltip is not shown any more
- Close and open the app again and check the FAB is shown but the tooltip is not shown any more
- Long-press the fab again anche check that a toast is shown with the message `Create a post or page`. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
