### PR TITLE
Fix for 11135: Only allow @username typing suggestions on sites owned by the user.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/CommentFullScreenDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/CommentFullScreenDialogFragment.kt
@@ -63,8 +63,13 @@ class CommentFullScreenDialogFragment : Fragment(), CollapseFullScreenDialogCont
             reply.setSelection(it.getInt(EXTRA_SELECTION_START), it.getInt(EXTRA_SELECTION_END))
             viewModel.init()
 
-            siteModel = siteStore.getSiteBySiteId(it.getLong(EXTRA_SITE_ID))
-            setupSuggestionServiceAndAdapter(siteModel)
+            // Allow @username suggestion in full screen comment Editor on the Reader,
+            // but only on sites in the siteStore (i.e: current user's site).
+            // No suggestion is available for external sites that the user follows in the Reader.
+            val siteModel : SiteModel? = siteStore.getSiteBySiteId(it.getLong(EXTRA_SITE_ID))
+            if(siteModel != null) {
+                setupSuggestionServiceAndAdapter(siteModel)
+            }
         }
 
         return layout

--- a/WordPress/src/main/java/org/wordpress/android/ui/CommentFullScreenDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/CommentFullScreenDialogFragment.kt
@@ -66,8 +66,8 @@ class CommentFullScreenDialogFragment : Fragment(), CollapseFullScreenDialogCont
             // Allow @username suggestion in full screen comment Editor on the Reader,
             // but only on sites in the siteStore (i.e: current user's site).
             // No suggestion is available for external sites that the user follows in the Reader.
-            val siteModel : SiteModel? = siteStore.getSiteBySiteId(it.getLong(EXTRA_SITE_ID))
-            if(siteModel != null) {
+            val siteModel: SiteModel? = siteStore.getSiteBySiteId(it.getLong(EXTRA_SITE_ID))
+            if (siteModel != null) {
                 setupSuggestionServiceAndAdapter(siteModel)
             }
         }


### PR DESCRIPTION
Fixes #11135 

As far as I can check, the crash happened because the suggestion system requires some information from the SiteStore about the current site. If a site is merely followed, and is not one of the current account's sites, then there's no information of that site in the SiteStore.

This fix limits the suggestion to only be made available on the Reader for the current account's sites's posts.

To test:

# For followed sites
1. Open the Reader, find a post from an external site that you follow and do not own,
2. Tap comment icon, then tap chevron icon on bottom left to open full screen comment editor,
3. There should be no crash, and the comment editor should open properly.

# For owned sites
1. Open the Reader, find a post from your own WordPress.com site,
2. Tap comment icon, then tap chevron icon on bottom left to open full screen comment editor,
3. The editor should load properly,
4. Write your own username starting with "@" (e.g: @hafizrahman), the suggestion popup should still appear at the bottom.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

