### PR TITLE
IA Reader: adding scroll flags to reader toolbar.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -395,6 +395,9 @@ public class ReaderPostListFragment extends Fragment
         mViewModel = ViewModelProviders.of((FragmentActivity) getActivity(), mViewModelFactory)
                                        .get(ReaderPostListViewModel.class);
 
+        AppLog.d(T.READER, "DBEUG VIEWMODEL - " + mViewModel);
+
+
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel) {
             mViewModel.getCurrentSubFilter().observe(this, subfilterListItem -> {
                 if (ReaderUtils.isFollowing(
@@ -443,6 +446,17 @@ public class ReaderPostListFragment extends Fragment
             });
         }
 
+        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
+            mViewModel.getShouldCollapseToolbar().observe(this, collapse -> {
+                if (collapse) {
+                    mRecyclerView.setToolbarScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
+                                                        | AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS);
+                } else {
+                    mRecyclerView.setToolbarScrollFlags(0);
+                }
+            });
+        }
+
         mViewModel.start(
                 mCurrentTag,
                 (ReaderUtils.isFollowing(
@@ -450,7 +464,8 @@ public class ReaderPostListFragment extends Fragment
                         BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel,
                         mRecyclerView
                 ) || ReaderUtils.isDefaultTag(mCurrentTag))
-                && BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel
+                && BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel,
+                BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel
         );
     }
 
@@ -861,8 +876,6 @@ public class ReaderPostListFragment extends Fragment
                     R.string.reader_screen_title,
                     getResources().getDimensionPixelSize(R.dimen.margin_extra_large)
             );
-            mRecyclerView.setToolbarScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
-                                                | AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS);
         } else {
             mRecyclerView.setToolbarLeftAndRightPadding(
                     getResources().getDimensionPixelSize(R.dimen.margin_medium),
@@ -973,6 +986,9 @@ public class ReaderPostListFragment extends Fragment
                 mSettingsMenuItem.setVisible(false);
                 mRecyclerView.setTabLayoutVisibility(false);
                 mViewModel.setSubfiltersVisibility(false);
+                if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel) {
+                    mViewModel.setCollapseToolbar(false);
+                }
 
                 // hide the bottom navigation when search is active
                 if (mBottomNavController != null) {
@@ -1018,6 +1034,7 @@ public class ReaderPostListFragment extends Fragment
                     mViewModel.setSubfiltersVisibility(
                             ReaderUtils.isFollowing(mCurrentTag, mIsTopLevel, mRecyclerView)
                     );
+                    mViewModel.setCollapseToolbar(true);
                 } else {
                     // return to the followed tag that was showing prior to searching
                     resetPostAdapter(ReaderPostListType.TAG_FOLLOWED);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -40,6 +40,7 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener;
@@ -860,6 +861,8 @@ public class ReaderPostListFragment extends Fragment
                     R.string.reader_screen_title,
                     getResources().getDimensionPixelSize(R.dimen.margin_extra_large)
             );
+            mRecyclerView.setToolbarScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
+                                                | AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS);
         } else {
             mRecyclerView.setToolbarLeftAndRightPadding(
                     getResources().getDimensionPixelSize(R.dimen.margin_medium),

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -395,9 +395,6 @@ public class ReaderPostListFragment extends Fragment
         mViewModel = ViewModelProviders.of((FragmentActivity) getActivity(), mViewModelFactory)
                                        .get(ReaderPostListViewModel.class);
 
-        AppLog.d(T.READER, "DBEUG VIEWMODEL - " + mViewModel);
-
-
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel) {
             mViewModel.getCurrentSubFilter().observe(this, subfilterListItem -> {
                 if (ReaderUtils.isFollowing(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -58,6 +58,9 @@ class ReaderPostListViewModel @Inject constructor(
     private val _isBottomSheetShowing = MutableLiveData<Event<Boolean>>()
     val isBottomSheetShowing: LiveData<Event<Boolean>> = _isBottomSheetShowing
 
+    private val _shouldCollapseToolbar = MutableLiveData<Boolean>()
+    val shouldCollapseToolbar: LiveData<Boolean> = _shouldCollapseToolbar
+
     /**
      * First tag for which the card was shown.
      */
@@ -68,7 +71,7 @@ class ReaderPostListViewModel @Inject constructor(
     /**
      * Tag may be null for Blog previews for instance.
      */
-    fun start(tag: ReaderTag?, shouldShowSubfilter: Boolean) {
+    fun start(tag: ReaderTag?, shouldShowSubfilter: Boolean, collapseToolbar: Boolean) {
         if (isStarted) {
             return
         }
@@ -79,6 +82,9 @@ class ReaderPostListViewModel @Inject constructor(
             _currentSubFilter.value = getCurrentSubfilterValue()
             _shouldShowSubFilters.value = shouldShowSubfilter
         }
+
+        _shouldCollapseToolbar.value = collapseToolbar
+
         isStarted = true
     }
 
@@ -260,6 +266,10 @@ class ReaderPostListViewModel @Inject constructor(
             ))
         }
         isFirstLoad = false
+    }
+
+    fun setCollapseToolbar(collapse: Boolean) {
+        _shouldCollapseToolbar.value = collapse
     }
 
     override fun onCleared() {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -61,13 +61,13 @@ class ReaderPostListViewModelTest {
 
     @Test
     fun verifyPullInvokedInOnStart() {
-        viewModel.start(initialTag, false)
+        viewModel.start(initialTag, false, false)
         verify(newsManager).pull(false)
     }
 
     @Test
     fun verifyViewModelPropagatesNewsItems() {
-        viewModel.start(initialTag, false)
+        viewModel.start(initialTag, false, false)
         liveData.postValue(item)
         liveData.postValue(null)
         liveData.postValue(item)
@@ -86,7 +86,7 @@ class ReaderPostListViewModelTest {
 
     @Test
     fun emitNullOnInitialTagChanged() {
-        viewModel.start(otherTag, false)
+        viewModel.start(otherTag, false, false)
         // propagates the item since the card hasn't been shown yet
         liveData.postValue(item)
         viewModel.onTagChanged(initialTag)
@@ -101,7 +101,7 @@ class ReaderPostListViewModelTest {
 
     @Test
     fun verifyNewsItemAvailableOnlyForFirstTagForWhichCardWasShown() {
-        viewModel.start(otherTag, false)
+        viewModel.start(otherTag, false, false)
         // propagate the item since the card hasn't been shown yet
         liveData.postValue(item)
         viewModel.onTagChanged(initialTag)


### PR DESCRIPTION
Fixes #10885 

With Reader navigation revised as part of the Information Architecture project, we introduced a 2 level filter capability (tabs filtering and subfilter component). This reduces the vertical space available for posts visualisation. So we want to make the toolbar collapsable with the same behavior as the Notifications screen toolbar. Please note that reader feature is available in zalpha flavor so you will need to use that one to test.

## To test
- Compile and run zalpha flavor
- go to reader and scroll down and check the toolbar collapses
- Scroll up and check the toolbar is visible again
- To ensure the previous behavior is still valid in vanilla flavor, compile and run vanilla
- Go to reader and check the toolbar does not collapse/uncollapse on scroll down/up.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

