### PR TITLE
Avoiding update subfilter status while we are in search mode.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -396,11 +396,11 @@ public class ReaderPostListFragment extends Fragment
 
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel) {
             mViewModel.getCurrentSubFilter().observe(this, subfilterListItem -> {
-                if (ReaderUtils.isFollowing(
+                if ((ReaderUtils.isFollowing(
                         mCurrentTag,
                         BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel,
                         mRecyclerView
-                ) || ReaderUtils.isDefaultTag(mCurrentTag)) {
+                ) || ReaderUtils.isDefaultTag(mCurrentTag)) && getPostListType() != ReaderPostListType.SEARCH_RESULTS) {
                   mViewModel.applySubfilter(subfilterListItem, true);
                 }
             });


### PR DESCRIPTION
Fixes #10952 

## To test
### Vanilla
This is to confirm we have still the correct behavior in vanilla
- Open the reader
- Select the Followed Sites filter
- Select the Search icon
- Rotate the device and see the posts list is not visible in the background and you have something similar to below

| Correct | Correct |
|---|---|
| ![image](https://user-images.githubusercontent.com/47797566/72917011-59fbd180-3d43-11ea-84eb-ad7c99c723b1.png) | ![image](https://user-images.githubusercontent.com/47797566/72917046-6d0ea180-3d43-11ea-97b9-f24ddf00b7f2.png) |

- smoke test the search and reader

### Zalpha
This is to confirm we now have the correct behavior also in zalpha
- Open the reader
- Select the Following tab
- Select the Search icon
- Rotate the device and see the posts list is not visible in the background and you have something similar to below

| Correct | Correct |
|---|---|
| ![image](https://user-images.githubusercontent.com/47797566/72917011-59fbd180-3d43-11ea-84eb-ad7c99c723b1.png) | ![image](https://user-images.githubusercontent.com/47797566/72917046-6d0ea180-3d43-11ea-97b9-f24ddf00b7f2.png) |

- smoke test the search and reader

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

