### PR TITLE
Comment Dialog Layout

### DIFF
--- a/WordPress/src/main/res/layout/comment_dialog_fragment.xml
+++ b/WordPress/src/main/res/layout/comment_dialog_fragment.xml
@@ -37,6 +37,8 @@
         android:layout_alignParentBottom="true"
         android:layout_height="0dp"
         android:layout_marginBottom="@dimen/margin_extra_large"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/margin_extra_large"
         android:layout_width="match_parent">
     </View>
 

--- a/WordPress/src/main/res/layout/comment_dialog_fragment.xml
+++ b/WordPress/src/main/res/layout/comment_dialog_fragment.xml
@@ -1,41 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ScrollView
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:clipChildren="false"
-    android:clipToPadding="false"
-    android:fillViewport="true"
     android:layout_height="match_parent"
-    android:layout_width="match_parent"
-    android:padding="@dimen/margin_extra_large"
-    android:scrollbarStyle="outsideOverlay">
+    android:layout_width="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:orientation="vertical"
+    <ScrollView
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:fillViewport="true"
+        android:layout_height="match_parent"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:padding="@dimen/margin_extra_large"
+        android:scrollbarStyle="outsideOverlay">
 
         <org.wordpress.android.widgets.SuggestionAutoCompleteText
             android:id="@+id/edit_comment_expand"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
             android:background="@android:color/transparent"
+            android:dropDownAnchor="@+id/dummy_hidden_view"
             android:gravity="start|top"
             android:hint="@string/reader_hint_comment_on_post"
             android:imeOptions="actionSend"
             android:inputType="text|textCapSentences|textMultiLine"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
             android:textAlignment="viewStart"
             android:textColorHint="@color/neutral_40"
-            android:textSize="@dimen/text_sz_large"
-            app:layout_constraintTop_toTopOf="parent"
-            android:dropDownAnchor="@+id/dummy_hidden_view" />
+            android:textSize="@dimen/text_sz_large">
+        </org.wordpress.android.widgets.SuggestionAutoCompleteText>
 
-        <View
-            android:id="@+id/dummy_hidden_view"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@android:color/transparent"
-            app:layout_constraintBottom_toBottomOf="parent" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</ScrollView>
+    </ScrollView>
+
+    <View
+        android:id="@+id/dummy_hidden_view"
+        android:background="@android:color/transparent"
+        android:layout_alignParentBottom="true"
+        android:layout_height="0dp"
+        android:layout_marginBottom="@dimen/margin_extra_large"
+        android:layout_width="match_parent">
+    </View>
+
+</RelativeLayout>


### PR DESCRIPTION
### Fix
Update the `comment_dialog_fragment` layout to allow the `SuggestionAutoCompleteText` view to fill the entire `ScrollView` as it was in the original implementation.  As a result of the @username suggestion feature addition in https://github.com/wordpress-mobile/WordPress-Android/pull/10781, the `SuggestionAutoCompleteText` view was reduced to the size of the hint text by default.  See the screenshots below for illustration.  ***Before*** is the layout before https://github.com/wordpress-mobile/WordPress-Android/pull/10781 and ***After*** is the layout after.

![emhanced_commenting_regression_01](https://user-images.githubusercontent.com/3827611/72772286-b8e50d80-3bc0-11ea-83f3-749e4a4e2d6a.png)

These changes update the layout while keeping the original functionality and the new @username suggestion feature.  See the screenshots below for illustration.  ***Before*** is the layout before https://github.com/wordpress-mobile/WordPress-Android/pull/10781, ***After*** is the layout after https://github.com/wordpress-mobile/WordPress-Android/pull/10781, and ***Update*** is the layout with these changes.

![emhanced_commenting_regression_02](https://user-images.githubusercontent.com/3827611/72773032-10847880-3bc3-11ea-8b23-6df6cd44feee.png)

### Test
0. Enable ***Show layout bounds*** developer setting.
1. Go to ***Reader*** tab.
2. Tap ***Comment*** button in footer of post.
3. Tap ***Expand*** chevron in comment input field.
4. Notice field with ***Reply to post...*** hint text has blue ***X*** filling the entire view except for outer padding.
5. Tap anywhere below ***Reply to post...*** hint text.
6. Notice contextual action menu appears (e.g. ***Paste*** button).
7. Enter ***@s*** text.
8. Notice username suggestion popup shows username's beginning with ***s***.

### Review
Only one developer is required to review these changes, but anyone can perform the review.  I would like to request @hafizrahman as an additional reviewer, but it doesn't seem like I can since he is not a member of the WordPress Mobile GitHub organization.  So I'll mention him here.  @hafizrahman, you would be a good reviewer since you last worked on this layout.  Let me know if I missed anything with regards to the suggestion feature.

### Release
These changes do not require release notes.