### PR TITLE
Site not removed from subfilter when unfollowed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -520,6 +520,11 @@ public class ReaderPostListFragment extends Fragment
                 refreshPosts();
             }
 
+            if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel) {
+                // Remove sticky event if not consumed
+                EventBus.getDefault().removeStickyEvent(ReaderEvents.TagAdded.class);
+            }
+
             // if the user tapped a site to show site preview, it's possible they also changed the follow
             // status so tell the search adapter to check whether it has the correct follow status
             if (getPostListType() == ReaderPostListType.SEARCH_RESULTS && mLastTappedSiteSearchResult != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -378,7 +378,7 @@ public class ReaderUtils {
 
                     // it's possible the default tag won't exist if the user just changed the app's
                     // language, in which case default to the first tag in the table
-                    if (!ReaderTagTable.tagExists(tag)) {
+                    if (!ReaderTagTable.tagExists(validTag)) {
                         validTag = ReaderTagTable.getFirstTag();
                     }
                 }


### PR DESCRIPTION
Fixes #10886 

All this PR applies to zalpha flavor.

## Notes
- While working on this I found a bug in the ReaderUtils (referencing the wrong object `tag` instead of the correct one `validTag`. `Test case 3` below refers to this and I put steps to reproduce a possible wrong behavior due to this and test the fix.
- Added [here](bca635969541d298842b820b3ed41ab4eb8244ab) code to remove the sticky event used to propagate to the reader a newly followed Tag from settings, in case it has not been consumed yet.

## To test
### Test case 1: unfollowed tag is removed from subfilter
- Go to Reader > Following tab
- Select a Tag from the subfilter
- Go to settings cog
- Remove the selected tag from the `FOLLOWED TAGS` list
- Press the back arrow and check that the subfilter set on `All sites` and show the all sites posts

### Test case 2: unfollowed site is removed from subfilter
- Go to Reader > Following tab
- Select a followed site from the subfilter
- Tap on a post to open it
- Use the green `Following` label to unfollow the site
- Press the back arrow and check that the subfilter set on `All sites` and show the all sites posts
 
### Test case 3: fix bug on tag vs validTag
- With a version before this PR zalpha (you can use develop zalpha), select a Tag in the subfilter
- Select now a Site in the subfilter
- Open settings cog and remove the Tag selected in the first step
- Press the back arrow and check that the tab `SAVED` is wrongly selected
- Repeat the above with this PR zalpha version and finally check the tab `FOLLOWING` is correctly selected instead of `SAVED` and the subfilter is still on the site you selected before.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

