### PR TITLE
Using postValue to account for background calls.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
@@ -122,7 +122,7 @@ class BaseListUseCase(
                 }
             }
         } else {
-            mutableSnackbarMessage.value = R.string.stats_site_not_loaded_yet
+            mutableSnackbarMessage.postValue(R.string.stats_site_not_loaded_yet)
         }
     }
 


### PR DESCRIPTION
Fixes #11103 (ot at least it tries 😊)

The issue seems due to the fact that we could end up calling the `BaseListUseCase.loadData` function from a background thread. In more details the execution path causing this is:

`InsightsManagementViewModel > onSaveInsights > BaseListUseCase.loadData`

that calls

```
private suspend fun loadData(refresh: Boolean, forced: Boolean) {
   if (statsSiteProvider.hasLoadedSite()) {
       ...
   } else {
      mutableSnackbarMessage.value = R.string.stats_site_not_loaded_yet
   }
```

Currently (20/01/2020) there is only 1 related event in sentry for 13.9 version. Also AFAIU the code involved is not recent but was there since months, so I would not try to hotfix this one (but of course we can discuss if I'm missing something here 👍).

## To test
I was not able to reproduce so not fully sure how to test. The modification is related to a snackbar logic and seems secure enough (also here if who will review has a suggestion about, I'm more than happy of course 🙇‍♂️; it could help to define how to force the test `if (statsSiteProvider.hasLoadedSite())` to fail; I made some verification playing around with the 
`Evaluate and log` debugger feature but probably there could be a better possibility).

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

