### PR TITLE
Ignore wp-gallery tag while generating excerpt from post content

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -258,7 +258,7 @@ public class PostUtils {
             return null;
         }
 
-        String s = HtmlUtils.fastStripHtml(description);
+        String s = HtmlUtils.fastStripHtml(removeWPGallery(description));
         if (s.length() < MAX_EXCERPT_LEN) {
             return trimEx(s);
         }
@@ -284,6 +284,15 @@ public class PostUtils {
             return null;
         }
         return trimEx(result.toString()) + "...";
+    }
+
+    /**
+     * Removes the wp-gallery tag and its internals from the given string.
+     *
+     * See https://github.com/wordpress-mobile/WordPress-Android/issues/11063
+     */
+    public static String removeWPGallery(String str) {
+        return str.replaceAll("(?s)<!--\\swp:gallery?(.*?)wp:gallery\\s-->", "");
     }
 
     public static String getFormattedDate(PostModel post) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
@@ -13,6 +13,38 @@ import org.wordpress.android.fluxc.model.post.PostStatus.PRIVATE
 @RunWith(MockitoJUnitRunner::class)
 class PostUtilsUnitTest {
     @Test
+    fun `removeWPGallery removes multiple wp-gallery tags and its internals without affecting content in between`() {
+        /**
+         * This content is generated using the Block Editor to test a real-world example. It includes 2 galleries,
+         * first one has 2 photos each with a caption and second one doesn't have a caption.
+         * In between 2 galleries there is a "Test Content" paragraph.
+         */
+        val content = """
+<!-- wp:gallery {"ids":[1554,1549]} -->
+<figure class="wp-block-gallery columns-2 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://leweo7test.files.wordpress.com/2020/01/pexels-photo-247502.jpeg" data-id="1554" class="wp-image-1554" /><figcaption class="blocks-gallery-item__caption">C1</figcaption></figure></li><li class="blocks-gallery-item"><figure><img src="https://leweo7test.files.wordpress.com/2019/04/img_20191023_150221-1.jpg" data-id="1549" class="wp-image-1549" /><figcaption class="blocks-gallery-item__caption">D2</figcaption></figure></li></ul></figure>
+<!-- /wp:gallery -->
+
+<!-- wp:paragraph -->
+<p>Test content</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:gallery {"ids":[1546]} -->
+<figure class="wp-block-gallery columns-1 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://leweo7test.files.wordpress.com/2019/04/kunkka_underlords.png" data-id="1546" class="wp-image-1546" /></figure></li></ul></figure>
+<!-- /wp:gallery -->
+"""
+        val expectedResult = """
+
+
+<!-- wp:paragraph -->
+<p>Test content</p>
+<!-- /wp:paragraph -->
+
+
+"""
+        assertThat(PostUtils.removeWPGallery(content)).isEqualTo(expectedResult)
+    }
+
+    @Test
     fun `prepareForPublish updates dateLocallyChanged`() {
         val post = invokePreparePostForPublish()
         assertThat(post.dateLocallyChanged).isNotEmpty()


### PR DESCRIPTION
Fixes #11063. When the excerpt is missing from the post, we use the content to create a temporary excerpt to show in post list. With the changes in this PR, we will ignore everything in between `<!-- wp:gallery` and `wp:gallery -->` tags including the tags themselves. We do this before we strip all the html tags from the string so we don't lose the tag information. It also includes a unit test from a real world example not only to ensure the current behavior but also to prevent a future regex change causing headaches.

Interestingly this is the first ever regex I have written myself, so saying that I am skeptical about it would be an understatement. It'd be good to have someone with regex experience to have a look at it if the reviewer is not confident in it either.

### To test:
**Scenario 1**
* Add a new post using Block Editor
* Add a gallery at the beginning of the post and make sure at least one media has caption in it
* Save or publish the post
* Verify that the caption texts are not included in the excerpt in post list (the detail text below the title)
Here are my tests: [before](https://cloudup.com/c6R5Tpiw9gp) and [after](https://cloudup.com/cBmgBloqzjn) -> Notice how after the change `A` and `B` captions don't show up in the post list, but before the change they do.

**Scenario 2**
* Add a new post using Block Editor
* Add a gallery at the beginning of the post and make sure at least one media has caption in it
* Add some content afterwards (paragraph)
* Add at least one more gallery (maybe also add a caption)
* Verify that the caption texts are not included in the excerpt in post list (the detail text below the title)
* Verify that the content you wrote is included in the excerpt
Here are my tests: [before](https://cloudup.com/c6R5Tpiw9gp) and [after](https://cloudup.com/cBoq9u5DXQT) -> Notice how all the captions are ignored in the excerpt and only the paragraph content is visible in the post list after the change, but not before.

_P.S: I first recorded my tests after the change and then I didn't feel the need to record new gifs for before the change because the screenshot seemed enough._

### PR submission checklist:
- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc @yaelirub 

